### PR TITLE
[FEATURE] Renseigner les traductions de Compétences pour la réplication via la table PG `translations`(PIX-8973).

### DIFF
--- a/api/lib/application/replication-data.js
+++ b/api/lib/application/replication-data.js
@@ -7,7 +7,7 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/databases/airtable',
       config: {
-        handler: function() {
+        handler: async function() {
           return promiseStreamer(usecase.getLearningContentForReplication());
         },
       },
@@ -16,7 +16,7 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/replication-data',
       config: {
-        handler: function() {
+        handler: async function() {
           return promiseStreamer(usecase.getLearningContentForReplication());
         },
       },

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -6,9 +6,13 @@ const challengeDatasource = require('../../infrastructure/datasources/airtable/c
 const tutorialDatasource = require('../../infrastructure/datasources/airtable/tutorial-datasource');
 const attachmentDatasource = require('../../infrastructure/datasources/airtable/attachment-datasource');
 const thematicDatasource = require('../../infrastructure/datasources/airtable/thematic-datasource');
+const tablesTranslations = require('../../infrastructure/translations');
+const translationRepository = require('../../infrastructure/repositories/translation-repository');
 const { knex } = require('../../../db/knex-database-connection');
 
-async function getLearningContentForReplication() {
+async function getLearningContentForReplication(dependencies = { translationRepository }) {
+  const { translationRepository } = dependencies;
+
   const [
     areas,
     competences,
@@ -30,6 +34,13 @@ async function getLearningContentForReplication() {
     thematicDatasource.list(),
     _getCoursesFromPGForReplication(),
   ]);
+
+  const translations = await translationRepository.list();
+
+  competences.forEach((competence) => {
+    const tableTranslations = tablesTranslations['Competences'];
+    tableTranslations.hydrateReleaseObject(competence, translations);
+  });
 
   return {
     areas,

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -82,6 +82,29 @@ describe('Acceptance | Controller | replication-data-controller', () => {
   describe('GET /api/replication-data', function() {
     it('should return data for replication', async function() {
       const expectedCurrentContent = await mockCurrentContent();
+
+      databaseBuilder.factory.buildTranslation({
+        key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+        locale: 'fr',
+        value: expectedCurrentContent.competences[0].name_i18n.fr,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+        locale: 'en',
+        value: expectedCurrentContent.competences[0].name_i18n.en,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+        locale: 'fr',
+        value: expectedCurrentContent.competences[0].description_i18n.fr,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+        locale: 'en',
+        value: expectedCurrentContent.competences[0].description_i18n.en,
+      });
+
+      await databaseBuilder.commit();
       const server = await createServer();
       const currentContentOptions = {
         method: 'GET',


### PR DESCRIPTION
## :unicorn: Problème
LCMS fournit un référentiel pour la réplication qui utilise encore les traductions de compétences depuis Airtable.

## :robot: Solution
Utiliser les traductions de la table PG `translations` dans le référentiel fourni à la réplication.

## :rainbow: Remarques
A quoi sert la route `/api/databases/airtable` ?

## :100: Pour tester
Appeler la route : `/api/replication-data` et vérifier que les traductions de compétences sont bien présentes.
Faire la même chose pour la route `/api/databases/airtable`.