### PR TITLE
[FEATURE] Permettre l'extraction de la liste des sujet en anglais (PIX-4156).

### DIFF
--- a/pix-editor/app/components/pop-in/pdf-entries.hbs
+++ b/pix-editor/app/components/pop-in/pdf-entries.hbs
@@ -12,21 +12,21 @@
        aria-hidden="true"
        tabindex="0"
       {{on "click" this.closeModal}}
-    ><span class="sr-only">Fermer la boite de dialogue</span></i>
+    ><span class="sr-only">{{t 'common.pop_in.close'}}</span></i>
     <h2 id="pdf-entries-header" class="header">
-      Export PDF
+      {{t 'target_profile.pdf_export.title'}}
     </h2>
     <div class="content">
       <form class="ui form" {{on "submit" this.validate}}>
         <div class="field">
-          <Field::Input @title="Titre"
+          <Field::Input @title={{t 'target_profile.pdf_export.field.title'}}
                         @value={{this.title}}
                         @edition={{true}}
                         data-test-pdf-title-field
           />
         </div>
         <div class="field">
-          <Field::Select @title="Langue"
+          <Field::Select @title={{t 'target_profile.pdf_export.field.language'}}
                          @value={{this.selectedLanguage}}
                          @options={{this.options.language}}
                          @edition={{true}}
@@ -41,7 +41,7 @@
               class="ui deny button"
         {{on "click" this.closeModal}}
       >
-        Annuler
+        {{t 'common.cancle'}}
       </button>
       <button type="submit"
               class="ui green button"
@@ -51,7 +51,7 @@
         <i class="checkmark icon"
            aria-hidden="true"
         ></i>
-        Valider
+        {{t 'common.validate'}}
       </button>
     </div>
   </div>

--- a/pix-editor/app/components/pop-in/pdf-entries.hbs
+++ b/pix-editor/app/components/pop-in/pdf-entries.hbs
@@ -1,0 +1,58 @@
+<ModalDialog @targetAttachment="center"
+             @overlayClassNames="custom-overlay-modal"
+             @onClose={{this.closeModal}}
+>
+  <div
+    class="ui modal visible active"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="pdf-entries-header"
+  >
+    <i class="close icon"
+       aria-hidden="true"
+       tabindex="0"
+      {{on "click" this.closeModal}}
+    ><span class="sr-only">Fermer la boite de dialogue</span></i>
+    <h2 id="pdf-entries-header" class="header">
+      Export PDF
+    </h2>
+    <div class="content">
+      <form class="ui form" {{on "submit" this.validate}}>
+        <div class="field">
+          <Field::Input @title="Titre"
+                        @value={{this.title}}
+                        @edition={{true}}
+                        data-test-pdf-title-field
+          />
+        </div>
+        <div class="field">
+          <Field::Select @title="Langue"
+                         @value={{this.selectedLanguage}}
+                         @options={{this.options.language}}
+                         @edition={{true}}
+                         @setValue={{this.setLanguage}}
+                         data-test-pdf-language-field
+          />
+        </div>
+      </form>
+    </div>
+    <div class="actions">
+      <button type="button"
+              class="ui deny button"
+        {{on "click" this.closeModal}}
+      >
+        Annuler
+      </button>
+      <button type="submit"
+              class="ui green button"
+              data-test-validate-pdf-entries
+        {{on "click" this.validate}}
+      >
+        <i class="checkmark icon"
+           aria-hidden="true"
+        ></i>
+        Valider
+      </button>
+    </div>
+  </div>
+</ModalDialog>

--- a/pix-editor/app/components/pop-in/pdf-entries.js
+++ b/pix-editor/app/components/pop-in/pdf-entries.js
@@ -1,0 +1,36 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class PopinPDFEntries extends Component {
+  options = {
+    language: [{ value:'en',label:'Anglais' }, { value:'fr',label:'Français' }],
+  };
+
+  @tracked title = 'Liste des thèmes et des sujets abordés dans Pix';
+  @tracked language = false;
+
+  get selectedLanguage() {
+    if (this.language) {
+      return this.language;
+    }
+    return this.options.language.find(option => option.value === 'fr');
+  }
+
+  @action
+  setLanguage(language) {
+    this.language = language;
+  }
+
+  @action
+  validate(e) {
+    e.preventDefault();
+    this.args.validateAction(this.title, this.selectedLanguage.value);
+    this.closeModal();
+  }
+
+  @action
+  closeModal() {
+    this.args.close();
+  }
+}

