### PR TITLE
[BUGFIX] Correction de duplication d'un acquis.

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -75,7 +75,7 @@ module.exports = {
           },
         },
         transform(challenge) {
-          challenge.skills = [challenge.skill];
+          challenge.skills = challenge.skill ? [challenge.skill] : [];
           delete challenge.skill;
           return challenge;
         }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -138,5 +138,27 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
       // Then
       expect(challenge).to.deep.equal(expectedDeserializedChallenge);
     });
+
+    it('should allow empty skill relationships', async function() {
+      // Given
+      const json = {
+        data: {
+          type: 'challenges',
+          id: 'challengeId',
+          attributes: {},
+          relationships: {
+            skill: {
+              data: null
+            },
+          },
+        }
+      };
+
+      // When
+      const challenge = await serializer.deserialize(json);
+
+      // Then
+      expect(challenge.skills).to.deep.equal([]);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la duplication d'un acquis se produisait une erreur à la creation des challenges.

## :robot: Solution
Corriger une regression effectuer dans le commit: 9240f2d3dbc2af0af9310faf11d8d3fbc8a67b85

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Dupliquer un acquis.
