### PR TITLE
[FEATURE] Ajouter un lien de prévisualisation de l'épreuve dans la liste des épreuves sur la page de détails d'un test statique (PIX-8515)

### DIFF
--- a/api/lib/domain/readmodels/ChallengeSummary.js
+++ b/api/lib/domain/readmodels/ChallengeSummary.js
@@ -5,11 +5,13 @@ module.exports = class ChallengeSummary {
     skillName,
     status,
     index,
+    previewUrl,
   }) {
     this.id = id;
     this.instruction = instruction;
     this.skillName = skillName;
     this.status = status;
     this.index = index;
+    this.previewUrl = previewUrl;
   }
 };

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -113,6 +113,7 @@ async function findChallengeSummaries(challengeIds) {
       skillName: correspondingSkill?.name || '',
       status: challengeFromAirtable.status,
       index: challengeIds.indexOf(challengeFromAirtable.id),
+      previewUrl: challengeFromAirtable.preview,
     });
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
@@ -26,7 +26,7 @@ module.exports = {
       challengeSummaries: {
         ref: 'id',
         included: true,
-        attributes: ['instruction', 'skillName', 'status', 'index'],
+        attributes: ['instruction', 'skillName', 'status', 'index', 'previewUrl'],
       },
       typeForAttribute(attribute) {
         if (attribute === 'challengeSummaries') return 'challenge-summaries';

--- a/api/tests/acceptance/application/static-courses/get_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course_test.js
@@ -26,6 +26,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
       instruction: 'instruction for challengeid1',
       skillId: 'skillid1',
       status: 'status for challengeid1',
+      preview: 'site/challenges/challengeid1',
     });
     const airtableSkill1 = airtableBuilder.factory.buildSkill({
       id: 'skillid1',
@@ -37,6 +38,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
       instruction: 'instruction for challengeid2',
       skillId: 'skillid2',
       status: 'status for challengeid2',
+      preview: 'site/challenges/challengeid2',
     });
     const airtableSkill2 = airtableBuilder.factory.buildSkill({
       id: 'skillid2',
@@ -92,6 +94,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid1',
             'skill-name': '@skillid1',
             status: 'status for challengeid1',
+            'preview-url': 'site/challenges/challengeid1',
           },
         },
         {
@@ -102,6 +105,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid2',
             'skill-name': '@skillid2',
             status: 'status for challengeid2',
+            'preview-url': 'site/challenges/challengeid2',
           },
         }
       ],

--- a/api/tests/acceptance/application/static-courses/post_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/post_static-course_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
       instruction: 'instruction for challengeid1',
       skillId: 'skillid1',
       status: 'status for challengeid1',
+      preview: 'site/challenges/challengeid1',
     });
     const airtableSkill1 = airtableBuilder.factory.buildSkill({
       id: 'skillid1',
@@ -35,6 +36,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
       instruction: 'instruction for challengeid2',
       skillId: 'skillid2',
       status: 'status for challengeid2',
+      preview: 'site/challenges/challengeid2',
     });
     const airtableSkill2 = airtableBuilder.factory.buildSkill({
       id: 'skillid2',
@@ -46,6 +48,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
       instruction: 'instruction for challengeid3',
       skillId: 'skillid3',
       status: 'status for challengeid3',
+      preview: 'site/challenges/challengeid3',
     });
     const airtableSkill3 = airtableBuilder.factory.buildSkill({
       id: 'skillid3',
@@ -57,6 +60,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
       instruction: 'instruction for challengeid4',
       skillId: 'skillid4',
       status: 'status for challengeid4',
+      preview: 'site/challenges/challengeid4',
     });
     const airtableSkill4 = airtableBuilder.factory.buildSkill({
       id: 'skillid4',
@@ -135,6 +139,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
             status: 'status for challengeid3',
+            'preview-url': 'site/challenges/challengeid3',
           },
         },
         {
@@ -145,6 +150,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
             instruction: 'instruction for challengeid1',
             'skill-name': '@skillid1',
             status: 'status for challengeid1',
+            'preview-url': 'site/challenges/challengeid1',
           },
         }
       ],

--- a/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
@@ -33,6 +33,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       instruction: 'instruction for challengeid2',
       skillId: 'skillid2',
       status: 'status for challengeid2',
