### PR TITLE
[BUGFIX] Réparer le rafraîchissement du jeton du seau OVH (PIX-4659).

### DIFF
--- a/pix-editor/app/services/storage.js
+++ b/pix-editor/app/services/storage.js
@@ -74,7 +74,7 @@ export default class StorageService extends Service {
     try {
       return await fn(token);
     } catch (error) {
-      if (error.response && error.response.status === 401 && !renewToken) {
+      if (error.status === 401 && !renewToken) {
         return this._callAPIWithRetry(fn, true);
       } else {
         throw error;

--- a/pix-editor/tests/unit/services/storage-test.js
+++ b/pix-editor/tests/unit/services/storage-test.js
@@ -212,7 +212,7 @@ module('Unit | Service | storage', function(hooks) {
     test('it should retry when token has expired', async function(assert) {
       // given
       fetch.onFirstCall().rejects({
-        response: { status: 401 }
+        status: 401
       });
 
       fetch.onSecondCall().resolves();
@@ -240,7 +240,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.expect(2);
       // given
       fetch.rejects({
-        response: { status: 401 }
+        status: 401
       });
 
       const date = {
@@ -263,7 +263,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.expect(2);
       // given
       fetch.rejects({
-        response: { status: 400 }
+        status: 400
       });
 
       const date = {
@@ -389,7 +389,7 @@ module('Unit | Service | storage', function(hooks) {
     test('it should retry when token has expired', async function(assert) {
       // given
       fetch.onFirstCall().rejects({
-        response: { status: 401 }
+        status: 401
       });
 
       fetch.onSecondCall().resolves();
@@ -412,7 +412,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.expect(2);
       // given
       fetch.rejects({
-        response: { status: 401 }
+        status: 401
       });
 
       // then
@@ -431,7 +431,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.expect(2);
       // given
       fetch.rejects({
-        response: { status: 400 }
+        status: 400
       });
 
       // then


### PR DESCRIPTION
## :unicorn: Problème
Le jeton du seau OVH ne se renouvelle pas lorsqu'il est est expiré.

## :robot: Solution
- Réparer le problème CORS en ajoutant un header depuis le proxy
- Le status de la réponse n'était pas correctement récupéré

## :rainbow: Remarques
RAS

## :100: Pour tester
Dans le code qui génère le nouveau jeton, remplacer le jeton par une chaîne de caractère de votre choix. Puis remplacer ou ajouter une image ou une pièce jointe et vérifier que la requête s’exécute deux fois.
