### PR TITLE
[FEATURE] Afficher le statut du test statique sur la liste des tests statiques et sur la page de détails d'un test statique (PIX-8643)

### DIFF
--- a/api/db/seeds/data/static-courses.js
+++ b/api/db/seeds/data/static-courses.js
@@ -8,4 +8,14 @@ module.exports = function(databaseBuilder) {
     createdAt: new Date(),
     isActive: true,
   });
+
+  databaseBuilder.factory.buildStaticCourse({
+    id: 'courseABC123CoCo',
+    name: 'Static Course 2',
+    description: 'Static Course 2 description',
+    challengeIds: 'challenge1NQqfx9mYKUQEO',
+    imageUrl: 'some/image/url',
+    createdAt: new Date('2021-01-01'),
+    isActive: false,
+  });
 };

--- a/api/lib/domain/readmodels/StaticCourse.js
+++ b/api/lib/domain/readmodels/StaticCourse.js
@@ -4,6 +4,7 @@ module.exports = class StaticCourse {
     name,
     description,
     challengeSummaries,
+    isActive,
     createdAt,
     updatedAt,
   }) {
@@ -11,6 +12,7 @@ module.exports = class StaticCourse {
     this.name = name;
     this.description = description;
     this.challengeSummaries = challengeSummaries;
+    this.isActive = isActive;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }

--- a/api/lib/domain/readmodels/StaticCourseSummary.js
+++ b/api/lib/domain/readmodels/StaticCourseSummary.js
@@ -3,11 +3,13 @@ module.exports = class StaticCourseSummary {
     id,
     name,
     challengeCount,
+    isActive,
     createdAt,
   }) {
     this.id = id;
     this.name = name;
     this.challengeCount = challengeCount;
+    this.isActive = isActive;
     this.createdAt = createdAt;
   }
 };

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -18,7 +18,7 @@ async function findReadSummaries({ page }) {
   const rowCount = await knex('static_courses').count('* as count').first();
 
   const staticCourses = await knex('static_courses')
-    .select('id', 'name', 'createdAt', 'challengeIds')
+    .select('id', 'name', 'createdAt', 'challengeIds', 'isActive')
     .orderBy('createdAt', 'desc')
     .offset((page.number - 1) * page.size).limit(page.size);
 
@@ -28,6 +28,7 @@ async function findReadSummaries({ page }) {
       name: staticCourse.name || '',
       createdAt: staticCourse.createdAt,
       challengeCount: staticCourse.challengeIds.split(',').length,
+      isActive: staticCourse.isActive,
     });
   });
 
@@ -53,6 +54,7 @@ async function getRead(id) {
       id: staticCourse.id,
       name: staticCourse.name,
       description: staticCourse.description,
+      isActive: staticCourse.isActive,
       createdAt: staticCourse.createdAt,
       updatedAt: staticCourse.updatedAt,
       challengeSummaries,

--- a/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
@@ -7,6 +7,7 @@ module.exports = {
         'name',
         'createdAt',
         'challengeCount',
+        'isActive',
       ],
       meta,
     }).serialize(staticCourseSummary);
