### PR TITLE
[FEATURE] Ajouter une vue 'en construction' pour la section acquis (PIX-3588).

### DIFF
--- a/pix-editor/app/components/competence/competence-actions.hbs
+++ b/pix-editor/app/components/competence/competence-actions.hbs
@@ -29,6 +29,7 @@
           {{/if}}
         </div>
         <div class="item workbench {{if (eq @view "workbench") "active" ""}}"  {{on "click" (fn @selectView "workbench")}}>Atelier</div>
+        <div data-test-select-draft-view class="item proposal {{if (eq @view "draft") "active" ""}}"  {{on "click" (fn @selectView "draft")}}>En construction</div>
       </div>
       {{#if (eq @view "production")}}
         <button class="ui button left item" type="button" {{on "click" @shareSkills}}>

--- a/pix-editor/app/components/competence/competence-grid-tube.hbs
+++ b/pix-editor/app/components/competence/competence-grid-tube.hbs
@@ -16,9 +16,18 @@
                                 @tube={{@tube}}
                                 @index={{index}} />
   {{/each}}
+{{else if (eq @view "draft")}}
+  {{#each @tube.filledLastDraftSkills as |skill index|}}
+    <Competence::Grid::GridCell @section={{@section}}
+                                @languageFilter={{@languageFilter}}
+                                @view={{@view}}
+                                @skill={{skill}}
+                                @link={{@link}}
+                                @tube={{@tube}}
+                                @index={{index}} />
+  {{/each}}
 {{else}}
   {{#each @tube.filledProductionSkills as |skill index|}}
-
     <Competence::Grid::GridCell @section={{@section}}
                                 @languageFilter={{@languageFilter}}
                                 @view={{@view}}

--- a/pix-editor/app/components/competence/competence-header.hbs
+++ b/pix-editor/app/components/competence/competence-header.hbs
@@ -7,7 +7,7 @@
       {{section.title}}
     </PowerSelect>
   </div>
-  {{#if this.isProductionViewAndSkillsOrChallengesSection}}
+  {{#if this.displayLanguageFilter}}
     <div class="selection ui small right floated header language-filter">
       <PowerSelect @dropdownClass="language-filter-dropdown" @searchEnabled={{false}} @options={{this.languageOptions}} @selected={{this.selectedLanguageToFilter}} @onChange={{@selectLanguageToFilter}} as |languageOption|>
         {{#if languageOption.local}}

--- a/pix-editor/app/components/competence/competence-header.js
+++ b/pix-editor/app/components/competence/competence-header.js
@@ -55,7 +55,10 @@ export default class CompetenceHeader extends Component {
     return this.languageOptions.find(languagesOption => languagesOption.local === languageFilter);
   }
 
-  get isProductionViewAndSkillsOrChallengesSection() {
-    return this.args.view === 'production' && (this.args.section === 'skills' || this.args.section === 'challenges');
+  get displayLanguageFilter() {
+    if (this.args.section === 'skills') {
+      return this.args.view === 'production' || this.args.view === 'draft';
+    }
+    return this.args.section === 'challenges' && this.args.view === 'production';
   }
 }

--- a/pix-editor/app/components/competence/grid/grid-cell.hbs
+++ b/pix-editor/app/components/competence/grid/grid-cell.hbs
@@ -6,6 +6,8 @@
   <Competence::Grid::CellSkillWorkbench @tube={{@tube}} @skill={{@skill}} @skills={{@skills}}/>
 {{else if (eq this.cellType "skill")}}
   <Competence::Grid::CellSkill @skill={{@skill}} @languageFilter={{@languageFilter}}/>
+{{else if (eq this.cellType "skill-draft")}}
+  <Competence::Grid::CellSkill @skill={{@skill}} @languageFilter={{@languageFilter}}/>
 {{else if (eq this.cellType "add-skill")}}
   <td>
     <LinkTo @route="competence.skills.new" @models={{array @tube.id @index}} class="add-skill">

--- a/pix-editor/app/components/competence/grid/grid-cell.js
+++ b/pix-editor/app/components/competence/grid/grid-cell.js
@@ -37,8 +37,14 @@ export default class GridCell extends Component {
               return 'add-skill';
             }
             break;
+          case 'draft' :
+            if (skill) {
+              return 'skill-draft';
+            } else if (this.access.mayEditSkills()) {
+              return 'add-skill';
+            }
+            break;
         }
-
         break;
       case 'quality':
         if (skill) {

--- a/pix-editor/app/models/tube.js
+++ b/pix-editor/app/models/tube.js
@@ -27,6 +27,10 @@ export default class TubeModel extends Model {
     return this.rawSkills.filter(skill => skill.isLive);
   }
 
+  get draftSkills() {
+    return this.rawSkills.filter(skill => skill.isDraft);
+  }
+
   get deadSkills() {
     return this.rawSkills.filter(skill => !skill.isLive);
   }
@@ -57,6 +61,19 @@ export default class TubeModel extends Model {
 
   get filledLiveSkills() {
     return this._getFilledOrderedVersions(this.liveSkills);
+  }
+
+  get filledDraftSkills() {
+    return this._getFilledOrderedVersions(this.draftSkills);
+  }
+
+  get filledLastDraftSkills() {
+    return this.filledDraftSkills.map((draftSkills) => {
+      if (draftSkills) {
+        return draftSkills[draftSkills.length - 1];
+      }
+      return draftSkills;
+    });
   }
 
   get filledDeadSkills() {

--- a/pix-editor/app/routes/competence/skills/index.js
+++ b/pix-editor/app/routes/competence/skills/index.js
@@ -6,7 +6,7 @@ export default class IndexRoute extends Route {
     const competenceController = this.controllerFor('competence');
     competenceController.setSection('skills');
     const view = competenceController.view;
-    if (!['production', 'workbench'].includes(view)) {
+    if (!['production', 'workbench', 'draft'].includes(view)) {
       competenceController.setView('production');
     }
     competenceController.maximizeLeft(false);

--- a/pix-editor/app/routes/competence/skills/single.js
+++ b/pix-editor/app/routes/competence/skills/single.js
@@ -22,7 +22,8 @@ export default class SingleRoute extends Route {
     competenceController.setSection('skills');
     if (model.isActive) {
       competenceController.setView('production');
-    } else {
+    }
+    if (!model.isActive && competenceController.view !== 'draft') {
       competenceController.setView('workbench');
     }
   }

--- a/pix-editor/tests/integration/components/competence/competence-actions-test.js
+++ b/pix-editor/tests/integration/components/competence/competence-actions-test.js
@@ -1,10 +1,57 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | competence/competence-actions', function(hooks) {
   setupRenderingTest(hooks);
+  let selectViewStub;
+
+  hooks.beforeEach(function () {
+    selectViewStub = sinon.stub();
+    this.selectView = selectViewStub;
+  });
+
+  module('#skillSection', function(hooks) {
+
+    hooks.beforeEach(function () {
+      this.section = 'skills';
+      this.exportSkills = sinon.stub();
+      this.refresh = sinon.stub();
+    });
+
+    test('it should display draft view', async function(assert) {
+      // when
+      await render(hbs` <Competence::CompetenceActions
+            @section={{this.section}}
+            @refresh={{this.refresh}}
+            @selectView={{this.selectView}}
+            @shareSkills={{this.exportSkills}}/>`);
+
+      await click('[data-test-select-draft-view]');
+
+      // then
+      assert.ok(selectViewStub.calledOnce);
+      assert.ok(selectViewStub.calledWith('draft'));
+    });
+
+    test('it should have draft active tab if view is set to `draft`', async function(assert) {
+      // given
+      this.view = 'draft';
+
+      // when
+      await render(hbs` <Competence::CompetenceActions
+            @section={{this.section}}
+            @refresh={{this.refresh}}
+            @selectView={{this.selectView}}
+            @view={{this.view}}
+            @shareSkills={{this.exportSkills}}/>`);
+
+      // then
+      assert.dom('[data-test-select-draft-view]').hasClass('active');
+    });
+  });
 
   test('it renders', async function(assert) {
 

--- a/pix-editor/tests/unit/component/grid/grid-cell_test.js
+++ b/pix-editor/tests/unit/component/grid/grid-cell_test.js
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | competence/grid/grid-cell', function(hooks) {
+  setupTest(hooks);
+  let section, view;
+  module('#draftSkill', function(hooks) {
+
+    hooks.beforeEach(function () {
+      section = 'skills';
+      view = 'draft';
+    });
+
+    test('it should return a proper cell type if there is a skill', function(assert) {
+      // given
+      const skill = {
+        id: 'skillId',
+        status: 'En construction'
+      };
+      const component = createGlimmerComponent('component:competence/grid/grid-cell', { section, view, skill });
+
+      // when
+      const result = component.cellType;
+
+      // then
+      assert.equal(result, 'skill-draft');
+    });
+    test('it should return `empty` if there isn\'t skill', function(assert) {
+      // given
+      const component = createGlimmerComponent('component:competence/grid/grid-cell', { section, view });
+
+      // when
+      const result = component.cellType;
+
+      // then
+      assert.equal(result, 'empty');
+    });
+
+    test('it should return `add-skill` if user may edit skill', function(assert) {
+      // given
+      class AccessService extends Service {
+        constructor() {
+          super(...arguments);
+          this.mayEditSkills = sinon.stub().returns(true);
+        }
+      }
+      this.owner.unregister('service:access');
+      this.owner.register('service:access', AccessService);
+
+      const component = createGlimmerComponent('component:competence/grid/grid-cell', { section, view });
+
+      // when
+      const result = component.cellType;
+
+      // then
+      assert.equal(result, 'add-skill');
+    });
+  });
+});

--- a/pix-editor/tests/unit/models/tube-test.js
+++ b/pix-editor/tests/unit/models/tube-test.js
@@ -49,6 +49,7 @@ module('Unit | Model | tube', function(hooks) {
       id: 'rec664261',
       level: 5,
       status:'en construction',
+      version: 1,
     });
     skillRecord6 = store.createRecord('skill',{
       id: 'rec674261',
@@ -69,7 +70,6 @@ module('Unit | Model | tube', function(hooks) {
     }));
   });
 
-  // Replace this with your real tests.
   test('it should return an array of skill with status is not `archivé` or `périmé`', function(assert) {
     assert.expect(4);
     // given
@@ -105,6 +105,47 @@ module('Unit | Model | tube', function(hooks) {
 
     // then
     assert.deepEqual(filledSkills,expectedArray);
+  });
+  module('#draftSkill', function(hooks) {
+    let skillRecord5v2, skillRecord1v2;
+    hooks.beforeEach(function () {
+      skillRecord1v2 = store.createRecord('skill',{
+        id: 'skillRecord1v2',
+        level: 1,
+        status:'en construction',
+        version: 2,
+      });
+      skillRecord5v2 = store.createRecord('skill',{
+        id: 'skillRecord5v2',
+        level: 5,
+        status:'en construction',
+        version: 2,
+      });
+      tube.rawSkills.pushObject(skillRecord1v2);
+      tube.rawSkills.pushObject(skillRecord5v2);
+    });
+
+    test('it should return an array of draftSkill positioned by level', function(assert) {
+      // given
+      const expectedArray = [[skillRecord1v2], false, false, false, [skillRecord5, skillRecord5v2], false, false];
+
+      // when
+      const filledSkills = tube.filledDraftSkills;
+
+      // then
+      assert.deepEqual(filledSkills, expectedArray);
+    });
+
+    test('it should return an array of last draftSkill positioned by level', function(assert) {
+      // given
+      const expectedArray = [skillRecord1v2, false, false, false, skillRecord5v2, false, false];
+
+      // when
+      const filledSkills = tube.filledLastDraftSkills;
+
+      // then
+      assert.deepEqual(filledSkills, expectedArray);
+    });
   });
 
   test('it should get a next skill version', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Aucune vue ne permet d'afficher l’état des indices ainsi que le nombre de tutoriels d'un acquis en construction.

## :robot: Solution
Créer une nouvelle vue qui n'affiche que les derniers acquis `en construction` et afficher l'état des indices ainsi que le nombre de tutoriels.

## :rainbow: Remarques
RAS

## :100: Pour tester
Depuis la section `acquis` sélectionner la vue `en construction` et admirer?
