### PR TITLE
[FEATURE] Importer une sélection de sujets généré depuis Pix Orga vers Pix Editor (PIX-3958).

### DIFF
--- a/pix-editor/tests/unit/controllers/target-profile-test.js
+++ b/pix-editor/tests/unit/controllers/target-profile-test.js
@@ -3,7 +3,6 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-
 module('Unit | Controller | target-profile', function (hooks) {
   setupTest(hooks);
   let tube1, skill1, skill2, skill5, skill6, skill7, skill8, skill9, tube2, areas, framework, controller;
@@ -249,119 +248,189 @@ module('Unit | Controller | target-profile', function (hooks) {
     assert.deepEqual(fileSaverStub.getCall(0).args[0], expectedResult);
   });
 
-  test('it should build a profile state', async function(assert) {
-    // given
-    const skill10 = {
-      id: 'recSkill3_1_1',
-      pixId: 'pixSkill3_1_1',
-      name: 'skill3_1_1',
-      level: 1
-    };
-    const skill11 = {
-      id: 'recSkill3_1_2',
-      pixId: 'pixSkill3_1_2',
-      name: 'skill3_1_2',
-      level: 2
-    };
-    const skill12 = {
-      id: 'recSkill3_1_6',
-      pixId: 'pixSkill3_1_6',
-      name: 'skill3_1_6',
-      level: 6
-    };
-    const tube3 = {
-      id: 'rec666457',
-      pixId: 'pix666457',
-      name: 'tube3',
-      productionSkills: [skill10, skill11, skill12]
-    };
-    const area3 = {
-      id: 'recArea3',
-      competences: [{
-        id: 'recCompetence3_1',
-        tubes: [tube3]
-      }]
-    };
-    const framework2 = {
-      name: 'Pix+',
-      areas: [area3]
-    };
-    area3.framework = framework2;
+  module('_determineFileType', function () {
+    test('should return orga when the file is an array of strings', function(assert) {
+      // given
+      const data = ['1', '2'];
 
-    this.owner.register('service:currentData', class MockService extends Service {
+      // when
+      const result = controller._determineFileType(data);
 
-      getAreas() {
-        return [area3, ...areas];
-      }
-
-      getFrameworks() {
-        return [framework, framework2];
-      }
+      // then
+      assert.equal(result, 'orga');
     });
 
-    const notifyMessageStub = sinon.stub();
+    test('should return editor when the file is an array of objects', function(assert) {
+      // given
+      const data = [{ id: '1' }, { id: '2' }];
 
-    class NotifyService extends Service {
-      message = notifyMessageStub;
-    }
+      // when
+      const result = controller._determineFileType(data);
 
-    this.owner.register('service:notify', NotifyService);
+      // then
+      assert.equal(result, 'editor');
+    });
+  });
 
-    controller._emptyOpenFile = () => { return true; };
+  module('_buildTargetProfileFromFile', function (hooks) {
+    let skill10, skill11, skill12, tube3, area3, framework2;
 
-    const targetResult = JSON.stringify([
-      {
-        id: 'pix123456',
-        level: 'max',
-      }, {
-        id: 'pix666457',
-        level: 2,
-        skills: ['pixSkill3_1_1', 'pixSkill3_1_2']
-      }]);
+    hooks.beforeEach(function () {
+      skill10 = {
+        id: 'recSkill3_1_1',
+        pixId: 'pixSkill3_1_1',
+        name: 'skill3_1_1',
+        level: 1
+      };
+      skill11 = {
+        id: 'recSkill3_1_2',
+        pixId: 'pixSkill3_1_2',
+        name: 'skill3_1_2',
+        level: 2
+      };
+      skill12 = {
+        id: 'recSkill3_1_6',
+        pixId: 'pixSkill3_1_6',
+        name: 'skill3_1_6',
+        level: 6
+      };
+      tube3 = {
+        id: 'rec666457',
+        pixId: 'pix666457',
+        name: 'tube3',
+        productionSkills: [skill10, skill11, skill12]
+      };
+      area3 = {
+        id: 'recArea3',
+        competences: [{
+          id: 'recCompetence3_1',
+          tubes: [tube3]
+        }]
+      };
+      framework2 = {
+        name: 'Pix+',
+        areas: [area3]
+      };
+      area3.framework = framework2;
 
-    const expectedTube1 = {
-      id: 'rec123456',
-      pixId: 'pix123456',
-      name: 'tube1',
-      selectedLevel: 6,
-      selectedSkills: [skill1.pixId, skill2.pixId, skill5.pixId, skill6.pixId],
-      selectedThematicResultLevel: 2,
-      selectedThematicResultSkills: [skill1.pixId, skill2.pixId],
-      productionSkills: [skill1, skill2, skill5, skill6]
-    };
+      this.owner.register('service:currentData', class MockService extends Service {
 
-    const expectedTube2 = {
-      id: 'rec123457',
-      pixId: 'pix123457',
-      name: 'tube1',
-      selectedLevel: false,
-      selectedSkills: [],
-      selectedThematicResultLevel: 1,
-      selectedThematicResultSkills: [skill7.pixId],
-      productionSkills: [skill7, skill8, skill9]
-    };
+        getAreas() {
+          return [area3, ...areas];
+        }
 
-    const expectedTube3 = {
-      id: 'rec666457',
-      pixId: 'pix666457',
-      name: 'tube3',
-      selectedLevel: 2,
-      selectedSkills: [skill10.pixId, skill11.pixId],
-      productionSkills: [skill10, skill11, skill12]
-    };
+        getFrameworks() {
+          return [framework, framework2];
+        }
+      });
+    });
 
-    const explectedSelectedFrameworks = [
-      { data: framework, label: 'Pix' },
-      { data: framework2, label: 'Pix+' },
-    ];
+    test('it should build a profile state from pix-editor json file', async function(assert) {
+      // given
+      const fileContent = [
+        {
+          id: 'pix123456',
+          level: 'max',
+        }, {
+          id: 'pix666457',
+          level: 2,
+          skills: ['pixSkill3_1_1', 'pixSkill3_1_2']
+        }
+      ];
 
-    // when
-    await controller._buildTargetProfileFromFile({ target:{ result: targetResult } });
+      const expectedTube1 = {
+        id: 'rec123456',
+        pixId: 'pix123456',
+        name: 'tube1',
+        selectedLevel: 6,
+        selectedSkills: [skill1.pixId, skill2.pixId, skill5.pixId, skill6.pixId],
+        selectedThematicResultLevel: 2,
+        selectedThematicResultSkills: [skill1.pixId, skill2.pixId],
+        productionSkills: [skill1, skill2, skill5, skill6]
+      };
 
-    // then
-    assert.deepEqual(tube1, expectedTube1);
-    assert.deepEqual(tube2, expectedTube2);
-    assert.deepEqual(tube3, expectedTube3);
-    assert.deepEqual(controller._selectedFrameworks, explectedSelectedFrameworks);
+      const expectedTube2 = {
+        id: 'rec123457',
+        pixId: 'pix123457',
+        name: 'tube1',
+        selectedLevel: false,
+        selectedSkills: [],
+        selectedThematicResultLevel: 1,
+        selectedThematicResultSkills: [skill7.pixId],
+        productionSkills: [skill7, skill8, skill9]
+      };
+
+      const expectedTube3 = {
+        id: 'rec666457',
+        pixId: 'pix666457',
+        name: 'tube3',
+        selectedLevel: 2,
+        selectedSkills: [skill10.pixId, skill11.pixId],
+        productionSkills: [skill10, skill11, skill12]
+      };
+
+      const explectedSelectedFrameworks = [
+        { data: framework, label: 'Pix' },
+        { data: framework2, label: 'Pix+' },
+      ];
+
+      // when
+      await controller._buildTargetProfileFromFile(fileContent);
+
+      // then
+      assert.deepEqual(tube1, expectedTube1);
+      assert.deepEqual(tube2, expectedTube2);
+      assert.deepEqual(tube3, expectedTube3);
+      assert.deepEqual(controller._selectedFrameworks, explectedSelectedFrameworks);
+    });
+
+    test('it should build a profile state from orga json file', async function(assert) {
+      // given
+      const fileContent = ['pix123456', 'pix666457'];
+      const expectedTube1 = {
+        id: 'rec123456',
+        pixId: 'pix123456',
+        name: 'tube1',
+        selectedLevel: 6,
+        selectedSkills: [skill1.pixId, skill2.pixId, skill5.pixId, skill6.pixId],
+        selectedThematicResultLevel: 2,
+        selectedThematicResultSkills: [skill1.pixId, skill2.pixId],
+        productionSkills: [skill1, skill2, skill5, skill6]
+      };
+
+      const expectedTube2 = {
+        id: 'rec123457',
+        pixId: 'pix123457',
+        name: 'tube1',
+        selectedLevel: false,
+        selectedSkills: [],
+        selectedThematicResultLevel: 1,
+        selectedThematicResultSkills: [skill7.pixId],
+        productionSkills: [skill7, skill8, skill9]
+      };
+
+      const expectedTube3 = {
+        id: 'rec666457',
+        pixId: 'pix666457',
+        name: 'tube3',
+        selectedLevel: 6,
+        selectedSkills: [skill10.pixId, skill11.pixId, skill12.pixId],
+        productionSkills: [skill10, skill11, skill12]
+      };
+
+      const explectedSelectedFrameworks = [
+        { data: framework, label: 'Pix' },
+        { data: framework2, label: 'Pix+' },
+      ];
+
+      // when
+      await controller._buildTargetProfileFromFile(fileContent);
+
+      // then
+      assert.deepEqual(tube1, expectedTube1);
+      assert.deepEqual(tube2, expectedTube2);
+      assert.deepEqual(tube3, expectedTube3);
+      assert.deepEqual(controller._selectedFrameworks, explectedSelectedFrameworks);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le générateur de profile cible nous n'acceptons pas le format de fichier généré par le sélection de sujets depuis Pix Orga.

## :robot: Solution
Généré un profile cible depuis le fichier de sélection de sujets générer sur Pix Orga.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur le générateur de profil cible et ouvrez un fichier formaté comme un fichier de sélection de sujet depuis Pix Orga [depuis ce cette PR.](https://github.com/1024pix/pix/pull/3856) Vérifier que les sujet sont bien sélection.
