### PR TITLE
[TECH] Mettre a jour le port utiliser par la base de donnée dans les variables d'environnement.

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -40,7 +40,7 @@
 # presence: required
 # type: Url
 # default: none
-DATABASE_URL=postgresql://postgres@localhost:5433/pix_lcms
+DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms
 
 # URL of the PostgreSQL databse used for API local testing.
 #
@@ -49,7 +49,7 @@ DATABASE_URL=postgresql://postgres@localhost:5433/pix_lcms
 # presence: required
 # type: Url
 # default: none
-TEST_DATABASE_URL=postgresql://postgres@localhost:5433/pix_lcms_test
+TEST_DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms_test
 
 # Connexion pool used by Knex. By default, Knex has has a default setting of a
 # min: 2, max: 10 for the PG library. On LCMS API, we override the max default

--- a/end-to-end-tests/package.json
+++ b/end-to-end-tests/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "npm run db:initialize && cypress open",
-    "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost:5433/pix_lcms_test npm run cy:open",
+    "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms_test npm run cy:open",
     "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",
-    "cy:run:local": "DATABASE_URL=postgresql://postgres@localhost:5433/pix_lcms_test npm run cy:run",
+    "cy:run:local": "DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms_test npm run cy:run",
     "cy:run:ci": "npm run db:initialize && cypress run && exit",
     "db:empty": "cd ../api && npm run db:empty && npm run db:seed",
     "db:initialize": "cd ../api && npm run db:prepare"


### PR DESCRIPTION
## :unicorn: Problème
Le port de la base de donnée n'a pas été changer dans les variables d'environnement suite a son changement dans le `docker-compose` dans la PR #69 

## :robot: Solution
La changer dans le `sample.env` ainsi que dans les test e2e

## :rainbow: Remarques
⚠️  A CHANGER DANS VOTRE FICHIER `.env` LOCAL

## :100: Pour tester
Lancer les tests en local
