### PR TITLE
[BUGFIX] Réparer la génération du fichier pdf de présentation du référentiel (PIX-6781).

### DIFF
--- a/pix-editor/app/components/target-profile/pdf-export.js
+++ b/pix-editor/app/components/target-profile/pdf-export.js
@@ -3,7 +3,7 @@ import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import Canvg, { presets } from 'canvg';
+import { Canvg, presets } from 'canvg';
 import { firstPageBackground, area1bg, area2bg, area3bg, area4bg, area5bg, area6bg, pixLogoWhite } from 'pdf-assets.js';
 import 'AmpleSoft-bold.js';
 import 'AmpleSoft-normal.js';


### PR DESCRIPTION
## :unicorn: Problème
La monté de version de canvvg (la librairie de génération de pdf) en v 4.0 entraîne une modification de son importt qui n'a pas été effectuer.

## :robot: Solution
Modifier l'import de la librairie de génération de pdf.
[Migration to v4 | canvg](https://canvg.js.org/docs/migration-to-v4)

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur la page de génération de profil cible et générer un pdf.
