### PR TITLE
[FEATURE] Adapter les seeds pour insérer les traductions dans la base PG (PIX-8986)

### DIFF
--- a/api/db/seeds/data/translations.js
+++ b/api/db/seeds/data/translations.js
@@ -1,8 +1,6 @@
 const Airtable = require('airtable');
 
 module.exports = async function(databaseBuilder) {
-  if (process.env.AIRTABLE_SAVE_TRANSLATIONS !== 'true') return;
-
   const {
     AIRTABLE_API_KEY: airtableApiKey,
     AIRTABLE_BASE: airtableBase,
@@ -10,7 +8,16 @@ module.exports = async function(databaseBuilder) {
 
   const airtableClient = new Airtable({ apiKey: airtableApiKey }).base(airtableBase);
 
-  const airtableTranslations = await airtableClient.table('translations').select().all();
+  let airtableTranslations;
+  try {
+    airtableTranslations = await airtableClient.table('translations').select().all();
+  } catch (err) {
+    if (err.statusCode === 404) {
+      console.log('Skipping translations seeding: did not find translations table in Airtable');
+      return;
+    }
+    throw err;
+  }
 
   const translations = airtableTranslations.map((translation) => {
     return {

--- a/api/db/seeds/data/translations.js
+++ b/api/db/seeds/data/translations.js
@@ -1,0 +1,24 @@
+const Airtable = require('airtable');
+
+module.exports = async function(databaseBuilder) {
+  if (process.env.AIRTABLE_SAVE_TRANSLATIONS !== 'true') return;
+
+  const {
+    AIRTABLE_API_KEY: airtableApiKey,
+    AIRTABLE_BASE: airtableBase,
+  } = process.env;
+
+  const airtableClient = new Airtable({ apiKey: airtableApiKey }).base(airtableBase);
+
+  const airtableTranslations = await airtableClient.table('translations').select().all();
+
+  const translations = airtableTranslations.map((translation) => {
+    return {
+      key: translation.get('key'),
+      locale: translation.get('locale'),
+      value: translation.get('value'),
+    };
+  });
+
+  translations.forEach(databaseBuilder.factory.buildTranslation);
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,7 +1,8 @@
 const DatabaseBuilder = require('../../tests/tooling/database-builder/database-builder');
 const staticCoursesBuilder = require('./data/static-courses.js');
+const translationsBuilder = require('./data/translations');
 
-exports.seed = (knex) => {
+exports.seed = async (knex) => {
   const databaseBuilder = new DatabaseBuilder({ knex });
   databaseBuilder.factory.buildUser({
     trigram: 'DEV',
@@ -32,6 +33,8 @@ exports.seed = (knex) => {
   });
 
   staticCoursesBuilder(databaseBuilder);
+
+  await translationsBuilder(databaseBuilder);
 
   return databaseBuilder.commit();
 };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -29,7 +29,6 @@ module.exports = (function() {
       apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
       base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
       editorBase: process.env.AIRTABLE_EDITOR_BASE,
-      saveTranslations: process.env.AIRTABLE_SAVE_TRANSLATIONS === 'true',
     },
 
     logging: {
@@ -112,7 +111,6 @@ module.exports = (function() {
     config.airtable.apiKey = 'airtableApiKeyValue';
     config.airtable.base = 'airtableBaseValue';
     config.airtable.editorBase = 'airtableEditorBaseValue';
-    config.airtable.saveTranslations = false;
 
     config.logging.enabled = false;
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -29,6 +29,7 @@ module.exports = (function() {
       apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
       base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
       editorBase: process.env.AIRTABLE_EDITOR_BASE,
+      saveTranslations: process.env.AIRTABLE_SAVE_TRANSLATIONS === 'true',
     },
 
     logging: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -112,6 +112,7 @@ module.exports = (function() {
     config.airtable.apiKey = 'airtableApiKeyValue';
     config.airtable.base = 'airtableBaseValue';
     config.airtable.editorBase = 'airtableEditorBaseValue';
+    config.airtable.saveTranslations = false;
 
     config.logging.enabled = false;
 

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -28,8 +28,20 @@ async function updateRecord(tableName, body) {
   return records[0];
 }
 
+async function upsertRecords(tableName, records, fieldsToMergeOn) {
+  return _airtableClient().table(tableName).update(
+    records,
+    {
+      performUpsert: {
+        fieldsToMergeOn,
+      },
+    },
+  );
+}
+
 module.exports = {
   findRecords,
   createRecord,
   updateRecord,
+  upsertRecords,
 };

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -40,10 +40,20 @@ const _DatasourcePrototype = {
 
   async upsert(models) {
     const airtableRecords = models.map((model) => this.toAirTableObject(model));
-    const airtableRawObjects = await airtable.upsertRecords(this.tableName, airtableRecords, this.fieldsToMergeOn);
-    return airtableRawObjects.map((airtableRawObject) => this.fromAirTableObject(airtableRawObject));
+    const allAirtableRawObjects = [];
+    for (const chunk of chunks(airtableRecords, 10)) {
+      const airtableRawObjects = await airtable.upsertRecords(this.tableName, chunk, this.fieldsToMergeOn);
+      allAirtableRawObjects.push(...airtableRawObjects.map((airtableRawObject) => this.fromAirTableObject(airtableRawObject)));
+    }
+    return allAirtableRawObjects;
   }
 };
+
+function* chunks(array, chunkSize) {
+  for (let i = 0; i < array.length; i += chunkSize) {
+    yield array.slice(i, i + chunkSize);
+  }
+}
 
 module.exports = {
 

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -37,6 +37,12 @@ const _DatasourcePrototype = {
     const airtableRawObject = await airtable.updateRecord(this.tableName, airtableRequestBody);
     return this.fromAirTableObject(airtableRawObject);
   },
+
+  async upsert(models) {
+    const airtableRecords = models.map((model) => this.toAirTableObject(model));
+    const airtableRawObjects = await airtable.upsertRecords(this.tableName, airtableRecords, this.fieldsToMergeOn);
+    return airtableRawObjects.map((airtableRawObject) => this.fromAirTableObject(airtableRawObject));
+  }
 };
 
 module.exports = {

--- a/api/lib/infrastructure/datasources/airtable/index.js
+++ b/api/lib/infrastructure/datasources/airtable/index.js
@@ -5,6 +5,7 @@ const SkillDatasource = require('./skill-datasource');
 const TubeDatasource = require('./tube-datasource');
 const TutorialDatasource = require('./tutorial-datasource');
 const AttachmentDatasource = require('./attachment-datasource');
+const TranslationDatasource = require('./translation-datasource');
 
 module.exports = {
   AreaDatasource,
@@ -14,4 +15,5 @@ module.exports = {
   TubeDatasource,
   TutorialDatasource,
   AttachmentDatasource,
+  TranslationDatasource,
 };

--- a/api/lib/infrastructure/datasources/airtable/translation-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/translation-datasource.js
@@ -1,0 +1,37 @@
+const datasource = require('./datasource');
+
+module.exports = datasource.extend({
+
+  modelName: 'Translation',
+
+  tableName: 'translations',
+
+  usedFields: [
+    'key',
+    'locale',
+    'value',
+  ],
+
+  fieldsToMergeOn: [
+    'key',
+    'locale',
+  ],
+
+  fromAirTableObject(airtableRecord) {
+    return {
+      key: airtableRecord.get('key'),
+      locale: airtableRecord.get('locale'),
+      value: airtableRecord.get('value'),
+    };
+  },
+
+  toAirTableObject(model) {
+    return {
+      fields: {
+        'key': model.key,
+        'locale': model.locale,
+        'value': model.value,
+      },
+    };
+  },
+});

--- a/api/lib/infrastructure/datasources/airtable/translation-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/translation-datasource.js
@@ -6,6 +6,8 @@ module.exports = datasource.extend({
 
   tableName: 'translations',
 
+  sortField: 'key_locale',
+
   usedFields: [
     'key',
     'locale',
@@ -34,4 +36,16 @@ module.exports = datasource.extend({
       },
     };
   },
+
+  async exists() {
+    try {
+      await this.list({ page: { size: 1 } });
+      return true;
+    } catch (err) {
+      if (err.statusCode === 404) {
+        return false;
+      }
+      throw err;
+    }
+  }
 });

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -1,4 +1,6 @@
 const { knex } = require('../../../db/knex-database-connection');
+const config = require('../../config');
+const translationDatasource = require('../datasources/airtable/translation-datasource');
 
 module.exports = {
   save,
@@ -7,12 +9,18 @@ module.exports = {
 };
 
 async function save(translations) {
-  if (translations.length > 0) {
-    return knex('translations')
-      .insert(translations)
-      .onConflict(['key', 'locale'])
-      .merge();
+  if (translations.length === 0) return [];
+
+  const savedTranslations = await knex('translations')
+    .insert(translations)
+    .onConflict(['key', 'locale'])
+    .merge();
+
+  if (config.airtable.saveTranslations) {
+    await translationDatasource.upsert(translations);
   }
+
+  return savedTranslations;
 }
 
 async function listByPrefix(prefix) {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -20,7 +20,7 @@
         "@hapi/vision": "^7.0.0",
         "@sentry/node": "^7.39.0",
         "adminjs": "^6.8.6",
-        "airtable": "^0.12.0",
+        "airtable": "^0.12.2",
         "axios": "^1.0.0",
         "axios-cookiejar-support": "^4.0.0",
         "base-x": "^4.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -49,7 +49,7 @@
     "@hapi/vision": "^7.0.0",
     "@sentry/node": "^7.39.0",
     "adminjs": "^6.8.6",
-    "airtable": "^0.12.0",
+    "airtable": "^0.12.2",
     "axios": "^1.0.0",
     "axios-cookiejar-support": "^4.0.0",
     "base-x": "^4.0.0",

--- a/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
@@ -13,14 +13,20 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
   beforeEach(() => {
     nock('https://api.test.pix.fr').post(/.*/).reply(200);
     nock('https://api.test.pix.fr').patch(/.*/).reply(200);
+
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
   });
 
-  afterEach(() => {
-    expect(nock.isDone()).to.be.true;
-  });
-
-  afterEach(function() {
-    return knex('translations').truncate();
+  afterEach(async () => {
+    try {
+      expect(nock.isDone()).to.be.true;
+    } finally {
+      await knex('translations').truncate();
+    }
   });
 
   describe('POST /api/airtable/content/Competences', () => {

--- a/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-refresh-cache_test.js
@@ -11,8 +11,12 @@ const createServer = require('../../../server');
 
 describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', () => {
 
-  afterEach(function() {
-    return knex('translations').truncate();
+  afterEach(async function() {
+    try {
+      expect(nock.isDone()).to.be.true;
+    } finally {
+      await knex('translations').truncate();
+    }
   });
 
   describe('POST /api/airtable/content/Competences', () => {
@@ -22,6 +26,12 @@ describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', ()
 
     let user;
     beforeEach(async function() {
+      nock('https://api.airtable.com')
+        .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .optionally()
+        .reply(404);
+
       user = databaseBuilder.factory.buildAdminUser();
       await databaseBuilder.commit();
       competenceDataObject = domainBuilder.buildCompetenceAirtableDataObject({ id: 'recCompetence' });

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -1,0 +1,48 @@
+const { expect, knex } = require('../../../test-helper');
+const translationRepository = require('../../../../lib/infrastructure/repositories/translation-repository');
+const config = require('../../../../lib/config');
+const nock = require('nock');
+
+describe('Integration | Repository | translation-repository', function() {
+
+  afterEach(async function() {
+    await knex('translations').delete();
+    config.airtable.saveTranslations = false;
+  });
+
+  context('#save', function() {
+
+    it('should save translations to airtable when AIRTABLE_SAVE_TRANSLATIONS is true', async function() {
+      // given
+      config.airtable.saveTranslations = true;
+
+      nock('https://api.airtable.com')
+        .patch('/v0/airtableBaseValue/translations/?', {
+          records: [
+            {
+              fields: {
+                key: 'entity.recordid.key',
+                locale: 'fr',
+                value: 'translationValue'
+              }
+            }
+          ],
+          performUpsert: {
+            fieldsToMergeOn: [
+              'key',
+              'locale'
+            ]
+          }
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: [] });
+
+      // when
+      await translationRepository.save([{ key: 'entity.recordid.key', locale: 'fr', value: 'translationValue' }]);
+
+      // then
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});
+

--- a/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
@@ -9,6 +9,12 @@ describe('Migrate translation from airtable', function() {
   let airtableClient;
 
   beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
     airtableClient = new Airtable({
       apiKey: 'airtableApiKeyValue',
     }).base('airtableBaseValue');


### PR DESCRIPTION
## :unicorn: Problème
On veut pouvoir alimenter facilement la table translations dans PG pour un nouvel environnement (en dev ou en RA).

## :robot: Solution
- On créé une table translations dans Airtable pour les environnements concernés, et on fait une double écriture des traductions dans PG et Airtable.
- Les seeds vont lire la table translations dans Airtable si elle existe, et copient toutes les traductions dans la table translations de PG
- Ces 2 mécanismes sont activés par un feature toggle, car ils ne sont pas nécessaires pour les environnements non concernés (PROD etc.)

## :rainbow: Remarques
N/A

## :100: Pour tester
Vérifier que les compétences sur cette RA ont bien un nom différent de "null".