### PR TITLE
[FEATURE] Créé l'entité training sur le PG LCMS (PIX-5418)

### DIFF
--- a/api/adminbro/components/list.duration.component.jsx
+++ b/api/adminbro/components/list.duration.component.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Box } from '@admin-bro/design-system'
+import { useInterval } from './use-interval';
+
+const ShowInterval = (record) => {
+  const params = record.record.params;
+  const value = useInterval(params);
+
+  return (
+    <Box>
+      {value}
+    </Box>
+  )
+}
+
+export default ShowInterval;

--- a/api/adminbro/components/show.duration.component.jsx
+++ b/api/adminbro/components/show.duration.component.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Box, ValueGroup } from '@admin-bro/design-system'
+import { useInterval } from './use-interval';
+
+const ShowInterval = (record) => {
+  const params = record.record.params;
+  const value = useInterval(params);
+
+  return (
+    <Box>
+      <ValueGroup
+        label="Duration"
+        value={value}
+      />
+    </Box>
+  )
+}
+
+export default ShowInterval;

--- a/api/adminbro/components/use-interval.js
+++ b/api/adminbro/components/use-interval.js
@@ -1,0 +1,6 @@
+export function useInterval(params) {
+  const days = params['duration.days'] ? `${params['duration.days']}d ` : '';
+  const hours = params['duration.hours'] ? `${params['duration.hours']}h ` : '';
+  const minutes = params['duration.minutes'] ? `${params['duration.minutes']}m` : '';
+  return `${days}${hours}${minutes}`.trim();
+}

--- a/api/db/migrations/20220727085301_add-trainings-table.js
+++ b/api/db/migrations/20220727085301_add-trainings-table.js
@@ -1,0 +1,26 @@
+const TABLE_NAME = 'trainings';
+
+exports.up = (knex) => {
+
+  function table(t) {
+    t.increments().primary();
+    t.string('title').notNullable();
+    t.string('link').notNullable();
+    t.string('type').notNullable();
+    t.specificType('duration', 'interval').notNullable();
+    t.string('locale').notNullable();
+    t.specificType('targetProfileIds', 'int[]').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  }
+
+  return knex.schema
+    .createTable(TABLE_NAME, table);
+};
+
+exports.down = (knex) => {
+
+  return knex.schema
+    .dropTable(TABLE_NAME);
+};
+

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -17,9 +17,26 @@ exports.seed = (knex) => {
     apiKey: process.env.REVIEW_APP_EDITOR_USER_API_KEY || defaultEditorUserApiKey,
   });
 
+  databaseBuilder.factory.buildTraining({
+    title: 'Travail de groupe et collaboration entre les personnels',
+    link: 'https://magistere.education.fr/ac-normandie/enrol/index.php?id=5924',
+    type: 'autoformation',
+    duration: '06:00:00',
+    locale: 'fr-fr',
+    targetProfileIds: [1822, 2214],
+  });
+
+  databaseBuilder.factory.buildTraining({
+    title: 'Moodle : Partager et échanger ses ressources',
+    link: 'https://tube-strasbourg.beta.education.fr/videos/watch/7df08eb6-603e-46a8-9be3-a34092fe7e68',
+    type: 'webinaire',
+    duration: '01:00:00',
+    locale: 'fr-fr',
+    targetProfileIds: [1777],
+  });
+
   return databaseBuilder.commit();
 };
 
 const adminUserApiKey = !process.env.REVIEW_APP && '8d03a893-3967-4501-9dc4-e0aa6c6dc442';
 const defaultEditorUserApiKey = !process.env.REVIEW_APP && 'adaf3eee-09dc-4f9a-a504-ff92e74c9d0f';
-

--- a/api/lib/models/index.js
+++ b/api/lib/models/index.js
@@ -3,33 +3,71 @@ const { database } = require('../config');
 
 const sequelize = new Sequelize(database.url);
 
