### PR TITLE
[TECH] Ajout du trigramme de l'utilisateur dans les rapports de Sentry.

### DIFF
--- a/pix-editor/app/components/pop-in/logout.js
+++ b/pix-editor/app/components/pop-in/logout.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import * as Sentry from '@sentry/ember';
 
 export default class LogoutComponent extends Component {
 
@@ -11,6 +12,7 @@ export default class LogoutComponent extends Component {
   logout() {
     event.preventDefault();
     this.auth.key = undefined;
+    Sentry.configureScope(scope => scope.setUser(null));
     this.window.reload();
   }
 }

--- a/pix-editor/app/services/config.js
+++ b/pix-editor/app/services/config.js
@@ -1,5 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import * as Sentry from '@sentry/ember';
 
 
 export default class ConfigService extends Service {
@@ -30,5 +31,7 @@ export default class ConfigService extends Service {
     this.storagePost = config.storagePost;
     this.storageBucket = config.storageBucket;
     this.localeToLanguageMap = config.localeToLanguageMap;
+
+    Sentry.setUser({ userName: this.author });
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons ajouter le trigramme dans les information reporté par Sentry.

## :robot: Solution
Ajout du trigramme de l'utilisateur dans les rapports de Sentry.

## :rainbow: Remarques
RAS

## :100: Pour tester
1. Mettre en variable d'environnement `SENTRY_ENABLED=true` et `SENTRY_DSN=dsn_de_prod`
2. Démarrer pix-editor
3. Ajouter un Sentry.captureMessage("mon message") dans la méthode du service config après le set de l'user
4. Aller sur l'interface et vérifier que dans la requête sentry on a le triagram de l'utilisateur
