### PR TITLE
[BUGFIX] Corriger la preview des nouvelles épreuves sur la recette (PIX-4181).

### DIFF
--- a/api/lib/infrastructure/pix-api-client.js
+++ b/api/lib/infrastructure/pix-api-client.js
@@ -32,6 +32,7 @@ async function _authenticate() {
   const data = qs.stringify({
     username: config.pixApi.user,
     password: config.pixApi.password,
+    grant_type: 'password',
   });
 
   const response = await axios.post(

--- a/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
     it('should refresh cache of updated record in pix api', async () => {
       // Given
       nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123' })
+        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, { 'access_token': token });
       const apiCacheScope = nock('https://api.test.pix.fr')
@@ -50,7 +50,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
     it('should return 200 when refresh cache fails', async () => {
       // Given
       nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123' })
+        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, { 'access_token': token });
 
@@ -82,7 +82,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
     it('should return 200 when Pix API authentication fails', async () => {
       // Given
       const apiTokenScope = nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123' })
+        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(400);
 
@@ -149,7 +149,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
         .reply(200, { records: [attachment] });
 
       nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123' })
+        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, { 'access_token': token });
 

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -655,7 +655,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
         .reply(200, { records: [] });
 
       const apiTokenScope = nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123' })
+        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, { 'access_token': token });
 

--- a/api/tests/unit/infrastructure/pix-api-client_test.js
+++ b/api/tests/unit/infrastructure/pix-api-client_test.js
@@ -38,7 +38,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
           .reply(401);
 
         const authInterceptor = nock('https://api.test.pix.fr')
-          .post('/api/token', 'username=adminUser&password=123')
+          .post('/api/token', 'username=adminUser&password=123&grant_type=password')
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, { 'access_token': newToken });
 
@@ -69,7 +69,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
           .reply(401);
 
         const authInterceptor = nock('https://api.test.pix.fr')
-          .post('/api/token', 'username=adminUser&password=123')
+          .post('/api/token', 'username=adminUser&password=123&grant_type=password')
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, { 'access_token': newToken });
 
@@ -106,7 +106,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
           .reply(200);
 
         const authInterceptor = nock('https://api.test.pix.fr')
-          .post('/api/token', 'username=adminUser&password=123')
+          .post('/api/token', 'username=adminUser&password=123&grant_type=password')
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, { 'access_token': token });
 
@@ -130,7 +130,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
           .reply(200);
 
         nock('https://api.test.pix.fr')
-          .post('/api/token', 'username=adminUser&password=123')
+          .post('/api/token', 'username=adminUser&password=123&grant_type=password')
           .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
           .reply(200, { 'access_token': token });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une nouvelle épreuve/déclinaison était crée celle-ci n'était plus testable sur l'environnement de recette.

## :robot: Solution
Ajouter `grant_type='password'` en paramètre lors de la connexion à l'API PIX.

## :rainbow: Remarques
Ce changement est du a l'instauration d'un refresh token sur pix dans la [PR#3865](https://github.com/1024pix/pix/pull/3865).

## :100: Pour tester
- Se rendre sur pix-editor
- Crée une nouvelle déclinaison
- Cliquer sur le bouton permettant d'afficher la preview
- Constater qu'elle s'affiche bien
