### PR TITLE
[TECH] Vérifier la validités des liens contenu dans les bonnes réponses des épreuves (PIX-6190).

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -19,6 +19,10 @@ function findUrlsProposalsFromChallenge(challenge) {
   return findUrlsInMarkdown(challenge.proposals || '');
 }
 
+function findUrlsSolutionFromChallenge(challenge) {
+  return findUrlsInMarkdown(challenge.solution || '');
+}
+
 function cleanUrl(url) {
   const index = url.indexOf('</');
   if (index >= 0) {
@@ -61,7 +65,8 @@ function findUrlsFromChallenges(challenges, release) {
   return challenges.flatMap((challenge) => {
     const functions = [
       findUrlsInstructionFromChallenge,
-      findUrlsProposalsFromChallenge
+      findUrlsProposalsFromChallenge,
+      findUrlsSolutionFromChallenge
     ];
     const urls = functions
       .flatMap((fun) => fun(challenge))
@@ -177,6 +182,7 @@ module.exports = {
   findUrlsInMarkdown,
   findUrlsInstructionFromChallenge,
   findUrlsProposalsFromChallenge,
+  findUrlsSolutionFromChallenge,
   findUrlsFromChallenges,
   findUrlsFromTutorials,
 };

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -23,6 +23,10 @@ function findUrlsSolutionFromChallenge(challenge) {
   return findUrlsInMarkdown(challenge.solution || '');
 }
 
+function findUrlsSolutionToDisplayFromChallenge(challenge) {
+  return findUrlsInMarkdown(challenge.solutionToDisplay || '');
+}
+
 function cleanUrl(url) {
   const index = url.indexOf('</');
   if (index >= 0) {
@@ -66,7 +70,8 @@ function findUrlsFromChallenges(challenges, release) {
     const functions = [
       findUrlsInstructionFromChallenge,
       findUrlsProposalsFromChallenge,
-      findUrlsSolutionFromChallenge
+      findUrlsSolutionFromChallenge,
+      findUrlsSolutionToDisplayFromChallenge
     ];
     const urls = functions
       .flatMap((fun) => fun(challenge))
@@ -183,6 +188,7 @@ module.exports = {
   findUrlsInstructionFromChallenge,
   findUrlsProposalsFromChallenge,
   findUrlsSolutionFromChallenge,
+  findUrlsSolutionToDisplayFromChallenge,
   findUrlsFromChallenges,
   findUrlsFromTutorials,
 };

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -5,6 +5,7 @@ const {
   findUrlsInstructionFromChallenge,
   findUrlsProposalsFromChallenge,
   findUrlsSolutionFromChallenge,
+  findUrlsSolutionToDisplayFromChallenge,
   findUrlsFromChallenges,
   getLiveChallenges,
   findUrlsFromTutorials
@@ -107,6 +108,28 @@ describe('Check urls from release', function() {
     });
   });
 
+  describe('#findUrlsSolutionToDisplayFromChallenge', function() {
+    it('should not find url solution to display from a challenge when there is no url', function() {
+      const challenge = {
+        id: 'challenge123',
+        solutionToDisplay: 'solution to display',
+      };
+      const urls = findUrlsSolutionToDisplayFromChallenge(challenge);
+
+      expect(urls).to.deep.equal([]);
+    });
+
+    it('should find url solution to display from a challenge', function() {
+      const challenge = {
+        id: 'challenge123',
+        solutionToDisplay: 'solution to display [link](https://example.com/)',
+      };
+      const urls = findUrlsSolutionToDisplayFromChallenge(challenge);
+
+      expect(urls).to.deep.equal(['https://example.com/']);
+    });
+  });
+
   describe('#findUrlsFromChallenges', function() {
     it('should find urls from challenges', function() {
       const release = {
@@ -136,6 +159,13 @@ describe('Check urls from release', function() {
           proposals: 'proposals [link](https://example.fr/)',
           skillId: undefined,
           status: 'validé',
+        },
+        {
+          id: 'challenge3',
+          instruction: 'instructions',
+          solutionToDisplay: 'solution to display https://solutionToDisplay_example.org/',
+          skillId: 'skill2',
+          status: 'validé',
         }
       ];
 
@@ -144,6 +174,7 @@ describe('Check urls from release', function() {
         { id: '@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
         { id: '@mySkill1;challenge1;validé', url: 'https://solution_example.net/' },
         { id: ';challenge2;validé', url: 'https://example.fr/' },
+        { id: '@mySkill2;challenge3;validé', url: 'https://solutionToDisplay_example.org/' },
       ];
 
       const urls = findUrlsFromChallenges(challenges, release);

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -4,6 +4,7 @@ const {
   findUrlsInMarkdown,
   findUrlsInstructionFromChallenge,
   findUrlsProposalsFromChallenge,
+  findUrlsSolutionFromChallenge,
   findUrlsFromChallenges,
   getLiveChallenges,
   findUrlsFromTutorials
@@ -84,6 +85,28 @@ describe('Check urls from release', function() {
     });
   });
 
+  describe('#findUrlsSolutionFromChallenge', function() {
+    it('should not find url solution from a challenge when there is no url', function() {
+      const challenge = {
+        id: 'challenge123',
+        solution: 'solution',
+      };
+      const urls = findUrlsSolutionFromChallenge(challenge);
+
+      expect(urls).to.deep.equal([]);
+    });
+
+    it('should find url solution from a challenge', function() {
+      const challenge = {
+        id: 'challenge123',
+        solution: 'solution [link](https://example.com/)',
+      };
+      const urls = findUrlsSolutionFromChallenge(challenge);
+
+      expect(urls).to.deep.equal(['https://example.com/']);
+    });
+  });
+
   describe('#findUrlsFromChallenges', function() {
     it('should find urls from challenges', function() {
       const release = {
@@ -103,6 +126,7 @@ describe('Check urls from release', function() {
           id: 'challenge1',
           instruction: 'instructions [link](https://example.net/) further instructions [other_link](https://other_example.net/)',
           proposals: 'proposals [link](https://example.net/)',
+          solution: 'solution [link](https://solution_example.net/)',
           skillId: 'skill1',
           status: 'validé',
         },
@@ -118,6 +142,7 @@ describe('Check urls from release', function() {
       const expectedOutput = [
         { id: '@mySkill1;challenge1;validé', url: 'https://example.net/' },
         { id: '@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
+        { id: '@mySkill1;challenge1;validé', url: 'https://solution_example.net/' },
         { id: ';challenge2;validé', url: 'https://example.fr/' },
       ];
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous vérifions la validité des liens contenus dans nos épreuves nous ne vérifions pas ceux présents dans les champs `bonne réponses` et `bonnes réponses à afficher`

## :robot: Solution
Vérifier les liens présentss dans les champs `bonne réponses` et `bonnes réponses à afficher` dans le script de check des URL

## :rainbow: Remarques
RAS

## :100: Pour tester
?
