### PR TITLE
[FEATURE]  Affichage du nom des thématiques en anglais (PIX-4258)

### DIFF
--- a/pix-editor/app/components/form/theme.hbs
+++ b/pix-editor/app/components/form/theme.hbs
@@ -1,3 +1,4 @@
 <form action="" class="ui form">
-  <Field::Input data-test-theme-name-field @value={{@theme.name}} @edition={{@edition}} @label="Nom"/>
+  <Field::Input data-test-theme-name-field @value={{@theme.name}} @edition={{@edition}} @label="Nom fr-fr"/>
+  <Field::Input data-test-theme-name-en-us-field @value={{@theme.nameEnUs}} @edition={{@edition}} @label="Nom en-us"/>
 </form>

--- a/pix-editor/app/models/theme.js
+++ b/pix-editor/app/models/theme.js
@@ -3,6 +3,7 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 export default class ThemeModel extends Model {
 
   @attr name;
+  @attr nameEnUs;
   @attr index;
 
   @belongsTo('competence') competence;

--- a/pix-editor/app/serializers/theme.js
+++ b/pix-editor/app/serializers/theme.js
@@ -5,6 +5,7 @@ export default class ThemeSerializer extends AirtableSerializer {
 
   attrs = {
     name: 'Nom',
+    nameEnUs:'Titre en-us',
     rawTubes: 'Tubes',
     competence: 'Competence',
     index: 'Index'

--- a/pix-editor/mirage/factories/theme.js
+++ b/pix-editor/mirage/factories/theme.js
@@ -3,5 +3,6 @@ import { Factory } from 'ember-cli-mirage';
 export default Factory.extend({
 
   name: 'nom',
+  nameEnUs: 'nom en us',
   index: '',
 });

--- a/pix-editor/tests/integration/components/form/theme-test.js
+++ b/pix-editor/tests/integration/components/form/theme-test.js
@@ -6,10 +6,11 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | form/theme', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display theme name', async function(assert) {
+  test('it should display theme name in french and in english', async function(assert) {
     // given
     const theme = {
-      name: 'themeName'
+      name: 'themeName',
+      nameEnUs: 'themeNameEnUs'
     };
     this.set('theme', theme);
 
@@ -17,7 +18,10 @@ module('Integration | Component | form/theme', function(hooks) {
     await render(hbs`<Form::Theme @theme={{this.theme}}/>`);
     // then
 
-    assert.dom('[data-test-theme-name-field]').hasText('Nom :');
+    assert.dom('[data-test-theme-name-field]').hasText('Nom fr-fr :');
     assert.dom('[data-test-theme-name-field] input').hasValue('themeName');
+
+    assert.dom('[data-test-theme-name-en-us-field]').hasText('Nom en-us :');
+    assert.dom('[data-test-theme-name-en-us-field] input').hasValue('themeNameEnUs');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le nom des thématiques n'est affiché qu'en français. 
Nous souhaitons avoir également leur nom en anglais.

## :robot: Solution
Ajouter le nom des thématiques en anglais sur Airtable et l'afficher.

## :rainbow: Remarques
Le champ a été rajouté sur le front mais n'est pas disponible sur LCMS.

## :100: Pour tester
Se rendre sur une vue acquis et cliquer sur une thématique, 
le nom anglais devrait être affiché.
