### PR TITLE
[TECH] Exécuter l'ordonnanceur dans un conteneur séparé

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -4,5 +4,5 @@ postdeploy: npm run postdeploy
 # see https://github.com/1024pix/pix/pull/796
 # and https://github.com/npm/npm/issues/4603
 # for more information
-web: cd api && exec node bin/www
+web: node bin/www
 background: node ./start-scheduler

--- a/Procfile
+++ b/Procfile
@@ -5,3 +5,4 @@ postdeploy: npm run postdeploy
 # and https://github.com/npm/npm/issues/4603
 # for more information
 web: cd api && exec node bin/www
+background: node ./start-scheduler

--- a/api/bin/www
+++ b/api/bin/www
@@ -2,20 +2,15 @@
 
 const createServer = require('../server');
 const logger = require('../lib/infrastructure/logger');
-const { queue: checkUrlQueue } = require('../lib/infrastructure/scheduled-jobs/check-urls-job');
-const releaseJob = require('../lib/infrastructure/scheduled-jobs/release-job');
 const { disconnect } = require('../db/knex-database-connection');
-
 const validateEnvironmentVariables = require('../lib/infrastructure/validate-environement-variables');
+
 validateEnvironmentVariables();
 
 const start = async () => {
   try {
     const server = await createServer();
     await server.start();
-
-    releaseJob.schedule();
-
     logger.info('Server running at %s', server.info.uri);
   } catch (err) {
     logger.error(err);
@@ -24,11 +19,9 @@ const start = async () => {
 };
 
 async function exitOnSignal(signal) {
-  logger.info(`Received signal ${signal}. Closing DB connections and queues before exiting.`);
+  logger.info(`Received signal ${signal}. Closing DB connections before exiting.`);
   try {
     await disconnect();
-    await checkUrlQueue.close();
-    await releaseJob.queue.close();
     process.exit(0);
   } catch(err) {
     logger.error(err);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -34,6 +34,7 @@ module.exports = (function() {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
       logLevel: (process.env.LOG_LEVEL || 'info'),
+      logOpsEvent: isFeatureEnabled(process.env.LOG_OPS_EVENT),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
       prettyPrint: isFeatureEnabled(process.env.LOG_PRETTY_PRINT)
     },

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -1,7 +1,10 @@
 const Joi = require('joi');
 
 const schema = Joi.object({
-  OPS_EVENT_EACH_SECONDS: Joi.number().integer().min(1).optional()
+  OPS_EVENT_EACH_SECONDS: Joi.number().integer().min(1).optional(),
+  CREATE_RELEASE_TIME: Joi.string().optional(),
+  CREATE_RELEASE_ATTEMPTS: Joi.number().integer().min(1).optional(),
+
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function() {

--- a/api/sample.env
+++ b/api/sample.env
@@ -179,6 +179,13 @@ LOG_ENABLED=true
 # default: "info"
 # LOG_LEVEL=debug
 
+# Log operations metrics
+#
+# presence: optional
+# type: boolean
+# default: false
+# LOG_OPS_EVENT=true
+
 # Log operations sample rate
 #
 # Time (seconds) each logging

--- a/api/server.js
+++ b/api/server.js
@@ -43,7 +43,7 @@ const createServer = async () => {
 
   const configuration = [].concat(plugins, routes);
 
-  await enableOpsMetrics(server);
+  if (config.logging.logOpsEvent)  await enableOpsMetrics(server);
 
   await server.register(configuration);
 

--- a/api/start-scheduler.js
+++ b/api/start-scheduler.js
@@ -1,8 +1,10 @@
 const releaseJob = require('./lib/infrastructure/scheduled-jobs/release-job');
 const logger = require('./lib/infrastructure/logger');
 const { queue: checkUrlQueue } = require('./lib/infrastructure/scheduled-jobs/check-urls-job');
+const validateEnvironmentVariables = require('./lib/infrastructure/validate-environement-variables');
 
 const main = async () => {
+  validateEnvironmentVariables();
   try {
     releaseJob.schedule();
     logger.info('Scheduler has been started');

--- a/api/start-scheduler.js
+++ b/api/start-scheduler.js
@@ -1,0 +1,29 @@
+const releaseJob = require('./lib/infrastructure/scheduled-jobs/release-job');
+const logger = require('./lib/infrastructure/logger');
+const { queue: checkUrlQueue } = require('./lib/infrastructure/scheduled-jobs/check-urls-job');
+
+const main = async () => {
+  try {
+    releaseJob.schedule();
+    logger.info('Scheduler has been started');
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+};
+async function exitOnSignal(signal) {
+  logger.info(`Received signal ${signal}. Closing queues before exiting.`);
+  try {
+    await checkUrlQueue.close();
+    await releaseJob.queue.close();
+    process.exit(0);
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+}
+
+process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
+
+main();


### PR DESCRIPTION
## :unicorn: Problème
L'ordonnanceur est exécuté dans le même conteneur que le serveur web.

Cela :
- rend la compréhension de l'architecture plus ardue;
- empêche le scaling de l'API si on en a besoin un jour;
- interrompt un job si l'API tombe.

## :robot: Solution
L'exécuter dans un conteneur dédié.

## :rainbow: Remarques
Ajout de la vérification de la configuration au démarrage.
Utilisation du buildpack monorepo en positionnant la variable `PROJECT_DIR=API`.
Permettre la désactivation des logs OPS.

## :100: Pour tester

### Web
Vérifier que le conteneur web démarre sans erreur.
```
scalingo --region osc-fr1 --app pix-lcms-review-pr84 logs --lines 10000 -F web 
```


### Ordonnanceur
Lancer un job de vérification d'URL en modifiant la planification via la variable `CREATE_RELEASE_TIME`.
Vérifier son exécution.
```
scalingo --region osc-fr1 --app pix-lcms-review-pr84 logs --lines 10000 -F background
```
### Métriques OPS	
Désactiver 
```
scalingo --region osc-fr1 --app pix-lcms-review-pr84 env-set LOG_OPS_EVENT=false
scalingo --region osc-fr1 --app pix-lcms-review-pr84 restart
```
Vérifier que les logs ne sont plus présentes
```
scalingo --region osc-fr1 --app pix-lcms-review-pr84 logs --lines 10000 -F web | grep "ops"
```
Activer 
```
scalingo --region osc-fr1 --app pix-lcms-review-pr84 env-set LOG_OPS_EVENT=true
scalingo --region osc-fr1 --app pix-lcms-review-pr84 restart
```
Vérifier que les logs sont présentes
```
scalingo --region
