### PR TITLE
[FEATURE] Faire en sorte qu'un test statique nouvellement créé soit actif par défaut (PIX-8567)

### DIFF
--- a/api/db/migrations/20230802085633_migrate-static-courses-from-airtable.js
+++ b/api/db/migrations/20230802085633_migrate-static-courses-from-airtable.js
@@ -5,6 +5,7 @@ const Airtable = require('airtable');
  * @returns { Promise<void> }
  */
 exports.up = async function(knex) {
+  if (process.env.NODE_ENV !== 'production') return;
   const airtableClient = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY,
   }).base(process.env.AIRTABLE_BASE);
@@ -17,8 +18,8 @@ exports.up = async function(knex) {
 
   const filteredStaticCourses = allStaticCourses
     .filter((course) => course.fields['Nom'] != null
-      && course.fields['Nb d\'épreuves'] !== 0
-      && course.fields['Épreuves (id persistant)'].toString().length <= 1000
+        && course.fields['Nb d\'épreuves'] !== 0
+        && course.fields['Épreuves (id persistant)'].toString().length <= 1000
     );
   console.log(filteredStaticCourses.length);
 

--- a/api/db/migrations/20230803133550_add-isactive-column-in-static-courses-table.js
+++ b/api/db/migrations/20230803133550_add-isactive-column-in-static-courses-table.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'static_courses';
+const IS_ACTIVE_COLUMN = 'isActive';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.boolean(IS_ACTIVE_COLUMN).notNullable().defaultTo(true);
+  });
+  return knex.raw('ALTER TABLE ?? ALTER COLUMN ?? DROP DEFAULT', [TABLE_NAME, IS_ACTIVE_COLUMN]);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(IS_ACTIVE_COLUMN);
+  });
+};

--- a/api/db/seeds/data/static-courses.js
+++ b/api/db/seeds/data/static-courses.js
@@ -6,5 +6,6 @@ module.exports = function(databaseBuilder) {
     challengeIds: 'challenge1NQqfx9mYKUQEO,challengeTYFrFy5EGYEet,challenge1rSPsnisQ8ft4W',
     imageUrl: 'some/image/url',
     createdAt: new Date(),
+    isActive: true,
   });
 };

