### PR TITLE
[FEATURE] Empêcher les utilisateurs avec un rôle "readpixonly" d'accéder aux fonctionnalités liées aux tests statiques (PIX-8589)

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -24,6 +24,13 @@ exports.seed = (knex) => {
     apiKey: process.env.REVIEW_APP_READ_PIX_ONLY_USER_API_KEY || readPixOnlyUserApiKey,
   });
 
+  databaseBuilder.factory.buildUser({
+    trigram: 'LOL',
+    name: 'Lecteur TOUT pour le développement',
+    access: 'readonly',
+    apiKey: process.env.REVIEW_APP_READ_ONLY_USER_API_KEY || readOnlyUserApiKey,
+  });
+
   staticCoursesBuilder(databaseBuilder);
 
   return databaseBuilder.commit();
@@ -32,3 +39,4 @@ exports.seed = (knex) => {
 const adminUserApiKey = !process.env.REVIEW_APP && '8d03a893-3967-4501-9dc4-e0aa6c6dc442';
 const defaultEditorUserApiKey = !process.env.REVIEW_APP && 'adaf3eee-09dc-4f9a-a504-ff92e74c9d0f';
 const readPixOnlyUserApiKey = !process.env.REVIEW_APP && '09ae36c4-11e1-4212-ae51-e5719d142f57';
+const readOnlyUserApiKey = !process.env.REVIEW_APP && '3b234506-e31e-45eb-a56e-17f64f31ca1b';

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -4,7 +4,9 @@
   <Sidebar::Search @displaySearch={{this.maySearch}} @close={{@close}} />
   <Sidebar::Navigation @displayFrameworkList={{this.maySwitchFramework}} @areas={{this.areas}} @close={{@close}}/>
   <div class="secondary-links">
-    <LinkTo @route="authenticated.static-courses"><FaIcon @icon="sheet-plastic" @prefix="fas"></FaIcon> Tests statiques</LinkTo>
+    {{#if this.mayAccessStaticCourses}}
+      <LinkTo @route="authenticated.static-courses"><FaIcon @icon="sheet-plastic" @prefix="fas"></FaIcon> Tests statiques</LinkTo>
+    {{/if}}
     {{#if this.mayGenerateTargetProfile}}
       <LinkTo data-test-target-profile-link @route="authenticated.target-profile" {{on "click" @close}}>
         <i class="crosshairs icon"></i> Générateur de profil cible

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -17,6 +17,10 @@ export default class SidebarMain extends Component {
     return this.currentData.getAreas();
   }
 
+  get mayAccessStaticCourses() {
+    return this.access.mayAccessStaticCourses();
+  }
+
   get mayGenerateTargetProfile() {
     return this.access.isReadOnly();
   }

--- a/pix-editor/app/routes/authenticated/static-courses.js
+++ b/pix-editor/app/routes/authenticated/static-courses.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class StaticCoursesRoute extends Route {
+  @service access;
+  @service router;
+
+  beforeModel() {
+    if (!this.access.mayAccessStaticCourses()) {
+      this.router.transitionTo('authenticated');
+    }
+  }
+}

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -153,6 +153,11 @@ export default class AccessService extends Service {
     return this.isAdmin() && challenge.isPrototype && challenge.isDraft;
   }
 
+  mayAccessStaticCourses() {
+    const level = this.config.accessLevel;
+    return level >= READ_ONLY;
+  }
+
   isReadOnly() {
     const level = this.config.accessLevel;
     return level >= READ_ONLY;


### PR DESCRIPTION
## :unicorn: Problème
On souhaite restreindre l'accès à la gestion des tests statiques. Seuls ceux avec un role readonly ou au-dessus doivent pouvoir y accéder.

## :robot: Solution
- Ajout d'une seed pour avoir tous les rôles dispo en local et sur la PR
- Cachage du bouton "Tests statiques" si le rôle de l'utilisateur est inférieur à "readpixonly"
- Empêcher l'utilisateur de naviguer via URL vers les tests statiques

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter avec différents utilisateurs pour tester les permissions
