### PR TITLE
[FEATURE] Supprimer l'usage des traductions de compétence de Airtable (PIX-9013)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -8,13 +8,7 @@ module.exports = datasource.extend({
 
   usedFields: [
     'id persistant',
-    'Titre',
-    'Titre fr-fr',
-    'Titre en-us',
     'Sous-domaine',
-    'Description',
-    'Description fr-fr',
-    'Description en-us',
     'Domaine (id persistant)',
     'Acquis (via Tubes) (id persistant)',
     'Thematiques',
@@ -25,15 +19,7 @@ module.exports = datasource.extend({
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.get('id persistant'),
-      name_i18n: {
-        fr: airtableRecord.get('Titre fr-fr') || airtableRecord.get('Titre'),
-        en: airtableRecord.get('Titre en-us') || airtableRecord.get('Titre'),
-      },
       index: airtableRecord.get('Sous-domaine'),
-      description_i18n: {
-        fr: airtableRecord.get('Description fr-fr') || airtableRecord.get('Description'),
-        en: airtableRecord.get('Description en-us') || airtableRecord.get('Description'),
-      },
       areaId: airtableRecord.get('Domaine (id persistant)') ? airtableRecord.get('Domaine (id persistant)')[0] : '',
       skillIds: airtableRecord.get('Acquis (via Tubes) (id persistant)') || [],
       thematicIds: airtableRecord.get('Thematiques') || [],

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -13,7 +13,6 @@ module.exports = datasource.extend({
     'Acquis (via Tubes) (id persistant)',
     'Thematiques',
     'Origine2',
-    'Référence',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -24,9 +23,7 @@ module.exports = datasource.extend({
       skillIds: airtableRecord.get('Acquis (via Tubes) (id persistant)') || [],
       thematicIds: airtableRecord.get('Thematiques') || [],
       origin: airtableRecord.get('Origine2')[0],
-      fullName: airtableRecord.get('Référence'),
     };
   },
-
 });
 

--- a/api/lib/infrastructure/transformers/competence-transformer.js
+++ b/api/lib/infrastructure/transformers/competence-transformer.js
@@ -4,8 +4,6 @@ function filterCompetencesFields(competences) {
   const fieldsToInclude = [
     'id',
     'index',
-    'name_i18n',
-    'description_i18n',
     'areaId',
     'skillIds',
     'thematicIds',

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -40,6 +40,14 @@ module.exports = {
         translation?.value ?? null;
     }
   },
+  dehydrateAirtableObject(competence) {
+    for (const {
+      airtableLocale,
+      airtableField,
+    } of localizedFields) {
+      delete competence[`${airtableField} ${airtableLocale}`];
+    }
+  },
   hydrateReleaseObject(competence, translations) {
     for (const { field } of fields) {
       competence[`${field}_i18n`] = {};

--- a/api/tests/acceptance/application/airtable-proxy-controller_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller_test.js
@@ -1,5 +1,12 @@
 const nock = require('nock');
-const { expect, airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } = require('../../test-helper');
+const {
+  expect,
+  airtableBuilder,
+  databaseBuilder,
+  inputOutputDataBuilder,
+  domainBuilder,
+  generateAuthorizationHeader
+} = require('../../test-helper');
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | airtable-proxy-controller', () => {
@@ -23,7 +30,10 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
       it('should proxy request to airtable', async () => {
         // Given
         const user = await createReadonlyUser();
-        const competenceDataObject = domainBuilder.buildCompetenceAirtableDataObject({
+        const competenceDataObject = domainBuilder.buildCompetenceAirtableDataObject();
+        const competence = airtableBuilder.factory.buildCompetence(competenceDataObject);
+        const inputOutputCompetence = inputOutputDataBuilder.factory.buildCompetence({
+          ...competenceDataObject,
           name_i18n: {
             en: null,
             fr: null,
@@ -33,7 +43,6 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
             fr: null,
           },
         });
-        const competence = airtableBuilder.factory.buildCompetence(competenceDataObject);
         nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Competences?key=value')
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
@@ -49,7 +58,7 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
 
         // Then
         expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.equal(competence);
+        expect(response.result).to.deep.equal(inputOutputCompetence);
       });
 
       it('should proxy post request to airtable', async () => {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -22,7 +22,16 @@ async function mockCurrentContent() {
   const expectedCurrentContent = {
     attachments: [domainBuilder.buildAttachment()],
     areas: [domainBuilder.buildAreaAirtableDataObject()],
-    competences: [domainBuilder.buildCompetenceAirtableDataObject()],
+    competences: [domainBuilder.buildCompetenceForRelease({
+      name_i18n: {
+        fr: 'Français',
+        en: 'English',
+      },
+      description_i18n: {
+        fr: 'Description française',
+        en: 'Description anglaise',
+      }
+    })],
     tubes: [domainBuilder.buildTubeAirtableDataObject()],
     skills: [domainBuilder.buildSkillAirtableDataObject()],
     challenges: [domainBuilder.buildChallengeAirtableDataObject()],

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -264,7 +264,6 @@ function _mockRichAirtableContent() {
     skillIds: ['skill11111', 'skill11112'],
     thematicIds: ['thematic111', 'thematic112'],
     origin: 'FrameworkA',
-    fullName: 'competence11 fullName',
   };
   const airtableCompetence11 = airtableBuilder.factory.buildCompetence(competence11);
   const competence12 = {
@@ -282,7 +281,6 @@ function _mockRichAirtableContent() {
     skillIds: ['skill12121'],
     thematicIds: ['thematic121'],
     origin: 'FrameworkA',
-    fullName: 'competence12 fullName',
   };
   const airtableCompetence12 = airtableBuilder.factory.buildCompetence(competence12);
   const competence21 = {
@@ -300,7 +298,6 @@ function _mockRichAirtableContent() {
     skillIds: ['skill21111'],
     thematicIds: ['thematic211'],
     origin: 'FrameworkA',
-    fullName: 'competence21 fullName',
   };
   const airtableCompetence21 = airtableBuilder.factory.buildCompetence(competence21);
   const airtableThematic111 = airtableBuilder.factory.buildThematic({

--- a/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
@@ -24,15 +24,11 @@ describe('Migrate translation from airtable', function() {
     // given
     const competence = airtableBuilder.factory.buildCompetence({
       index: 1,
-      name_i18n: {
-        fr: 'Bonjour',
-        en: 'Hello',
-      },
-      description_i18n: {
-        fr: 'Description',
-        en: 'Describe',
-      },
     });
+    competence.fields['Titre fr-fr'] = 'Bonjour';
+    competence.fields['Description fr-fr'] = 'Description';
+    competence.fields['Titre en-us'] = 'Hello';
+    competence.fields['Description en-us'] = 'Describe';
     const competences = [competence];
 
     nock('https://api.airtable.com')

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -22,6 +22,10 @@ afterEach(async () => {
 // Knex
 const { knex } = require('../db/knex-database-connection');
 
+// Input Data Builder
+const InputOutputDataBuilder = require('./tooling/input-output-data-builder/input-output-data-builder');
+const inputOutputDataBuilder = new InputOutputDataBuilder();
+
 // DatabaseBuilder
 const DatabaseBuilder = require('./tooling/database-builder/database-builder');
 const databaseBuilder = new DatabaseBuilder({ knex });
@@ -154,6 +158,7 @@ chai.use(function(chai) {
 module.exports = {
   airtableBuilder,
   catchErr,
+  inputOutputDataBuilder,
   databaseBuilder,
   domainBuilder: require('./tooling/domain-builder/factory'),
   expect,

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -5,7 +5,6 @@ module.exports = function buildCompetence({
   skillIds,
   thematicIds,
   origin,
-  fullName,
 } = {}) {
   return {
     id,
@@ -16,7 +15,6 @@ module.exports = function buildCompetence({
       'Acquis (via Tubes) (id persistant)': skillIds,
       'Thematiques': thematicIds,
       'Origine2': [origin],
-      'Référence': fullName,
     },
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
@@ -1,15 +1,7 @@
 module.exports = function buildCompetenceAirtableDataObject({
   id = 'recsvLz0W2ShyfD63',
-  name_i18n = {
-    fr: 'Mener une recherche et une veille d’information',
-    en: 'Browsing, searching and filtering data, information and digital content',
-  },
   index = '1.1',
   areaId = 'recvoGdo7z2z7pXWa',
-  description_i18n = {
-    fr: 'Une description',
-    en: 'Some description',
-  },
   origin = 'Pix',
   skillIds = [
     'recV11ibSCXvaUzZd',
@@ -28,13 +20,11 @@ module.exports = function buildCompetenceAirtableDataObject({
 
   return {
     id,
-    name_i18n,
     index,
     areaId,
     origin,
     skillIds,
     thematicIds,
-    description_i18n,
     fullName,
   };
 };

--- a/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-airtable-data-object.js
@@ -15,7 +15,6 @@ module.exports = function buildCompetenceAirtableDataObject({
     'rec50NXHkatsRkjVQ',
   ],
   thematicIds = ['recFvllz2Ckz'],
-  fullName = '1.1 Mener une recherche et une veille d’information',
 } = {}) {
 
   return {
@@ -25,6 +24,5 @@ module.exports = function buildCompetenceAirtableDataObject({
     origin,
     skillIds,
     thematicIds,
-    fullName,
   };
 };

--- a/api/tests/tooling/input-output-data-builder/factory/build-competence.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-competence.js
@@ -7,7 +7,6 @@ module.exports = function buildCompetence({
   skillIds,
   thematicIds,
   origin,
-  fullName,
 } = {}) {
   return {
     id,
@@ -22,7 +21,6 @@ module.exports = function buildCompetence({
       'Origine2': [origin],
       'Description fr-fr': descriptionFrFr,
       'Description en-us': descriptionEnUs,
-      'Référence': fullName,
     },
   };
 };

--- a/api/tests/tooling/input-output-data-builder/factory/build-competence.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-competence.js
@@ -1,6 +1,8 @@
 module.exports = function buildCompetence({
   id = 'competenceid1',
   index,
+  name_i18n: { fr: nameFrFr, en: nameEnUs },
+  description_i18n: { fr: descriptionFrFr, en: descriptionEnUs } = { fr: null, en: null },
   areaId,
   skillIds,
   thematicIds,
@@ -13,9 +15,13 @@ module.exports = function buildCompetence({
       'id persistant': id,
       'Sous-domaine': index,
       'Domaine (id persistant)': [areaId],
+      'Titre fr-fr': nameFrFr,
+      'Titre en-us': nameEnUs,
       'Acquis (via Tubes) (id persistant)': skillIds,
       'Thematiques': thematicIds,
       'Origine2': [origin],
+      'Description fr-fr': descriptionFrFr,
+      'Description en-us': descriptionEnUs,
       'Référence': fullName,
     },
   };

--- a/api/tests/tooling/input-output-data-builder/factory/index.js
+++ b/api/tests/tooling/input-output-data-builder/factory/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  buildCompetence: require('./build-competence'),
+};

--- a/api/tests/tooling/input-output-data-builder/input-output-data-builder.js
+++ b/api/tests/tooling/input-output-data-builder/input-output-data-builder.js
@@ -1,0 +1,9 @@
+
+const factory = require('./factory/index');
+
+module.exports = class InputOutputDataBuilder {
+  constructor() {
+    this.factory = factory;
+  }
+};
+

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -27,7 +27,6 @@ describe('Unit | Domain | Content', () => {
         skillIds: [],
         thematicIds: [],
         description: 'descriptionCompetenceA',
-        fullName: '1.2 nameCompetenceA',
       });
       const skillAirtable = domainBuilder.buildSkillAirtableDataObject({
         id: 'recSkillA',

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -18,23 +18,15 @@ describe('Unit | Domain | Content', () => {
         competenceAirtableIds: ['recAirCompA', 'recAirCompB'],
         frameworkId: 'recFrameworkA',
       });
-      const competenceAirtable = domainBuilder.buildCompetenceAirtableDataObject({
+      const competenceAirtable = domainBuilder.buildCompetenceForRelease({
         id: 'recCompetenceA',
         name: 'nameCompetenceA',
-        name_i18n: {
-          fr: 'nameFrCompetenceA',
-          en: 'nameEnCompetenceA',
-        },
         index: '1.2',
         areaId: 'recAreaA',
         origin: 'Pix',
         skillIds: [],
         thematicIds: [],
         description: 'descriptionCompetenceA',
-        description_i18n: {
-          fr: 'descriptionFrCompetenceA',
-          en: 'descriptionEnCompetenceA',
-        },
         fullName: '1.2 nameCompetenceA',
       });
       const skillAirtable = domainBuilder.buildSkillAirtableDataObject({
@@ -168,20 +160,12 @@ describe('Unit | Domain | Content', () => {
       const expectedCompetence = domainBuilder.buildCompetenceForRelease({
         id: 'recCompetenceA',
         name: 'nameCompetenceA',
-        name_i18n: {
-          fr: 'nameFrCompetenceA',
-          en: 'nameEnCompetenceA',
-        },
         index: '1.2',
         areaId: 'recAreaA',
         origin: 'Pix',
         skillIds: [],
         thematicIds: [],
         description: 'descriptionCompetenceA',
-        description_i18n: {
-          fr: 'descriptionFrCompetenceA',
-          en: 'descriptionEnCompetenceA',
-        },
       });
       const expectedSkill = domainBuilder.buildSkillForRelease({
         id: 'recSkillA',

--- a/api/tests/unit/infrastructure/transformers/competence-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/competence-transformer_test.js
@@ -9,6 +9,5 @@ describe('Unit | Infrastructure | competence-transformer', function() {
     const competences = filterCompetencesFields(airtableCompetences);
 
     expect(competences.length).to.equal(1);
-    expect(competences[0].fullName).to.not.exist;
   });
 });

--- a/api/tests/unit/infrastructure/translations/competence_test.js
+++ b/api/tests/unit/infrastructure/translations/competence_test.js
@@ -3,198 +3,216 @@ const {
   extractFromAirtableObject,
   hydrateReleaseObject,
   hydrateToAirtableObject,
+  dehydrateAirtableObject
 } = require('../../../../lib/infrastructure/translations/competence');
 
 describe('Unit | Infrastructure | Competence translations', () => {
-  describe('#airtable', () => {
-    describe('#extract', () => {
-      it('should return the list of translations', () => {
-        // given
-        const competence = {
-          'id persistant': 'test',
-          'Titre fr-fr': 'titre fr-fr',
-          'Titre en-us': 'title en-us',
-          'Description fr-fr': 'description en français',
-          'Description en-us': 'english description',
-        };
+  describe('#extractFromAirtableObject', () => {
+    it('should return the list of translations', () => {
+      // given
+      const competence = {
+        'id persistant': 'test',
+        'Titre fr-fr': 'titre fr-fr',
+        'Titre en-us': 'title en-us',
+        'Description fr-fr': 'description en français',
+        'Description en-us': 'english description',
+      };
 
-        // when
-        const translations = extractFromAirtableObject(competence);
+      // when
+      const translations = extractFromAirtableObject(competence);
 
-        // then
-        expect(translations).to.deep.equal([
-          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-          {
-            key: 'competence.test.description',
-            locale: 'fr',
-            value: 'description en français',
-          },
-          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-          {
-            key: 'competence.test.description',
-            locale: 'en',
-            value: 'english description',
-          },
-        ]);
-      });
+      // then
+      expect(translations).to.deep.equal([
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+        {
+          key: 'competence.test.description',
+          locale: 'fr',
+          value: 'description en français',
+        },
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+        {
+          key: 'competence.test.description',
+          locale: 'en',
+          value: 'english description',
+        },
+      ]);
+    });
 
-      it('should return translations only for field w/ values', () => {
-        // given
-        const competence = {
-          'id persistant': 'test',
-          'Titre fr-fr': 'titre fr-fr',
-          'Titre en-us': 'titre en-us',
-        };
+    it('should return translations only for field w/ values', () => {
+      // given
+      const competence = {
+        'id persistant': 'test',
+        'Titre fr-fr': 'titre fr-fr',
+        'Titre en-us': 'titre en-us',
+      };
 
-        // when
-        const translations = extractFromAirtableObject(competence);
+      // when
+      const translations = extractFromAirtableObject(competence);
 
-        // then
-        expect(translations).to.deep.equal([
-          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-          { key: 'competence.test.name', locale: 'en', value: 'titre en-us' },
-        ]);
+      // then
+      expect(translations).to.deep.equal([
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+        { key: 'competence.test.name', locale: 'en', value: 'titre en-us' },
+      ]);
+    });
+  });
+  describe('#hydrateAirtableObject', () => {
+    it('should set translated fields into the object', () => {
+      // given
+      const competence = {
+        'id persistant': 'test',
+        'Titre fr-fr': 'titre fr-fr initial',
+        otherField: 'foo',
+      };
+      const translations = [
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+        {
+          key: 'competence.test.description',
+          locale: 'fr',
+          value: 'description en français',
+        },
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+        {
+          key: 'competence.test.description',
+          locale: 'en',
+          value: 'english description',
+        },
+      ];
+
+      // when
+      hydrateToAirtableObject(competence, translations);
+
+      // then
+      expect(competence).to.deep.equal({
+        'id persistant': 'test',
+        'Titre fr-fr': 'titre fr-fr',
+        'Titre en-us': 'title en-us',
+        'Description fr-fr': 'description en français',
+        'Description en-us': 'english description',
+        otherField: 'foo',
       });
     });
 
-    describe('#hydrate', () => {
-      it('should set translated fields into the object', () => {
-        // given
-        const competence = {
-          'id persistant': 'test',
-          'Titre fr-fr': 'titre fr-fr initial',
-          otherField: 'foo',
-        };
-        const translations = [
-          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-          {
-            key: 'competence.test.description',
-            locale: 'fr',
-            value: 'description en français',
-          },
-          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-          {
-            key: 'competence.test.description',
-            locale: 'en',
-            value: 'english description',
-          },
-        ];
+    it('should set null value for missing translations', () => {
+      // given
+      const competence = {
+        'id persistant': 'test',
+        'Titre fr-fr': 'titre fr-fr initial',
+      };
+      const translations = [
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+        {
+          key: 'competence.test.description',
+          locale: 'en',
+          value: 'english description',
+        },
+      ];
 
-        // when
-        hydrateToAirtableObject(competence, translations);
+      // when
+      hydrateToAirtableObject(competence, translations);
 
-        // then
-        expect(competence).to.deep.equal({
-          'id persistant': 'test',
-          'Titre fr-fr': 'titre fr-fr',
-          'Titre en-us': 'title en-us',
-          'Description fr-fr': 'description en français',
-          'Description en-us': 'english description',
-          otherField: 'foo',
-        });
-      });
-
-      it('should set null value for missing translations', () => {
-        // given
-        const competence = {
-          'id persistant': 'test',
-          'Titre fr-fr': 'titre fr-fr initial',
-        };
-        const translations = [
-          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-          {
-            key: 'competence.test.description',
-            locale: 'en',
-            value: 'english description',
-          },
-        ];
-
-        // when
-        hydrateToAirtableObject(competence, translations);
-
-        // then
-        expect(competence).to.deep.equal({
-          'id persistant': 'test',
-          'Titre fr-fr': null,
-          'Titre en-us': 'title en-us',
-          'Description fr-fr': null,
-          'Description en-us': 'english description',
-        });
+      // then
+      expect(competence).to.deep.equal({
+        'id persistant': 'test',
+        'Titre fr-fr': null,
+        'Titre en-us': 'title en-us',
+        'Description fr-fr': null,
+        'Description en-us': 'english description',
       });
     });
   });
-  describe('#release', () => {
-    describe('#hydrate', () => {
-      it('should set translated fields into the object', () => {
-        // given
-        const competence = {
-          id: 'test',
-          otherField: 'foo',
-        };
-        const translations = [
-          { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
-          {
-            key: 'competence.test.description',
-            locale: 'fr',
-            value: 'description en français',
-          },
-          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-          {
-            key: 'competence.test.description',
-            locale: 'en',
-            value: 'english description',
-          },
-        ];
 
-        // when
-        hydrateReleaseObject(competence, translations);
+  describe('#dehydrateAirtableObject', () => {
+    it('should set translated fields into the object', () => {
+      // given
+      const competence = {
+        'id persistant': 'test',
+        'Titre fr-fr': 'titre fr-fr initial',
+        'Description fr-fr': 'description fr-fr initial',
+        otherField: 'foo',
+      };
 
-        // then
-        expect(competence).to.deep.equal({
-          id: 'test',
-          name_i18n: {
-            fr: 'titre fr-fr',
-            en: 'title en-us',
-          },
-          description_i18n: {
-            fr: 'description en français',
-            en: 'english description',
-          },
-          otherField: 'foo',
-        });
+      // when
+      dehydrateAirtableObject(competence);
+
+      // then
+      expect(competence).to.deep.equal({
+        'id persistant': 'test',
+        otherField: 'foo',
       });
+    });
+  });
 
-      it('should set null value for missing translations', () => {
-        // given
-        const competence = {
-          id: 'test',
-          otherField: 'foo',
-        };
-        const translations = [
-          { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
-          {
-            key: 'competence.test.description',
-            locale: 'en',
-            value: 'english description',
-          },
-        ];
+  describe('#hydrateReleaseObject', () => {
+    it('should set translated fields into the object', () => {
+      // given
+      const competence = {
+        id: 'test',
+        otherField: 'foo',
+      };
+      const translations = [
+        { key: 'competence.test.name', locale: 'fr', value: 'titre fr-fr' },
+        {
+          key: 'competence.test.description',
+          locale: 'fr',
+          value: 'description en français',
+        },
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+        {
+          key: 'competence.test.description',
+          locale: 'en',
+          value: 'english description',
+        },
+      ];
 
-        // when
-        hydrateReleaseObject(competence, translations);
+      // when
+      hydrateReleaseObject(competence, translations);
 
-        // then
-        expect(competence).to.deep.equal({
-          id: 'test',
-          name_i18n: {
-            fr: null,
-            en: 'title en-us',
-          },
-          description_i18n: {
-            fr: null,
-            en: 'english description',
-          },
-          otherField: 'foo',
-        });
+      // then
+      expect(competence).to.deep.equal({
+        id: 'test',
+        name_i18n: {
+          fr: 'titre fr-fr',
+          en: 'title en-us',
+        },
+        description_i18n: {
+          fr: 'description en français',
+          en: 'english description',
+        },
+        otherField: 'foo',
+      });
+    });
+
+    it('should set null value for missing translations', () => {
+      // given
+      const competence = {
+        id: 'test',
+        otherField: 'foo',
+      };
+      const translations = [
+        { key: 'competence.test.name', locale: 'en', value: 'title en-us' },
+        {
+          key: 'competence.test.description',
+          locale: 'en',
+          value: 'english description',
+        },
+      ];
+
+      // when
+      hydrateReleaseObject(competence, translations);
+
+      // then
+      expect(competence).to.deep.equal({
+        id: 'test',
+        name_i18n: {
+          fr: null,
+          en: 'title en-us',
+        },
+        description_i18n: {
+          fr: null,
+          en: 'english description',
+        },
+        otherField: 'foo',
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Il restait les traductions fr et en des compétences de Airtable, qui ne sont plus utilisées puisqu'on passe par PG maintenant.

## :robot: Solution
Suppression des champs concernés.

## :rainbow: Remarques
Les test ont dû être en partie ré-écrits pour cause de champ fullName (ou Référence en fonction d'où on se trouve) qui est récupéré, supprimé, puis renvoyé, mais a priori totalement inutilisé en Release (et en Répli).
A voir si on veut finir par totalement s'en débarrasser.

## :100: Pour tester
Modifier ou créer une compétence, et vérifier que les colonnes de traduction de titre et description de compétence ne sont pas remplies.