### PR TITLE
[TECH] Mise a jour caniuse-lite (PIX-5719).

### DIFF
--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -8830,9 +8830,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001309",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
-      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
+      "version": "1.0.30001399",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
+      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
       "dev": true
     },
     "canvg": {


### PR DESCRIPTION
## :unicorn: Problème
caniuse-lite n'est pas jour et émet du bruit dans les logs

## :robot: Solution
le mettre a jour avec la commande: `npx browserslist@latest --update-db`

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Lancer pix-editor et constater l'absence de logs concernant browserlist
