### PR TITLE
[TECH] Ajout du linter eslint-plugin-qunit

### DIFF
--- a/pix-editor/.eslintrc.js
+++ b/pix-editor/.eslintrc.js
@@ -11,11 +11,13 @@ module.exports = {
     }
   },
   plugins: [
-    'ember'
+    'ember',
+    'qunit',
   ],
   extends: [
     'eslint:recommended',
-    'plugin:ember/recommended'
+    'plugin:ember/recommended',
+    'plugin:qunit/recommended',
   ],
   env: {
     browser: true

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -15469,6 +15469,33 @@
         }
       }
     },
+    "eslint-plugin-qunit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.2.0.tgz",
+      "integrity": "sha512-KvPmkIC2MHpfRxs/r8WUeeGkG6y+3qwSi2AZIBtjcM/YG6Z3k0GxW5Hbu3l7X0TDhljVCeBb9Q5puUkHzl83Mw==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "requireindex": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -26403,6 +26430,12 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -75,6 +75,7 @@
     "eslint": "7.18.0",
     "eslint-plugin-ember": "10.1.2",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-qunit": "^6.2.0",
     "liquid-fire": "^0.31.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/pix-editor/tests/acceptance/competence/prototypes/list-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/list-test.js
@@ -17,7 +17,7 @@ const deadSkillPixId = 'pixDeadSkill';
 const challengeId2 = 'recChallenge2';
 
 module('Acceptance | competence/prototypes/list', function () {
-  module('visiting /competence/:competence_id/prototypes/list/:tube_id/:skill_id', async function (hooks) {
+  module('visiting /competence/:competence_id/prototypes/list/:tube_id/:skill_id', function (hooks) {
 
     setupApplicationTest(hooks);
     setupMirage(hooks);

--- a/pix-editor/tests/acceptance/create-framework-test.js
+++ b/pix-editor/tests/acceptance/create-framework-test.js
@@ -4,7 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { mockAuthService } from '../mock-auth';
 
-module.only('Acceptance | Search', function(hooks) {
+module('Acceptance | Search', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let apiKey, store;

--- a/pix-editor/tests/acceptance/login-test.js
+++ b/pix-editor/tests/acceptance/login-test.js
@@ -37,7 +37,7 @@ module('Acceptance | Login', function(hooks) {
     await click('[data-test-login-button]');
 
     // then
-    assert.equal(windowReloadStub.called, true);
+    assert.true(windowReloadStub.called);
   });
 });
 

--- a/pix-editor/tests/integration/components/field/toggle-field-test.js
+++ b/pix-editor/tests/integration/components/field/toggle-field-test.js
@@ -162,7 +162,7 @@ module('Integration | Component | field/toggle-field', function(hooks) {
 
       // then
       assert.ok(setDisplayFieldStub.calledWith(false));
-      assert.ok(this.modelData.someField === '');
+      assert.equal(this.modelData.someField, '');
       assert.ok(confirmAskStub.calledWith('Suppression', 'Êtes-vous sûr de vouloir supprimer le champ ?'));
     });
   });

--- a/pix-editor/tests/integration/components/pop-in/changelog-test.js
+++ b/pix-editor/tests/integration/components/pop-in/changelog-test.js
@@ -16,6 +16,6 @@ module('Integration | Component | popin-changelog', function(hooks) {
     await click('[data-test-save-changelog-button]');
 
     //then
-    assert.equal(this.approve.called, true);
+    assert.true(this.approve.called);
   });
 });

--- a/pix-editor/tests/integration/components/pop-in/login-form-test.js
+++ b/pix-editor/tests/integration/components/pop-in/login-form-test.js
@@ -45,7 +45,7 @@ module('Integration | Component | popin-login-form', function(hooks) {
 
     test('it should use load api from config service', async function(assert) {
       // then
-      assert.equal(configLoadStub.called, true);
+      assert.true(configLoadStub.called);
     });
 
     test('it should not display error message', async function(assert) {

--- a/pix-editor/tests/integration/components/pop-in/logout-test.js
+++ b/pix-editor/tests/integration/components/pop-in/logout-test.js
@@ -8,7 +8,7 @@ import { mockAuthService } from '../../../mock-auth';
 
 module('Integration | Component | logout', function(hooks) {
   setupRenderingTest(hooks);
-  
+
   test('it should ask for deconnection', async function(assert) {
     // given
     this.onDeny = sinon.stub();
@@ -21,17 +21,17 @@ module('Integration | Component | logout', function(hooks) {
   });
 
   module('deny button', function() {
-    
+
     test('it should call onDeny function', async function(assert) {
       // given
       this.onDeny = sinon.stub();
       await render(hbs`<PopIn::Logout @onDeny={{this.onDeny}}/>`);
-      
+
       // when
       await click('[data-test-logout-cancel-button]');
-      
+
       // then
-      assert.equal(this.onDeny.called, true);
+      assert.true(this.onDeny.called);
     });
   });
 
@@ -50,7 +50,7 @@ module('Integration | Component | logout', function(hooks) {
         }
       }
       this.owner.register('service:window', MockWindowService);
-      
+
       // when
       await click('[data-test-logout-ok-button]');
     });
@@ -59,12 +59,12 @@ module('Integration | Component | logout', function(hooks) {
       //then
       assert.equal(this.owner.lookup('service:auth').key, undefined);
     });
-    
+
     test('it should reload application', async function(assert) {
       //then
-      assert.equal(windowReloadStub.called, true);
+      assert.true(windowReloadStub.called);
     });
-    
+
   });
-      
+
 });

--- a/pix-editor/tests/integration/components/pop-in/select-location-test.js
+++ b/pix-editor/tests/integration/components/pop-in/select-location-test.js
@@ -177,7 +177,7 @@ module('Integration | Component | popin-select-location', function (hooks) {
       }
     });
   });
-  module('if `isPrototypeLocation`', async function (hooks) {
+  module('if `isPrototypeLocation`', function (hooks) {
     hooks.beforeEach(async function () {
       // when
       this.setSkills = sinon.stub();
@@ -214,6 +214,7 @@ module('Integration | Component | popin-select-location', function (hooks) {
     });
 
     test('it should display a list of skills on click', async function (assert) {
+      assert.expect(5);
       // given
       const expectedGroupResult = ['Niveau 1', 'Niveau 6'];
       const expectedOptionsResult = [ 'skill1_2_1_1_1 (v.1)', 'skill1_2_1_1_2 (v.1)', 'skill1_2_1_1_3 (v.2)'];
@@ -226,7 +227,7 @@ module('Integration | Component | popin-select-location', function (hooks) {
       const options = findAll('.ember-power-select-options ul>li');
 
       groupOptions.forEach((groupOption, i)=>{
-        assert.ok(groupOption.textContent.trim().indexOf(expectedGroupResult[i]) !== -1);
+        assert.notStrictEqual(groupOption.textContent.trim().indexOf(expectedGroupResult[i]), -1);
       });
 
       options.forEach((option, i)=>{

--- a/pix-editor/tests/integration/components/pop-in/select-location-test.js
+++ b/pix-editor/tests/integration/components/pop-in/select-location-test.js
@@ -281,7 +281,7 @@ module('Integration | Component | popin-select-location', function (hooks) {
       }]);
     });
   });
-  module('if `isSkillLocation`', async function (hooks) {
+  module('if `isSkillLocation`', function (hooks) {
     hooks.beforeEach(async function () {
       // when
       this.copyToNewLocation = sinon.stub();

--- a/pix-editor/tests/integration/components/pop-in/sorting-test.js
+++ b/pix-editor/tests/integration/components/pop-in/sorting-test.js
@@ -55,8 +55,8 @@ module('Integration | Component | pop-in/sorting', function(hooks) {
     await drag('mouse', draggableItem, () => { return { dy: draggableItem.offsetHeight * 2 + 1, dx: undefined };});
 
     // then
-    assert.ok(modelToSort2.index === 2);
-    assert.ok(modelToSort3.index === 1);
+    assert.equal(modelToSort2.index, 2);
+    assert.equal(modelToSort3.index, 1);
   });
 
   test('it should trigger approve action', async function (assert) {

--- a/pix-editor/tests/integration/components/pop-in/tube-level-test.js
+++ b/pix-editor/tests/integration/components/pop-in/tube-level-test.js
@@ -64,25 +64,27 @@ module('Integration | Component | popin-tube-level', function (hooks) {
   });
 
   test('it should display a list of an ordered list of skills level', function (assert) {
+    assert.expect(8);
     // when
     const expectedResult = ['1', '2', '', '', '5', '6', '', ''];
 
     // then
     const skillsList = this.element.querySelectorAll('.levels .level');
     skillsList.forEach((node, i) => {
-      assert.ok(node.textContent.trim() === expectedResult[i]);
+      assert.equal(node.textContent.trim(), expectedResult[i]);
     });
   });
 
   test('it should display selected skill level', function (assert) {
+    assert.expect(3);
     // when
     const expectedResult = ['1', '2'];
 
     // then
     const skillsList = this.element.querySelectorAll('.levels .level.selected');
-    assert.ok(skillsList.length === expectedResult.length);
+    assert.equal(skillsList.length, expectedResult.length);
     skillsList.forEach((node, i) => {
-      assert.ok(node.textContent.trim() === expectedResult[i]);
+      assert.equal(node.textContent.trim(), expectedResult[i]);
     });
   });
 

--- a/pix-editor/tests/integration/components/pop-in/tutorial-test.js
+++ b/pix-editor/tests/integration/components/pop-in/tutorial-test.js
@@ -40,8 +40,7 @@ module('Integration | Component | pop-in/tutorial', function(hooks) {
     await render(hbs`<PopIn::Tutorial @close={{this.close}} @tutorial={{this.tutorial}} @saveTutorial={{this.saveTutorial}}/>`);
 
     //then
-    // assert.dom('.ember-modal-dialog').exists();
-    assert.equal(this.element.querySelector('.ui.button.positive').disabled, true);
+    assert.true(this.element.querySelector('.ui.button.positive').disabled);
   });
 
   test('save input should not be disabled if mandatory field are empty', async function(assert) {
@@ -64,6 +63,6 @@ module('Integration | Component | pop-in/tutorial', function(hooks) {
     await render(hbs`<PopIn::Tutorial @close={{this.close}} @tutorial={{this.tutorial}} @saveTutorial={{this.saveTutorial}}/>`);
 
     //then
-    assert.equal(this.element.querySelector('.ui.button.positive').disabled, false);
+    assert.false(this.element.querySelector('.ui.button.positive').disabled);
   });
 });

--- a/pix-editor/tests/integration/components/sidebar/navigation-test.js
+++ b/pix-editor/tests/integration/components/sidebar/navigation-test.js
@@ -61,6 +61,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
     });
 
     test('it should display a list of frameworks with a creation item', async function(assert) {
+      assert.expect(3);
       // given
       const expectedFrameworks = ['Pix', 'Pix +', 'Créer un nouveau référentiel'];
 
@@ -76,6 +77,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
     });
 
     test('it should display only a list of areas', async function(assert) {
+      assert.expect(3);
       // given
       const expectedAreas = ['area_1', 'area_2'];
 
@@ -115,6 +117,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
     });
 
     test('it should display only a list of competences', async function(assert) {
+      assert.expect(3);
       // given
       const expectedCompenteces = ['competence1_1', 'competence1_2'];
 

--- a/pix-editor/tests/unit/controllers/competence-test.js
+++ b/pix-editor/tests/unit/controllers/competence-test.js
@@ -109,7 +109,7 @@ module('Unit | Controller | competence', function(hooks) {
       controller.displaySortThemesPopIn();
 
       // then
-      assert.ok(controller.sortingPopInTitle === 'Tri des thématiques');
+      assert.equal(controller.sortingPopInTitle, 'Tri des thématiques');
       assert.ok(controller.displaySortingPopIn);
       assert.deepEqual(controller.sortingPopInApproveAction, controller.sortThemes);
       assert.deepEqual(controller.sortingPopInCancelAction, controller.cancelThemesSorting);
@@ -160,7 +160,7 @@ module('Unit | Controller | competence', function(hooks) {
       controller.displaySortTubesPopIn([tube1, tube2]);
 
       // then
-      assert.ok(controller.sortingPopInTitle === 'Tri des tubes');
+      assert.equal(controller.sortingPopInTitle, 'Tri des tubes');
       assert.ok(controller.displaySortingPopIn);
       assert.deepEqual(controller.sortingModel, [tube1, tube2]);
       assert.deepEqual(controller.sortingPopInApproveAction, controller.sortTubes);

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -722,7 +722,7 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
 
       // then
       assert.deepEqual(challenge.files, [expectedPdfAttachement, expectedIllustration]);
-      assert.equal(storageServiceStub.renameFile.calledOnce, true);
+      assert.true(storageServiceStub.renameFile.calledOnce);
     });
 
   });

--- a/pix-editor/tests/unit/controllers/target-profile-test.js
+++ b/pix-editor/tests/unit/controllers/target-profile-test.js
@@ -101,6 +101,7 @@ module('Unit | Controller | target-profile', function (hooks) {
   });
 
   test('it should set tube-level arguments for production tube', function (assert) {
+    assert.expect(7);
     // when
     controller.displayTube(tube1);
 
@@ -127,6 +128,7 @@ module('Unit | Controller | target-profile', function (hooks) {
       assert.equal(value, expectedResult[i]);
     });
   });
+
   test('it should set a profile tube, with a level and a list of production skill id under this level ', function (assert) {
     // when
     controller.setProfileTube(tube1, 2, [skill1.pixId, skill2.pixId]);
@@ -150,7 +152,9 @@ module('Unit | Controller | target-profile', function (hooks) {
     // then
     assert.deepEqual([tube1.selectedLevel, tube1.selectedSkills], [false, []]);
   });
+
   test('it should set tube-level arguments for thematic result tube', function (assert) {
+    assert.expect(7);
     // when
     controller.displayThematicResultTube(tube1);
 

--- a/pix-editor/tests/unit/models/theme-test.js
+++ b/pix-editor/tests/unit/models/theme-test.js
@@ -65,23 +65,25 @@ module('Unit | Model | theme', function(hooks) {
   });
 
   test('it should not return workbench tubes', function(assert) {
+    assert.expect(3);
     // when
     const tubes = theme.tubes;
 
     // then
-    tubes.forEach(tube=>{
+    tubes.forEach((tube) => {
       assert.ok(['@tube_2', '@tube_3', '@tube_4'].includes(tube.name));
     });
   });
 
   test('it should return sorted production tubes', function(assert) {
+    assert.expect(2);
     // when
     const tubes = theme.productionTubes;
     const expectedSortedTube = ['@tube_2', '@tube_4'];
 
     // then
-    tubes.forEach((tube, index)=>{
-      assert.ok(tube.name === expectedSortedTube[index]);
+    tubes.forEach((tube, index) => {
+      assert.equal(tube.name, expectedSortedTube[index]);
     });
   });
 
@@ -90,7 +92,7 @@ module('Unit | Model | theme', function(hooks) {
     const selectedProductionTubeLength = theme.selectedProductionTubeLength;
 
     // then
-    assert.ok(selectedProductionTubeLength === 1);
+    assert.equal(selectedProductionTubeLength, 1);
   });
 
   module('#hasSelectedProductionTube', function () {

--- a/pix-editor/tests/unit/models/tube-test.js
+++ b/pix-editor/tests/unit/models/tube-test.js
@@ -71,6 +71,7 @@ module('Unit | Model | tube', function(hooks) {
 
   // Replace this with your real tests.
   test('it should return an array of skill with status is not `archivé` or `périmé`', function(assert) {
+    assert.expect(4);
     // given
     const wrongStatus = ['archivé', 'périmé'];
 
@@ -78,7 +79,7 @@ module('Unit | Model | tube', function(hooks) {
     const liveSkills = tube.liveSkills;
 
     // then
-    liveSkills.forEach(skill=>{
+    liveSkills.forEach(skill => {
       assert.notOk(wrongStatus.includes(skill.status));
     });
   });

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -28,6 +28,7 @@ module('Unit | Service | access', function(hooks) {
   module('mayEdit', function() {
 
     test('it should return `false` if challenge is not live', function (assert) {
+      assert.expect(2);
       //given
       const challenges = [{
         id: 'rec123655',
@@ -48,6 +49,7 @@ module('Unit | Service | access', function(hooks) {
     });
 
     test('it should return `true` if challenge is live and level is `EDITOR` or more', function (assert) {
+      assert.expect(2);
       //given
       const challenge = {
         id: 'rec123655',
@@ -56,7 +58,7 @@ module('Unit | Service | access', function(hooks) {
         isPrototype: true
       };
 
-      const roles = [ADMIN,EDITOR];
+      const roles = [ADMIN, EDITOR];
 
       //when
       roles.forEach(role => {

--- a/pix-editor/tests/unit/services/changelog-entry-test.js
+++ b/pix-editor/tests/unit/services/changelog-entry-test.js
@@ -6,6 +6,7 @@ module('Unit | Service | changelog-entry', function(hooks) {
 
   // Replace this with your real tests.
   test('it should return an elementType', function(assert) {
+    assert.expect(2);
     //given
     const keys = ['skill', 'challenge'];
     const expectedResults = ['acquis', 'épreuve'];

--- a/pix-editor/tests/unit/services/storage-test.js
+++ b/pix-editor/tests/unit/services/storage-test.js
@@ -237,6 +237,7 @@ module('Unit | Service | storage', function(hooks) {
     });
 
     test('it should retry when token has expired only one time', async function(assert) {
+      assert.expect(2);
       // given
       fetch.rejects({
         response: { status: 401 }
@@ -259,6 +260,7 @@ module('Unit | Service | storage', function(hooks) {
     });
 
     test('it should raise error when API call failed', async function(assert) {
+      assert.expect(2);
       // given
       fetch.rejects({
         response: { status: 400 }
@@ -407,6 +409,7 @@ module('Unit | Service | storage', function(hooks) {
     });
 
     test('it should retry when token has expired only one time', async function(assert) {
+      assert.expect(2);
       // given
       fetch.rejects({
         response: { status: 401 }
@@ -425,6 +428,7 @@ module('Unit | Service | storage', function(hooks) {
     });
 
     test('it should raise error when API call failed', async function(assert) {
+      assert.expect(2);
       // given
       fetch.rejects({
         response: { status: 400 }


### PR DESCRIPTION
## :unicorn: Problème
Les tests n'étaient pas correctement linter, ce qui fait que nous avons oublié des `only` certaines fois.

## :robot: Solution
Installer le plugin et corriger les ereurs

## :rainbow: Remarques
Beaucoup de plaisir

## :100: Pour tester
Vérifier que `npm lint` ne renvoit pas d'erreurs.
