### PR TITLE
[FEATURE] Add default selected value on geographic field (PIX-3590)

### DIFF
--- a/pix-editor/app/components/field/select.hbs
+++ b/pix-editor/app/components/field/select.hbs
@@ -9,7 +9,7 @@
     {{/if}}
   </PowerSelectMultiple>
 {{else}}
-  <PowerSelect @placeholder={{if @defaultText @defaultText ""}} @searchEnabled={{false}} @options={{@options}} @disabled={{if @edition false true}} @selected={{if @value @value "" }} @onChange={{@setValue}} as |option|>
+  <PowerSelect @placeholder={{if @defaultText @defaultText ""}} @searchEnabled={{false}} @options={{@options}} @disabled={{if @edition false true}} @selected={{if @value @value @defaultValue}} @onChange={{@setValue}} as |option|>
     {{#if option.label}}
       {{option.label}}
     {{else}}

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -176,6 +176,7 @@
           @value={{@challenge.area}}
           @edition={{@edition}}
           @multiple={{false}}
+          @defaultValue="Neutre"
           @options={{this.options.area}}
           @setValue={{fn (mut @challenge.area)}}
         />


### PR DESCRIPTION
## :unicorn: Problème
Dans pixEditor, lors de la création d'une épreuve : par défaut le champ géographie est vide

## :robot: Solution
Mettre le champ géographie à "neutre"

## :100: Pour tester
Aller dans l'atelier et créer un nouveau prototype, vous aurez accès au champ géographie
