### PR TITLE
[FEATURE] Modification de la popin de changelog lors de la modification

### DIFF
--- a/end-to-end-tests/cypress/integration/modify-challenge.spec.js
+++ b/end-to-end-tests/cypress/integration/modify-challenge.spec.js
@@ -13,10 +13,10 @@ context('Modifying challenge', () => {
     cy.contains('@eval2').click();
     cy.contains('Modifier').click();
     cy.contains('Enregistrer').click();
-    cy.intercept('POST', '/api/**').as('route');
+    cy.intercept('PATCH', '/api/*/**').as('route');
 
     // when
-    cy.contains('Enregistrer').click();
+    cy.contains('Valider').click();
 
     // then
     cy.wait('@route').its('response.statusCode').should('be.within', 200, 204);

--- a/pix-editor/app/components/pop-in/confirm-log.hbs
+++ b/pix-editor/app/components/pop-in/confirm-log.hbs
@@ -2,9 +2,12 @@
   <div class="ui standard modal visible active">
     <div class="header">{{@title}}</div>
     <div class="content">
-      {{@content}}
+      <p>
+        {{@content}}
+      </p>
     <form class="ui form">
       <Field::Checkbox
+        class="checkbox-layout"
         @label="Je veux ajouter une note de changelog"
         @checked={{this.displayTextarea}}
         data-test-confirm-log-check

--- a/pix-editor/app/components/pop-in/confirm-log.hbs
+++ b/pix-editor/app/components/pop-in/confirm-log.hbs
@@ -1,0 +1,33 @@
+<ModalDialog @targetAttachment="center" @overlayClassNames="custom-overlay-modal">
+  <div class="ui standard modal visible active">
+    <div class="header">{{@title}}</div>
+    <div class="content">
+      {{@content}}
+    <form class="ui form">
+      <Field::Checkbox
+        @label="Je veux ajouter une note de changelog"
+        @checked={{this.displayTextarea}}
+        data-test-confirm-log-check
+      />
+      {{#if this.displayTextarea}}
+      <div class="changelog-layout">
+       <label for={{this.inputId}} >
+          {{@label}}
+        </label>
+        <Textarea id={{this.inputId}} @value={{this.defaultValue}} @rows="4" class="changelog-textarea"/>
+        </div>
+      {{/if}}
+    </form>
+    </div>
+    <div class="actions">
+      <button type="button" class="ui blue cancel button" {{on "click" @onDeny}} data-test-confirm-log-cancel>
+        <i class="remove icon" ></i>
+        {{t 'common.cancel'}}
+      </button>
+      <button type="button" class="ui green ok button" {{on "click" (fn @onApprove this.changeLogValue)}} data-test-confirm-log-approve>
+        <i class="checkmark icon" ></i>
+        {{t 'common.validate'}}
+      </button>
+    </div>
+  </div>
+</ModalDialog>

--- a/pix-editor/app/components/pop-in/confirm-log.js
+++ b/pix-editor/app/components/pop-in/confirm-log.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+
+export default class PopInConfirmLog extends Component {
+  @tracked displayTextarea = false;
+  @tracked defaultValue = this.args.defaultValue;
+  inputId = this.args.inputId;
+
+  get changeLogValue() {
+    if (this.displayTextarea) {
+      return this.defaultValue;
+    }
+    return null;
+  }
+}

--- a/pix-editor/app/components/pop-in/pdf-entries.hbs
+++ b/pix-editor/app/components/pop-in/pdf-entries.hbs
@@ -41,7 +41,7 @@
               class="ui deny button"
         {{on "click" this.closeModal}}
       >
-        {{t 'common.cancle'}}
+        {{t 'common.cancel'}}
       </button>
       <button type="submit"
               class="ui green button"

--- a/pix-editor/app/controllers/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/controllers/competence/prototypes/single/alternatives/single.js
@@ -33,5 +33,4 @@ export default class SingleController extends PrototypeController {
   minimize() {
     this.parentController.maximizeRight(false);
   }
-
 }

--- a/pix-editor/app/styles/_confirm-log.scss
+++ b/pix-editor/app/styles/_confirm-log.scss
@@ -1,0 +1,10 @@
+.changelog-layout {
+  display: flex;
+  flex-direction: column;
+  padding-top: 1.5rem;
+
+  .changelog-textarea {
+    margin-top: 0.3rem;
+    padding: 0.5rem;
+  }
+}

--- a/pix-editor/app/styles/_confirm-log.scss
+++ b/pix-editor/app/styles/_confirm-log.scss
@@ -1,3 +1,8 @@
+.checkbox-layout {
+  padding-top: 1rem;
+}
+
+
 .changelog-layout {
   display: flex;
   flex-direction: column;

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -9,6 +9,7 @@
 @import 'i18n';
 @import 'tube';
 @import 'challenge-log';
+@import 'confirm-log';
 @import 'custom-accordion';
 @import 'custom-tooltip';
 @import 'custom-sortable-group';

--- a/pix-editor/app/templates/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/competence/prototypes/single.hbs
@@ -126,8 +126,19 @@
 {{/if}}
 {{#if this.displayChangeLog}}
   <PopIn::Changelog
-    @onApprove={{this.changelogApprove}}
-    @defaultValue={{this.changelogDefault}} />
+          @onApprove={{this.changelogApprove}}
+          @defaultValue={{this.changelogDefault}} />
+{{/if}}
+{{#if this.displayConfirmLog}}
+  <PopIn::ConfirmLog
+    @title={{t 'common.confirm-log.save'}}
+    @onApprove={{this.saveChallengeCallback}}
+    @defaultValue={{this.defaultSaveChangelog}}
+    @inputId="changelog-message"
+    @onDeny={{this.closeComfirmLogPopin}}
+    @content={{t 'common.confirm-log.content'}}
+    @label={{t 'common.confirm-log.label'}}
+  />
 {{/if}}
 {{#if this.mayMove}}
   {{#if this.displaySelectLocation}}

--- a/pix-editor/app/templates/competence/skills/single.hbs
+++ b/pix-editor/app/templates/competence/skills/single.hbs
@@ -110,3 +110,14 @@
           @onApprove={{this.approveChangelog}}
           @defaultValue={{this.changelogText}} />
 {{/if}}
+{{#if this.displayConfirmLog}}
+  <PopIn::ConfirmLog
+    @title={{t 'common.modify.save'}}
+    @onApprove={{this.saveSkillCallBack}}
+    @defaultValue={{this.defaultSaveChangelog}}
+    @inputId="changelog-message"
+    @onDeny={{this.closeComfirmLogPopin}}
+    @content={{t 'common.confirm-log.content'}}
+    @label={{t 'common.confirm-log.label'}}
+  />
+{{/if}}

--- a/pix-editor/tests/acceptance/create-challenge-alternative-test.js
+++ b/pix-editor/tests/acceptance/create-challenge-alternative-test.js
@@ -111,10 +111,11 @@ module('Acceptance | Controller | Create alternative challenge', function(hooks)
     await click(find('[data-test-new-alternative-action]'));
     await click(find('[data-test-save-challenge-button]'));
 
+
     await click(findAll('[data-test-modify-challenge-button]')[1]);
     await click(find('[data-test-delete-attachment-button]'));
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     // then
     assert.dom('[data-test-main-message]').hasText('Déclinaison numéro 1 enregistrée');

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-attachment-test.js
@@ -55,7 +55,7 @@ module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
 
     await later(this, async () => {}, 400);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');
@@ -90,7 +90,7 @@ module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
 
     await later(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-illustration-test.js
@@ -55,7 +55,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
 
     await later(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');
@@ -96,7 +96,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
 
     await later(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');
@@ -138,7 +138,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
 
     await later(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');
@@ -184,7 +184,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
 
     await later(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -42,7 +42,7 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     // Attempted to access the computed <pixeditor@component:tui-editor::ember393>.options on a destroyed object, which is not allowed
     await later(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
-    await click(find('[data-test-save-changelog-button]'));
+    await click(find('[data-test-confirm-log-approve]'));
 
     // then
     assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');

--- a/pix-editor/tests/integration/components/pop-in/confirm-log-test.js
+++ b/pix-editor/tests/integration/components/pop-in/confirm-log-test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+module('Integration | Component | popin-confirm-log', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it saves without changelog', async function(assert) {
+    // given
+    const approveActionStub = sinon.stub();
+    const denyActionStub = sinon.stub();
+    this.approveAction = approveActionStub;
+    this.denyAction = denyActionStub;
+    this.defaultSaveChangelog = 'Mise à jour du prototype';
+
+    // when
+    await render(hbs`<PopIn::ConfirmLog
+        @onApprove={{this.approveAction}}
+        @onDeny={{this.denyAction}}
+        @defaultValue={{this.defaultSaveChangelog}}/>`);
+
+    await click('[data-test-confirm-log-approve]');
+
+    // then
+    assert.dom('.ember-modal-dialog').exists();
+    assert.ok(approveActionStub.calledOnce);
+    assert.equal(approveActionStub.getCall(0).args[0], null);
+  });
+
+  test('it saves with changelog', async function(assert) {
+    // given
+    const approveActionStub = sinon.stub();
+    const denyActionStub = sinon.stub();
+    this.approveAction = approveActionStub;
+    this.denyAction = denyActionStub;
+    this.defaultSaveChangelog = 'Mise à jour du prototype';
+
+    // when
+    await render(hbs`<PopIn::ConfirmLog
+        @onApprove={{this.approveAction}}
+        @onDeny={{this.denyAction}}
+        @defaultValue={{this.defaultSaveChangelog}}/>`);
+
+    await click('[data-test-confirm-log-check] input');
+    await click('[data-test-confirm-log-approve]');
+
+    // then
+    assert.dom('.ember-modal-dialog').exists();
+    assert.ok(approveActionStub.calledOnce);
+    assert.equal(approveActionStub.getCall(0).args[0], 'Mise à jour du prototype');
+  });
+
+  test('it should cancel', async function(assert) {
+    // given
+    const approveActionStub = sinon.stub();
+    const denyActionStub = sinon.stub();
+    this.approveAction = approveActionStub;
+    this.denyAction = denyActionStub;
+    this.defaultSaveChangelog = 'Mise à jour du prototype';
+
+    // when
+    await render(hbs`<PopIn::ConfirmLog
+        @onApprove={{this.approveAction}}
+        @onDeny={{this.denyAction}}
+        @defaultValue={{this.defaultSaveChangelog}}/>`);
+
+    await click('[data-test-confirm-log-cancel]');
+
+    // then
+    assert.dom('.ember-modal-dialog').exists();
+    assert.ok(denyActionStub.calledOnce);
+  });
+});

--- a/pix-editor/tests/setup-intl-rendering.js
+++ b/pix-editor/tests/setup-intl-rendering.js
@@ -1,0 +1,7 @@
+import setupIntl from './setup-intl';
+import { setupRenderingTest } from 'ember-qunit';
+
+export default function setupIntlRenderingTest(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+}

--- a/pix-editor/tests/setup-intl.js
+++ b/pix-editor/tests/setup-intl.js
@@ -1,0 +1,6 @@
+export default function setupIntl(hooks, locale = ['fr']) {
+  hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
+    this.intl.setLocale(locale);
+  });
+}

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 
+import setupIntlRenderingTest from '../../../../setup-intl-rendering';
+
 module('Unit | Controller | competence/prototypes/single', function (hooks) {
-  setupTest(hooks);
+  setupIntlRenderingTest(hooks);
   let controller, messageStub, startStub, stopStub, errorStub;
 
   hooks.beforeEach(function () {

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -69,7 +69,7 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
       const changelog = 'some changelog';
 
       // when
-      await controller._saveChallengeCallback(changelog);
+      await controller.saveChallengeCallback(changelog);
 
       // then
       assert.ok(startStub.calledOnce);
@@ -90,7 +90,7 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
       controller.displaySolutionToDisplayField = true;
 
       // when
-      await controller._saveChallengeCallback();
+      await controller.saveChallengeCallback();
 
       // then
       assert.notOk(controller.displayAlternativeInstructionsField);

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -3,6 +3,7 @@ competence:
     archive: Archiver
     obsolete: Rendre obsolète
     validate: Valider
+    cancel: Annuler
   skills:
     archive: Archiver
     obsolete: Rendre obsolète

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -2,8 +2,6 @@ competence:
   prototypes:
     archive: Archiver
     obsolete: Rendre obsolète
-    validate: Valider
-    cancel: Annuler
   skills:
     archive: Archiver
     obsolete: Rendre obsolète
@@ -21,7 +19,9 @@ challenge:
     obsolete: Déclinaison n°{number} périmée
 skill:
   changelog:
-    update: Mise à jour de l'acquis
+    update-message: Mise à jour de l'acquis
+    update-status: Acquis mis à jour
+    update-error: Erreur lors de la mise à jour de l'acquis
     archive: Archivage de l'acquis
     obsolete: Obsolescence de l'acquis
   archive:
@@ -54,10 +54,22 @@ target_profile:
   pdf_export:
     title: Export PDF
     field:
-      title: Tittre
+      title: Titre
       language: Langue
+prototype:
+  changelog:
+    update-message: Mise à jour du prototype
+    update-status: Épreuve mise à jour
+    update-error: Erreur lors de la mise à jour
 common:
   validate: Valider
-  cancle: Annuler
+  cancel: Annuler
   pop_in:
     close: Fermer la boite de dialogue
+  confirm-log:
+    save: Enregistrer les modifications
+    content: Êtes vous sûr de vouloir enregistrer ?
+    label: Message d'enregistrement
+  modify:
+    cancel: Modification annulée
+


### PR DESCRIPTION
## :unicorn: Problème
Lors de la modification d'un acquis/prototype/déclinaison, on forçait l'envoi de changelog ce qui surchargeait la table de logs.

## :robot: Solution
Rendre optionnel le fait d'ajouter un messsage de changelog.

## :100: Pour tester
Modifier un acquis/prototype/déclinaison, vérifier que la popin s'affiche bien et que l'envoi des logs est fait lorsqu'un message est ajouté.
