### PR TITLE
[BUGFIX] La "Duplication vers" d'un acquis pour le passer d'un sujet à un autre ne fonctionne pas (PIX-8485)

### DIFF
--- a/pix-editor/app/templates/authenticated/competence/skills/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/skills/single.hbs
@@ -104,11 +104,11 @@
         @close={{this.closeSelectLocation}}
         @showModal={{this.displaySelectLocation}}
 />
-{{#if this.displayChangeLog}}
-  <PopIn::Changelog
-          @onApprove={{this.approveChangelog}}
-          @defaultValue={{this.changelogText}} />
-{{/if}}
+<PopIn::Changelog
+  @onApprove={{this.approveChangelog}}
+  @defaultValue={{this.changelogText}}
+  @showModal={{this.displayChangeLog}}
+/>
 <PopIn::ConfirmLog
   @title={{t 'common.confirm-log.save'}}
   @onApprove={{this.saveSkillCallBack}}


### PR DESCRIPTION
## :unicorn: Problème
Reproduire le bug :
- Se rendre dans une compétence
- Vue "Acquis"
- Cliquer sur un acquis
- Appuyer sur le bouton "Dupliquer vers" (celui qui a le logo de copier-coller à gauche)
- Remplir le formulaire
- Valider l'action et constater qu'il ne s'est rien passé

## :robot: Solution
Lors de la correction apportée autour de l'affichage des modales, on en a oublié une ! (woups)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Essayer de reproduire le bug en vain 🎉 
