### PR TITLE
[TECH] Déplace la création de release dans un process dédié

### DIFF
--- a/api/lib/infrastructure/scheduled-jobs/check-urls-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/check-urls-job.js
@@ -2,6 +2,7 @@ const createQueue = require('./create-queue');
 const config = require('../../config');
 
 const queue = createQueue('check-urls-queue');
+queue.process(__dirname + '/check-urls-job-processor.js');
 
 const checkUrlsJobOptions = {
   attempts: config.scheduledJobs.attempts,
@@ -9,8 +10,6 @@ const checkUrlsJobOptions = {
   removeOnComplete: true,
   removeOnFail: 1,
 };
-
-queue.process(__dirname + '/check-urls-job-processor.js');
 
 function start() {
   queue.add({}, checkUrlsJobOptions);

--- a/api/lib/infrastructure/scheduled-jobs/check-urls-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/check-urls-job.js
@@ -2,7 +2,8 @@ const createQueue = require('./create-queue');
 const config = require('../../config');
 
 const queue = createQueue('check-urls-queue');
-queue.process(__dirname + '/check-urls-job-processor.js');
+const processFile = __dirname + '/check-urls-job-processor.js';
+queue.process(process.env.NODE_ENV === 'test' ? require(processFile) : processFile);
 
 const checkUrlsJobOptions = {
   attempts: config.scheduledJobs.attempts,

--- a/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
@@ -1,0 +1,42 @@
+const SlackNotifier = require('../notifications/SlackNotifier');
+const checkUrlsJob = require('./check-urls-job');
+const config = require('../../config');
+const learningContentNotification = require('../../domain/services/learning-content-notification');
+const logger = require('../../infrastructure/logger');
+const releaseRepository = require('../repositories/release-repository.js');
+const { disconnect } = require('../../../db/knex-database-connection');
+
+module.exports = async function(job) {
+  try {
+    const releaseId = await releaseRepository.create();
+    if (_isSlackNotificationGloballyEnabled() && job.data.slackNotification === true) {
+      await learningContentNotification.notifyReleaseCreationSuccess(new SlackNotifier(config.notifications.slack.webhookUrl));
+    }
+    logger.info(`Periodic release created with id ${releaseId}`);
+    checkUrlsJob.start();
+    return releaseId;
+  } catch (error) {
+    if (_isSlackNotificationGloballyEnabled()) {
+      await learningContentNotification.notifyReleaseCreationFailure(error.message, new SlackNotifier(config.notifications.slack.webhookUrl));
+    }
+    logger.error(error);
+  }
+};
+
+function _isSlackNotificationGloballyEnabled() {
+  return config.notifications.slack.enable;
+}
+
+async function exitOnSignal(signal) {
+  logger.info(`Processor received signal ${signal}. Closing DB connections before exiting.`);
+  try {
+    await disconnect();
+    process.exit(0);
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+}
+
+process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/api/lib/infrastructure/scheduled-jobs/release-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job.js
@@ -3,7 +3,8 @@ const config = require('../../config');
 const logger = require('../logger');
 
 const queue = createQueue('create-release-queue');
-queue.process(__dirname + '/release-job-processor.js');
+const processFile = __dirname + '/release-job-processor.js';
+queue.process(process.env.NODE_ENV === 'test' ? require(processFile) : processFile);
 
 const releaseJobOptions = {
   attempts: config.scheduledJobs.attempts,

--- a/api/lib/infrastructure/scheduled-jobs/release-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job.js
@@ -1,13 +1,9 @@
 const createQueue = require('./create-queue');
 const config = require('../../config');
 const logger = require('../logger');
-const releaseRepository = require('../repositories/release-repository.js');
-const SlackNotifier = require('../notifications/SlackNotifier');
-const learningContentNotification = require('../../domain/services/learning-content-notification');
-const checkUrlsJob = require('./check-urls-job');
 
 const queue = createQueue('create-release-queue');
-queue.process(createRelease);
+queue.process(__dirname + '/release-job-processor.js');
 
 const releaseJobOptions = {
   attempts: config.scheduledJobs.attempts,
@@ -19,23 +15,6 @@ const releaseJobOptions = {
     tz: 'Europe/Paris',
   },
 };
-
-async function createRelease(job) {
-  try {
-    const releaseId = await releaseRepository.create();
-    if (_isSlackNotificationGloballyEnabled() && job.data.slackNotification === true) {
-      await learningContentNotification.notifyReleaseCreationSuccess(new SlackNotifier(config.notifications.slack.webhookUrl));
-    }
-    logger.info(`Periodic release created with id ${releaseId}`);
-    checkUrlsJob.start();
-    return releaseId;
-  } catch (error) {
-    if (_isSlackNotificationGloballyEnabled()) {
-      await learningContentNotification.notifyReleaseCreationFailure(error.message, new SlackNotifier(config.notifications.slack.webhookUrl));
-    }
-    logger.error(error);
-  }
-}
 
 function schedule() {
   if (!_isScheduledReleaseEnabled()) {
@@ -49,12 +28,7 @@ function _isScheduledReleaseEnabled() {
   return config.scheduledJobs.createReleaseTime && config.scheduledJobs.redisUrl;
 }
 
-function _isSlackNotificationGloballyEnabled() {
-  return config.notifications.slack.enable;
-}
-
 module.exports = {
   schedule,
   queue,
-  createRelease,
 };

--- a/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon } = require('../../../test-helper');
 const releaseRepository = require('../../../../lib/infrastructure/repositories/release-repository');
 const Release = require('../../../../lib/domain/models/Release');
-const releaseJob = require('../../../../lib/infrastructure/scheduled-jobs/release-job');
+const releaseJobProcessor = require('../../../../lib/infrastructure/scheduled-jobs/release-job-processor');
 const learningContentNotification = require('../../../../lib/domain/services/learning-content-notification');
 const logger = require('../../../../lib/infrastructure/logger');
 const SlackNotifier = require('../../../../lib/infrastructure/notifications/SlackNotifier');
@@ -18,7 +18,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
       sinon.stub(learningContentNotification, 'notifyReleaseCreationSuccess').resolves();
 
       // when
-      await releaseJob.createRelease({ data: {} });
+      await releaseJobProcessor({ data: {} });
 
       // then
       expect(releaseRepository.create).to.have.been.called;
@@ -35,7 +35,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
       it('should return the persisted release ID', async () => {
         // when
-        const releaseId = await releaseJob.createRelease({ data: {} });
+        const releaseId = await releaseJobProcessor({ data: {} });
 
         // then
         expect(releaseId).to.exist;
@@ -47,7 +47,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         const successLogStub = sinon.stub(logger, 'info');
 
         //when
-        await releaseJob.createRelease({ data: {} });
+        await releaseJobProcessor({ data: {} });
 
         //then
         expect(successLogStub).to.have.been.called;
@@ -58,7 +58,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         sinon.stub(config.notifications, 'slack').value({ webhookUrl: 'http://webook.url', enable: true });
 
         // when
-        await releaseJob.createRelease({ data: { slackNotification: true } });
+        await releaseJobProcessor({ data: { slackNotification: true } });
 
         // then
         expect(learningContentNotification.notifyReleaseCreationSuccess).to.have.been.calledWith(new SlackNotifier('http://webook.url'));
@@ -69,7 +69,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         sinon.stub(config.notifications.slack, 'enable').value(false);
 
         // When
-        await releaseJob.createRelease({ data: { slackNotification: true } });
+        await releaseJobProcessor({ data: { slackNotification: true } });
 
         // Then
         expect(learningContentNotification.notifyReleaseCreationSuccess).to.not.have.been.called;
@@ -80,7 +80,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         sinon.stub(config.notifications.slack, 'enable').value(true);
 
         // When
-        await releaseJob.createRelease({ data: { slackNotification: false } });
+        await releaseJobProcessor({ data: { slackNotification: false } });
 
         // Then
         expect(learningContentNotification.notifyReleaseCreationSuccess).to.not.have.been.called;
@@ -99,7 +99,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         const errorLogStub = sinon.stub(logger, 'error');
 
         // when
-        await releaseJob.createRelease({ data: {} });
+        await releaseJobProcessor({ data: {} });
 
         // then
         expect(errorLogStub).to.have.been.called;
@@ -110,7 +110,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         sinon.stub(config.notifications, 'slack').value({ webhookUrl: 'http://webook.url', enable: true });
 
         // when
-        await releaseJob.createRelease({ data: { slackNotification: false } });
+        await releaseJobProcessor({ data: { slackNotification: false } });
 
         // then
         expect(learningContentNotification.notifyReleaseCreationFailure).to.have.been.calledWith('Network error', new SlackNotifier('http://webook.url'));
@@ -121,7 +121,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         sinon.stub(config.notifications.slack, 'enable').value(false);
 
         // When
-        await releaseJob.createRelease({ data: {} });
+        await releaseJobProcessor({ data: {} });
 
         // Then
         expect(learningContentNotification.notifyReleaseCreationFailure).to.not.have.been.called;


### PR DESCRIPTION
## :unicorn: Problème
Le travail asynchrone de création de release du référentiel est fait dans le même process que le serveur web, ce qui peut perturber le traitement des requêtes. Il arrive en production que ces travaux soient considéré comme bloqué (et donc relancer).

## :robot: Solution
Déplacer la création de release dans un processus dédié, voir [la doc de bull](
https://github.com/OptimalBits/bull#separate-processes).

## :rainbow: Remarques
Nock ne peut pas se brancher sur les sous processus lancés par l'application, ce qui contraint pour pouvoir tester la création de release de bout en bout de faire une condition sur le process d'exécution.

## :100: Pour tester
1. Créer une release
2. Voir le job se finir correctement