+      preview: 'site/challenges/challengeid2',
     });
     const airtableSkill2 = airtableBuilder.factory.buildSkill({
       id: 'skillid2',
@@ -44,6 +45,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       instruction: 'instruction for challengeid3',
       skillId: 'skillid3',
       status: 'status for challengeid3',
+      preview: 'site/challenges/challengeid3',
     });
     const airtableSkill3 = airtableBuilder.factory.buildSkill({
       id: 'skillid3',
@@ -55,6 +57,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       instruction: 'instruction for challengeid4',
       skillId: 'skillid4',
       status: 'status for challengeid4',
+      preview: 'site/challenges/challengeid4',
     });
     const airtableSkill4 = airtableBuilder.factory.buildSkill({
       id: 'skillid4',
@@ -122,6 +125,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid2',
             'skill-name': '@skillid2',
             status: 'status for challengeid2',
+            'preview-url': 'site/challenges/challengeid2',
           },
         },
         {
@@ -132,6 +136,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
             status: 'status for challengeid3',
+            'preview-url': 'site/challenges/challengeid3',
           },
         },
         {
@@ -142,6 +147,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid4',
             'skill-name': '@skillid4',
             status: 'status for challengeid4',
+            'preview-url': 'site/challenges/challengeid4',
           },
         }
       ],

--- a/api/tests/acceptance/application/static-courses/put_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course_test.js
@@ -34,6 +34,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       instruction: 'instruction for challengeid1',
       skillId: 'skillid1',
       status: 'status for challengeid1',
+      preview: 'site/challenges/challengeid1',
     });
     const airtableSkill1 = airtableBuilder.factory.buildSkill({
       id: 'skillid1',
@@ -45,6 +46,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       instruction: 'instruction for challengeid2',
       skillId: 'skillid2',
       status: 'status for challengeid2',
+      preview: 'site/challenges/challengeid2',
     });
     const airtableSkill2 = airtableBuilder.factory.buildSkill({
       id: 'skillid2',
@@ -56,6 +58,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       instruction: 'instruction for challengeid3',
       skillId: 'skillid3',
       status: 'status for challengeid3',
+      preview: 'site/challenges/challengeid3',
     });
     const airtableSkill3 = airtableBuilder.factory.buildSkill({
       id: 'skillid3',
@@ -67,6 +70,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       instruction: 'instruction for challengeid4',
       skillId: 'skillid4',
       status: 'status for challengeid4',
+      preview: 'site/challenges/challengeid4',
     });
     const airtableSkill4 = airtableBuilder.factory.buildSkill({
       id: 'skillid4',
@@ -144,6 +148,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
             status: 'status for challengeid3',
+            'preview-url': 'site/challenges/challengeid3',
           },
         },
         {
@@ -154,6 +159,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid1',
             'skill-name': '@skillid1',
             status: 'status for challengeid1',
+            'preview-url': 'site/challenges/challengeid1',
           },
         }
       ],

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -77,12 +77,14 @@ describe('Integration | Repository | static-course-repository', function() {
           instruction: 'instructionA',
           status: 'A',
           skillId: 'skillA',
+          preview: 'site/challenges/challengeA',
         }),
         domainBuilder.buildChallengeAirtableDataObject({
           id: 'challengeB',
           instruction: 'instructionB',
           status: 'B',
           skillId: 'skillB',
+          preview: 'site/challenges/challengeB',
         }),
       ];
       const stubFilterChallengeDatasource = sinon.stub(challengeDatasource, 'filter');
@@ -99,7 +101,6 @@ describe('Integration | Repository | static-course-repository', function() {
       //then
       expect(staticCourse.id).to.equal('rec123');
     });
-
   });
 });
 

--- a/pix-editor/app/models/challenge-summary.js
+++ b/pix-editor/app/models/challenge-summary.js
@@ -5,6 +5,7 @@ export default class ChallengeSummaryModel extends Model {
   @attr skillName;
   @attr status;
   @attr index;
+  @attr previewUrl;
 
   get indexForDisplay() {
     return this.index + 1;

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
@@ -73,6 +73,7 @@
             <col class="table__column--wide" />
             <col class="table__column--small" />
             <col class="table__column--small" />
+            <col class="table__column--small" />
           </colgroup>
           <thead>
           <tr>
@@ -81,6 +82,7 @@
             <th>Consigne</th>
             <th>Acquis</th>
             <th>Statut</th>
+            <th>Prévisualisation</th>
           </tr>
           </thead>
           <tbody>
@@ -112,6 +114,15 @@
                     @color="purple-light"
                   >{{challengeSummary.status}}</PixTag>
                 {{/if}}
+              </td>
+              <td>
+                <a
+                  href="{{challengeSummary.previewUrl}}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <FaIcon @icon="eye" @prefix="fas"/>
+                </a>
               </td>
             </tr>
           {{/each}}


### PR DESCRIPTION
## :unicorn: Problème
Dans la page de détails d'un test statique, on n'a que les IDs des épreuves, il n'est pas pratique de visualiser rapidement l'épreuve (il faut reporter son ID dans la recherche pix editor par exemple, etc)... 

## :robot: Solution
Avoir un bouton pour prévisualiser l'épreuve sur Pix depuis la liste des épreuves dans la page de détails d'un test statique.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur la page de détails d'un test statique et cliquer sur les boutons de prévisualisation des épreuves