--- a/api/lib/domain/models/StaticCourse.js
+++ b/api/lib/domain/models/StaticCourse.js
@@ -8,12 +8,14 @@ module.exports = class StaticCourse {
     name,
     description,
     challengeIds,
+    isActive,
     createdAt,
     updatedAt,
   }) {
     this.id = id;
     this.name = name;
     this.description = description;
+    this.isActive = isActive;
     this.challengeIds = challengeIds;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
@@ -33,7 +35,7 @@ module.exports = class StaticCourse {
     if (validationError.hasErrors()) {
       return CommandResult.Failure({ value: null, error: validationError });
     }
-    const staticCourse = new StaticCourse({ ...attributes, id: idGenerator('course') });
+    const staticCourse = new StaticCourse({ ...attributes, id: idGenerator('course'), isActive: true });
     return CommandResult.Success({ value: staticCourse });
   }
 
@@ -43,6 +45,7 @@ module.exports = class StaticCourse {
       id: this.id,
       name: updateCommand.name.trim(),
       description: updateCommand.description.trim(),
+      isActive: this.isActive,
       challengeIds: updateCommand.challengeIds.map((challengeId) => challengeId.trim()),
       createdAt: this.createdAt,
       updatedAt: timestamp,
@@ -61,6 +64,7 @@ module.exports = class StaticCourse {
       name: this.name,
       description: this.description,
       challengeIds: this.challengeIds,
+      isActive: this.isActive,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -72,6 +72,7 @@ async function get(id) {
       name: staticCourse.name,
       description: staticCourse.description,
       challengeIds: staticCourse.challengeIds.split(','),
+      isActive: staticCourse.isActive,
       createdAt: staticCourse.createdAt,
       updatedAt: staticCourse.updatedAt,
     });
@@ -86,6 +87,7 @@ async function save(staticCourseForCreation) {
     name: staticCourseDTO.name,
     description: staticCourseDTO.description,
     challengeIds: staticCourseDTO.challengeIds.join(','),
+    isActive: staticCourseDTO.isActive,
     createdAt: staticCourseDTO.createdAt,
     updatedAt: staticCourseDTO.updatedAt,
   };

--- a/api/tests/tooling/database-builder/factory/build-static-course.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course.js
@@ -6,11 +6,12 @@ function buildStaticCourse({
   description = 'Ma super description de test statique',
   challengeIds = 'challengeABC, challengeDEF',
   imageUrl = 'ma/super/image.png',
+  isActive = true,
   createdAt = new Date('2010-01-04'),
   updatedAt = new Date('2010-01-11'),
 } = {}) {
 
-  const values = { id, name, description, challengeIds, imageUrl, createdAt, updatedAt };
+  const values = { id, name, description, challengeIds, imageUrl, createdAt, updatedAt, isActive };
 
   return databaseBuffer.pushInsertable({
     tableName: 'static_courses',

--- a/api/tests/tooling/domain-builder/factory/build-static-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-static-course.js
@@ -5,6 +5,7 @@ module.exports = function buildStaticCourse({
   name = 'static course name',
   description = 'static course description',
   challengeIds = ['challengeid-1', 'challengeid-2'],
+  isActive = true,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -13,6 +14,7 @@ module.exports = function buildStaticCourse({
     name,
     description,
     challengeIds,
+    isActive,
     createdAt,
     updatedAt,
   });

--- a/api/tests/unit/domain/models/StaticCourse_test.js
+++ b/api/tests/unit/domain/models/StaticCourse_test.js
@@ -36,6 +36,7 @@ describe('Unit | Domain | StaticCourse', function() {
           name: 'some valid name',
           description: 'some valid description',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
+          isActive: true,
           createdAt: new Date('2021-10-29T03:04:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
         });
@@ -58,6 +59,7 @@ describe('Unit | Domain | StaticCourse', function() {
           id: 'courseABC123',
           name: 'some valid name',
           description: '',
+          isActive: true,
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           createdAt: new Date('2021-10-29T03:04:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
@@ -202,6 +204,7 @@ describe('Unit | Domain | StaticCourse', function() {
         name: 'old name',
         description: 'old description',
         challengeIds: ['chalDEF ', ' chalJKF'],
+        isActive: false,
         createdAt: new Date('2021-00-00T09:00:00Z'),
         updatedAt: new Date('2021-00-00T09:00:00Z'),
       });
@@ -226,6 +229,7 @@ describe('Unit | Domain | StaticCourse', function() {
           name: 'some valid name',
           description: 'some valid description',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
+          isActive: false,
           createdAt: new Date('2021-00-00T09:00:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
         });
@@ -247,6 +251,7 @@ describe('Unit | Domain | StaticCourse', function() {
           id: 'myAwesomeCourse66',
           name: 'some valid name',
           description: '',
+          isActive: false,
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           createdAt: new Date('2021-00-00T09:00:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),


### PR DESCRIPTION
## :unicorn: Problème
La notion de status d'un test statique, ce jour telle qu'elle existe sur Airtable, est complètement en vrac.
On souhaite remettre à zéro le concept et pour le moment n'introduire qu'une notion de status avec deux status possibles : actif et inactif.
Un test créé via PixEditor doit être actif par défaut.

## :robot: Solution
- Ajout d'une colonne booléenne "isActive"
- Par défaut à true lors de la création d'un test statique
- Ajout du code pour ne pas casser les tests. La colonne étant NOT NULLABLE, il a fallu aussi réécrire le statut en BDD lors de la mise à jour d'un test statique

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Créer un test statique, aller en bdd et constater qu'il est actif
