### PR TITLE
[TECH] Corriger l'ajout d'une source contenant une apostrophe (PIX-7819) 

### DIFF
--- a/pix-editor/app/components/form/tutorial.js
+++ b/pix-editor/app/components/form/tutorial.js
@@ -39,9 +39,9 @@ export default class TutorialForm extends Component {
 
   @action
   getSearchSourceResults(query) {
-    const queryLowerCase = query.toLowerCase();
+    const queryLowerCaseWithEscapedQuote = query.toLowerCase().replaceAll('\'', '\\\'');
     return this.store.query('tutorial', {
-      filterByFormula: `FIND('${queryLowerCase}', LOWER(source))`,
+      filterByFormula: `FIND('${queryLowerCaseWithEscapedQuote}', LOWER(source))`,
       maxRecords: 4,
       sort: [{ field: 'Source', direction: 'asc' }]
     })


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'ajout d'un source nous vérifions si la source existe déjà via une formula. Si on ajout une apostrophe dans notre source alors ça casse la formula.

## :robot: Solution
Échapper les apostrophes avant de faire la formula.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un nouveau tutoriel et ajouter une source contenant une apostrophe.
