### PR TITLE
[TECH] Nettoyage d'attribut et de l'utilisation de nock.cleanAll

### DIFF
--- a/api/tests/acceptance/application/airtable-proxy-controller-changelog_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-changelog_test.js
@@ -4,10 +4,6 @@ const createServer = require('../../../server');
 
 describe('Acceptance | Controller | airtable-proxy-controller-changelog', () => {
   describe('PATCH /api/airtable/changelog/Notes', () => {
-    afterEach(function() {
-      nock.cleanAll();
-    });
-
     it('should proxy patch changelog to airtable', async () => {
       //Given
       const user = databaseBuilder.factory.buildAdminUser();

--- a/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
@@ -15,9 +15,6 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
       await databaseBuilder.commit();
 
     });
-    afterEach(function() {
-      nock.cleanAll();
-    });
 
     it('should refresh cache of updated record in pix api', async () => {
       // Given
@@ -130,9 +127,6 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
       user = databaseBuilder.factory.buildAdminUser();
       await databaseBuilder.commit();
 
-    });
-    afterEach(function() {
-      nock.cleanAll();
     });
 
     it('should refresh cache of updated record in pix api', async () => {

--- a/api/tests/acceptance/application/airtable-proxy-controller_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller_test.js
@@ -18,10 +18,6 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
       return user;
     }
 
-    afterEach(function() {
-      nock.cleanAll();
-    });
-
     describe('nominal cases', () => {
 
       it('should proxy request to airtable', async () => {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -6,11 +6,13 @@ chai.use(require('chai-sorted'));
 const sinon = require('sinon');
 chai.use(require('sinon-chai'));
 const cache = require('../lib/infrastructure/cache');
+const nock = require('nock');
 
 afterEach(async () => {
   airtableBuilder.cleanAll();
   await databaseBuilder.clean();
   cache.flushAll();
+  nock.cleanAll();
   return sinon.restore();
 });
 
@@ -90,7 +92,6 @@ function streamToPromise(stream) {
 }
 
 // Nock
-const nock = require('nock');
 nock.disableNetConnect();
 
 // airtableBuilder

--- a/api/tests/unit/infrastructure/event-notifier/updated-record-notifier_test.js
+++ b/api/tests/unit/infrastructure/event-notifier/updated-record-notifier_test.js
@@ -1,12 +1,7 @@
-const nock = require('nock');
 const { expect, domainBuilder, sinon } = require('../../../test-helper');
 const updatedRecordNotifier = require('../../../../lib/infrastructure/event-notifier/updated-record-notifier');
 
 describe('Unit | Infrastructure | EventNotifier | UpdatedRecordedNotifier', () => {
-
-  afterEach(function() {
-    nock.cleanAll();
-  });
 
   describe('#Notify', () => {
 

--- a/api/tests/unit/infrastructure/pix-api-client_test.js
+++ b/api/tests/unit/infrastructure/pix-api-client_test.js
@@ -4,9 +4,6 @@ const pixApiClient = require('../../../lib/infrastructure/pix-api-client');
 const cache = require('../../../lib/infrastructure/cache');
 
 describe('Unit | Infrastructure | PIX API Client', () => {
-  afterEach(function() {
-    nock.cleanAll();
-  });
 
   describe('#request', () => {
     context('when token is in cache', () => {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import Model, { attr, hasMany } from '@ember-data/model';
+import { tracked } from '@glimmer/tracking';
 
 export default class ChallengeModel extends Model {
 
@@ -33,7 +34,6 @@ export default class ChallengeModel extends Model {
   @attr responsive;
   @attr locales;
   @attr area;
-  @attr({ readOnly:true }) _definedBaseName;
   @attr autoReply;
 
   @hasMany('skill') skills;
@@ -43,6 +43,8 @@ export default class ChallengeModel extends Model {
   @service config;
   @service idGenerator;
 
+  @tracked _definedBaseName;
+  
   get illustration() {
     return this.files.find((file) => file.type === 'illustration' && !file.isDeleted);
   }

--- a/pix-editor/mirage/factories/challenge.js
+++ b/pix-editor/mirage/factories/challenge.js
@@ -31,7 +31,6 @@ export default Factory.extend({
   responsive: 'responsive',
   locales: 'languages',
   area: 'area',
-  _definedBaseName: '_definedBaseName',
   autoReply: 'autoReply',
   files: null,
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans #185, on a 2 commits qui n'ont rien a voir avec la choucroute. Une mauvaise utilisation d'un attribut du model et `nock.cleanAll()` qui n'était pas géré d'une manière globale.

## :robot: Solution
Récupérer les 2 commits en question pour les merger tout de suite

## :rainbow: Remarques
RAS

## :100: Pour tester
`npm test` doit être :green_circle: 