### PR TITLE
[BUGFIX] Changer le suffixe des traductions des compétences

### DIFF
--- a/api/db/migrations/20230825091746_change-competence-translations-suffix.js
+++ b/api/db/migrations/20230825091746_change-competence-translations-suffix.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'translations';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function(knex) {
+  await knex(TABLE_NAME)
+    .whereLike('key', 'competence.%.title')
+    .update({ key: knex.raw('regexp_replace (key, \'\\.title$\', \'.name\')') });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function(knex) {
+  await knex(TABLE_NAME)
+    .whereLike('key', 'competence.%.name')
+    .update({ key: knex.raw('regexp_replace (key, \'\\.name$\', \'.title\')') });
+};

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -6,7 +6,7 @@ const locales = [
 ];
 
 const fields = [
-  { airtableField: 'Titre', field: 'title' },
+  { airtableField: 'Titre', field: 'name' },
   { airtableField: 'Description', field: 'description' },
 ];
 

--- a/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
@@ -68,7 +68,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
         const translations = await knex('translations').select('key', 'locale', 'value');
         expect(translations.length).to.equal(4);
         expect(translations[0]).to.deep.equal({
-          key: 'competence.mon_id_persistant.title',
+          key: 'competence.mon_id_persistant.name',
           locale: 'fr',
           value: 'Pouet'
         });
@@ -78,7 +78,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
           value: 'C\'est le bruit d\'un klaxon'
         });
         expect(translations[2]).to.deep.equal({
-          key: 'competence.mon_id_persistant.title',
+          key: 'competence.mon_id_persistant.name',
           locale: 'en',
           value: 'Toot'
         });
@@ -114,12 +114,12 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
-        key: 'competence.mon_id_persistant.title',
+        key: 'competence.mon_id_persistant.name',
         value: 'Pouet'
       });
       databaseBuilder.factory.buildTranslation({
         locale: 'en',
-        key: 'competence.mon_id_persistant.title',
+        key: 'competence.mon_id_persistant.name',
         value: 'Toot'
       });
       databaseBuilder.factory.buildTranslation({
@@ -159,7 +159,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
         const translations = await knex('translations').select('key', 'locale', 'value');
         expect(translations.length).to.equal(4);
         expect(translations[0]).to.deep.equal({
-          key: 'competence.mon_id_persistant.title',
+          key: 'competence.mon_id_persistant.name',
           locale: 'fr',
           value: 'AAA'
         });
@@ -169,7 +169,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
           value: 'CCCCCCCCCCCCCCCC'
         });
         expect(translations[2]).to.deep.equal({
-          key: 'competence.mon_id_persistant.title',
+          key: 'competence.mon_id_persistant.name',
           locale: 'en',
           value: 'BBB'
         });
@@ -213,12 +213,12 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve compete
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
-        key: 'competence.mon_id_persistant.title',
+        key: 'competence.mon_id_persistant.name',
         value: 'Prout'
       });
       databaseBuilder.factory.buildTranslation({
         locale: 'en',
-        key: 'competence.mon_id_persistant.title',
+        key: 'competence.mon_id_persistant.name',
         value: 'Fart'
       });
 
@@ -279,12 +279,12 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve compete
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
-        key: 'competence.mon_id_persistant.title',
+        key: 'competence.mon_id_persistant.name',
         value: 'Prout'
       });
       databaseBuilder.factory.buildTranslation({
         locale: 'en',
-        key: 'competence.mon_id_persistant.title',
+        key: 'competence.mon_id_persistant.name',
         value: 'Fart'
       });
 

--- a/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
@@ -49,12 +49,12 @@ describe('Migrate translation from airtable', function() {
         value: 'Description'
       },
       {
-        key: 'competence.competenceid1.title',
+        key: 'competence.competenceid1.name',
         locale: 'en',
         value: 'Hello'
       },
       {
-        key: 'competence.competenceid1.title',
+        key: 'competence.competenceid1.name',
         locale: 'fr',
         value: 'Bonjour'
       },

--- a/api/tests/unit/infrastructure/translations/competence_test.js
+++ b/api/tests/unit/infrastructure/translations/competence_test.js
@@ -21,13 +21,13 @@ describe('Unit | Infrastructure | Competence translations', () => {
 
       // then
       expect(translations).to.deep.equal([
-        { key: 'competence.test.title', locale: 'fr', value: 'titre fr-fr' },
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
         {
           key: 'competence.test.description',
           locale: 'fr',
           value: 'description en français',
         },
-        { key: 'competence.test.title', locale: 'en', value: 'title en-us' },
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
         {
           key: 'competence.test.description',
           locale: 'en',
@@ -48,7 +48,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
 
       // then
       expect(translations).to.deep.equal([
-        { key: 'competence.test.title', locale: 'fr', value: 'titre fr-fr' },
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
       ]);
     });
   });
@@ -62,13 +62,13 @@ describe('Unit | Infrastructure | Competence translations', () => {
         otherField: 'foo',
       };
       const translations = [
-        { key: 'competence.test.title', locale: 'fr', value: 'titre fr-fr' },
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
         {
           key: 'competence.test.description',
           locale: 'fr',
           value: 'description en français',
         },
-        { key: 'competence.test.title', locale: 'en', value: 'title en-us' },
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
         {
           key: 'competence.test.description',
           locale: 'en',
@@ -97,7 +97,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
         'Titre fr-fr': 'titre fr-fr initial',
       };
       const translations = [
-        { key: 'competence.test.title', locale: 'en', value: 'title en-us' },
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
         {
           key: 'competence.test.description',
           locale: 'en',


### PR DESCRIPTION
## :unicorn: Problème
Dans la table `translations` les titres de compétences sont suffixés par `.title`, mais dans la release le champ correspondant s'appelle `name`.

## :robot: Solution
Changer le suffixe dans la table `translations` en `.name`.

## :rainbow: Remarques
N/A

## :100: Pour tester
