### PR TITLE
[FEATURE] Permettre de choisir si on veut afficher aléatoirement les options des QCU/QCM (PIX-7737)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ pix-editor/app/config-private-test.js
 
 # intellij
 **/.idea
+
+# MACOS
+.DS_Store

--- a/api/lib/domain/models/ChallengeForRelease.js
+++ b/api/lib/domain/models/ChallengeForRelease.js
@@ -28,6 +28,7 @@ module.exports = class ChallengeForRelease {
     attachments,
     illustrationAlt,
     illustrationUrl,
+    shuffled,
   }) {
     this.id = id;
     this.instruction = instruction;
@@ -57,5 +58,6 @@ module.exports = class ChallengeForRelease {
     this.attachments = attachments;
     this.illustrationAlt = illustrationAlt;
     this.illustrationUrl = illustrationUrl;
+    this.shuffled = shuffled;
   }
 };

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -52,7 +52,8 @@ module.exports = datasource.extend({
     'created_at',
     'validated_at',
     'archived_at',
-    'made_obsolete_at'
+    'made_obsolete_at',
+    'shuffled',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -111,6 +112,7 @@ module.exports = datasource.extend({
       archivedAt: airtableRecord.get('archived_at'),
       madeObsoleteAt: airtableRecord.get('made_obsolete_at'),
       createdAt: airtableRecord.get('created_at'),
+      shuffled: airtableRecord.get('shuffled'),
     };
   },
 
@@ -152,6 +154,7 @@ module.exports = datasource.extend({
         'validated_at': model.validatedAt,
         'archived_at': model.archivedAt,
         'made_obsolete_at': model.madeObsoleteAt,
+        'shuffled': model.shuffled,
       }
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -41,7 +41,8 @@ module.exports = {
         'updatedAt',
         'validatedAt',
         'archivedAt',
-        'madeObsoleteAt'
+        'madeObsoleteAt',
+        'shuffled',
       ],
       typeForAttribute(attribute) {
         if (attribute === 'files') return 'attachments';

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -38,6 +38,7 @@ function _filterChallengeFields(challenge) {
     't3Status',
     'timer',
     'type',
+    'shuffled',
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -46,7 +46,8 @@ const challengeAirtableFields = [
   'created_at',
   'validated_at',
   'archived_at',
-  'made_obsolete_at'
+  'made_obsolete_at',
+  'shuffled',
 ];
 
 describe('Acceptance | Controller | challenges-controller', () => {
@@ -144,6 +145,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+              shuffled: false,
             },
             relationships: {
               skill: {
@@ -238,6 +240,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+              shuffled: false,
             },
             relationships: {
               skill: {
@@ -295,6 +298,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+              shuffled: false,
             },
             relationships: {
               skill: {
@@ -451,6 +455,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+            shuffled: false,
           },
           relationships: {
             skill: {
@@ -566,6 +571,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+              shuffled: false,
             },
             relationships: {
               skill: {
@@ -630,6 +636,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+            shuffled: false,
           },
           relationships: {
             skill: {
@@ -731,6 +738,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'validated-at': challenge.validatedAt,
               'archived-at': challenge.archivedAt,
               'made-obsolete-at': challenge.madeObsoleteAt,
+              shuffled: false,
             },
             relationships: {
               skill: {
@@ -820,6 +828,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'validated-at': '2023-02-02T14:17:30.820Z',
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+              shuffled: false,
             },
             relationships: {
               skill: {
@@ -884,6 +893,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+            shuffled: false,
           },
           relationships: {
             skill: {

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -423,6 +423,7 @@ function _mockRichAirtableContent() {
     delta: 1.1,
     alpha: 2.2,
     updatedAt: 'challenge121211 updatedAt',
+    shuffled: false,
   });
   const airtableChallenge121212 = airtableBuilder.factory.buildChallenge({
     id: 'challenge121212',
@@ -464,6 +465,7 @@ function _mockRichAirtableContent() {
     delta: 123,
     alpha: 456,
     updatedAt: 'challenge121212 updatedAt',
+    shuffled: true,
   });
   const airtableChallenge211111 = airtableBuilder.factory.buildChallenge({
     id: 'challenge211111',
@@ -505,6 +507,7 @@ function _mockRichAirtableContent() {
     delta: 100,
     alpha: 200,
     updatedAt: 'challenge211111 updatedAt',
+    shuffled: false,
   });
   const airtableChallenge211112 = airtableBuilder.factory.buildChallenge({
     id: 'challenge211112',
@@ -546,6 +549,7 @@ function _mockRichAirtableContent() {
     delta: 100,
     alpha: 200,
     updatedAt: 'challenge211112 updatedAt',
+    shuffled: false,
   });
   const airtableChallenge211113 = airtableBuilder.factory.buildChallenge({
     id: 'challenge211113',
@@ -587,6 +591,7 @@ function _mockRichAirtableContent() {
     delta: 100,
     alpha: 200,
     updatedAt: 'challenge211113 updatedAt',
+    shuffled: false,
   });
   const airtableTutorial1 = airtableBuilder.factory.buildTutorial({
     id: 'tutorial1',
@@ -1018,6 +1023,7 @@ function _getRichCurrentContentDTO() {
       attachments: ['attachment1 url', 'attachment2 url'],
       illustrationUrl: null,
       illustrationAlt: null,
+      shuffled: false,
     },
     {
       id: 'challenge121212',
@@ -1047,6 +1053,7 @@ function _getRichCurrentContentDTO() {
       alpha: 456,
       illustrationUrl: null,
       illustrationAlt: null,
+      shuffled: true,
     },
     {
       id: 'challenge211111',
@@ -1077,6 +1084,7 @@ function _getRichCurrentContentDTO() {
       attachments: ['attachment3 url'],
       illustrationUrl: null,
       illustrationAlt: null,
+      shuffled: false,
     },
     {
       id: 'challenge211112',
@@ -1106,6 +1114,7 @@ function _getRichCurrentContentDTO() {
       alpha: 200,
       illustrationUrl: null,
       illustrationAlt: null,
+      shuffled: false,
     },
     {
       id: 'challenge211113',
@@ -1135,6 +1144,7 @@ function _getRichCurrentContentDTO() {
       alpha: 200,
       illustrationUrl: null,
       illustrationAlt: null,
+      shuffled: false,
     },
   ];
   const expectedCourseDTOs = [

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -42,6 +42,7 @@ const buildChallenge = function buildChallenge({
   archivedAt,
   madeObsoleteAt,
   createdAt = '1986-14-07',
+  shuffled,
 }) {
   return {
     id: airtableId,
@@ -89,6 +90,7 @@ const buildChallenge = function buildChallenge({
       'archived_at': archivedAt,
       'made_obsolete_at': madeObsoleteAt,
       'created_at': createdAt,
+      'shuffled': shuffled,
     },
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-airtable-data-object.js
@@ -42,8 +42,8 @@ module.exports = function buildChallengeAirtableDataObject({
   validatedAt = '2023-02-02T14:17:30.820Z',
   archivedAt = '2023-03-03T10:47:05.555Z',
   madeObsoleteAt = '2023-04-04T10:47:05.555Z',
+  shuffled = false,
 } = {}) {
-
   return {
     id,
     instruction,
@@ -88,5 +88,6 @@ module.exports = function buildChallengeAirtableDataObject({
     validatedAt,
     archivedAt,
     madeObsoleteAt,
+    shuffled,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -29,6 +29,7 @@ module.exports = function buildChallengeForRelease({
   attachments,
   illustrationAlt = 'alt illu',
   illustrationUrl = 'url illu',
+  shuffled = false,
 } = {}) {
 
   return new ChallengeForRelease({
@@ -60,5 +61,6 @@ module.exports = function buildChallengeForRelease({
     attachments,
     illustrationAlt,
     illustrationUrl,
+    shuffled,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -46,6 +46,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+            shuffled: false,
           },
           relationships: {
             skill: {
@@ -121,6 +122,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'validated-at': '2023-02-02T14:17:30.820Z',
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
+            'shuffled': false,
           },
           relationships: {
             skill: {

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -32,6 +32,15 @@
       @options={{this.options.types}}
       @edition={{@edition}}
       @setValue={{this.setChallengeType}}
+      data-test-select-type
+    />
+  {{/if}}
+  {{#if this.typeIsQCUOrQCM}}
+    <Field::Checkbox
+      @label="Afficher aléatoirement l'ordre des propositions"
+      @checked={{@challenge.shuffled}}
+      @disabled={{not @edition}}
+      data-test-checkbox-shuffle
     />
   {{/if}}
   {{#if (and this.typeIsQROCOrQROCMInd (not this.isAutoReply))}}
@@ -63,7 +72,11 @@
     data-test-answers-field
   />
   {{#if (and @challenge.isTextBased (not this.isAutoReply))}}
-    <div id="toleranceField" data-test-tolerence-fields class="field {{if @edition '' 'disabled'}}">
+    <div
+      id="toleranceField"
+      data-test-tolerence-fields
+      class="field {{if @edition '' 'disabled'}}"
+    >
       <label>Tolérance</label>
       <div class="three fields">
         <div class="field">
@@ -74,7 +87,11 @@
           />
         </div>
         <div class="field">
-          <Field::Checkbox @label="T2 (ponctuation)" @checked={{@challenge.t2Status}} @disabled={{not @edition}} />
+          <Field::Checkbox
+            @label="T2 (ponctuation)"
+            @checked={{@challenge.t2Status}}
+            @disabled={{not @edition}}
+          />
         </div>
         <div class="field">
           <Field::Checkbox
@@ -113,7 +130,11 @@
     data-test-file-input-illustration
   />
   {{#if @challenge.illustration}}
-    <Field::Textarea @value={{@challenge.illustration.alt}} @title="Texte alternatif" @edition={{@edition}} />
+    <Field::Textarea
+      @value={{@challenge.illustration.alt}}
+      @title="Texte alternatif"
+      @edition={{@edition}}
+    />
   {{/if}}
   <Field::Files
     @title="Pièces jointes"
@@ -124,9 +145,22 @@
     @removeAttachment={{this.removeAttachment}}
     data-test-file-input-attachment
   />
-  <Field::Input @title="Embed" @value={{@challenge.embedURL}} @edition={{@edition}} @label="URL" />
-  <Field::Input @value={{@challenge.embedHeight}} @edition={{@edition}} @label="Hauteur" />
-  <Field::Input @value={{@challenge.embedTitle}} @edition={{@edition}} @label="Titre" />
+  <Field::Input
+    @title="Embed"
+    @value={{@challenge.embedURL}}
+    @edition={{@edition}}
+    @label="URL"
+  />
+  <Field::Input
+    @value={{@challenge.embedHeight}}
+    @edition={{@edition}}
+    @label="Hauteur"
+  />
+  <Field::Input
+    @value={{@challenge.embedTitle}}
+    @edition={{@edition}}
+    @label="Titre"
+  />
   {{#if @challenge.isPrototype}}
     <Field::Select
       @title="Type pédagogie"
@@ -146,13 +180,21 @@
     />
   {{/if}}
   <div class="field {{if @edition '' 'disabled'}}">
-    <Field::Checkbox @label="Timer" @checked={{@challenge.timerOn}} @disabled={{not @edition}} />
+    <Field::Checkbox
+      @label="Timer"
+      @checked={{@challenge.timerOn}}
+      @disabled={{not @edition}}
+    />
     {{#if @challenge.timer}}
       <Field::Input @value={{@challenge.timer}} @edition={{@edition}} />
     {{/if}}
   </div>
   <div class="field {{if @edition '' 'disabled'}}">
-    <Field::Checkbox @label="Focus" @checked={{@challenge.focusable}} @disabled={{not @edition}} />
+    <Field::Checkbox
+      @label="Focus"
+      @checked={{@challenge.focusable}}
+      @disabled={{not @edition}}
+    />
   </div>
   {{#if @challenge.isDraft}}
     <Field::Quality @edition={{@edition}} @challenge={{@challenge}} />

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -97,6 +97,17 @@ export default class ChallengeForm extends Component {
     }
   }
 
+  get typeIsQCUOrQCM() {
+    const type = this.args.challenge.type;
+    switch (type) {
+      case 'QCU':
+      case 'QCM':
+        return true;
+      default:
+        return false;
+    }
+  }
+
   get isAutoReply() {
     return this.args.challenge.autoReply;
   }
@@ -112,6 +123,11 @@ export default class ChallengeForm extends Component {
 
   @action
   setChallengeType({ value }) {
+    this.args.challenge.type = value;
+    this.args.challenge.autoReply = false;
+    this.args.challenge.format = null;
+    this.args.challenge.shuffled = false;
+
     if (value === 'autoReply') {
       this.args.challenge.type = 'QROC';
       this.args.challenge.autoReply = true;
@@ -120,10 +136,10 @@ export default class ChallengeForm extends Component {
       this.args.challenge.t1Status = null;
       this.args.challenge.t2Status = null;
       this.args.challenge.t3Status = null;
-    } else {
-      this.args.challenge.type = value;
-      this.args.challenge.autoReply = false;
-      this.args.challenge.format = null;
+    }
+
+    if (['QCU', 'QCM'].includes(value)) {
+      this.args.challenge.shuffled = true;
     }
   }
 

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -39,6 +39,7 @@ export default class ChallengeModel extends Model {
   @attr('date') validatedAt;
   @attr('date') archivedAt;
   @attr('date') madeObsoleteAt;
+  @attr('boolean') shuffled;
 
   @belongsTo('skill') skill;
   @hasMany('attachment', { inverse: 'challenge' }) files;

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -33,5 +33,45 @@ module('Integration | Component | challenge-form', function(hooks) {
     ['data-test-format-field', 'data-test-tolerence-fields', 'data-test-suggestion-field'].forEach(field => {
       assert.dom(`[${field}]`).doesNotExist();
     });
+  });
+
+  test('it should display autochecked checkbox if challenge type is `QCM`', async function(assert) {
+    // Given
+    const store = this.owner.lookup('service:store');
+    const challengeData = store.createRecord('challenge',{
+      id: 'recChallenge0',
+      genealogy: 'Prototype 1',
+    });
+    this.set('challengeData', challengeData);
+
+    // When
+    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}/>`);
+
+    await click(find('[data-test-select-type] .ember-basic-dropdown-trigger'));
+    await click(findAll('.ember-power-select-option')[1]);
+
+    // Then
+    assert.dom('[data-test-checkbox-shuffle]').exists();
+    assert.dom('[data-test-checkbox-shuffle] > input').isChecked();
+  });
+
+  test('it should display autochecked checkbox if challenge type is `QCU`', async function(assert) {
+    // Given
+    const store = this.owner.lookup('service:store');
+    const challengeData = store.createRecord('challenge',{
+      id: 'recChallenge0',
+      genealogy: 'Prototype 1',
+    });
+    this.set('challengeData', challengeData);
+
+    // When
+    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}/>`);
+
+    await click(find('[data-test-select-type] .ember-basic-dropdown-trigger'));
+    await click(findAll('.ember-power-select-option')[0]);
+
+    // Then
+    assert.dom('[data-test-checkbox-shuffle]').exists();
+    assert.dom('[data-test-checkbox-shuffle] > input').isChecked();
   });
 });

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, find, findAll, render } from '@ember/test-helpers';
+import { click, find, findAll, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -53,6 +53,10 @@ module('Integration | Component | challenge-form', function(hooks) {
     // Then
     assert.dom('[data-test-checkbox-shuffle]').exists();
     assert.dom('[data-test-checkbox-shuffle] > input').isChecked();
+
+    // WORKAROUND: https://github.com/1024pix/pix-editor/pull/107#issuecomment-1547481515
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await settled();
   });
 
   test('it should display autochecked checkbox if challenge type is `QCU`', async function(assert) {
@@ -73,5 +77,9 @@ module('Integration | Component | challenge-form', function(hooks) {
     // Then
     assert.dom('[data-test-checkbox-shuffle]').exists();
     assert.dom('[data-test-checkbox-shuffle] > input').isChecked();
+
+    // WORKAROUND: https://github.com/1024pix/pix-editor/pull/107#issuecomment-1547481515
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await settled();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
PixApp supporte maintenant l'ordre aléatoire sur les QCU/QCM, mais PixEditor ne permet pas de l'activer !

## :robot: Solution
Ajouter la possibilité d'activer/désactiver l'ordre aléatoire sur une épreuve dans PixEditor.

## :rainbow: Remarques
N/A

## :100: Pour tester
Modifier un challenge QCU ou QCM pour le mettre en ordre aléatoire et vérifier avec la preview que ça fonctionne bien.

Créer une nouvelle release et vérifier qu'elle comporte bien l'ordre aléatoire également.