### PR TITLE
[FEATURE] Adapter la release pour insérer les translations de PG (PIX-8706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,7 +506,7 @@
 
 
 ### :rocket: Enhancement
-- [#16](https://github.com/1024pix/pix-editor/pull/16) [FEATURE] Ajout de contexte sur l'extract des URLs du référentiel (PIX-4154)
+- [#16](https://github.com/1024pix/pix-editor/pull/16) [FEATURE] Ajout de contexte sur l'extractFromAirtable des URLs du référentiel (PIX-4154)
 
 ### :bug: Bug fix
 - [#17](https://github.com/1024pix/pix-editor/pull/17) [BUGFIX] Corrige la concurrence de vérifications des URLs

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -35,18 +35,18 @@ exports.register = async function(server) {
             if (response.data.records) {
               const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
               response.data.records.forEach((entity) => {
-                tableTranslations.hydrate(entity.fields, translations) ;
+                tableTranslations.hydrateToAirtableObject(entity.fields, translations) ;
               });
             } else {
               const id = response.data.fields['id persistant'];
               const translations = await translationRepository.listByPrefix(`${tableTranslations.prefix}${id}.`);
-              tableTranslations.hydrate(response.data.fields, translations) ;
+              tableTranslations.hydrateToAirtableObject(response.data.fields, translations) ;
             }
           }
 
           if ((request.method === 'post' || request.method === 'patch') && _isResponseOK(response)) {
             if (tableTranslations) {
-              const translations = tableTranslations.extract(request.payload.fields) ?? [];
+              const translations = tableTranslations.extractFromAirtableObject(request.payload.fields) ?? [];
               await translationRepository.save(translations);
             }
 

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -12,11 +12,13 @@ const challengeTransformer = require('../transformers/challenge-transformer');
 const competenceTransformer = require('../transformers/competence-transformer');
 const tubeTransformer = require('../transformers/tube-transformer');
 const skillTransformer = require('../transformers/skill-transformer');
+const translationRepository = require('./translation-repository');
 const tutorialTransformer = require('../transformers/tutorial-transformer');
 const Release = require('../../domain/models/Release');
 const Content = require('../../domain/models/Content');
 
 const { knex } = require('../../../db/knex-database-connection');
+const tablesTranslations = require('../translations');
 
 module.exports = {
   getCurrentContent() {
@@ -72,6 +74,12 @@ module.exports = {
       const challenge = transformChallenge(updatedRecord);
 
       return { updatedRecord: challenge, model };
+    }
+
+    const tableTranslations = tablesTranslations[type];
+    if (tableTranslations) {
+      const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
+      tableTranslations.hydrateReleaseObject(updatedRecord, translations);
     }
 
     return { updatedRecord, model };

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -12,7 +12,6 @@ const challengeTransformer = require('../transformers/challenge-transformer');
 const competenceTransformer = require('../transformers/competence-transformer');
 const tubeTransformer = require('../transformers/tube-transformer');
 const skillTransformer = require('../transformers/skill-transformer');
-const translationRepository = require('./translation-repository');
 const tutorialTransformer = require('../transformers/tutorial-transformer');
 const Release = require('../../domain/models/Release');
 const Content = require('../../domain/models/Content');
@@ -50,7 +49,7 @@ module.exports = {
     return _toDomain(release[0]);
   },
 
-  async serializeEntity({ entity, type }) {
+  async serializeEntity({ type, entity, translations }) {
     const { updatedRecord, model } = airtableSerializer.serialize({
       airtableObject: entity,
       tableName: type
@@ -76,11 +75,7 @@ module.exports = {
       return { updatedRecord: challenge, model };
     }
 
-    const tableTranslations = tablesTranslations[type];
-    if (tableTranslations) {
-      const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
-      tableTranslations.hydrateReleaseObject(updatedRecord, translations);
-    }
+    tablesTranslations[type]?.hydrateReleaseObject(updatedRecord, translations);
 
     return { updatedRecord, model };
   },

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -2,7 +2,8 @@ const { knex } = require('../../../db/knex-database-connection');
 
 module.exports = {
   save,
-  listByPrefix
+  listByPrefix,
+  list,
 };
 
 async function save(translations) {
@@ -18,4 +19,8 @@ async function listByPrefix(prefix) {
   return knex('translations')
     .select()
     .whereLike('key', `${prefix}%`);
+}
+
+async function list() {
+  return knex('translations').select();
 }

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -18,10 +18,10 @@ const localizedFields = locales.flatMap((locale) =>
 );
 
 module.exports = {
-  extract(competence) {
+  extractFromAirtableObject(competence) {
     return Array.from(translationsExtractor(competence));
   },
-  hydrate(competence, translations) {
+  hydrateToAirtableObject(competence, translations) {
     const id = competence['id persistant'];
 
     for (const {

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -40,6 +40,19 @@ module.exports = {
         translation?.value ?? null;
     }
   },
+  hydrateReleaseObject(competence, translations) {
+    for (const { field } of fields) {
+      competence[`${field}_i18n`] = {};
+      for (const { locale } of locales) {
+        const translation = translations.find(
+          (translation) =>
+            translation.key === `${prefix}${competence.id}.${field}` &&
+            translation.locale === locale
+        );
+        competence[`${field}_i18n`][locale] = translation?.value ?? null;
+      }
+    }
+  },
   prefix,
 };
 

--- a/api/scripts/migrate-competences-translation-from-airtable/index.js
+++ b/api/scripts/migrate-competences-translation-from-airtable/index.js
@@ -22,7 +22,7 @@ async function main() {
       .all();
 
     const translations = allCompetences.flatMap((competence) =>
-      competenceTranslations.extract(competence.fields)
+      competenceTranslations.extractFromAirtableObject(competence.fields)
     );
 
     await translationsRepository.save(translations);

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -182,6 +182,28 @@ async function mockCurrentContent() {
     challengeIds: 'recChallenge0',
     imageUrl: 'Image du Course',
   });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+    locale: 'fr',
+    value: expectedCurrentContent.competences[0].name_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+    locale: 'en',
+    value: expectedCurrentContent.competences[0].name_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+    locale: 'fr',
+    value: expectedCurrentContent.competences[0].description_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+    locale: 'en',
+    value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+
   await databaseBuilder.commit();
 
   return expectedCurrentContent;
@@ -349,6 +371,28 @@ async function mockContentForRelease() {
     challengeIds: 'recChallenge0',
     imageUrl: 'Image du Course',
   });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+    locale: 'fr',
+    value: expectedCurrentContent.competences[0].name_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+    locale: 'en',
+    value: expectedCurrentContent.competences[0].name_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+    locale: 'fr',
+    value: expectedCurrentContent.competences[0].description_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+    locale: 'en',
+    value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+
   await databaseBuilder.commit();
   return expectedCurrentContent;
 }

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -162,7 +162,39 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getCurrentContent', function() {
 
     beforeEach(function() {
-      _mockRichAirtableContent();
+      const { competences } = _mockRichAirtableContent();
+
+      for (const competence of competences) {
+        if (competence.name_i18n?.fr) {
+          databaseBuilder.factory.buildTranslation({
+            key: `competence.${competence.id}.name`,
+            locale: 'fr',
+            value: competence.name_i18n.fr,
+          });
+        }
+        if (competence.name_i18n?.en) {
+          databaseBuilder.factory.buildTranslation({
+            key: `competence.${competence.id}.name`,
+            locale: 'en',
+            value: competence.name_i18n.en,
+          });
+        }
+        if (competence.description_i18n?.fr) {
+          databaseBuilder.factory.buildTranslation({
+            key: `competence.${competence.id}.description`,
+            locale: 'fr',
+            value: competence.description_i18n.fr,
+          });
+        }
+        if (competence.description_i18n?.en) {
+          databaseBuilder.factory.buildTranslation({
+            key: `competence.${competence.id}.description`,
+            locale: 'en',
+            value: competence.description_i18n.en,
+          });
+        }
+      }
+
       databaseBuilder.factory.buildStaticCourse({
         id: 'course1PG',
         name: 'course1PG name',
@@ -218,7 +250,7 @@ function _mockRichAirtableContent() {
     color: 'area2 color',
     frameworkId: 'frameworkA',
   });
-  const airtableCompetence11 = airtableBuilder.factory.buildCompetence({
+  const competence11 = {
     id: 'competence11',
     index: 'competence11 index',
     name_i18n: {
@@ -234,8 +266,9 @@ function _mockRichAirtableContent() {
     thematicIds: ['thematic111', 'thematic112'],
     origin: 'FrameworkA',
     fullName: 'competence11 fullName',
-  });
-  const airtableCompetence12 = airtableBuilder.factory.buildCompetence({
+  };
+  const airtableCompetence11 = airtableBuilder.factory.buildCompetence(competence11);
+  const competence12 = {
     id: 'competence12',
     index: 'competence12 index',
     name_i18n: {
@@ -251,8 +284,9 @@ function _mockRichAirtableContent() {
     thematicIds: ['thematic121'],
     origin: 'FrameworkA',
     fullName: 'competence12 fullName',
-  });
-  const airtableCompetence21 = airtableBuilder.factory.buildCompetence({
+  };
+  const airtableCompetence12 = airtableBuilder.factory.buildCompetence(competence12);
+  const competence21 = {
     id: 'competence21',
     index: 'competence21 index',
     name_i18n: {
@@ -268,7 +302,8 @@ function _mockRichAirtableContent() {
     thematicIds: ['thematic211'],
     origin: 'FrameworkA',
     fullName: 'competence21 fullName',
-  });
+  };
+  const airtableCompetence21 = airtableBuilder.factory.buildCompetence(competence21);
   const airtableThematic111 = airtableBuilder.factory.buildThematic({
     id: 'thematic111',
     name_i18n: {
@@ -725,6 +760,10 @@ function _mockRichAirtableContent() {
     tutorials: [airtableTutorial1, airtableTutorial2],
     attachments: [airtableAttachment1, airtableAttachment2, airtableAttachment3],
   });
+
+  return {
+    competences: [competence11, competence12, competence21],
+  };
 }
 
 function _getRichCurrentContentDTO() {

--- a/api/tests/unit/infrastructure/translations/competence_test.js
+++ b/api/tests/unit/infrastructure/translations/competence_test.js
@@ -1,121 +1,200 @@
 const { expect } = require('../../../test-helper');
 const {
   extractFromAirtableObject,
+  hydrateReleaseObject,
   hydrateToAirtableObject,
 } = require('../../../../lib/infrastructure/translations/competence');
 
 describe('Unit | Infrastructure | Competence translations', () => {
-  describe('#extract', () => {
-    it('should return the list of translations', () => {
-      // given
-      const competence = {
-        'id persistant': 'test',
-        'Titre fr-fr': 'titre fr-fr',
-        'Titre en-us': 'title en-us',
-        'Description fr-fr': 'description en français',
-        'Description en-us': 'english description',
-      };
+  describe('#airtable', () => {
+    describe('#extract', () => {
+      it('should return the list of translations', () => {
+        // given
+        const competence = {
+          'id persistant': 'test',
+          'Titre fr-fr': 'titre fr-fr',
+          'Titre en-us': 'title en-us',
+          'Description fr-fr': 'description en français',
+          'Description en-us': 'english description',
+        };
 
-      // when
-      const translations = extractFromAirtableObject(competence);
+        // when
+        const translations = extractFromAirtableObject(competence);
 
-      // then
-      expect(translations).to.deep.equal([
-        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-        {
-          key: 'competence.test.description',
-          locale: 'fr',
-          value: 'description en français',
-        },
-        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-        {
-          key: 'competence.test.description',
-          locale: 'en',
-          value: 'english description',
-        },
-      ]);
+        // then
+        expect(translations).to.deep.equal([
+          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+          {
+            key: 'competence.test.description',
+            locale: 'fr',
+            value: 'description en français',
+          },
+          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+          {
+            key: 'competence.test.description',
+            locale: 'en',
+            value: 'english description',
+          },
+        ]);
+      });
+
+      it('should return translations only for field w/ values', () => {
+        // given
+        const competence = {
+          'id persistant': 'test',
+          'Titre fr-fr': 'titre fr-fr',
+        };
+
+        // when
+        const translations = extractFromAirtableObject(competence);
+
+        // then
+        expect(translations).to.deep.equal([
+          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+        ]);
+      });
     });
 
-    it('should return translations only for field w/ values', () => {
-      // given
-      const competence = {
-        'id persistant': 'test',
-        'Titre fr-fr': 'titre fr-fr',
-      };
+    describe('#hydrate', () => {
+      it('should set translated fields into the object', () => {
+        // given
+        const competence = {
+          'id persistant': 'test',
+          'Titre fr-fr': 'titre fr-fr initial',
+          otherField: 'foo',
+        };
+        const translations = [
+          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+          {
+            key: 'competence.test.description',
+            locale: 'fr',
+            value: 'description en français',
+          },
+          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+          {
+            key: 'competence.test.description',
+            locale: 'en',
+            value: 'english description',
+          },
+        ];
 
-      // when
-      const translations = extractFromAirtableObject(competence);
+        // when
+        hydrateToAirtableObject(competence, translations);
 
-      // then
-      expect(translations).to.deep.equal([
-        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-      ]);
+        // then
+        expect(competence).to.deep.equal({
+          'id persistant': 'test',
+          'Titre fr-fr': 'titre fr-fr',
+          'Titre en-us': 'title en-us',
+          'Description fr-fr': 'description en français',
+          'Description en-us': 'english description',
+          otherField: 'foo',
+        });
+      });
+
+      it('should set null value for missing translations', () => {
+        // given
+        const competence = {
+          'id persistant': 'test',
+          'Titre fr-fr': 'titre fr-fr initial',
+        };
+        const translations = [
+          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+          {
+            key: 'competence.test.description',
+            locale: 'en',
+            value: 'english description',
+          },
+        ];
+
+        // when
+        hydrateToAirtableObject(competence, translations);
+
+        // then
+        expect(competence).to.deep.equal({
+          'id persistant': 'test',
+          'Titre fr-fr': null,
+          'Titre en-us': 'title en-us',
+          'Description fr-fr': null,
+          'Description en-us': 'english description',
+        });
+      });
     });
   });
+  describe('#release', () => {
+    describe('#hydrate', () => {
+      it('should set translated fields into the object', () => {
+        // given
+        const competence = {
+          id: 'test',
+          otherField: 'foo',
+        };
+        const translations = [
+          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+          {
+            key: 'competence.test.description',
+            locale: 'fr',
+            value: 'description en français',
+          },
+          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+          {
+            key: 'competence.test.description',
+            locale: 'en',
+            value: 'english description',
+          },
+        ];
 
-  describe('#hydrate', () => {
-    it('should set translated fields into the object', () => {
-      // given
-      const competence = {
-        'id persistant': 'test',
-        'Titre fr-fr': 'titre fr-fr initial',
-        otherField: 'foo',
-      };
-      const translations = [
-        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-        {
-          key: 'competence.test.description',
-          locale: 'fr',
-          value: 'description en français',
-        },
-        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-        {
-          key: 'competence.test.description',
-          locale: 'en',
-          value: 'english description',
-        },
-      ];
+        // when
+        hydrateReleaseObject(competence, translations);
 
-      // when
-      hydrateToAirtableObject(competence, translations);
+        // then
+        expect(competence).to.deep.equal({
+          id: 'test',
+          name_i18n: {
+            fr: 'titre fr-fr',
+            en: 'title en-us',
+          },
+          description_i18n: {
+            fr: 'description en français',
+            en: 'english description',
+          },
+          otherField: 'foo',
+        });
+      });
 
-      // then
-      expect(competence).to.deep.equal({
-        'id persistant': 'test',
-        'Titre fr-fr': 'titre fr-fr',
-        'Titre en-us': 'title en-us',
-        'Description fr-fr': 'description en français',
-        'Description en-us': 'english description',
-        otherField: 'foo',
+      it('should set null value for missing translations', () => {
+        // given
+        const competence = {
+          id: 'test',
+          otherField: 'foo',
+        };
+        const translations = [
+          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+          {
+            key: 'competence.test.description',
+            locale: 'en',
+            value: 'english description',
+          },
+        ];
+
+        // when
+        hydrateReleaseObject(competence, translations);
+
+        // then
+        expect(competence).to.deep.equal({
+          id: 'test',
+          name_i18n: {
+            fr: null,
+            en: 'title en-us',
+          },
+          description_i18n: {
+            fr: null,
+            en: 'english description',
+          },
+          otherField: 'foo',
+        });
       });
     });
 
-    it('should set null value for missing translations', () => {
-      // given
-      const competence = {
-        'id persistant': 'test',
-        'Titre fr-fr': 'titre fr-fr initial',
-      };
-      const translations = [
-        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-        {
-          key: 'competence.test.description',
-          locale: 'en',
-          value: 'english description',
-        },
-      ];
-
-      // when
-      hydrateToAirtableObject(competence, translations);
-
-      // then
-      expect(competence).to.deep.equal({
-        'id persistant': 'test',
-        'Titre fr-fr': null,
-        'Titre en-us': 'title en-us',
-        'Description fr-fr': null,
-        'Description en-us': 'english description',
-      });
-    });
   });
 });

--- a/api/tests/unit/infrastructure/translations/competence_test.js
+++ b/api/tests/unit/infrastructure/translations/competence_test.js
@@ -1,7 +1,7 @@
 const { expect } = require('../../../test-helper');
 const {
-  extract,
-  hydrate,
+  extractFromAirtableObject,
+  hydrateToAirtableObject,
 } = require('../../../../lib/infrastructure/translations/competence');
 
 describe('Unit | Infrastructure | Competence translations', () => {
@@ -17,7 +17,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
       };
 
       // when
-      const translations = extract(competence);
+      const translations = extractFromAirtableObject(competence);
 
       // then
       expect(translations).to.deep.equal([
@@ -44,7 +44,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
       };
 
       // when
-      const translations = extract(competence);
+      const translations = extractFromAirtableObject(competence);
 
       // then
       expect(translations).to.deep.equal([
@@ -77,7 +77,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
       ];
 
       // when
-      hydrate(competence, translations);
+      hydrateToAirtableObject(competence, translations);
 
       // then
       expect(competence).to.deep.equal({
@@ -106,7 +106,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
       ];
 
       // when
-      hydrate(competence, translations);
+      hydrateToAirtableObject(competence, translations);
 
       // then
       expect(competence).to.deep.equal({


### PR DESCRIPTION
## :unicorn: Problème
La release n'inclut pas les translations venant de PG.

## :robot: Solution
On inclut les translations venant de PG dans notre Release.

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer le script de migration pour seeder la DB,
(facultatif) changer un champ sur Airtable (pour vérifier que nos traductions viennent bien de PG et non plus de Airtable)
créer une release et vérifier que les champs traduits existent bien et sont bien renseignés.
