### PR TITLE
[BUGFIX] Logs d'erreur à tort lors de l'enregistrement de traductions (PIX-9077)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/translation-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/translation-datasource.js
@@ -45,7 +45,7 @@ module.exports = datasource.extend({
     } catch (err) {
       // When using API key, Airtable returns status code 404 if table doesn't exist
       // When using personal access token, Airtable returns status code 403 if table doesn't exist
-      if (err.statusCode !== 403 || err.statusCode !== 404) {
+      if (err.statusCode !== 403 && err.statusCode !== 404) {
         logger.error(err, 'Error while checking for Airtable translations table');
       }
       return false;


### PR DESCRIPTION
## :unicorn: Problème
Si la table translations n’existe pas dans Airtable, on log une erreur systématiquement à tort.

## :robot: Solution
Logger une erreur uniquement en cas de code d'erreur non attendu.

## :rainbow: Remarques
N/A

## :100: Pour tester
Créer/modifier une compétence et vérifier qu'il n'y a pas de log d'erreur `Error while checking for Airtable translations table`