--- a/pix-editor/app/components/target-profile/pdf-export.hbs
+++ b/pix-editor/app/components/target-profile/pdf-export.hbs
@@ -2,5 +2,5 @@
   <i class="pdf file icon"></i>PDF
 </button>
 {{#if this.displayTitleInput}}
-  <PopIn::SingleEntry @class="popin-enter-profile-id" @title="Titre de l'export" @label="Titre" @labelValue="Liste des thèmes et des sujets abordés dans Pix" @setValue={{this.generatePDF}} @close={{this.closeTitleInput}} />
+  <PopIn::PdfEntries @validateAction={{this.generatePDF}} @close={{this.closeTitleInput}} />
 {{/if}}

--- a/pix-editor/app/styles/_global.scss
+++ b/pix-editor/app/styles/_global.scss
@@ -274,3 +274,15 @@ footer.ui.attached.header {
 .rotate-90 {
   transform: rotate(90deg);
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}
+

--- a/pix-editor/tests/integration/components/pop-in/pdf-entries-test.js
+++ b/pix-editor/tests/integration/components/pop-in/pdf-entries-test.js
@@ -1,0 +1,47 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pop-in/pdf-entries', function(hooks) {
+  setupRenderingTest(hooks);
+  let callBackActionStub, closeTitleInputStub;
+
+  hooks.beforeEach(async function() {
+    // given
+    callBackActionStub = sinon.stub();
+    closeTitleInputStub = sinon.stub();
+    this.callBackAction = callBackActionStub;
+    this.closeTitleInput = closeTitleInputStub;
+
+    // when
+    await render(hbs `<PopIn::PdfEntries
+                       @validateAction={{this.callBackAction}}
+                       @close={{this.closeTitleInput}}
+                       />`);
+  });
+
+  test('it should set default title and language on validate', async function(assert) {
+    // when
+    await click('[data-test-validate-pdf-entries]');
+
+    // then
+    assert.ok(callBackActionStub.calledOnce);
+    assert.ok(closeTitleInputStub.calledOnce);
+    assert.deepEqual(this.callBackAction.getCall(0).args, ['Liste des thèmes et des sujets abordés dans Pix', 'fr']);
+  });
+
+  test('it should set custom title and selected language on validate', async function(assert) {
+    // when
+    await fillIn('[data-test-pdf-title-field] input', 'mont titre');
+    await click('[data-test-pdf-language-field] .ember-basic-dropdown-trigger');
+    await click('.ember-power-select-option');
+    await click('[data-test-validate-pdf-entries]');
+
+    // then
+    assert.ok(callBackActionStub.calledOnce);
+    assert.ok(closeTitleInputStub.calledOnce);
+    assert.deepEqual(this.callBackAction.getCall(0).args, ['mont titre', 'en']);
+  });
+});

--- a/pix-editor/tests/unit/component/target-profile/pdf-export-test.js
+++ b/pix-editor/tests/unit/component/target-profile/pdf-export-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | target-profile/pdf-export', function(hooks) {
+  setupTest(hooks);
+  let component;
+
+  hooks.beforeEach(function() {
+    component = createGlimmerComponent('component:target-profile/pdf-export');
+  });
+
+  module('#_getTranslatedField', function(hooks) {
+    let model, keys;
+
+    hooks.beforeEach(function () {
+      model = {
+        id: 'modelId',
+        titleEnUs: 'English name',
+        titleFrFr: 'French name',
+      };
+      keys = {
+        en: 'titleEnUs',
+        fr: 'titleFrFr'
+      };
+    });
+
+    test('it should get the english field if language is `en`', async function(assert) {
+      // given
+      const language = 'en';
+
+      // when
+      const result = component._getTranslatedField(keys, language, model);
+
+      // then
+      assert.equal(result, 'English name');
+    });
+
+    test('it should get the french field if language is `fr`', async function(assert) {
+      // given
+      const language = 'fr';
+
+      // when
+      const result = component._getTranslatedField(keys, language, model);
+
+      // then
+      assert.equal(result, 'French name');
+    });
+  });
+});

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -49,3 +49,14 @@ skill:
       changelog: Obscolescence de l'épreuve suite à l'obsolescence de l'acquis {skillName}
       prototype: Prototype périmé
       alternative: Déclinaison n°{number} périmée
+target_profile:
+  pdf_export:
+    title: Export PDF
+    field:
+      title: Tittre
+      language: Langue
+common:
+  validate: Valider
+  cancle: Annuler
+  pop_in:
+    close: Fermer la boite de dialogue


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons pas la possibilité d'extraire la liste des sujets en anglais.

## :robot: Solution
Permettre de choisir la langue lors de l'export PDF afin de pouvoir afficher la liste des sujet en anglais.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se rendre sur la page de sélection d'un profile cible
- Sélectionner ou pas les sujets que l'on veut exporter
- Cliquer sur le bouton `PDF`
- Choisir la langue Anglaise
- Constater que l'ensemble des champs sont bien traduits dans la langue sélectionné
