### PR TITLE
[BUGFIX] Permettre la duplication d'un acquis avec ses épreuves.

### DIFF
--- a/pix-editor/app/components/pop-in/select-location.hbs
+++ b/pix-editor/app/components/pop-in/select-location.hbs
@@ -19,7 +19,7 @@
               </PowerSelect>
             </div>
           {{else}}
-            <Field::Select @title="Niveau" @value={{this.selectedLevel}} @options={{this.selectLevelOptions}} @edition={{true}} @setValue={{this.selectLevel}}/>
+            <Field::Select @title="Niveau" data-test-select-level @value={{this.selectedLevel}} @options={{this.selectLevelOptions}} @edition={{true}} @setValue={{this.selectLevel}}/>
           {{/if}}
         {{/if}}
       {{/if}}

--- a/pix-editor/app/controllers/competence/skills/single.js
+++ b/pix-editor/app/controllers/competence/skills/single.js
@@ -185,7 +185,7 @@ export default class SingleController extends Controller {
     const liveChallenges = challenges.filter(challenge => challenge.isLive);
     const newChallenges = await Promise.all(liveChallenges.map(async (challenge) => {
       const newChallenge = await challenge.copyForDifferentSkill();
-      newChallenge.skills = [newSkill];
+      newChallenge.skill = newSkill;
       await newChallenge.save();
       await this._saveDuplicatedAttachments(newChallenge);
       return newChallenge;

--- a/pix-editor/app/templates/competence/skills/single.hbs
+++ b/pix-editor/app/templates/competence/skills/single.hbs
@@ -3,7 +3,7 @@
     <div class="ui left menu">
       {{#unless this.edition}}
         {{#if this.mayDuplicate}}
-          <button class="ui icon button" {{on "click" this.duplicateSkill}} type="button" title="Dupliquer vers"><i
+          <button data-test-duplicate-skill-action class="ui icon button" {{on "click" this.duplicateSkill}} type="button" title="Dupliquer vers"><i
                   class="icon copy"></i></button>
         {{/if}}
         <LinkTo class="ui button icon item"

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -139,7 +139,7 @@ function routes() {
   this.post('/airtable/content/Acquis', (schema, request) => {
     const skillPayload = JSON.parse(request.requestBody);
     const skill = _deserializePayload(skillPayload, 'skill');
-    const createdSkill =  schema.themes.create(skill);
+    const createdSkill =  schema.skills.create(skill);
     return _serializeModel(createdSkill, 'skill');
   });
 

--- a/pix-editor/tests/acceptance/competence/skills/single-test.js
+++ b/pix-editor/tests/acceptance/competence/skills/single-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, visit, click, find } from '@ember/test-helpers';
+import { currentURL, visit, click, find, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { mockAuthService } from '../../../mock-auth';
@@ -7,7 +7,7 @@ import { mockAuthService } from '../../../mock-auth';
 module('Acceptance | single', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  let apiKey;
+  let apiKey, skill1, competence1, tube1;
 
   hooks.beforeEach(function() {
     this.server.create('config', 'default');
@@ -15,16 +15,43 @@ module('Acceptance | single', function(hooks) {
     mockAuthService.call(this, apiKey);
     this.server.create('user', { apiKey, trigram: 'ABC' });
 
-    this.server.create('tube', { id: 'recTube1' });
-    this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawTubeIds: ['recTube1'] });
-    this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
-    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+    const challenge1 = this.server.create('challenge', { id: 'recChallenge1', status: 'proposé' });
+    const challenge2 = this.server.create('challenge', { id: 'recChallenge2', status: 'proposé' });
+    skill1 = this.server.create('skill', { id: 'skillId1', challengeIds: [challenge1.id, challenge2.id], level:1 });
+    tube1 = this.server.create('tube', { id: 'recTube1', rawSkillIds: [skill1.id] });
+    const theme1 = this.server.create('theme', { id: 'recTheme1', rawTubeIds: [tube1.id] });
+    competence1 = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: [theme1.id], rawTubeIds: [tube1.id] });
+    const area1 = this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: [competence1.id] });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: [area1.id] });
   });
 
   test('close single', async function(assert) {
-    await visit('/competence/recCompetence1.1/skills/new/recTube1/0?leftMaximized=true&view=workbench');
+    await visit(`/competence/${competence1.id}/skills/new/${tube1.id}/0?leftMaximized=true&view=workbench`);
     await click(find('.icon.window.close'));
 
-    assert.equal(currentURL(), '/competence/recCompetence1.1/skills?view=workbench');
+    assert.equal(currentURL(), `/competence/${competence1.id}/skills?view=workbench`);
+  });
+
+  module('#duplicateToLocation', function() {
+    test('it should duplicate a skill and his challenges to new location', async function(assert) {
+      // given
+      const SKILL_LEVEL_CHOOSE = 4;
+      const store = this.owner.lookup('service:store');
+
+      // when
+      await visit(`/competence/${competence1.id}/skills/${skill1.id}?leftMaximized=true&view=workbench`);
+      await click(find('[data-test-duplicate-skill-action]'));
+      await click(find('[data-test-select-level] .ember-basic-dropdown-trigger'));
+      await click(findAll('.ember-power-select-options li')[SKILL_LEVEL_CHOOSE - 1]);
+      await click(find('[data-test-move-action]'));
+      await click(find('[data-test-save-changelog-button]'));
+
+      const tube = await store.peekRecord('tube', 'recTube1');
+      const newSkill = tube.rawSkills.find(skill => skill.level === SKILL_LEVEL_CHOOSE);
+      // then
+      assert.ok(newSkill);
+      assert.equal(newSkill.challenges.length, 2);
+      assert.equal(currentURL(), `/competence/${competence1.id}/skills/${newSkill.id}?leftMaximized=true&view=workbench`);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La relation entre épreuves et acquis n'était pas valoriser lors de la duplication d'un acquis.

## :robot: Solution
Corriger la relation épreuves > acquis lors de la duplication d'un acquis.

## :rainbow: Remarques
Nous en avons profité pour réparer la création d'un acquis sur mirage.

## :100: Pour tester
Se rendre sur la RA et dupliquer un acquis qui possède des épreuves et vérifier que sa version dupliquer continent bien des épreuves. 
