### PR TITLE
[BUGFIX] Améliorer le libellé indiquant la présence d'une alternative textuelle sur les illustrations dans une épreuve

### DIFF
--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -1,173 +1,188 @@
 <form action="" class="ui form">
-  <Field::Mde @title="Consigne"
-              @value={{@challenge.instruction}}
-              @edition={{@edition}}
-              @helpContent={{this.helpInstructions}}
-              @setValue={{fn (mut @challenge.instruction)}}/>
-  <Field::ToggleField @edition={{@edition}}
-                      @model={{@challenge}}
-                      @modelField="alternativeInstruction"
-                      @hideTextButton="Supprimer la consigne alternative"
-                      @displayTextButton="Ajouter une consigne alternative"
-                      @confirmText="la consigne alternative"
-                      @displayField={{@displayAlternativeInstructionsField}}
-                      @setDisplayField={{@setDisplayAlternativeInstructionsField}}>
-    <Field::Mde @title="Consigne alternative"
-                @value={{@challenge.alternativeInstruction}}
-                @edition={{@edition}}
-                @helpContent={{this.helpInstructions}}
-                @setValue={{fn (mut @challenge.alternativeInstruction)}}
-                data-test-alternative-instructions-field />
+  <Field::Mde
+    @title="Consigne"
+    @value={{@challenge.instruction}}
+    @edition={{@edition}}
+    @helpContent={{this.helpInstructions}}
+    @setValue={{fn (mut @challenge.instruction)}}
+  />
+  <Field::ToggleField
+    @edition={{@edition}}
+    @model={{@challenge}}
+    @modelField="alternativeInstruction"
+    @hideTextButton="Supprimer l'alternative textuelle"
+    @displayTextButton="Ajouter une alternative textuelle"
+    @confirmText="l'alternative textuelle"
+    @displayField={{@displayAlternativeInstructionsField}}
+    @setDisplayField={{@setDisplayAlternativeInstructionsField}}
+  >
+    <Field::Mde
+      @title="Alternative textuelle"
+      @value={{@challenge.alternativeInstruction}}
+      @edition={{@edition}}
+      @helpContent={{this.helpInstructions}}
+      @setValue={{fn (mut @challenge.alternativeInstruction)}}
+      data-test-alternative-instructions-field
+    />
   </Field::ToggleField>
   {{#if @challenge.isPrototype}}
-    <Field::Select @title="Type"
-                   @value={{this.challengeTypeValue}}
-                   @options={{this.options.types}}
-                   @edition={{@edition}}
-                   @setValue={{this.setChallengeType}} />
+    <Field::Select
+      @title="Type"
+      @value={{this.challengeTypeValue}}
+      @options={{this.options.types}}
+      @edition={{@edition}}
+      @setValue={{this.setChallengeType}}
+    />
   {{/if}}
   {{#if (and this.typeIsQROCOrQROCMInd (not this.isAutoReply))}}
-    <Field::Select @title="Format QROC"
-                   @value={{@challenge.format}}
-                   @defaultText="Mots"
-                   @options={{this.options.format}}
-                   @edition={{@edition}}
-                   @setValue={{fn (mut @challenge.format)}}
-                   data-test-format-field />
+    <Field::Select
+      @title="Format QROC"
+      @value={{@challenge.format}}
+      @defaultText="Mots"
+      @options={{this.options.format}}
+      @edition={{@edition}}
+      @setValue={{fn (mut @challenge.format)}}
+      data-test-format-field
+    />
   {{/if}}
   {{#unless this.isAutoReply}}
-    <Field::Mde @title="Propositions"
-                @value={{@challenge.proposals}}
-                @setValue={{fn (mut @challenge.proposals)}}
-                @edition={{@edition}}
-                @helpContent={{this.helpSuggestions}}
-                data-test-suggestion-field />
+    <Field::Mde
+      @title="Propositions"
+      @value={{@challenge.proposals}}
+      @setValue={{fn (mut @challenge.proposals)}}
+      @edition={{@edition}}
+      @helpContent={{this.helpSuggestions}}
+      data-test-suggestion-field
+    />
   {{/unless}}
-  <Field::Textarea @title="Réponses"
-                   @value={{@challenge.solution}}
-                   @edition={{@edition}}
-                   @helpContent={{this.helpAnswers}}
-                   data-test-answers-field />
+  <Field::Textarea
+    @title="Réponses"
+    @value={{@challenge.solution}}
+    @edition={{@edition}}
+    @helpContent={{this.helpAnswers}}
+    data-test-answers-field
+  />
   {{#if (and @challenge.isTextBased (not this.isAutoReply))}}
-      <div id="toleranceField" data-test-tolerence-fields class="field {{if @edition "" "disabled"}}">
-          <label>Tolérance</label>
-          <div class="three fields">
-              <div class="field">
-                <Field::Checkbox @label="T1 (espaces/casse/accents)"
-                                 @checked={{@challenge.t1Status}}
-                                 @disabled={{not @edition}} />
-              </div>
-              <div class="field">
-                <Field::Checkbox @label="T2 (ponctuation)"
-                                 @checked={{@challenge.t2Status}}
-                                 @disabled={{not @edition}} />
-              </div>
-              <div class="field">
-                <Field::Checkbox @label="T3 (distance d'édition)"
-                                 @checked={{@challenge.t3Status}}
-                                 @disabled={{not @edition}} />
-              </div>
-          </div>
+    <div id="toleranceField" data-test-tolerence-fields class="field {{if @edition '' 'disabled'}}">
+      <label>Tolérance</label>
+      <div class="three fields">
+        <div class="field">
+          <Field::Checkbox
+            @label="T1 (espaces/casse/accents)"
+            @checked={{@challenge.t1Status}}
+            @disabled={{not @edition}}
+          />
+        </div>
+        <div class="field">
+          <Field::Checkbox @label="T2 (ponctuation)" @checked={{@challenge.t2Status}} @disabled={{not @edition}} />
+        </div>
+        <div class="field">
+          <Field::Checkbox
+            @label="T3 (distance d'édition)"
+            @checked={{@challenge.t3Status}}
+            @disabled={{not @edition}}
+          />
+        </div>
       </div>
+    </div>
   {{/if}}
-  <Field::ToggleField @edition={{@edition}}
-                      @model={{@challenge}}
-                      @modelField="solutionToDisplay"
-                      @hideTextButton="Supprimer la bonne réponse à afficher"
-                      @displayTextButton="Ajouter une bonne réponse à afficher"
-                      @confirmText="la bonne réponse à afficher"
-                      @displayField={{@displaySolutionToDisplayField}}
-                      @setDisplayField={{@setDisplaySolutionToDisplayField}}>
-    <Field::Textarea @title="Bonne réponse à afficher"
-                     @value={{@challenge.solutionToDisplay}}
-                     @edition={{@edition}}
-                     data-test-solution-to-display-field />
+  <Field::ToggleField
+    @edition={{@edition}}
+    @model={{@challenge}}
+    @modelField="solutionToDisplay"
+    @hideTextButton="Supprimer la bonne réponse à afficher"
+    @displayTextButton="Ajouter une bonne réponse à afficher"
+    @confirmText="la bonne réponse à afficher"
+    @displayField={{@displaySolutionToDisplayField}}
+    @setDisplayField={{@setDisplaySolutionToDisplayField}}
+  >
+    <Field::Textarea
+      @title="Bonne réponse à afficher"
+      @value={{@challenge.solutionToDisplay}}
+      @edition={{@edition}}
+      data-test-solution-to-display-field
+    />
   </Field::ToggleField>
-  <Field::Illustration @title="Illustration"
-                       @value={{@challenge.illustration}}
-                       @edition={{@edition}}
-                       @addIllustration={{this.addIllustration}}
-                       @removeIllustration={{this.removeIllustration}}
-                       @display={{@showIllustration}}
-                       data-test-file-input-illustration />
+  <Field::Illustration
+    @title="Illustration"
+    @value={{@challenge.illustration}}
+    @edition={{@edition}}
+    @addIllustration={{this.addIllustration}}
+    @removeIllustration={{this.removeIllustration}}
+    @display={{@showIllustration}}
+    data-test-file-input-illustration
+  />
   {{#if @challenge.illustration}}
-    <Field::Textarea @value={{@challenge.illustration.alt}}
-                     @title="Texte alternatif"
-                     @edition={{@edition}} />
+    <Field::Textarea @value={{@challenge.illustration.alt}} @title="Texte alternatif" @edition={{@edition}} />
   {{/if}}
-  <Field::Files @title="Pièces jointes"
-                @value={{@challenge.attachments}}
-                @baseName={{@challenge.attachmentBaseName}}
-                @addAttachment={{this.addAttachment}}
-                @edition={{@edition}}
-                @removeAttachment={{this.removeAttachment}}
-                data-test-file-input-attachment />
-  <Field::Input @title="Embed"
-                @value={{@challenge.embedURL}}
-                @edition={{@edition}}
-                @label="URL" />
-  <Field::Input @value={{@challenge.embedHeight}}
-                @edition={{@edition}}
-                @label="Hauteur" />
-  <Field::Input @value={{@challenge.embedTitle}}
-                @edition={{@edition}}
-                @label="Titre" />
+  <Field::Files
+    @title="Pièces jointes"
+    @value={{@challenge.attachments}}
+    @baseName={{@challenge.attachmentBaseName}}
+    @addAttachment={{this.addAttachment}}
+    @edition={{@edition}}
+    @removeAttachment={{this.removeAttachment}}
+    data-test-file-input-attachment
+  />
+  <Field::Input @title="Embed" @value={{@challenge.embedURL}} @edition={{@edition}} @label="URL" />
+  <Field::Input @value={{@challenge.embedHeight}} @edition={{@edition}} @label="Hauteur" />
+  <Field::Input @value={{@challenge.embedTitle}} @edition={{@edition}} @label="Titre" />
   {{#if @challenge.isPrototype}}
-    <Field::Select @title="Type pédagogie"
-                   @value={{@challenge.pedagogy}}
-                   @options={{this.options.pedagogy}}
-                   @edition={{@edition}}
-                   @setValue={{fn (mut @challenge.pedagogy)}}/>
+    <Field::Select
+      @title="Type pédagogie"
+      @value={{@challenge.pedagogy}}
+      @options={{this.options.pedagogy}}
+      @edition={{@edition}}
+      @setValue={{fn (mut @challenge.pedagogy)}}
+    />
   {{/if}}
   {{#if @challenge.isPrototype}}
-    <Field::Select @title="Déclinable"
-                   @value={{@challenge.declinable}}
-                   @options={{this.options.declinable}}
-                   @edition={{@edition}}
-                   @setValue={{fn (mut @challenge.declinable)}}/>
+    <Field::Select
+      @title="Déclinable"
+      @value={{@challenge.declinable}}
+      @options={{this.options.declinable}}
+      @edition={{@edition}}
+      @setValue={{fn (mut @challenge.declinable)}}
+    />
   {{/if}}
-  <div class="field {{if @edition "" "disabled"}}">
-      <Field::Checkbox @label="Timer"
-                       @checked={{@challenge.timerOn}}
-                       @disabled={{not @edition}} />
+  <div class="field {{if @edition '' 'disabled'}}">
+    <Field::Checkbox @label="Timer" @checked={{@challenge.timerOn}} @disabled={{not @edition}} />
     {{#if @challenge.timer}}
-      <Field::Input @value={{@challenge.timer}}
-                    @edition={{@edition}} />
+      <Field::Input @value={{@challenge.timer}} @edition={{@edition}} />
     {{/if}}
   </div>
-  <div class="field {{if @edition "" "disabled"}}">
-      <Field::Checkbox @label="Focus"
-                       @checked={{@challenge.focusable}}
-                       @disabled={{not @edition}} />
+  <div class="field {{if @edition '' 'disabled'}}">
+    <Field::Checkbox @label="Focus" @checked={{@challenge.focusable}} @disabled={{not @edition}} />
   </div>
   {{#if @challenge.isDraft}}
-      <Field::Quality @edition={{@edition}}
-                      @challenge={{@challenge}}/>
+    <Field::Quality @edition={{@edition}} @challenge={{@challenge}} />
   {{/if}}
-  <div class="field {{if @edition "" "disabled"}}">
-      <label>Internationalisation</label>
-      <div class="two fields">
-          <div class="field">
-            <Field::Select @title="Langue(s)"
-                           @value={{this.languages}}
-                           @edition={{@edition}}
-                           @multiple={{true}}
-                           @options={{this.options.locales}}
-                           @setValue={{this.setLocales}}/>
-          </div>
-          <div class="field">
-            <Field::Select @title="Géographie"
-                           @value={{@challenge.area}}
-                           @edition={{@edition}}
-                           @multiple={{false}}
-                           @options={{this.options.area}}
-                           @setValue={{fn (mut @challenge.area)}} />
-          </div>
+  <div class="field {{if @edition '' 'disabled'}}">
+    <label>Internationalisation</label>
+    <div class="two fields">
+      <div class="field">
+        <Field::Select
+          @title="Langue(s)"
+          @value={{this.languages}}
+          @edition={{@edition}}
+          @multiple={{true}}
+          @options={{this.options.locales}}
+          @setValue={{this.setLocales}}
+        />
       </div>
+      <div class="field">
+        <Field::Select
+          @title="Géographie"
+          @value={{@challenge.area}}
+          @edition={{@edition}}
+          @multiple={{false}}
+          @options={{this.options.area}}
+          @setValue={{fn (mut @challenge.area)}}
+        />
+      </div>
+    </div>
   </div>
   {{#unless @edition}}
-    <Field::Input @value={{@challenge.id}}
-                  @title="Id"
-                  @edition={{false}} />
+    <Field::Input @value={{@challenge.id}} @title="Id" @edition={{false}} />
   {{/unless}}
 </form>


### PR DESCRIPTION
## :unicorn: Problème
Le libellé de formulaire indiquant qu'il existe une alternative textuelle sur les illustrations dans une épreuve n'était pas assez explicite.

## :robot: Solution
Améliorer son wording.

## :rainbow: Remarques
See https://github.com/1024pix/pix/pull/4638 pour le même travail côté Pix App.

## :100: Pour tester
Vérifier les libellés d'alternative textuelle dans l'écran de modification d'une épreuve.
