### PR TITLE
[FEATURE] Ajouter les formations à la release (PIX-5436).

### DIFF
--- a/api/lib/domain/models/Content.js
+++ b/api/lib/domain/models/Content.js
@@ -7,6 +7,7 @@ const Skill = require('./Skill');
 const Thematic = require('./Thematic');
 const Tube = require('./Tube');
 const Tutorial = require('./Tutorial');
+const Training = require('./Training');
 
 module.exports = class Content {
   constructor({
@@ -19,6 +20,7 @@ module.exports = class Content {
     thematics,
     tubes,
     tutorials,
+    trainings,
   } = {}) {
     this.areas = areas;
     this.challenges = challenges;
@@ -29,6 +31,7 @@ module.exports = class Content {
     this.thematics = thematics;
     this.tubes = tubes;
     this.tutorials = tutorials;
+    this.trainings = trainings;
   }
 
   static from({
@@ -41,6 +44,7 @@ module.exports = class Content {
     thematics,
     tubes,
     tutorials,
+    trainings,
   }) {
     const content = new Content();
     content.areas = areas ? areas.map((area) => new Area(area)) : [];
@@ -52,6 +56,7 @@ module.exports = class Content {
     content.thematics = thematics ? thematics.map((thematic) => new Thematic(thematic)) : [];
     content.tubes = tubes ? tubes.map((tube) => new Tube(tube)) : [];
     content.tutorials = tutorials ? tutorials.map((tutorial) => new Tutorial(tutorial)) : [];
+    content.trainings = trainings ? trainings.map((training) => new Training(training)) : [];
 
     return content;
   }

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -1,0 +1,23 @@
+module.exports = class Training {
+  constructor({
+    id,
+    title,
+    link,
+    type,
+    duration,
+    locale,
+    targetProfileIds,
+    createdAt,
+    updatedAt
+  } = {}) {
+    this.id = id;
+    this.title = title;
+    this.link = link;
+    this.type = type;
+    this.duration = duration;
+    this.locale = locale;
+    this.targetProfileIds = targetProfileIds;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+};

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -7,8 +7,6 @@ module.exports = class Training {
     duration,
     locale,
     targetProfileIds,
-    createdAt,
-    updatedAt
   } = {}) {
     this.id = id;
     this.title = title;
@@ -17,7 +15,5 @@ module.exports = class Training {
     this.duration = duration;
     this.locale = locale;
     this.targetProfileIds = targetProfileIds;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
 };

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -14,6 +14,7 @@ const competenceTransformer = require('../transformers/competence-transformer');
 const courseTransformer = require('../transformers/course-transformer');
 const skillTransformer = require('../transformers/skill-transformer');
 const tutorialTransformer = require('../transformers/tutorial-transformer');
+const trainingRepository = require('./training-repository');
 const Release = require('../../domain/models/Release');
 const Content = require('../../domain/models/Content');
 
@@ -104,6 +105,7 @@ async function _getCurrentContent() {
     thematics,
     tubes,
     tutorials,
+    trainings,
   ] = await Promise.all([
     areaDatasource.list(),
     attachmentDatasource.list(),
@@ -115,6 +117,7 @@ async function _getCurrentContent() {
     thematicDatasource.list(),
     tubeDatasource.list(),
     tutorialDatasource.list(),
+    trainingRepository.list(),
   ]);
   const learningContent = {
     areas,
@@ -146,5 +149,6 @@ async function _getCurrentContent() {
     thematics,
     tubes,
     tutorials: filteredTutorials,
+    trainings
   };
 }

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -1,0 +1,16 @@
+const { knex } = require('../../../db/knex-database-connection');
+const Training = require('../../domain/models/Training');
+
+async function list() {
+  const trainings = await knex('trainings').orderBy('id', 'asc');
+
+  return trainings.map(_toDomain);
+}
+
+function _toDomain(training) {
+  return new Training(training);
+}
+
+module.exports = {
+  list,
+};

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -20,7 +20,7 @@ describe('Integration | Repository | release-repository', function() {
 
     it('should return saved release with id and creation date', async function() {
       // Given
-      const currentContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] };
+      const currentContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [], trainings: [] };
       const fakeGetCurrentContent = async function() { return currentContent; };
 
       // When
@@ -36,7 +36,7 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getLatestRelease', function() {
     it('should return content of newest created release', async function() {
       // Given
-      const newestReleaseContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] };
+      const newestReleaseContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [], trainings: [] };
       const oldestReleaseContent = { some: 'old-property' };
 
       databaseBuilder.factory.buildRelease({ createdAt: '2021-01-01', content: newestReleaseContent });
@@ -55,7 +55,7 @@ describe('Integration | Repository | release-repository', function() {
     it('should return content of given release', async function() {
       // Given
       const otherReleaseContent = { some: 'property' };
-      const expectedReleaseContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [] };
+      const expectedReleaseContent = { areas: [], challenges: [], competences: [], courses: [], frameworks: [], skills: [], thematics: [], tubes: [], tutorials: [], trainings: [] };
 
       databaseBuilder.factory.buildRelease({ id: 11, createdAt: '2021-01-01', content: otherReleaseContent });
       databaseBuilder.factory.buildRelease({ id: 12, createdAt: '2020-01-01', content: expectedReleaseContent });

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -1,0 +1,55 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const trainingRepository = require('../../../../lib/infrastructure/repositories/training-repository');
+const Training = require('../../../../lib/domain/models/Training');
+
+describe('Integration | Repository | training-repository', function() {
+  describe('#list', () => {
+    let training1;
+    let training2;
+
+    beforeEach(async () => {
+      training1 = databaseBuilder.factory.buildTraining({
+        title: 'Travail de groupe et collaboration entre les personnels',
+        link: 'https://magistere.education.fr/ac-normandie/enrol/index.php?id=5924',
+        type: 'autoformation',
+        duration: '06:00:00',
+        locale: 'fr-fr',
+        targetProfileIds: [1822, 2214],
+      });
+
+      training2 = databaseBuilder.factory.buildTraining({
+        title: 'Moodle : Partager et échanger ses ressources',
+        link: 'https://tube-strasbourg.beta.education.fr/videos/watch/7df08eb6-603e-46a8-9be3-a34092fe7e68',
+        type: 'webinaire',
+        duration: '01:00:00',
+        locale: 'fr-fr',
+        targetProfileIds: [1777],
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should list all trainings', async () => {
+      // Given
+      training1.duration = { hours: 6 };
+      training2.duration = { hours: 1 };
+
+      const expectedTrainings = [new Training(training1), new Training(training2)];
+
+      // When
+      const trainings = await trainingRepository.list();
+
+      // Then
+      expect(trainings).to.have.length(2);
+      expect(trainings[0]).to.be.instanceOf(Training);
+      expect(trainings[0].id).to.equal(expectedTrainings[0].id);
+      expect(trainings[0].title).to.equal(expectedTrainings[0].title);
+      expect(trainings[0].link).to.equal(expectedTrainings[0].link);
+      expect(trainings[0].type).to.equal(expectedTrainings[0].type);
+      expect(trainings[0].duration.hours).to.equal(training1.duration.hours);
+      expect(trainings[0].locale).to.equal(expectedTrainings[0].locale);
+      expect(trainings[0].targetProfileIds).to.deep.equal(expectedTrainings[0].targetProfileIds);
+      expect(trainings[0].createdAt).to.deep.equal(expectedTrainings[0].createdAt);
+      expect(trainings[0].updatedAt).to.deep.equal(expectedTrainings[0].updatedAt);
+    });
+  });
+});

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -34,6 +34,7 @@ describe('Unit | Repository | release-repository', () => {
       const thematics = [];
       const tubes = [];
       const tutorials = [];
+      const trainings = [];
       const transformedCompetences = [Symbol('transformed-competence')];
       const transformedSkills = [Symbol('transformed-skill')];
       const transformedCourses = [Symbol('transformed-course')];
@@ -47,6 +48,7 @@ describe('Unit | Repository | release-repository', () => {
         skills: transformedSkills,
         thematics,
         tubes: [],
+        trainings,
         tutorials: transformedTutorials,
       };
 
@@ -239,8 +241,9 @@ describe('Unit | Repository | release-repository', () => {
           frameworks: [],
           skills: [],
           thematics: [],
+          trainings: [],
           tubes: [],
-          tutorials: []
+          tutorials: [],
         },
         createdAt: '2021-08-31'
       };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous avons ajouté une table comprénant les formations, cependant ces dernières ne sont pas encore ajoutés à la release et par conséquent ne sont pas disponible dans l'API principale.

## :robot: Solution
Ajouter les formations dans la release : 
- Un model a été ajouté
- Il s'agit de la première table hors Airtable présente dans la release.

## :rainbow: Remarques
Le format Interval nous a posé quelque soucis pour vérifier les équalités des objets dans les tests. 

## :100: Pour tester
- Créer des trainings via AdminBro
- Créer une release
- Récupérer la release et constater qu'elle contient la clé `trainings` et les formations créées. 
