### PR TITLE
[TECH] Configurer le pool minimal de connexion à 0

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -6,7 +6,7 @@ function localPostgresEnv(database) {
     client: 'postgresql',
     connection: database.url,
     pool: {
-      min: 1,
+      min: database.poolMinSize,
       max: database.poolMaxSize,
     },
     migrations: {
@@ -30,7 +30,7 @@ module.exports = {
     client: 'postgresql',
     connection: database.url,
     pool: {
-      min: 1,
+      min: database.poolMinSize,
       max: database.poolMaxSize,
     },
     migrations: {
@@ -47,7 +47,7 @@ module.exports = {
     client: 'postgresql',
     connection: database.url,
     pool: {
-      min: 1,
+      min: database.poolMinSize,
       max: database.poolMaxSize,
     },
     migrations: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -80,6 +80,7 @@ module.exports = (function() {
 
     database: {
       url: process.env.DATABASE_URL,
+      poolMinSize: _getNumber(process.env.DATABASE_CONNECTION_POOL_MIN_SIZE, 0),
       poolMaxSize: _getNumber(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 4),
       asyncStackTraceEnabled: isFeatureEnabled(process.env.KNEX_ASYNC_STACKTRACE_ENABLED),
       sslEnabled: isFeatureEnabled(process.env.DATABASE_SSL_ENABLED),


### PR DESCRIPTION
## :unicorn: Problème

La configuration du pool de connexion actuelle de Postgres force le maintien d'au moins une connexion à Postgres.
Cela pose des problèmes de gestion de keepalive sur des connexions très longues sans activité, ce qui pourrait être à l'origine des erreurs rencontrées lors de la création de la release.
Cette configuration ne se justifie également pas par des raisons de besoins de performances d'accès à Postgres.

## :robot: Solution

Configurer le nombre de connexions minimal à 0, ce qui fait que le client coupera les connexions inactives et recréera les connexions lorsqu'elles seront nécessaires.

## 🌈 Remarques

La documentation de knex recommande cette configuration : 

```
Note that the default value of min is 2 only for historical reasons.

It can result in problems with stale connections, despite tarn's default idle connection timeout of 30 seconds, which is only applied when there are more than min active connections. 

It is recommended to set min: 0 so all idle connections can be terminated.
```

> https://knexjs.org/guide/#pool

## :100: Pour tester
🟢 Les tests sont au vert et la RA fonctionne et parvient à se connecter à Postgres + créer la release, et fait expirer les connexions après 30 secondes


Surveiller le nombre de connexions utilisées par l'application : 
`\watch select count(*) from pg_stat_activity where query NOT LIKE '%pg_stat_activity%' AND usename = 'pix_lcms_re_713';`

Lancer une release :
`curl -H "Authorization: Bearer ****" -X POST https://pix-lcms-review-pr106.osc-fr1.scalingo.io/api/releases`

Vérifier que le nombre passe à 1 pour la connexion et ensuite pour l'insertion de la release en bdd , puis une fois la release créée, il repasse à 0 au bout de 30 secondes.
