### PR TITLE
[BUGFIX] Problème d'enregistrement de compétence incomplète lorsque la description n'est pas renseignée (PIX-9026)

### DIFF
--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -65,7 +65,7 @@ function* translationsExtractor(competence) {
     airtableField,
     field,
   } of localizedFields) {
-    if (!competence[`${airtableField} ${airtableLocale}`]) return;
+    if (!competence[`${airtableField} ${airtableLocale}`]) continue;
 
     yield {
       key: `${prefix}${id}.${field}`,

--- a/api/tests/unit/infrastructure/translations/competence_test.js
+++ b/api/tests/unit/infrastructure/translations/competence_test.js
@@ -43,6 +43,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
         const competence = {
           'id persistant': 'test',
           'Titre fr-fr': 'titre fr-fr',
+          'Titre en-us': 'titre en-us',
         };
 
         // when
@@ -51,6 +52,7 @@ describe('Unit | Infrastructure | Competence translations', () => {
         // then
         expect(translations).to.deep.equal([
           { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+          { key: 'competence.test.name', locale: 'en', value: 'titre en-us' },
         ]);
       });
     });
@@ -195,6 +197,5 @@ describe('Unit | Infrastructure | Competence translations', () => {
         });
       });
     });
-
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’une compétence ne possède pas tous les champs renseignés, l’enregistrement est incomplet.

Si par exemple on renseigne uniquement les titres français et anglais, seul le titre français est enregistré car ça attend également la description française avant d’enregistrer le titre anglais.

## :robot: Solution
Corriger le code d'extraction des traductions d'une compétence.

## :rainbow: Remarques
Il faut repasser le script de migration des traductions des compétences afin d'être sûr que toutes les traductions sont dans la table.

## :100: Pour tester
Créer une compétence avec seulement des titres (fr et en) et vérifier que les 2 traductions sont dans la table.
