### PR TITLE
[TECH] Renommer la clé d'api admin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,14 +63,14 @@ Dans un second processus ou terminal, toujours depuis le répertoire racine :
 [L'API](http://localhost:3002) tourne en local sur le port 3002.
 [L'application Pix-Editor](http://localhost:4300) sur le port 4300.
 
-> ℹ️ Par défaut, et en local, utiliser l'un des 2 jetons renseignés dans le fichier `./api/db/seeds/seed.js` (cf. `defaultUserApiKey` [admin] et `defaultEditorUserApiKey` [éditeur]) pour s'authentifier dans l'interface de connexion.
+> ℹ️ Par défaut, et en local, utiliser l'un des 2 jetons renseignés dans le fichier `./api/db/seeds/seed.js` (cf. `adminUserApiKey` [admin] et `defaultEditorUserApiKey` [éditeur]) pour s'authentifier dans l'interface de connexion.
 
 > ⚠️ Si vous parvenez à vous authentifier, mais qu'une page blanche s'affiche, cela signifie très probablement que votre schéma de base Airtable est différent de celui utilisé pour le projet Pix. Nous vous invitons à vous rapprocher de l'équipe support via [le centre d'aide](support.pix.fr) de Pix.
- 
+
 ## Configuration
 
 La description et le format attendu de chaque option/variable est documentée dans le fichier `sample.env`.
 
-Dans le fichier `sample.env` : 
+Dans le fichier `sample.env` :
 - toutes les variables requises pour un fonctionnement optimal (100%) sont décommentées
 - malgré cela, seules les variables non renseignées illustrées d'un 🔴 sont absolument nécessaires pour un fonctionnement dégradé / partiel, permettant d'avoir un rendu en lecture globale.

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -7,7 +7,7 @@ exports.seed = (knex) => {
     trigram: 'DEV',
     name: 'Utilisateur pour le développement',
     access: 'admin',
-    apiKey: process.env.REVIEW_APP_USER_API_KEY || defaultUserApiKey,
+    apiKey: process.env.REVIEW_APP_USER_API_KEY || adminUserApiKey,
   });
 
   databaseBuilder.factory.buildUser({
@@ -20,6 +20,6 @@ exports.seed = (knex) => {
   return databaseBuilder.commit();
 };
 
-const defaultUserApiKey = !process.env.REVIEW_APP && '8d03a893-3967-4501-9dc4-e0aa6c6dc442';
+const adminUserApiKey = !process.env.REVIEW_APP && '8d03a893-3967-4501-9dc4-e0aa6c6dc442';
 const defaultEditorUserApiKey = !process.env.REVIEW_APP && 'adaf3eee-09dc-4f9a-a504-ff92e74c9d0f';
 


### PR DESCRIPTION
## :unicorn: Problème
La clé d'api admin `defaultUserApiKey` portait à confusion avec la clé d'api éditeur `defaultEditorUserApiKey` qui laissait croire que cette dernière avait plus de droit.

## :robot: Solution
Rennomer `defaultUserApiKey`  en `adminUserApiKey` 

## :100: Pour tester
:)
