### PR TITLE
[FEATURE] Ajout d'un nouveau rôle pour limiter l’accès au référentiel pix (PIX-5618).

### DIFF
--- a/api/.adminbro/.entry.js
+++ b/api/.adminbro/.entry.js
@@ -1,0 +1,1 @@
+AdminBro.UserComponents = {}

--- a/api/db/migrations/20220906082935_add-read-pix-only-role.js
+++ b/api/db/migrations/20220906082935_add-read-pix-only-role.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'users';
+
+exports.up = function(knex) {
+  return knex.schema.raw(`
+    ALTER TABLE "users"
+    DROP CONSTRAINT "users_access_check",
+    ADD CONSTRAINT "users_access_check"
+    CHECK (access IN ('readpixonly', 'readonly', 'replicator', 'editor', 'admin'))
+  `);
+};
+
+exports.down = async function(knex) {
+  await knex(TABLE_NAME).update({
+    access: 'readonly'
+  }).where('access', 'readpixonly');
+
+  return knex.schema.raw(`
+    ALTER TABLE "users"
+    DROP CONSTRAINT "users_access_check",
+    ADD CONSTRAINT "users_access_check"
+    CHECK (access IN ('readonly', 'replicator', 'editor', 'admin'))
+  `);
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -7,7 +7,7 @@ exports.seed = (knex) => {
     trigram: 'DEV',
     name: 'Utilisateur pour le développement',
     access: 'admin',
-    apiKey: process.env.REVIEW_APP_USER_API_KEY || adminUserApiKey,
+    apiKey: process.env.REVIEW_APP_ADMIN_USER_API_KEY || adminUserApiKey,
   });
 
   databaseBuilder.factory.buildUser({
@@ -15,6 +15,13 @@ exports.seed = (knex) => {
     name: 'Editeur pour le développement',
     access: 'editor',
     apiKey: process.env.REVIEW_APP_EDITOR_USER_API_KEY || defaultEditorUserApiKey,
+  });
+
+  databaseBuilder.factory.buildUser({
+    trigram: 'RPO',
+    name: 'Lecteur pix pour le développement',
+    access: 'readpixonly',
+    apiKey: process.env.REVIEW_APP_READ_PIX_ONLY_USER_API_KEY || readPixOnlyUserApiKey,
   });
 
   databaseBuilder.factory.buildTraining({
@@ -58,3 +65,4 @@ exports.seed = (knex) => {
 
 const adminUserApiKey = !process.env.REVIEW_APP && '8d03a893-3967-4501-9dc4-e0aa6c6dc442';
 const defaultEditorUserApiKey = !process.env.REVIEW_APP && 'adaf3eee-09dc-4f9a-a504-ff92e74c9d0f';
+const readPixOnlyUserApiKey = !process.env.REVIEW_APP && '09ae36c4-11e1-4212-ae51-e5719d142f57';

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "db:prepare": "npm run db:delete && npm run db:create && npm run db:migrate",
     "db:seed": "knex --knexfile db/knexfile.js seed:run",
     "db:reset": "npm run db:prepare && npm run db:seed",
+    "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
     "lint": "eslint lib tests",
     "lint:fix": "eslint lib tests --fix",
     "preinstall": "npx check-engine",

--- a/pix-editor/app/components/sidebar/navigation.hbs
+++ b/pix-editor/app/components/sidebar/navigation.hbs
@@ -1,4 +1,6 @@
-<Field::Select data-test-frameworks-select id="select-framework" @value={{this.selectedFramework}} @options={{this.frameworkList}} @setValue={{this.setFramework}} @edition={{true}}/>
+{{#if this.mayShowFrameworkList}}
+  <Field::Select data-test-frameworks-select id="select-framework" @value={{this.selectedFramework}} @options={{this.frameworkList}} @setValue={{this.setFramework}} @edition={{true}}/>
+{{/if}}
 <AccordionList as |accordion|>
     {{#each this.areas as |area|}}
       <accordion.item as |accordionItem|>

--- a/pix-editor/app/components/sidebar/navigation.js
+++ b/pix-editor/app/components/sidebar/navigation.js
@@ -55,6 +55,10 @@ export default class SidebarNavigationComponent extends Component {
     return frameworkList;
   }
 
+  get mayShowFrameworkList() {
+    return this.access.isReadOnly();
+  }
+
   get mayCreateCompetence() {
     return this.access.isAdmin() && !this.currentData.isPixFramework;
   }

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -1,5 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 
+const READ_PIX_ONLY = 0;
 const READ_ONLY = 1;
 const REPLICATOR = 2;
 const EDITOR = 3;
@@ -152,6 +153,11 @@ export default class AccessService extends Service {
     return this.isAdmin() && challenge.isPrototype && challenge.isDraft;
   }
 
+  isReadOnly() {
+    const level = this.config.accessLevel;
+    return level >= READ_ONLY;
+  }
+
   isReplicator() {
     const level = this.config.accessLevel;
     return (level >= REPLICATOR);
@@ -169,6 +175,8 @@ export default class AccessService extends Service {
 
   getLevel(accessString) {
     switch (accessString) {
+      case 'readpixonly' :
+        return READ_PIX_ONLY;
       case 'readonly':
         return READ_ONLY;
       case 'replicator':

--- a/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
+++ b/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { mockAuthService } from '../mock-auth';
+
+module('Acceptance | Navigate through frameworks', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  let apiKey;
+  hooks.beforeEach(function () {
+    this.owner.lookup('service:store');
+    this.server.create('config', 'default');
+    apiKey = 'valid-api-key';
+    mockAuthService.call(this, apiKey);
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
+  });
+
+  for (const role of ['readonly', 'replicator', 'editor', 'admin']) {
+    module(`when user is ${role}`, function(hooks) {
+      hooks.beforeEach(function () {
+        this.server.create('user', { apiKey, trigram: 'ABC', access: role, });
+      });
+      test('it should display select framework', async function (assert) {
+        // when
+        await visit('/');
+
+        // then
+        assert.dom('[data-test-frameworks-select]').exists();
+      });
+    });
+  }
+
+  module('when user is `readpixonly`', function(hooks) {
+    hooks.beforeEach(function () {
+      this.server.create('user', { apiKey, trigram: 'ABC', access: 'readpixonly', });
+    });
+    test('it should not have access to framework list', async function (assert) {
+      // when
+      await visit('/');
+
+      // then
+      assert.dom('[data-test-frameworks-select]').doesNotExist();
+    });
+  });
+});

--- a/pix-editor/tests/integration/components/sidebar/navigation-test.js
+++ b/pix-editor/tests/integration/components/sidebar/navigation-test.js
@@ -57,6 +57,9 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
         }
       });
       this.owner.register('service:access', class MockService extends Service {
+        isReadOnly() {
+          return true;
+        }
         isAdmin() {
           return true;
         }


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons limiter l’accès au référentiel PIX pour certains utilisateurs.

## :robot: Solution
Ajouter un nouveau rôle `readpixonly` limitant l’accès au seul référentiel PIX.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter avec le nouveau rôle `readpixonly` et constater que l'on ne peut pas changer de référentiel et donc que l'on est limité à celui de PIX.
