### PR TITLE
[TECH] Ajout d'un script pour peupler les champs alpha et delta des challenges à partir d'un CSV

### DIFF
--- a/scripts/populate-alpha-and-delta-column-with-csv/index-tests.js
+++ b/scripts/populate-alpha-and-delta-column-with-csv/index-tests.js
@@ -1,0 +1,131 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+const expect = chai.expect;
+const AirtableRecord = require('airtable').Record;
+const _ = require('lodash');
+const { parseData, findAirtableIds, updateRecords } = require('.');
+
+describe('Populate alpha and delta column', function() {
+  describe('#parseData', function() {
+    it('should return a object table with challenge persistent id, alpha and delta', async function() {
+      const csvData = 'items,difficulties,discriminants\nrec1,0.8423189520825876,1.6760518550872801\nrec2,-0.9423189520825878,2.6760518550872802';
+
+      const expectedResult = [{
+        id: 'rec1',
+        alpha: '1.6760518550872801',
+        delta: '0.8423189520825876',
+      }, {
+        id: 'rec2',
+        alpha: '2.6760518550872802',
+        delta: '-0.9423189520825878',
+      }];
+
+      const result = await parseData(csvData);
+
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#findAirtableIds', function() {
+    it('should request airtable with the persistent ids', async function() {
+      const data = [{
+        id: 'recPix1',
+        alpha: 0.123,
+        delta: 0.654321,
+      }, {
+        id: 'recPix2',
+        alpha: -0.321,
+        delta: 0.98765432166556,
+      }];
+
+      const airtableData = [
+        new AirtableRecord('Challenge', 'recAirtableId1', {
+          fields: {
+            'id persistant': 'recPix1'
+          },
+        }),
+        new AirtableRecord('Challenge', 'recAirtableId2', {
+          fields: {
+            'id persistant': 'recPix2'
+          },
+        })
+      ];
+
+      const base = {
+        select: sinon.stub().returns({
+          all: sinon.stub().resolves(airtableData)
+        }),
+      };
+
+      const expectedResult = [{
+        id: 'recAirtableId1',
+        alpha: 0.123,
+        delta: 0.654321,
+      }, {
+        id: 'recAirtableId2',
+        alpha: -0.321,
+        delta: 0.98765432166556,
+      }];
+
+      const result = await findAirtableIds(base, data);
+
+      expect(base.select).to.have.been.calledWith({
+        fields: ['Record ID', 'id persistant'],
+        filterByFormula: 'OR(\'recPix1\' = {id persistant},\'recPix2\' = {id persistant})',
+      });
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#updateRecords', function() {
+    it('updates alpha and delta in challenges records', async function() {
+      const data = [{
+        id: 'recAirtableId1',
+        alpha: 0.123,
+        delta: 0.654321,
+      }, {
+        id: 'recAirtableId2',
+        alpha: -0.321,
+        delta: 0.98765432166556,
+      }];
+      const base = {
+        update: sinon.stub().yields(),
+      };
+      await updateRecords(base, data);
+      expect(base.update).to.be.calledWith([
+        {
+          id: 'recAirtableId1',
+          fields: {
+            'Difficulté calculée': '0.654321',
+            'Discrimination calculée': '0.123'
+          }
+        },
+        {
+          id: 'recAirtableId2',
+          fields: {
+            'Difficulté calculée': '0.98765432166556',
+            'Discrimination calculée': '-0.321'
+          }
+        }
+      ]);
+    });
+
+    it('should batch updates with up to 10 records at a time', async function() {
+      const data = _.times(11).map((index) => {
+        return {
+          id: index,
+          alpha: 1,
+          delta: 2
+        };
+      });
+      const base = {
+        update: sinon.stub().yields(),
+      };
+      await updateRecords(base, data);
+      expect(base.update).to.have.been.calledTwice;
+    });
+  });
+});
+

--- a/scripts/populate-alpha-and-delta-column-with-csv/index.js
+++ b/scripts/populate-alpha-and-delta-column-with-csv/index.js
@@ -1,0 +1,112 @@
+// Populate the alpha and dela columns
+// You must have 1 file:
+//  - a csv file with challengId, alpha and beta columns
+// To run the script:
+// > cd scripts
+// > npm ci
+// > AIRTABLE_API_KEY=XXX AIRTABLE_BASE=XXXX node populate-alpha-and-delta-column-with-csv/
+
+const _ = require('lodash');
+const fs = require('fs');
+const Airtable = require('airtable');
+const { parseString } = require('@fast-csv/parse');
+const ProgressBar = require('progress');
+
+const HEADERS_MAPPING = {
+  items: 'id',
+  difficulties: 'delta',
+  discriminants: 'alpha',
+};
+
+function parseData(csvData) {
+  return new Promise((resolve, reject) => {
+    const result = [];
+
+    parseString(csvData, { headers: (headers) => headers.map((h) => HEADERS_MAPPING[h]) })
+      .on('error', (error) => {
+        console.error(error);
+        reject(error);
+      })
+      .on('data', (row) => {
+        result.push(row);
+      })
+      .on('end', () => resolve(result));
+  });
+}
+
+async function findAirtableIds(base, challengesWithPersistentIds) {
+  const challengesWithPersistentIdsWithChunk = _.chunk(challengesWithPersistentIds, 100);
+  const promises = challengesWithPersistentIdsWithChunk.map((chunk) => {
+    return base
+      .select({
+        fields: ['Record ID', 'id persistant'],
+        filterByFormula: 'OR(' + chunk.map(({ id }) => `'${id}' = {id persistant}`).join(',') + ')',
+      })
+      .all();
+  });
+  const airtableRecords = (await Promise.all(promises)).flat();
+
+  return airtableRecords.map((airtableRecord) => {
+    const data = challengesWithPersistentIds.find((row) => row.id === airtableRecord.get('id persistant'));
+    return {
+      ...data,
+      id: airtableRecord.id
+    };
+  });
+}
+
+async function updateRecords(base, data) {
+  const payloadWithoutLimit = data.map(({ id, alpha, delta }) => {
+    return {
+      id,
+      fields: {
+        'Difficulté calculée': `${delta}`,
+        'Discrimination calculée': `${alpha}`
+      },
+    };
+  });
+  const payloadByChunk = _.chunk(payloadWithoutLimit, 10);
+  const bar = new ProgressBar('[:bar] :percent', {
+    total: payloadByChunk.length,
+    width: 50,
+  });
+  const promises = payloadByChunk.map((payload) => {
+    return new Promise((resolve, reject) => {
+      base.update(
+        payload,
+        (err) => {
+          bar.tick();
+          if (err) reject();
+          else resolve();
+        });
+    });
+  });
+  return Promise.all(promises);
+}
+
+function getBaseChallenges() {
+  const base = new Airtable({
+    apiKey: process.env.AIRTABLE_API_KEY
+  }).base(process.env.AIRTABLE_BASE);
+
+  return base('Epreuves');
+}
+
+async function main() {
+  const csv = fs.readFileSync('./file.csv', 'utf-8');
+
+  const base = getBaseChallenges();
+  const matchedData = await parseData(csv);
+  const matchedDataWithAirtableIds = await findAirtableIds(base, matchedData);
+  await updateRecords(base, matchedDataWithAirtableIds);
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  main();
+}
+
+module.exports = {
+  parseData,
+  findAirtableIds,
+  updateRecords,
+};


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de la certif next-gen, l'équipe data réalise des calibrations du référentiel qui mettent à jour les propriétés `discriminants` et `difficultés` des épreuves.
Le résultat de ces calibrations est obtenu dans un fichier CSV que l'on doit importer pour mettre à jour le référentiel dans Airtable

## :robot: Solution

Copie d'un script déjà existant sans la partie concernant le matching des données hashées avec les recIds des épreuves (non nécessaire car le csv contient les ids)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
