### PR TITLE
[BUGFIX] Ne pas appeler `process.exit` dans les tests (PIX-9015)

### DIFF
--- a/api/scripts/migrate-competences-translation-from-airtable/index.js
+++ b/api/scripts/migrate-competences-translation-from-airtable/index.js
@@ -1,41 +1,50 @@
 const Airtable = require('airtable');
 const competenceTranslations = require('../../lib/infrastructure/translations/competence');
 const translationsRepository = require('../../lib/infrastructure/repositories/translation-repository');
+const { disconnect } = require('../../db/knex-database-connection');
+
+async function migrateCompetencesTranslationFromAirtable({ airtableClient }) {
+  const allCompetences = await airtableClient
+    .table('Competences')
+    .select({
+      fields: [
+        'id persistant',
+        'Titre fr-fr',
+        'Titre en-us',
+        'Description fr-fr',
+        'Description en-us',
+      ],
+    })
+    .all();
+
+  const translations = allCompetences.flatMap((competence) =>
+    competenceTranslations.extractFromAirtableObject(competence.fields)
+  );
+
+  await translationsRepository.save(translations);
+}
+
+const isLaunchedFromCommandLine = require.main === module;
 
 async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
   try {
     const airtableClient = new Airtable({
       apiKey: process.env.AIRTABLE_API_KEY,
     }).base(process.env.AIRTABLE_BASE);
 
-    const allCompetences = await airtableClient
-      .table('Competences')
-      .select({
-        fields: [
-          'id persistant',
-          'Titre fr-fr',
-          'Titre en-us',
-          'Description fr-fr',
-          'Description en-us',
-        ],
-      })
-      .all();
-
-    const translations = allCompetences.flatMap((competence) =>
-      competenceTranslations.extractFromAirtableObject(competence.fields)
-    );
-
-    await translationsRepository.save(translations);
+    await migrateCompetencesTranslationFromAirtable({ airtableClient });
   } catch (e) {
     console.error(e);
-    process.exit(1);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
   }
 }
 
-if (process.env.NODE_ENV !== 'test') {
-  main();
-}
+main();
 
 module.exports = {
-  main,
+  migrateCompetencesTranslationFromAirtable,
 };

--- a/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
@@ -1,13 +1,21 @@
 const { expect, airtableBuilder, knex } = require('../test-helper');
+const Airtable = require('airtable');
 const nock = require('nock');
 
-const { main } = require('../../scripts/migrate-competences-translation-from-airtable');
+const { migrateCompetencesTranslationFromAirtable } = require('../../scripts/migrate-competences-translation-from-airtable');
 
 describe('Migrate translation from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
   it('fills translations table', async function() {
     // given
-    process.env.AIRTABLE_API_KEY = 'airtableApiKeyValue';
-    process.env.AIRTABLE_BASE = 'airtableBaseValue';
     const competence = airtableBuilder.factory.buildCompetence({
       index: 1,
       name_i18n: {
@@ -28,7 +36,7 @@ describe('Migrate translation from airtable', function() {
       .reply(200, { records: competences });
 
     // when
-    await main();
+    await migrateCompetencesTranslationFromAirtable({ airtableClient });
 
     // then
     const translations = await knex('translations').select().orderBy([{


### PR DESCRIPTION
## :unicorn: Problème
Dans les tests du script de migration des traductions des compétences, on appelle potentiellement `process.exit`, ce qui interrompt les tests.

## :robot: Solution
Ne pas inclure le `try...catch` de gestion d'erreur dans le test, et utiliser `process.exitCode` à la place de `process.exit`.

## :rainbow: Remarques
N/A

## :100: Pour tester
Tests au vert.
Exécuter le script.