@@ -17,6 +18,7 @@ module.exports = {
       attributes: [
         'name',
         'description',
+        'isActive',
         'createdAt',
         'updatedAt',
         'challengeSummaries',

--- a/api/tests/acceptance/application/static-courses_test.js
+++ b/api/tests/acceptance/application/static-courses_test.js
@@ -20,6 +20,7 @@ describe('Acceptance | API | static courses', function() {
         name: 'static course 1',
         challengeIds: 'challengeid1,challengeid2',
         createdAt: new Date('2021-01-01'),
+        isActive: true,
       });
 
       databaseBuilder.factory.buildStaticCourse({
@@ -27,6 +28,7 @@ describe('Acceptance | API | static courses', function() {
         name: 'static course 2',
         challengeIds: 'challengeid3,challengeid4,challengeid5',
         createdAt: new Date('2021-01-03'),
+        isActive: false,
       });
 
       await databaseBuilder.commit();
@@ -48,7 +50,8 @@ describe('Acceptance | API | static courses', function() {
           attributes: {
             name: 'static course 2',
             'created-at': new Date('2021-01-03'),
-            'challenge-count': 3
+            'challenge-count': 3,
+            'is-active': false,
           },
         },
         {
@@ -57,7 +60,8 @@ describe('Acceptance | API | static courses', function() {
           attributes: {
             name: 'static course 1',
             'created-at': new Date('2021-01-01'),
-            'challenge-count': 2
+            'challenge-count': 2,
+            'is-active': true,
           },
         }
       ]);
@@ -76,6 +80,7 @@ describe('Acceptance | API | static courses', function() {
         challengeIds: 'challengeid1,challengeid2',
         createdAt: new Date('2021-01-01'),
         updatedAt: new Date('2021-02-02'),
+        isActive: true,
       });
       await databaseBuilder.commit();
       const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
@@ -123,6 +128,7 @@ describe('Acceptance | API | static courses', function() {
             description: 'static course description',
             'created-at': new Date('2021-01-01'),
             'updated-at': new Date('2021-02-02'),
+            'is-active': true,
           },
           relationships: {
             'challenge-summaries': {
@@ -265,6 +271,7 @@ describe('Acceptance | API | static courses', function() {
             description: 'static course description',
             'created-at': new Date('2021-10-29T03:04:00Z'),
             'updated-at': new Date('2021-10-29T03:04:00Z'),
+            'is-active': true,
           },
           relationships: {
             'challenge-summaries': {
@@ -322,6 +329,7 @@ describe('Acceptance | API | static courses', function() {
         name: 'some old name',
         description: 'some old description',
         challengeIds: ['challengeid2', 'challengeid3', 'challengeid4'],
+        isActive: false,
         createdAt: new Date('2020-01-01T00:00:10Z'),
         updatedAt: new Date('2020-01-01T00:00:10Z'),
       });
@@ -415,6 +423,7 @@ describe('Acceptance | API | static courses', function() {
             description: 'static course description',
             'created-at': new Date('2020-01-01T00:00:10Z'),
             'updated-at': new Date('2021-10-29T03:04:00Z'),
+            'is-active': false,
           },
           relationships: {
             'challenge-summaries': {

--- a/pix-editor/app/models/static-course-summary.js
+++ b/pix-editor/app/models/static-course-summary.js
@@ -2,8 +2,9 @@ import Model, { attr } from '@ember-data/model';
 
 export default class StaticCourseSummaryModel extends Model {
   @attr name;
-  @attr createdAt;
   @attr challengeCount;
+  @attr isActive;
+  @attr createdAt;
 
   get previewURL() {
     return `https://app.recette.pix.fr/courses/${this.id}`;

--- a/pix-editor/app/models/static-course.js
+++ b/pix-editor/app/models/static-course.js
@@ -3,6 +3,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class StaticCourseModel extends Model {
   @attr name;
   @attr description;
+  @attr isActive;
   @attr createdAt;
   @attr updatedAt;
 

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -36,12 +36,14 @@
           <col class="table__column--small" />
           <col class="table__column--small" />
           <col class="table__column--small" />
+          <col class="table__column--small" />
         </colgroup>
         <thead>
         <tr>
           <th>Nom</th>
           <th>Epreuves</th>
           <th>Créé le</th>
+          <th>Statut</th>
           <th>Prévisualisation</th>
         </tr>
         </thead>
@@ -53,6 +55,11 @@
             </td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{staticCourseSummary.challengeCount}}</td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{dayjs-format staticCourseSummary.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
+            <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
+              <PixTag @color="{{if staticCourseSummary.isActive "green-light" "grey-light"}}">
+                {{if staticCourseSummary.isActive "Actif" "Inactif"}}
+              </PixTag>
+            </td>
             <td class="actions">
               <PixTooltip
                 @id='copy-static-course-link-tooltip'

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
@@ -22,6 +22,11 @@
           <span class="bold">Description : </span>
           <div class="static-course-details__description">{{this.model.staticCourse.description}}</div>
         </li>
+        <li><span class="bold">Statut du test : </span>
+          <PixTag @color="{{if this.model.staticCourse.isActive "green-light" "grey-light"}}">
+            {{if this.model.staticCourse.isActive "Actif" "Inactif"}}
+          </PixTag>
+        </li>
         <li><span class="bold">Crée le : </span>{{dayjs-format this.model.staticCourse.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
         <li><span class="bold">Dernière modification : </span>{{dayjs-format this.model.staticCourse.updatedAt "DD/MM/YYYY" allow-empty=true}}</li>
       </ul>

--- a/pix-editor/tests/acceptance/static-courses/details-test.js
+++ b/pix-editor/tests/acceptance/static-courses/details-test.js
@@ -39,6 +39,7 @@ module('Acceptance | Static Courses | Details', function(hooks) {
       id: 'courseA',
       name: 'Premier test statique',
       description: 'Ma super description',
+      isActive: true,
       createdAt: new Date('2021-01-01'),
       updatedAt: new Date('2021-02-02'),
       challengeSummaries,
@@ -57,13 +58,14 @@ module('Acceptance | Static Courses | Details', function(hooks) {
     // then
     assert.strictEqual(currentURL(), '/static-courses/courseA');
     // information section
-    const [nameItem, descriptionItem, createdAtItem, updatedAtItem] = screen.getAllByRole('listitem');
+    const [nameItem, descriptionItem, statusItem, createdAtItem, updatedAtItem] = screen.getAllByRole('listitem');
     const removeWhitespacesFnc = (str) => str
       .trim()
       .replace(/\s{2,}/g, '')
       .replace(/\s?:\s?/g, ':');
     assert.strictEqual(removeWhitespacesFnc(nameItem.textContent), 'Nom:Premier test statique');
     assert.strictEqual(removeWhitespacesFnc(descriptionItem.textContent), 'Description:Ma super description');
+    assert.strictEqual(removeWhitespacesFnc(statusItem.textContent), 'Statut du test:Actif');
     assert.strictEqual(removeWhitespacesFnc(createdAtItem.textContent), 'Crée le:01/01/2021');
     assert.strictEqual(removeWhitespacesFnc(updatedAtItem.textContent), 'Dernière modification:02/02/2021');
     // challenges section


### PR DESCRIPTION
## :unicorn: Problème
On a introduit le nouveau concept de statut d'activité sur les tests statiques mais cette info n'est pas visible depuis le front.

## :robot: Solution
Ajout du statut d'un test statique sur la liste et sur la page de détails

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur l'onglet tests statiques.
Constater l'affichage du statut dans la liste.
Se rendre sur une page de détails et constater l'affichage du statut sur cette page.
