### PR TITLE
[BUGFIX] Prévenir les erreurs 500 sur PATCH /api/challenges/{id} (PIX-7095)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -94,6 +94,17 @@ exports.register = async function(server) {
           params: Joi.object({
             id: challengeIdType,
           }),
+          payload: Joi.object({
+            data: {
+              type: 'challenges',
+              attributes: {
+                locales: Joi.required(),
+              },
+            },
+          }),
+          options: {
+            allowUnknown: true,
+          },
         },
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -899,5 +899,28 @@ describe('Acceptance | Controller | challenges-controller', () => {
         },
       });
     });
+    it('should return 400 error on invalid request', async () => {
+      // Given
+      const server = await createServer();
+
+      // When
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/challenges/challengeBidon',
+        headers: generateAuthorizationHeader(user),
+        payload: {
+          data: {
+            type: 'challenges',
+            id: 'challengeBidon',
+            attributes: {
+              'nimportequoi': 'par exemple'
+            },
+          },
+        },
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(400);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La route `PATCH /api/challenges` renoie une erreur 500 si le format du payload est incorrect.
Mais on ne peut pas identifier quel est le champ en question.

## :robot: Solution
Soit ajouter une vérification en entrée (Joi).
Soit inspecter le retour de l'appel Airtable.

## :rainbow: Remarques
Ajout de tests sur le comportement existant.

## :100: Pour tester
Vérifier la CI.
