### PR TITLE
[FEATURE] Ajout de contexte sur l'extract des URLs du référentiel (PIX-4154)

### DIFF
--- a/api/scripts/get-external-urls-list/index.js
+++ b/api/scripts/get-external-urls-list/index.js
@@ -22,8 +22,8 @@ async function getExternalUrlsList() {
 
   const uniqUrls = _.uniqBy(urlsFromChallenges, 'url');
 
-  uniqUrls.forEach(({ origin, url, locales }) => {
-    console.log([origin, url, locales.join(';')].join(','));
+  uniqUrls.forEach(({ origin, url, locales, status }) => {
+    console.log([origin, url, locales.join(';'), status].join(','));
   });
 }
 
@@ -36,7 +36,7 @@ function findUrlsFromChallenges(challenges) {
     return functions
       .flatMap((fun) => fun(challenge))
       .map((url) => {
-        return { id: challenge.id, locales: challenge.locales, url, skillIds: challenge.skillIds };
+        return { id: challenge.id, locales: challenge.locales, url, skillIds: challenge.skillIds, status: challenge.status };
       });
   });
   return _.uniqBy(urlsFromChallenges, 'url');

--- a/api/scripts/get-external-urls-list/index.js
+++ b/api/scripts/get-external-urls-list/index.js
@@ -18,12 +18,13 @@ async function getExternalUrlsList() {
   urlsFromChallenges.forEach((urlChallenge) => {
     urlChallenge.origin = skillIdsWithFramework[urlChallenge.skillIds[0]];
     urlChallenge.url = baseUrl(urlChallenge.url);
+    urlChallenge.tube = getTubeName(release, urlChallenge);
   });
 
   const uniqUrls = _.uniqBy(urlsFromChallenges, 'url');
 
-  uniqUrls.forEach(({ origin, url, locales, status }) => {
-    console.log([origin, url, locales.join(';'), status].join(','));
+  uniqUrls.forEach(({ origin, url, locales, status, tube }) => {
+    console.log([origin, tube, url, locales.join(';'), status].join(','));
   });
 }
 
@@ -41,6 +42,16 @@ function findUrlsFromChallenges(challenges) {
   });
   return _.uniqBy(urlsFromChallenges, 'url');
 }
+
+function getTubeName(release, challenge) {
+  const skill = release.skills.find((skill) => {
+    return skill.id === challenge.skillIds[0];
+  });
+  const tube = release.tubes.find((tube) => {
+    return tube.id === skill.tubeId;
+  });
+  return tube.name;
+};
 
 function getSkillIdsWithFramework(release) {
   return release.competences.reduce((memo, competence) => {


### PR DESCRIPTION
## :unicorn: Problème
Les URLs que nous extrayons du référentiel manquent de contexte, car nous n'avons pas le non du sujet ni le statut de l'épreuve

## :robot: Solution
Ajouter dans la sortie le nom du sujet et le statut de l'épreuve

## :100: Pour tester
Sur une base avec un release,
1. lancer le script `cd api && node scripts/get-external-urls-list`
2. Vérifier que dans la sortie il y a il a 2 nouvelle colonnes
