### PR TITLE
[TECH] Ajout d'attribut dictionnaire i18n sur les modèles de la Release (PIX-5731)

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -5,7 +5,7 @@ const LOCALE = {
   ITALIAN_SPOKEN: 'it',
   DEUTSCH_SPOKEN: 'de',
   PORTUGUESE_SPOKEN: 'pt',
-  SPANISH_SPOKEN: 'es'
+  SPANISH_SPOKEN: 'es',
 };
 
 const LOCALE_TO_LANGUAGE_MAP = Object.freeze({

--- a/api/lib/domain/models/AreaForRelease.js
+++ b/api/lib/domain/models/AreaForRelease.js
@@ -19,5 +19,14 @@ module.exports = class AreaForRelease {
     this.competenceAirtableIds = competenceAirtableIds;
     this.color = color;
     this.frameworkId = frameworkId;
+
+    this.title_i18n = _computeTitleForI18N({ titleFrFr, titleEnUs });
   }
 };
+
+function _computeTitleForI18N({ titleFrFr, titleEnUs }) {
+  return {
+    fr: titleFrFr,
+    en: titleEnUs,
+  };
+}

--- a/api/lib/domain/models/AreaForRelease.js
+++ b/api/lib/domain/models/AreaForRelease.js
@@ -1,3 +1,5 @@
+const generateI18NAttribute = require('../services/i18n-key-generator-for-release-models');
+
 module.exports = class AreaForRelease {
   constructor({
     id,
@@ -19,14 +21,7 @@ module.exports = class AreaForRelease {
     this.competenceAirtableIds = competenceAirtableIds;
     this.color = color;
     this.frameworkId = frameworkId;
-
-    this.title_i18n = _computeTitleForI18N({ titleFrFr, titleEnUs });
+    const { key, value } = generateI18NAttribute('title', { frValue: titleFrFr, enValue: titleEnUs });
+    this[key] = value;
   }
 };
-
-function _computeTitleForI18N({ titleFrFr, titleEnUs }) {
-  return {
-    fr: titleFrFr,
-    en: titleEnUs,
-  };
-}

--- a/api/lib/domain/models/CompetenceForRelease.js
+++ b/api/lib/domain/models/CompetenceForRelease.js
@@ -1,4 +1,5 @@
 const { LOCALE } = require('../constants');
+
 module.exports = class CompetenceForRelease {
   constructor({
     id,

--- a/api/lib/domain/models/CompetenceForRelease.js
+++ b/api/lib/domain/models/CompetenceForRelease.js
@@ -1,4 +1,4 @@
-const { LOCALE } = require('../constants');
+const generateI18NAttribute = require('../services/i18n-key-generator-for-release-models');
 
 module.exports = class CompetenceForRelease {
   constructor({
@@ -28,21 +28,9 @@ module.exports = class CompetenceForRelease {
     this.thematicIds = thematicIds;
     this.origin = origin;
 
-    this.name_i18n = _computeNameForI18N({ nameFrFr, nameEnUs });
-    this.description_i18n = _computeDescriptionForI18N({ descriptionFrFr, descriptionEnUs });
+    const { key: nameKey, value: nameValue } = generateI18NAttribute('name', { frValue: nameFrFr, enValue: nameEnUs });
+    this[nameKey] = nameValue;
+    const { key: descriptionKey, value: descriptionValue } = generateI18NAttribute('description', { frValue: descriptionFrFr, enValue: descriptionEnUs });
+    this[descriptionKey] = descriptionValue;
   }
 };
-
-function _computeNameForI18N({ nameFrFr, nameEnUs }) {
-  return {
-    fr: nameFrFr,
-    en: nameEnUs,
-  };
-}
-
-function _computeDescriptionForI18N({ descriptionFrFr, descriptionEnUs }) {
-  return {
-    fr: descriptionFrFr,
-    en: descriptionEnUs,
-  };
-}

--- a/api/lib/domain/models/CompetenceForRelease.js
+++ b/api/lib/domain/models/CompetenceForRelease.js
@@ -1,3 +1,4 @@
+const { LOCALE } = require('../constants');
 module.exports = class CompetenceForRelease {
   constructor({
     id,
@@ -25,5 +26,22 @@ module.exports = class CompetenceForRelease {
     this.skillIds = skillIds;
     this.thematicIds = thematicIds;
     this.origin = origin;
+
+    this.name_i18n = _computeNameForI18N({ nameFrFr, nameEnUs });
+    this.description_i18n = _computeDescriptionForI18N({ descriptionFrFr, descriptionEnUs });
   }
 };
+
+function _computeNameForI18N({ nameFrFr, nameEnUs }) {
+  return {
+    fr: nameFrFr,
+    en: nameEnUs,
+  };
+}
+
+function _computeDescriptionForI18N({ descriptionFrFr, descriptionEnUs }) {
+  return {
+    fr: descriptionFrFr,
+    en: descriptionEnUs,
+  };
+}

--- a/api/lib/domain/models/SkillForRelease.js
+++ b/api/lib/domain/models/SkillForRelease.js
@@ -27,5 +27,14 @@ module.exports = class SkillForRelease {
     this.tubeId = tubeId;
     this.version = version;
     this.level = level;
+
+    this.hint_i18n = _computeHintForI18N({ hintFrFr, hintEnUs });
   }
 };
+
+function _computeHintForI18N({ hintFrFr, hintEnUs }) {
+  return {
+    fr: hintFrFr,
+    en: hintEnUs,
+  };
+}

--- a/api/lib/domain/models/SkillForRelease.js
+++ b/api/lib/domain/models/SkillForRelease.js
@@ -1,3 +1,5 @@
+const generateI18NAttribute = require('../services/i18n-key-generator-for-release-models');
+
 module.exports = class SkillForRelease {
   constructor({
     id,
@@ -28,13 +30,7 @@ module.exports = class SkillForRelease {
     this.version = version;
     this.level = level;
 
-    this.hint_i18n = _computeHintForI18N({ hintFrFr, hintEnUs });
+    const { key, value } = generateI18NAttribute('hint', { frValue: hintFrFr, enValue: hintEnUs });
+    this[key] = value;
   }
 };
-
-function _computeHintForI18N({ hintFrFr, hintEnUs }) {
-  return {
-    fr: hintFrFr,
-    en: hintEnUs,
-  };
-}

--- a/api/lib/domain/models/ThematicForRelease.js
+++ b/api/lib/domain/models/ThematicForRelease.js
@@ -1,3 +1,5 @@
+const generateI18NAttribute = require('../services/i18n-key-generator-for-release-models');
+
 module.exports = class ThematicForRelease {
   constructor({
     id,
@@ -14,13 +16,7 @@ module.exports = class ThematicForRelease {
     this.competenceId = competenceId;
     this.tubeIds = tubeIds;
 
-    this.name_i18n = _computeNameForI18N({ name, nameEnUs });
+    const { key, value } = generateI18NAttribute('name', { frValue: name, enValue: nameEnUs });
+    this[key] = value;
   }
 };
-
-function _computeNameForI18N({ name, nameEnUs }) {
-  return {
-    fr: name,
-    en: nameEnUs,
-  };
-}

--- a/api/lib/domain/models/ThematicForRelease.js
+++ b/api/lib/domain/models/ThematicForRelease.js
@@ -13,5 +13,14 @@ module.exports = class ThematicForRelease {
     this.index = index;
     this.competenceId = competenceId;
     this.tubeIds = tubeIds;
+
+    this.name_i18n = _computeNameForI18N({ name, nameEnUs });
   }
 };
+
+function _computeNameForI18N({ name, nameEnUs }) {
+  return {
+    fr: name,
+    en: nameEnUs,
+  };
+}

--- a/api/lib/domain/models/TubeForRelease.js
+++ b/api/lib/domain/models/TubeForRelease.js
@@ -23,5 +23,23 @@ module.exports = class TubeForRelease {
     this.competenceId = competenceId;
     this.isMobileCompliant = isMobileCompliant;
     this.isTabletCompliant = isTabletCompliant;
+
+    this.practicalTitle_i18n = _computePracticalTitleForI18N({ practicalTitleFrFr, practicalTitleEnUs });
+    this.practicalDescription_i18n = _computePracticalDescriptionForI18N({ practicalDescriptionFrFr, practicalDescriptionEnUs });
   }
 };
+
+function _computePracticalTitleForI18N({ practicalTitleFrFr, practicalTitleEnUs }) {
+  return {
+    fr: practicalTitleFrFr,
+    en: practicalTitleEnUs,
+  };
+}
+
+function _computePracticalDescriptionForI18N({ practicalDescriptionFrFr, practicalDescriptionEnUs }) {
+  return {
+    fr: practicalDescriptionFrFr,
+    en: practicalDescriptionEnUs,
+  };
+}
+

--- a/api/lib/domain/models/TubeForRelease.js
+++ b/api/lib/domain/models/TubeForRelease.js
@@ -1,3 +1,5 @@
+const generateI18NAttribute = require('../services/i18n-key-generator-for-release-models');
+
 module.exports = class TubeForRelease {
   constructor({
     id,
@@ -24,22 +26,9 @@ module.exports = class TubeForRelease {
     this.isMobileCompliant = isMobileCompliant;
     this.isTabletCompliant = isTabletCompliant;
 
-    this.practicalTitle_i18n = _computePracticalTitleForI18N({ practicalTitleFrFr, practicalTitleEnUs });
-    this.practicalDescription_i18n = _computePracticalDescriptionForI18N({ practicalDescriptionFrFr, practicalDescriptionEnUs });
+    const { key: practicalTitleKey, value: practicalTitleValue } = generateI18NAttribute('practicalTitle', { frValue: practicalTitleFrFr, enValue: practicalTitleEnUs });
+    this[practicalTitleKey] = practicalTitleValue;
+    const { key: practicalDescriptionKey, value: practicalDescriptionValue } = generateI18NAttribute('practicalDescription', { frValue: practicalDescriptionFrFr, enValue: practicalDescriptionEnUs });
+    this[practicalDescriptionKey] = practicalDescriptionValue;
   }
 };
-
-function _computePracticalTitleForI18N({ practicalTitleFrFr, practicalTitleEnUs }) {
-  return {
-    fr: practicalTitleFrFr,
-    en: practicalTitleEnUs,
-  };
-}
-
-function _computePracticalDescriptionForI18N({ practicalDescriptionFrFr, practicalDescriptionEnUs }) {
-  return {
-    fr: practicalDescriptionFrFr,
-    en: practicalDescriptionEnUs,
-  };
-}
-

--- a/api/lib/domain/services/i18n-key-generator-for-release-models.js
+++ b/api/lib/domain/services/i18n-key-generator-for-release-models.js
@@ -1,0 +1,12 @@
+module.exports = function generateI18NAttribute(originalAttributeName, {
+  frValue,
+  enValue,
+}) {
+  return {
+    key: `${originalAttributeName}_i18n`,
+    value: {
+      fr: frValue,
+      en: enValue,
+    },
+  };
+};

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -189,6 +189,14 @@ async function mockContentForRelease() {
       description: 'Description de la compétence',
       descriptionFrFr: 'Description de la compétence - fr',
       descriptionEnUs: 'Description de la compétence - en',
+      name_i18n: {
+        en: 'Nom de la Compétence - en',
+        fr: 'Nom de la Compétence - fr',
+      },
+      description_i18n: {
+        en: 'Description de la compétence - en',
+        fr: 'Description de la compétence - fr',
+      },
     }],
     frameworks: [{
       id: 'recFramework0',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -171,6 +171,10 @@ async function mockContentForRelease() {
       competenceAirtableIds: ['recCompetence123'],
       color: 'jaffa',
       frameworkId: 'recFramework0',
+      title_i18n: {
+        en: 'Titre du Domaine - en',
+        fr: 'Titre du Domaine - fr',
+      },
     }],
     competences: [{
       id: 'recCompetence0',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -214,6 +214,14 @@ async function mockContentForRelease() {
       competenceId: 'recCompetence0',
       isMobileCompliant: true,
       isTabletCompliant: false,
+      practicalTitle_i18n: {
+        en: 'Titre pratique du Tube - en',
+        fr: 'Titre pratique du Tube - fr',
+      },
+      practicalDescription_i18n: {
+        en: 'Description pratique du Tube - en',
+        fr: 'Description pratique du Tube - fr',
+      },
     }],
     skills: [{
       id: 'recSkill0',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -285,7 +285,11 @@ async function mockContentForRelease() {
       nameEnUs: 'name',
       competenceId: 'recCompetence0',
       tubeIds: ['recTube'],
-      index: 0
+      index: 0,
+      name_i18n: {
+        en: 'name',
+        fr: 'Nom',
+      },
     }],
   };
 

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -229,6 +229,10 @@ async function mockContentForRelease() {
       tubeId: 'recTube0',
       version: 1,
       level: 1,
+      hint_i18n: {
+        en: 'Indice - en',
+        fr: 'Indice - fr',
+      },
     }],
     challenges: [{
       id: 'recChallenge0',

--- a/api/tests/unit/domain/models/AreaForRelease_test.js
+++ b/api/tests/unit/domain/models/AreaForRelease_test.js
@@ -1,0 +1,25 @@
+const { expect } = require('../../../test-helper');
+const AreaForRelease = require('../../../../lib/domain/models/AreaForRelease');
+
+describe('Unit | Domain | AreaForRelease', function() {
+  describe('#constructor', function() {
+    context('i18n', function() {
+      it('should build special attribute title_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          titleFrFr: 'titre fr',
+          titleEnUs: 'titre en',
+        };
+
+        // when
+        const areaForRelease = new AreaForRelease(inputArguments);
+
+        // then
+        expect(areaForRelease.title_i18n).to.deep.equal({
+          fr: 'titre fr',
+          en: 'titre en',
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/CompetenceForRelease_test.js
+++ b/api/tests/unit/domain/models/CompetenceForRelease_test.js
@@ -1,0 +1,43 @@
+const { expect } = require('../../../test-helper');
+const CompetenceForRelease = require('../../../../lib/domain/models/CompetenceForRelease');
+
+describe('Unit | Domain | CompetenceForRelease', function() {
+  describe('#constructor', function() {
+    context('i18n', function() {
+      it('should build special attribute name_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          name: 'name default',
+          nameFrFr: 'name fr',
+          nameEnUs: 'name en',
+        };
+
+        // when
+        const competenceForRelease = new CompetenceForRelease(inputArguments);
+
+        // then
+        expect(competenceForRelease.name_i18n).to.deep.equal({
+          fr: 'name fr',
+          en: 'name en',
+        });
+      });
+      it('should build special attribute description_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          description: 'description default',
+          descriptionFrFr: 'description fr',
+          descriptionEnUs: 'description en',
+        };
+
+        // when
+        const competenceForRelease = new CompetenceForRelease(inputArguments);
+
+        // then
+        expect(competenceForRelease.description_i18n).to.deep.equal({
+          fr: 'description fr',
+          en: 'description en',
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/SkillForRelease_test.js
+++ b/api/tests/unit/domain/models/SkillForRelease_test.js
@@ -1,0 +1,25 @@
+const { expect } = require('../../../test-helper');
+const SkillForRelease = require('../../../../lib/domain/models/SkillForRelease');
+
+describe('Unit | Domain | SkillForRelease', function() {
+  describe('#constructor', function() {
+    context('i18n', function() {
+      it('should build special attribute hint_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          hintFrFr: 'hint fr',
+          hintEnUs: 'hint en',
+        };
+
+        // when
+        const skillForRelease = new SkillForRelease(inputArguments);
+
+        // then
+        expect(skillForRelease.hint_i18n).to.deep.equal({
+          fr: 'hint fr',
+          en: 'hint en',
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/ThematicForRelease_test.js
+++ b/api/tests/unit/domain/models/ThematicForRelease_test.js
@@ -1,0 +1,25 @@
+const { expect } = require('../../../test-helper');
+const ThematicForRelease = require('../../../../lib/domain/models/ThematicForRelease');
+
+describe('Unit | Domain | ThematicForRelease', function() {
+  describe('#constructor', function() {
+    context('i18n', function() {
+      it('should build special attribute name_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          name: 'name default',
+          nameEnUs: 'name en',
+        };
+
+        // when
+        const thematicForRelease = new ThematicForRelease(inputArguments);
+
+        // then
+        expect(thematicForRelease.name_i18n).to.deep.equal({
+          fr: 'name default',
+          en: 'name en',
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/TubeForRelease_test.js
+++ b/api/tests/unit/domain/models/TubeForRelease_test.js
@@ -1,0 +1,41 @@
+const { expect } = require('../../../test-helper');
+const TubeForRelease = require('../../../../lib/domain/models/TubeForRelease');
+
+describe('Unit | Domain | TubeForRelease', function() {
+  describe('#constructor', function() {
+    context('i18n', function() {
+      it('should build special attribute practicalTitle_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          practicalTitleFrFr: 'practicalTitle fr',
+          practicalTitleEnUs: 'practicalTitle en',
+        };
+
+        // when
+        const tubeForRelease = new TubeForRelease(inputArguments);
+
+        // then
+        expect(tubeForRelease.practicalTitle_i18n).to.deep.equal({
+          fr: 'practicalTitle fr',
+          en: 'practicalTitle en',
+        });
+      });
+      it('should build special attribute practicalDescription_i18n correctly', function() {
+        // given
+        const inputArguments = {
+          practicalDescriptionFrFr: 'practicalDescription fr',
+          practicalDescriptionEnUs: 'practicalDescription en',
+        };
+
+        // when
+        const tubeForRelease = new TubeForRelease(inputArguments);
+
+        // then
+        expect(tubeForRelease.practicalDescription_i18n).to.deep.equal({
+          fr: 'practicalDescription fr',
+          en: 'practicalDescription en',
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lors de la mob review de https://github.com/1024pix/pix-editor/pull/60, on s'est rendu compte de plusieurs petits problèmes avec la solution proposée, notamment :
- Assez peu généralisable si y'a ajout d'autres langues (même si c'est pas un besoin immédiat + la PR reflète un travail en construction)
- mais surtout, va provoquer une multiplication de la taille de la release récupérée par les clients (en l'occurrence l'API Pix) de x3

## :robot: Solution
Un des reviewers a proposé une solution qui va limiter ce grossissement et va permettre de proposer une déclinaison compatible i18n pour les attributs qui en ont besoin tout en gardant une rétrocompatibilité (le temps que les clients se mettent à la page).
En gros, les attributs avec plusieurs traductions sont dupliqués en version `<attribute>_i18n`, et sont en fait un dictionnaire avec pour clés les langues et pour valeur la valeur de l'attribut pour ladite langue.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
