### PR TITLE
[CLEANUP] Met à jour l'action d'auto merge commune

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,19 +1,21 @@
 name: automerge check
+
 on:
   pull_request:
     types:
       - labeled
-  pull_request_review:
-    types:
-      - submitted
+      - unlabeled
   check_suite:
     types:
       - completed
   status:
+    types:
+      - success
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: 1024pix/pix-actions/auto-merge@v0.1.3
+      - uses: 1024pix/pix-actions/auto-merge@v0
         with:
-          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
+          auto_merge_token: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"


### PR DESCRIPTION
## :unicorn: Problème
Nous utilisons une version spécifique de l'action d'automerge et les trigger sont différents de ceux documentés.

## :robot: Solution
Utiliser la v0 et utiliser le template du dépot pix-actions.