### PR TITLE
[BUGFIX] Attribuer la bonne relation épreuves > acquis dans nos scriptes

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -45,7 +45,7 @@ function findUrlsInMarkdown(value) {
 }
 
 function findSkillsNameFromChallenge(challenge, release) {
-  const skills = release.skills.filter(({ id }) => challenge.skillIds.includes(id));
+  const skills = release.skills.filter(({ id }) => challenge.skillId === id);
   return skills.map((s) => s.name).join(' ');
 }
 

--- a/api/scripts/get-external-urls-list/index.js
+++ b/api/scripts/get-external-urls-list/index.js
@@ -16,7 +16,7 @@ async function getExternalUrlsList() {
   };
 
   urlsFromChallenges.forEach((urlChallenge) => {
-    urlChallenge.origin = skillIdsWithFramework[urlChallenge.skillIds[0]];
+    urlChallenge.origin = skillIdsWithFramework[urlChallenge.skillId];
     urlChallenge.url = baseUrl(urlChallenge.url);
     urlChallenge.tube = getTubeName(release, urlChallenge);
   });
@@ -37,7 +37,7 @@ function findUrlsFromChallenges(challenges) {
     return functions
       .flatMap((fun) => fun(challenge))
       .map((url) => {
-        return { id: challenge.id, locales: challenge.locales, url, skillIds: challenge.skillIds, status: challenge.status };
+        return { id: challenge.id, locales: challenge.locales, url, skillId: challenge.skillId, status: challenge.status };
       });
   });
   return _.uniqBy(urlsFromChallenges, 'url');
@@ -45,13 +45,13 @@ function findUrlsFromChallenges(challenges) {
 
 function getTubeName(release, challenge) {
   const skill = release.skills.find((skill) => {
-    return skill.id === challenge.skillIds[0];
+    return skill.id === challenge.skillId;
   });
   const tube = release.tubes.find((tube) => {
     return tube.id === skill.tubeId;
   });
   return tube.name;
-};
+}
 
 function getSkillIdsWithFramework(release) {
   return release.competences.reduce((memo, competence) => {

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -103,21 +103,14 @@ describe('Check urls from release', function() {
           id: 'challenge1',
           instruction: 'instructions [link](https://example.net/) further instructions [other_link](https://other_example.net/)',
           proposals: 'proposals [link](https://example.net/)',
-          skillIds: ['skill1'],
+          skillId: 'skill1',
           status: 'validé',
         },
         {
           id: 'challenge2',
           instruction: 'instructions',
           proposals: 'proposals [link](https://example.fr/)',
-          skillIds: [],
-          status: 'validé',
-        },
-        {
-          id: 'challenge3',
-          instruction: 'instructions [link](https://example.com/)',
-          proposals: 'proposals',
-          skillIds: ['skill1', 'skill2'],
+          skillId: undefined,
           status: 'validé',
         }
       ];
@@ -126,7 +119,6 @@ describe('Check urls from release', function() {
         { id: '@mySkill1;challenge1;validé', url: 'https://example.net/' },
         { id: '@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
         { id: ';challenge2;validé', url: 'https://example.fr/' },
-        { id: '@mySkill1 @mySkill2;challenge3;validé', url: 'https://example.com/' },
       ];
 
       const urls = findUrlsFromChallenges(challenges, release);


### PR DESCRIPTION
## :unicorn: Problème
La relation epreuve acquis à changé de `one to many` à `one to one`. Mais elle n'a pas été mise à jour dans le code de nos scriptes.

## :robot: Solution
Mettre à jour la relation épreuves acquis dans nos scripts.

## :rainbow: Remarques
RAS

## :100: Pour tester
- validate-urls-from-release : Faire une release de LCMS et vérifier que la validation d'url fonctionne bien.
- get-external-urls-list : Lancer le script en locale et vérifier qu'on obtient bien une liste d'url

