### PR TITLE
|BUGFIX] Corrige certaines urls injustement marqué comme invalides

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -79,7 +79,10 @@ function findUrlsFromTutorials(tutorials, release) {
 
 async function analyzeUrls(urlList) {
   const options = {
-    headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:64.0) Gecko/20100101 Firefox/80.0' },
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:64.0) Gecko/20100101 Firefox/80.0',
+      'Accept': '*/*'
+    },
     timeout: 15000,
     maxRedirects: 10,
     bulk: 50,

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -2,6 +2,8 @@ const showdown = require('showdown');
 const _ = require('lodash');
 const urlRegex = require('url-regex-safe');
 const axios = require('axios');
+const { wrapper } = require('axios-cookiejar-support');
+const { CookieJar } = require('tough-cookie');
 
 const logger = require('../../infrastructure/logger');
 
@@ -124,10 +126,12 @@ async function analyze(lines, options) {
 }
 
 async function checkUrl(url, config) {
+  const jar = new CookieJar();
+  const client = wrapper(axios.create({ jar }));
   try {
-    return (await axios.head(url, config));
+    return (await client.head(url, config));
   } catch (e) {
-    return (await axios.get(url, config));
+    return (await client.get(url, config));
   }
 }
 

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -171,6 +171,7 @@ async function checkAndUploadKOUrlsFromTutorials(release, { urlErrorRepository }
 }
 
 module.exports = {
+  checkUrl,
   validateUrlsFromRelease,
   getLiveChallenges,
   findUrlsInMarkdown,

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4524,6 +4524,14 @@
         "follow-redirects": "^1.14.4"
       }
     },
+    "axios-cookiejar-support": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-2.0.3.tgz",
+      "integrity": "sha512-tvMB+0JhxXLjjvePsXzqXhBI4DMlW4ImR4pKKNl+xclwF0IviNV+CkuhubQCCFjPzOXv7PIzOq3z7WFiF9pMpw==",
+      "requires": {
+        "http-cookie-agent": "^1.0.2"
+      }
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -6584,6 +6592,14 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
+    "http-cookie-agent": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.4.tgz",
+      "integrity": "sha512-2gSYSE3m38/QMKPPbbS/6lEIm8OTbGA5sY3aBLtr/BUTNOFNeL4WqkdNQM6WmIBT7AWKC20aYfU3uq+cgR+Byg==",
+      "requires": {
+        "agent-base": "^6.0.2"
+      }
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -9047,6 +9063,11 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -9065,8 +9086,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -10476,6 +10496,23 @@
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
+      }
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
       }
     },
     "tr46": {

--- a/api/package.json
+++ b/api/package.json
@@ -50,6 +50,7 @@
     "admin-bro": "^4.0.1",
     "airtable": "^0.11.1",
     "axios": "^0.23.0",
+    "axios-cookiejar-support": "^2.0.3",
     "blipp": "4.0.2",
     "bull": "^4.0.0",
     "dotenv": "^10.0.0",
@@ -69,6 +70,7 @@
     "qs": "^6.10.1",
     "sequelize": "^6.6.2",
     "showdown": "^1.9.1",
+    "tough-cookie": "^4.0.0",
     "url-regex-safe": "^2.0.2"
   },
   "devDependencies": {

--- a/api/scripts/check-url.js
+++ b/api/scripts/check-url.js
@@ -1,0 +1,21 @@
+const { checkUrl } = require('../lib/domain/usecases/validate-urls-from-release');
+
+async function main(url) {
+  console.log('checking', url);
+  try {
+    const result = await checkUrl(url, {
+      timeout: 4000,
+      maxRedirects: 10,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:64.0) Gecko/20100101 Firefox/80.0',
+        'Accept': '*/*',
+      },
+    });
+    console.log(result.status);
+  } catch (e) {
+    console.log(e.response?.headers);
+    console.log(e.message);
+  }
+}
+
+main(process.argv[2]);


### PR DESCRIPTION
## :unicorn: Problème
Nous avons des URLs qui sont marqué comme en erreur dans le job de vérifications des URLs du référentiel. 
2 cas ont été identifié, le manque du header Accept et les cookies manquant.

## :robot: Solution
Ajouter le header `Accept` et le support des cookies dans la vérifications des URLs

## :rainbow: Remarques
J'ai rajouter un mini script pour tester les modifications sans tester tout le référentiel.

## :100: Pour tester

1. node scripts/check-url.js https://peertube.fr/
2. node scripts/check-url.js https://www.reseau-canope.fr/
