### PR TITLE
[CLEANUP] Supprime la gestion des status pré-validé et validé sans test des épreuves (PIX-4126)

### DIFF
--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -67,8 +67,7 @@ export default class ChallengeModel extends Model {
   }
 
   get isValidated() {
-    const status = this.status;
-    return ['validé', 'validé sans test', 'pré-validé'].includes(status);
+    return this.status === 'validé';
   }
 
   get skillNames() {
@@ -96,8 +95,6 @@ export default class ChallengeModel extends Model {
     const status = this.status;
     switch (status) {
       case 'validé':
-      case 'validé sans test':
-      case 'pré-validé':
         return 'validated';
       case 'proposé':
         return 'suggested';

--- a/scripts/copy-skills-and-set-challenges-as-focusable/index-tests.js
+++ b/scripts/copy-skills-and-set-challenges-as-focusable/index-tests.js
@@ -105,8 +105,7 @@ describe('Copy skills and set challenges as focusable', function() {
 
       expect(base.select).to.have.been.calledWith({
         fields: USEFUL_CHALLENGE_FIELDS,
-        filterByFormula : 'AND(FIND(\'1\', ARRAYJOIN({Acquix (id persistant)})), ' +
-          'OR({Statut} = \'validé\', {Statut} = \'validé sans test\', {Statut} = \'pré-validé\'))',
+        filterByFormula : 'AND(FIND(\'1\', ARRAYJOIN({Acquix (id persistant)})), {Statut} = \'validé\'))',
       });
     });
   });
@@ -236,7 +235,7 @@ describe('Copy skills and set challenges as focusable', function() {
         new AirtableRecord('Challenges', 'recAirtableId2', {
           fields: {
             'id persistant': '2',
-            'Statut': 'validé sans test',
+            'Statut': 'validé',
             'Consigne': 'Coucou',
             'Focalisée': false,
           },

--- a/scripts/copy-skills-and-set-challenges-as-focusable/index.js
+++ b/scripts/copy-skills-and-set-challenges-as-focusable/index.js
@@ -107,7 +107,7 @@ async function duplicateSkill(base, idGenerator, skill) {
 async function findChallengesFromASkill(base, sourceSkillIdPersistent) {
   return base.select({
     fields: USEFUL_CHALLENGE_FIELDS,
-    filterByFormula: `AND(FIND('${sourceSkillIdPersistent}', ARRAYJOIN({Acquix (id persistant)})), OR({Statut} = 'validé', {Statut} = 'validé sans test', {Statut} = 'pré-validé'))`,
+    filterByFormula: `AND(FIND('${sourceSkillIdPersistent}', ARRAYJOIN({Acquix (id persistant)})), {Statut} = 'validé'))`,
   }).all();
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Les status pré-validé et validé sans test des épreuves sont de l'historique. Nous avons décidé de réécrire l'histoire pour simplifier la vérification du status des épreuves.

## :robot: Solution
Les données dans airtable ont été mise à jour pour ne permettre que l'état "validé". Nous mettons desormais le code a jour dans Pix Editor

## :rainbow: Remarques
Le statut "idée" qui n'était pas géré dans Pix Editor a également été supprimé.

## :100: Pour tester
1. vérifier qu'il n'y a plus d'épreuves en statut pré-validé et validé sans test coté airtable
2. vérifier que les épreuves validé s'affichent toujours comme tel dans Pix Editor
