### PR TITLE
[TECH] Ajout de règles eslint pour les directions des dépendances dans l'api

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -2,3 +2,34 @@ extends: '../.eslintrc.yaml'
 
 globals:
   include: true
+rules:
+  "import/no-import-module-exports": "off"
+  'import/no-restricted-paths': [ 'error',
+    "basePath": "lib",
+    "zones": [
+      {
+        "target": "domain",
+        "from": "infrastructure",
+        "message": "Domain is closed to the outside. You need to do a dependency injection"
+      },
+      {
+        "target": "domain",
+        "from": "application",
+        "message": "Domain is closed to the outside. It's Application calling Domain"
+      },
+      {
+        "target": "application",
+        "from": "infrastructure",
+        "message": "Application should only talk to Domain"
+      },
+      {
+        "target": "infrastructure",
+        "from": "application",
+        "message": "Infrastructure should only talk to Domain"
+      }
+    ]
+  ]
+overrides:
+   - files: ['tests/**/*.js', 'routes.js', 'plugins.js', 'config.js', 'lib/models/*.js', 'lib/interfaces/**/*.js' ]
+     rules :
+       'import/no-restricted-paths': off


### PR DESCRIPTION
## :unicorn: Problème
La direction des dépendances entre domain, application & infrastructure n'est pas toujours respectés.

## :robot: Solution
Ajout d'une règle eslint

## :100: Pour tester
Lancer le linter
