### PR TITLE
[TECH] Récupérer la déclinaison du challenge (PIX-7702)

### DIFF
--- a/api/lib/domain/models/ChallengeForRelease.js
+++ b/api/lib/domain/models/ChallengeForRelease.js
@@ -29,6 +29,7 @@ module.exports = class ChallengeForRelease {
     illustrationAlt,
     illustrationUrl,
     shuffled,
+    alternativeVersion
   }) {
     this.id = id;
     this.instruction = instruction;
@@ -59,5 +60,6 @@ module.exports = class ChallengeForRelease {
     this.illustrationAlt = illustrationAlt;
     this.illustrationUrl = illustrationUrl;
     this.shuffled = shuffled;
+    this.alternativeVersion = alternativeVersion;
   }
 };

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -39,6 +39,7 @@ function _filterChallengeFields(challenge) {
     'timer',
     'type',
     'shuffled',
+    'alternativeVersion'
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1082,6 +1082,7 @@ function _getRichCurrentContentDTO() {
       illustrationUrl: null,
       illustrationAlt: null,
       shuffled: false,
+      alternativeVersion: 'challenge121211 alternativeVersion',
     },
     {
       id: 'challenge121212',
@@ -1112,6 +1113,7 @@ function _getRichCurrentContentDTO() {
       illustrationUrl: null,
       illustrationAlt: null,
       shuffled: true,
+      alternativeVersion: 'challenge121212 alternativeVersion',
     },
     {
       id: 'challenge211111',
@@ -1143,6 +1145,7 @@ function _getRichCurrentContentDTO() {
       illustrationUrl: null,
       illustrationAlt: null,
       shuffled: false,
+      alternativeVersion: 'challenge211111 alternativeVersion',
     },
     {
       id: 'challenge211112',
@@ -1173,6 +1176,7 @@ function _getRichCurrentContentDTO() {
       illustrationUrl: null,
       illustrationAlt: null,
       shuffled: false,
+      alternativeVersion: 'challenge211112 alternativeVersion',
     },
     {
       id: 'challenge211113',
@@ -1203,6 +1207,7 @@ function _getRichCurrentContentDTO() {
       illustrationUrl: null,
       illustrationAlt: null,
       shuffled: false,
+      alternativeVersion: 'challenge211113 alternativeVersion',
     },
   ];
   const expectedCourseDTOs = [

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -30,6 +30,7 @@ module.exports = function buildChallengeForRelease({
   illustrationAlt = 'alt illu',
   illustrationUrl = 'url illu',
   shuffled = false,
+  alternativeVersion = 2
 } = {}) {
 
   return new ChallengeForRelease({
@@ -62,5 +63,6 @@ module.exports = function buildChallengeForRelease({
     illustrationAlt,
     illustrationUrl,
     shuffled,
+    alternativeVersion
   });
 };

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -126,6 +126,7 @@ describe('Unit | Domain | Content', () => {
         alpha: 0.5,
         responsive: 'Smartphone',
         genealogy: 'Prototype 1',
+        alternativeVersion: 6,
       });
       challengeAirtable.attachments = ['some_url'];
       challengeAirtable.illustrationUrl = null;
@@ -277,6 +278,7 @@ describe('Unit | Domain | Content', () => {
         attachments: ['some_url'],
         illustrationAlt: null,
         illustrationUrl: null,
+        alternativeVersion: 6,
       });
       const expectedFramework = domainBuilder.buildFrameworkForRelease({ id: 'recFramework', name: 'le framework' });
 


### PR DESCRIPTION
## :unicorn: Problème
Pour Pix1d, on a plusieurs épreuves pour un niveau donné. Pour certain niveau, on souhaiterait que l'utilisateur garde le même "sujet" pour toute les épreuves de ce niveau (ex: pour rechercher sur internet, on souhaite que toutes les épreuves concernent la  'Tour Eiffel ')
Pour garder le même "sujet", on pense utiliser le numéro de déclinaison. Mais cette donnée n'est pas remontée lors de la création de la release.

## :robot: Solution
Ajouter le numéro de déclinaison pour y accéder dans la release.

## :rainbow: Remarques
On n'a pas pu testé localement car on a pas de point env.

## :100: Pour tester
on ne sait pas comment tester 😅 
