### PR TITLE
[BUG FIX] Archiver ou rendre obsolète un prototype actif crée un soucis dans la gestion du statut de son acquis (PIX 4064)

### DIFF
--- a/pix-editor/app/controllers/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single.js
@@ -527,13 +527,11 @@ export default class SingleController extends Controller {
 
   _archiveOrDeactivateSkill(challenge) {
     const skill = challenge.firstSkill;
-    const isProductionPrototype = skill.productionPrototype?.id === challenge.id;
+    const isProductionPrototype = this._isProductionPrototype(challenge);
     if (!isProductionPrototype) {
       return;
     }
-    const prototypesStatusOtherVersion = skill.prototypes
-      .filter((prototype) => prototype.id !== challenge.id)
-      .map((prototype) => prototype.status);
+    const prototypesStatusOtherVersion = this._getPrototypesStatusOtherVersion(skill, challenge);
     const haveProposalPrototype = prototypesStatusOtherVersion.includes('proposé');
     if (haveProposalPrototype) {
       return skill.deactivate();
@@ -543,13 +541,11 @@ export default class SingleController extends Controller {
 
   _obsoleteArchiveOrDeactivateSkill(challenge) {
     const skill = challenge.firstSkill;
-    const isProductionPrototype = skill.productionPrototype?.id === challenge.id;
+    const isProductionPrototype = this._isProductionPrototype(challenge);
     if (!isProductionPrototype) {
       return;
     }
-    const prototypesStatusOtherVersion = skill.prototypes
-      .filter((prototype) => prototype.id !== challenge.id)
-      .map((prototype) => prototype.status);
+    const prototypesStatusOtherVersion = this._getPrototypesStatusOtherVersion(skill, challenge);
     if (prototypesStatusOtherVersion.includes('proposé')) {
       return skill.deactivate();
     }
@@ -557,6 +553,17 @@ export default class SingleController extends Controller {
       return skill.archive();
     }
     return skill.obsolete();
+  }
+
+  _isProductionPrototype(challenge) {
+    const skill = challenge.firstSkill;
+    return skill.productionPrototype?.id === challenge.id;
+  }
+
+  _getPrototypesStatusOtherVersion(skill, challenge) {
+    return skill.prototypes
+      .filter((prototype) => prototype.id !== challenge.id)
+      .map((prototype) => prototype.status);
   }
 
   async _handleIllustration(challenge) {

--- a/pix-editor/app/controllers/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single.js
@@ -500,7 +500,7 @@ export default class SingleController extends Controller {
     }
     const tube = await currentSkill.tube;
     const skillVersions = tube.filledLiveSkills[currentSkill.level - 1];
-    const activeSkill = skillVersions.find(skill => skill.isActive);
+    const activeSkill = skillVersions ? skillVersions.find(skill => skill.isActive) : false;
     if (!activeSkill) {
       return;
     }

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -200,7 +200,7 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
         proposalPrototype1_1.validate();
 
         //when
-        await controller._checkSkillsValidation(proposalPrototype1_1);
+        await controller._checkSkillValidation(proposalPrototype1_1);
 
         //then
         assert.equal(skill1.status, 'actif');

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -252,6 +252,51 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
         assert.equal(validateChallenge2_1.status, 'archivé');
       });
     });
+
+    module('on prototype obsolete', function() {
+      test('it should obsolete alternative', async function(assert) {
+        // when
+        await controller._obsoleteAlternatives(validatePrototype2_1);
+
+        // then
+        assert.equal(validateChallenge2_1.status, 'périmé');
+      });
+      test('it should deactivate the current active skill if there is proposal prototype', async function(assert) {
+        // when
+        await controller._obsoleteArchiveOrDeactivateSkill(validatePrototype2_1);
+
+        // then
+        assert.equal(skill2.status, 'en construction');
+      });
+      test('it should archive the current active skill if there is archive prototype', async function(assert) {
+        // given
+        await proposalPrototype2_2.archive();
+
+        // when
+        await controller._obsoleteArchiveOrDeactivateSkill(validatePrototype2_1);
+
+        // then
+        assert.equal(skill2.status, 'archivé');
+      });
+      test('it should delete the current active skill if there is no archive or proposal prototype', async function(assert) {
+        // given
+        await proposalPrototype2_2.obsolete();
+
+        // when
+        await controller._obsoleteArchiveOrDeactivateSkill(validatePrototype2_1);
+
+        // then
+        assert.equal(skill2.status, 'périmé');
+      });
+      test('it should not change the skill status if is not a production prototype', async function(assert) {
+        // when
+        await controller._obsoleteArchiveOrDeactivateSkill(proposalPrototype2_2);
+
+        // then
+        assert.equal(skill2.status, 'actif');
+        assert.equal(skill1.status, 'en construction');
+      });
+    });
   });
 
   test('it should cancel edition', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Archiver ou rendre obsolète un prototype actif crée un soucis dans la gestion du statut de son acquis ce qui engendre des bug au niveau de pix-editor et rend  le référentiel caduque.

## :robot: Solution
Amélioré la gestion du statut d'un acquis lors de l'archivage ou la mise en obsolescence de son prototype `actif`.

Pour un prototype `actif` lors de l'archivage : 
- Si l'acquis contient encore des versions de prototype `en construction` alors l'acquis passe `en construction`.
- Si l'acquis ne contient plus que des versions `archivé` ou `périmé` alors l'acquis est `archivé`.

Pour un prototype `actif`  lors de la suppression: 
- Si l'acquis contient encore des versions de prototype `en construction` alors l'acquis passe `en construction`.
- Si l'acquis contient encore des versions de prototype `archivé` alors l'acquis est `archivé`.
- Si l'acquis ne contient plus que des versions `périmé` alors l'acquis est `périmé`.

## :rainbow: Remarques
Avec cette PR on casse l'ordre de vie d'un acquis (`en construction` > `actif` > `archivé` > `périmé`). En effet un acquis `actif` peut passé `en construction` si on archive/supprime le prototype `en production` et que l'acquis avait d'autre version de prototype `en construction`.
Ici on assume que l'état de l'acquis se passe en deux temps 
-  un passage en mode `en construction` lors de l'archivage/ suppression de son prototype 
-  et que son statut dépendra ensuite de ce que l'utilisateur voudra faire de la version du prototype `en construction` en le validant directement ce qui passe l'acquis à l'état `actif`.
Le cas où on voudrait les périmer est plus délicat car il faudra périmer le prototype 'en construction' et en suite passer l'acquis en 'archiver' pour que le prototype premièrement archivé soit joué. (j'espère que je ne vous ai pas perdu).
Car archiver directement l'acquis passera le prototype du statut 'en construction' au statut 'archivé' et risquera de se trouver joué alors que jamais validé.

## :100: Pour tester
Créer un acquis et lui attacher des versions de prototype de différente version et ensuite archiver/supprimer le prototype actif et vérifier le statut de l'acquis.