-const User = sequelize.define('user', {
-  name: {
-    type: DataTypes.STRING,
-    allowNull: false
+const User = sequelize.define(
+  'user',
+  {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    trigram: {
+      type: DataTypes.STRING,
+    },
+    access: {
+      type: DataTypes.STRING,
+    },
+    apiKey: {
+      type: DataTypes.UUIDV4,
+      allowNull: false,
+    },
   },
-  trigram: {
-    type: DataTypes.STRING
-  },
-  access : {
-    type: DataTypes.STRING
-  },
-  apiKey: {
-    type: DataTypes.UUIDV4,
-    allowNull: false
-  }
-}, {
-});
+  {}
+);
 
-const Release = sequelize.define('release', {
-  createdAt: {
-    type: DataTypes.DATE,
+const Release = sequelize.define(
+  'release',
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+    },
+  },
+  {
+    timestamps: false,
   }
-}, {
-  timestamps: false,
+);
+
+const Training = sequelize.define('training', {
+  title: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  link: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    validate: {
+      isUrl: true,
+    },
+  },
+  type: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  duration: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  locale: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  targetProfileIds: {
+    type: DataTypes.ARRAY(DataTypes.INTEGER),
+    allowNull: false,
+  },
 });
 
 module.exports = {
   User,
   Release,
+  Training,
 };

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -7,37 +7,74 @@ const Vision = require('@hapi/vision');
 const AdminBro = require('admin-bro');
 const AdminBroPlugin = require('@admin-bro/hapi');
 const AdminBroSequelize = require('@admin-bro/sequelize');
-const { User, Release } = require('./models');
+const { User, Release, Training } = require('./models');
 const { get } = require('lodash');
 const monitoringTools = require('./infrastructure/monitoring-tools');
 
 AdminBro.registerAdapter(AdminBroSequelize);
 
 const adminBroOptions = {
-  resources: [{
-    resource: User,
-    options: {
-      properties: {
-        access: {
-          availableValues: [
-            {
-              value: 'readonly',
-              label: 'Lecture seule'
-            },
-            {
-              value: 'editor',
-              label: 'Editeur'
-            },
-            {
-              value: 'admin',
-              label: 'Admin'
-            }
-          ],
+  resources: [
+    {
+      resource: User,
+      options: {
+        properties: {
+          access: {
+            availableValues: [
+              {
+                value: 'readonly',
+                label: 'Lecture seule',
+              },
+              {
+                value: 'editor',
+                label: 'Editeur',
+              },
+              {
+                value: 'admin',
+                label: 'Admin',
+              },
+            ],
+          },
         },
       },
     },
-  }, Release],
-  auth: { strategy: 'simple' }
+    Release,
+    {
+      resource: Training,
+      options: {
+        properties: {
+          locale: {
+            availableValues: [
+              {
+                value: 'fr-fr',
+                label: 'Franco Français',
+              },
+            ],
+          },
+          type: {
+            availableValues: [
+              {
+                value: 'autoformation',
+                label: 'Parcours d\'autoformation',
+              },
+              {
+                value: 'webinaire',
+                label: 'Webinaire',
+              },
+            ],
+          },
+          duration: {
+            props: { placeholder: '1d 10h 30m' },
+            components: {
+              show: AdminBro.bundle('../adminbro/components/show.duration.component.jsx'),
+              list: AdminBro.bundle('../adminbro/components/list.duration.component.jsx'),
+            },
+          },
+        },
+      },
+    },
+  ],
+  auth: { strategy: 'simple' },
 };
 
 function logObjectSerializer(obj) {
@@ -49,7 +86,7 @@ function logObjectSerializer(obj) {
       metrics: get(context, 'metrics'),
     };
   } else {
-    return { ... obj };
+    return { ...obj };
   }
 }
 
@@ -72,26 +109,26 @@ const plugins = [
     plugin: AdminBroPlugin,
     options: adminBroOptions,
   },
-  ...(settings.sentry.enabled ? [
-    {
-      plugin: require('hapi-sentry'),
-      options: {
-        client: {
-          dsn: settings.sentry.dsn,
-          environment: settings.sentry.environment,
-          release: `v${Pack.version}`,
-          maxBreadcrumbs: settings.sentry.maxBreadcrumbs,
-          debug: settings.sentry.debug,
-          maxValueLength: settings.sentry.maxValueLength,
-        },
-        scope: {
-          tags: [
-            { name: 'source', value: 'api' },
-          ],
+  ...(settings.sentry.enabled
+    ? [
+      {
+        plugin: require('hapi-sentry'),
+        options: {
+          client: {
+            dsn: settings.sentry.dsn,
+            environment: settings.sentry.environment,
+            release: `v${Pack.version}`,
+            maxBreadcrumbs: settings.sentry.maxBreadcrumbs,
+            debug: settings.sentry.debug,
+            maxValueLength: settings.sentry.maxValueLength,
+          },
+          scope: {
+            tags: [{ name: 'source', value: 'api' }],
+          },
         },
       },
-    },
-  ] : []),
+    ]
+    : []),
 ];
 
 module.exports = plugins;

--- a/api/tests/tooling/database-builder/factory/build-training.js
+++ b/api/tests/tooling/database-builder/factory/build-training.js
@@ -1,0 +1,30 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildTraining({
+  id,
+  title,
+  link,
+  type,
+  duration,
+  locale,
+  targetProfileIds,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+} = {}) {
+  const values = {
+    id,
+    title,
+    link,
+    type,
+    duration,
+    locale,
+    targetProfileIds,
+    createdAt,
+    updatedAt,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'trainings',
+    values,
+  });
+};

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   ...require('./build-user'),
   buildRelease: require('./build-release'),
+  buildTraining: require('./build-training'),
 };


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin de persister une nouvelle entité `training` pour donner accès à des contenus de formations sur Pix.

## :robot: Solution
Après échanges, nous avons souhaité expérimenter la création d'une nouvelle table sur le PostgreSQL LCMS. Les données de cette table sont accessibles en lecture et écriture via AdminBro.

## :rainbow: Remarques
- 2 exemples de trainings sont seedés au `db:reset`
- on a dû créer des composants JSX custom pour afficher correctement notre champ de type `interval` (champ `duration`)

## :100: Pour tester
Vérifier en RA que la table existe bien et est éditable via `/admin`.
