### PR TITLE
[TECH] Supprimer la colonne "imageUrl" de la table des tests statiques, attribut non utilisé (PIX-9080)

### DIFF
--- a/api/db/migrations/20230802085633_migrate-static-courses-from-airtable.js
+++ b/api/db/migrations/20230802085633_migrate-static-courses-from-airtable.js
@@ -1,11 +1,12 @@
 const Airtable = require('airtable');
+const TESTS_TABLE_IN_AIRTABLE_EXISTS = false;
 
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
 exports.up = async function(knex) {
-  if (process.env.NODE_ENV !== 'production') return;
+  if (process.env.NODE_ENV !== 'production' || !TESTS_TABLE_IN_AIRTABLE_EXISTS) return;
   const airtableClient = new Airtable({
     apiKey: process.env.AIRTABLE_API_KEY,
   }).base(process.env.AIRTABLE_BASE);

--- a/api/db/migrations/20230905083431_drop-column-imageurl-in-table-static-courses.js
+++ b/api/db/migrations/20230905083431_drop-column-imageurl-in-table-static-courses.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'static_courses';
+const IMAGE_URL_COLUMN = 'imageUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(IMAGE_URL_COLUMN);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.string(IMAGE_URL_COLUMN);
+  });
+};
+

--- a/api/db/seeds/data/static-courses.js
+++ b/api/db/seeds/data/static-courses.js
@@ -4,7 +4,6 @@ module.exports = function(databaseBuilder) {
     name: 'Static Course 1',
     description: 'Static Course 1 description',
     challengeIds: 'challenge1NQqfx9mYKUQEO,challengeTYFrFy5EGYEet,challenge1rSPsnisQ8ft4W',
-    imageUrl: 'some/image/url',
     createdAt: new Date(),
     isActive: true,
   });
