### PR TITLE
[FEATURE] N'afficher que les tests statiques actifs par défaut et permettre à l'utilisateur de pouvoir tous les afficher (PIX-8648)

### DIFF
--- a/api/lib/application/static-courses/static-courses.js
+++ b/api/lib/application/static-courses/static-courses.js
@@ -22,8 +22,8 @@ module.exports = {
 };
 
 async function findSummaries(request, h) {
-  const { page } = extractParameters(request.query);
-  const { results: staticCourseSummaries, meta } = await staticCourseRepository.findReadSummaries({ page: normalizePage(page) });
+  const { filter, page } = extractParameters(request.query);
+  const { results: staticCourseSummaries, meta } = await staticCourseRepository.findReadSummaries({ filter: normalizeFilter(filter), page: normalizePage(page) });
   return h.response(staticCourseSerializer.serializeSummary(staticCourseSummaries, meta));
 }
 
@@ -89,6 +89,23 @@ function normalizePage(page) {
   return {
     number: _.isInteger(page.number) && Math.sign(page.number) === 1 ? page.number : DEFAULT_PAGE.number,
     size: _.isInteger(page.size) && Math.sign(page.size) === 1 ? Math.min(page.size, DEFAULT_PAGE.maxSize) : DEFAULT_PAGE.size,
+  };
+}
+
+function normalizeFilter(filter) {
+  let isActive;
+  if (filter.isActive === undefined)
+    isActive = null;
+  else if (_.isString(filter.isActive)) {
+    const trimmedValueFromFilter = filter.isActive.trim().toLowerCase();
+    if (trimmedValueFromFilter === '') isActive = null;
+    else isActive = trimmedValueFromFilter === 'true';
+  } else {
+    isActive = false;
+  }
+
+  return {
+    isActive,
   };
 }
 

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -1,4 +1,5 @@
 const { knex } = require('../../../db/knex-database-connection');
+const { fetchPage } = require('../utils/knex-utils');
 const ChallengeSummary_Read = require('../../domain/readmodels/ChallengeSummary');
 const StaticCourse_Read = require('../../domain/readmodels/StaticCourse');
 const StaticCourseSummary_Read = require('../../domain/readmodels/StaticCourseSummary');
