### PR TITLE
[FEATURE] Ajouter les liens vers la thématique parente et les acquis enfants sur le modèle Tube de la release (PIX-6331)

### DIFF
--- a/api/lib/domain/models/TubeForRelease.js
+++ b/api/lib/domain/models/TubeForRelease.js
@@ -13,6 +13,8 @@ module.exports = class TubeForRelease {
     competenceId,
     isMobileCompliant,
     isTabletCompliant,
+    thematicId,
+    skillIds,
   }) {
     this.id = id;
     this.name = name;
@@ -25,6 +27,8 @@ module.exports = class TubeForRelease {
     this.competenceId = competenceId;
     this.isMobileCompliant = isMobileCompliant;
     this.isTabletCompliant = isTabletCompliant;
+    this.thematicId = thematicId;
+    this.skillIds = skillIds;
 
     const { key: practicalTitleKey, value: practicalTitleValue } = generateI18NAttribute('practicalTitle', { frValue: practicalTitleFrFr, enValue: practicalTitleEnUs });
     this[practicalTitleKey] = practicalTitleValue;

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -115,7 +115,7 @@ async function _getCurrentContent() {
   ]);
   const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments });
   const transformedChallenges = challenges.map(transformChallenge);
-  const transformedTubes = tubeTransformer.transform({ tubes, skills, challenges: transformedChallenges });
+  const transformedTubes = tubeTransformer.transform({ tubes, skills, challenges: transformedChallenges, thematics });
   const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);
   const filteredSkills = skillTransformer.filterSkillsFields(skills);
   const filteredCourses = courseTransformer.filterCoursesFields(courses);

--- a/api/lib/infrastructure/transformers/tube-transformer.js
+++ b/api/lib/infrastructure/transformers/tube-transformer.js
@@ -2,18 +2,31 @@ const VALIDATED_CHALLENGE = 'validé';
 const PROTOTYPE_CHALLENGE = 'Prototype 1';
 
 function transform({ tubes, skills, challenges, thematics }) {
-  return _addDeviceCompliance({ tubes, skills, challenges, thematics });
+  tubes.forEach((tube) => {
+    _addLinks({ tube, skills, thematics });
+    _addDeviceCompliance({ tube, skills, challenges });
+  });
+  return tubes;
 }
 
