### PR TITLE
[BUGFIX] Corrige la concurrence de vérifications des URLs

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -116,7 +116,7 @@ async function analyze(lines, options) {
     } finally {
       logger.trace(`done checking ${line.url}`);
     }
-  }, options.bulk);
+  }, { concurrency: options.bulk });
   return newLines;
 }
 


### PR DESCRIPTION
## :unicorn: Problème
La concurrence pour vérifier les URLs externe du référentiel est censé être de 50. Mais une erreur de configuration de p-map fait qu'on vérifiait tout d'un coup.

## :robot: Solution
Corriger le code pour passer l'option `concurrency` correctement.

## :100: Pour tester
1. Mettre le `LOG_LEVEL` a `trace`
1. Créer une release
1. Vérifier que la vérification d'url se lance a la fin de la création a la release
1. Vérifier que lors de la vérification d'url on a bien un alternance de logs de "checking xxx" et de "done checking xxx"