### PR TITLE
[FEATURE] Extraire les urls depuis le référentiel Pix

### DIFF
--- a/api/scripts/get-external-urls-list/index.js
+++ b/api/scripts/get-external-urls-list/index.js
@@ -1,55 +1,66 @@
 require('dotenv').config({ path: __dirname + '/../../.env' });
 const _ = require('lodash');
-const { findUrlsFromChallenges } = require('../../lib/domain/usecases/validate-urls-from-release');
+const { findUrlsInstructionFromChallenge, findUrlsProposalsFromChallenge } = require('../../lib/domain/usecases/validate-urls-from-release');
 const releaseRepository = require('../../lib/infrastructure/repositories/release-repository');
 const { disconnect } = require('../../db/knex-database-connection');
 
 async function getExternalUrlsList() {
   const release = (await releaseRepository.getLatestRelease()).content;
-  const skillIdsFromPixFramework = getActiveSkillIdsFromPixFramework(release);
-  const challengesFromPixFramework = getChallengesFromPixFramework(release, skillIdsFromPixFramework);
-  const activeChallenges = getActiveChallenges(challengesFromPixFramework);
+  const skillIdsWithFramework = getSkillIdsWithFramework(release);
+  const activeChallenges = getActiveChallenges(release.challenges);
   const urlsFromChallenges = findUrlsFromChallenges(activeChallenges, release);
 
-  const urls = urlsFromChallenges.map(({ url }) => {
+  const baseUrl = function(url) {
     const parsedUrl = new URL(url);
     return parsedUrl.protocol + '//' + parsedUrl.host;
+  };
+
+  urlsFromChallenges.forEach((urlChallenge) => {
+    urlChallenge.origin = skillIdsWithFramework[urlChallenge.skillIds[0]];
+    urlChallenge.url = baseUrl(urlChallenge.url);
   });
 
-  const uniqUrls = _.uniq(urls).filter((url) => {
-    return !url.includes('epreuves.pix.fr');
-  });
+  const uniqUrls = _.uniqBy(urlsFromChallenges, 'url');
 
-  uniqUrls.forEach((url) => {
-    console.log(url);
+  uniqUrls.forEach(({ origin, url, locales }) => {
+    console.log([origin, url, locales.join(';')].join(','));
   });
 }
 
-function getActiveSkillIdsFromPixFramework(release) {
-  const competencesFromPixFramework = release.competences.filter((competence) =>  competence.origin === 'Pix');
-  const skillIds = competencesFromPixFramework.flatMap((competence) => competence.skillIds);
-  return getActiveSkillIds(release, skillIds);
+function findUrlsFromChallenges(challenges) {
+  const urlsFromChallenges = challenges.flatMap((challenge) => {
+    const functions = [
+      findUrlsInstructionFromChallenge,
+      findUrlsProposalsFromChallenge
+    ];
+    return functions
+      .flatMap((fun) => fun(challenge))
+      .map((url) => {
+        return { id: challenge.id, locales: challenge.locales, url, skillIds: challenge.skillIds };
+      });
+  });
+  return _.uniqBy(urlsFromChallenges, 'url');
 }
 
-function getChallengesFromPixFramework(release, skillIds) {
-  return release.challenges.filter((challenge) => skillIds.includes(challenge.skillIds[0]));
+function getSkillIdsWithFramework(release) {
+  return release.competences.reduce((memo, competence) => {
+    return {
+      ...competence.skillIds.reduce((memo2, skillId) => {
+        return {
+          [skillId]: competence.origin,
+          ...memo2
+        };
+      }, {}),
+      ...memo
+    };
+  }, {});
 }
 
 function getActiveChallenges(challenges) {
   const challengeInactiveStatus = ['périmé', 'proposé'];
   return challenges.filter((challenge) =>  {
-    return !challengeInactiveStatus.includes(challenge.status) && !challenge.locales.includes('en');
+    return !challengeInactiveStatus.includes(challenge.status);
   });
-}
-
-function getActiveSkillIds(release, skillIds) {
-  const skills = release.skills;
-  return skills.reduce((acc, skill) => {
-    if (skillIds.includes(skill.id) && skill.name !== '@workbench') {
-      acc.push(skill.id);
-    }
-    return acc;
-  }, []);
 }
 
 getExternalUrlsList().finally(() => { disconnect(); });

--- a/api/scripts/get-external-urls-list/index.js
+++ b/api/scripts/get-external-urls-list/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ path: __dirname + '/../../.env' });
 const _ = require('lodash');
 const { findUrlsFromChallenges } = require('../../lib/domain/usecases/validate-urls-from-release');
 const releaseRepository = require('../../lib/infrastructure/repositories/release-repository');
@@ -6,7 +6,9 @@ const { disconnect } = require('../../db/knex-database-connection');
 
 async function getExternalUrlsList() {
   const release = (await releaseRepository.getLatestRelease()).content;
-  const activeChallenges = getActiveChallenges(release);
+  const skillIdsFromPixFramework = getActiveSkillIdsFromPixFramework(release);
+  const challengesFromPixFramework = getChallengesFromPixFramework(release, skillIdsFromPixFramework);
+  const activeChallenges = getActiveChallenges(challengesFromPixFramework);
   const urlsFromChallenges = findUrlsFromChallenges(activeChallenges, release);
 
   const urls = urlsFromChallenges.map(({ url }) => {
@@ -23,9 +25,31 @@ async function getExternalUrlsList() {
   });
 }
 
-function getActiveChallenges(release) {
-  const challengeInactiveStatus = ['périmé', 'proposé'];
-  return release.challenges.filter((challenge) => !challengeInactiveStatus.includes(challenge.status));
+function getActiveSkillIdsFromPixFramework(release) {
+  const competencesFromPixFramework = release.competences.filter((competence) =>  competence.origin === 'Pix');
+  const skillIds = competencesFromPixFramework.flatMap((competence) => competence.skillIds);
+  return getActiveSkillIds(release, skillIds);
 }
 
-getExternalUrlsList().finally(() => { disconnect() });
+function getChallengesFromPixFramework(release, skillIds) {
+  return release.challenges.filter((challenge) => skillIds.includes(challenge.skillIds[0]));
+}
+
+function getActiveChallenges(challenges) {
+  const challengeInactiveStatus = ['périmé', 'proposé'];
+  return challenges.filter((challenge) =>  {
+    return !challengeInactiveStatus.includes(challenge.status) && !challenge.locales.includes('en');
+  });
+}
+
+function getActiveSkillIds(release, skillIds) {
+  const skills = release.skills;
+  return skills.reduce((acc, skill) => {
+    if (skillIds.includes(skill.id) && skill.name !== '@workbench') {
+      acc.push(skill.id);
+    }
+    return acc;
+  }, []);
+}
+
+getExternalUrlsList().finally(() => { disconnect(); });


### PR DESCRIPTION
## :unicorn: Problème
Pour s'assurer que les organisations qui fassent passer Pix puissent accéder aux URLs contenu dans les épreuves, on sort une ligne des URLs externes pour qu'elles soient sur une liste autorisées.

## :robot: Solution
Extraire les urls du référentiel coeur.

## 🌈  Remarques
Nous filtrons aussi les urls selon leur langue (français/francophone). 
Questionnement ? 
- Améliorer le script en configurant la langue via une variable d'env.
- Ajouter une variable d'env pour le référentiel 'Pix'.

## :100: Pour tester
Lancer le script `get-external-urls-list` et vérifier que la liste des liens proviennent bien du référentiel Pix. 