### PR TITLE
[TECH] Désactivation de google analytics dans TUI editor

### DIFF
--- a/pix-editor/app/components/field/mde.hbs
+++ b/pix-editor/app/components/field/mde.hbs
@@ -15,7 +15,7 @@
     {{@title}}
   </label>
   {{#if @edition}}
-    <TuiEditor data-test-tui-editor @value={{@value}} @onChange={{@setValue}} />
+    <TuiEditor data-test-tui-editor @value={{@value}} @onChange={{@setValue}} @usageStatistics={{false}} />
   {{else}}
     <div data-test-markdow-to-html class="mde-preview">
       <MarkdownToHtml @markdown={{@value}} />


### PR DESCRIPTION
## :unicorn: Problème
L'éditeur de texte riche TUI editor envoie des requêtes google analytics par défaut.

## :robot: Solution
Désactiver l'envoi de ces requêtes dans la config de l'éditeur.

## :rainbow: Remarques
N/A

## :100: Pour tester
- Aller sur la RA avec une clé ayant les droits d'édition.
- Aller sur une épreuve quelconque.
- Ouvrir la console du navigateur afin de surveiller l'onglet Network.
- (En cas de tests répétés, supprimer la clé `"TOAST UI editor for pix-lcms-review-pr134.osc-fr1.scalingo.io: Statistics"` dans le LocalStorage si elle existe)
- Cliquer sur le bouton Modifier de l'épreuve
- Vérifier qu'aucune requête n'est envoyée vers google analytics