### PR TITLE
[BUGFIX] Le titre de la popIn qui s'affiche lors de la modification d'un acquis ne possède pas de traduction (PIX-4352).

### DIFF
--- a/pix-editor/app/templates/competence/skills/single.hbs
+++ b/pix-editor/app/templates/competence/skills/single.hbs
@@ -112,7 +112,7 @@
 {{/if}}
 {{#if this.displayConfirmLog}}
   <PopIn::ConfirmLog
-    @title={{t 'common.modify.save'}}
+    @title={{t 'common.confirm-log.save'}}
     @onApprove={{this.saveSkillCallBack}}
     @defaultValue={{this.defaultSaveChangelog}}
     @inputId="changelog-message"


### PR DESCRIPTION
## :unicorn: Problème
Le titre de la popIn qui s'affiche lors de la modification d'un acquis ne possède pas de traduction

## :robot: Solution
Pointer vers la bonne traduction.

## :rainbow: Remarques
RAS

## :100: Pour tester
Modifier un acquis puis cliquer sur enregistrer et vérifier que le titre de la popIn s'affiche correctement.