-function _addDeviceCompliance({ tubes, skills, challenges, thematics }) {
-  return tubes.map((tube) => {
-    const tubeChallenges = _filterValidatedPrototypeTubeChallenges(skills, challenges, tube.id);
-    tube.isMobileCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeSmartphoneCompliant);
-    tube.isTabletCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeTabletCompliant);
-    tube.thematicId = _findThematicId(tube.id, thematics);
-    tube.skillIds = _findSkillIds(tube.id, skills);
-    return tube;
-  });
+function _addLinks({ tube, skills, thematics }) {
+  tube.thematicId = _findThematicId(tube.id, thematics);
+  tube.skillIds = _findSkillIds(tube.id, skills);
+}
+
+function _findThematicId(tubeId, thematics) {
+  const correspondingThematic = thematics.find((thematic) => thematic.tubeIds?.includes(tubeId));
+  return correspondingThematic?.id || null;
+}
+
+function _findSkillIds(tubeId, skills) {
+  return skills.filter((skill) => skill.tubeId === tubeId).map((skill) => skill.id);
+}
+
+function _addDeviceCompliance({ tube, skills, challenges }) {
+  const tubeChallenges = _filterValidatedPrototypeTubeChallenges(skills, challenges, tube.id);
+  tube.isMobileCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeSmartphoneCompliant);
+  tube.isTabletCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeTabletCompliant);
 }
 
 function _filterValidatedPrototypeTubeChallenges(skills, challenges, tubeId) {
@@ -31,15 +44,6 @@ function _isChallengeSmartphoneCompliant(challenge) {
 
 function _isChallengeTabletCompliant(challenge) {
   return challenge.responsive?.includes('Tablet');
-}
-
-function _findThematicId(tubeId, thematics) {
-  const correspondingThematic = thematics.find((thematic) => thematic.tubeIds.includes(tubeId));
-  return correspondingThematic.id;
-}
-
-function _findSkillIds(tubeId, skills) {
-  return skills.filter((skill) => skill.tubeId === tubeId).map((skill) => skill.id);
 }
 
 module.exports = {

--- a/api/lib/infrastructure/transformers/tube-transformer.js
+++ b/api/lib/infrastructure/transformers/tube-transformer.js
@@ -1,15 +1,17 @@
 const VALIDATED_CHALLENGE = 'validé';
 const PROTOTYPE_CHALLENGE = 'Prototype 1';
 
-function transform({ tubes, skills, challenges }) {
-  return _addDeviceCompliance({ tubes, skills, challenges });
+function transform({ tubes, skills, challenges, thematics }) {
+  return _addDeviceCompliance({ tubes, skills, challenges, thematics });
 }
 
-function _addDeviceCompliance({ tubes, skills, challenges }) {
+function _addDeviceCompliance({ tubes, skills, challenges, thematics }) {
   return tubes.map((tube) => {
     const tubeChallenges = _filterValidatedPrototypeTubeChallenges(skills, challenges, tube.id);
     tube.isMobileCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeSmartphoneCompliant);
     tube.isTabletCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeTabletCompliant);
+    tube.thematicId = _findThematicId(tube.id, thematics);
+    tube.skillIds = _findSkillIds(tube.id, skills);
     return tube;
   });
 }
@@ -29,6 +31,15 @@ function _isChallengeSmartphoneCompliant(challenge) {
 
 function _isChallengeTabletCompliant(challenge) {
   return challenge.responsive?.includes('Tablet');
+}
+
+function _findThematicId(tubeId, thematics) {
+  const correspondingThematic = thematics.find((thematic) => thematic.tubeIds.includes(tubeId));
+  return correspondingThematic.id;
+}
+
+function _findSkillIds(tubeId, skills) {
+  return skills.filter((skill) => skill.tubeId === tubeId).map((skill) => skill.id);
 }
 
 module.exports = {

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -18,6 +18,10 @@ const {
 async function mockCurrentContent() {
 
   const expectedCurrentContent = {
+    frameworks: [{
+      id: 'recFramework0',
+      name: 'Nom du referentiel'
+    }],
     areas: [{
       id: 'recArea0',
       name: 'Nom du Domaine',
@@ -43,9 +47,13 @@ async function mockCurrentContent() {
       descriptionFrFr: 'Description de la compétence - fr',
       descriptionEnUs: 'Description de la compétence - en',
     }],
-    frameworks: [{
-      id: 'recFramework0',
-      name: 'Nom du referentiel'
+    thematics: [{
+      id: 'recThematic0',
+      name: 'Nom',
+      nameEnUs: 'name',
+      competenceId: 'recCompetence0',
+      tubeIds: ['recTube0'],
+      index: 0
     }],
     tubes: [{
       id: 'recTube0',
@@ -57,6 +65,8 @@ async function mockCurrentContent() {
       practicalDescriptionFrFr: 'Description pratique du Tube - fr',
       practicalDescriptionEnUs: 'Description pratique du Tube - en',
       competenceId: 'recCompetence0',
+      thematicId: 'recThematic0',
+      skillIds: ['recSkill0'],
       isMobileCompliant: true,
       isTabletCompliant: false,
     }],
@@ -122,14 +132,6 @@ async function mockCurrentContent() {
       challenges: ['recChallenge0'],
       imageUrl: 'Image du Course',
     }],
-    thematics: [{
-      id: 'recThematic0',
-      name: 'Nom',
-      nameEnUs: 'name',
-      competenceId: 'recCompetence0',
-      tubeIds: ['recTube'],
-      index: 0
-    }],
   };
 
   const attachments = [{
@@ -161,6 +163,10 @@ async function mockCurrentContent() {
 
 async function mockContentForRelease() {
   const expectedCurrentContent = {
+    frameworks: [{
+      id: 'recFramework0',
+      name: 'Nom du referentiel'
+    }],
     areas: [{
       id: 'recArea0',
       name: 'Nom du Domaine',
@@ -198,9 +204,17 @@ async function mockContentForRelease() {
         fr: 'Description de la compétence - fr',
       },
     }],
-    frameworks: [{
-      id: 'recFramework0',
-      name: 'Nom du referentiel'
+    thematics: [{
+      id: 'recThematic0',
+      name: 'Nom',
+      nameEnUs: 'name',
+      competenceId: 'recCompetence0',
+      tubeIds: ['recTube0'],
+      index: 0,
+      name_i18n: {
+        en: 'name',
+        fr: 'Nom',
+      },
     }],
     tubes: [{
       id: 'recTube0',
@@ -212,6 +226,8 @@ async function mockContentForRelease() {
       practicalDescriptionFrFr: 'Description pratique du Tube - fr',
       practicalDescriptionEnUs: 'Description pratique du Tube - en',
       competenceId: 'recCompetence0',
+      thematicId: 'recThematic0',
+      skillIds: ['recSkill0'],
       isMobileCompliant: true,
       isTabletCompliant: false,
       practicalTitle_i18n: {
@@ -286,18 +302,6 @@ async function mockContentForRelease() {
       competences: ['recCompetence0'],
       challenges: ['recChallenge0'],
       imageUrl: 'Image du Course',
-    }],
-    thematics: [{
-      id: 'recThematic0',
-      name: 'Nom',
-      nameEnUs: 'name',
-      competenceId: 'recCompetence0',
-      tubeIds: ['recTube'],
-      index: 0,
-      name_i18n: {
-        en: 'name',
-        fr: 'Nom',
-      },
     }],
   };
 

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -770,6 +770,8 @@ function _getRichCurrentContentDTO() {
       competenceId: 'competence11',
       isMobileCompliant: false,
       isTabletCompliant: false,
+      thematicId: 'thematic111',
+      skillIds: ['skill11111', 'skill11112'],
     },
     {
       id: 'tube1121',
@@ -783,6 +785,8 @@ function _getRichCurrentContentDTO() {
       competenceId: 'competence11',
       isMobileCompliant: false,
       isTabletCompliant: false,
+      thematicId: 'thematic112',
+      skillIds: [],
     },
     {
       id: 'tube1211',
@@ -796,6 +800,8 @@ function _getRichCurrentContentDTO() {
       competenceId: 'competence12',
       isMobileCompliant: false,
       isTabletCompliant: false,
+      thematicId: 'thematic121',
+      skillIds: [],
     },
     {
       id: 'tube1212',
@@ -809,6 +815,8 @@ function _getRichCurrentContentDTO() {
       competenceId: 'competence12',
       isMobileCompliant: true,
       isTabletCompliant: false,
+      thematicId: 'thematic121',
+      skillIds: ['skill12121'],
     },
     {
       id: 'tube2111',
@@ -822,6 +830,8 @@ function _getRichCurrentContentDTO() {
       competenceId: 'competence21',
       isMobileCompliant: false,
       isTabletCompliant: true,
+      thematicId: 'thematic211',
+      skillIds: ['skill21111'],
     },
   ];
   const expectedSkillDTOs = [

--- a/api/tests/tooling/domain-builder/factory/build-tube-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube-for-release.js
@@ -10,6 +10,8 @@ const buildTubeForRelease = function({
   practicalDescriptionFrFr = 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
   practicalDescriptionEnUs = 'Identify a web browser and a search engine, know how the search engine works',
   competenceId = 'recsvLz0W2ShyfD63',
+  thematicId = 'thematic123',
+  skillIds = ['skillABC', 'skillDEF'],
 } = {}) {
   return new TubeForRelease({
     id,
@@ -21,6 +23,8 @@ const buildTubeForRelease = function({
     practicalDescriptionFrFr,
     practicalDescriptionEnUs,
     competenceId,
+    thematicId,
+    skillIds,
   });
 };
 

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -2,7 +2,6 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const Content = require('../../../../lib/domain/models/Content');
 
 describe('Unit | Domain | Content', () => {
-  // TODO this test is not logical
   describe('#buildForRelease', () => {
     let data;
     beforeEach(function() {

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -2,6 +2,7 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const Content = require('../../../../lib/domain/models/Content');
 
 describe('Unit | Domain | Content', () => {
+  // TODO this test is not logical
   describe('#buildForRelease', () => {
     let data;
     beforeEach(function() {
@@ -118,6 +119,8 @@ describe('Unit | Domain | Content', () => {
         id: 'recFramework',
         name: 'le framework',
       });
+      tubeAirtable.thematicId = 'recThematic1';
+      tubeAirtable.skillIds = ['recSkillA'];
       data = {
         areas: [areaAirtable],
         competences: [competenceAirtable],
@@ -186,6 +189,8 @@ describe('Unit | Domain | Content', () => {
         practicalDescriptionFrFr: 'practicalDescriptionFr',
         practicalDescriptionEnUs: 'practicalDescriptionEn',
         competenceId: 'recCompetence1',
+        thematicId: 'recThematic1',
+        skillIds: ['recSkillA'],
       });
       const expectedTutorial = domainBuilder.buildTutorialForRelease({
         id: 'recTutorialA',


### PR DESCRIPTION
## :unicorn: Problème
Le référentiel est un arbre. Mais dans le modèle TubeForRelease, il manque des branches pour naviguer facilement, en l'occurrence vers son parent direct, _**la thématique**_, et ses enfants **_les acquis_**.

## :robot: Solution
Ajouter ces informations à la création de la release

## :rainbow: Remarques
- A quel moment a t-on besoin de taper la route GET /api/current-content

## :100: Pour tester
Vérifier un payload de récupération de release après création et s'assurer que les liens sont présents
