### PR TITLE
[FEATURE] Ajouter la date d'archivage dans Airtable à l'archivage d'une épreuve (PIX-6543)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -104,6 +104,7 @@ module.exports = datasource.extend({
       alpha: parseFloat(airtableRecord.get('Discrimination calculée')),
       updatedAt: airtableRecord.get('updated_at'),
       validatedAt: airtableRecord.get('validated_at'),
+      archivedAt: airtableRecord.get('archived_at'),
     };
   },
 
@@ -143,6 +144,7 @@ module.exports = datasource.extend({
         'Géographie': model.area,
         'files': model.files,
         'validated_at': model.validatedAt,
+        'archived_at': model.archivedAt,
       }
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -40,6 +40,7 @@ module.exports = {
         'files',
         'updatedAt',
         'validatedAt',
+        'archivedAt',
       ],
       typeForAttribute(attribute) {
         if (attribute === 'files') return 'attachments';

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -136,7 +136,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
-              'validated-at': '2023-02-02T14:17:30.820Z'
+              'validated-at': '2023-02-02T14:17:30.820Z',
+              'archived-at': '2023-03-03T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -228,7 +229,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
-              'validated-at': '2023-02-02T14:17:30.820Z'
+              'validated-at': '2023-02-02T14:17:30.820Z',
+              'archived-at': '2023-03-03T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -283,7 +285,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
-              'validated-at': '2023-02-02T14:17:30.820Z'
+              'validated-at': '2023-02-02T14:17:30.820Z',
+              'archived-at': '2023-03-03T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -437,7 +440,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
-            'validated-at': '2023-02-02T14:17:30.820Z'
+            'validated-at': '2023-02-02T14:17:30.820Z',
+            'archived-at': '2023-03-03T10:47:05.555Z',
           },
           relationships: {
             skill: {
@@ -550,7 +554,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': challenge.autoReply,
               focusable: challenge.focusable,
               'updated-at': '2021-10-04',
-              'validated-at': '2023-02-02T14:17:30.820Z'
+              'validated-at': '2023-02-02T14:17:30.820Z',
+              'archived-at': '2023-03-03T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -612,7 +617,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
-            'validated-at': '2023-02-02T14:17:30.820Z'
+            'validated-at': '2023-02-02T14:17:30.820Z',
+            'archived-at': '2023-03-03T10:47:05.555Z',
           },
           relationships: {
             skill: {
@@ -712,6 +718,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': challenge.autoReply,
               focusable: challenge.focusable,
               'validated-at': challenge.validatedAt,
+              'archived-at': challenge.archivedAt,
             },
             relationships: {
               skill: {
@@ -798,7 +805,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'auto-reply': challenge.autoReply,
               focusable: challenge.focusable,
               'updated-at': '2021-10-04',
-              'validated-at': '2023-02-02T14:17:30.820Z'
+              'validated-at': '2023-02-02T14:17:30.820Z',
+              'archived-at': '2023-03-03T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -860,7 +868,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
-            'validated-at': '2023-02-02T14:17:30.820Z'
+            'validated-at': '2023-02-02T14:17:30.820Z',
+            'archived-at': '2023-03-03T10:47:05.555Z',
           },
           relationships: {
             skill: {

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -39,6 +39,7 @@ const buildChallenge = function buildChallenge({
   alpha,
   updatedAt,
   validatedAt,
+  archivedAt,
 }) {
   return {
     id: airtableId,
@@ -83,6 +84,7 @@ const buildChallenge = function buildChallenge({
       'Discrimination calculée': alpha ? alpha.toString() : '',
       'updated_at': updatedAt,
       'validated_at': validatedAt,
+      'archived_at': archivedAt,
     },
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
@@ -38,7 +38,8 @@ module.exports = function buildChallengeAirtableDataObject({
   delta = 0.2,
   alpha = 0.5,
   updatedAt = '2021-10-04',
-  validatedAt = '2023-02-02T14:17:30.820Z'
+  validatedAt = '2023-02-02T14:17:30.820Z',
+  archivedAt = '2023-03-03T10:47:05.555Z',
 } = {}) {
 
   return {
@@ -81,6 +82,7 @@ module.exports = function buildChallengeAirtableDataObject({
     delta,
     alpha,
     updatedAt,
-    validatedAt
+    validatedAt,
+    archivedAt,
   };
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -44,6 +44,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             focusable: false,
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
+            'archived-at': '2023-03-03T10:47:05.555Z',
           },
           relationships: {
             skill: {
@@ -116,6 +117,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             competenceId: 'recsvLz0W2ShyfD63',
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
+            'archived-at': '2023-03-03T10:47:05.555Z',
           },
           relationships: {
             skill: {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -37,6 +37,7 @@ export default class ChallengeModel extends Model {
   @attr focusable;
   @attr('date') updatedAt;
   @attr('date') validatedAt;
+  @attr('date') archivedAt;
 
   @belongsTo('skill') skill;
   @hasMany('attachment', { inverse: 'challenge' }) files;
@@ -211,6 +212,7 @@ export default class ChallengeModel extends Model {
 
   archive() {
     this.status = 'archivé';
+    this.archivedAt = new Date();
     return this.save();
   }
 


### PR DESCRIPTION
## :unicorn: Problème
L'équipe Data a besoin d'avoir la date d'archivage d'une épreuve

## :robot: Solution
Ajouter cette donnée au moment de l'archivage d'une épreuve côté PixEditor.
Ajouter aussi la nouvelle colonne dans les bases Airtable.

## :rainbow: Remarques
La colonne a été ajoutée dans les bases Airtable selon la méthode démontrée dans la PR précédente d'ajout de date de validation


## :100: Pour tester
Archiver une épreuve, et ou bien regarder dans les payloads ou dans la base airtable que la date a bien été ajoutée
