### PR TITLE
[FEATURE] Ajouter la date de péremption d'une épreuve (PIX-7022)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -105,6 +105,7 @@ module.exports = datasource.extend({
       updatedAt: airtableRecord.get('updated_at'),
       validatedAt: airtableRecord.get('validated_at'),
       archivedAt: airtableRecord.get('archived_at'),
+      madeObsoleteAt: airtableRecord.get('made_obsolete_at'),
     };
   },
 
@@ -145,6 +146,7 @@ module.exports = datasource.extend({
         'files': model.files,
         'validated_at': model.validatedAt,
         'archived_at': model.archivedAt,
+        'made_obsolete_at': model.madeObsoleteAt,
       }
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -41,6 +41,7 @@ module.exports = {
         'updatedAt',
         'validatedAt',
         'archivedAt',
+        'madeObsoleteAt'
       ],
       typeForAttribute(attribute) {
         if (attribute === 'files') return 'attachments';

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -138,6 +138,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'updated-at': '2021-10-04',
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
+              'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -231,6 +232,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'updated-at': '2021-10-04',
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
+              'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -287,6 +289,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'updated-at': '2021-10-04',
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
+              'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -442,6 +445,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
+            'made-obsolete-at': '2023-04-04T10:47:05.555Z',
           },
           relationships: {
             skill: {
@@ -556,6 +560,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'updated-at': '2021-10-04',
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
+              'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -619,6 +624,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
+            'made-obsolete-at': '2023-04-04T10:47:05.555Z',
           },
           relationships: {
             skill: {
@@ -719,6 +725,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               focusable: challenge.focusable,
               'validated-at': challenge.validatedAt,
               'archived-at': challenge.archivedAt,
+              'made-obsolete-at': challenge.madeObsoleteAt,
             },
             relationships: {
               skill: {
@@ -807,6 +814,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'updated-at': '2021-10-04',
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
+              'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             },
             relationships: {
               skill: {
@@ -870,6 +878,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
+            'made-obsolete-at': '2023-04-04T10:47:05.555Z',
           },
           relationships: {
             skill: {

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -40,6 +40,7 @@ const buildChallenge = function buildChallenge({
   updatedAt,
   validatedAt,
   archivedAt,
+  madeObsoleteAt,
 }) {
   return {
     id: airtableId,
@@ -85,6 +86,7 @@ const buildChallenge = function buildChallenge({
       'updated_at': updatedAt,
       'validated_at': validatedAt,
       'archived_at': archivedAt,
+      'made_obsolete_at': madeObsoleteAt,
     },
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
@@ -40,6 +40,7 @@ module.exports = function buildChallengeAirtableDataObject({
   updatedAt = '2021-10-04',
   validatedAt = '2023-02-02T14:17:30.820Z',
   archivedAt = '2023-03-03T10:47:05.555Z',
+  madeObsoleteAt = '2023-04-04T10:47:05.555Z',
 } = {}) {
 
   return {
@@ -84,5 +85,6 @@ module.exports = function buildChallengeAirtableDataObject({
     updatedAt,
     validatedAt,
     archivedAt,
+    madeObsoleteAt,
   };
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -45,6 +45,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
+            'made-obsolete-at': '2023-04-04T10:47:05.555Z',
           },
           relationships: {
             skill: {
@@ -118,6 +119,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'updated-at': '2021-10-04',
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
+            'made-obsolete-at': '2023-04-04T10:47:05.555Z',
           },
           relationships: {
             skill: {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -38,6 +38,7 @@ export default class ChallengeModel extends Model {
   @attr('date') updatedAt;
   @attr('date') validatedAt;
   @attr('date') archivedAt;
+  @attr('date') madeObsoleteAt;
 
   @belongsTo('skill') skill;
   @hasMany('attachment', { inverse: 'challenge' }) files;
@@ -218,6 +219,7 @@ export default class ChallengeModel extends Model {
 
   obsolete() {
     this.status = 'périmé';
+    this.madeObsoleteAt = new Date();
     return this.save();
   }
 


### PR DESCRIPTION
Co-authored by Nicolas Lepage
Co-authored by Thomas Evano
CO-authored by Laura Bergoens

## :unicorn: Problème
Besoin de la date de péremption pour la team data dans le cadre des notifs push pour suivi des signalements

## :robot: Solution
Ajout de la date de péremption dans airtable

## :rainbow: Remarques


## :100: Pour tester
Périmer un challenge et voir si il y a bien la date de péremption dans airtable.
