### PR TITLE
[FEATURE] Créer la table des tests statiques (PIX-7792)

### DIFF
--- a/api/db/migrations/20230614145342_add-static-courses-table.js
+++ b/api/db/migrations/20230614145342_add-static-courses-table.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'static_courses';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  function table(t) {
+    t.string('id').primary();
+    t.string('name').notNullable();
+    t.string('description').nullable();
+    t.string('challengeIds').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  }
+
+  return knex.schema
+    .createTable(TABLE_NAME, table);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+
+  return knex.schema
+    .dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/static-courses.js
+++ b/api/db/seeds/data/static-courses.js
@@ -1,0 +1,8 @@
+module.exports = function(databaseBuilder) {
+  databaseBuilder.factory.buildStaticCourse({
+    id: 'static-course-1',
+    name: 'Static Course 1',
+    description: 'Static Course 1 description',
+    challengeIds: 'challenge1NQqfx9mYKUQEO,challengeTYFrFy5EGYEet,challenge1rSPsnisQ8ft4W',
+  });
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,8 +1,8 @@
 const DatabaseBuilder = require('../../tests/tooling/database-builder/database-builder');
+const staticCoursesBuilder = require('./data/static-courses.js');
 
 exports.seed = (knex) => {
   const databaseBuilder = new DatabaseBuilder({ knex });
-
   databaseBuilder.factory.buildUser({
     trigram: 'DEV',
     name: 'Utilisateur pour le développement',
@@ -23,6 +23,8 @@ exports.seed = (knex) => {
     access: 'readpixonly',
     apiKey: process.env.REVIEW_APP_READ_PIX_ONLY_USER_API_KEY || readPixOnlyUserApiKey,
   });
+
+  staticCoursesBuilder(databaseBuilder);
 
   return databaseBuilder.commit();
 };

--- a/api/tests/tooling/database-builder/factory/build-static-course.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course.js
@@ -1,0 +1,21 @@
+const databaseBuffer = require('../database-buffer');
+
+function buildStaticCourse({
+  id,
+  name,
+  description,
+  challengeIds,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+} = {}) {
+
+  const values = { id, name, description, challengeIds, createdAt, updatedAt };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'static_courses',
+    values,
+  });
+}
+
+module.exports = buildStaticCourse;
+

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   ...require('./build-user'),
   buildRelease: require('./build-release'),
+  buildStaticCourse: require('./build-static-course'),
 };


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas de table pour les tests statiques

## :robot: Solution
créer la table

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
vérifier les données seed
```
npm run db:reset
pgcli 
select * from static_courses 
```