### PR TITLE
[FEATURE] Ne pas afficher le champ de recherche pour les utilisateurs `READ_PIX_ONLY` (PIX-5819). 

### DIFF
--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -1,7 +1,7 @@
 <div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite" ""}}">
   <h1 class="header">Pix Editor</h1>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
-  <Sidebar::Search @close={{@close}} />
+  <Sidebar::Search @mayShowFrameworkList={{this.mayGenerateTargetProfile}} @close={{@close}} />
   <Sidebar::Navigation @mayShowFrameworkList={{this.mayGenerateTargetProfile}} @areas={{this.areas}} @close={{@close}}/>
   <div class="secondary-links">
     {{#if this.mayGenerateTargetProfile}}

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -1,8 +1,8 @@
 <div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite" ""}}">
   <h1 class="header">Pix Editor</h1>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
-  <Sidebar::Search @mayShowSearch={{this.mayGenerateTargetProfile}} @close={{@close}} />
-  <Sidebar::Navigation @mayShowFrameworkList={{this.mayGenerateTargetProfile}} @areas={{this.areas}} @close={{@close}}/>
+  <Sidebar::Search @displaySearch={{this.maySearch}} @close={{@close}} />
+  <Sidebar::Navigation @displayFrameworkList={{this.maySwitchFramework}} @areas={{this.areas}} @close={{@close}}/>
   <div class="secondary-links">
     {{#if this.mayGenerateTargetProfile}}
       <LinkTo data-test-target-profile-link @route="target-profile" {{on "click" @close}}>

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -1,7 +1,7 @@
 <div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite" ""}}">
   <h1 class="header">Pix Editor</h1>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
-  <Sidebar::Search @mayShowFrameworkList={{this.mayGenerateTargetProfile}} @close={{@close}} />
+  <Sidebar::Search @mayShowSearch={{this.mayGenerateTargetProfile}} @close={{@close}} />
   <Sidebar::Navigation @mayShowFrameworkList={{this.mayGenerateTargetProfile}} @areas={{this.areas}} @close={{@close}}/>
   <div class="secondary-links">
     {{#if this.mayGenerateTargetProfile}}

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -20,4 +20,12 @@ export default class SidebarMain extends Component {
   get mayGenerateTargetProfile() {
     return this.access.isReadOnly();
   }
+
+  get maySwitchFramework() {
+    return this.access.isReadOnly();
+  }
+
+  get maySearch() {
+    return this.access.isReadOnly();
+  }
 }

--- a/pix-editor/app/components/sidebar/navigation.hbs
+++ b/pix-editor/app/components/sidebar/navigation.hbs
@@ -1,4 +1,4 @@
-{{#if @mayShowFrameworkList}}
+{{#if @displayFrameworkList}}
   <Field::Select data-test-frameworks-select id="select-framework" @value={{this.selectedFramework}} @options={{this.frameworkList}} @setValue={{this.setFramework}} @edition={{true}}/>
 {{/if}}
 <AccordionList as |accordion|>

--- a/pix-editor/app/components/sidebar/search.hbs
+++ b/pix-editor/app/components/sidebar/search.hbs
@@ -1,4 +1,4 @@
-{{#if @mayShowSearch}}
+{{#if @displaySearch}}
   <div data-test-sidebar-search class="sidebar-search">
     <PowerSelect
       @searchEnabled={{true}}

--- a/pix-editor/app/components/sidebar/search.hbs
+++ b/pix-editor/app/components/sidebar/search.hbs
@@ -1,3 +1,4 @@
+{{#if @mayShowFrameworkList}}
   <div data-test-sidebar-search class="sidebar-search">
     <PowerSelect
       @searchEnabled={{true}}
@@ -17,3 +18,4 @@
       {{/if}}
     </PowerSelect>
   </div>
+{{/if}}

--- a/pix-editor/app/components/sidebar/search.hbs
+++ b/pix-editor/app/components/sidebar/search.hbs
@@ -1,4 +1,4 @@
-{{#if @mayShowFrameworkList}}
+{{#if @mayShowSearch}}
   <div data-test-sidebar-search class="sidebar-search">
     <PowerSelect
       @searchEnabled={{true}}

--- a/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
+++ b/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
@@ -35,6 +35,11 @@ module('Acceptance | Navigate through frameworks', function(hooks) {
         // then
         assert.dom('[data-test-target-profile-link]').exists();
       });
+
+      test('it should display search bar', function(assert) {
+        // then
+        assert.dom('[data-test-sidebar-search]').exists();
+      });
     });
   }
 
@@ -55,6 +60,11 @@ module('Acceptance | Navigate through frameworks', function(hooks) {
     test('it should not display generator target profile link', async function (assert) {
       // then
       assert.dom('[data-test-target-profile-link]').doesNotExist();
+    });
+
+    test('it should not display search bar', function(assert) {
+      // then
+      assert.dom('[data-test-sidebar-search]').doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/integration/components/sidebar/navigation-test.js
+++ b/pix-editor/tests/integration/components/sidebar/navigation-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
 
     hooks.beforeEach(function () {
       this.closeAction = sinon.stub();
-      this.mayShowFrameworkList = sinon.stub().returns(true);
+      this.displayFrameworkList = sinon.stub().returns(true);
 
       areas = [{
         name: 'area_1',
@@ -70,7 +70,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       const expectedFrameworks = ['Pix', 'Pix +', 'Créer un nouveau référentiel'];
 
       // when
-      await render(hbs`<Sidebar::Navigation @mayShowFrameworkList={{this.mayShowFrameworkList}} @close={{this.closeAction}}/>`);
+      await render(hbs`<Sidebar::Navigation @displayFrameworkList={{this.displayFrameworkList}} @close={{this.closeAction}}/>`);
 
       await click('[data-test-frameworks-select] .ember-basic-dropdown-trigger');
 

--- a/pix-editor/tests/integration/components/sidebar/search-test.js
+++ b/pix-editor/tests/integration/components/sidebar/search-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | sidebar/search', function(hooks) {
   setupRenderingTest(hooks);
@@ -9,8 +10,9 @@ module('Integration | Component | sidebar/search', function(hooks) {
   test('it renders', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
+    this.mayShowFrameworkList = sinon.stub().returns(true);
 
-    await render(hbs`<Sidebar::Search />`);
+    await render(hbs`<Sidebar::Search @mayShowFrameworkList={{this.mayShowFrameworkList}} />`);
 
     assert.dom('.sidebar-search').exists();
   });

--- a/pix-editor/tests/integration/components/sidebar/search-test.js
+++ b/pix-editor/tests/integration/components/sidebar/search-test.js
@@ -8,12 +8,13 @@ module('Integration | Component | sidebar/search', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-    this.mayShowFrameworkList = sinon.stub().returns(true);
+    // given
+    this.mayShowSearch = sinon.stub().returns(true);
 
-    await render(hbs`<Sidebar::Search @mayShowFrameworkList={{this.mayShowFrameworkList}} />`);
+    // when
+    await render(hbs`<Sidebar::Search @mayShowSearch={{this.mayShowSearch}} />`);
 
+    // then
     assert.dom('.sidebar-search').exists();
   });
 });

--- a/pix-editor/tests/integration/components/sidebar/search-test.js
+++ b/pix-editor/tests/integration/components/sidebar/search-test.js
@@ -9,10 +9,10 @@ module('Integration | Component | sidebar/search', function(hooks) {
 
   test('it renders', async function(assert) {
     // given
-    this.mayShowSearch = sinon.stub().returns(true);
+    this.maySearch = sinon.stub().returns(true);
 
     // when
-    await render(hbs`<Sidebar::Search @mayShowSearch={{this.mayShowSearch}} />`);
+    await render(hbs`<Sidebar::Search @displaySearch={{this.maySearch}} />`);
 
     // then
     assert.dom('.sidebar-search').exists();


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons limiter l’accès hors référentiel coeur pour les utilisateurs ayant le rôle READ_PIX_ONLY.

## :robot: Solution
Ne pas afficher le champ de recherche pour les utilisateurs READ_PIX_ONLY.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur la page index en se connectant avec le rôle READ_PIX_ONLY et vérifier que le champ de recherche n'apparaît pas.
