### PR TITLE
[BUGFIX] Corrige la taille du bouton dropdown pour changer le statut d'un acquis/épreuve

### DIFF
--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -149,6 +149,10 @@ img.clickable {
       display: none;
     }
 
+    .ember-basic-dropdown-trigger, .ember-basic-dropdown-trigger .item {
+      height: 100%;
+    }
+
     .ember-basic-dropdown-content .ui.button {
       margin:0;
     }


### PR DESCRIPTION
## :unicorn: Problème
Le bouton éclair pour changer le statut d'un acquis ou d'une épreuve ne prenait pas toute la hauteur.
![Screenshot 2021-12-29 at 16-53-29 Pix Editor](https://user-images.githubusercontent.com/86659/147680327-7cba7243-520c-4642-a423-ea6edbfe28c4.png)


## :robot: Solution
Prendre toute la hauteur.
![Screenshot 2021-12-29 at 16-55-08 Pix Editor](https://user-images.githubusercontent.com/86659/147680347-23469698-8ca1-4d75-88e6-84ab64d8f2e7.png)

## :100: Pour tester
1. Aller sur la page d'un acquis
2. Constater qu'au survol du bouton éclair, celui ci prend toute la hauteur disponible
