### PR TITLE
[BUGFIX] Les logs système ne sont pas désactivables

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -34,6 +34,7 @@ module.exports = (function() {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
       logLevel: (process.env.LOG_LEVEL || 'info'),
+      logOpsMetrics: isFeatureEnabled(process.env.LOG_OPS_METRICS),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
       prettyPrint: isFeatureEnabled(process.env.LOG_PRETTY_PRINT)
     },

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 
 const schema = Joi.object({
+  LOG_OPS_METRICS: Joi.string().valid('true', 'false').optional(),
   OPS_EVENT_EACH_SECONDS: Joi.number().integer().min(1).optional()
 }).options({ allowUnknown: true });
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -179,6 +179,16 @@ LOG_ENABLED=true
 # default: "info"
 # LOG_LEVEL=debug
 
+# Log operations metrics
+#
+# Log core container metrics: CPU, memory, load-average, http calls...
+# Sample output: {"event":"ops","timestamp":1630419363680,"host":"pix-api-production-web-2","pid":22,"os":{"load":[2.16,1.97,1.85],"mem":{"total":42185723904,"free":6782152704},"uptime":8208319.46},"proc":{"uptime":81367.686662047,"mem":{"rss":196128768,"heapTotal":109948928,"heapUsed":104404328,"external":6004718,"arrayBuffers":4416211},"delay":0.11345672607421875},"load":{"requests":{"21344":{"total":55,"disconnects":0,"statusCodes":{"200":43,"201":10,"204":1,"401":1}}},"responseTimes":{"21344":{"avg":19.472727272727273,"max":64}},"sockets":{"http":{"total":0},"https":{"total":0}}}}
+#
+# presence: optional
+# type: Boolean
+# default: `undefined` (`false`)
+# LOG_OPS_METRICS=true
+
 # Log operations sample rate
 #
 # Time (seconds) each logging

--- a/api/server.js
+++ b/api/server.js
@@ -43,7 +43,7 @@ const createServer = async () => {
 
   const configuration = [].concat(plugins, routes);
 
-  await enableOpsMetrics(server);
+  if (config.logging.logOpsMetrics) await enableOpsMetrics(server);
 
   await server.register(configuration);
 


### PR DESCRIPTION
## :unicorn: Problème
La désactivation des logs système a été désactivée par erreur dans https://github.com/1024pix/pix-editor/pull/79

## :robot: Solution
La restaurer

## :100: Pour tester
Passer LOG_OPS_METRICS=true
Vérifier que les logs sont présents

Passer LOG_OPS_METRICS=false
Vérifier que les logs sont absents
