### PR TITLE
[FEATURE] Faire que le lien vers le test statique soit dirigé vers l'environnement de production (PIX-8949)

### DIFF
--- a/pix-editor/app/models/static-course-summary.js
+++ b/pix-editor/app/models/static-course-summary.js
@@ -7,6 +7,6 @@ export default class StaticCourseSummaryModel extends Model {
   @attr createdAt;
 
   get previewURL() {
-    return `https://app.recette.pix.fr/courses/${this.id}`;
+    return `https://app.pix.fr/courses/${this.id}`;
   }
 }

--- a/pix-editor/app/models/static-course.js
+++ b/pix-editor/app/models/static-course.js
@@ -11,7 +11,7 @@ export default class StaticCourseModel extends Model {
   @hasMany('challenge-summary') challengeSummaries;
 
   get previewURL() {
-    return `https://app.recette.pix.fr/courses/${this.id}`;
+    return `https://app.pix.fr/courses/${this.id}`;
   }
 
   get sortedChallengeSummaries() {

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
@@ -65,6 +65,18 @@
             @icon="eye"
             @prefix="fas"></FaIcon> Prévisualiser
         </PixButtonLink>
+        <PixTooltip
+          @id="info-preview-links-tooltip"
+          @position="right"
+          @isWide={{true}}
+        >
+          <:triggerElement>
+            <FaIcon @icon="circle-info" aria-describedby="'info-preview-links-tooltip"></FaIcon>
+          </:triggerElement>
+          <:tooltip>
+            Le test statique sera accessible à compter du lendemain de sa création / mise à jour. Si besoin d’accéder au test d’ici-là, recharger le cache de la recette depuis l’application PixAdmin puis “copier le lien” du test et remplacer la partie de l’URL “app.pix” par “app.recette.pix”.
+          </:tooltip>
+        </PixTooltip>
       </div>
     </Card>
     <Card @title="2. Liste des épreuves">

--- a/pix-editor/config/icons.js
+++ b/pix-editor/config/icons.js
@@ -9,6 +9,7 @@ module.exports = function () {
       'award',
       'book',
       'bullhorn',
+      'circle-info',
       'check',
       'chevron-down',
       'chevron-up',


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les participants d’un test statique arrivent à la fin d’un test, un lien incite à continuer son expérience sur Pix. Lorsque l’utilisateur clique sur ce lien il est mené vers la page de connexion à pix.

Le lien généré menant sur la recette, ils se créent alors un compte en recette ce qui est gênant point de vue RGPD en plus d'être embêtant car ce compte ne servira qu’une fois et ils ne peuvent pas utiliser leur compte de production s’ils en possèdent un.

## :robot: Solution
Modifier le lien pour qu'il pointe sur l'environnement de production + ajout d'une infobulle au niveau de la page de détails du test statique

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Copier / prévisualiser liens tests statiques. Constater que l'url pointe vers la prod.
Check l'info bulle à côté des boutons d'actions dans la page de détails d'un test statique
