### PR TITLE
[FEATURE] Met à jour le wording de mise en obsolescence des acquis (PIX-4092)

### DIFF
--- a/pix-editor/app/components/competence/grid/cell-skill-workbench.hbs
+++ b/pix-editor/app/components/competence/grid/cell-skill-workbench.hbs
@@ -15,8 +15,8 @@
       <span data-test-archived-count class="workbench-status archive-skill ui tiny label" title="Archivé">{{this.archivedCount}}</span>
     {{/if}}
 
-    {{#if this.hasDeletedSkill}}
-      <span data-test-deleted-count class="workbench-status deleted-skill ui tiny label" title="Supprimé">{{this.deletedCount}}</span>
+    {{#if this.hasObsoleteSkill}}
+      <span data-test-obsolete-count class="workbench-status obsolete-skill ui tiny label" title="Périmé">{{this.obsoleteCount}}</span>
     {{/if}}
   </div>
 </LinkTo>

--- a/pix-editor/app/components/competence/grid/cell-skill-workbench.js
+++ b/pix-editor/app/components/competence/grid/cell-skill-workbench.js
@@ -8,9 +8,9 @@ export default class CompetenceGridCellSkillWorkbenchComponent extends Component
     return archivedSkill.length;
   }
 
-  get deletedCount() {
-    const deletedSkill = this.args.skills.filter(skill=> skill.isDeleted);
-    return deletedSkill.length;
+  get obsoleteCount() {
+    const obsoleteSkills = this.args.skills.filter(skill=> skill.isObsolete);
+    return obsoleteSkills.length;
   }
 
   get draftCount() {
@@ -31,7 +31,7 @@ export default class CompetenceGridCellSkillWorkbenchComponent extends Component
     return this.archivedCount > 0;
   }
 
-  get hasDeletedSkill() {
-    return this.deletedCount > 0;
+  get hasObsoleteSkill() {
+    return this.obsoleteCount > 0;
   }
 }

--- a/pix-editor/app/components/competence/grid/cell-workbench.hbs
+++ b/pix-editor/app/components/competence/grid/cell-workbench.hbs
@@ -10,8 +10,8 @@
       {{#if this.hasArchivedPrototypes}}
         <span data-test-archived-prototype-count class="archived-prototype ui tiny label" title="Archivé">{{this.archivedPrototypesCount}}</span>
       {{/if}}
-      {{#if this.hasDeletedPrototypes}}
-        <span data-test-deleted-prototype-count class="deleted-prototype ui tiny label" title="Supprimé"> {{this.deletedPrototypesCount}}</span>
+      {{#if this.hasObsoletePrototypes}}
+        <span data-test-obsolete-prototype-count class="obsolete-prototype ui tiny label" title="Périmé"> {{this.obsoletePrototypesCount}}</span>
       {{/if}}
   </div>
 </LinkTo>

--- a/pix-editor/app/components/competence/grid/cell-workbench.js
+++ b/pix-editor/app/components/competence/grid/cell-workbench.js
@@ -20,9 +20,9 @@ export default class CellWorkbench extends Component {
     return archivedPrototypes.length;
   }
 
-  get deletedPrototypesCount() {
-    const deletedPrototypes = this.prototypes.filter(prototype => prototype.isDeleted);
-    return deletedPrototypes.length;
+  get obsoletePrototypesCount() {
+    const obsoletePrototypes = this.prototypes.filter(prototype => prototype.isObsolete);
+    return obsoletePrototypes.length;
   }
 
   get hasDraftPrototypes() {
@@ -33,7 +33,7 @@ export default class CellWorkbench extends Component {
     return this.archivedPrototypesCount > 0;
   }
 
-  get hasDeletedPrototypes() {
-    return this.deletedPrototypesCount > 0;
+  get hasObsoletePrototypes() {
+    return this.obsoletePrototypesCount > 0;
   }
 }

--- a/pix-editor/app/controllers/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single.js
@@ -466,11 +466,11 @@ export default class SingleController extends Controller {
     }
     const alternativesArchive = toArchive.map(alternative => {
       return alternative.archive()
-        .then(alternative => this._message(`Alternative n°${alternative.alternativeVersion} archivée`));
+        .then(alternative => this._message(this.intl.t('challenge.alternative.archive', { number: alternative.alternativeVersion })));
     });
     const alternativesObsolete = toObsolete.map(alternative => {
       return alternative.obsolete()
-        .then(alternative => this._message(`Alternative n°${alternative.alternativeVersion} supprimée`));
+        .then(alternative => this._message(this.intl.t('challenge.alternative.obsolete', { number: alternative.alternativeVersion })));
     });
     const alternativesArchiveAndObsolete = [...alternativesArchive, ...alternativesObsolete];
     return Promise.all(alternativesArchiveAndObsolete)
@@ -487,7 +487,7 @@ export default class SingleController extends Controller {
     }
     const alternativesObsolete = toObsolete.map(alternative => {
       return alternative.obsolete()
-        .then(alternative => this._message(`Alternative n°${alternative.alternativeVersion} supprimée`));
+        .then(alternative => this._message(this.intl.t('challenge.alternative.obsolete', { number: alternative.alternativeVersion })));
     });
     return Promise.all(alternativesObsolete)
       .then(() => challenge);

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -54,8 +54,8 @@ export default class SingleController extends Controller {
     return this.access.mayArchiveSkill(this.skill);
   }
 
-  get mayDelete() {
-    return this.access.mayDeleteSkill(this.skill);
+  get mayObsolete() {
+    return this.access.mayObsoleteSkill(this.skill);
   }
 
   get previewPrototypeUrl() {
@@ -243,7 +243,7 @@ export default class SingleController extends Controller {
   }
 
   @action
-  deleteSkill(dropdown) {
+  obsoleteSkill(dropdown) {
     if (this.skill.productioPrototype) {
       this.notify.error(this.intl.t('skill.obsolete.skill_with_live_challenges'));
       return;

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -256,7 +256,7 @@ export default class SingleController extends Controller {
       .then(() => {
         this._displayChangelogPopIn(this.intl.t('skill.changelog.obsolete'), (changelogValue) => {
           this.loader.start(this.intl.t('skill.obsolete.loader_start'));
-          return this.skill.delete()
+          return this.skill.obsolete()
             .then(()=>this._handleSkillChangelog(this.skill, changelogValue, this.changelogEntry.deleteAction))
             .then(() => {
               this.close();

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -263,8 +263,8 @@ export default class SingleController extends Controller {
               this.notify.message(this.intl.t('skill.obsolete.success'));
             })
             .then(() => {
-              const updateChallenges = challenges.filter(challenge => !challenge.isDeleted).map(challenge => {
-                return challenge.delete()
+              const updateChallenges = challenges.filter(challenge => !challenge.isObsolete).map(challenge => {
+                return challenge.obsolete()
                   .then(()=>this._handleChallengeChangelog(challenge, this.intl.t('skill.obsolete.challenge.changelog', { skillName: this.skill.name })))
                   .then(() => {
                     if (challenge.isPrototype) {

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -244,7 +244,7 @@ export default class SingleController extends Controller {
 
   @action
   obsoleteSkill(dropdown) {
-    if (this.skill.productioPrototype) {
+    if (this.skill.productionPrototype) {
       this.notify.error(this.intl.t('skill.obsolete.skill_with_live_challenges'));
       return;
     }

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -83,10 +83,9 @@ export default class ChallengeModel extends Model {
     return this.status === 'archivé';
   }
 
-  get isDeleted() {
+  get isObsolete() {
     return this.status === 'périmé';
   }
-
 
   get notDeclinable() {
     const declinable = this.declinable;
@@ -221,7 +220,7 @@ export default class ChallengeModel extends Model {
     return this.save();
   }
 
-  delete() {
+  obsolete() {
     this.status = 'périmé';
     return this.save();
   }

--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -120,7 +120,7 @@ export default class SkillModel extends Model {
     return this.status === 'actif' || this.status === 'en construction';
   }
 
-  get isDeleted() {
+  get isObsolete() {
     return this.status === 'périmé';
   }
 

--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -164,7 +164,7 @@ export default class SkillModel extends Model {
     return this.save();
   }
 
-  delete() {
+  obsolete() {
     this.status = 'périmé';
     return this.save();
   }

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -70,7 +70,7 @@ export default class AccessService extends Service {
   }
 
   mayObsoleteSkill(skill) {
-    if (skill.isDeleted) {
+    if (skill.isObsolete) {
       return false;
     }
     const level = this.config.accessLevel;

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -69,7 +69,7 @@ export default class AccessService extends Service {
     }
   }
 
-  mayDeleteSkill(skill) {
+  mayObsoleteSkill(skill) {
     if (skill.isDeleted) {
       return false;
     }

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -89,9 +89,9 @@ export default class AccessService extends Service {
     const level = this.config.accessLevel;
     const production = challenge.isValidated;
     const archived = challenge.isArchived;
-    const deleted = challenge.isDeleted;
+    const obsolete = challenge.isObsolete;
     const prototype = challenge.isPrototype;
-    if (archived || deleted) {
+    if (archived || obsolete) {
       return false;
     }
     return level >= EDITOR || (!production && !prototype && level === REPLICATOR);
@@ -133,8 +133,8 @@ export default class AccessService extends Service {
     }
   }
 
-  mayDelete(challenge) {
-    if (challenge.isDeleted) {
+  mayObsolete(challenge) {
+    if (challenge.isObsolete) {
       return false;
     }
     const level = this.config.accessLevel;

--- a/pix-editor/app/styles/_competence.scss
+++ b/pix-editor/app/styles/_competence.scss
@@ -261,7 +261,7 @@
                 color: white;
               }
 
-              &.deleted-skill {
+              &.obsolete-skill {
                 background: $deleted-background-color;
                 color: white;
               }

--- a/pix-editor/app/styles/_competence.scss
+++ b/pix-editor/app/styles/_competence.scss
@@ -161,7 +161,7 @@
                 color: white;
               }
 
-              &.deleted-prototype {
+              &.obsolete-prototype {
                 background: $deleted-background-color;
                 color: white;
               }

--- a/pix-editor/app/templates/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/competence/prototypes/single.hbs
@@ -8,7 +8,7 @@
       {{#if (and this.challenge.isPrototype (not this.challenge.isWorkbench))}}
           <button class="ui button icon item" {{on "click" this.showVersions}} type="button"><i class="clone icon"></i>&nbsp;v{{this.challenge.version}}</button>
       {{/if}}
-      {{#if (or this.mayValidate this.mayArchive this.mayDelete)}}
+      {{#if (or this.mayValidate this.mayArchive this.mayObsolete)}}
         <BasicDropdown @id="testdd" @renderInPlace={{true}} @class="icon ui dropdown " @horizontalPosition="left" as |dd|>
           <dd.Trigger><button class="ui icon button item" type="button"><i class="bolt icon"></i></button></dd.Trigger>
           <dd.Content @class="dropdown-content dropdown-content-challenge slide-fade">
@@ -24,8 +24,8 @@
                   {{t 'competence.prototypes.archive'}}
                 </button>
               {{/if}}
-              {{#if this.mayDelete}}
-              <button class="ui button archive item"  {{on "click" (fn this.delete dd)}} type="button">
+              {{#if this.mayObsolete}}
+              <button class="ui button archive item"  {{on "click" (fn this.obsolete dd)}} type="button">
                   <i class="trash alternate icon"></i>
                   {{t 'competence.prototypes.obsolete'}}
                 </button>

--- a/pix-editor/app/templates/competence/skills/single.hbs
+++ b/pix-editor/app/templates/competence/skills/single.hbs
@@ -21,13 +21,13 @@
               {{#if this.mayArchive}}
                 <button class="ui button archive item"  {{on "click" (fn this.archiveSkill dd)}} type="button">
                   <i class="archive icon"></i>
-                  Archiver
+                  {{t 'competence.skills.archive'}}
                 </button>
               {{/if}}
               {{#if this.mayDelete}}
                 <button class="ui button delete item"  {{on "click" (fn this.deleteSkill dd)}} type="button">
                   <i class="trash alternate icon"></i>
-                  Supprimer
+                  {{t 'competence.skills.obsolete'}}
                 </button>
               {{/if}}
             </dd.Content>

--- a/pix-editor/app/templates/competence/skills/single.hbs
+++ b/pix-editor/app/templates/competence/skills/single.hbs
@@ -12,7 +12,7 @@
                 @models={{array this.skill.tube.id this.skill.level}}>
           <i class="clone icon"></i>&nbsp;v{{this.skill.version}}
         </LinkTo>
-        {{#if (or this.mayArchive this.mayDelete)}}
+        {{#if (or this.mayArchive this.mayObsolete)}}
           <BasicDropdown title="Actions" @renderInPlace={{true}} @class="icon ui dropdown " @horizontalPosition="left" as |dd|>
             <dd.Trigger>
               <button class="ui icon button item" type="button"><i class="bolt icon"></i></button>
@@ -24,8 +24,8 @@
                   {{t 'competence.skills.archive'}}
                 </button>
               {{/if}}
-              {{#if this.mayDelete}}
-                <button class="ui button delete item"  {{on "click" (fn this.deleteSkill dd)}} type="button">
+              {{#if this.mayObsolete}}
+                <button class="ui button delete item"  {{on "click" (fn this.obsoleteSkill dd)}} type="button">
                   <i class="trash alternate icon"></i>
                   {{t 'competence.skills.obsolete'}}
                 </button>

--- a/pix-editor/tests/integration/components/competence/grid/cell-skill-workbench-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-skill-workbench-test.js
@@ -82,7 +82,7 @@ module('Integration | Component | competence/grid/cell-skill-workbench', functio
     assert.dom('[data-test-draft-count]').hasText('2');
     assert.dom('[data-test-active-count]').hasText('1');
     assert.dom('[data-test-archived-count]').hasText('2');
-    assert.dom('[data-test-deleted-count]').hasText('1');
+    assert.dom('[data-test-obsolete-count]').hasText('1');
   });
 
 });

--- a/pix-editor/tests/integration/components/competence/grid/cell-workbench-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-workbench-test.js
@@ -70,6 +70,6 @@ module('Integration | Component | competence/grid/cell-workbench', function(hook
     assert.dom('[data-test-draft-prototype-count]').hasText('1');
     assert.dom('[data-test-validated-prototype-count]').hasText('1');
     assert.dom('[data-test-archived-prototype-count]').hasText('3');
-    assert.dom('[data-test-deleted-prototype-count]').hasText('2');
+    assert.dom('[data-test-obsolete-prototype-count]').hasText('2');
   });
 });

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -37,7 +37,7 @@ module('Unit | Service | access', function(hooks) {
       },{
         id: 'rec123656',
         name: 'deletedChallenge',
-        isDeleted: true
+        isObsolete: true
       }];
 
       //when

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -3,6 +3,9 @@ competence:
     archive: Archiver
     obsolete: Rendre obsolète
     validate: Valider
+  skills:
+    archive: Archiver
+    obsolete: Rendre obsolète
 challenge:
   obsolete:
     confirm:
@@ -12,3 +15,34 @@ challenge:
     success: Épreuve périmée
     error: Erreur lors de l'obsolescence de l'épreuve
     cancel: Obsolescence abandonnée
+skill:
+  changelog:
+    update: Mise à jour de l'acquis
+    archive: Archivage de l'acquis
+    obsolete: Obsolescence de l'acquis
+  archive:
+    skill_with_live_challenges: Vous ne pouvez pas archiver un acquis avec des épreuves publiées
+    confirm:
+      title: Archivage
+      message: Êtes-vous sûr de vouloir archiver l'acquis ?
+    loader_start: Archivage de l'acquis
+    success: Acquis archivé
+    error: Erreur lors de l'archivage de l'acquis
+    cancel: Archivage abandonné
+    challenge:
+      changelog: Archivage de l'épreuve suite à l'archivage de l'acquis {skillName}
+      prototype: Prototype archivé
+      alternative: Déclinaison n°{number} archivée
+  obsolete:
+    skill_with_live_challenges: Vous ne pouvez pas rendre obsolète un acquis avec des épreuves publiées
+    confirm:
+      title: Suppression
+      message: Êtes-vous sûr de vouloir rendre obsolète l'acquis ?
+    loader_start: Obsolescence de l'acquis
+    success: Acquis périmé
+    error: Erreur lors de l'obsolescence de l'acquis
+    cancel: Obsolescence abandonnée
+    challenge:
+      changelog: Obscolescence de l'épreuve suite à l'obsolescence de l'acquis {skillName}
+      prototype: Prototype périmé
+      alternative: Déclinaison n°{number} périmée

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -15,6 +15,9 @@ challenge:
     success: Épreuve périmée
     error: Erreur lors de l'obsolescence de l'épreuve
     cancel: Obsolescence abandonnée
+  alternative:
+    archive: Déclinaison n°{number} archivée
+    obsolete: Déclinaison n°{number} périmée
 skill:
   changelog:
     update: Mise à jour de l'acquis


### PR DESCRIPTION
## :unicorn: Problème
Le wording pour rendre obsolète un acquis n'est pas consistent dans l'application. L'action est "supprimé", l'état est "périmé".

## :robot: Solution
Mettre à jour le wording un peu partout.

## :rainbow: Remarques
Les méthodes, class css, et autres ont également été renommée. Et le wording a été déplacé dans la traduction.

## :100: Pour tester
1. Aller sur un acquis
2. Cliquer sur "Rendre obsolète" en cliquant sur l'élair dans la barre d'outils
