### PR TITLE
[TECH] Support du header HTTP If-Modified-Since sur /api/releases/latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ pix-editor/app/config-private-test.js
 
 # intellij
 **/.idea
+
+# vscode
+**/.vscode

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -40,6 +40,15 @@ module.exports = {
     return this.toDomain(release[0]);
   },
 
+  async getLatestReleaseInfo() {
+    const release = await knex('releases')
+      .select('id', 'createdAt')
+      .orderBy('createdAt', 'desc')
+      .limit(1);
+
+    return this.toDomain(release[0]);
+  },
+
   async getRelease(id) {
     const release = await knex('releases')
       .select('id', 'content', 'createdAt')
@@ -86,7 +95,7 @@ module.exports = {
     }
     return new Release({
       id: releaseDTO.id,
-      content: Content.from(releaseDTO.content),
+      content: releaseDTO.content != null ? Content.from(releaseDTO.content) : null,
       createdAt: releaseDTO.createdAt,
     });
   }


### PR DESCRIPTION
## :unicorn: Problème

L'appel à la ressource `/api/releases/latest` est couteux car la payload de réponse a une taille élevée.

## :robot: Solution

En supportant les headers HTTP `Last-Modified` et [`If-Modified-Since`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since), on offre la possibilité au client de mettre cette ressource en cache.

Si le client possède déjà la dernière release en cache, le serveur renvoie le code HTTP `304 Not Modified` avec une payload vide.

## :rainbow: Remarques

N/A

## :100: Pour tester

Effectuer un 1er appel sans le header `If-Modified-Since`:

```
curl http://localhost:3002/api/releases/latest -v -H 'Authorization: Bearer xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
```

Vérifier que le code HTTP est `200 OK` et que la payload contient la dernière release.

Récupérer la valeur du header `Last-Modified` et refaire un appel avec le header `If-Modified-Since`:

```
curl http://localhost:3002/api/releases/latest -v -H 'Authorization: Bearer xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' -H 'If-Modified-Since: Mon, 14 Mar 2022 09:24:24 GMT'
```

Vérifier que le code HTTP est `304 Not Modified` et que la payload est vide.

Créer une nouvelle release, refaire l'appel avec le header `If-Modified-Since`, et vérifier que le code HTTP est `200 OK` et que la payload contient la nouvelle release.
