### PR TITLE
[TECH] Ne pas lancer le check des URL lors de la création d'une release en dehors de l'environnement de production (PIX-6878).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -74,6 +74,7 @@ module.exports = (function() {
       redisUrl: process.env.REDIS_URL,
       createReleaseTime: process.env.CREATE_RELEASE_TIME,
       attempts: _getNumber(process.env.CREATE_RELEASE_ATTEMPTS, 4),
+      startCheckUrlJob: isFeatureEnabled(process.env.START_CHECK_URL_JOB)
     },
 
     database: {

--- a/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
@@ -13,7 +13,9 @@ module.exports = async function(job) {
       await learningContentNotification.notifyReleaseCreationSuccess(new SlackNotifier(config.notifications.slack.webhookUrl));
     }
     logger.info(`Periodic release created with id ${releaseId}`);
-    checkUrlsJob.start();
+    if (config.scheduledJobs.startCheckUrlJob) {
+      checkUrlsJob.start();
+    }
     return releaseId;
   } catch (error) {
     if (_isSlackNotificationGloballyEnabled()) {

--- a/api/sample.env
+++ b/api/sample.env
@@ -356,6 +356,21 @@ CREATE_RELEASE_TIME=0 0 * * *
 # URLS CHECKING JOB
 # =================
 
+# Job toggle
+#
+# If true job is scheduled, else is not
+# type: String
+# default: 'false'
+START_CHECK_URL_JOB=false
+
+#
+# Stringified auth json
+#
+# presence: required for this job
+# type: String
+# default: '{}'
+GOOGLE_AUTH_CREDENTIALS=
+
 # Google auth credentials
 #
 # If not present, the "URL checking" scheduled job will fail but the


### PR DESCRIPTION
## :unicorn: Problème
Le job de check des URL n’est pas utile en locale et crée du bruit. 

## :robot: Solution
Ne lancer le job lorsque la variable d’environnement `START_CHECK_URL_JOB` est égale à `true`

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer une release en locale et vérifier que le job de check des urls ne se lance pas.
