### PR TITLE
[TECH] Réparer CircleCI (Fail sur Install ChromeDriver)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/pix-editor
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:
@@ -104,7 +104,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/pix-editor
-      - browser-tools/install-browser-tools
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:


### PR DESCRIPTION
## :unicorn: Problème
CircleCI est KO sur l'étape d'installation des browser tools...

## :robot: Solution
 - Supprimer l'installation des browser tools pour l'e2e (non nécessaire en fait)
 - Installer uniquement Chrome pour les tests Ember (le reste n'est pas nécessaire)

## :rainbow: Remarques
N/A

## :100: Pour tester
Voir la CI
