### PR TITLE
[FEATURE] Renvoit le fichier index.html en cas de 404 (PIX-8350)

### DIFF
--- a/api/lib/application/static/index.js
+++ b/api/lib/application/static/index.js
@@ -17,4 +17,3 @@ exports.register = async function(server) {
 };
 
 exports.name = 'static-api';
-

--- a/api/lib/application/static/index.js
+++ b/api/lib/application/static/index.js
@@ -1,3 +1,5 @@
+const config = require('../../config');
+
 exports.register = async function(server) {
   server.route([
     {
@@ -8,7 +10,7 @@ exports.register = async function(server) {
       },
       handler: {
         directory: {
-          path: 'public/pix-editor',
+          path: `${config.hapi.publicDir}/pix-editor`,
           redirectToSlash: true
         }
       }

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -22,6 +22,7 @@ module.exports = (function() {
     hapi: {
       options: {},
       enableRequestMonitoring: isFeatureEnabled(process.env.ENABLE_REQUEST_MONITORING),
+      publicDir: 'public/',
     },
 
     airtable: {
@@ -104,6 +105,7 @@ module.exports = (function() {
 
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
+    config.hapi.publicDir = 'tests/public-tests/';
 
     config.airtable.apiKey = 'airtableApiKeyValue';
     config.airtable.base = 'airtableBaseValue';

--- a/api/lib/infrastructure/utils/pre-response-utils.js
+++ b/api/lib/infrastructure/utils/pre-response-utils.js
@@ -1,6 +1,7 @@
 const errorManager = require('./error-manager');
 const { DomainError } = require('../../domain/errors');
 const { InfrastructureError } = require('../errors');
+const config = require('../../config');
 
 function catchDomainAndInfrastructureErrors(request, h) {
   const response = request.response;
@@ -12,7 +13,7 @@ function catchDomainAndInfrastructureErrors(request, h) {
     if (response.output.statusCode === 404 &&
         request.method === 'get' &&
         !request.path.startsWith('/api')) {
-      return h.file('public/pix-editor/index.html').code(200);
+      return h.file(`${config.hapi.publicDir}/pix-editor/index.html`).code(200);
     }
   }
 

--- a/api/lib/infrastructure/utils/pre-response-utils.js
+++ b/api/lib/infrastructure/utils/pre-response-utils.js
@@ -8,6 +8,13 @@ function catchDomainAndInfrastructureErrors(request, h) {
   if (response instanceof DomainError || response instanceof InfrastructureError) {
     return errorManager.send(h, response);
   }
+  if (response.isBoom) {
+    if (response.output.statusCode === 404 &&
+        request.method === 'get' &&
+        !request.path.startsWith('/api')) {
+      return h.file('public/pix-editor/index.html').code(200);
+    }
+  }
 
   return h.continue;
 }

--- a/api/tests/acceptance/application/static_test.js
+++ b/api/tests/acceptance/application/static_test.js
@@ -1,0 +1,49 @@
+const { expect } = require('../../test-helper');
+const createServer = require('../../../server');
+
+describe('Acceptance | Controller | static', () => {
+  it('Return the index.html in case of 404', async () => {
+    // Given
+    const server = await createServer();
+    const request = {
+      method: 'GET',
+      url: '/toto.html',
+    };
+
+    // When
+    const response = await server.inject(request);
+
+    // Then
+    expect(response.statusCode).to.equal(200);
+  });
+
+  it('Returns a 404 on api request', async () => {
+    // Given
+    const server = await createServer();
+    const request = {
+      method: 'GET',
+      url: '/api/toto.html',
+    };
+
+    // When
+    const response = await server.inject(request);
+
+    // Then
+    expect(response.statusCode).to.equal(404);
+  });
+
+  it('Returns a 404 on POST request', async () => {
+    // Given
+    const server = await createServer();
+    const request = {
+      method: 'POST',
+      url: '/toto.html',
+    };
+
+    // When
+    const response = await server.inject(request);
+
+    // Then
+    expect(response.statusCode).to.equal(404);
+  });
+});

--- a/api/tests/public-tests/pix-editor/index.html
+++ b/api/tests/public-tests/pix-editor/index.html
@@ -1,0 +1,1 @@
+<html><title>TEST</title></html>


### PR DESCRIPTION
## :unicorn: Problème
Avec le passage en mode history de l'app ember, les URLS ne sont pas accessible si on recharge.

## :robot: Solution
Il faut servir le fichier index.html en cas de 404.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Se rendre que la page https://pix-lcms-review-pr113.osc-fr1.scalingo.io/connexion fonctionne
