### PR TITLE
[CLEANUP] Correction du badge circleci dans le readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/1024pix/pix/tree/dev.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/1024pix/pix) PIX EDITOR
+[![CircleCI](https://circleci.com/gh/1024pix/pix-editor/tree/dev.svg?style=shield)](https://circleci.com/gh/1024pix/pix-editor) PIX EDITOR
 ===
 
 Présentation


### PR DESCRIPTION
## :unicorn: Problème
Le lien vers circle ci et le status pointe sur le dépot pix, plutôt que pix-editor.

## :robot: Solution
Changer vers pix-editor.

## :100: Pour tester
- Cliquer sur le lien et voir le badge.
