### PR TITLE
[BUGFIX] Le lien de PixEditor vers Airtable est invalide

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -48,6 +48,7 @@ module.exports = (function() {
 
     pixEditor: {
       airtableUrl: process.env.AIRTABLE_URL,
+      airtableBase: process.env.AIRTABLE_BASE,
       tableChallenges: process.env.TABLE_CHALLENGES,
       tableSkills: process.env.TABLE_SKILLS,
       tableTubes: process.env.TABLE_TUBES,

--- a/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
@@ -5,6 +5,7 @@ module.exports = {
     return new Serializer('config', {
       attributes: [
         'airtableUrl',
+        'airtableBase',
         'tableChallenges',
         'tableSkills',
         'tableTubes',

--- a/api/sample.env
+++ b/api/sample.env
@@ -15,7 +15,6 @@
 #
 # Line size max: 80 characters.
 
-
 # ======
 # SERVER
 # ======
@@ -26,7 +25,6 @@
 # type: Boolean
 # default: `undefined` (`false`)
 # ENABLE_REQUEST_MONITORING=true
-
 
 # =========
 # DATABASES
@@ -84,7 +82,6 @@ TEST_DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms_test
 # default: `undefined` (`false`)
 # KNEX_ASYNC_STACKTRACE_ENABLED=true
 
-
 # ================
 # LEARNING CONTENT
 # ================
@@ -100,8 +97,7 @@ TEST_DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms_test
 # example: keyBZKw**********
 AIRTABLE_API_KEY=
 
-# 🔴 API token provided in your Airtable database configuration used for fetching
-# learning content.
+# 🔴 Airtable ID of the Airtable base used in project
 #
 # If not present the application will crash during data fetching.
 #
@@ -111,8 +107,8 @@ AIRTABLE_API_KEY=
 # example: app5JZ0**********
 AIRTABLE_BASE=
 
-# 🔴 API token provided in your Airtable database configuration used for storing
-# notes
+# 🔴 Airtable ID of the Airtable base used for storing notes.
+# It can be the same airtable base as above. In such case AIRTABLE_BASE = AIRTABLE_EDITOR_BASE.
 #
 # If not present the application will crash during saving changes.
 #
@@ -123,7 +119,7 @@ AIRTABLE_EDITOR_BASE=
 
 # Airtable url used to redirect to airtable entry
 #
-# If not present the application will not be able to open airtable record.
+# If not present the application will not be able to link to airtable records.
 #
 # presence: required
 # type: String
@@ -132,7 +128,7 @@ AIRTABLE_URL=https://airtable.com/
 
 # Airtable id of challenges table
 #
-# If not present the application will not be able to open airtable challenges.
+# If not present the application will not be able to link to airtable challenges.
 #
 # presence: required
 # type: String
@@ -142,7 +138,7 @@ TABLE_CHALLENGES=
 
 # Airtable id of skills table
 #
-# If not present the application will not be able to open airtable skills.
+# If not present the application will not be able to link to airtable skills.
 #
 # presence: required
 # type: String
@@ -159,7 +155,6 @@ TABLE_SKILLS=
 # default: none
 # example: tblt90e**********
 TABLE_TUBES=
-
 
 # =======
 # LOGGING
@@ -206,7 +201,6 @@ LOG_ENABLED=true
 # type: Boolean
 # default: `undefined` (`false`)
 # LOG_PRETTY_PRINT=true
-
 
 # =======
 # STORAGE
@@ -272,7 +266,6 @@ STORAGE_AUTH=
 # default: none
 STORAGE_BUCKET=
 
-
 # ================
 # PIX BUSINESS API
 # ================
@@ -306,7 +299,6 @@ PIX_API_USER_EMAIL=
 # default: none
 PIX_API_USER_PASSWORD=
 
-
 # ==============
 # SCHEDULED JOBS
 # ==============
@@ -339,7 +331,6 @@ CREATE_RELEASE_TIME=0 0 * * *
 # default: 4
 # CREATE_RELEASE_ATTEMPTS=2
 
-
 # ============
 # NOTIFICATION
 # ============
@@ -360,7 +351,6 @@ CREATE_RELEASE_TIME=0 0 * * *
 # type: Url
 # default: none
 # NOTIFICATIONS_SLACK_WEBHOOK_URL=
-
 
 # =================
 # URLS CHECKING JOB
@@ -424,7 +414,6 @@ CHECK_URLS_CHALLENGES_SHEET_NAME=
 # type: String
 # default: none
 CHECK_URLS_TUTORIALS_SHEET_NAME=
-
 
 # ===================================
 # SENTRY (ERROR LOGGING & MANAGEMENT)

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -109,7 +109,7 @@ export default class SingleController extends Controller {
 
 
   get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.tableChallenges}/${ this.challenge.id}`;
+    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableChallenges}/${ this.challenge.airtableId}`;
   }
 
   get lastUpdatedAtISO() {

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -68,7 +68,7 @@ export default class SingleController extends Controller {
   }
 
   get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.tableSkills}/${this.skill.id}`;
+    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableSkills}/${this.skill.id}`;
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/single.js
@@ -49,7 +49,7 @@ export default class SingleController extends Controller {
   }
 
   get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.tableTubes}/${this.tube.id}`;
+    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableTubes}/${this.tube.id}`;
   }
 
   @action

--- a/pix-editor/app/models/config.js
+++ b/pix-editor/app/models/config.js
@@ -2,6 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class ConfigModel extends Model {
   @attr airtableUrl;
+  @attr airtableBase;
   @attr tableChallenges;
   @attr tableSkills;
   @attr tableTubes;

--- a/pix-editor/app/services/config.js
+++ b/pix-editor/app/services/config.js
@@ -10,6 +10,7 @@ export default class ConfigService extends Service {
   @tracked author;
   @tracked accessLevel;
   @tracked airtableUrl;
+  @tracked airtableBase;
   @tracked tableChallenges;
   @tracked tableSkills;
   @tracked tableTubes;
@@ -24,6 +25,7 @@ export default class ConfigService extends Service {
     this.author = currentUser.trigram;
     this.accessLevel = this.access.getLevel(currentUser.access);
     this.airtableUrl = config.airtableUrl;
+    this.airtableBase = config.airtableBase;
     this.tableChallenges = config.tableChallenges;
     this.tableSkills = config.tableSkills;
     this.tableTubes = config.tableTubes;


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Editor, sur les affichages des acquis, épreuves et tubes, le lien vers Airtable est cassé car il lui manque l'ID de la base Airtable. 

## :robot: Solution
Faire remonter du back-end l'ID de la base Airtable nécessaire aux liens renvoyant vers Airtable.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à sur Pix-Editor
- Dans l'affichage d'un Tube, un Acquis ou une Epreuve, cliquer sur le lien Airtable
- Confirmer que le lien vers Airtable fonctionne 