### PR TITLE
[BUGFIX] L'utilisateur ne pouvait plus créer de domaine (PIX-8612)

### DIFF
--- a/pix-editor/app/models/area.js
+++ b/pix-editor/app/models/area.js
@@ -1,17 +1,25 @@
-import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class AreaModel extends Model {
   @attr({ readonly: true }) name;
   @attr pixId;
   @attr titleFrFr;
   @attr titleEnUs;
-  @attr('number') code;
+  @attr() code;
 
   @hasMany('competence') competences;
   @belongsTo('framework') framework;
 
   get sortedCompetences() {
-    return this.competences.sortBy('code');
+    return this.competences
+      .toArray()
+      .sort((competenceA, competenceB) => {
+        const [domainCodeA, competenceCodeA] = competenceA.code.split('.');
+        const [domainCodeB, competenceCodeB] = competenceB.code.split('.');
+        if (parseInt(domainCodeA) === parseInt(domainCodeB))
+          return parseInt(competenceCodeA) > parseInt(competenceCodeB);
+        return parseInt(domainCodeA) > parseInt(domainCodeB);
+      });
   }
 
   get productionTubeCount() {

--- a/pix-editor/app/models/framework.js
+++ b/pix-editor/app/models/framework.js
@@ -3,10 +3,11 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class FrameworkModel extends Model {
 
   @attr name
-
   @hasMany('area') areas;
 
   get sortedAreas() {
-    return this.areas.sortBy('code');
+    return this.areas
+      .toArray()
+      .sort((areaA, areaB) => parseInt(areaA.code) > parseInt(areaB.code));
   }
 }

--- a/pix-editor/tests/unit/services/current-data-test.js
+++ b/pix-editor/tests/unit/services/current-data-test.js
@@ -19,12 +19,12 @@ module('Unit | Service | current-data', function(hooks) {
 
     pixFranceArea = store.createRecord('area',{
       id: 'pixFranceArea',
-      code: 1,
+      code: '1',
     });
 
     pixArea = store.createRecord('area',{
       id: 'pixArea',
-      code: 2,
+      code: '2',
     });
 
     pixFranceFramework = store.createRecord('framework', {


### PR DESCRIPTION
## :unicorn: Problème
Bug introduit dans https://github.com/1024pix/pix-editor/pull/111
La création de domaine est en erreur.

## :robot: Solution
Côté EmberModel, le code du domaine a été casté en `number`. Or, Airtable attend un `string`.
Je propose de retirer le cast forcé et de coder le tri des domaines pour faire en sorte que ça trie correctement des nombres "chaînes".
Au passage, on profite aussi de corriger le tri des compétences lorsqu'une des deux parties de leur code dépasse 10, exemples : "11.2" ou "2.54"

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Tester la création de domaine et de compétence.
Vérifier que l'affichage trié marche correctement dans l'arborescence de gauche pour les domaines et les compétences en bidouillant l'airtable de revue
