### PR TITLE
[BUGFIX] N'essaye pas d'ouvrir airtable ou la preview toujours dans la même fenêtre

### DIFF
--- a/pix-editor/app/controllers/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single.js
@@ -140,12 +140,12 @@ export default class SingleController extends Controller {
   @action
   preview() {
     const challenge = this.challenge;
-    window.open(challenge.preview, challenge.id);
+    window.open(challenge.preview);
   }
 
   @action
   openAirtable() {
-    window.open(this.config.airtableUrl + this.config.tableChallenges + '/' + this.challenge.id, 'airtable');
+    window.open(this.config.airtableUrl + this.config.tableChallenges + '/' + this.challenge.id);
   }
 
   @action

--- a/pix-editor/app/controllers/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single.js
@@ -100,6 +100,15 @@ export default class SingleController extends Controller {
     }
   }
 
+  get previewUrl() {
+    return this.challenge.preview;
+  }
+
+
+  get airtableUrl() {
+    return `${this.config.airtableUrl}${this.config.tableChallenges}/${ this.challenge.id}`;
+  }
+
   @action
   setDisplayAlternativeInstructionsField(value) {
     this.displayAlternativeInstructionsField = value;
@@ -135,17 +144,6 @@ export default class SingleController extends Controller {
   @action
   close() {
     this.parentController.send('closeChildComponent');
-  }
-
-  @action
-  preview() {
-    const challenge = this.challenge;
-    window.open(challenge.preview);
-  }
-
-  @action
-  openAirtable() {
-    window.open(this.config.airtableUrl + this.config.tableChallenges + '/' + this.challenge.id);
   }
 
   @action

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -62,15 +62,13 @@ export default class SingleController extends Controller {
     return this.access.mayDeleteSkill(this.skill);
   }
 
-  @action
-  previewPrototype() {
+  get previewPrototypeUrl() {
     const prototype = this.skill.productionPrototype;
-    window.open(prototype.preview);
+    return prototype.preview;
   }
 
-  @action
-  openAirtable() {
-    window.open(this.config.airtableUrl + this.config.tableSkills + '/' + this.skill.id);
+  get airtableUrl() {
+    return `${this.config.airtableUrl}${this.config.tableSkills}/${this.skill.id}`;
   }
 
   @action

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -65,12 +65,12 @@ export default class SingleController extends Controller {
   @action
   previewPrototype() {
     const prototype = this.skill.productionPrototype;
-    window.open(prototype.preview, prototype.id);
+    window.open(prototype.preview);
   }
 
   @action
   openAirtable() {
-    window.open(this.config.airtableUrl + this.config.tableSkills + '/' + this.skill.id, 'airtable');
+    window.open(this.config.airtableUrl + this.config.tableSkills + '/' + this.skill.id);
   }
 
   @action

--- a/pix-editor/app/controllers/competence/tubes/single.js
+++ b/pix-editor/app/controllers/competence/tubes/single.js
@@ -105,7 +105,7 @@ export default class SingleController extends Controller {
 
   @action
   openAirtable() {
-    window.open(`${this.config.airtableUrl}${this.config.tableTubes}/${this.tube.id}`, 'airtable');
+    window.open(`${this.config.airtableUrl}${this.config.tableTubes}/${this.tube.id}`);
   }
 
   @action

--- a/pix-editor/app/controllers/competence/tubes/single.js
+++ b/pix-editor/app/controllers/competence/tubes/single.js
@@ -47,6 +47,10 @@ export default class SingleController extends Controller {
     return this.isEmptyMandatoryField;
   }
 
+  get airtableUrl() {
+    return `${this.config.airtableUrl}${this.config.tableTubes}/${this.tube.id}`;
+  }
+
   @action
   maximize() {
     this.parentController.maximizeLeft(true);
@@ -101,11 +105,6 @@ export default class SingleController extends Controller {
         this.loader.stop();
         this.notify.error('Erreur lors de la mise à jour du tube');
       });
-  }
-
-  @action
-  openAirtable() {
-    window.open(`${this.config.airtableUrl}${this.config.tableTubes}/${this.tube.id}`);
   }
 
   @action

--- a/pix-editor/app/templates/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/competence/prototypes/single.hbs
@@ -76,10 +76,10 @@
       Annuler
     </button>
   {{else}}
-    <button class="ui button item" {{on "click" this.preview}} type="button">
+    <a class="ui button item" href={{this.previewUrl}} target="_blank" rel="noopener noreferrer">
       <i class="eye icon"></i>
       Prévisualiser
-    </button>
+    </a>
     {{#if this.mayEdit}}
       <button data-test-modify-challenge-button class="ui button item" {{on "click" this.edit}} type="button">
         <i class="edit icon"></i>
@@ -93,10 +93,10 @@
       </button>
     {{/if}}
     {{#if this.mayAccessAirtable}}
-      <button class="ui button item" {{on "click" this.openAirtable}} type="button">
+      <a class="ui button item" href={{this.airtableUrl}} target="_blank" rel="noopener noreferrer">
         <i class="table icon"></i>
         Airtable
-      </button>
+      </a>
     {{/if}}
     <button class="ui button item" {{on "click" this.copyLink}} type="button">
       <i class="linkify icon"></i>

--- a/pix-editor/app/templates/competence/skills/single.hbs
+++ b/pix-editor/app/templates/competence/skills/single.hbs
@@ -67,10 +67,10 @@
       </button>
     {{else}}
       {{#if this.skill.productionPrototype}}
-        <button class="ui button item" {{on "click" this.previewPrototype}} type="button">
+        <a class="ui button item" href={{this.previewPrototypeUrl}} target="_blank" rel="noopener noreferrer">
           <i class="eye icon"></i>
           Prévisualiser
-        </button>
+        </a>
       {{/if}}
       {{#if this.mayEdit}}
         <button class="ui button item" {{on "click" this.edit}} type="button">
@@ -79,10 +79,10 @@
         </button>
       {{/if}}
       {{#if this.mayAccessAirtable}}
-        <button class="ui button item" {{on "click" this.openAirtable}} type="button">
+        <a class="ui button item" href={{this.airtableUrl}} target="_blank"  rel="noopener noreferrer">
           <i class="table icon"></i>
           Airtable
-        </button>
+        </a>
       {{/if}}
       {{#unless this.skill.isLive}}
         <button class="ui button item" {{on "click" this.displayChallenges}} type="button">

--- a/pix-editor/app/templates/competence/tubes/single.hbs
+++ b/pix-editor/app/templates/competence/tubes/single.hbs
@@ -44,10 +44,10 @@
         </button>
       {{/if}}
       {{#if this.mayAccessAirtable}}
-        <button class="ui button item" {{on "click" this.openAirtable}} type="button">
+        <a class="ui button item" href={{this.airtableUrl}} target="_blank" rel="noopener noreferrer">
           <i class="table icon"></i>
           Airtable
-        </button>
+        </a>
       {{/if}}
     {{/if}}
   </div>


### PR DESCRIPTION
## :unicorn: Problème
L'utilisation de `window.open` avec un paramètre name permet de toujours ouvrir le même onglet l'url. Mais avec chrome et dérivé, si l'utilisateur va sur un autre site, le lien est cassé et le clic ne rafraichissait pas l'onglet.

## :robot: Solution
Utiliser des vrais liens HTML qui s'ouvrent dans un nouvel onglet.

## :100: Pour tester
Dans les tubes, acquis et épreuves, cliquer sur les liens *Prévisualiser* et *Airtable*.