### PR TITLE
[TECH] Ajouter le champ responsive d'une épreuve a la release du référentiel (PIX-4202).

### DIFF
--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -44,6 +44,7 @@ function _filterChallengeFields(_learningContent, challenge) {
     'focusable',
     'alpha',
     'delta',
+    'responsive',
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -92,6 +92,7 @@ function mockCurrentContent() {
       focusable: false,
       delta: 0.5,
       alpha: 0.9,
+      responsive: 'Smartphone',
     }],
     tutorials: [{
       id: 'recTutorial0',

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -22,6 +22,7 @@ module.exports = function buildChallengeForRelease({
   focusable = false,
   delta = 0.2,
   alpha = 0.5,
+  responsive = 'Smartphone',
 } = {}) {
 
   return {
@@ -48,5 +49,6 @@ module.exports = function buildChallengeForRelease({
     focusable,
     delta,
     alpha,
+    responsive,
   };
 };


### PR DESCRIPTION
## :unicorn: Problème
La propriété responsive d'un challenge n'était pas présente dans la release du référentiel.

## :robot: Solution
L'ajouter.

## :rainbow: Remarques
R.A.S

## :100: Pour tester
- Vérifier qu'un challenge comporte bien la propriété `responsive` dans la release.
