### PR TITLE
[FEATURE] Pouvoir renseigner un commentaire lors de la désactivation d'un test statique et écrire ce commentaire à côté du statut (PIX-8647)

### DIFF
--- a/api/db/migrations/20230810160953_add-column-deactivation-reason-in-table-static-courses.js
+++ b/api/db/migrations/20230810160953_add-column-deactivation-reason-in-table-static-courses.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'static_courses';
+const DEACTIVATION_REASON_COLUMN = 'deactivationReason';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.string(DEACTIVATION_REASON_COLUMN, 255);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(DEACTIVATION_REASON_COLUMN);
+  });
+};

--- a/api/db/seeds/data/static-courses.js
+++ b/api/db/seeds/data/static-courses.js
@@ -17,5 +17,6 @@ module.exports = function(databaseBuilder) {
     imageUrl: 'some/image/url',
     createdAt: new Date('2021-01-01'),
     isActive: false,
+    deactivationReason: 'Les épreuves sont trop faciles',
   });
 };

--- a/api/lib/application/static-courses/static-courses.js
+++ b/api/lib/application/static-courses/static-courses.js
@@ -74,11 +74,12 @@ async function update(request, h) {
 
 async function deactivate(request, h) {
   const staticCourseId = request.params.id;
+  const deactivationCommand = normalizeDeactivationCommand(request.payload.data.attributes);
   const staticCourseToUpdate = await staticCourseRepository.get(staticCourseId);
   if (!staticCourseToUpdate) {
     throw new NotFoundError(`Le test statique d'id ${staticCourseId} n'existe pas ou son accès restreint`);
   }
-  const commandResult = staticCourseToUpdate.deactivate();
+  const commandResult = staticCourseToUpdate.deactivate(deactivationCommand);
   if (commandResult.isFailure()) {
     throw commandResult.error;
   }
@@ -99,5 +100,11 @@ function normalizeCreationOrUpdateCommand(attrs) {
     name: _.isString(attrs.name) ? attrs.name : '',
     description: _.isString(attrs.description) ? attrs.description : '',
     challengeIds: _.isArray(attrs['challenge-ids']) ? attrs['challenge-ids'] : [],
+  };
+}
+
+function normalizeDeactivationCommand(attrs) {
+  return {
+    reason: _.isString(attrs.reason) ? attrs.reason : '',
   };
 }

--- a/api/lib/application/static-courses/static-courses.js
+++ b/api/lib/application/static-courses/static-courses.js
@@ -5,7 +5,7 @@ const staticCourseRepository = require('../../infrastructure/repositories/static
 const staticCourseSerializer = require('../../infrastructure/serializers/jsonapi/static-course-serializer');
 const idGenerator = require('../../infrastructure/utils/id-generator');
 const StaticCourse = require('../../domain/models/StaticCourse');
-const { NotFoundError, StaticCourseIsInactiveError } = require('../../domain/errors');
+const { NotFoundError } = require('../../domain/errors');
 
 const DEFAULT_PAGE = {
   number: 1,
@@ -55,9 +55,6 @@ async function update(request, h) {
   const staticCourseToUpdate = await staticCourseRepository.get(staticCourseId);
   if (!staticCourseToUpdate) {
     throw new NotFoundError(`Le test statique d'id ${staticCourseId} n'existe pas ou son accès restreint`);
-  }
-  if (!staticCourseToUpdate.isActive) {
-    throw new StaticCourseIsInactiveError();
   }
   const allChallengeIds = await challengeRepository.getAllIdsIn(updateCommand.challengeIds);
   const commandResult = staticCourseToUpdate.update({

--- a/api/lib/domain/models/StaticCourse.js
+++ b/api/lib/domain/models/StaticCourse.js
@@ -9,6 +9,7 @@ module.exports = class StaticCourse {
     description,
     challengeIds,
     isActive,
+    deactivationReason,
     createdAt,
     updatedAt,
   }) {
@@ -16,6 +17,7 @@ module.exports = class StaticCourse {
     this.name = name;
     this.description = description;
     this.isActive = isActive;
+    this.deactivationReason = deactivationReason;
     this.challengeIds = challengeIds;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
@@ -35,7 +37,7 @@ module.exports = class StaticCourse {
     if (validationError.hasErrors()) {
       return CommandResult.Failure({ value: null, error: validationError });
     }
-    const staticCourse = new StaticCourse({ ...attributes, id: idGenerator('course'), isActive: true });
+    const staticCourse = new StaticCourse({ ...attributes, id: idGenerator('course'), isActive: true, deactivationReason: '' });
     return CommandResult.Success({ value: staticCourse });
   }
 
@@ -46,6 +48,7 @@ module.exports = class StaticCourse {
       name: updateCommand.name.trim(),
       description: updateCommand.description.trim(),
       isActive: this.isActive,
+      deactivationReason: this.deactivationReason,
       challengeIds: updateCommand.challengeIds.map((challengeId) => challengeId.trim()),
       createdAt: this.createdAt,
       updatedAt: timestamp,
@@ -58,7 +61,7 @@ module.exports = class StaticCourse {
     return CommandResult.Success({ value: staticCourse });
   }
 
-  deactivate() {
+  deactivate(deactivationCommand) {
     const timestamp = new Date();
 
     const attributes = {
@@ -66,6 +69,7 @@ module.exports = class StaticCourse {
       name: this.name,
       description: this.description,
       isActive: false,
+      deactivationReason: deactivationCommand.reason,
       challengeIds: this.challengeIds,
       createdAt: this.createdAt,
       updatedAt: timestamp,
@@ -79,8 +83,9 @@ module.exports = class StaticCourse {
       id: this.id,
       name: this.name,
       description: this.description,
-      challengeIds: this.challengeIds,
       isActive: this.isActive,
+      deactivationReason: this.deactivationReason,
+      challengeIds: this.challengeIds,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/api/lib/domain/models/StaticCourse.js
+++ b/api/lib/domain/models/StaticCourse.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const CommandResult = require('../CommandResult');
-const { InvalidStaticCourseCreationOrUpdateError } = require('../errors');
+const { InvalidStaticCourseCreationOrUpdateError, StaticCourseIsInactiveError } = require('../errors');
 
 module.exports = class StaticCourse {
   constructor({
@@ -42,6 +42,9 @@ module.exports = class StaticCourse {
   }
 
   update({ updateCommand, allChallengeIds }) {
+    if (!this.isActive) {
+      return CommandResult.Failure({ value: null, error: new StaticCourseIsInactiveError() });
+    }
     const timestamp = new Date();
     const attributes = {
       id: this.id,

--- a/api/lib/domain/readmodels/StaticCourse.js
+++ b/api/lib/domain/readmodels/StaticCourse.js
@@ -5,6 +5,7 @@ module.exports = class StaticCourse {
     description,
     challengeSummaries,
     isActive,
+    deactivationReason,
     createdAt,
     updatedAt,
   }) {
@@ -13,6 +14,7 @@ module.exports = class StaticCourse {
     this.description = description;
     this.challengeSummaries = challengeSummaries;
     this.isActive = isActive;
+    this.deactivationReason = deactivationReason;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -55,6 +55,7 @@ async function getRead(id) {
       name: staticCourse.name,
       description: staticCourse.description,
       isActive: staticCourse.isActive,
+      deactivationReason: staticCourse.deactivationReason || '',
       createdAt: staticCourse.createdAt,
       updatedAt: staticCourse.updatedAt,
       challengeSummaries,

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -91,6 +91,7 @@ async function save(staticCourseForCreation) {
     description: staticCourseDTO.description,
     challengeIds: staticCourseDTO.challengeIds.join(','),
     isActive: staticCourseDTO.isActive,
+    deactivationReason: staticCourseDTO.deactivationReason,
     createdAt: staticCourseDTO.createdAt,
     updatedAt: staticCourseDTO.updatedAt,
   };

--- a/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
@@ -19,6 +19,7 @@ module.exports = {
         'name',
         'description',
         'isActive',
+        'deactivationReason',
         'createdAt',
         'updatedAt',
         'challengeSummaries',

--- a/api/tests/acceptance/application/static-courses/get_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course_test.js
@@ -18,7 +18,8 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
       challengeIds: 'challengeid1,challengeid2',
       createdAt: new Date('2021-01-01'),
       updatedAt: new Date('2021-02-02'),
-      isActive: true,
+      isActive: false,
+      deactivationReason: 'Les fruits c genial',
     });
     await databaseBuilder.commit();
     const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
@@ -68,7 +69,8 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
           description: 'static course description',
           'created-at': new Date('2021-01-01'),
           'updated-at': new Date('2021-02-02'),
-          'is-active': true,
+          'is-active': false,
+          'deactivation-reason': 'Les fruits c genial',
         },
         relationships: {
           'challenge-summaries': {

--- a/api/tests/acceptance/application/static-courses/post_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/post_static-course_test.js
@@ -114,6 +114,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
           'created-at': new Date('2021-10-29T03:04:00Z'),
           'updated-at': new Date('2021-10-29T03:04:00Z'),
           'is-active': true,
+          'deactivation-reason': '',
         },
         relationships: {
           'challenge-summaries': {

--- a/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
@@ -96,6 +96,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           'created-at': new Date('2020-01-01T00:00:10Z'),
           'updated-at': new Date('2021-10-29T03:04:00Z'),
           'is-active': false,
+          'deactivation-reason': '',
         },
         relationships: {
           'challenge-summaries': {

--- a/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
@@ -76,12 +76,22 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
   });
 
   it('deactivates and returns the static course', async function() {
+    // given
+    const payload = {
+      data: {
+        attributes: {
+          reason: 'je le veux',
+        },
+      },
+    };
+
     // when
     const server = await createServer();
     const response = await server.inject({
       method: 'PUT',
       url: `/api/static-courses/${staticCourseId}/deactivate`,
       headers: generateAuthorizationHeader(user),
+      payload,
     });
 
     // then
@@ -96,7 +106,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           'created-at': new Date('2020-01-01T00:00:10Z'),
           'updated-at': new Date('2021-10-29T03:04:00Z'),
           'is-active': false,
-          'deactivation-reason': '',
+          'deactivation-reason': 'je le veux',
         },
         relationships: {
           'challenge-summaries': {

--- a/api/tests/acceptance/application/static-courses/put_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course_test.js
@@ -123,6 +123,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
           'created-at': new Date('2020-01-01T00:00:10Z'),
           'updated-at': new Date('2021-10-29T03:04:00Z'),
           'is-active': true,
+          'deactivation-reason': '',
         },
         relationships: {
           'challenge-summaries': {

--- a/api/tests/tooling/database-builder/factory/build-static-course.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course.js
@@ -7,11 +7,12 @@ function buildStaticCourse({
   challengeIds = 'challengeABC, challengeDEF',
   imageUrl = 'ma/super/image.png',
   isActive = true,
+  deactivationReason = '',
   createdAt = new Date('2010-01-04'),
   updatedAt = new Date('2010-01-11'),
 } = {}) {
 
-  const values = { id, name, description, challengeIds, imageUrl, createdAt, updatedAt, isActive };
+  const values = { id, name, description, deactivationReason, challengeIds, imageUrl, createdAt, updatedAt, isActive };
 
   return databaseBuffer.pushInsertable({
     tableName: 'static_courses',

--- a/api/tests/tooling/domain-builder/factory/build-static-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-static-course.js
@@ -6,6 +6,7 @@ module.exports = function buildStaticCourse({
   description = 'static course description',
   challengeIds = ['challengeid-1', 'challengeid-2'],
   isActive = true,
+  deactivationReason = '',
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -15,6 +16,7 @@ module.exports = function buildStaticCourse({
     description,
     challengeIds,
     isActive,
+    deactivationReason,
     createdAt,
     updatedAt,
   });

--- a/api/tests/unit/domain/models/StaticCourse_test.js
+++ b/api/tests/unit/domain/models/StaticCourse_test.js
@@ -37,6 +37,7 @@ describe('Unit | Domain | StaticCourse', function() {
           description: 'some valid description',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           isActive: true,
+          deactivationReason: '',
           createdAt: new Date('2021-10-29T03:04:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
         });
@@ -60,6 +61,7 @@ describe('Unit | Domain | StaticCourse', function() {
           name: 'some valid name',
           description: '',
           isActive: true,
+          deactivationReason: '',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           createdAt: new Date('2021-10-29T03:04:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
@@ -205,6 +207,7 @@ describe('Unit | Domain | StaticCourse', function() {
         description: 'old description',
         challengeIds: ['chalDEF ', ' chalJKF'],
         isActive: false,
+        deactivationReason: 'some reason',
         createdAt: new Date('2021-00-00T09:00:00Z'),
         updatedAt: new Date('2021-00-00T09:00:00Z'),
       });
@@ -230,6 +233,7 @@ describe('Unit | Domain | StaticCourse', function() {
           description: 'some valid description',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           isActive: false,
+          deactivationReason: 'some reason',
           createdAt: new Date('2021-00-00T09:00:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
         });
@@ -252,6 +256,7 @@ describe('Unit | Domain | StaticCourse', function() {
           name: 'some valid name',
           description: '',
           isActive: false,
+          deactivationReason: 'some reason',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           createdAt: new Date('2021-00-00T09:00:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
@@ -389,6 +394,7 @@ describe('Unit | Domain | StaticCourse', function() {
 
     it('should make the static course inactive when it is active', function() {
       // given
+      const deactivationCommand = { reason: 'On en a un mieux' };
       const activeStaticCourse = domainBuilder.buildStaticCourse({
         id: 'myAwesomeCourse66',
         name: 'name',
@@ -400,7 +406,7 @@ describe('Unit | Domain | StaticCourse', function() {
       });
 
       // when
-      const commandResult = activeStaticCourse.deactivate();
+      const commandResult = activeStaticCourse.deactivate(deactivationCommand);
 
       // then
       expect(commandResult.isSuccess()).to.be.true;
@@ -410,6 +416,7 @@ describe('Unit | Domain | StaticCourse', function() {
         description: 'description',
         challengeIds: ['chalABC ', 'chalDEF'],
         isActive: false,
+        deactivationReason: 'On en a un mieux',
         createdAt: new Date('2021-00-00T09:00:00Z'),
         updatedAt: new Date('2021-10-29T03:04:00Z'),
       });
@@ -417,6 +424,7 @@ describe('Unit | Domain | StaticCourse', function() {
 
     it('should let the static course inactive when it is already inactive', function() {
       // given
+      const deactivationCommand = { reason: '' };
       const inactiveStaticCourse = domainBuilder.buildStaticCourse({
         id: 'myAwesomeCourse66',
         name: 'name',
@@ -428,7 +436,7 @@ describe('Unit | Domain | StaticCourse', function() {
       });
 
       // when
-      const commandResult = inactiveStaticCourse.deactivate();
+      const commandResult = inactiveStaticCourse.deactivate(deactivationCommand);
 
       // then
       expect(commandResult.isSuccess()).to.be.true;
@@ -438,6 +446,7 @@ describe('Unit | Domain | StaticCourse', function() {
         description: 'description',
         challengeIds: ['chalABC ', 'chalDEF'],
         isActive: false,
+        deactivationReason: '',
         createdAt: new Date('2021-00-00T09:00:00Z'),
         updatedAt: new Date('2021-10-29T03:04:00Z'),
       });

--- a/api/tests/unit/domain/models/StaticCourse_test.js
+++ b/api/tests/unit/domain/models/StaticCourse_test.js
@@ -1,5 +1,6 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const StaticCourse = require('../../../../lib/domain/models/StaticCourse');
+const { StaticCourseIsInactiveError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | StaticCourse', function() {
   context('static buildFromCreationCommand', function() {
@@ -206,7 +207,7 @@ describe('Unit | Domain | StaticCourse', function() {
         name: 'old name',
         description: 'old description',
         challengeIds: ['chalDEF ', ' chalJKF'],
-        isActive: false,
+        isActive: true,
         deactivationReason: 'some reason',
         createdAt: new Date('2021-00-00T09:00:00Z'),
         updatedAt: new Date('2021-00-00T09:00:00Z'),
@@ -232,7 +233,7 @@ describe('Unit | Domain | StaticCourse', function() {
           name: 'some valid name',
           description: 'some valid description',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
-          isActive: false,
+          isActive: true,
           deactivationReason: 'some reason',
           createdAt: new Date('2021-00-00T09:00:00Z'),
           updatedAt: new Date('2021-10-29T03:04:00Z'),
@@ -255,7 +256,7 @@ describe('Unit | Domain | StaticCourse', function() {
           id: 'myAwesomeCourse66',
           name: 'some valid name',
           description: '',
-          isActive: false,
+          isActive: true,
           deactivationReason: 'some reason',
           challengeIds: ['chalGHI', 'chalABC', 'chalJKF'],
           createdAt: new Date('2021-00-00T09:00:00Z'),
@@ -263,193 +264,218 @@ describe('Unit | Domain | StaticCourse', function() {
         });
       });
 
-      context('invalid commands', function() {
-        context('when name is invalid', function() {
-          it('should return a failed CommandResult', function() {
-            // given
-            const invalidUpdateCommand = {
-              ...validUpdateCommand,
-              name: '',
-            };
-
-            // when
-            const commandResult = staticCourseToUpdate.update({
-              updateCommand: invalidUpdateCommand,
-              allChallengeIds,
-            });
-
-            // then
-            expect(commandResult.isFailure()).to.be.true;
-            expect(commandResult.value).to.be.null;
-            expect(commandResult.error.errors).to.deepEqualArray([
-              { code: 'MANDATORY_FIELD', field: 'name' },
-            ]);
-          });
+      it('should return a failed CommandResult when static course is inactive', function() {
+        // given
+        const inactiveStaticCourse = domainBuilder.buildStaticCourse({
+          id: 'myAwesomeCourse66',
+          name: 'old name',
+          description: 'old description',
+          challengeIds: ['chalDEF ', ' chalJKF'],
+          isActive: false,
+          deactivationReason: 'some reason',
+          createdAt: new Date('2021-00-00T09:00:00Z'),
+          updatedAt: new Date('2021-00-00T09:00:00Z'),
         });
 
-        context('when challengeIds is invalid', function() {
-          it('should create an invalid StaticCourse when at least one challenge does not exist', function() {
-            // given
-            const invalidUpdateCommand = {
-              ...validUpdateCommand,
-              challengeIds: ['chalABC', 'xchalLOL', 'chalGHI', 'chalDEFF'],
-            };
-
-            // when
-            const commandResult = staticCourseToUpdate.update({
-              updateCommand: invalidUpdateCommand,
-              allChallengeIds,
-            });
-
-            // then
-            expect(commandResult.isFailure()).to.be.true;
-            expect(commandResult.value).to.be.null;
-            expect(commandResult.error.errors).to.deepEqualArray([
-              { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
-            ]);
-          });
-
-          it('should create an invalid StaticCourse when at least one challenge appears more than once', function() {
-            // given
-            const invalidUpdateCommand = {
-              ...validUpdateCommand,
-              challengeIds: ['chalJKF', 'chalABC', 'chalGHI', 'chalJKF', 'chalABC'],
-            };
-
-            // when
-            const commandResult = staticCourseToUpdate.update({
-              updateCommand: invalidUpdateCommand,
-              allChallengeIds,
-            });
-
-            // then
-            expect(commandResult.isFailure()).to.be.true;
-            expect(commandResult.value).to.be.null;
-            expect(commandResult.error.errors).to.deepEqualArray([
-              { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalJKF', 'chalABC'] },
-            ]);
-          });
-
-          it('should create an invalid StaticCourse when no challenges are provided', function() {
-            // given
-            const invalidUpdateCommand = {
-              ...validUpdateCommand,
-              challengeIds: [],
-            };
-
-            // when
-            const commandResult = staticCourseToUpdate.update({
-              updateCommand: invalidUpdateCommand,
-              allChallengeIds,
-            });
-
-            // then
-            expect(commandResult.isFailure()).to.be.true;
-            expect(commandResult.value).to.be.null;
-            expect(commandResult.error.errors).to.deepEqualArray([
-              { code: 'MANDATORY_FIELD', field: 'challengeIds' },
-            ]);
-          });
+        // when
+        const commandResult = inactiveStaticCourse.update({
+          updateCommand: validUpdateCommand,
+          allChallengeIds,
         });
 
-        context('when static course is invalid for several reasons', function() {
-          it('should create an invalid StaticCourse with all reasons why it is', function() {
-            // given
-            const invalidUpdateCommand = {
-              ...validUpdateCommand,
-              name: '',
-              challengeIds: ['chalABC', 'xchalLOL', 'chalGHI', 'chalDEFF', 'chalGHI'],
-            };
+        // then
+        expect(commandResult.isFailure()).to.be.true;
+        expect(commandResult.value).to.be.null;
+        expect(commandResult.error).to.be.instanceOf(StaticCourseIsInactiveError);
+      });
+    });
 
-            // when
-            const commandResult = staticCourseToUpdate.update({
-              updateCommand: invalidUpdateCommand,
-              allChallengeIds,
-            });
+    context('invalid commands', function() {
+      context('when name is invalid', function() {
+        it('should return a failed CommandResult', function() {
+          // given
+          const invalidUpdateCommand = {
+            ...validUpdateCommand,
+            name: '',
+          };
 
-            // then
-            expect(commandResult.isFailure()).to.be.true;
-            expect(commandResult.value).to.be.null;
-            expect(commandResult.error.errors).to.deepEqualArray([
-              { code: 'MANDATORY_FIELD', field: 'name' },
-              { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
-              { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalGHI'] },
-            ]);
+          // when
+          const commandResult = staticCourseToUpdate.update({
+            updateCommand: invalidUpdateCommand,
+            allChallengeIds,
           });
+
+          // then
+          expect(commandResult.isFailure()).to.be.true;
+          expect(commandResult.value).to.be.null;
+          expect(commandResult.error.errors).to.deepEqualArray([
+            { code: 'MANDATORY_FIELD', field: 'name' },
+          ]);
+        });
+      });
+
+      context('when challengeIds is invalid', function() {
+        it('should create an invalid StaticCourse when at least one challenge does not exist', function() {
+          // given
+          const invalidUpdateCommand = {
+            ...validUpdateCommand,
+            challengeIds: ['chalABC', 'xchalLOL', 'chalGHI', 'chalDEFF'],
+          };
+
+          // when
+          const commandResult = staticCourseToUpdate.update({
+            updateCommand: invalidUpdateCommand,
+            allChallengeIds,
+          });
+
+          // then
+          expect(commandResult.isFailure()).to.be.true;
+          expect(commandResult.value).to.be.null;
+          expect(commandResult.error.errors).to.deepEqualArray([
+            { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
+          ]);
+        });
+
+        it('should create an invalid StaticCourse when at least one challenge appears more than once', function() {
+          // given
+          const invalidUpdateCommand = {
+            ...validUpdateCommand,
+            challengeIds: ['chalJKF', 'chalABC', 'chalGHI', 'chalJKF', 'chalABC'],
+          };
+
+          // when
+          const commandResult = staticCourseToUpdate.update({
+            updateCommand: invalidUpdateCommand,
+            allChallengeIds,
+          });
+
+          // then
+          expect(commandResult.isFailure()).to.be.true;
+          expect(commandResult.value).to.be.null;
+          expect(commandResult.error.errors).to.deepEqualArray([
+            { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalJKF', 'chalABC'] },
+          ]);
+        });
+
+        it('should create an invalid StaticCourse when no challenges are provided', function() {
+          // given
+          const invalidUpdateCommand = {
+            ...validUpdateCommand,
+            challengeIds: [],
+          };
+
+          // when
+          const commandResult = staticCourseToUpdate.update({
+            updateCommand: invalidUpdateCommand,
+            allChallengeIds,
+          });
+
+          // then
+          expect(commandResult.isFailure()).to.be.true;
+          expect(commandResult.value).to.be.null;
+          expect(commandResult.error.errors).to.deepEqualArray([
+            { code: 'MANDATORY_FIELD', field: 'challengeIds' },
+          ]);
+        });
+      });
+
+      context('when static course is invalid for several reasons', function() {
+        it('should create an invalid StaticCourse with all reasons why it is', function() {
+          // given
+          const invalidUpdateCommand = {
+            ...validUpdateCommand,
+            name: '',
+            challengeIds: ['chalABC', 'xchalLOL', 'chalGHI', 'chalDEFF', 'chalGHI'],
+          };
+
+          // when
+          const commandResult = staticCourseToUpdate.update({
+            updateCommand: invalidUpdateCommand,
+            allChallengeIds,
+          });
+
+          // then
+          expect(commandResult.isFailure()).to.be.true;
+          expect(commandResult.value).to.be.null;
+          expect(commandResult.error.errors).to.deepEqualArray([
+            { code: 'MANDATORY_FIELD', field: 'name' },
+            { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
+            { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalGHI'] },
+          ]);
         });
       });
     });
   });
+});
 
-  context('deactivate', function() {
-    let clock;
+context('deactivate', function() {
+  let clock;
 
-    beforeEach(function() {
-      clock = sinon.useFakeTimers(new Date('2021-10-29T03:04:00Z'));
+  beforeEach(function() {
+    clock = sinon.useFakeTimers(new Date('2021-10-29T03:04:00Z'));
+  });
+
+  afterEach(function() {
+    clock.restore();
+  });
+
+  it('should make the static course inactive when it is active', function() {
+    // given
+    const deactivationCommand = { reason: 'On en a un mieux' };
+    const activeStaticCourse = domainBuilder.buildStaticCourse({
+      id: 'myAwesomeCourse66',
+      name: 'name',
+      description: 'description',
+      challengeIds: ['chalABC ', 'chalDEF'],
+      isActive: true,
+      createdAt: new Date('2021-00-00T09:00:00Z'),
+      updatedAt: new Date('2021-00-00T09:00:00Z'),
     });
 
-    afterEach(function() {
-      clock.restore();
+    // when
+    const commandResult = activeStaticCourse.deactivate(deactivationCommand);
+
+    // then
+    expect(commandResult.isSuccess()).to.be.true;
+    expect(commandResult.value.toDTO()).to.deep.equal({
+      id: 'myAwesomeCourse66',
+      name: 'name',
+      description: 'description',
+      challengeIds: ['chalABC ', 'chalDEF'],
+      isActive: false,
+      deactivationReason: 'On en a un mieux',
+      createdAt: new Date('2021-00-00T09:00:00Z'),
+      updatedAt: new Date('2021-10-29T03:04:00Z'),
+    });
+  });
+
+  it('should let the static course inactive when it is already inactive', function() {
+    // given
+    const deactivationCommand = { reason: '' };
+    const inactiveStaticCourse = domainBuilder.buildStaticCourse({
+      id: 'myAwesomeCourse66',
+      name: 'name',
+      description: 'description',
+      challengeIds: ['chalABC ', 'chalDEF'],
+      isActive: false,
+      createdAt: new Date('2021-00-00T09:00:00Z'),
+      updatedAt: new Date('2021-00-00T09:00:00Z'),
     });
 
-    it('should make the static course inactive when it is active', function() {
-      // given
-      const deactivationCommand = { reason: 'On en a un mieux' };
-      const activeStaticCourse = domainBuilder.buildStaticCourse({
-        id: 'myAwesomeCourse66',
-        name: 'name',
-        description: 'description',
-        challengeIds: ['chalABC ', 'chalDEF'],
-        isActive: true,
-        createdAt: new Date('2021-00-00T09:00:00Z'),
-        updatedAt: new Date('2021-00-00T09:00:00Z'),
-      });
+    // when
+    const commandResult = inactiveStaticCourse.deactivate(deactivationCommand);
 
-      // when
-      const commandResult = activeStaticCourse.deactivate(deactivationCommand);
-
-      // then
-      expect(commandResult.isSuccess()).to.be.true;
-      expect(commandResult.value.toDTO()).to.deep.equal({
-        id: 'myAwesomeCourse66',
-        name: 'name',
-        description: 'description',
-        challengeIds: ['chalABC ', 'chalDEF'],
-        isActive: false,
-        deactivationReason: 'On en a un mieux',
-        createdAt: new Date('2021-00-00T09:00:00Z'),
-        updatedAt: new Date('2021-10-29T03:04:00Z'),
-      });
-    });
-
-    it('should let the static course inactive when it is already inactive', function() {
-      // given
-      const deactivationCommand = { reason: '' };
-      const inactiveStaticCourse = domainBuilder.buildStaticCourse({
-        id: 'myAwesomeCourse66',
-        name: 'name',
-        description: 'description',
-        challengeIds: ['chalABC ', 'chalDEF'],
-        isActive: false,
-        createdAt: new Date('2021-00-00T09:00:00Z'),
-        updatedAt: new Date('2021-00-00T09:00:00Z'),
-      });
-
-      // when
-      const commandResult = inactiveStaticCourse.deactivate(deactivationCommand);
-
-      // then
-      expect(commandResult.isSuccess()).to.be.true;
-      expect(commandResult.value.toDTO()).to.deep.equal({
-        id: 'myAwesomeCourse66',
-        name: 'name',
-        description: 'description',
-        challengeIds: ['chalABC ', 'chalDEF'],
-        isActive: false,
-        deactivationReason: '',
-        createdAt: new Date('2021-00-00T09:00:00Z'),
-        updatedAt: new Date('2021-10-29T03:04:00Z'),
-      });
+    // then
+    expect(commandResult.isSuccess()).to.be.true;
+    expect(commandResult.value.toDTO()).to.deep.equal({
+      id: 'myAwesomeCourse66',
+      name: 'name',
+      description: 'description',
+      challengeIds: ['chalABC ', 'chalDEF'],
+      isActive: false,
+      deactivationReason: '',
+      createdAt: new Date('2021-00-00T09:00:00Z'),
+      updatedAt: new Date('2021-10-29T03:04:00Z'),
     });
   });
 });

--- a/pix-editor/app/adapters/static-course.js
+++ b/pix-editor/app/adapters/static-course.js
@@ -16,8 +16,9 @@ export default class StaticCourseAdapter extends ApplicationAdapter {
       return this.ajax(url, 'PUT', { data: payload });
     }
     if (action === 'deactivate') {
+      const payload = preparePayloadForDeactivate(this.serialize(snapshot), snapshot.adapterOptions);
       const url = this.buildURL(type.modelName, snapshot.id, snapshot, 'updateRecord');
-      return this.ajax(`${url}/deactivate`, 'PUT');
+      return this.ajax(`${url}/deactivate`, 'PUT', { data: payload });
     }
     return super.updateRecord(store, type, snapshot);
   }
@@ -28,5 +29,11 @@ function preparePayloadForCreateAndUpdate(payload, adapterOptions) {
   payload.data.attributes.name = adapterOptions.name;
   payload.data.attributes.description = adapterOptions.description;
   payload.data.attributes['challenge-ids'] = adapterOptions.challengeIds;
+  return payload;
+}
+
+function preparePayloadForDeactivate(payload, adapterOptions) {
+  payload.data.attributes = {};
+  payload.data.attributes.reason = adapterOptions.reason;
   return payload;
 }

--- a/pix-editor/app/controllers/authenticated/static-courses/static-course/details.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/static-course/details.js
@@ -7,6 +7,7 @@ export default class StaticCoursesController extends Controller {
   @service router;
   @service notifications;
   @tracked shouldDisplayDeactivationModal = false;
+  @tracked deactivationReason = '';
 
   get canEditStaticCourse() {
     return this.model.userMayEditStaticCourse && this.model.staticCourse.isActive;
@@ -24,6 +25,7 @@ export default class StaticCoursesController extends Controller {
   @action
   showDeactivationModal() {
     this.shouldDisplayDeactivationModal = true;
+    this.deactivationReason = '';
   }
 
   @action
@@ -32,9 +34,14 @@ export default class StaticCoursesController extends Controller {
   }
 
   @action
+  setDeactivationReason(event) {
+    this.deactivationReason = event.target.value;
+  }
+
+  @action
   async deactivateStaticCourse() {
     try {
-      await this.model.staticCourse.save({ adapterOptions: { action: 'deactivate' } });
+      await this.model.staticCourse.save({ adapterOptions: { reason: this.deactivationReason.trim(), action: 'deactivate' } });
       this.notifications.success('Test statique désactivé avec succès.');
     } catch (err) {
       await this.notifications.error('Une erreur est survenue lors de la désactivation du test statique.');

--- a/pix-editor/app/models/static-course.js
+++ b/pix-editor/app/models/static-course.js
@@ -4,6 +4,7 @@ export default class StaticCourseModel extends Model {
   @attr name;
   @attr description;
   @attr isActive;
+  @attr deactivationReason;
   @attr createdAt;
   @attr updatedAt;
 

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
@@ -34,6 +34,9 @@
           <PixTag @color="{{if this.model.staticCourse.isActive "green-light" "grey-light"}}">
             {{if this.model.staticCourse.isActive "Actif" "Inactif"}}
           </PixTag>
+          {{#if this.model.staticCourse.deactivationReason}}
+            (Motif: {{this.model.staticCourse.deactivationReason}})
+          {{/if}}
         </li>
         <li><span class="bold">Crée le : </span>{{dayjs-format this.model.staticCourse.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
         <li><span class="bold">Dernière modification : </span>{{dayjs-format this.model.staticCourse.updatedAt "DD/MM/YYYY" allow-empty=true}}</li>
@@ -159,7 +162,13 @@
   <:content>
     <p data-test-logout-message >
       Êtes-vous sûr de vouloir désactiver le test statique <b>{{this.model.staticCourse.name}}</b> ?<br/>
-      Cette action est irréversible et il ne sera alors plus possible d’utiliser ce test.
+      Cette action est irréversible et il ne sera alors plus possible d’utiliser ce test.<br/>
+      <PixInput
+        @id="deactivationReason"
+        @label="Raison de désactivation (facultatif)"
+        @value={{this.deactivationReason}}
+        {{on "input" this.setDeactivationReason}}
+      />
     </p>
   </:content>
   <:footer>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -267,9 +267,11 @@ function routes() {
   });
 
   this.put('/static-courses/:id/deactivate', function(schema, request) {
+    const attributes = JSON.parse(request.requestBody).data.attributes;
     const staticCourse = schema.staticCourses.find(request.params.id);
     staticCourse.update({
       isActive: false,
+      deactivationReason: attributes.reason,
     });
     return staticCourse;
   });

--- a/pix-editor/tests/acceptance/static-courses/deactivation-test.js
+++ b/pix-editor/tests/acceptance/static-courses/deactivation-test.js
@@ -3,7 +3,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { click } from '@ember/test-helpers';
-import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Static Courses | Deactivation', function(hooks) {
   setupApplicationTest(hooks);
@@ -104,12 +104,14 @@ module('Acceptance | Static Courses | Deactivation', function(hooks) {
       // when
       await clickByName('Désactiver');
       await screen.findByRole('dialog');
+      await fillByLabel('Raison de désactivation (facultatif)', 'c comme ca');
       await clickByName('Oui');
 
       // then
       const button = screen.getByText('Désactiver');
       assert.dom(button).isDisabled();
       assert.dom(screen.getByText('Inactif')).exists();
+      assert.dom(screen.getByText('(Motif: c comme ca)')).exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'équipe métier aimerait pouvoir historiser pourquoi elle désactive un test statique.

## :robot: Solution
Donner la possibilité d'écrire un commentaire lors de la désactivation du test.
Ce commentaire, facultatif, sera inscrit sur la page de détails du test désactivé, à côté du statut

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Désactiver un test statique :
- avec commentaire, et vérifier que le commentaire est écrit
- sans commentaire, vérifier que rien n'est ajouté à côté du statut
