### PR TITLE
[TECH] Utilise une base de données spécifique pour redis en mode test

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -110,6 +110,8 @@ module.exports = (function() {
     };
 
     config.database.url = process.env.TEST_DATABASE_URL;
+
+    config.scheduledJobs.redisUrl = config.scheduledJobs.redisUrl + '/1';
   }
 
   return config;


### PR DESCRIPTION
## :unicorn: Problème
En local nous avons un test flacky sur la création de release en local lorsque nous avons l'api qui tourne en parallèle. En effet le job de création de release peut être pris par l'API qui tourne.

## :robot: Solution
Utilise une autre base de données redis dans les tests

## :100: Pour tester
1. Avoir l'API qui tourne en parallèle (pas en mode watch)
2. Lancer les tests plusieurs fois
3. Vérifier que tout les tests passent a chaque fois
