### PR TITLE
[TECH] Prévenir le commit de secrets (PIX-8664)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# In case filename contains spaces [https://www.baeldung.com/linux/reading-output-into-array#1-output-may-contain-spaces](https://www.baeldung.com/linux/reading-output-into-array#1-output-may-contain-spaces)
+IFS=$'\n'
+
+CHANGED_FILES=($(git diff --name-only --cached --diff-filter=ACMR))
+
+SECRET=postgres://postgres:J9FUMSBhei8oU@db.dbhostprovider.com:5434/thedb
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NO_COLOR='\033[0m'
+
+for file in "${CHANGED_FILES[@]}"
+do
+  echo -e "Inspecting file : ${GREEN} ${file} ${NO_COLOR}"
+  MATCHES="$(grep --count "$SECRET" "${file}" || true)"
+  if [[ "$MATCHES" > 0 ]]
+    then
+      echo -e "Oops, we found the secret ${RED} ${SECRET} ${NO_COLOR} in file ${file} ! "
+      exit 255
+  fi
+done

--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,7 @@
     "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
     "lint": "eslint lib tests",
     "lint:fix": "eslint lib tests --fix",
-    "preinstall": "npx check-engine && {git config core.hooksPath .githooks || true;}",
+    "preinstall": "npx check-engine && git config core.hooksPath .githooks || true",
     "start": "node bin/www",
     "start:watch": "nodemon --signal SIGTERM bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",

--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,7 @@
     "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
     "lint": "eslint lib tests",
     "lint:fix": "eslint lib tests --fix",
-    "preinstall": "npx check-engine",
+    "preinstall": "npx check-engine && {git config core.hooksPath .githooks || true;}",
     "start": "node bin/www",
     "start:watch": "nodemon --signal SIGTERM bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "cd pix-editor && npm run build -- --output-path=../api/public/pix-editor",
     "scalingo-post-ra-creation": "cd api && npm run scalingo-post-ra-creation",
     "postdeploy": "cd api && npm run postdeploy",
-    "preinstall": "npx check-engine && {git config core.hooksPath .githooks || true;}"
+    "preinstall": "git config core.hooksPath .githooks || true"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start": "cd api && npm start",
     "build": "cd pix-editor && npm run build -- --output-path=../api/public/pix-editor",
     "scalingo-post-ra-creation": "cd api && npm run scalingo-post-ra-creation",
-    "postdeploy": "cd api && npm run postdeploy"
+    "postdeploy": "cd api && npm run postdeploy",
+    "preinstall": "npx check-engine && {git config core.hooksPath .githooks || true;}"
   },
   "repository": {
     "type": "git",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -21,7 +21,7 @@
     "lint:scss": "stylelint app/styles/*.scss",
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:js": "eslint . --cache",
-    "preinstall": "npx check-engine && {git config core.hooksPath .githooks || true;}",
+    "preinstall": "npx check-engine && git config core.hooksPath .githooks || true",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve --proxy http://localhost:3002",
     "test": "npm-run-all lint test:*",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -21,7 +21,7 @@
     "lint:scss": "stylelint app/styles/*.scss",
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:js": "eslint . --cache",
-    "preinstall": "npx check-engine",
+    "preinstall": "npx check-engine && {git config core.hooksPath .githooks || true;}",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve --proxy http://localhost:3002",
     "test": "npm-run-all lint test:*",


### PR DESCRIPTION
## :unicorn: Problème
Des secrets peuvent être commités et diffusés publiquement.

## :robot: Solution
Contrôler la présence de secrets dans un hook de pré-commit.

## :100: Pour tester
- récupérer le référentiel
  - essayer de le commiter et observer qu'une alerte est levée et qu'il n'est pas possible de le commiter (bon, un --no-verify vous fera passer outre) 
- ajouter des fichiers test, dans plusieurs répertoires, par exemple :
  - api/tests/unit/tooling/empty-json-file.json
  - docs/adr/fake-adr-with-secret.md
  - pix-editor/empty-file-test.md
  - pix-editor/referential-in-pix-editor-directory.json
  - referential.json
  - test espace.md _(un fichier contenant un espace dans le nom)_
  - api/chars-file-\*\$§.md (nom avec des caractères spéciaux qui va générer une erreur sur le script)
