### PR TITLE
[TECH] Ajouter le champ du nom de la thématique traduite en anglais dans la release (PIX-4855).

### DIFF
--- a/api/lib/domain/models/Thematic.js
+++ b/api/lib/domain/models/Thematic.js
@@ -2,12 +2,14 @@ module.exports = class Thematic {
   constructor({
     id,
     name,
+    nameEnUs,
     index,
     competenceId,
     tubeIds,
   } = {}) {
     this.id = id;
     this.name = name;
+    this.nameEnUs = nameEnUs;
     this.index = index;
     this.competenceId = competenceId;
     this.tubeIds = tubeIds;

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -8,6 +8,7 @@ module.exports = datasource.extend({
 
   usedFields: [
     'Nom',
+    'Titre en-us',
     'Competence (id persistant)',
     'Tubes (id persistant)',
     'Index',
@@ -19,6 +20,7 @@ module.exports = datasource.extend({
     return {
       id: airtableRecord.id,
       name: airtableRecord.get('Nom'),
+      nameEnUs: airtableRecord.get('Titre en-us'),
       competenceId: airtableRecord.get('Competence (id persistant)')[0],
       tubeIds: airtableRecord.get('Tubes (id persistant)'),
       index: airtableRecord.get('Index'),

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -120,7 +120,8 @@ function mockCurrentContent() {
     }],
     thematics: [{
       id: 'recThematic0',
-      name: 'Name',
+      name: 'Nom',
+      nameEnUs: 'name',
       competenceId: 'recCompetence0',
       tubeIds: ['recTube'],
       index: 0
@@ -334,5 +335,4 @@ describe('Acceptance | Controller | release-controller', () => {
       });
     });
   });
-
 });

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -2,6 +2,7 @@ module.exports = function buildThematic(
   {
     id,
     name,
+    nameEnUs,
     competenceId,
     tubeIds,
     index,
@@ -10,6 +11,7 @@ module.exports = function buildThematic(
     id,
     'fields': {
       'Nom': name,
+      'Titre en-us': nameEnUs,
       'Competence (id persistant)': [competenceId],
       'Tubes (id persistant)': tubeIds,
       'Index': index

--- a/api/tests/tooling/domain-builder/factory/build-thematic.js
+++ b/api/tests/tooling/domain-builder/factory/build-thematic.js
@@ -2,6 +2,7 @@ module.exports = function buildThematic(
   {
     id = 'recFvllz2Ckz',
     name = 'Nom de la thématique',
+    nameEnUs = 'Thematic\'s name',
     competenceId = 'recCompetence0',
     tubeIds = ['recTube0'],
     index = 0
@@ -9,6 +10,7 @@ module.exports = function buildThematic(
   return {
     id,
     name,
+    nameEnUs,
     competenceId,
     tubeIds,
     index,


### PR DESCRIPTION
## :unicorn: Problème
Le champ du nom de la thématique traduite en anglais n'est pas exposé dans la release.

## :robot: Solution
L'ajouter à la release

## :rainbow: Remarques
RAS

## :100: Pour tester
Générer une release et vérifier qu'elle contient bien le champ `nameEnUs` pour les thématiques.
