### PR TITLE
[FEATURE] Uniformiser le wording de suppression d'épreuve

### DIFF
--- a/pix-editor/app/controllers/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single.js
@@ -34,6 +34,7 @@ export default class SingleController extends Controller {
   @service loader;
   @service confirm;
   @service changelogEntry;
+  @service intl;
 
   get maximized() {
     return this.parentController.leftMaximized;
@@ -300,28 +301,28 @@ export default class SingleController extends Controller {
     if (dropdown) {
       dropdown.actions.close();
     }
-    return this.confirm.ask('Suppression', 'Êtes-vous sûr de vouloir supprimer l\'épreuve ?')
+    return this.confirm.ask(this.intl.t('challenge.obsolete.confirm.title'), this.intl.t('challenge.obsolete.confirm.message'))
       .then(() => {
-        this._displayChangelogPopIn('Suppression de l\'épreuve', (changelog) => {
+        this._displayChangelogPopIn(this.intl.t('challenge.obsolete.changelog'), (changelog) => {
           this.loader.start();
           return this.challenge.delete()
             .then(challenge => this._deleteAlternatives(challenge))
             .then(challenge => this._handleChangelog(challenge, changelog))
             .then(challenge => this._checkSkillsValidation(challenge))
             .then(() => {
-              this._message('Épreuve supprimée');
+              this._message(this.intl.t('challenge.obsolete.success'));
               this.send('close');
             })
             .catch((error) => {
               Sentry.captureException(error);
-              this._errorMessage('Erreur lors de la suppression');
+              this._errorMessage(this.intl.t('challenge.obsolete.error'));
             })
             .finally(() => this.loader.stop());
         });
       })
       .catch((error) => {
         Sentry.captureException(error);
-        this._message('Suppression abandonnée');
+        this._message(this.intl.t('challenge.obsolete.cancel'));
       });
   }
 

--- a/pix-editor/app/templates/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/competence/prototypes/single.hbs
@@ -15,19 +15,19 @@
               {{#if this.mayValidate}}
                 <button class="ui button validate item"  {{on "click" (fn this.validate dd)}} type="button">
                   <i class="checkmark icon"></i>
-                  Valider
+                  {{t 'competence.prototypes.validate'}}
                 </button>
               {{/if}}
               {{#if this.mayArchive}}
                 <button class="ui button archive item"  {{on "click" (fn this.archive dd)}} type="button">
                   <i class="archive icon"></i>
-                  Archiver
+                  {{t 'competence.prototypes.archive'}}
                 </button>
               {{/if}}
               {{#if this.mayDelete}}
               <button class="ui button archive item"  {{on "click" (fn this.delete dd)}} type="button">
                   <i class="trash alternate icon"></i>
-                  Supprimer
+                  {{t 'competence.prototypes.obsolete'}}
                 </button>
               {{/if}}
           </dd.Content>

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -1,1 +1,14 @@
-price_banner: The {product} costs {price, number, ::currency/USD}
+competence:
+  prototypes:
+    archive: Archiver
+    obsolete: Rendre obsolète
+    validate: Valider
+challenge:
+  obsolete:
+    confirm:
+      title: Rendre obsolète
+      message: Êtes-vous sûr de vouloir de rendre obsolète l'épreuve ?
+    changelog: Obsolescence de l'épreuve
+    success: Épreuve périmée
+    error: Erreur lors de l'obsolescence de l'épreuve
+    cancel: Obsolescence abandonnée


### PR DESCRIPTION
## :unicorn: Problème
Dans l'interface on mélange le wording de suppression qui en fait rend l'épreuve "périmée".

## :robot: Solution
Uniformiser un peu le wording en n'utilisant plus le terme de suppression, mais un mix entre obsolescence et périmé.

## :100: Pour tester
1. Aller sur une épreuve proposé ou validé
2. Cliquer sur l'éclair et ensuite sur 'Rendre obsolète'
