### PR TITLE
[FEATURE] Ajouté le nom de la compétence dans le résultat du check des URL (PIX-6042).

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -52,6 +52,28 @@ function findUrlsInMarkdown(value) {
   return _.uniq(urls.map(cleanUrl).map(prependProtocol));
 }
 
+function findCompetenceNameFromChallenge(challenge, release) {
+  const skill = release.skills.find(({ id }) => challenge.skillId === id);
+  if (!skill) return '';
+  return findCompetenceNameFromSkill(skill, release);
+}
+
+function findCompetencesNameFromTutorial(tutorial, release) {
+  const skills = release.skills.filter((skill) => {
+    return skill.tutorialIds.includes(tutorial.id) ||
+      skill.learningMoreTutorialIds.includes(tutorial.id);
+  });
+  const competenceNames =  _.uniq(skills.map((skill) => skill ? findCompetenceNameFromSkill(skill, release) : ''));
+  return competenceNames.join(' ');
+}
+
+function findCompetenceNameFromSkill(skill, release) {
+  const tube = release.tubes.find(({ id }) => skill.tubeId === id);
+  if (!tube) return '';
+  const competence = release.competences.find(({ id }) => tube.competenceId === id);
+  return competence?.name_i18n.fr || '';
+}
+
 function findSkillsNameFromChallenge(challenge, release) {
   const skills = release.skills.filter(({ id }) => challenge.skillId === id);
   return skills.map((s) => s.name).join(' ');
@@ -76,7 +98,7 @@ function findUrlsFromChallenges(challenges, release) {
     const urls = functions
       .flatMap((fun) => fun(challenge))
       .map((url) => {
-        return { id: [findSkillsNameFromChallenge(challenge, release), challenge.id, challenge.status].join(';'), url };
+        return { id: [findCompetenceNameFromChallenge(challenge, release), findSkillsNameFromChallenge(challenge, release), challenge.id, challenge.status].join(';'), url };
       });
 
     return _.uniqBy(urls, 'url');
@@ -85,7 +107,7 @@ function findUrlsFromChallenges(challenges, release) {
 
 function findUrlsFromTutorials(tutorials, release) {
   return tutorials.map((tutorial) => {
-    return { id: [findSkillsNameFromTutorial(tutorial, release), tutorial.id].join(';'), url: tutorial.link };
+    return { id: [findCompetencesNameFromTutorial(tutorial, release), findSkillsNameFromTutorial(tutorial, release), tutorial.id].join(';'), url: tutorial.link };
   });
 }
 

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -133,13 +133,29 @@ describe('Check urls from release', function() {
   describe('#findUrlsFromChallenges', function() {
     it('should find urls from challenges', function() {
       const release = {
+        competences: [
+          {
+            id: 'competence1',
+            name_i18n: {
+              fr: 'competence 1.1'
+            }
+          }
+        ],
+        tubes: [
+          {
+            id: 'tube1',
+            competenceId: 'competence1'
+          }
+        ],
         skills: [
           {
             id: 'skill1',
+            tubeId: 'tube1',
             name: '@mySkill1'
           },
           {
             id: 'skill2',
+            tubeId: 'tube1',
             name: '@mySkill2'
           }
         ]
@@ -170,11 +186,11 @@ describe('Check urls from release', function() {
       ];
 
       const expectedOutput = [
-        { id: '@mySkill1;challenge1;validé', url: 'https://example.net/' },
-        { id: '@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
-        { id: '@mySkill1;challenge1;validé', url: 'https://solution_example.net/' },
-        { id: ';challenge2;validé', url: 'https://example.fr/' },
-        { id: '@mySkill2;challenge3;validé', url: 'https://solutionToDisplay_example.org/' },
+        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://example.net/' },
+        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
+        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://solution_example.net/' },
+        { id: ';;challenge2;validé', url: 'https://example.fr/' },
+        { id: 'competence 1.1;@mySkill2;challenge3;validé', url: 'https://solutionToDisplay_example.org/' },
       ];
 
       const urls = findUrlsFromChallenges(challenges, release);
@@ -223,14 +239,40 @@ describe('Check urls from release', function() {
   describe('#findUrlsFromTutorials', function() {
     it('should find urls from tutorials', function() {
       const release = {
+        competences: [
+          {
+            id: 'competence1',
+            name_i18n: {
+              fr: 'competence 1.1'
+            }
+          },
+          {
+            id: 'competence2',
+            name_i18n: {
+              fr: 'competence 1.2'
+            }
+          }
+        ],
+        tubes: [
+          {
+            id: 'tube1',
+            competenceId: 'competence1'
+          },
+          {
+            id: 'tube2',
+            competenceId: 'competence2'
+          }
+        ],
         skills: [
           {
             name: '@mySkill1',
+            tubeId: 'tube1',
             tutorialIds: ['tutorial1', 'tutorial3'],
             learningMoreTutorialIds: [],
           },
           {
             name: '@mySkill2',
+            tubeId: 'tube2',
             tutorialIds: [],
             learningMoreTutorialIds: ['tutorial3'],
           },
@@ -253,15 +295,15 @@ describe('Check urls from release', function() {
 
       const expectedOutput = [
         {
-          id: '@mySkill1;tutorial1',
+          id: 'competence 1.1;@mySkill1;tutorial1',
           url: 'https://example.net/'
         },
         {
-          id: ';tutorial2',
+          id: ';;tutorial2',
           url: 'https://example.net/'
         },
         {
-          id: '@mySkill1 @mySkill2;tutorial3',
+          id: 'competence 1.1 competence 1.2;@mySkill1 @mySkill2;tutorial3',
           url: 'https://example.net/'
         }
       ];


### PR DESCRIPTION
## :unicorn: Problème
Nous n'affichons que l'acquis des épreuves ou tutoriels lors du check des URL. Mais pour traiter un soucis nous avons besoin de connaitre le nom de la compétence pour savoir quel est la personne à contacter.

## :robot: Solution
Ajouter le nom de la compétence dans le résultat du check des URL.

## :rainbow: Remarques
RAS

## :100: Pour tester
Je ne sais pas trop comment tester fonctionnellement le code.
