### PR TITLE
[BUGFIX] Réparer la création d'une nouvelle version d'un prototype (PIX-4476)

### DIFF
--- a/pix-editor/app/controllers/competence/prototypes/new.js
+++ b/pix-editor/app/controllers/competence/prototypes/new.js
@@ -46,30 +46,14 @@ export default class NewController extends Prototype {
       });
   }
 
-  _setVersion(challenge) {
-    let operation;
-    if (challenge.isWorkbench) {
-      operation = Promise.resolve(challenge);
-    } else {
-      const skill = challenge.skill;
-      if (!skill) {
-        operation = Promise.resolve(challenge);
-      } else {
-        const version = skill.getNextPrototypeVersion();
-        if (version > 0) {
-          challenge.version = version;
-          operation = challenge.save();
-        } else {
-          operation = Promise.resolve(challenge);
-        }
-      }
+  async _setVersion(challenge) {
+    if (!challenge.isWorkbench) {
+      const skill = await challenge.skill;
+      const version = skill.getNextPrototypeVersion();
+      challenge.version = version;
+      await challenge.save();
+      this._message(this.intl.t('challenge.new.version', { version }), true);
     }
-    return operation.then(challenge => {
-      const version = challenge.version;
-      if (version > 0) {
-        this._message(`Nouvelle version : ${version}`, true);
-      }
-      return challenge;
-    });
+    return challenge;
   }
 }

--- a/pix-editor/tests/unit/controllers/competence/prototypes/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/new-test.js
@@ -1,12 +1,71 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+import setupIntlRenderingTest from '../../../../setup-intl-rendering';
 
 module('Unit | Controller | competence/prototypes/new', function(hooks) {
-  setupTest(hooks);
+  setupIntlRenderingTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const controller = this.owner.lookup('controller:competence/prototypes/new');
-    assert.ok(controller);
+  module('#_setVersion', function(hooks) {
+    let controller,
+      messageStub,
+      prototype1_1,
+      savePrototypeStub,
+      newPrototype1_2,
+      skill;
+
+    hooks.beforeEach(function() {
+      controller = this.owner.lookup('controller:competence/prototypes/new');
+      messageStub = sinon.stub();
+      controller._message = messageStub;
+
+      const store = this.owner.lookup('service:store');
+
+      prototype1_1 = store.createRecord('challenge', {
+        id: 'rec_proto1_1',
+        pixId: 'pix_proto1_1',
+        genealogy: 'Prototype 1',
+        version: 1,
+      });
+
+      newPrototype1_2 = store.createRecord('challenge',{
+        id: 'rec_proto1_2',
+        pixId: 'pix_proto1_1',
+        genealogy: 'Prototype 1',
+      });
+      savePrototypeStub = sinon.stub().resolves(newPrototype1_2);
+      newPrototype1_2.save = savePrototypeStub;
+
+      skill = store.createRecord('skill',{
+        id: 'rec_proto1_2',
+        pixId: 'pix_proto1_1',
+        genealogy: 'Prototype 1',
+        challenges:[prototype1_1, newPrototype1_2],
+      });
+    });
+
+    test('it should set proper version of a prototype', async function(assert) {
+      // when
+      await controller._setVersion(newPrototype1_2);
+
+      // then
+      assert.equal(newPrototype1_2.version, 2);
+      assert.ok(messageStub.calledOnce);
+      assert.ok(messageStub.calledWith('Nouvelle version : 2', true));
+      assert.ok(savePrototypeStub.calledOnce);
+    });
+
+    test('it should not set version if is workbench prototype', async function(assert) {
+      // given
+      skill.name = '@workbench';
+
+      // when
+      await controller._setVersion(newPrototype1_2);
+
+      // then
+      assert.equal(newPrototype1_2.version, undefined);
+      assert.notOk(messageStub.calledOnce);
+      assert.notOk(savePrototypeStub.calledOnce);
+    });
   });
 });

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -23,6 +23,8 @@ challenge:
   alternative:
     archive: Déclinaison n°{number} archivée
     obsolete: Déclinaison n°{number} périmée
+  new:
+    version: "Nouvelle version : {version}"
 skill:
   changelog:
     update-message: Mise à jour de l'acquis


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on crée une nouvelle version d'un prototype sont numéro de version n'est pas calculé.

## :robot: Solution
Réparer la fonction de calcule de la version.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer une nouvelle version d'un prototype et vérifier que sa version est bien calculé.
