### PR TITLE
[FEATURE] Récupérer et sauvegarder les traductions des compétences depuis airtable (PIX-8705)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -29,6 +29,7 @@
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "NODE_ENV=test mocha --recursive --exit --reporter dot tests",
     "test:api:unit": "env NODE_ENV=test mocha --recursive --exit --reporter dot tests/unit",
+    "test:api:scripts": "env NODE_ENV=test mocha --recursive --exit --reporter dot tests/scripts",
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:lint": "npm test && npm run lint",

--- a/api/scripts/migrate-competences-translation-from-airtable/index.js
+++ b/api/scripts/migrate-competences-translation-from-airtable/index.js
@@ -1,0 +1,41 @@
+const Airtable = require('airtable');
+const extractor = require('../../lib/infrastructure/translations-extractors/competence');
+const translationsRepository = require('../../lib/infrastructure/repositories/translation-repository');
+
+async function main() {
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    const allCompetences = await airtableClient
+      .table('Competences')
+      .select({
+        fields: [
+          'id persistant',
+          'Titre fr-fr',
+          'Titre en-us',
+          'Description fr-fr',
+          'Description en-us',
+        ],
+      })
+      .all();
+
+    const translations = allCompetences.flatMap((competence) =>
+      extractor.extractTranslations(competence.fields)
+    );
+
+    await translationsRepository.save(translations);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  main();
+}
+
+module.exports = {
+  main,
+};

--- a/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
@@ -1,0 +1,63 @@
+const { expect, airtableBuilder, knex } = require('../test-helper');
+const nock = require('nock');
+
+const { main } = require('../../scripts/migrate-competences-translation-from-airtable');
+
+describe('Migrate translation from airtable', function() {
+  it('fills translations table', async function() {
+    // given
+    process.env.AIRTABLE_API_KEY = 'airtableApiKeyValue';
+    process.env.AIRTABLE_BASE = 'airtableBaseValue';
+    const competence = airtableBuilder.factory.buildCompetence({
+      index: 1,
+      name_i18n: {
+        fr: 'Bonjour',
+        en: 'Hello',
+      },
+      description_i18n: {
+        fr: 'Description',
+        en: 'Describe',
+      },
+    });
+    const competences = [competence];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Competences')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: competences });
+
+    // when
+    await main();
+
+    // then
+    const translations = await knex('translations').select().orderBy([{
+      column: 'key',
+      order: 'asc'
+    }, { column: 'locale', order: 'asc' }]);
+
+    expect(translations).to.have.lengthOf(4);
+    expect(translations).to.deep.equal([
+      {
+        key: 'competence.competenceid1.description',
+        locale: 'en',
+        value: 'Describe'
+      },
+      {
+        key: 'competence.competenceid1.description',
+        locale: 'fr',
+        value: 'Description'
+      },
+      {
+        key: 'competence.competenceid1.title',
+        locale: 'en',
+        value: 'Hello'
+      },
+      {
+        key: 'competence.competenceid1.title',
+        locale: 'fr',
+        value: 'Bonjour'
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On ne pouvait pas récupérer les traductions de Airtable.

## :robot: Solution
On a ajouté la fonctionnalité permettant de le faire (un script)

## :rainbow: Remarques
A tester en RA

## :100: Pour tester
1. Sur la ra: 
  - cd api
  - node scripts/migrate-competences-translation-from-airtable/
  - regarder la table translations en se connectant au pg `select * from translations;`