### PR TITLE
[BUGFIX] Corrige la configuration des notifications slack

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -87,7 +87,7 @@ module.exports = (function() {
     notifications: {
       slack: {
         webhookUrl: process.env.NOTIFICATIONS_SLACK_WEBHOOK_URL,
-        enable: process.env.NOTIFICATIONS_SLACK_ENABLE,
+        enable: isFeatureEnabled(process.env.NOTIFICATIONS_SLACK_ENABLE),
       }
     },
 


### PR DESCRIPTION
## :unicorn: Problème
Si on met la variable d'environnement `NOTIFICATIONS_SLACK_ENABLE` a false, on essaye quand même de faire la notification slack.

## :robot: Solution
Transformer correctement la variable d'environnement sous forme de string en boolean.

## :100: Pour tester
Mettre la variable d'environnement a false et tenter de faire une release. Voir que rien ne plante.
