### PR TITLE
[TECH] Vérification de la présence des hooks git (PIX-8666)

### DIFF
--- a/.github/workflows/check-pre-hooks.yaml
+++ b/.github/workflows/check-pre-hooks.yaml
@@ -1,0 +1,38 @@
+name: Check if somes git hooks are present
+
+on:
+  # eslint-disable-next-line yml/no-empty-mapping-value
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-git-hooks:
+    name: Check git hooks
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: |
+            .githooks
+
+      - name: Check if `pre-commit` hook is present and executable
+        run: |
+          test -f .githooks/pre-commit && \
+          test -x .githooks/pre-commit
+
+      - name: Set env
+        uses: sergeysova/jq-action@v2
+        with:
+         cmd: |
+          echo "PREINSTALL_SCRIPT=$(jq '.scripts.preinstall' package.json -r)" >> $GITHUB_ENV
+
+      - name: Check if `pre-commit` hook is install with npm on preinstall step
+        run: |
+          echo "${PREINSTALL_SCRIPT}" | grep 'core.hooksPath' && \
+          echo "${PREINSTALL_SCRIPT}" | grep '.githooks'


### PR DESCRIPTION
## :unicorn: Problème
Afin d'éviter la fuite de secrets, un hook git est ajouté sur le repository.

Ce hook est installé sur le poste de développement. Il faut vérifier que par défaut le script de précommit existe et qu'il est bien installé automatiquement.

## :robot: Solution
La solution consiste à ajouter une action Github qui vérifie ça.

## :rainbow: Remarques
Pour tester que la vérification écoue, supprimer le fichier `.githooks/pre-commit` et/ou modifier la section `preinstall` du fichier `package.json` pour enlever les mots hook.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
