### PR TITLE
[BUGFIX]  Réparer le déplacement d'un prototype (PIX-4476).

### DIFF
--- a/pix-editor/app/components/pop-in/select-location.js
+++ b/pix-editor/app/components/pop-in/select-location.js
@@ -252,7 +252,7 @@ export default class PopinSelectLocation extends Component {
     this.skillsGroupByLevelList.find(groupOptions=>{
       if (groupOptions) {
         result = groupOptions.options.find(skill=> {
-          return skill.id === this.args.skill.id;
+          return skill.id === this.args.skill.get('id');
         });
         return !!result;
       }
@@ -274,7 +274,7 @@ export default class PopinSelectLocation extends Component {
       this.args.onChange(competence, theme);
     }
     if (this.args.isPrototypeLocation) {
-      this.args.onChange([this._selectedSkill]);
+      this.args.onChange(this._selectedSkill);
     }
     if (this.args.isSkillLocation) {
       const tube = this.selectedTube.data;

--- a/pix-editor/app/templates/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/competence/prototypes/single.hbs
@@ -34,7 +34,7 @@
         </BasicDropdown>
       {{/if}}
       {{#if this.mayMove}}
-        <button class="ui icon button item" {{on "click" this.movePrototype}} type="button"><i class="icon random"></i></button>
+        <button data-test-move-button class="ui icon button item" {{on "click" this.movePrototype}} type="button"><i class="icon random"></i></button>
       {{/if}}
     {{/unless}}
       </div>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -120,7 +120,7 @@ function routes() {
   this.post('/airtable/content/Tubes', (schema, request) => {
     const tubePayload = JSON.parse(request.requestBody);
     const tube = _deserializePayload(tubePayload, 'tube');
-    const createdTube =  schema.themes.create(tube);
+    const createdTube =  schema.tubes.create(tube);
     return _serializeModel(createdTube, 'tube');
   });
 
@@ -204,7 +204,14 @@ function routes() {
   });
 
   this.patch('/challenges/:id', (schema, request) => {
-    return schema.challenges.find(request.params.id);
+    const challenge = schema.challenges.find(request.params.id);
+    const body = JSON.parse(request.requestBody);
+
+    const skillId = body.data.relationships.skill.data.id;
+    const skill = schema.skills.find(skillId);
+    challenge.skill = skill;
+
+    return challenge;
   });
 }
 

--- a/pix-editor/tests/acceptance/competence/prototypes/single-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/single-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, click, findAll } from '@ember/test-helpers';
+import { visit, click, findAll, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { mockAuthService } from '../../../mock-auth';
@@ -8,17 +8,17 @@ module('Acceptance | Controller | Get Challenge', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  let apiKey;
-
   hooks.beforeEach(function() {
     this.server.create('config', 'default');
-    apiKey = 'valid-api-key';
+    const apiKey = 'valid-api-key';
     mockAuthService.call(this, apiKey);
     this.server.create('user', { apiKey, trigram: 'ABC' });
 
     this.server.create('challenge', { id: 'recChallenge1', updatedAt: '2021-10-04T14:00:00Z' });
-    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'] });
-    this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+    this.server.create('challenge', { id: 'recChallenge2', status: 'proposé', updatedAt: '2021-10-04T14:00:00Z', genealogy: 'Prototype 1' });
+    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1', 'recChallenge2'], level: 1 });
+    this.server.create('skill', { id: 'recSkill2', status: 'en construction', challengeIds: [], level: 2, name:'@skill2' });
+    this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1', 'recSkill2'] });
     this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
     this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
@@ -32,5 +32,21 @@ module('Acceptance | Controller | Get Challenge', function(hooks) {
     await click(findAll('[data-test-skill-cell]')[0]);
 
     assert.dom('time').hasAttribute('datetime','2021-10-04T14:00:00.000Z');
+  });
+
+  test('it should change prototype location', async function (assert) {
+    //when
+    await visit('/competence/recCompetence1.1/prototypes/recChallenge2?leftMaximized=false&view=workbench');
+    await click(find('[data-test-move-button]'));
+    await click(find('[data-test-skill-list] .ember-basic-dropdown-trigger'));
+    await click(findAll('.skill-list')[2]);
+    await click(find('[data-test-move-action]'));
+    await click(find('[data-test-save-changelog-button]'));
+    const store = this.owner.lookup('service:store');
+
+    //then
+    const challenge = await store.peekRecord('challenge', 'recChallenge2');
+    assert.dom('[data-test-main-message]').hasText('Changement d\'acquis effectué pour le prototype');
+    assert.equal(challenge.skill.get('id'), 'recSkill2');
   });
 });

--- a/pix-editor/tests/integration/components/pop-in/select-location-test.js
+++ b/pix-editor/tests/integration/components/pop-in/select-location-test.js
@@ -51,7 +51,10 @@ module('Integration | Component | popin-select-location', function (hooks) {
       name: 'skill1_2_1_1_2',
       level: 6,
       version: 1,
-      status: 'actif'
+      status: 'actif',
+      get() {
+        return  'skill1_2_1_1_2';
+      }
     };
     skill1_2_1_1_3 = {
       id: 'skill1_2_1_1_3',
@@ -270,14 +273,14 @@ module('Integration | Component | popin-select-location', function (hooks) {
       await click('[data-test-move-action]');
 
       // then
-      assert.deepEqual(this.setSkill.getCall(0).args[0], [{
+      assert.deepEqual(this.setSkill.getCall(0).args[0], {
         id: 'skill1_2_1_2_1',
         pixId: 'pixIdSkill1_2_1_2_1',
         name: 'skill1_2_1_2_1',
         level: 3,
         status: 'actif',
         version: 1
-      }]);
+      });
     });
   });
   module('if `isSkillLocation`', function (hooks) {

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -101,7 +101,15 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
   });
 
   module('#prototype actions', function(hooks) {
-    let proposalPrototype1_1, validatePrototype2_1, proposalPrototype2_2, proposalChallenge1_1, validateChallenge2_1, proposalChallenge2_2, skill1, skill2, tube;
+    let proposalPrototype1_1,
+      validatePrototype2_1,
+      proposalPrototype2_2,
+      proposalChallenge1_1,
+      validateChallenge2_1,
+      proposalChallenge2_2,
+      skill1,
+      skill2,
+      tube;
 
     hooks.beforeEach(function () {
       const saveStub = sinon.stub().resolves({});
@@ -111,6 +119,7 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
         id: 'rec_proto1_1',
         pixId: 'pix_proto1_1',
         genealogy: 'Prototype 1',
+        version: 1,
         status: 'proposé',
         save: saveStub
       });
@@ -118,12 +127,15 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
         id: 'rec_challenge1_1',
         pixId: 'pix_challenge1_1',
         status: 'proposé',
+        version: 1,
+        alternativeVersion: 1,
         save: saveStub
       });
       validatePrototype2_1 = store.createRecord('challenge', {
         id: 'rec_proto2_1',
         pixId: 'pix_proto2_1',
         status: 'validé',
+        version: 1,
         genealogy: 'Prototype 1',
         save: saveStub
       });
@@ -131,18 +143,21 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
         id: 'rec_challenge2_1',
         pixId: 'pix_challenge2_1',
         status: 'validé',
+        version: 1,
         save: saveStub
       });
       proposalPrototype2_2 = store.createRecord('challenge', {
         id: 'rec_proto2_2',
         pixId: 'pix_proto2_2',
         status: 'proposé',
+        version: 2,
         genealogy: 'Prototype 1',
         save: saveStub
       });
       proposalChallenge2_2 = store.createRecord('challenge', {
         id: 'rec_challenge2_2',
         pixId: 'pix_challenge2_2',
+        version: 2,
         status: 'proposé',
         save: saveStub
       });
@@ -175,6 +190,9 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
 
     module('on prototype validation', function() {
       test('it should archive previous active prototype and alternatives or delete draft alternative', async function (assert) {
+        //given
+        proposalChallenge2_2.version = 1;
+
         //when
         await controller._archivePreviousPrototype(proposalPrototype2_2);
 

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -316,6 +316,30 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
         assert.equal(skill1.status, 'en construction');
       });
     });
+
+    module('#setSkill', function () {
+      test('it should display an error message if have no skill', async function(assert) {
+        // when
+        await controller.setSkill();
+
+        // then
+        assert.ok(errorStub.calledWith('Aucun acquis sélectionné'));
+      });
+
+      test('it should set a new skill for prototype and is alternative with proper version', async function(assert) {
+        // when
+        await controller._setSkill(proposalPrototype1_1, skill2);
+
+        // then
+        assert.ok(messageStub.calledTwice);
+        assert.ok(messageStub.getCalls()[0].calledWith('Changement d\'acquis effectué pour la déclinaison n°1'));
+        assert.ok(messageStub.getCalls()[1].calledWith('Changement d\'acquis effectué pour le prototype'));
+        assert.equal(proposalChallenge1_1.skill.get('id'), skill2.id);
+        assert.equal(proposalChallenge1_1.skill.get('id'), skill2.id);
+        assert.equal(proposalChallenge1_1.version, 3);
+        assert.equal(proposalChallenge1_1.version, 3);
+      });
+    });
   });
 
   test('it should cancel edition', async function(assert) {

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -6,6 +6,12 @@ competence:
     archive: Archiver
     obsolete: Rendre obsolète
 challenge:
+  move:
+    message: Changement d'acquis de l'épreuve
+    success-prototype-message: Changement d'acquis effectué pour le prototype
+    success-alternative-message: Changement d'acquis effectué pour la déclinaison n°{number}
+    error-no-skill: Aucun acquis sélectionné
+    error: Le changement d'acquis de l'épreuve a échoué
   obsolete:
     confirm:
       title: Rendre obsolète


### PR DESCRIPTION
## :unicorn: Problème
Suite à  la PR #37 nous avons introduit une régression qui empêche le déplacement d'une épreuve vers un nouvel acquis.

## :robot: Solution
Corriger le soucis

## :rainbow: Remarques
J'en ai profité pour refacto la méthode setSkill.

## :100: Pour tester
Se rendre sur un épreuve prototype et la déplacer.