### PR TITLE
[TECH] Récupérer les dates de : mise en production, archivage et obsolescence des épreuves en se basant sur le Changelog et les releases (PIX-5210)

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -181,6 +181,25 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
       "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
     },
+    "@types/pg": {
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
+      "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "@types/pg-cursor": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.0.tgz",
+      "integrity": "sha512-4Milg/OUqTO2VuPvvRwPxaQTaiVb+bXvSK+ZCwiHjwinbD4/lPqV9AREg8sJAT0cy5ruY38aaajBc2FbdPaKcA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/pg": "*"
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -333,6 +352,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -1240,6 +1264,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1278,10 +1307,92 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
+    "pg": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.9.0.tgz",
+      "integrity": "sha512-ZJM+qkEbtOHRuXjmvBtOgNOXOtLSbxiMiUVMgE4rV6Zwocy03RicCVvDXgx8l4Biwo8/qORUnEqn2fdQzV7KCg==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "pg-cursor": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.8.0.tgz",
+      "integrity": "sha512-LrOaEHK+R1C40e+xeri3FTRY/VKp9uTOCVsKtGB7LJ57qbeaphYvWjbVly8AesdT1GfHXYcAnVdExKhW7DKOvA=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w=="
+    },
+    "pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      }
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -1443,6 +1554,11 @@
           "dev": true
         }
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1699,6 +1815,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,6 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "@samwen/base62-util": "^1.0.4",
+    "@types/pg": "^8.6.6",
+    "@types/pg-cursor": "^2.7.0",
     "airtable": "0.11.1",
     "axios": "^0.21.1",
     "bluebird": "^3.7.2",
@@ -21,6 +23,8 @@
     "lodash": "4.17.21",
     "mocha": "8.2.1",
     "p-limit": "3.1.0",
+    "pg": "^8.9.0",
+    "pg-cursor": "^2.8.0",
     "progress": "2.0.3",
     "sinon": "9.2.4",
     "sinon-chai": "^3.5.0",

--- a/scripts/restore-challenges-validated-and-archived-at/index.js
+++ b/scripts/restore-challenges-validated-and-archived-at/index.js
@@ -1,5 +1,7 @@
 const { Client } = require('pg');
 const Cursor = require('pg-cursor');
