### PR TITLE
[BUGFIX] Le titre du bouton valider lorsqu'on met en production une épreuve en "proposée" ne possède pas de traduction.

### DIFF
--- a/pix-editor/app/templates/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/competence/prototypes/single.hbs
@@ -15,7 +15,7 @@
               {{#if this.mayValidate}}
                 <button class="ui button validate item"  {{on "click" (fn this.validate dd)}} type="button">
                   <i class="checkmark icon"></i>
-                  {{t 'competence.prototypes.validate'}}
+                  {{t 'common.validate'}}
                 </button>
               {{/if}}
               {{#if this.mayArchive}}


### PR DESCRIPTION
## :unicorn: Problème
Le titre du bouton valider lorsqu'on met en production une épreuve "proposée" ne possède pas de traduction.

## :robot: Solution
Ajouter la bonne clé dans le fichier de traduction.

## :rainbow: Remarques

## :100: Pour tester
Se rendre sur PE, ouvrir une déclinaison en statut "proposé", cliquer le bouton en forme d'éclair et constater que la traduction "Valider" est bien présente. 
