### PR TITLE
[TECH] Renommer AIRTABLE_BASE et AIRTABLE_EDITOR_BASE

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -11,7 +11,7 @@ LCMS_API_URL=http://localhost:3002/api
 ```
 
 2. Côté LCMS, indiquer la base Airtable 
-   souhaitée dans le .env via `AIRTABLE_API_KEY` et `AIRTABLE_BASE`.
+   souhaitée dans le .env via `AIRTABLE_API_KEY` et `AIRTABLE_DATABASE_ID`.
    S'assurer que les autres variables d'environnement **requises** dans le fichier `sample.env` soient aussi renseignées.
    
 3. Côté LCMS, démarrer les containers docker et initialiser la base de données:

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -23,7 +23,7 @@ exports.register = async function(server) {
           }
         }],
         handler: async function(request, h) {
-          const response = await _proxyRequestToAirtable(request, h, config.airtable.base);
+          const response = await _proxyRequestToAirtable(request, h, config.airtable.databaseId);
           if (
             (request.method === 'post' || request.method === 'patch')
             && response.statusCode >= 200
@@ -57,7 +57,7 @@ exports.register = async function(server) {
           }
         }],
         handler: async function(request, h) {
-          return _proxyRequestToAirtable(request, h, config.airtable.editorBase);
+          return _proxyRequestToAirtable(request, h, config.airtable.editorDatabaseId);
         }
       },
     }

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -27,8 +27,8 @@ module.exports = (function() {
 
     airtable: {
       apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
-      base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
-      editorBase: process.env.AIRTABLE_EDITOR_BASE,
+      databaseId: process.env.CYPRESS_AIRTABLE_DATABASE_ID || process.env.AIRTABLE_DATABASE_ID,
+      editorDatabaseId: process.env.AIRTABLE_EDITOR_DATABASE_ID,
     },
 
     logging: {
@@ -48,7 +48,7 @@ module.exports = (function() {
 
     pixEditor: {
       airtableUrl: process.env.AIRTABLE_URL,
-      airtableBase: process.env.AIRTABLE_BASE,
+      airtableDatabaseId: process.env.AIRTABLE_DATABASE_ID,
       tableChallenges: process.env.TABLE_CHALLENGES,
       tableSkills: process.env.TABLE_SKILLS,
       tableTubes: process.env.TABLE_TUBES,
@@ -109,8 +109,8 @@ module.exports = (function() {
     config.hapi.publicDir = 'tests/public-tests/';
 
     config.airtable.apiKey = 'airtableApiKeyValue';
-    config.airtable.base = 'airtableBaseValue';
-    config.airtable.editorBase = 'airtableEditorBaseValue';
+    config.airtable.databaseId = 'airtableDatabaseIdValue';
+    config.airtable.editorDatabaseId = 'airtableEditorBaseValue';
 
     config.logging.enabled = false;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -27,8 +27,8 @@ module.exports = (function() {
 
     airtable: {
       apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
-      databaseId: process.env.CYPRESS_AIRTABLE_DATABASE_ID || process.env.AIRTABLE_DATABASE_ID,
-      editorDatabaseId: process.env.AIRTABLE_EDITOR_DATABASE_ID,
+      databaseId: process.env.CYPRESS_AIRTABLE_DATABASE_ID || process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_DATABASE_ID || process.env.AIRTABLE_BASE,
+      editorDatabaseId: process.env.AIRTABLE_EDITOR_DATABASE_ID || process.env.AIRTABLE_EDITOR_BASE,
     },
 
     logging: {

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -3,7 +3,7 @@ const airtableSettings = require('../config').airtable;
 const logger = require('./logger');
 
 function _airtableClient() {
-  return new Airtable({ apiKey: airtableSettings.apiKey }).base(airtableSettings.base);
+  return new Airtable({ apiKey: airtableSettings.apiKey }).base(airtableSettings.databaseId);
 }
 
 function findRecords(tableName, options = {}) {

--- a/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
@@ -5,7 +5,7 @@ module.exports = {
     return new Serializer('config', {
       attributes: [
         'airtableUrl',
-        'airtableBase',
+        'airtableDatabaseId',
         'tableChallenges',
         'tableSkills',
         'tableTubes',

--- a/api/sample.env
+++ b/api/sample.env
@@ -105,17 +105,17 @@ AIRTABLE_API_KEY=
 # type: String
 # default: none
 # example: app5JZ0**********
-AIRTABLE_BASE=
+AIRTABLE_DATABASE_ID=
 
 # 🔴 Airtable ID of the Airtable base used for storing notes.
-# It can be the same airtable base as above. In such case AIRTABLE_BASE = AIRTABLE_EDITOR_BASE.
+# It can be the same airtable base as above. In such case AIRTABLE_DATABASE_ID = AIRTABLE_EDITOR_DATABASE_ID.
 #
 # If not present the application will crash during saving changes.
 #
 # presence: required
 # type: String
 # example: app5JZ0**********
-AIRTABLE_EDITOR_BASE=
+AIRTABLE_EDITOR_DATABASE_ID=
 
 # Airtable url used to redirect to airtable entry
 #

--- a/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
@@ -29,7 +29,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
         .reply(200);
 
       nock('https://api.airtable.com')
-        .post('/v0/airtableBaseValue/Competences', competence)
+        .post('/v0/airtableDatabaseIdValue/Competences', competence)
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, competence);
       const server = await createServer();
@@ -61,7 +61,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
         .reply(400);
 
       nock('https://api.airtable.com')
-        .post('/v0/airtableBaseValue/Competences', competence)
+        .post('/v0/airtableDatabaseIdValue/Competences', competence)
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, competence);
       const server = await createServer();
@@ -88,7 +88,7 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
         .reply(400);
 
       nock('https://api.airtable.com')
-        .post('/v0/airtableBaseValue/Competences', competence)
+        .post('/v0/airtableDatabaseIdValue/Competences', competence)
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, competence);
       const server = await createServer();
@@ -137,12 +137,12 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
       };
 
       nock('https://api.airtable.com')
-        .post('/v0/airtableBaseValue/Epreuves', challenge)
+        .post('/v0/airtableDatabaseIdValue/Epreuves', challenge)
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, challenge);
 
       const attachmentsScope = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Attachments')
+        .get('/v0/airtableDatabaseIdValue/Attachments')
         .query({ filterByFormula: '{challengeId persistant} = \'recChallenge\'' })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [attachment] });

--- a/api/tests/acceptance/application/airtable-proxy-controller_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
         // Given
         const user = await createReadonlyUser();
         nock('https://api.airtable.com')
-          .get('/v0/airtableBaseValue/Competences?key=value')
+          .get('/v0/airtableDatabaseIdValue/Competences?key=value')
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .reply(200, 'ok');
         const server = await createServer();
@@ -45,7 +45,7 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
         // Given
         const user = await createAdminUser();
         nock('https://api.airtable.com')
-          .post('/v0/airtableBaseValue/Epreuves?key=value', { param: 'value' })
+          .post('/v0/airtableDatabaseIdValue/Epreuves?key=value', { param: 'value' })
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .matchHeader('content-type', 'application/json')
           .reply(200, 'ok');
@@ -71,7 +71,7 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
         // Given
         const user = await createAdminUser();
         nock('https://api.airtable.com')
-          .post('/v0/airtableBaseValue/Epreuves?key=value', { param: 'value' })
+          .post('/v0/airtableDatabaseIdValue/Epreuves?key=value', { param: 'value' })
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .matchHeader('content-type', 'application/json')
           .reply(401, 'Unauthorized');

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -173,7 +173,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       const challenge1 = domainBuilder.buildChallengeAirtableDataObject({ id: '1' });
       const challenge2 = domainBuilder.buildChallengeAirtableDataObject({ id: '2' });
       const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
+        .get('/v0/airtableDatabaseIdValue/Epreuves')
         .query({
           fields: {
             '': challengeAirtableFields,
@@ -324,7 +324,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
     it('should search challenges', async () => {
       // Given
       const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
+        .get('/v0/airtableDatabaseIdValue/Epreuves')
         .query({
           fields: {
             '': challengeAirtableFields,
@@ -352,7 +352,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
     it('should search challenges with limit',  async() => {
       const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
+        .get('/v0/airtableDatabaseIdValue/Epreuves')
         .query({
           fields: {
             '': challengeAirtableFields,
@@ -391,7 +391,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       const challenge = domainBuilder.buildChallengeAirtableDataObject({ id: 'recChallengeId1' });
       const airtableChallenge = airtableBuilder.factory.buildChallenge(challenge);
       const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
+        .get('/v0/airtableDatabaseIdValue/Epreuves')
         .query({
           fields: {
             '': challengeAirtableFields,
@@ -480,7 +480,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
     it('should return a 404 error when the challenge doesn\'t exist', async () => {
       const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
+        .get('/v0/airtableDatabaseIdValue/Epreuves')
         .query({
           fields: {
             '': challengeAirtableFields,
@@ -520,7 +520,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       const expectedBody = { records: [expectedBodyChallenge] };
 
       const airtableCall = nock('https://api.airtable.com')
-        .post('/v0/airtableBaseValue/Epreuves/?', expectedBody)
+        .post('/v0/airtableDatabaseIdValue/Epreuves/?', expectedBody)
         .reply(
           200,
           { records: [airtableBuilder.factory.buildChallenge(challenge)] }
@@ -671,7 +671,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       const token = 'not-a-real-token';
 
       const attachmentsScope = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Attachments')
+        .get('/v0/airtableDatabaseIdValue/Attachments')
         .query({ filterByFormula: '{challengeId persistant} = \'recChallengeId\'' })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [] });
@@ -687,7 +687,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
         .reply(200);
 
       const airtableCall = nock('https://api.airtable.com')
-        .post('/v0/airtableBaseValue/Epreuves/?', expectedBody)
+        .post('/v0/airtableDatabaseIdValue/Epreuves/?', expectedBody)
         .reply(
           200,
           { records: [airtableBuilder.factory.buildChallenge(challenge)] }
@@ -776,7 +776,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       const expectedBody = { records: [expectedBodyChallenge] };
 
       const airtableCall = nock('https://api.airtable.com')
-        .patch('/v0/airtableBaseValue/Epreuves/?', expectedBody)
+        .patch('/v0/airtableDatabaseIdValue/Epreuves/?', expectedBody)
         .reply(
           200,
           { records: [airtableChallenge] }

--- a/api/tests/tooling/airtable-builder/airtable-mock-route.js
+++ b/api/tests/tooling/airtable-builder/airtable-mock-route.js
@@ -47,7 +47,7 @@ AirtableMockRoute.ROUTE_TYPE = ROUTE_TYPE;
 module.exports = AirtableMockRoute;
 
 function generateUrlForRouteType({ routeType, tableName, returnBody }) {
-  const url = `/v0/airtableBaseValue/${tableName}`;
+  const url = `/v0/airtableDatabaseIdValue/${tableName}`;
   const returnBodyId = returnBody && returnBody.fields && returnBody.fields['id persistant'];
 
   if (!returnBodyId && routeType === ROUTE_TYPE.GET) {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -109,7 +109,7 @@ export default class SingleController extends Controller {
 
 
   get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableChallenges}/${ this.challenge.airtableId}`;
