### PR TITLE
[BUGFIX]  Inverser l'ordre des challenges des tests statiques(PIX-8898)

### DIFF
--- a/scripts/migrate-static-courses-from-airtable/index.js
+++ b/scripts/migrate-static-courses-from-airtable/index.js
@@ -1,0 +1,61 @@
+const { Client } = require('pg');
+const Airtable = require('airtable');
+
+(async function() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    console.log('reading all static courses from Airtable...');
+    const allStaticCourses = await airtableClient.table('Tests').select({
+      fields: ['id persistant', 'Nom', 'Description', 'Épreuves (id persistant)', 'created_at', 'updated_at', 'Nb d\'épreuves'],
+    }).all();
+    console.log('done');
+
+    const filteredStaticCourses = allStaticCourses
+      .filter((course) => course.fields['Nom'] != null
+                && course.fields['Nb d\'épreuves'] !== 0
+                && course.fields['Épreuves (id persistant)'].toString().length <= 1000
+      );
+    console.log(filteredStaticCourses.length);
+
+    const cleanedStaticCourses = filteredStaticCourses.map((course) => {
+      const challengeIds = course.fields['Épreuves (id persistant)'].toString().split(',');
+      const reversedChallengeIds = challengeIds.reverse();
+      return {
+        id: course.fields['id persistant'],
+        name: course.fields['Nom'],
+        description: course.fields['Description']?.trim() || '',
+        challengeIds: reversedChallengeIds.toString(),
+        createdAt: course.fields['created_at'],
+        updatedAt: course.fields['updated_at'] || course.fields['created_at'],
+        isActive: true,
+      };
+    });
+    console.log('Copying them to PG...');
+    await client.connect();
+    await client.query('BEGIN');
+    for (const cleanedStaticCourse of cleanedStaticCourses) {
+      await client.query('INSERT INTO static_courses (id, name, description, "challengeIds", "createdAt", "updatedAt", "isActive") VALUES ($1, $2, $3, $4, $5, $6, $7)', [
+        cleanedStaticCourse.id,
+        cleanedStaticCourse.name,
+        cleanedStaticCourse.description,
+        cleanedStaticCourse.challengeIds,
+        cleanedStaticCourse.createdAt,
+        cleanedStaticCourse.updatedAt,
+        cleanedStaticCourse.isActive,
+      ]);
+    }
+    await client.query('COMMIT');
+    console.log('DONE');
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+})();
+

--- a/scripts/reverse-static-courses-challenges-order/index.js
+++ b/scripts/reverse-static-courses-challenges-order/index.js
@@ -1,0 +1,16 @@
+const { knex } = require('../../api/db/knex-database-connection');
+
+(async function() {
+  const staticCourses = await knex('static_courses')
+    .select('id', 'name', 'challengeIds');
+  for (const staticCourse of staticCourses) {
+    const challengeIds = staticCourse.challengeIds.split(',');
+    const reversedChallengeIds = challengeIds.reverse();
+    await knex('static_courses')
+      .where('id', staticCourse.id)
+      .update({
+        challengeIds: reversedChallengeIds.join(','),
+      });
+  }
+})();
+


### PR DESCRIPTION
## :unicorn: Problème
l'ordre n'était pas bon suite à la migration depuis airtable

## :robot: Solution
inverser l'ordre

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
run le script scripts/reverse-static-courses-challenges-order/index.js en local