### PR TITLE
[FEATURE] Ajout de l'information de la relation competence -> thematique (PIX-3948)

### DIFF
--- a/api/lib/domain/models/Competence.js
+++ b/api/lib/domain/models/Competence.js
@@ -10,6 +10,7 @@ module.exports = class Competence {
     descriptionEnUs,
     areaId,
     skillIds,
+    thematicIds,
     origin,
   } = {}) {
     this.id = id;
@@ -22,6 +23,7 @@ module.exports = class Competence {
     this.descriptionEnUs = descriptionEnUs;
     this.areaId = areaId;
     this.skillIds = skillIds;
+    this.thematicIds = thematicIds;
     this.origin = origin;
   }
 };

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -17,6 +17,7 @@ module.exports = datasource.extend({
     'Description en-us',
     'Domaine (id persistant)',
     'Acquis (via Tubes) (id persistant)',
+    'Thematiques',
     'Origine2',
     'Référence',
   ],
@@ -33,6 +34,7 @@ module.exports = datasource.extend({
       descriptionEnUs: airtableRecord.get('Description en-us') || airtableRecord.get('Description'),
       areaId: airtableRecord.get('Domaine (id persistant)') ? airtableRecord.get('Domaine (id persistant)')[0] : '',
       skillIds: airtableRecord.get('Acquis (via Tubes) (id persistant)') || [],
+      thematicIds: airtableRecord.get('Thematiques') || [],
       origin: airtableRecord.get('Origine2')[0],
       fullName: airtableRecord.get('Référence'),
     };

--- a/api/lib/infrastructure/transformers/competence-transformer.js
+++ b/api/lib/infrastructure/transformers/competence-transformer.js
@@ -12,6 +12,7 @@ function filterCompetencesFields(competences) {
     'descriptionEnUs',
     'areaId',
     'skillIds',
+    'thematicIds',
     'origin',
   ];
   return competences.map((competence) => _.pick(competence, fieldsToInclude));

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -35,6 +35,7 @@ function mockCurrentContent() {
       areaId: '1',
       origin: 'Pix',
       skillIds: ['recSkill0'],
+      thematicIds: ['recThematic0'],
       description: 'Description de la compétence',
       descriptionFrFr: 'Description de la compétence - fr',
       descriptionEnUs: 'Description de la compétence - en',

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -9,6 +9,7 @@ module.exports = function buildCompetence({
   descriptionEnUs,
   areaId,
   skillIds,
+  thematicIds,
   origin,
   fullName,
 }) {
@@ -22,6 +23,7 @@ module.exports = function buildCompetence({
       'Titre fr-fr': nameFrFr,
       'Titre en-us': nameEnUs,
       'Acquis (via Tubes) (id persistant)': skillIds,
+      'Thematiques': thematicIds,
       'Origine2': [origin],
       'Description': description,
       'Description fr-fr': descriptionFrFr,

--- a/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
@@ -20,6 +20,7 @@ module.exports = function buildCompetenceAirtableDataObject({
     'recRV35kIeqUQj8cI',
     'rec50NXHkatsRkjVQ',
   ],
+  thematicIds = ['recFvllz2Ckz'],
   fullName = '1.1 Mener une recherche et une veille d’information',
 } = {}) {
 
@@ -32,6 +33,7 @@ module.exports = function buildCompetenceAirtableDataObject({
     areaId,
     origin,
     skillIds,
+    thematicIds,
     description,
     descriptionFrFr,
     descriptionEnUs,


### PR DESCRIPTION
## :unicorn: Problème
Dans la release du référentiel, on ne donne pas le lien entre les compétences et les thématiques. 

## :robot: Solution
Ajouter cette information.

## :100: Pour tester
1. Créer une release `http POST http://localhost:4300/api/releases "Authorization: 8d03a893-3967-4501-9dc4-e0aa6c6dc442"`
2. vérifier que le champ `thematicIds` est présent sur les compétences