@@ -14,13 +15,10 @@ module.exports = {
 };
 
 async function findReadSummaries({ page }) {
-
-  const rowCount = await knex('static_courses').count('* as count').first();
-
-  const staticCourses = await knex('static_courses')
+  const query = knex('static_courses')
     .select('id', 'name', 'createdAt', 'challengeIds', 'isActive')
-    .orderBy('createdAt', 'desc')
-    .offset((page.number - 1) * page.size).limit(page.size);
+    .orderBy('createdAt', 'desc');
+  const { results: staticCourses, pagination } = await fetchPage(query, page);
 
   const staticCoursesSummaries = staticCourses.map((staticCourse) => {
     return new StaticCourseSummary_Read({
@@ -32,14 +30,7 @@ async function findReadSummaries({ page }) {
     });
   });
 
-  const meta = {
-    page: page.number,
-    pageSize: page.size,
-    pageCount: Math.ceil(rowCount.count / page.size),
-    rowCount: rowCount.count
-  };
-
-  return { results: staticCoursesSummaries, meta };
+  return { results: staticCoursesSummaries, meta: pagination };
 }
 
 async function getRead(id) {

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -14,10 +14,13 @@ module.exports = {
   save,
 };
 
-async function findReadSummaries({ page }) {
+async function findReadSummaries({ filter, page }) {
   const query = knex('static_courses')
     .select('id', 'name', 'createdAt', 'challengeIds', 'isActive')
     .orderBy('createdAt', 'desc');
+  if (filter.isActive !== null) {
+    query.where('isActive', filter.isActive);
+  }
   const { results: staticCourses, pagination } = await fetchPage(query, page);
 
   const staticCoursesSummaries = staticCourses.map((staticCourse) => {

--- a/api/lib/infrastructure/utils/knex-utils.js
+++ b/api/lib/infrastructure/utils/knex-utils.js
@@ -1,0 +1,34 @@
+const { knex } = require('../../../db/knex-database-connection');
+
+/**
+ * Paginate a knex query with given page parameters
+ * @param {*} queryBuilder - a knex query builder
+ * @param {Object} page - page parameters
+ * @param {Number} page.number - the page number to retrieve
+ * @param {Number} page.size - the size of the page
+ */
+const fetchPage = async (
+  queryBuilder,
+  { number, size },
+) => {
+  const page = number < 1 ? 1 : number;
+  const offset = (page - 1) * size;
+
+  const clone = queryBuilder.clone();
+  // we cannot execute the query and count the total rows at the same time
+  // because it would not work when there are DISTINCT selection in the SELECT clause
+  const { rowCount } = await knex.count('*', { as: 'rowCount' }).from(clone.as('query_all_results')).first();
+  const results = await queryBuilder.limit(size).offset(offset);
+
+  return {
+    results,
+    pagination: {
+      page,
+      pageSize: size,
+      rowCount,
+      pageCount: Math.ceil(rowCount / size),
+    },
+  };
+};
+
+module.exports = { fetchPage };

--- a/api/tests/acceptance/application/static-courses/get_static-course-summaries_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course-summaries_test.js
@@ -17,7 +17,6 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
       createdAt: new Date('2021-01-01'),
       isActive: true,
     });
-
     databaseBuilder.factory.buildStaticCourse({
       id: 'courseid2',
       name: 'static course 2',
@@ -25,7 +24,6 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
       createdAt: new Date('2021-01-03'),
       isActive: false,
     });
-
     await databaseBuilder.commit();
 
     // When

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -4,67 +4,7 @@ const challengeDatasource = require('../../../../lib/infrastructure/datasources/
 const skillDatasource = require('../../../../lib/infrastructure/datasources/airtable/skill-datasource');
 
 describe('Integration | Repository | static-course-repository', function() {
-  describe('#findReadSummaries', function() {
-    describe('pagination', function() {
-      beforeEach(function() {
-        // 8 Static courses
-        [new Date('2010-01-01'), new Date('2011-01-01'),
-          new Date('2012-01-01'), new Date('2013-01-01'),
-          new Date('2014-01-01'), new Date('2015-01-01'),
-          new Date('2016-01-01'), new Date('2017-01-01')]
-          .map((createdAt, index) => {
-            databaseBuilder.factory.buildStaticCourse({
-              id: `courseId${index}`,
-              createdAt,
-            });
-          });
-        return databaseBuilder.commit();
-      });
-
-      it('should return the static courses and the appropriate meta pagination data that are within the pagination constraints', async function() {
-        // given
-        const page = { number: 2, size: 3 };
-
-        // when
-        const {
-          results: actualStaticCourseSummaries,
-          meta
-        } = await staticCourseRepository.findReadSummaries({ page });
-
-        // then
-        const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
-        expect(actualStaticCourseSummaryIds).to.deepEqualArray(['courseId4', 'courseId3', 'courseId2']);
-        expect(meta).to.deep.equal({
-          page: 2,
-          pageSize: 3,
-          rowCount: 8,
-          pageCount: 3,
-        });
-      });
-
-      it('should return an empty array and the appropriate meta pagination data when pagination goes over the static courses total count', async function() {
-        // given
-        const page = { number: 5, size: 3 };
-
-        // when
-        const {
-          results: actualStaticCourseSummaries,
-          meta
-        } = await staticCourseRepository.findReadSummaries({ page });
-
-        // then
-        expect(actualStaticCourseSummaries).to.be.deep.equal([]);
-        expect(meta).to.deep.equal({
-          page: 5,
-          pageSize: 3,
-          rowCount: 8,
-          pageCount: 3,
-        });
-      });
-    });
-  });
-
-  describe('#getRead', function() {
+  context('#getRead', function() {
     it('should return the static course', async function() {
       //given
       databaseBuilder.factory.buildStaticCourse({

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -4,6 +4,128 @@ const challengeDatasource = require('../../../../lib/infrastructure/datasources/
 const skillDatasource = require('../../../../lib/infrastructure/datasources/airtable/skill-datasource');
 
 describe('Integration | Repository | static-course-repository', function() {
+  context('#findReadSummaries', function() {
+    context('filter', function() {
+      context('isActive', function() {
+        const page = { number: 1, size: 20 };
+
+        context('with results', function() {
+          beforeEach(function() {
+            // 4 Static courses
+            [new Date('2010-01-01'), new Date('2011-01-01'),
+              new Date('2012-01-01'), new Date('2013-01-01'),]
+              .map((createdAt, index) => {
+                databaseBuilder.factory.buildStaticCourse({
+                  id: `courseId${index}`,
+                  isActive: index % 2 === 0, // pair actif, impair inactif
+                  createdAt,
+                });
+              });
+            return databaseBuilder.commit();
+          });
+          it('should return all the static courses regardless of the isActive value when isActive filter is null', async function() {
+            // given
+            const filter = { isActive: null };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await staticCourseRepository.findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).to.deepEqualArray(['courseId3', 'courseId2', 'courseId1', 'courseId0']);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 4,
+              pageCount: 1,
+            });
+          });
+
+          it('should return active static courses when isActive filter is true', async function() {
+            // given
+            const filter = { isActive: true };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await staticCourseRepository.findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).to.deepEqualArray(['courseId2', 'courseId0']);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 2,
+              pageCount: 1,
+            });
+          });
+
+          it('should return inactive static courses when isActive filter is false', async function() {
+            // given
+            const filter = { isActive: false };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await staticCourseRepository.findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).to.deepEqualArray(['courseId3', 'courseId1']);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 2,
+              pageCount: 1,
+            });
+          });
+        });
+
+        context('no results', function() {
+          beforeEach(function() {
+            // 4 Static courses
+            [new Date('2010-01-01'), new Date('2011-01-01'),
+              new Date('2012-01-01'), new Date('2013-01-01'),]
+              .map((createdAt, index) => {
+                databaseBuilder.factory.buildStaticCourse({
+                  id: `courseId${index}`,
+                  isActive: true,
+                  createdAt,
+                });
+              });
+            return databaseBuilder.commit();
+          });
+
+          it('should return an empty result when no static course matches the isActive filter', async function() {
+            // given
+            const filter = { isActive: false };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await staticCourseRepository.findReadSummaries({ filter, page });
+
+            // then
+            expect(actualStaticCourseSummaries).to.be.deep.equal([]);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 0,
+              pageCount: 0,
+            });
+          });
+        });
+      });
+    });
+  });
+
   context('#getRead', function() {
     it('should return the static course', async function() {
       //given

--- a/api/tests/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/knex-utils_test.js
@@ -1,0 +1,242 @@
+const _ = require('lodash');
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { fetchPage } = require('../../../../lib/infrastructure/utils/knex-utils');
+
+describe('Integration | Infrastructure | Utils | Knex utils', function() {
+  context('fetchPage', function() {
+    const somePage = { number: 1, size: 10 };
+    it('should fetch the given page and return results and pagination data', async function() {
+      // given
+      const letterA = 'a'.charCodeAt(0);
+      _.times(5, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `${String.fromCharCode(letterA + index)}` }));
+      await databaseBuilder.commit();
+
+      // when
+      const query = knex.select('name').from('static_courses').orderBy('name', 'ASC');
+      const { results, pagination } = await fetchPage(query, { number: 2, size: 2 });
+
+      // then
+      expect(results).to.have.lengthOf(2);
+      expect(results.map((result) => result.name)).exactlyContainInOrder(['c', 'd']);
+      expect(pagination).to.deep.equal({
+        page: 2,
+        pageSize: 2,
+        rowCount: 5,
+        pageCount: 3,
+      });
+    });
+
+    it('should correctly count rowCount with a distinct in the select clause', async function() {
+      // given
+      databaseBuilder.factory.buildStaticCourse({ id: 'staticCourse1', name: 'DoublonA' });
+      databaseBuilder.factory.buildStaticCourse({ id: 'staticCourse2', name: 'DoublonA' });
+      databaseBuilder.factory.buildStaticCourse({ id: 'staticCourse3', name: 'DoublonB' });
+      databaseBuilder.factory.buildStaticCourse({ id: 'staticCourse4', name: 'DoublonB' });
+      await databaseBuilder.commit();
+
+      // when
+      const query = knex.distinct('name').from('static_courses');
+      const { results, pagination } = await fetchPage(query, somePage);
+
+      // then
+      expect(results).to.have.lengthOf(2);
+      expect(results.map((result) => result.name)).exactlyContain(['DoublonA', 'DoublonB']);
+      expect(pagination.rowCount).to.equal(2);
+    });
+
+    context('#pagination.page', function() {
+      it('should return the requested page when there are results', async function() {
+        // given
+        const pageNumber = 2;
+        const pageSize = 1;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.not.be.empty;
+        expect(pagination.page).to.equal(pageNumber);
+      });
+
+      it('should return the requested page even when there are no results', async function() {
+        // given
+        const pageNumber = 10000;
+        const pageSize = 1;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.be.empty;
+        expect(pagination.page).to.equal(pageNumber);
+      });
+
+      it('should return the page 1 when requesting for page 1 or lower', async function() {
+        // given
+        const pageNumber = 0;
+        const pageSize = 1;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.not.be.empty;
+        expect(pagination.page).to.equal(1);
+      });
+    });
+
+    context('#pagination.pageSize', function() {
+      it('should return the requested pageSize when there are results', async function() {
+        // given
+        const pageNumber = 1;
+        const pageSize = 2;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.have.length(pageSize);
+        expect(pagination.pageSize).to.equal(pageSize);
+      });
+
+      it('should return the requested page size even when there less results than expected', async function() {
+        // given
+        const pageNumber = 1;
+        const total = 3;
+        const pageSize = 6;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.have.length(total);
+        expect(pagination.pageSize).to.equal(pageSize);
+      });
+
+      it('should return the requested page size even when there are no results', async function() {
+        // given
+        const pageNumber = 1000;
+        const pageSize = 5;
+        const total = 1;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.be.empty;
+        expect(pagination.pageSize).to.equal(pageSize);
+      });
+    });
+
+    context('#pagination.rowCount', function() {
+      it('should return the rowCount for the whole query when pagination has results', async function() {
+        // given
+        const pageNumber = 1;
+        const pageSize = 3;
+        const total = 5;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.not.be.empty;
+        expect(pagination.rowCount).to.equal(total);
+      });
+
+      it('should return the rowCount for the whole query even if there are no results with requested pagination', async function() {
+        // given
+        const pageNumber = 100000;
+        const pageSize = 2;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.be.empty;
+        expect(pagination.rowCount).to.equal(total);
+      });
+    });
+
+    context('#pagination.pageCount', function() {
+      it('should return the pageCount according to the total row count for the whole query according to the requested page size', async function() {
+        // given
+        const pageNumber = 1;
+        const pageSize = 2;
+        const total = 10;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.not.be.empty;
+        expect(pagination.pageCount).to.equal(5);
+      });
+
+      it('should return the pageCount even when the last page would be partially filled', async function() {
+        // given
+        const pageNumber = 1;
+        const pageSize = 2;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.not.be.empty;
+        expect(pagination.pageCount).to.equal(2);
+      });
+
+      it('should return the pageCount even if there are no results with requested pagination', async function() {
+        // given
+        const pageNumber = 100000;
+        const pageSize = 2;
+        const total = 3;
+        _.times(total, (index) => databaseBuilder.factory.buildStaticCourse({ id: `staticCourse${index}`, name: `c-${index}` }));
+        await databaseBuilder.commit();
+
+        // when
+        const query = knex.select('name').from('static_courses');
+        const { results, pagination } = await fetchPage(query, { number: pageNumber, size: pageSize });
+
+        // then
+        expect(results).to.be.empty;
+        expect(pagination.pageCount).to.equal(2);
+      });
+    });
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -132,6 +132,25 @@ global.chaiErr = function globalErr(fn, val) {
   throw new chai.AssertionError('Expected an error');
 };
 
+chai.use(function(chai) {
+  const Assertion = chai.Assertion;
+
+  Assertion.addMethod('exactlyContainInOrder', function(expectedElements) {
+    const errorMessage = `expect [${this._obj}] to exactly contain in order [${expectedElements}]`;
+
+    new Assertion(this._obj, errorMessage).to.deep.equal(expectedElements);
+  });
+});
+
+chai.use(function(chai) {
+  const Assertion = chai.Assertion;
+
+  Assertion.addMethod('exactlyContain', function(expectedElements) {
+    const errorMessage = `expect [${this._obj}] to exactly contain [${expectedElements}]`;
+    new Assertion(this._obj, errorMessage).to.deep.have.members(expectedElements);
+  });
+});
+
 module.exports = {
   airtableBuilder,
   catchErr,

--- a/api/tests/unit/application/static-courses/static-courses_test.js
+++ b/api/tests/unit/application/static-courses/static-courses_test.js
@@ -9,6 +9,8 @@ describe('Unit | Controller | static courses controller', function() {
   describe('findSummaries', function() {
     describe('pagination normalization', function() {
       let stub;
+      const filter = { isActive: null };
+
       beforeEach(function() {
         stub = sinon.stub(staticCourseRepository, 'findReadSummaries');
         stub.resolves({ results: [], meta: {} });
@@ -22,61 +24,138 @@ describe('Unit | Controller | static courses controller', function() {
         await staticCourseController.findSummaries(request, hFake);
 
         // then
-        expect(stub).to.have.been.calledWithExactly({ page: { number: 3, size: 5 } });
+        expect(stub).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 5 } });
       });
 
-      it('should use default page.size default value when it is not a positive integer', async function() {
+      it('ignore unknown pagination parameters', async function() {
         // given
-        const request0 = { query: { 'page[size]': -5, 'page[number]': 3 } };
-        const request1 = { query: { 'page[size]': 'coucou', 'page[number]': 3 } };
-        const request2 = { query: { 'page[number]': 3 } };
-        const request3 = { query: { 'page[size]': null, 'page[number]': 3 } };
+        const request = { query: { 'page[size]': 5, 'page[number]': 3, 'page[hello]': 'oui' } };
 
         // when
-        await staticCourseController.findSummaries(request0, hFake);
-        await staticCourseController.findSummaries(request1, hFake);
-        await staticCourseController.findSummaries(request2, hFake);
-        await staticCourseController.findSummaries(request3, hFake);
+        await staticCourseController.findSummaries(request, hFake);
 
         // then
-        expect(stub.getCall(0)).to.have.been.calledWithExactly({ page: { number: 3, size: 10 } });
-        expect(stub.getCall(1)).to.have.been.calledWithExactly({ page: { number: 3, size: 10 } });
-        expect(stub.getCall(2)).to.have.been.calledWithExactly({ page: { number: 3, size: 10 } });
-        expect(stub.getCall(3)).to.have.been.calledWithExactly({ page: { number: 3, size: 10 } });
+        expect(stub).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 5 } });
       });
 
-      it('should ceil page.size value to max value when it overflows', async function() {
-        // given
-        const request0 = { query: { 'page[size]': 100, 'page[number]': 3 } };
-        const request1 = { query: { 'page[size]': 101, 'page[number]': 3 } };
+      context('page size', function() {
 
-        // when
-        await staticCourseController.findSummaries(request0, hFake);
-        await staticCourseController.findSummaries(request1, hFake);
+        it('should use default page.size default value when it is not a positive integer', async function() {
+          // given
+          const request0 = { query: { 'page[size]': -5, 'page[number]': 3 } };
+          const request1 = { query: { 'page[size]': 'coucou', 'page[number]': 3 } };
+          const request2 = { query: { 'page[number]': 3 } };
+          const request3 = { query: { 'page[size]': null, 'page[number]': 3 } };
 
-        // then
-        expect(stub.getCall(0)).to.have.been.calledWithExactly({ page: { number: 3, size: 100 } });
-        expect(stub.getCall(1)).to.have.been.calledWithExactly({ page: { number: 3, size: 100 } });
+          // when
+          await staticCourseController.findSummaries(request0, hFake);
+          await staticCourseController.findSummaries(request1, hFake);
+          await staticCourseController.findSummaries(request2, hFake);
+          await staticCourseController.findSummaries(request3, hFake);
+
+          // then
+          expect(stub.getCall(0)).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 10 } });
+          expect(stub.getCall(1)).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 10 } });
+          expect(stub.getCall(2)).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 10 } });
+          expect(stub.getCall(3)).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 10 } });
+        });
+
+        it('should ceil page.size value to max value when it overflows', async function() {
+          // given
+          const request0 = { query: { 'page[size]': 100, 'page[number]': 3 } };
+          const request1 = { query: { 'page[size]': 101, 'page[number]': 3 } };
+
+          // when
+          await staticCourseController.findSummaries(request0, hFake);
+          await staticCourseController.findSummaries(request1, hFake);
+
+          // then
+          expect(stub.getCall(0)).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 100 } });
+          expect(stub.getCall(1)).to.have.been.calledWithExactly({ filter, page: { number: 3, size: 100 } });
+        });
       });
 
-      it('should use default page.number default value when it is not a positive integer', async function() {
+      context('page number', function() {
+
+        it('should use default page.number default value when it is not a positive integer', async function() {
+          // given
+          const request0 = { query: { 'page[size]': 5, 'page[number]': -3 } };
+          const request1 = { query: { 'page[size]': 5, 'page[number]': 'coucou' } };
+          const request2 = { query: { 'page[size]': 5 } };
+          const request3 = { query: { 'page[size]': 5, 'page[number]': null } };
+
+          // when
+          await staticCourseController.findSummaries(request0, hFake);
+          await staticCourseController.findSummaries(request1, hFake);
+          await staticCourseController.findSummaries(request2, hFake);
+          await staticCourseController.findSummaries(request3, hFake);
+
+          // then
+          expect(stub.getCall(0)).to.have.been.calledWithExactly({ filter, page: { number: 1, size: 5 } });
+          expect(stub.getCall(1)).to.have.been.calledWithExactly({ filter, page: { number: 1, size: 5 } });
+          expect(stub.getCall(2)).to.have.been.calledWithExactly({ filter, page: { number: 1, size: 5 } });
+          expect(stub.getCall(3)).to.have.been.calledWithExactly({ filter, page: { number: 1, size: 5 } });
+        });
+      });
+
+    });
+
+    describe('filter normalization', function() {
+      let stub;
+      const page = { number: 1, size: 10 };
+      beforeEach(function() {
+        stub = sinon.stub(staticCourseRepository, 'findReadSummaries');
+        stub.resolves({ results: [], meta: {} });
+      });
+
+      it('should pass along filter from query params when all is valid', async function() {
         // given
-        const request0 = { query: { 'page[size]': 5, 'page[number]': -3 } };
-        const request1 = { query: { 'page[size]': 5, 'page[number]': 'coucou' } };
-        const request2 = { query: { 'page[size]': 5 } };
-        const request3 = { query: { 'page[size]': 5, 'page[number]': null } };
+        const request = { query: { 'filter[isActive]': 'true' } };
 
         // when
-        await staticCourseController.findSummaries(request0, hFake);
-        await staticCourseController.findSummaries(request1, hFake);
-        await staticCourseController.findSummaries(request2, hFake);
-        await staticCourseController.findSummaries(request3, hFake);
+        await staticCourseController.findSummaries(request, hFake);
 
         // then
-        expect(stub.getCall(0)).to.have.been.calledWithExactly({ page: { number: 1, size: 5 } });
-        expect(stub.getCall(1)).to.have.been.calledWithExactly({ page: { number: 1, size: 5 } });
-        expect(stub.getCall(2)).to.have.been.calledWithExactly({ page: { number: 1, size: 5 } });
-        expect(stub.getCall(3)).to.have.been.calledWithExactly({ page: { number: 1, size: 5 } });
+        expect(stub).to.have.been.calledWithExactly({ filter: { isActive: true }, page });
+      });
+
+      it('ignore unknown filter parameters', async function() {
+        // given
+        const request = { query: { 'filter[isActive]': 'true', 'filter[damn]': 'ok' } };
+
+        // when
+        await staticCourseController.findSummaries(request, hFake);
+
+        // then
+        expect(stub).to.have.been.calledWithExactly({ filter: { isActive: true }, page });
+      });
+
+      context('filter isActive', function() {
+        it('extract isActive parameter correctly', async function() {
+          // given
+          const request0 = { query: { 'filter[isActive]': 3 } };
+          const request1 = { query: { 'filter[isActive]': 'ok' } };
+          const request2 = { query: { 'filter[somethingElse]': 'coucou' } };
+          const request3 = { query: { 'filter[isActive]': 'true' } };
+          const request4 = { query: { 'filter[isActive]': 'false' } };
+          const request5 = { query: { 'filter[isActive]': '' } };
+
+          // when
+          await staticCourseController.findSummaries(request0, hFake);
+          await staticCourseController.findSummaries(request1, hFake);
+          await staticCourseController.findSummaries(request2, hFake);
+          await staticCourseController.findSummaries(request3, hFake);
+          await staticCourseController.findSummaries(request4, hFake);
+          await staticCourseController.findSummaries(request5, hFake);
+
+          // then
+          expect(stub.getCall(0)).to.have.been.calledWithExactly({ filter: { isActive: false }, page });
+          expect(stub.getCall(1)).to.have.been.calledWithExactly({ filter: { isActive: false }, page });
+          expect(stub.getCall(2)).to.have.been.calledWithExactly({ filter: { isActive: null }, page });
+          expect(stub.getCall(3)).to.have.been.calledWithExactly({ filter: { isActive: true }, page });
+          expect(stub.getCall(4)).to.have.been.calledWithExactly({ filter: { isActive: false }, page });
+          expect(stub.getCall(5)).to.have.been.calledWithExactly({ filter: { isActive: null }, page });
+        });
       });
     });
   });

--- a/pix-editor/app/controllers/authenticated/static-courses/list.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/list.js
@@ -1,9 +1,15 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class StaticCoursesController extends Controller {
   @service router;
+  queryParams = ['pageNumber', 'pageSize', 'isActive'];
+  @tracked pageNumber = 1;
+  @tracked pageSize = 10;
+  @tracked showActiveOnly = true;
+  @tracked isActive = true;
 
   @action
   async copyStaticCoursePreviewUrl(staticCourseSummary) {
@@ -14,5 +20,17 @@ export default class StaticCoursesController extends Controller {
   async goToStaticCourseDetails(staticCourseId, event) {
     event.preventDefault();
     this.router.transitionTo('authenticated.static-courses.static-course.details', staticCourseId);
+  }
+
+  @action
+  async toggleShowActiveOnly() {
+    this.showActiveOnly = !this.showActiveOnly;
+    this.isActive = this.showActiveOnly || null;
+  }
+
+  @action
+  clearFilters() {
+    this.showActiveOnly = true;
+    this.isActive = true;
   }
 }

--- a/pix-editor/app/routes/authenticated/static-courses/list.js
+++ b/pix-editor/app/routes/authenticated/static-courses/list.js
@@ -9,6 +9,9 @@ export default class StaticCoursesRoute extends Route {
     pageSize: {
       refreshModel: true,
     },
+    isActive: {
+      refreshModel: true,
+    },
   };
 
   @service store;
@@ -22,6 +25,9 @@ export default class StaticCoursesRoute extends Route {
           number: params.pageNumber,
           size: params.pageSize,
         },
+        filter: {
+          isActive: params.isActive,
+        },
       },
       { reload: true }
     );
@@ -29,12 +35,5 @@ export default class StaticCoursesRoute extends Route {
       staticCourseSummaries,
       mayCreateStaticCourse: this.access.mayCreateOrEditStaticCourse(),
     };
-  }
-
-  resetController(controller, isExiting) {
-    if (isExiting) {
-      controller.pageNumber = 1;
-      controller.pageSize = 10;
-    }
   }
 }

--- a/pix-editor/app/styles/globals/table.scss
+++ b/pix-editor/app/styles/globals/table.scss
@@ -1,3 +1,7 @@
+.table-filter-banner {
+  margin: 12px 0;
+}
+
 .panel-table-v2 {
   border-radius: 4px;
   border: none;

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -29,6 +29,23 @@
 </header>
 <main class="page-body">
   <section class="page-section">
+    <PixFilterBanner
+    @title="Filtres"
+    class="table-filter-banner"
+    @clearFiltersLabel="Réinitialiser les filtres"
+    @onClearFilters={{this.clearFilters}}
+    @isClearFilterButtonDisabled={{false}}
+    >
+      <PixToggle
+        @label="Statut"
+        @inline={{true}}
+        @onLabel="Actifs"
+        @offLabel="Tous"
+        @toggled={{this.showActiveOnly}}
+        @onChange={{this.toggleShowActiveOnly}}
+        @screenReaderOnly={{true}}
+      />
+    </PixFilterBanner>
     <div class="panel-table-v2">
       <table class="content-text content-text--small">
         <colgroup class="table__column">

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -227,7 +227,16 @@ function routes() {
 
   this.get('/static-course-summaries', function(schema, request) {
     const queryParams = request.queryParams;
-    const allStaticCourseSummaries = schema.staticCourseSummaries.all().models;
+    const {
+      'filter[isActive]': isActiveFilter,
+    } = queryParams;
+    let allStaticCourseSummaries;
+    if (isActiveFilter === '') {
+      allStaticCourseSummaries = schema.staticCourseSummaries.all().models;
+    } else {
+      const isActive = isActiveFilter === 'true';
+      allStaticCourseSummaries = schema.staticCourseSummaries.where({ isActive }).models;
+    }
     const rowCount = allStaticCourseSummaries.length;
 
     const pagination = _getPaginationFromQueryParams(queryParams);

--- a/pix-editor/tests/acceptance/static-courses/deactivation-test.js
+++ b/pix-editor/tests/acceptance/static-courses/deactivation-test.js
@@ -14,7 +14,7 @@ module('Acceptance | Static Courses | Deactivation', function(hooks) {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     staticCourseSummary = this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', challengeCount: 3, createdAt: new Date('2020-01-01'), isActive: true });
-    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', challengeCount: 10, createdAt: new Date('2019-01-01'), isActive: true, });
+    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', challengeCount: 10, createdAt: new Date('2019-01-01'), isActive: true });
 
     const challengeSummaries = [];
     challengeSummaries.push(this.server.create('challenge-summary', {
@@ -87,6 +87,7 @@ module('Acceptance | Static Courses | Deactivation', function(hooks) {
         // when
         const screen = await visit('/');
         await clickByName('Tests statiques');
+        await click(await screen.findByRole('button', { name: 'Statut' }));
         await click(screen.getAllByRole('cell')[0]);
 
         // then

--- a/pix-editor/tests/acceptance/static-courses/details-test.js
+++ b/pix-editor/tests/acceptance/static-courses/details-test.js
@@ -10,8 +10,8 @@ module('Acceptance | Static Courses | Details', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function() {
-    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', challengeCount: 3, createdAt: new Date('2020-01-01') });
-    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', challengeCount: 10, createdAt: new Date('2019-01-01') });
+    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01') });
+    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: true, challengeCount: 10, createdAt: new Date('2019-01-01') });
 
     const challengeSummaries = [];
     challengeSummaries.push(this.server.create('challenge-summary', {

--- a/pix-editor/tests/acceptance/static-courses/edition-test.js
+++ b/pix-editor/tests/acceptance/static-courses/edition-test.js
@@ -95,6 +95,7 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
         // when
         const screen = await visit('/');
         await clickByName('Tests statiques');
+        await click(await screen.findByRole('button', { name: 'Statut' }));
         await click(screen.getAllByRole('cell')[0]);
         await click(screen.getAllByText('Éditer le test statique')[0]);
 

--- a/pix-editor/tests/acceptance/static-courses/list-test.js
+++ b/pix-editor/tests/acceptance/static-courses/list-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Static Courses | List', function(hooks) {
@@ -12,15 +12,27 @@ module('Acceptance | Static Courses | List', function(hooks) {
   hooks.beforeEach(function() {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
-    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', challengeCount: 3, createdAt: new Date('2020-01-01') });
-    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', challengeCount: 10, createdAt: new Date('2019-01-01') });
+    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01') });
+    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: false, challengeCount: 10, createdAt: new Date('2019-01-01') });
     return authenticateSession();
   });
 
-  test('should display static courses when accessing list', async function(assert) {
+  test('should display active static courses by default when accessing list', async function(assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');
+
+    // then
+    assert.strictEqual(currentURL(), '/static-courses');
+    assert.dom(screen.getByText('Premier test statique')).exists();
+    assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
+  });
+
+  test('should display all static courses when accessing list and toggling filter', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Tests statiques');
+    await click(await screen.findByRole('button', { name: 'Statut' }));
 
     // then
     assert.strictEqual(currentURL(), '/static-courses');


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui de base la liste des tests statiques contient et les tests actifs et les tests inactifs.
La plupart du temps ça sert assez peu de voir les tests inactifs.

## :robot: Solution
- n'afficher que les tests statiques actifs par défaut
- offrir la possibilité de tous les afficher via un toggle

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Aller sur la page des tests statiques et jouer avec le filtre
