### PR TITLE
[FEATURE] Ajouter la date de validation d'une épreuve dans la table d'Airtable "Epreuves" (PIX-6541)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -102,7 +102,8 @@ module.exports = datasource.extend({
       area: airtableRecord.get('Géographie'),
       delta: parseFloat(airtableRecord.get('Difficulté calculée')),
       alpha: parseFloat(airtableRecord.get('Discrimination calculée')),
-      updatedAt: airtableRecord.get('updated_at')
+      updatedAt: airtableRecord.get('updated_at'),
+      validatedAt: airtableRecord.get('validated_at'),
     };
   },
 
@@ -141,6 +142,7 @@ module.exports = datasource.extend({
         'Responsive': model.responsive,
         'Géographie': model.area,
         'files': model.files,
+        'validated_at': model.validatedAt,
       }
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -39,6 +39,7 @@ module.exports = {
         'skill',
         'files',
         'updatedAt',
+        'validatedAt',
       ],
       typeForAttribute(attribute) {
         if (attribute === 'files') return 'attachments';

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -136,6 +136,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
+              'validated-at': '2023-02-02T14:17:30.820Z'
             },
             relationships: {
               skill: {
@@ -227,6 +228,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
+              'validated-at': '2023-02-02T14:17:30.820Z'
             },
             relationships: {
               skill: {
@@ -281,6 +283,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
+              'validated-at': '2023-02-02T14:17:30.820Z'
             },
             relationships: {
               skill: {
@@ -434,6 +437,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
+            'validated-at': '2023-02-02T14:17:30.820Z'
           },
           relationships: {
             skill: {
@@ -546,6 +550,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': challenge.autoReply,
               focusable: challenge.focusable,
               'updated-at': '2021-10-04',
+              'validated-at': '2023-02-02T14:17:30.820Z'
             },
             relationships: {
               skill: {
@@ -607,6 +612,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
+            'validated-at': '2023-02-02T14:17:30.820Z'
           },
           relationships: {
             skill: {
@@ -705,6 +711,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               area: challenge.area,
               'auto-reply': challenge.autoReply,
               focusable: challenge.focusable,
+              'validated-at': challenge.validatedAt,
             },
             relationships: {
               skill: {
@@ -719,11 +726,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
       });
 
       // Then
+      expect(response).to.have.property('statusCode', 201);
       expect(attachmentsScope.isDone()).to.be.true;
       expect(apiTokenScope.isDone()).to.be.true;
       expect(airtableCall.isDone()).to.be.true;
       expect(apiCacheScope.isDone()).to.be.true;
-      expect(response.statusCode).to.equal(201);
     });
   });
 
@@ -791,6 +798,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': challenge.autoReply,
               focusable: challenge.focusable,
               'updated-at': '2021-10-04',
+              'validated-at': '2023-02-02T14:17:30.820Z'
             },
             relationships: {
               skill: {
@@ -852,6 +860,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
+            'validated-at': '2023-02-02T14:17:30.820Z'
           },
           relationships: {
             skill: {

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -38,6 +38,7 @@ const buildChallenge = function buildChallenge({
   delta,
   alpha,
   updatedAt,
+  validatedAt,
 }) {
   return {
     id: airtableId,
@@ -81,6 +82,7 @@ const buildChallenge = function buildChallenge({
       'Difficulté calculée': delta ? delta.toString() : '',
       'Discrimination calculée': alpha ? alpha.toString() : '',
       'updated_at': updatedAt,
+      'validated_at': validatedAt,
     },
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
@@ -37,7 +37,8 @@ module.exports = function buildChallengeAirtableDataObject({
   airtableId = 'airtable id',
   delta = 0.2,
   alpha = 0.5,
-  updatedAt = '2021-10-04'
+  updatedAt = '2021-10-04',
+  validatedAt = '2023-02-02T14:17:30.820Z'
 } = {}) {
 
   return {
@@ -79,6 +80,7 @@ module.exports = function buildChallengeAirtableDataObject({
     area,
     delta,
     alpha,
-    updatedAt
+    updatedAt,
+    validatedAt
   };
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -42,7 +42,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             area: 'France',
             'auto-reply': false,
             focusable: false,
-            'updated-at': '2021-10-04'
+            'updated-at': '2021-10-04',
+            'validated-at': '2023-02-02T14:17:30.820Z',
           },
           relationships: {
             skill: {
@@ -114,6 +115,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             focusable: false,
             competenceId: 'recsvLz0W2ShyfD63',
             'updated-at': '2021-10-04',
+            'validated-at': '2023-02-02T14:17:30.820Z',
           },
           relationships: {
             skill: {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -36,6 +36,7 @@ export default class ChallengeModel extends Model {
   @attr autoReply;
   @attr focusable;
   @attr('date') updatedAt;
+  @attr('date') validatedAt;
 
   @belongsTo('skill') skill;
   @hasMany('attachment', { inverse: 'challenge' }) files;
@@ -220,6 +221,7 @@ export default class ChallengeModel extends Model {
 
   validate() {
     this.status = 'validé';
+    this.validatedAt = new Date();
     return this.save();
   }
 


### PR DESCRIPTION
## :unicorn: Problème
L'équipe Data a besoin d'avoir la date de mise en production d'une épreuve

## :robot: Solution
Ajouter cette donnée au moment de la validation d'une épreuve côté PixEditor.
Ajouter aussi la nouvelle colonne dans les bases Airtable.

## :rainbow: Remarques
vidéo d'ajout de la colonne dans Airtable
https://user-images.githubusercontent.com/48727874/216307932-ae2169e4-b32f-407a-8760-a557b0e9b6d5.mp4


## :100: Pour tester
Valider une épreuve, et ou bien regarder dans les payloads ou dans la base airtable que la date a bien été ajoutée