+    return `${this.config.airtableUrl}${this.config.airtableDatabaseId}/${this.config.tableChallenges}/${ this.challenge.airtableId}`;
   }
 
   get lastUpdatedAtISO() {

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -68,7 +68,7 @@ export default class SingleController extends Controller {
   }
 
   get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableSkills}/${this.skill.id}`;
+    return `${this.config.airtableUrl}${this.config.airtableDatabaseId}/${this.config.tableSkills}/${this.skill.id}`;
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/single.js
@@ -49,7 +49,7 @@ export default class SingleController extends Controller {
   }
 
   get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableTubes}/${this.tube.id}`;
+    return `${this.config.airtableUrl}${this.config.airtableDatabaseId}/${this.config.tableTubes}/${this.tube.id}`;
   }
 
   @action

--- a/pix-editor/app/models/config.js
+++ b/pix-editor/app/models/config.js
@@ -2,7 +2,7 @@ import Model, { attr } from '@ember-data/model';
 
 export default class ConfigModel extends Model {
   @attr airtableUrl;
-  @attr airtableBase;
+  @attr airtableDatabaseId;
   @attr tableChallenges;
   @attr tableSkills;
   @attr tableTubes;

--- a/pix-editor/app/services/config.js
+++ b/pix-editor/app/services/config.js
@@ -10,7 +10,7 @@ export default class ConfigService extends Service {
   @tracked author;
   @tracked accessLevel;
   @tracked airtableUrl;
-  @tracked airtableBase;
+  @tracked airtableDatabaseId;
   @tracked tableChallenges;
   @tracked tableSkills;
   @tracked tableTubes;
@@ -25,7 +25,7 @@ export default class ConfigService extends Service {
     this.author = currentUser.trigram;
     this.accessLevel = this.access.getLevel(currentUser.access);
     this.airtableUrl = config.airtableUrl;
-    this.airtableBase = config.airtableBase;
+    this.airtableDatabaseId = config.airtableDatabaseId;
     this.tableChallenges = config.tableChallenges;
     this.tableSkills = config.tableSkills;
     this.tableTubes = config.tableTubes;

--- a/scripts/copy-skills-and-set-challenges-as-focusable/index.js
+++ b/scripts/copy-skills-and-set-challenges-as-focusable/index.js
@@ -52,7 +52,7 @@ async function main() {
 function createAirtableClient() {
   return new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  }).base(process.env.AIRTABLE_DATABASE_ID);
 }
 
 function getBaseSkills(table) {

--- a/scripts/enable-shuffled-on-challenges/index.js
+++ b/scripts/enable-shuffled-on-challenges/index.js
@@ -16,7 +16,7 @@ const logger = createLogger({
 
 const enableShuffledOnChallenges = async ({ airtableClient, dryRun, sample }) => {
   const excludedSkillIds = await readExcludes({ airtableClient });
-  
+
   const challenges = await _listChallengesToBeShuffled({ airtableClient, excludedSkillIds, sample });
 
   if (!dryRun) {
@@ -28,7 +28,7 @@ const enableShuffledOnChallenges = async ({ airtableClient, dryRun, sample }) =>
 
 /**
  * @param {{
- *   airtableClient: Airtable.Base
+ *   airtableClient: airtable.databaseId
  * }} config
  */
 async function readExcludes({ airtableClient }) {
@@ -57,7 +57,7 @@ async function readExcludes({ airtableClient }) {
 
 /**
  * @param {{
- *   airtableClient: Airtable.Base
+ *   airtableClient: airtable.databaseId
  *   excludedSkillIds: string[]
  *   sample: boolean
  * }} config
@@ -92,7 +92,7 @@ async function _listChallengesToBeShuffled({ airtableClient, excludedSkillIds, s
 /**
  * @param challenges {Airtable.Records<Airtable.FieldSet>}
  * @param {{
- *   airtableClient: Airtable.Base
+ *   airtableClient: airtable.databaseId
  * }} config
  */
 async function _shuffleChallenges(challenges, { airtableClient }) {
@@ -139,7 +139,7 @@ async function main() {
 
   const {
     AIRTABLE_API_KEY: airtableApiKey,
-    AIRTABLE_BASE: airtableBase,
+    AIRTABLE_DATABASE_ID: airtableDatabaseId,
   } = process.env;
 
   const dryRun = process.env.DRY_RUN !== 'false';
@@ -149,11 +149,11 @@ async function main() {
 
   logger.info(`Script ${__filename} has started`, {
     airtableApiKey,
-    airtableBase,
+    airtableDatabaseId,
     dryRun,
   });
 
-  const airtableClient = createAirtableClient({ apiKey: airtableApiKey, base: airtableBase });
+  const airtableClient = createAirtableClient({ apiKey: airtableApiKey, base: airtableDatabaseId });
   await enableShuffledOnChallenges({ airtableClient, dryRun, sample });
 
   const endTime = performance.now();

--- a/scripts/migrate-attachments-in-subfolder/index.js
+++ b/scripts/migrate-attachments-in-subfolder/index.js
@@ -15,7 +15,7 @@ module.exports = {
 function getBaseAttachments() {
   const base = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  }).base(process.env.AIRTABLE_DATABASE_ID);
 
   return base('Attachments');
 }

--- a/scripts/populate-alpha-and-delta-column/index.js
+++ b/scripts/populate-alpha-and-delta-column/index.js
@@ -5,7 +5,7 @@
 // To run the script:
 // > cd scripts
 // > npm ci
-// > AIRTABLE_API_KEY=XXX AIRTABLE_BASE=XXXX node populate-alpha-and-delta-column/
+// > AIRTABLE_API_KEY=XXX AIRTABLE_DATABASE_ID=XXXX node populate-alpha-and-delta-column/
 
 const _ = require('lodash');
 const fs = require('fs');
@@ -88,7 +88,7 @@ async function updateRecords(base, data) {
 function getBaseChallenges() {
   const base = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  }).base(process.env.AIRTABLE_DATABASE_ID);
 
   return base('Epreuves');
 }

--- a/scripts/restore-challenges-validated-and-archived-at/index.js
+++ b/scripts/restore-challenges-validated-and-archived-at/index.js
@@ -9,11 +9,11 @@ function getStatus(status) {
     'pré-validé': 'validé',
   }[status] ?? status;
 }
-    
+
 (async function() {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   let cursor;
-      
+
   try {
     await client.connect();
     const result = await client.query('SELECT "createdAt" FROM releases ORDER BY "createdAt" limit 1');
@@ -111,7 +111,7 @@ async function _parseChangelog(oldestReleaseDate) {
 
   const changelogAirtableClient = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY,
-  }).base(process.env.AIRTABLE_EDITOR_BASE);
+  }).base(process.env.AIRTABLE_EDITOR_DATABASE_ID);
 
   console.log(`reading all changelogs older than ${oldestReleaseDate} from Airtable changelog base...`);
   const allChangelogs = await changelogAirtableClient.table('Notes').select({
@@ -186,7 +186,7 @@ async function _updateAirtable(challengesInfo) {
 
   const airtableClient =  new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY,
-  }).base(process.env.AIRTABLE_BASE);
+  }).base(process.env.AIRTABLE_DATABASE_ID);
 
   console.log('reading all challenges from Airtable...');
   const allChallenges = await airtableClient.table('Epreuves').select({


### PR DESCRIPTION
## :unicorn: Problème
Les variables d'environnement AIRTABLE_BASE et AIRTABLE_EDITOR_BASE contienent l'ID des bases de données Airtable et Airtable Editor, mais leur nom ne nous semble pas parlant. 

## :robot: Solution
Renommer AIRTABLE_BASE en AIRTABLE_DATABASE_ID et AIRTABLE_EDITOR_BASE en AIRTABLE_EDITOR_DATABASE_ID. 

## :rainbow: Remarques
Ne pas oublier de modifier ces variables d'environnement dans les environnements où ils seront déployés. Il se pourrait qu'il soit également nécessaire de modifier CYPRESS_AIRTABLE_BASE en CYPRESS_AIRTABLE_DATABASE_ID.

## :100: Pour tester
Pix Editor doit toujours fonctionner. 