+const Airtable = require('airtable');
+const _ = require('lodash');
 
 function getStatus(status) {
   return {
@@ -10,9 +12,6 @@ function getStatus(status) {
     
 (async function() {
   const client = new Client({
-    host: 'localhost',
-    port: 5433,
-    user: 'pix_lcms',
   });
   let cursor;
       
@@ -25,51 +24,97 @@ function getStatus(status) {
     const statuses = new Set();
     
     while (true) { // eslint-disable-line no-constant-condition
-      const [release] = await cursor.read(1);
-      if (!release) break;
+      const releases = await cursor.read(10);
+      if (!releases.length) break;
 
-      console.log(`reading release ${release.id}`);
+      for (const release of releases) {  
+        console.log(`reading release ${release.id}`);
 
-      for (const challenge of release.content.challenges) {
-        const status = getStatus(challenge.status);
+        for (const challenge of release.content.challenges) {
+          const status = getStatus(challenge.status);
         
-        if (!challengesInfo.has(challenge.id)) {
-          challengesInfo.set(challenge.id, {
-            status,
-            validatedAt: null,
-            archivedAt: null,
-            madeObsoleteAt: null,
-          });
+          if (!challengesInfo.has(challenge.id)) {
+            challengesInfo.set(challenge.id, {
+              recordId: null,
+              id: challenge.id,
+              status,
+              validatedAt: null,
+              archivedAt: null,
+              madeObsoleteAt: null,
+            });
+          }
+
+          const challengeInfo = challengesInfo.get(challenge.id);
+
+          statuses.add(status);
+
+          if (status === challengeInfo.status) continue;
+
+          switch (status) {
+            case 'validé':
+              challengeInfo.validatedAt = release.createdAt;
+              break;
+            case 'archivé':
+              challengeInfo.archivedAt = release.createdAt;
+              break;
+            case 'périmé':
+              challengeInfo.madeObsoleteAt = release.madeObsoleteAt;
+              break;
+          }
+
+          challengeInfo.status = status;
         }
-
-        const challengeInfo = challengesInfo.get(challenge.id);
-
-        statuses.add(status);
-
-        if (status === challengeInfo.status) continue;
-
-        switch (status) {
-          case 'validé':
-            challengeInfo.validatedAt = release.createdAt;
-            break;
-          case 'archivé':
-            challengeInfo.archivedAt = release.createdAt;
-            break;
-          case 'périmé':
-            challengeInfo.madeObsoleteAt = release.madeObsoleteAt;
-            break;
-        }
-
-        challengeInfo.status = status;
       }
     }
 
+    const challengesToUpdate = [...challengesInfo.values()].filter(({ validatedAt,archivedAt, madeObsoleteAt })=> validatedAt || archivedAt || madeObsoleteAt);
+    console.log(challengesToUpdate);
     console.log('total:', challengesInfo.size);
     console.log('validated:', [...challengesInfo.values()].filter(({ validatedAt })=>validatedAt).length);
     console.log('archived:', [...challengesInfo.values()].filter(({ archivedAt })=>archivedAt).length);
     console.log('madeObsoleteAt:', [...challengesInfo.values()].filter(({ madeObsoleteAt })=>madeObsoleteAt).length);
-    console.log([...challengesInfo.values()].filter(({ validatedAt,archivedAt, madeObsoleteAt })=> validatedAt || archivedAt || madeObsoleteAt));
     console.log(statuses);
+
+    const airtableClient =  new Airtable({
+      apiKey: ''
+    }).base('');
+
+    console.log('reading all challenges from Airtable...');
+    const allChallenges = await airtableClient.table('Epreuves').select({
+      fields: ['id persistant', 'validated_at', 'archived_at', 'made_obsolete_at'],
+    }).all();
+
+    const updates = [];
+    for (const challengeToUpdate of challengesToUpdate) {
+      const airtableChallenge = allChallenges.find((challenge) => {
+        return challenge.fields['id persistant'] === challengeToUpdate.id;
+      });
+      const update = {
+        id: airtableChallenge.id,
+        fields: {}
+      };
+      if (challengeToUpdate.validatedAt != null && airtableChallenge.fields['validated_at'] == null) {
+        update.fields['validated_at'] = challengeToUpdate.validatedAt;
+      }
+      if (challengeToUpdate.archivedAt != null && airtableChallenge.fields['archived_at'] == null) {
+        update.fields['archived_at'] = challengeToUpdate.archivedAt;
+      }      
+      if (challengeToUpdate.madeObsoleteAt != null && airtableChallenge.fields['made_obsolete_at'] == null) {
+        update.fields['made_obsolete_at'] = challengeToUpdate.madeObsoleteAt;
+      }
+      if (update.fields['validated_at'] || update.fields['archived_at'] || update.fields['made_obsolete_at']) {
+        updates.push(update);
+      }
+    }
+
+    const updatesChunks = _.chunk(updates, 10);
+
+    console.log('updating records to Airtable...');
+    for (const updatesChunk of updatesChunks) {
+      await airtableClient.table('Epreuves').update(updatesChunk);
+    }
+
+    console.log('DONE!');
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/scripts/restore-challenges-validated-and-archived-at/index.js
+++ b/scripts/restore-challenges-validated-and-archived-at/index.js
@@ -11,110 +11,25 @@ function getStatus(status) {
 }
     
 (async function() {
-  const client = new Client({
-  });
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
   let cursor;
       
   try {
     await client.connect();
+    const result = await client.query('SELECT "createdAt" FROM releases ORDER BY "createdAt" limit 1');
+    const oldestReleaseDate = result.rows[0]['createdAt'];
 
+    // changelog
+    const changelogChallengesInfo = await _parseChangelog(oldestReleaseDate);
+
+    // bdd
     cursor = client.query(new Cursor('SELECT id, "createdAt", content FROM releases ORDER BY "createdAt"'));
+    const releasesChallengesInfo = await _parseReleases(cursor);
 
-    const challengesInfo = new Map();
-    const statuses = new Set();
-    
-    while (true) { // eslint-disable-line no-constant-condition
-      const releases = await cursor.read(10);
-      if (!releases.length) break;
+    const challengesInfo = _mergeChallengesInfo(changelogChallengesInfo, releasesChallengesInfo);
 
-      for (const release of releases) {  
-        console.log(`reading release ${release.id}`);
-
-        for (const challenge of release.content.challenges) {
-          const status = getStatus(challenge.status);
-        
-          if (!challengesInfo.has(challenge.id)) {
-            challengesInfo.set(challenge.id, {
-              recordId: null,
-              id: challenge.id,
-              status,
-              validatedAt: null,
-              archivedAt: null,
-              madeObsoleteAt: null,
-            });
-          }
-
-          const challengeInfo = challengesInfo.get(challenge.id);
-
-          statuses.add(status);
-
-          if (status === challengeInfo.status) continue;
-
-          switch (status) {
-            case 'validé':
-              challengeInfo.validatedAt = release.createdAt;
-              break;
-            case 'archivé':
-              challengeInfo.archivedAt = release.createdAt;
-              break;
-            case 'périmé':
-              challengeInfo.madeObsoleteAt = release.madeObsoleteAt;
-              break;
-          }
-
-          challengeInfo.status = status;
-        }
-      }
-    }
-
-    const challengesToUpdate = [...challengesInfo.values()].filter(({ validatedAt,archivedAt, madeObsoleteAt })=> validatedAt || archivedAt || madeObsoleteAt);
-    console.log(challengesToUpdate);
-    console.log('total:', challengesInfo.size);
-    console.log('validated:', [...challengesInfo.values()].filter(({ validatedAt })=>validatedAt).length);
-    console.log('archived:', [...challengesInfo.values()].filter(({ archivedAt })=>archivedAt).length);
-    console.log('madeObsoleteAt:', [...challengesInfo.values()].filter(({ madeObsoleteAt })=>madeObsoleteAt).length);
-    console.log(statuses);
-
-    const airtableClient =  new Airtable({
-      apiKey: ''
-    }).base('');
-
-    console.log('reading all challenges from Airtable...');
-    const allChallenges = await airtableClient.table('Epreuves').select({
-      fields: ['id persistant', 'validated_at', 'archived_at', 'made_obsolete_at'],
-    }).all();
-
-    const updates = [];
-    for (const challengeToUpdate of challengesToUpdate) {
-      const airtableChallenge = allChallenges.find((challenge) => {
-        return challenge.fields['id persistant'] === challengeToUpdate.id;
-      });
-      const update = {
-        id: airtableChallenge.id,
-        fields: {}
-      };
-      if (challengeToUpdate.validatedAt != null && airtableChallenge.fields['validated_at'] == null) {
-        update.fields['validated_at'] = challengeToUpdate.validatedAt;
-      }
-      if (challengeToUpdate.archivedAt != null && airtableChallenge.fields['archived_at'] == null) {
-        update.fields['archived_at'] = challengeToUpdate.archivedAt;
-      }      
-      if (challengeToUpdate.madeObsoleteAt != null && airtableChallenge.fields['made_obsolete_at'] == null) {
-        update.fields['made_obsolete_at'] = challengeToUpdate.madeObsoleteAt;
-      }
-      if (update.fields['validated_at'] || update.fields['archived_at'] || update.fields['made_obsolete_at']) {
-        updates.push(update);
-      }
-    }
-
-    const updatesChunks = _.chunk(updates, 10);
-
-    console.log('updating records to Airtable...');
-    for (const updatesChunk of updatesChunks) {
-      await airtableClient.table('Epreuves').update(updatesChunk);
-    }
-
-    console.log('DONE!');
+    // airtable
+    await _updateAirtable(challengesInfo);
   } catch (e) {
     console.error(e);
     process.exit(1);
@@ -123,3 +38,193 @@ function getStatus(status) {
     await client.end();
   }
 })();
+
+function _mergeChallengesInfo(...challengesInfos) {
+  const allChallengesInfo = new Map();
+
+  for (const challengesInfo of challengesInfos) {
+    for (const [id, newInfo] of challengesInfo) {
+      if (allChallengesInfo.has(id)) {
+        const oldInfo = allChallengesInfo.get(id);
+        oldInfo.validatedAt = oldInfo.validatedAt ?? newInfo.validatedAt;
+        oldInfo.archivedAt = oldInfo.archivedAt ?? newInfo.archivedAt;
+        oldInfo.madeObsoleteAt = oldInfo.madeObsoleteAt ?? newInfo.madeObsoleteAt;
+      } else {
+        allChallengesInfo.set(id, newInfo);
+      }
+    }
+  }
+
+  return allChallengesInfo;
+}
+
+async function _parseReleases(cursor) {
+  const challengesInfo = new Map();
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const releases = await cursor.read(25);
+    if (!releases.length) break;
+
+    for (const release of releases) {
+      console.log(`reading release ${release.id}`);
+
+      for (const challenge of release.content.challenges) {
+        const status = getStatus(challenge.status);
+
+        if (!challengesInfo.has(challenge.id)) {
+          challengesInfo.set(challenge.id, {
+            recordId: null,
+            id: challenge.id,
+            status,
+            validatedAt: null,
+            archivedAt: null,
+            madeObsoleteAt: null,
+          });
+        }
+
+        const challengeInfo = challengesInfo.get(challenge.id);
+
+        if (status === challengeInfo.status) continue;
+
+        switch (status) {
+          case 'validé':
+            challengeInfo.validatedAt = release.createdAt;
+            break;
+          case 'archivé':
+            challengeInfo.archivedAt = release.createdAt;
+            break;
+          case 'périmé':
+            challengeInfo.madeObsoleteAt = release.createdAt;
+            break;
+        }
+
+        challengeInfo.status = status;
+      }
+    }
+  }
+
+  return challengesInfo;
+}
+
+async function _parseChangelog(oldestReleaseDate) {
+  const challengesInfo = new Map();
+
+  const changelogAirtableClient = new Airtable({
+    apiKey: process.env.AIRTABLE_API_KEY,
+  }).base(process.env.AIRTABLE_EDITOR_BASE);
+
+  console.log(`reading all changelogs older than ${oldestReleaseDate} from Airtable changelog base...`);
+  const allChangelogs = await changelogAirtableClient.table('Notes').select({
+    fields: ['Texte', 'Record_Id', 'Date'],
+  }).all();
+  console.log('done');
+
+  const dateFilteredChangelogs = allChangelogs
+    .filter((changelog) => new Date(changelog.fields['Date']) < oldestReleaseDate)
+    .sort((changelogA, changelogB) => {
+      if (new Date(changelogA.fields['Date']) < new Date(changelogB.fields['Date'])) return -1;
+      if (new Date(changelogA.fields['Date']) > new Date(changelogB.fields['Date'])) return 1;
+      if (new Date(changelogA.fields['Date']) === new Date(changelogB.fields['Date'])) return 0;
+    });
+
+  const TEXT_VALIDATE_PROTO = 'Mise en production du prototype';
+  const TEXT_VALIDATE_ALTER = 'Mise en production de la déclinaison';
+  const TEXT_ARCHIVE = 'Archivage de l\'épreuve';
+  const TEXT_OBSOLETE = 'Obsolescence de l\'épreuve';
+  const TEXT_SUPPRESSION = 'Suppression de l\'épreuve';
+
+  for (const changelog of dateFilteredChangelogs) {
+    const challengeId = changelog.fields['Record_Id'];
+    if (!challengesInfo.has(challengeId)) {
+      challengesInfo.set(challengeId, {
+        recordId: null,
+        id: challengeId,
+        status: null,
+        validatedAt: null,
+        archivedAt: null,
+        madeObsoleteAt: null,
+      });
+    }
+    const text = changelog.fields['Texte'];
+    let challengeInfo;
+
+    if (text.includes(TEXT_VALIDATE_PROTO) || text.includes(TEXT_VALIDATE_ALTER) || text.includes(TEXT_ARCHIVE) || text.includes(TEXT_OBSOLETE) || text.includes(TEXT_SUPPRESSION)) {
+      if (!challengesInfo.has(challengeId)) {
+        challengesInfo.set(challengeId, {
+          recordId: null,
+          id: challengeId,
+          status: null,
+          validatedAt: null,
+          archivedAt: null,
+          madeObsoleteAt: null,
+        });
+      }
+      challengeInfo = challengesInfo.get(challengeId);
+    }
+    if (text.includes(TEXT_VALIDATE_PROTO) || text.includes(TEXT_VALIDATE_ALTER)) {
+      challengeInfo.status = 'validé';
+      challengeInfo.validatedAt = new Date(changelog.fields['Date']);
+    }
+    if (text.includes(TEXT_ARCHIVE)) {
+      challengeInfo.status = 'archivé';
+      challengeInfo.archivedAt = new Date(changelog.fields['Date']);
+    }
+    if (text.includes(TEXT_OBSOLETE) || text.includes(TEXT_SUPPRESSION)) {
+      challengeInfo.status = 'périmé';
+      challengeInfo.madeObsoleteAt = new Date(changelog.fields['Date']);
+    }
+  }
+
+  return challengesInfo;
+}
+
+async function _updateAirtable(challengesInfo) {
+  const challengesToUpdate = [...challengesInfo.values()].filter(({ validatedAt,archivedAt, madeObsoleteAt })=> validatedAt || archivedAt || madeObsoleteAt);
+  console.log('validated:', [...challengesInfo.values()].filter(({ validatedAt })=>validatedAt).length);
+  console.log('archived:', [...challengesInfo.values()].filter(({ archivedAt })=>archivedAt).length);
+  console.log('madeObsoleteAt:', [...challengesInfo.values()].filter(({ madeObsoleteAt })=>madeObsoleteAt).length);
+
+  const airtableClient =  new Airtable({
+    apiKey: process.env.AIRTABLE_API_KEY,
+  }).base(process.env.AIRTABLE_BASE);
+
+  console.log('reading all challenges from Airtable...');
+  const allChallenges = await airtableClient.table('Epreuves').select({
+    fields: ['id persistant', 'validated_at', 'archived_at', 'made_obsolete_at'],
+  }).all();
+  console.log('done');
+
+  const updates = [];
+  for (const challengeToUpdate of challengesToUpdate) {
+    const airtableChallenge = allChallenges.find((challenge) => {
+      return challenge.fields['id persistant'] === challengeToUpdate.id;
+    });
+    const update = {
+      id: airtableChallenge.id,
+      fields: {}
+    };
+    if (challengeToUpdate.validatedAt != null && airtableChallenge.fields['validated_at'] == null) {
+      update.fields['validated_at'] = challengeToUpdate.validatedAt;
+    }
+    if (challengeToUpdate.archivedAt != null && airtableChallenge.fields['archived_at'] == null) {
+      update.fields['archived_at'] = challengeToUpdate.archivedAt;
+    }
+    if (challengeToUpdate.madeObsoleteAt != null && airtableChallenge.fields['made_obsolete_at'] == null) {
+      update.fields['made_obsolete_at'] = challengeToUpdate.madeObsoleteAt;
+    }
+    if (update.fields['validated_at'] || update.fields['archived_at'] || update.fields['made_obsolete_at']) {
+      updates.push(update);
+    }
+  }
+  console.log('REAL total:', updates.length);
+
+  console.log(updates);
+  const updatesChunks = _.chunk(updates, 10);
+
+  console.log('updating records to Airtable...');
+  for (const updatesChunk of updatesChunks) {
+    await airtableClient.table('Epreuves').update(updatesChunk);
+  }
+
+  console.log('DONE!');
+}

--- a/scripts/restore-challenges-validated-and-archived-at/index.js
+++ b/scripts/restore-challenges-validated-and-archived-at/index.js
@@ -1,0 +1,80 @@
+const { Client } = require('pg');
+const Cursor = require('pg-cursor');
+
+function getStatus(status) {
+  return {
+    'validé sans test': 'validé',
+    'pré-validé': 'validé',
+  }[status] ?? status;
+}
+    
+(async function() {
+  const client = new Client({
+    host: 'localhost',
+    port: 5433,
+    user: 'pix_lcms',
+  });
+  let cursor;
+      
+  try {
+    await client.connect();
+
+    cursor = client.query(new Cursor('SELECT id, "createdAt", content FROM releases ORDER BY "createdAt"'));
+
+    const challengesInfo = new Map();
+    const statuses = new Set();
+    
+    while (true) { // eslint-disable-line no-constant-condition
+      const [release] = await cursor.read(1);
+      if (!release) break;
+
+      console.log(`reading release ${release.id}`);
+
+      for (const challenge of release.content.challenges) {
+        const status = getStatus(challenge.status);
+        
+        if (!challengesInfo.has(challenge.id)) {
+          challengesInfo.set(challenge.id, {
+            status,
+            validatedAt: null,
+            archivedAt: null,
+            madeObsoleteAt: null,
+          });
+        }
+
+        const challengeInfo = challengesInfo.get(challenge.id);
+
+        statuses.add(status);
+
+        if (status === challengeInfo.status) continue;
+
+        switch (status) {
+          case 'validé':
+            challengeInfo.validatedAt = release.createdAt;
+            break;
+          case 'archivé':
+            challengeInfo.archivedAt = release.createdAt;
+            break;
+          case 'périmé':
+            challengeInfo.madeObsoleteAt = release.madeObsoleteAt;
+            break;
+        }
+
+        challengeInfo.status = status;
+      }
+    }
+
+    console.log('total:', challengesInfo.size);
+    console.log('validated:', [...challengesInfo.values()].filter(({ validatedAt })=>validatedAt).length);
+    console.log('archived:', [...challengesInfo.values()].filter(({ archivedAt })=>archivedAt).length);
+    console.log('madeObsoleteAt:', [...challengesInfo.values()].filter(({ madeObsoleteAt })=>madeObsoleteAt).length);
+    console.log([...challengesInfo.values()].filter(({ validatedAt,archivedAt, madeObsoleteAt })=> validatedAt || archivedAt || madeObsoleteAt));
+    console.log(statuses);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  } finally {
+    cursor.close();
+    await client.end();
+  }
+})();


### PR DESCRIPTION
## 🏴‍☠️ Problème
On a ajouté les 3 infos pour les modifications à venir apportées aux épreuves. Idéalement, la team data aimerait qu'on réussisse à récupérer des infos du passé.

## :robot: Solution
On a deux sources d'information pour cela :
- Le changelog
- Les releases

Les releases sont la source d'info la plus "complète", malheureusement la première release date de mars 2021. Ce qui veut dire que pour avant cette date, on va parcourir le changelog et voir si on peut extraire des informations, grâce au texte de changelog par défaut.

En somme, les épreuves pour lesquelles on ne pourra pas retrouver l'info sont :
- Les épreuves dont la modification (validation/archivage/obsolescence) a été réalisée avant mars 2021
- ET donc le texte de changelog ayant accompagné la modification a été profondément modifier par l'utilisateur PixEditor

## :rainbow: Remarques
N/A

## :100: Pour tester
Pour faire un test :
- Dupliquer les bases de prod airtable : réf et changelog
- Se débrouiller pour se connecter à la BDD LCMS de prod avec les releases (on dira pas comment 😯 )
- Lancer le script et vérifier que ça glisse
- Supprimer les bases dupliquées pour passer inaperçu 😄 