@@ -14,7 +13,6 @@ module.exports = function(databaseBuilder) {
     name: 'Static Course 2',
     description: 'Static Course 2 description',
     challengeIds: 'challenge1NQqfx9mYKUQEO',
-    imageUrl: 'some/image/url',
     createdAt: new Date('2021-01-01'),
     isActive: false,
     deactivationReason: 'Les épreuves sont trop faciles',

--- a/api/lib/domain/models/CourseForRelease.js
+++ b/api/lib/domain/models/CourseForRelease.js
@@ -6,7 +6,6 @@ module.exports = class CourseForRelease {
     isActive,
     competences,
     challenges,
-    imageUrl,
   }) {
     this.id = id;
     this.name = name;
@@ -14,6 +13,5 @@ module.exports = class CourseForRelease {
     this.isActive = isActive;
     this.competences = competences;
     this.challenges = challenges;
-    this.imageUrl = imageUrl;
   }
 };

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -151,10 +151,10 @@ async function _getCurrentContentFromAirtable(challenges) {
 
 async function _getCurrentContentFromPG(airtableChallenges) {
   const staticCoursesDTO = await knex('static_courses')
-    .select(['id', 'name', 'description', 'isActive', 'challengeIds', 'imageUrl'])
+    .select(['id', 'name', 'description', 'isActive', 'challengeIds'])
     .orderBy('id');
   return {
-    courses: staticCoursesDTO.map(({ id, name, description, isActive, challengeIds, imageUrl }) => {
+    courses: staticCoursesDTO.map(({ id, name, description, isActive, challengeIds }) => {
       const challenges = challengeIds.replaceAll(' ', '').split(',');
       const competences = challenges.map((challengeId) => {
         return airtableChallenges.find((airtableChallenge) => airtableChallenge.id === challengeId).competenceId;
@@ -166,7 +166,6 @@ async function _getCurrentContentFromPG(airtableChallenges) {
         isActive,
         challenges,
         competences,
-        imageUrl,
       };
     }),
   };

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -54,7 +54,6 @@ async function mockCurrentContent() {
     name: 'nameCourse2',
     description: 'Description du Course',
     challengeIds: 'recChallenge0',
-    imageUrl: 'Image du Course',
   });
 
   databaseBuilder.factory.buildStaticCourse({
@@ -62,7 +61,6 @@ async function mockCurrentContent() {
     name: 'nameCourse1',
     description: 'Description du Course',
     challengeIds: 'recChallenge0',
-    imageUrl: 'Image du Course',
   });
 
   await databaseBuilder.commit();

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -148,7 +148,6 @@ async function mockCurrentContent() {
       isActive: true,
       competences: ['recCompetence0'],
       challenges: ['recChallenge0'],
-      imageUrl: 'Image du Course',
     }],
   };
 
@@ -180,7 +179,6 @@ async function mockCurrentContent() {
     description: 'Description du Course',
     isActive: true,
     challengeIds: 'recChallenge0',
-    imageUrl: 'Image du Course',
   });
 
   databaseBuilder.factory.buildTranslation({
@@ -336,7 +334,6 @@ async function mockContentForRelease() {
       isActive: true,
       competences: ['recCompetence0'],
       challenges: ['recChallenge0'],
-      imageUrl: 'Image du Course',
     }],
   };
 

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -201,7 +201,6 @@ describe('Integration | Repository | release-repository', function() {
         description: 'course1PG description',
         isActive: false,
         challengeIds: 'challenge121212,challenge211113',
-        imageUrl: 'course1PG/image.png',
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2020-01-02'),
       });
@@ -1257,7 +1256,6 @@ function _getRichCurrentContentDTO() {
       isActive: false,
       competences: ['competence12', 'competence21'],
       challenges: ['challenge121212', 'challenge211113'],
-      imageUrl: 'course1PG/image.png',
     },
   ];
   const expectedTutorialDTOs = [

--- a/api/tests/tooling/database-builder/factory/build-static-course.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course.js
@@ -5,14 +5,13 @@ function buildStaticCourse({
   name = 'Mon super test statique',
   description = 'Ma super description de test statique',
   challengeIds = 'challengeABC, challengeDEF',
-  imageUrl = 'ma/super/image.png',
   isActive = true,
   deactivationReason = '',
   createdAt = new Date('2010-01-04'),
   updatedAt = new Date('2010-01-11'),
 } = {}) {
 
-  const values = { id, name, description, deactivationReason, challengeIds, imageUrl, createdAt, updatedAt, isActive };
+  const values = { id, name, description, deactivationReason, challengeIds, createdAt, updatedAt, isActive };
 
   return databaseBuffer.pushInsertable({
     tableName: 'static_courses',

--- a/api/tests/tooling/domain-builder/factory/build-course-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-course-for-release.js
@@ -3,7 +3,6 @@ const CourseForRelease = require('../../../../lib/domain/models/CourseForRelease
 module.exports = function buildCourseForRelease({
   id = 'recPBOj7JzBcgXEtO',
   description = 'Programmer niveau 1 et 2',
-  imageUrl = 'https://dl.airtable.com/otNiedKYSTBmoAPdyIk2_woman-163426_1920.jpg',
   name = '3.4 niveau 1 et 2',
   challenges = ['recs9uvUWKQ4HDzw6'],
   competences = ['rec8116cdd76088af'],
@@ -11,7 +10,6 @@ module.exports = function buildCourseForRelease({
   return new CourseForRelease({
     id,
     description,
-    imageUrl,
     name,
     challenges,
     competences,

--- a/api/tests/tooling/domain-builder/factory/build-course-postgres-data-object.js
+++ b/api/tests/tooling/domain-builder/factory/build-course-postgres-data-object.js
@@ -2,7 +2,6 @@ module.exports = function buildCoursePostgresDataObject(
   {
     id = 'recPBOj7JzBcgXEtO',
     description = 'Programmer niveau 1 et 2',
-    imageUrl = 'https://dl.airtable.com/otNiedKYSTBmoAPdyIk2_woman-163426_1920.jpg',
     name = '3.4 niveau 1 et 2',
     challenges = [
       'recs9uvUWKQ4HDzw6',
@@ -19,7 +18,6 @@ module.exports = function buildCoursePostgresDataObject(
   return {
     id,
     description,
-    imageUrl,
     name,
     challenges,
     competences,

--- a/api/tests/unit/domain/models/Content_test.js
+++ b/api/tests/unit/domain/models/Content_test.js
@@ -95,7 +95,6 @@ describe('Unit | Domain | Content', () => {
       const coursePostgres = domainBuilder.buildCoursePostgresDataObject({
         id: 'recCourse1',
         description: 'descriptionCourse1',
-        imageUrl: 'http://www.example.com/this-is-an-example.jpg',
         name: 'nameCourse1',
         challenges: ['recChallengeId1'],
         competences: ['recCompetenceId1'],
@@ -244,7 +243,6 @@ describe('Unit | Domain | Content', () => {
       const expectedCourse = domainBuilder.buildCourseForRelease({
         id: 'recCourse1',
         description: 'descriptionCourse1',
-        imageUrl: 'http://www.example.com/this-is-an-example.jpg',
         name: 'nameCourse1',
         challenges: ['recChallengeId1'],
         competences: ['recCompetenceId1'],


### PR DESCRIPTION
## :unicorn: Problème
La colonne imageUrl de la table des tests statiques n'est utilisé nulle part (pas non plus par les consommateurs de la release ou la réplication)

## :robot: Solution
- On drop la colonne
- On supprime toute référence à cet attribut

## :rainbow: Remarques
Petit commit supplémentaire correctif pour une migration.
Finalement c'était une boulette de mettre la migration de donnée dans une migration KNEX. Là la migration échoue car la table TESTS n'existe plus dans Airtable.
On apprend de nos erreurs 🚀 

## :100: Pour tester
Non rég autour des tests statiques (et encore)
