### PR TITLE
[FEATURE] Exposer le niveau des acquis dans la release

### DIFF
--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -12,6 +12,7 @@ module.exports = class Skill {
     status,
     tubeId,
     version,
+    level,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -25,5 +26,6 @@ module.exports = class Skill {
     this.status = status;
     this.tubeId = tubeId;
     this.version = version;
+    this.level = level;
   }
 };

--- a/api/lib/infrastructure/transformers/skill-transformer.js
+++ b/api/lib/infrastructure/transformers/skill-transformer.js
@@ -13,7 +13,8 @@ function filterSkillsFields(skills) {
     'pixValue',
     'status',
     'tubeId',
-    'version'
+    'version',
+    'level'
   ];
   return skills.map((skill) => _.pick(skill, fieldsToInclude));
 }

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -70,6 +70,7 @@ function mockCurrentContent() {
       status: 'validé',
       tubeId: 'recTube0',
       version: 1,
+      level: 1,
     }],
     challenges: [{
       id: 'recChallenge0',

--- a/api/tests/unit/infrastructure/transformers/skill-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/skill-transformer_test.js
@@ -11,7 +11,7 @@ describe('Unit | Infrastructure | skill-transformer', function() {
     expect(skills.length).to.equal(1);
     expect(skills[0].name).to.exist;
     expect(skills[0].description).to.not.exist;
-    expect(skills[0].level).to.not.exist;
+    expect(skills[0].level).to.equal(5);
     expect(skills[0].internationalisation).to.not.exist;
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le niveau des acquis n'est pas exposé dans la release et nécessaire pour https://github.com/1024pix/pix/pull/4401

## :robot: Solution
Exposer le niveau des acquis dans la release.

## :rainbow: Remarques
N/A

## :100: Pour tester

```sh
curl -H "Authorization: Bearer b03b5cca-10b7-11ec-91a9-1b6020fa19dc" https://pix-lcms-review-pr52.osc-fr1.scalingo.io/api/releases/latest
```

Puis vérifier que le champ `level` est bien présent sur les skills.
