### PR TITLE
[BUGFIX] Corriger la déconnexion d'une page

### DIFF
--- a/pix-editor/app/routes/application.js
+++ b/pix-editor/app/routes/application.js
@@ -4,8 +4,7 @@ import { inject as service } from '@ember/service';
 import { scheduleOnce } from '@ember/runloop';
 
 export default class ApplicationRoute extends Route {
-  configured = false;
-
+  @service auth;
   @service config;
   @service currentData;
   @service intl;
@@ -17,19 +16,18 @@ export default class ApplicationRoute extends Route {
   async beforeModel() {
     try {
       await this.config.load();
-      this.configured = true;
+      this.auth.connected = true;
       this.intl.setLocale(['fr']);
-    } catch (error) {
-      this.configured = false;
+    } catch (_e) {
     }
 
-    if (!this.configured) {
+    if (!this.auth.connected) {
       scheduleOnce('afterRender', this, this._openLoginForm);
     }
   }
 
   model() {
-    if (this.configured) {
+    if (this.auth.connected) {
       return this.store.findAll('framework');
     }
   }

--- a/pix-editor/app/routes/application.js
+++ b/pix-editor/app/routes/application.js
@@ -18,7 +18,8 @@ export default class ApplicationRoute extends Route {
       await this.config.load();
       this.auth.connected = true;
       this.intl.setLocale(['fr']);
-    } catch (_e) {
+    } catch (_) {
+      console.log('not authenticated');
     }
 
     if (!this.auth.connected) {

--- a/pix-editor/app/routes/area-management/new.js
+++ b/pix-editor/app/routes/area-management/new.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../authenticated';
 
-export default class AreaManagementNewRoute extends Route {
+export default class AreaManagementNewRoute extends AuthenticatedRoute {
 
   @service idGenerator;
   @service currentData;

--- a/pix-editor/app/routes/authenticated.js
+++ b/pix-editor/app/routes/authenticated.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class AuthenticatedRoute extends Route {
+  @service auth;
+  @service router;
+
+  beforeModel() {
+    if (!this.auth.connected) {
+      this.router.transitionTo('index');
+    }
+  }
+}

--- a/pix-editor/app/routes/authenticated.js
+++ b/pix-editor/app/routes/authenticated.js
@@ -7,7 +7,7 @@ export default class AuthenticatedRoute extends Route {
 
   beforeModel() {
     if (!this.auth.connected) {
-      this.router.transitionTo('index');
+      this.router.transitionTo('');
     }
   }
 }

--- a/pix-editor/app/routes/challenge.js
+++ b/pix-editor/app/routes/challenge.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from './authenticated';
 
-export default class ChallengeRoute extends Route {
+export default class ChallengeRoute extends AuthenticatedRoute {
   model(params) {
     return this.store.findRecord('challenge', params.challenge_id);
   }

--- a/pix-editor/app/routes/competence-management/new.js
+++ b/pix-editor/app/routes/competence-management/new.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../authenticated';
 
-export default class CompetenceManagementNewRoute extends Route {
+export default class CompetenceManagementNewRoute extends AuthenticatedRoute {
   templateName = 'competence-management/single';
   @service idGenerator;
   @service currentData;

--- a/pix-editor/app/routes/competence-management/single.js
+++ b/pix-editor/app/routes/competence-management/single.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../authenticated';
 
-export default class CompetenceManagementSingleRoute extends Route {
+export default class CompetenceManagementSingleRoute extends AuthenticatedRoute {
 
   @service currentData;
 

--- a/pix-editor/app/routes/competence.js
+++ b/pix-editor/app/routes/competence.js
@@ -5,6 +5,14 @@ import { inject as service } from '@ember/service';
 export default class CompetenceRoute extends Route {
   @service paginatedQuery;
   @service currentData;
+  @service auth;
+  @service router;
+
+  beforeModel(transition) {
+    if (!this.auth.connected) {
+      this.router.transitionTo('index');
+    }
+  }
 
   model(params) {
     return this.store.findRecord('competence', params.competence_id);

--- a/pix-editor/app/routes/competence.js
+++ b/pix-editor/app/routes/competence.js
@@ -1,18 +1,10 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from './authenticated';
 
-export default class CompetenceRoute extends Route {
+export default class CompetenceRoute extends AuthenticatedRoute {
   @service paginatedQuery;
   @service currentData;
-  @service auth;
-  @service router;
-
-  beforeModel(transition) {
-    if (!this.auth.connected) {
-      this.router.transitionTo('index');
-    }
-  }
 
   model(params) {
     return this.store.findRecord('competence', params.competence_id);

--- a/pix-editor/app/routes/competence/i18n/index.js
+++ b/pix-editor/app/routes/competence/i18n/index.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class CompetenceI18nIndexRoute extends Route {
+export default class CompetenceI18nIndexRoute extends AuthenticatedRoute {
   setupController() {
     super.setupController(...arguments);
     const competenceController = this.controllerFor('competence');

--- a/pix-editor/app/routes/competence/i18n/single.js
+++ b/pix-editor/app/routes/competence/i18n/single.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class CompetenceI18nSingleRoute extends Route {
+export default class CompetenceI18nSingleRoute extends AuthenticatedRoute {
 
   model(params) {
     return this.store.findRecord('skill', params.skill_id);

--- a/pix-editor/app/routes/competence/index.js
+++ b/pix-editor/app/routes/competence/index.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../authenticated';
 
-export default class CompetenceIndexRoute extends Route {
+export default class CompetenceIndexRoute extends AuthenticatedRoute {
   @service currentData;
 
   afterModel() {

--- a/pix-editor/app/routes/competence/prototypes/index.js
+++ b/pix-editor/app/routes/competence/prototypes/index.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class IndexRoute extends Route {
+export default class IndexRoute extends AuthenticatedRoute {
   setupController() {
     super.setupController(...arguments);
     const competenceController = this.controllerFor('competence');

--- a/pix-editor/app/routes/competence/prototypes/list.js
+++ b/pix-editor/app/routes/competence/prototypes/list.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class ListRoute extends Route {
+export default class ListRoute extends AuthenticatedRoute {
 
   async model(params) {
     const tube = await this.store.findRecord('tube', params.tube_id);

--- a/pix-editor/app/routes/competence/prototypes/single.js
+++ b/pix-editor/app/routes/competence/prototypes/single.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class SingleRoute extends Route {
+export default class SingleRoute extends AuthenticatedRoute {
 
   @service currentData
 

--- a/pix-editor/app/routes/competence/prototypes/single/alternatives.js
+++ b/pix-editor/app/routes/competence/prototypes/single/alternatives.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../../authenticated';
 
-export default class AlternativesRoute extends Route {
+export default class AlternativesRoute extends AuthenticatedRoute {
 
   model() {
     return this.modelFor('competence.prototypes.single');

--- a/pix-editor/app/routes/competence/prototypes/single/alternatives/new.js
+++ b/pix-editor/app/routes/competence/prototypes/single/alternatives/new.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../../../authenticated';
 
-export default class NewRoute extends Route {
+export default class NewRoute extends AuthenticatedRoute {
   templateName = 'competence/prototypes/single';
 
   async model(params) {

--- a/pix-editor/app/routes/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/routes/competence/prototypes/single/alternatives/single.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import AuthenticatedRoute from '../../../../authenticated';
 
-export default class SingleRoute extends Route {
+export default class SingleRoute extends AuthenticatedRoute {
   model(params) {
     return this.store.findRecord('challenge', params.alternative_id);
   }

--- a/pix-editor/app/routes/competence/quality.js
+++ b/pix-editor/app/routes/competence/quality.js
@@ -1,3 +1,3 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../authenticated';
 
-export default class QualityRoute extends Route {}
+export default class QualityRoute extends AuthenticatedRoute {}

--- a/pix-editor/app/routes/competence/quality/index.js
+++ b/pix-editor/app/routes/competence/quality/index.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class IndexRoute extends Route {
+export default class IndexRoute extends AuthenticatedRoute {
   setupController() {
     super.setupController(...arguments);
     const competenceController = this.controllerFor('competence');

--- a/pix-editor/app/routes/competence/skills/index.js
+++ b/pix-editor/app/routes/competence/skills/index.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class IndexRoute extends Route {
+export default class IndexRoute extends AuthenticatedRoute {
   setupController() {
     super.setupController(...arguments);
     const competenceController = this.controllerFor('competence');

--- a/pix-editor/app/routes/competence/skills/list.js
+++ b/pix-editor/app/routes/competence/skills/list.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class CompetenceSkillsListRoute extends Route {
+export default class CompetenceSkillsListRoute extends AuthenticatedRoute {
 
   async model(params) {
     const tube = await this.store.findRecord('tube', params.tube_id);

--- a/pix-editor/app/routes/competence/skills/single.js
+++ b/pix-editor/app/routes/competence/skills/single.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class SingleRoute extends Route {
+export default class SingleRoute extends AuthenticatedRoute {
 
   @service
   currentData;

--- a/pix-editor/app/routes/competence/skills/single/archive.js
+++ b/pix-editor/app/routes/competence/skills/single/archive.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../../authenticated';
 
-export default class CompetenceSkillsSingleArchiveRoute extends Route {
+export default class CompetenceSkillsSingleArchiveRoute extends AuthenticatedRoute {
   renderTemplate() {
     this.render('competence/skills/single/archive', {
       into: 'competence',

--- a/pix-editor/app/routes/competence/skills/single/archive/single.js
+++ b/pix-editor/app/routes/competence/skills/single/archive/single.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../../../../authenticated';
 
-export default class CompetenceSkillsSingleArchiveSingleRoute extends Route {
+export default class CompetenceSkillsSingleArchiveSingleRoute extends AuthenticatedRoute {
   model(params) {
     return this.store.findRecord('challenge', params.challenge_id);
   }

--- a/pix-editor/app/routes/competence/themes/single.js
+++ b/pix-editor/app/routes/competence/themes/single.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import AuthenticatedRoute from '../../authenticated';
 
 
-export default class CompetenceThemesSingleRoute extends Route {
+export default class CompetenceThemesSingleRoute extends AuthenticatedRoute {
   model(params) {
     return this.store.findRecord('theme', params.theme_id);
   }

--- a/pix-editor/app/routes/competence/tubes/single.js
+++ b/pix-editor/app/routes/competence/tubes/single.js
@@ -1,8 +1,8 @@
-import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from '../../authenticated';
 
-export default class SingleRoute extends Route {
+export default class SingleRoute extends AuthenticatedRoute {
 
   @service currentData;
 

--- a/pix-editor/app/routes/events-log.js
+++ b/pix-editor/app/routes/events-log.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from './authenticated';
 
-export default class EventsLogRoute extends Route {
+export default class EventsLogRoute extends AuthenticatedRoute {
 
   @service paginatedQuery;
 

--- a/pix-editor/app/routes/skill.js
+++ b/pix-editor/app/routes/skill.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from './authenticated';
 
-export default class SkillRoute extends Route {
+export default class SkillRoute extends AuthenticatedRoute {
   model(params) {
     return this.store.query('skill', { filterByFormula:`FIND('${params.skill_name}', {Nom})`, maxRecords: 1 });
   }

--- a/pix-editor/app/routes/statistics.js
+++ b/pix-editor/app/routes/statistics.js
@@ -1,7 +1,7 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import AuthenticatedRoute from './authenticated';
 
-export default class StatisticsRoute extends Route {
+export default class StatisticsRoute extends AuthenticatedRoute {
 
   @service currentData;
 

--- a/pix-editor/app/routes/target-profile.js
+++ b/pix-editor/app/routes/target-profile.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from './authenticated';
 
-export default class TargetProfileRoute extends Route {
+export default class TargetProfileRoute extends AuthenticatedRoute {
 
   model() {
     return this.modelFor('application');

--- a/pix-editor/app/services/auth.js
+++ b/pix-editor/app/services/auth.js
@@ -1,8 +1,11 @@
 import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 const LOCAL_STORAGE_API_KEY = 'pix-api-key';
 
 export default class AuthService extends Service {
+  @tracked connected = false;
+
   get key() {
     return localStorage.getItem(LOCAL_STORAGE_API_KEY);
   }

--- a/pix-editor/tests/acceptance/competence/competence-test.js
+++ b/pix-editor/tests/acceptance/competence/competence-test.js
@@ -1,0 +1,22 @@
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { mockAuthService } from '../../mock-auth';
+
+module('Acceptance | competence | competence', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    mockAuthService.call(this, undefined);
+  });
+
+  module('when unlogged', function() {
+    test('it should show loggin popin', async function(assert) {
+      // when
+      await visit('/competence/recCompetence1');
+
+      // then
+      assert.dom('#login-api-key').exists();
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on se déconnecte d'une page nous avons une erreur et nous e somme pas redirigé vers le formulaire de connexion. 

## :robot: Solution
Ajout d'une nouvelle `class` de type route `AuthentificationRoute`  qui gère la redirection vers la page index pour l'ensemble des routes authentifié.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur une page competence/recID en n'étant pas authentifié et vérifier que nous sommes bien redirigé vers la page `index` et que le formulaire de connexion s'affiche.
