### PR TITLE
[TECH] :green_heart: Déclarer les environnements CircleCI dans des executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,60 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.4.3
 
-jobs:
-  pix-editor-test:
+executors:
+  node-docker:
+    parameters:
+      node-version:
+        # renovate datasource=node-version depName=node
+        default: 16.19.1
+        type: string
     docker:
-      - image: cimg/node:16.19.1-browsers
+      - image: cimg/node:<<parameters.node-version>>
+    resource_class: small
+  node-redis-postgres-docker:
+    parameters:
+      node-version:
+        # renovate datasource=node-version depName=node
+        default: 16.19.1
+        type: string
+    docker:
+      - image: cimg/node:<<parameters.node-version>>
+      - image: postgres:14.6-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:6.2.10-alpine
+    resource_class: small
+  node-browsers-docker:
+    parameters:
+      node-version:
+        # renovate datasource=node-version depName=node
+        default: 16.19.1
+        type: string
+    docker:
+      - image: cimg/node:<<parameters.node-version>>-browsers
         environment:
           JOBS: 2
+    resource_class: small
+  node-browsers-redis-postgres-docker:
+    parameters:
+      node-version:
+        # renovate datasource=node-version depName=node
+        default: 16.19.1
+        type: string
+    docker:
+      - image: cimg/node:<<parameters.node-version>>-browsers
+      - image: postgres:14.6-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
+      - image: redis:6.2.10-alpine
+    resource_class: medium
+
+
+jobs:
+  pix-editor-test:
+    executor: node-browsers-docker
     working_directory: ~/pix-editor/pix-editor
     steps:
       - attach_workspace:
@@ -33,8 +81,7 @@ jobs:
             npm test
 
   checkout:
-    docker:
-      - image: cimg/node:16.19.1
+    executor: node-docker
     working_directory: ~/pix-editor
     steps:
       - checkout
@@ -44,13 +91,7 @@ jobs:
             - .
 
   api_build_and_test:
-    docker:
-      - image: cimg/node:16.19.1
-      - image: postgres:14.6-alpine
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:6.2-alpine
+    executor: node-redis-postgres-docker
     working_directory: ~/pix-editor/api
     steps:
       - attach_workspace:
@@ -72,8 +113,7 @@ jobs:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
 
   scripts_test:
-    docker:
-      - image: cimg/node:16.19.1
+    executor: node-docker
     working_directory: ~/pix-editor/scripts
     steps:
       - attach_workspace:
@@ -93,13 +133,7 @@ jobs:
             npm test
 
   e2e_test:
-    docker:
-      - image: cimg/node:16.19.1-browsers
-      - image: postgres:14.6-alpine
-        environment:
-          POSTGRES_USER: circleci
-          POSTGRES_HOST_AUTH_METHOD: trust
-      - image: redis:6.2-alpine
+    executor: node-browsers-redis-postgres-docker
     working_directory: ~/pix-editor/end-to-end-tests
     steps:
       - attach_workspace:


### PR DESCRIPTION
## :unicorn: Problème

La définition des environnement d'exécution de CircleCI actuelle contient des duplications.
Renovate ne traite pas les montées de versions de cimg/node.

## :robot: Proposition

Définir ces environnements en tant qu'executor CircleCI et utiliser ces executors dans nos jobs.
Définir les paramètres des executors en tant que version du package node pour renovate. 

## :rainbow: Remarques

J'ai repassé les ressource en small pour la plupart des jobs qui n'avaient pas besoin de medium

## :100: Pour tester

Les tests doivent être 🟢 