### PR TITLE
[FEATURE] Expose les différentiels référentiels dans la release  

### DIFF
--- a/api/lib/domain/models/Area.js
+++ b/api/lib/domain/models/Area.js
@@ -8,6 +8,7 @@ module.exports = class Area {
     competenceIds,
     competenceAirtableIds,
     color,
+    frameworkId,
   } = {}) {
     this.id = id;
     this.code = code;
@@ -17,5 +18,6 @@ module.exports = class Area {
     this.name = name;
     this.competenceAirtableIds = competenceAirtableIds;
     this.color = color;
+    this.frameworkId = frameworkId;
   }
 };

--- a/api/lib/domain/models/Content.js
+++ b/api/lib/domain/models/Content.js
@@ -2,10 +2,11 @@ const Area = require('./Area');
 const Challenge = require('./Challenge');
 const Competence = require('./Competence');
 const Course = require('./Course');
+const Framework = require('./Framework');
 const Skill = require('./Skill');
 const Thematic = require('./Thematic');
-const Tutorial = require('./Tutorial');
 const Tube = require('./Tube');
+const Tutorial = require('./Tutorial');
 
 module.exports = class Content {
   constructor({
@@ -13,6 +14,7 @@ module.exports = class Content {
     challenges,
     competences,
     courses,
+    frameworks,
     skills,
     thematics,
     tubes,
@@ -22,6 +24,7 @@ module.exports = class Content {
     this.challenges = challenges;
     this.competences = competences;
     this.courses = courses;
+    this.frameworks = frameworks;
     this.skills = skills;
     this.thematics = thematics;
     this.tubes = tubes;
@@ -33,6 +36,7 @@ module.exports = class Content {
     challenges,
     competences,
     courses,
+    frameworks,
     skills,
     thematics,
     tubes,
@@ -43,6 +47,7 @@ module.exports = class Content {
     content.challenges = challenges ? challenges.map((challenge) => new Challenge(challenge)) : [];
     content.competences = competences ? competences.map((competence) => new Competence(competence)) : [];
     content.courses = courses ? courses.map((course) => new Course(course)) : [];
+    content.frameworks = frameworks ? frameworks.map((framework) => new Framework(framework)) : [];
     content.skills = skills ? skills.map((skill) => new Skill(skill)) : [];
     content.thematics = thematics ? thematics.map((thematic) => new Thematic(thematic)) : [];
     content.tubes = tubes ? tubes.map((tube) => new Tube(tube)) : [];

--- a/api/lib/domain/models/Framework.js
+++ b/api/lib/domain/models/Framework.js
@@ -1,0 +1,9 @@
+module.exports = class Framework {
+  constructor({
+    id,
+    name,
+  } = {}) {
+    this.id = id;
+    this.name = name;
+  }
+};

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -16,6 +16,7 @@ module.exports = datasource.extend({
     'Competences (identifiants) (id persistant)',
     'Competences (identifiants)',
     'Couleur',
+    'Referentiel',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -28,8 +29,8 @@ module.exports = datasource.extend({
       competenceIds: airtableRecord.get('Competences (identifiants) (id persistant)'),
       competenceAirtableIds: airtableRecord.get('Competences (identifiants)'),
       color: airtableRecord.get('Couleur'),
+      frameworkId: airtableRecord.get('Referentiel')[0],
     };
   },
 
 });
-

--- a/api/lib/infrastructure/datasources/airtable/framework-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/framework-datasource.js
@@ -1,0 +1,23 @@
+const datasource = require('./datasource');
+
+module.exports = datasource.extend({
+
+  modelName: 'Framework',
+
+  tableName: 'Referentiel',
+
+  sortField: 'Nom',
+
+  usedFields: [
+    'Nom',
+  ],
+
+  fromAirTableObject(airtableRecord) {
+    return {
+      id: airtableRecord.id,
+      name: airtableRecord.get('Nom')
+    };
+  },
+
+});
+

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -1,17 +1,18 @@
 const areaDatasource = require('../datasources/airtable/area-datasource');
-const competenceDatasource = require('../datasources/airtable/competence-datasource');
-const tubeDatasource = require('../datasources/airtable/tube-datasource');
-const skillDatasource = require('../datasources/airtable/skill-datasource');
-const challengeDatasource = require('../datasources/airtable/challenge-datasource');
-const tutorialDatasource = require('../datasources/airtable/tutorial-datasource');
-const courseDatasource = require('../datasources/airtable/course-datasource');
 const attachmentDatasource = require('../datasources/airtable/attachment-datasource');
+const challengeDatasource = require('../datasources/airtable/challenge-datasource');
+const competenceDatasource = require('../datasources/airtable/competence-datasource');
+const courseDatasource = require('../datasources/airtable/course-datasource');
+const frameworkDatasource = require('../datasources/airtable/framework-datasource');
+const skillDatasource = require('../datasources/airtable/skill-datasource');
 const thematicDatasource = require('../datasources/airtable/thematic-datasource');
+const tubeDatasource = require('../datasources/airtable/tube-datasource');
+const tutorialDatasource = require('../datasources/airtable/tutorial-datasource');
 const airtableSerializer = require('../serializers/airtable-serializer');
 const challengeTransformer = require('../transformers/challenge-transformer');
 const competenceTransformer = require('../transformers/competence-transformer');
-const skillTransformer = require('../transformers/skill-transformer');
 const courseTransformer = require('../transformers/course-transformer');
+const skillTransformer = require('../transformers/skill-transformer');
 const tutorialTransformer = require('../transformers/tutorial-transformer');
 const Release = require('../../domain/models/Release');
 const Content = require('../../domain/models/Content');
@@ -94,35 +95,38 @@ module.exports = {
 async function _getCurrentContent() {
   const [
     areas,
-    competences,
-    tubes,
-    skills,
-    challengesWithoutAttachments,
-    tutorials,
-    courses,
     attachments,
+    challengesWithoutAttachments,
+    competences,
+    courses,
+    frameworks,
+    skills,
     thematics,
+    tubes,
+    tutorials,
   ] = await Promise.all([
     areaDatasource.list(),
-    competenceDatasource.list(),
-    tubeDatasource.list(),
-    skillDatasource.list(),
-    challengeDatasource.list(),
-    tutorialDatasource.list(),
-    courseDatasource.list(),
     attachmentDatasource.list(),
+    challengeDatasource.list(),
+    competenceDatasource.list(),
+    courseDatasource.list(),
+    frameworkDatasource.list(),
+    skillDatasource.list(),
     thematicDatasource.list(),
+    tubeDatasource.list(),
+    tutorialDatasource.list(),
   ]);
   const learningContent = {
     areas,
-    competences,
-    tubes,
-    skills,
-    challengesWithoutAttachments,
-    tutorials,
-    courses,
     attachments,
+    challengesWithoutAttachments,
+    competences,
+    courses,
+    frameworks,
+    skills,
     thematics,
+    tubes,
+    tutorials,
   };
   const transformChallenge = challengeTransformer.createChallengeTransformer(learningContent);
   const challenges = challengesWithoutAttachments.map(transformChallenge);
@@ -134,12 +138,13 @@ async function _getCurrentContent() {
 
   return {
     areas,
-    competences: filteredCompetences,
-    tubes,
-    skills: filteredSkills,
     challenges,
-    tutorials: filteredTutorials,
+    competences: filteredCompetences,
     courses: filteredCourses,
+    frameworks,
+    skills: filteredSkills,
     thematics,
+    tubes,
+    tutorials: filteredTutorials,
   };
 }

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -26,6 +26,7 @@ function mockCurrentContent() {
       competenceIds: ['recCompetence0'],
       competenceAirtableIds: ['recCompetence123'],
       color: 'jaffa',
+      frameworkId: 'recFramework0',
     }],
     competences: [{
       id: 'recCompetence0',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -4,14 +4,15 @@ const axios = require('axios');
 
 const {
   buildArea,
-  buildCompetence,
-  buildTube,
-  buildSkill,
-  buildChallenge,
-  buildTutorial,
-  buildCourse,
   buildAttachment,
+  buildChallenge,
+  buildCompetence,
+  buildCourse,
+  buildFramework,
+  buildSkill,
   buildThematic,
+  buildTube,
+  buildTutorial,
 } = airtableBuilder.factory;
 
 function mockCurrentContent() {
@@ -39,6 +40,10 @@ function mockCurrentContent() {
       description: 'Description de la compétence',
       descriptionFrFr: 'Description de la compétence - fr',
       descriptionEnUs: 'Description de la compétence - en',
+    }],
+    frameworks: [{
+      id: 'recFramework0',
+      name: 'Nom du referentiel'
     }],
     tubes: [{
       id: 'recTube0',
@@ -135,14 +140,15 @@ function mockCurrentContent() {
 
   airtableBuilder.mockLists({
     areas: [buildArea(expectedCurrentContent.areas[0])],
-    competences: [buildCompetence(expectedCurrentContent.competences[0])],
-    tubes: [buildTube(expectedCurrentContent.tubes[0])],
-    skills: [buildSkill(expectedCurrentContent.skills[0])],
-    challenges: [buildChallenge(domainBuilder.buildChallenge(expectedCurrentContent.challenges[0]))],
-    tutorials: [buildTutorial(expectedCurrentContent.tutorials[0])],
-    courses: [buildCourse(expectedCurrentContent.courses[0])],
     attachments: attachments.map(buildAttachment),
+    challenges: [buildChallenge(domainBuilder.buildChallenge(expectedCurrentContent.challenges[0]))],
+    competences: [buildCompetence(expectedCurrentContent.competences[0])],
+    courses: [buildCourse(expectedCurrentContent.courses[0])],
+    frameworks: [buildFramework(expectedCurrentContent.frameworks[0])],
+    skills: [buildSkill(expectedCurrentContent.skills[0])],
     thematics: expectedCurrentContent.thematics.map(buildThematic),
+    tubes: [buildTube(expectedCurrentContent.tubes[0])],
+    tutorials: [buildTutorial(expectedCurrentContent.tutorials[0])],
   });
 
   return expectedCurrentContent;
@@ -210,7 +216,7 @@ describe('Acceptance | Controller | release-controller', () => {
 
       it('should return latest release of learning content', async () => {
         // Given
-        const expectedLatestRelease = databaseBuilder.factory.buildRelease({ content: { areas: [], challenges: [], competences: [], courses: [], skills: [], thematics: [], tubes: [], tutorials: [] } });
+        const expectedLatestRelease = databaseBuilder.factory.buildRelease({ content: { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] } });
         await databaseBuilder.commit();
 
         const server = await createServer();
@@ -288,7 +294,7 @@ describe('Acceptance | Controller | release-controller', () => {
     context('nominal case', () => {
       it('should return release specified by id', async () => {
         // Given
-        const expectedRelease = databaseBuilder.factory.buildRelease({ id: 42, content: { areas: [], challenges: [], competences: [], courses: [], skills: [], thematics: [], tubes: [], tutorials: [] }, createdAt: new Date('2021-01-01') });
+        const expectedRelease = databaseBuilder.factory.buildRelease({ id: 42, content: { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] }, createdAt: new Date('2021-01-01') });
         databaseBuilder.factory.buildRelease({ id: 43, content: { some: 'other-release' }, createdAt: new Date('2022-01-01') });
         await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -20,7 +20,7 @@ describe('Integration | Repository | release-repository', function() {
 
     it('should return saved release with id and creation date', async function() {
       // Given
-      const currentContent = { areas: [], challenges: [], competences: [], courses: [], skills: [], thematics: [], tubes: [], tutorials: [] };
+      const currentContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] };
       const fakeGetCurrentContent = async function() { return currentContent; };
 
       // When
@@ -36,7 +36,7 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getLatestRelease', function() {
     it('should return content of newest created release', async function() {
       // Given
-      const newestReleaseContent = { areas: [], challenges: [], competences: [], courses: [], skills: [], thematics: [], tubes: [], tutorials: [] };
+      const newestReleaseContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] };
       const oldestReleaseContent = { some: 'old-property' };
 
       databaseBuilder.factory.buildRelease({ createdAt: '2021-01-01', content: newestReleaseContent });
@@ -55,7 +55,7 @@ describe('Integration | Repository | release-repository', function() {
     it('should return content of given release', async function() {
       // Given
       const otherReleaseContent = { some: 'property' };
-      const expectedReleaseContent = { areas: [], challenges: [], competences: [], courses: [], skills: [], thematics: [], tubes: [], tutorials: [] };
+      const expectedReleaseContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] };
 
       databaseBuilder.factory.buildRelease({ id: 11, createdAt: '2021-01-01', content: otherReleaseContent });
       databaseBuilder.factory.buildRelease({ id: 12, createdAt: '2020-01-01', content: expectedReleaseContent });

--- a/api/tests/tooling/airtable-builder/airtable-builder.js
+++ b/api/tests/tooling/airtable-builder/airtable-builder.js
@@ -29,15 +29,19 @@ module.exports = class AirtableBuilder {
 
   mockLists({
     areas,
-    competences,
-    tubes,
-    skills,
-    challenges,
-    courses,
-    tutorials,
     attachments,
+    challenges,
+    competences,
+    courses,
+    frameworks,
+    skills,
     thematics,
+    tubes,
+    tutorials,
   }) {
+    this.mockList({ tableName: 'Referentiel' })
+      .returns(frameworks)
+      .activate();
     this.mockList({ tableName: 'Domaines' })
       .returns(areas)
       .activate();

--- a/api/tests/tooling/airtable-builder/factory/build-area.js
+++ b/api/tests/tooling/airtable-builder/factory/build-area.js
@@ -7,6 +7,7 @@ const buildArea = function buildArea({
   code,
   name,
   color,
+  frameworkId,
 } = {}) {
   return {
     id,
@@ -18,7 +19,8 @@ const buildArea = function buildArea({
       'Titre en-us': titleEnUs,
       'Code': code,
       'Nom': name,
-      'Couleur': color
+      'Couleur': color,
+      'Referentiel': [frameworkId],
     },
   };
 };

--- a/api/tests/tooling/airtable-builder/factory/build-framework.js
+++ b/api/tests/tooling/airtable-builder/factory/build-framework.js
@@ -1,0 +1,13 @@
+const buildFramework = function buildFramework({
+  id,
+  name,
+} = {}) {
+  return {
+    id,
+    'fields': {
+      'Nom': name,
+    },
+  };
+};
+
+module.exports = buildFramework;

--- a/api/tests/tooling/airtable-builder/factory/index.js
+++ b/api/tests/tooling/airtable-builder/factory/index.js
@@ -4,8 +4,9 @@ module.exports = {
   buildChallenge: require('./build-challenge'),
   buildCompetence: require('./build-competence'),
   buildCourse: require('./build-course'),
+  buildFramework: require('./build-framework'),
   buildSkill: require('./build-skill'),
+  buildThematic: require('./build-thematic'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),
-  buildThematic: require('./build-thematic'),
 };

--- a/api/tests/tooling/domain-builder/factory/build-area-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-area-airtable-data-object.js
@@ -13,6 +13,7 @@ module.exports = function buildAreaAirtableDataObject({
     'recChallenge0'
   ],
   color = 'jaffa',
+  frameworkId = 'recFramework0',
 } = {}) {
 
   return {
@@ -24,5 +25,6 @@ module.exports = function buildAreaAirtableDataObject({
     competenceIds,
     competenceAirtableIds,
     color,
+    frameworkId,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-framework.js
+++ b/api/tests/tooling/domain-builder/factory/build-framework.js
@@ -1,0 +1,10 @@
+module.exports = function buildFramework(
+  {
+    id = 'recFvllz2Ckz',
+    name = 'Nom du referentiel'
+  } = {}) {
+  return {
+    id,
+    name
+  };
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   buildAreaAirtableDataObject: require('./build-area-airtable-data-object'),
   buildCourse: require('./build-course-airtable-data-object'),
+  buildFramework: require('./build-framework'),
   buildRelease: require('./build-release'),
   buildChallenge: require('./build-challenge-airtable-data-object'),
   buildChallengeForRelease: require('./build-challenge-for-release'),

--- a/api/tests/unit/infrastructure/datasources/airtable/framwork-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/framwork-datasource_test.js
@@ -1,0 +1,23 @@
+const { expect, domainBuilder, airtableBuilder } = require('../../../../test-helper');
+const frameworkDatasource = require('../../../../../lib/infrastructure/datasources/airtable/framework-datasource');
+const AirtableRecord = require('airtable').Record;
+
+describe('Unit | Infrastructure | Datasource | Airtable | FrameworkDatasource', () => {
+
+  describe('#fromAirTableObject', () => {
+
+    it('should create a Framework from the AirtableRecord', () => {
+      // given
+      const expectedFramework = domainBuilder.buildFramework();
+      const airtableFramework = airtableBuilder.factory.buildFramework(expectedFramework);
+      const recordFramework = new AirtableRecord('Referentiel', airtableFramework.id, airtableFramework);
+      
+      // when
+      const framework = frameworkDatasource.fromAirTableObject(recordFramework);
+
+      // then
+      expect(framework).to.deep.equal(expectedFramework);
+    });
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/airtable-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable-serializer_test.js
@@ -1,7 +1,7 @@
 const { expect, domainBuilder, airtableBuilder } = require('../../../test-helper');
 const airtableSerializer = require('../../../../lib/infrastructure/serializers/airtable-serializer');
 
-describe('API | Infrastructure | Serializers | Airtable Serializer', () => {
+describe('Unit | Infrastructure | Serializers | Airtable Serializer', () => {
   describe('#serialize', () => {
 
     it('should create a Area from the AirtableRecord', () => {
@@ -20,6 +20,7 @@ describe('API | Infrastructure | Serializers | Airtable Serializer', () => {
         titleFrFr: 'Information et données',
         titleEnUs: 'Information and data',
         color: 'jaffa',
+        frameworkId: 'recFramework0'
       });
       const tableName = 'Domaines';
 

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -144,6 +144,7 @@ describe('Unit | Repository | release-repository', () => {
         competenceAirtableIds: [],
         titleFrFr: 'Bonjour',
         titleEnUs: 'Hello',
+        frameworkId: 'recFramework0',
       });
       const type = 'Domaines';
       sinon.stub(attachmentDatasource, 'filterByChallengeId');
@@ -160,6 +161,7 @@ describe('Unit | Repository | release-repository', () => {
         competenceAirtableIds: [],
         titleFrFr: 'Bonjour',
         titleEnUs: 'Hello',
+        frameworkId: 'recFramework0',
       });
       expect(attachmentDatasource.filterByChallengeId).to.not.have.been.called;
       expect(challengeDatasource.filterById).to.not.have.been.called;

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -6,6 +6,7 @@ const skillDatasource = require('../../../lib/infrastructure/datasources/airtabl
 const challengeDatasource = require('../../../lib/infrastructure/datasources/airtable/challenge-datasource');
 const tutorialDatasource = require('../../../lib/infrastructure/datasources/airtable/tutorial-datasource');
 const courseDatasource = require('../../../lib/infrastructure/datasources/airtable/course-datasource');
+const frameworkDatasource = require('../../../lib/infrastructure/datasources/airtable/framework-datasource');
 const attachmentDatasource = require('../../../lib/infrastructure/datasources/airtable/attachment-datasource');
 const thematicDatasource = require('../../../lib/infrastructure/datasources/airtable/thematic-datasource');
 const releaseRepository = require('../../../lib/infrastructure/repositories/release-repository');
@@ -24,38 +25,41 @@ describe('Unit | Repository | release-repository', () => {
     it('should return current content', async () => {
       //Given
       const areas = [];
-      const competences = [];
-      const tubes = [];
-      const skills = [];
-      const challenges = [];
-      const tutorials = [];
-      const courses = [];
       const attachments = [];
+      const challenges = [];
+      const competences = [];
+      const courses = [];
+      const frameworks = [];
+      const skills = [];
       const thematics = [];
+      const tubes = [];
+      const tutorials = [];
       const transformedCompetences = [Symbol('transformed-competence')];
       const transformedSkills = [Symbol('transformed-skill')];
       const transformedCourses = [Symbol('transformed-course')];
       const transformedTutorials = [Symbol('transformed-tutorial')];
       const expectedCurrentContent = {
         areas: [],
-        competences: transformedCompetences,
-        tubes: [],
-        skills: transformedSkills,
         challenges: [],
-        tutorials: transformedTutorials,
+        competences: transformedCompetences,
         courses: transformedCourses,
+        frameworks: [],
+        skills: transformedSkills,
         thematics,
+        tubes: [],
+        tutorials: transformedTutorials,
       };
 
       sinon.stub(areaDatasource, 'list').resolves(areas);
-      sinon.stub(competenceDatasource, 'list').resolves(competences);
-      sinon.stub(tubeDatasource, 'list').resolves(tubes);
-      sinon.stub(skillDatasource, 'list').resolves(skills);
-      sinon.stub(challengeDatasource, 'list').resolves(challenges);
-      sinon.stub(tutorialDatasource, 'list').resolves(tutorials);
-      sinon.stub(courseDatasource, 'list').resolves(courses);
       sinon.stub(attachmentDatasource, 'list').resolves(attachments);
+      sinon.stub(challengeDatasource, 'list').resolves(challenges);
+      sinon.stub(competenceDatasource, 'list').resolves(competences);
+      sinon.stub(courseDatasource, 'list').resolves(courses);
+      sinon.stub(frameworkDatasource, 'list').resolves(frameworks);
+      sinon.stub(skillDatasource, 'list').resolves(skills);
       sinon.stub(thematicDatasource, 'list').resolves(thematics);
+      sinon.stub(tubeDatasource, 'list').resolves(tubes);
+      sinon.stub(tutorialDatasource, 'list').resolves(tutorials);
       sinon.stub(challengeTransformer, 'createChallengeTransformer').returns(() => {});
       sinon.stub(competenceTransformer, 'filterCompetencesFields').returns(transformedCompetences);
       sinon.stub(skillTransformer, 'filterSkillsFields').returns(transformedSkills);
@@ -69,14 +73,15 @@ describe('Unit | Repository | release-repository', () => {
       expect(currentContent).to.deep.equal(expectedCurrentContent);
       expect(challengeTransformer.createChallengeTransformer).to.have.been.calledWithExactly({
         areas,
-        competences,
-        tubes,
-        skills,
-        courses,
-        tutorials,
         attachments,
+        challengesWithoutAttachments: challenges,
+        competences,
+        courses,
+        frameworks,
+        skills,
         thematics,
-        challengesWithoutAttachments: challenges
+        tubes,
+        tutorials
       });
       expect(competenceTransformer.filterCompetencesFields).to.have.been.calledWithExactly(competences);
       expect(skillTransformer.filterSkillsFields).to.have.been.calledWithExactly(skills);
@@ -222,7 +227,21 @@ describe('Unit | Repository | release-repository', () => {
 
   describe('#toDomain', function() {
     it('should build Release model with given parameters', function() {
-      const databaseObjectRelease = { id: 123, content: { areas: [], challenges: [], competences: [], courses: [], skills: [], thematics: [], tubes: [], tutorials: [] }, createdAt: '2021-08-31' };
+      const databaseObjectRelease = {
+        id: 123,
+        content: {
+          areas: [],
+          challenges: [],
+          competences: [],
+          courses: [],
+          frameworks: [],
+          skills: [],
+          thematics: [],
+          tubes: [],
+          tutorials: []
+        },
+        createdAt: '2021-08-31'
+      };
 
       const release = releaseRepository.toDomain(databaseObjectRelease);
 


### PR DESCRIPTION
## :unicorn: Problème
La notion de référentiel n'est pas explicite dans la release qui est faite. Elle est actuellement porté par la compétence dans le champ origine pour des raisons historique.

## :robot: Solution
Exposer les référentiels Pix et Pix+ sous forme de nouvelle collection dans la release. Ce sont les domaines qui portent l'information de l'appartenance a un référentiel.

## :100: Pour tester
1. Faire une release du référentiel
2. Constater la nouvelle collection frameworks
3. Vérifier la présence d'un frameworkId sur les domaines
