### PR TITLE
[FEATURE] Afficher les domaines ordonnés par code (PIX-8216).

### DIFF
--- a/pix-editor/app/models/area.js
+++ b/pix-editor/app/models/area.js
@@ -5,7 +5,7 @@ export default class AreaModel extends Model {
   @attr pixId;
   @attr titleFrFr;
   @attr titleEnUs;
-  @attr code;
+  @attr('number') code;
 
   @hasMany('competence') competences;
   @belongsTo('framework') framework;

--- a/pix-editor/app/models/framework.js
+++ b/pix-editor/app/models/framework.js
@@ -5,4 +5,8 @@ export default class FrameworkModel extends Model {
   @attr name
 
   @hasMany('area') areas;
+
+  get sortedAreas() {
+    return this.areas.sortBy('code');
+  }
 }

--- a/pix-editor/app/services/current-data.js
+++ b/pix-editor/app/services/current-data.js
@@ -44,7 +44,7 @@ export default class CurrentDataService extends Service {
 
   getAreas(filteredBySource = true) {
     if (filteredBySource && this._framework) {
-      return this._framework.areas;
+      return this._framework.sortedAreas;
     }
     return this._areas;
   }

--- a/pix-editor/tests/unit/services/current-data-test.js
+++ b/pix-editor/tests/unit/services/current-data-test.js
@@ -1,35 +1,44 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import EmberObject from '@ember/object';
 
 module('Unit | Service | current-data', function(hooks) {
   setupTest(hooks);
   let service, pixFramework, pixFranceFramework, pixArea, pixFranceArea, competence, prototype;
 
   hooks.beforeEach(function() {
+    const store = this.owner.lookup('service:store');
+
     // Given
-    prototype = EmberObject.create({
+    prototype = store.createRecord('challenge',{
       id: 'prototype'
     });
-    competence = EmberObject.create({
+
+    competence = store.createRecord('competence',{
       id: 'competence'
     });
-    pixFranceArea = EmberObject.create({
-      id: 'pixFranceArea'
+
+    pixFranceArea = store.createRecord('area',{
+      id: 'pixFranceArea',
+      code: 1,
     });
-    pixArea = EmberObject.create({
-      id: 'pixArea'
+
+    pixArea = store.createRecord('area',{
+      id: 'pixArea',
+      code: 2,
     });
-    pixFranceFramework = EmberObject.create({
+
+    pixFranceFramework = store.createRecord('framework', {
       id: 'pixFranceFramework',
       name: 'France',
       areas: [pixFranceArea]
     });
-    pixFramework = EmberObject.create({
+
+    pixFramework = store.createRecord('framework', {
       id: 'pixFramework',
       name: 'Pix',
       areas: [pixArea]
     });
+
     service = this.owner.lookup('service:current-data');
     service.setFrameworks([pixFramework, pixFranceFramework]);
     service.setFramework(pixFramework);
@@ -65,6 +74,7 @@ module('Unit | Service | current-data', function(hooks) {
   test('it should return areas of set framework when have no argument ', async function(assert) {
     // when
     const areas = service.getAreas();
+
     // then
     assert.deepEqual(areas, [pixArea]);
   });


### PR DESCRIPTION
## :unicorn: Problème
L'ordre d'affichage par code des domaines n'est pas contrôlé, s'il est affiché dans l'ordre c'est car les domaine sont créer les uns après les autres dans l'ordre chronologique.
Hors nous avons besoin de modifier le code de certain domaine et que ces domaine soit bien ordonnés.

## :robot: Solution
Ajouter une méthode pour récupérer les domaines dans le bon ordre.

## :rainbow: Remarques
RAS

## :100: Pour tester
Modifier le code d'un domaine dans la base airtable et vérifier que l'ordre des domaine est bien modifié.
