### PR TITLE
[FEATURE] Ne pas afficher le générateur de profile cible pour les utilisateur `READ_PIX_ONLY` (PIX-5671).

### DIFF
--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -2,9 +2,9 @@
   <h1 class="header">Pix Editor</h1>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
   <Sidebar::Search @close={{@close}} />
-  <Sidebar::Navigation @areas={{this.areas}} @close={{@close}}/>
+  <Sidebar::Navigation @mayShowFrameworkList={{this.mayGenerateTargetProfile}} @areas={{this.areas}} @close={{@close}}/>
   <div class="secondary-links">
-    {{#if this.mayShowFrameworkList}}
+    {{#if this.mayGenerateTargetProfile}}
       <LinkTo data-test-target-profile-link @route="target-profile" {{on "click" @close}}>
         <i class="crosshairs icon"></i> Générateur de profil cible
       </LinkTo>

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -4,9 +4,11 @@
   <Sidebar::Search @close={{@close}} />
   <Sidebar::Navigation @areas={{this.areas}} @close={{@close}}/>
   <div class="secondary-links">
-    <LinkTo @route="target-profile" {{on "click" @close}}>
-      <i class="crosshairs icon"></i> Générateur de profil cible
-    </LinkTo>
+    {{#if this.mayShowFrameworkList}}
+      <LinkTo data-test-target-profile-link @route="target-profile" {{on "click" @close}}>
+        <i class="crosshairs icon"></i> Générateur de profil cible
+      </LinkTo>
+    {{/if}}
     <Sidebar::Export @areas={{this.areas}}/>
     <LinkTo @route="statistics" {{on "click" @close}}>
       <i class="chart bar icon"></i> Statistiques

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -17,7 +17,7 @@ export default class SidebarMain extends Component {
     return this.currentData.getAreas();
   }
 
-  get mayShowFrameworkList() {
+  get mayGenerateTargetProfile() {
     return this.access.isReadOnly();
   }
 }

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -5,6 +5,7 @@ import ENV from 'pixeditor/config/environment';
 export default class SidebarMain extends Component {
   version = ENV.APP.version;
 
+  @service access;
   @service config;
   @service currentData;
 
@@ -16,4 +17,7 @@ export default class SidebarMain extends Component {
     return this.currentData.getAreas();
   }
 
+  get mayShowFrameworkList() {
+    return this.access.isReadOnly();
+  }
 }

--- a/pix-editor/app/components/sidebar/navigation.hbs
+++ b/pix-editor/app/components/sidebar/navigation.hbs
@@ -1,4 +1,4 @@
-{{#if this.mayShowFrameworkList}}
+{{#if @mayShowFrameworkList}}
   <Field::Select data-test-frameworks-select id="select-framework" @value={{this.selectedFramework}} @options={{this.frameworkList}} @setValue={{this.setFramework}} @edition={{true}}/>
 {{/if}}
 <AccordionList as |accordion|>

--- a/pix-editor/app/components/sidebar/navigation.js
+++ b/pix-editor/app/components/sidebar/navigation.js
@@ -55,10 +55,6 @@ export default class SidebarNavigationComponent extends Component {
     return frameworkList;
   }
 
-  get mayShowFrameworkList() {
-    return this.access.isReadOnly();
-  }
-
   get mayCreateCompetence() {
     return this.access.isAdmin() && !this.currentData.isPixFramework;
   }

--- a/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
+++ b/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
@@ -18,29 +18,43 @@ module('Acceptance | Navigate through frameworks', function(hooks) {
 
   for (const role of ['readonly', 'replicator', 'editor', 'admin']) {
     module(`when user is ${role}`, function(hooks) {
-      hooks.beforeEach(function () {
+      hooks.beforeEach(async function () {
+        //given
         this.server.create('user', { apiKey, trigram: 'ABC', access: role, });
-      });
-      test('it should display select framework', async function (assert) {
-        // when
-        await visit('/');
 
+        //when
+        await visit('/');
+      });
+
+      test('it should display select framework', async function (assert) {
         // then
         assert.dom('[data-test-frameworks-select]').exists();
+      });
+
+      test('it should display generator target profile link', async function (assert) {
+        // then
+        assert.dom('[data-test-target-profile-link]').exists();
       });
     });
   }
 
   module('when user is `readpixonly`', function(hooks) {
-    hooks.beforeEach(function () {
+    hooks.beforeEach(async function () {
+      //given
       this.server.create('user', { apiKey, trigram: 'ABC', access: 'readpixonly', });
-    });
-    test('it should not have access to framework list', async function (assert) {
+
       // when
       await visit('/');
+    });
 
+    test('it should not have access to framework list', async function (assert) {
       // then
       assert.dom('[data-test-frameworks-select]').doesNotExist();
+    });
+
+    test('it should not display generator target profile link', async function (assert) {
+      // then
+      assert.dom('[data-test-target-profile-link]').doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/integration/components/sidebar/navigation-test.js
+++ b/pix-editor/tests/integration/components/sidebar/navigation-test.js
@@ -12,6 +12,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
 
     hooks.beforeEach(function () {
       this.closeAction = sinon.stub();
+      this.mayShowFrameworkList = sinon.stub().returns(true);
 
       areas = [{
         name: 'area_1',
@@ -57,9 +58,6 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
         }
       });
       this.owner.register('service:access', class MockService extends Service {
-        isReadOnly() {
-          return true;
-        }
         isAdmin() {
           return true;
         }
@@ -72,7 +70,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       const expectedFrameworks = ['Pix', 'Pix +', 'Créer un nouveau référentiel'];
 
       // when
-      await render(hbs`<Sidebar::Navigation @close={{this.closeAction}}/>`);
+      await render(hbs`<Sidebar::Navigation @mayShowFrameworkList={{this.mayShowFrameworkList}} @close={{this.closeAction}}/>`);
 
       await click('[data-test-frameworks-select] .ember-basic-dropdown-trigger');
 


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons limité l’accès au générateur de profile cible pour les utilisateurs qui ont le rôle `READ_PIX_ONLY`.

## :robot: Solution
Ne pas afficher le lien du générateur de profile cible pour les utilisateurs qui ont le rôle `READ_PIX_ONLY`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur la page index en se connectant avec le rôle `READ_PIX_ONLY` et vérifier que l'on a pas accès au  lien du générateur de profile cible.