### PR TITLE
[BUGFIX] Réordonner l'affichage des compétences (PIX-8760).

### DIFF
--- a/pix-editor/app/models/area.js
+++ b/pix-editor/app/models/area.js
@@ -17,8 +17,8 @@ export default class AreaModel extends Model {
         const [domainCodeA, competenceCodeA] = competenceA.code.split('.');
         const [domainCodeB, competenceCodeB] = competenceB.code.split('.');
         if (parseInt(domainCodeA) === parseInt(domainCodeB))
-          return parseInt(competenceCodeA) > parseInt(competenceCodeB);
-        return parseInt(domainCodeA) > parseInt(domainCodeB);
+          return parseInt(competenceCodeA) - parseInt(competenceCodeB);
+        return parseInt(domainCodeA) - parseInt(domainCodeB);
       });
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Les compétences ne sont pas bien ordonnées.

## :robot: Solution
Réordonner l'affichage des compétences.

## :rainbow: Remarques
RAS

## :100: Pour tester
Afficher les compétences dans le menu latérale et vérifier qu'elles sont bien ordonnées.
