### PR TITLE
[BUGFIX] Les images des épreuves ne sont plus présentes dans le payload de récupération de releases (PIX-6394)

### DIFF
--- a/api/lib/domain/models/ChallengeForRelease.js
+++ b/api/lib/domain/models/ChallengeForRelease.js
@@ -26,6 +26,8 @@ module.exports = class ChallengeForRelease {
     responsive,
     genealogy,
     attachments,
+    illustrationAlt,
+    illustrationUrl,
   }) {
     this.id = id;
     this.instruction = instruction;
@@ -53,5 +55,7 @@ module.exports = class ChallengeForRelease {
     this.delta = delta;
     this.alpha = alpha;
     this.attachments = attachments;
+    this.illustrationAlt = illustrationAlt;
+    this.illustrationUrl = illustrationUrl;
   }
 };

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -56,7 +56,7 @@ function _assignAttachmentToChallenge(challenge, attachment) {
 }
 
 function _addAttachmentsToChallenge({ attachments }, challenge) {
-  const newChallenge = { ...challenge };
+  const newChallenge = { ...challenge, illustrationAlt: null, illustrationUrl: null };
   const challengeAttachments = attachments.filter((attachment) => attachment.challengeId === newChallenge.id);
   challengeAttachments.forEach((attachment) => _assignAttachmentToChallenge(newChallenge, attachment));
 

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -631,7 +631,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
     it('should invalidate the cache on the PIX API', async () => {
       // Given
       const challenge = domainBuilder.buildChallengeAirtableDataObject({ id: 'recChallengeId' });
-      const expectedChallengeRelease = JSON.parse(JSON.stringify(domainBuilder.buildChallengeForRelease(challenge)));
+      const expectedChallengeRelease = JSON.parse(JSON.stringify(domainBuilder.buildChallengeForRelease({
+        ...challenge,
+        illustrationUrl: null,
+        illustrationAlt: null,
+      })));
       const expectedBodyChallenge = _removeReadonlyFields(airtableBuilder.factory.buildChallenge(challenge), true);
       const expectedBody = { records: [expectedBodyChallenge] };
       const token = 'not-a-real-token';

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -285,6 +285,8 @@ async function mockContentForRelease() {
       responsive: ['Smartphone'],
       genealogy: 'Prototype 1',
       attachments: ['url de la pièce jointe'],
+      illustrationUrl: 'url de l‘illustration',
+      illustrationAlt: 'Texte alternatif illustration',
     }],
     tutorials: [{
       id: 'recTutorial0',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -924,6 +924,8 @@ function _getRichCurrentContentDTO() {
       delta: 1.1,
       alpha: 2.2,
       attachments: ['attachment1 url', 'attachment2 url'],
+      illustrationUrl: null,
+      illustrationAlt: null,
     },
     {
       id: 'challenge121212',
@@ -951,6 +953,8 @@ function _getRichCurrentContentDTO() {
       focusable: 'challenge121212 focusable',
       delta: 123,
       alpha: 456,
+      illustrationUrl: null,
+      illustrationAlt: null,
     },
     {
       id: 'challenge211111',
@@ -979,6 +983,8 @@ function _getRichCurrentContentDTO() {
       delta: 100,
       alpha: 200,
       attachments: ['attachment3 url'],
+      illustrationUrl: null,
+      illustrationAlt: null,
     },
     {
       id: 'challenge211112',
@@ -1006,6 +1012,8 @@ function _getRichCurrentContentDTO() {
       focusable: 'challenge211112 focusable',
       delta: 100,
       alpha: 200,
+      illustrationUrl: null,
+      illustrationAlt: null,
     },
     {
       id: 'challenge211113',
@@ -1033,6 +1041,8 @@ function _getRichCurrentContentDTO() {
       focusable: 'challenge211113 focusable',
       delta: 100,
       alpha: 200,
+      illustrationUrl: null,
+      illustrationAlt: null,
     },
   ];
   const expectedCourseDTOs = [

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -27,6 +27,8 @@ module.exports = function buildChallengeForRelease({
   responsive = 'Smartphone',
   genealogy = 'Prototype 1',
   attachments,
+  illustrationAlt = 'alt illu',
+  illustrationUrl = 'url illu',
 } = {}) {
 
   return new ChallengeForRelease({
@@ -56,5 +58,7 @@ module.exports = function buildChallengeForRelease({
     responsive,
     genealogy,
     attachments,
+    illustrationAlt,
+    illustrationUrl,
   });
 };

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -114,6 +114,8 @@ describe('Unit | Domain | Content', () => {
         genealogy: 'Prototype 1',
       });
       challengeAirtable.attachments = ['some_url'];
+      challengeAirtable.illustrationUrl = null;
+      challengeAirtable.illustrationAlt = null;
       const frameworkAirtable = domainBuilder.buildFrameworkAirtableDataObject({
         id: 'recFramework',
         name: 'le framework',
@@ -245,6 +247,8 @@ describe('Unit | Domain | Content', () => {
         responsive: 'Smartphone',
         genealogy: 'Prototype 1',
         attachments: ['some_url'],
+        illustrationAlt: null,
+        illustrationUrl: null,
       });
       const expectedFramework = domainBuilder.buildFrameworkForRelease({ id: 'recFramework', name: 'le framework' });
 


### PR DESCRIPTION
## :unicorn: Problème
Les épreuves avec images n'affichaient plus l'image 😢 

## :robot: Solution
Bien que les images soient bien indiquées dans la release en BDD côté LCMS, c'est au moment de convertir la donnée et de répondre au client avec la release que les images sont perdues en chemin

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer tout en local (api pix / mon-pix / lcms)
- Refaire une release (dans le doute)
- Lancer des épreuves pix et voir que les épreuves avec images ont bien une image affichée
