### PR TITLE
[TECH] Tracer facilement les métriques infra

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -34,7 +34,6 @@ module.exports = (function() {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
       logLevel: (process.env.LOG_LEVEL || 'info'),
-      logOpsMetrics: isFeatureEnabled(process.env.LOG_OPS_METRICS),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
       prettyPrint: isFeatureEnabled(process.env.LOG_PRETTY_PRINT)
     },

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -1,7 +1,6 @@
 const Joi = require('joi');
 
 const schema = Joi.object({
-  LOG_OPS_METRICS: Joi.string().valid('true', 'false').optional(),
   OPS_EVENT_EACH_SECONDS: Joi.number().integer().min(1).optional()
 }).options({ allowUnknown: true });
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2929,14 +2929,6 @@
         "@hapi/vise": "^4.0.0"
       }
     },
-    "@hapi/oppsy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/oppsy/-/oppsy-3.0.0.tgz",
-      "integrity": "sha512-0kfUEAqIi21GzFVK2snMO07znMEBiXb+/pOx1dmgOO9TuvFstcfmHU5i56aDfiFP2DM5WzQCU2UWc2gK1lMDhQ==",
-      "requires": {
-        "@hapi/hoek": "9.x.x"
-      }
-    },
     "@hapi/pez": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
@@ -8084,6 +8076,13 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "oppsy": {
+      "version": "git+https://github.com/1024pix/oppsy.git#ca8c3f37989eee9089dd7127e1c5d1c57f827de0",
+      "from": "git+https://github.com/1024pix/oppsy.git#main",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
       }
     },
     "optionator": {

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "@hapi/cookie": "^11.0.2",
     "@hapi/hapi": "^20.2.0",
     "@hapi/inert": "^6.0.5",
-    "@hapi/oppsy": "^3.0.0",
+    "oppsy": "https://github.com/1024pix/oppsy#main",
     "@hapi/vision": "^6.1.0",
     "@sentry/node": "^6.13.2",
     "adminjs": "^6.1.2",

--- a/api/sample.env
+++ b/api/sample.env
@@ -179,16 +179,6 @@ LOG_ENABLED=true
 # default: "info"
 # LOG_LEVEL=debug
 
-# Log operations metrics
-#
-# Log core container metrics: CPU, memory, load-average, http calls...
-# Sample output: {"event":"ops","timestamp":1630419363680,"host":"pix-api-production-web-2","pid":22,"os":{"load":[2.16,1.97,1.85],"mem":{"total":42185723904,"free":6782152704},"uptime":8208319.46},"proc":{"uptime":81367.686662047,"mem":{"rss":196128768,"heapTotal":109948928,"heapUsed":104404328,"external":6004718,"arrayBuffers":4416211},"delay":0.11345672607421875},"load":{"requests":{"21344":{"total":55,"disconnects":0,"statusCodes":{"200":43,"201":10,"204":1,"401":1}}},"responseTimes":{"21344":{"avg":19.472727272727273,"max":64}},"sockets":{"http":{"total":0},"https":{"total":0}}}}
-#
-# presence: optional
-# type: Boolean
-# default: `undefined` (`false`)
-# LOG_OPS_METRICS=true
-
 # Log operations sample rate
 #
 # Time (seconds) each logging

--- a/api/server.js
+++ b/api/server.js
@@ -2,7 +2,7 @@
 // https://www.npmjs.com/package/dotenv#usage
 require('dotenv').config();
 const Hapi = require('@hapi/hapi');
-const Oppsy = require('@hapi/oppsy');
+const Oppsy = require('oppsy');
 
 const preResponseUtils = require('./lib/infrastructure/utils/pre-response-utils');
 

--- a/api/server.js
+++ b/api/server.js
@@ -43,7 +43,7 @@ const createServer = async () => {
 
   const configuration = [].concat(plugins, routes);
 
-  if (config.logging.logOpsMetrics) await enableOpsMetrics(server);
+  await enableOpsMetrics(server);
 
   await server.register(configuration);
 


### PR DESCRIPTION
## :unicorn: Problème
La librairie `oppsy` monitore plusieurs process HapiJs, ce qui rend les logs difficiles à parser.

## :robot: Solution
Utiliser la version custom.

## :rainbow: Remarques
On fait comme sur le monorepo.

## :100: Pour tester
Vérifier que des logs sont produits, de la forme suivante.
```shell
2022-12-27 09:58:15.924739991 +0100 CET [web-1] {"level":30,"time":1672131495924,"pid":20,"hostname":"pix-lcms-review-pr79-web-1","tags":["ops"],"data":{"host":"pix-lcms-review-pr79-web-1","osload":[2.41,2.92,3.22],"osmem":{"total":42077519872,"free":5125840896},"osup":20287865.81,"psup":6933.722004849,"psmem":{"rss":172498944,"heapTotal":117403648,"heapUsed":110548800,"external":3094387,"arrayBuffers":1381379},"pscpu":{"user":21831110,"system":7240535},"psdelay":0.09513092041015625,"requests":{"total":0,"disconnects":0,"statusCodes":{},"activeRequests":0},"responseTimes":{"avg":null,"max":null},"sockets":{"http":{"total":0},"https":{"total":0}}}} 
```
