### PR TITLE
[FEATURE] Exporter les traductions depuis l'interface d'admin (PIX-8977).

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -37,7 +37,7 @@ export async function seed(knex) {
   await translationsBuilder(databaseBuilder);
 
   return databaseBuilder.commit();
-};
+}
 
 const adminUserApiKey = !process.env.REVIEW_APP && '8d03a893-3967-4501-9dc4-e0aa6c6dc442';
 const defaultEditorUserApiKey = !process.env.REVIEW_APP && 'adaf3eee-09dc-4f9a-a504-ff92e74c9d0f';

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -22,9 +22,9 @@ export async function checkUserIsAuthenticatedViaBasicAndAdmin(username) {
     if (user.access !== 'admin') {
       throw new Error('not an admin');
     }
-    return { isValid: true, credentials: { user } };
+    return { email: username };
   } catch (error) {
-    return { isValid: false };
+    return false;
   }
 }
 

--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -1,11 +1,16 @@
-export default async function register(server) {
+import { PassThrough } from 'node:stream';
+import { exportTranslations } from '../domain/usecases/export-translations';
+
+export async function register(server) {
   server.route([
     {
       method: 'GET',
       path: '/api/translations.csv',
       config: {
-        handler: function(request, h) {
-          return h.response('ok');
+        handler: function(_, h) {
+          const stream = new PassThrough();
+          exportTranslations(stream);
+          return h.response(stream).header('Content-type', 'text/csv');
         }
       },
     },

--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -1,0 +1,16 @@
+export default async function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/translations.csv',
+      config: {
+        handler: function(request, h) {
+          return h.response('ok');
+        }
+      },
+    },
+  ]);
+}
+
+export const name = 'translations-api';
+

--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -1,5 +1,5 @@
 import { PassThrough } from 'node:stream';
-import { exportTranslations } from '../domain/usecases/export-translations';
+import { exportTranslations } from '../domain/usecases/export-translations.js';
 
 export async function register(server) {
   server.route([

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -1,0 +1,14 @@
+import csv from 'fast-csv';
+import { translationRepository } from '../../infrastructure/repositories/index.js';
+
+export async function exportTranslations(stream, dependencies = { translationRepository }) {
+
+  const translations = await dependencies.translationRepository.list();
+  const csvStream = csv.format({ headers: true });
+  csvStream.pipe(stream);
+
+  translations.forEach((translation)=> {
+    csvStream.write(translation);
+  });
+  csvStream.end();
+}

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -2,13 +2,8 @@ import csv from 'fast-csv';
 import { translationRepository } from '../../infrastructure/repositories/index.js';
 
 export async function exportTranslations(stream, dependencies = { translationRepository }) {
-
-  const translations = await dependencies.translationRepository.list();
+  const translationsStream = dependencies.translationRepository.streamList();
   const csvStream = csv.format({ headers: true });
   csvStream.pipe(stream);
-
-  translations.forEach((translation)=> {
-    csvStream.write(translation);
-  });
-  csvStream.end();
+  translationsStream.pipe(csvStream);
 }

--- a/api/lib/infrastructure/plugins/adminjs/components/ExportComponent.jsx
+++ b/api/lib/infrastructure/plugins/adminjs/components/ExportComponent.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { Box, Button, Loader } from '@adminjs/design-system'
+import { useCurrentAdmin, useNotice } from 'adminjs';
+import { saveAs } from 'file-saver';
+
+const ExportComponent = () => {
+  const [isFetching, setFetching] = useState();
+  const sendNotice = useNotice();
+  const [currentAdmin] = useCurrentAdmin();
+
+  async function exportTranslations() {
+    setFetching(true);
+    try {
+      const token = currentAdmin?.email;
+      const { data } = await axios.get('/api/translations.csv', {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        },
+      });
+      const blob = new Blob([data], { type: 'text/csv' });
+      saveAs(blob, 'export-translations.csv');
+      sendNotice({ message: 'Exported successfully', type: 'success' });
+    } catch (e) {
+      sendNotice({ message: e.message, type: 'error' });
+    }
+    setFetching(false);
+  }
+
+  if (isFetching) {
+    return <Loader />;
+  }
+
+  return (
+    <Box>
+      <Box display="flex" justifyContent="left">
+        <Box key="csv" m={2}>
+          <Button
+            onClick={exportTranslations}
+            variant="outlined"
+            disabled={isFetching}
+          >
+            Exporter toutes les traductions dans un fichier CSV
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ExportComponent;

--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -1,14 +1,18 @@
-import AdminJS from 'adminjs';
+import { AdminJS, ComponentLoader } from 'adminjs';
 import AdminJSSequelize from '@adminjs/sequelize';
-import { User, Release } from './models.js';
-import AdminJSHapi from '@adminjs/hapi';
+import { User, Release, Translations } from './models.js';
 
 AdminJS.registerAdapter(AdminJSSequelize);
 
-// HACK: to be removed after upgrading to adminjs v7
-export const plugin = AdminJSHapi.default ?? AdminJSHapi;
+export { default as plugin } from '@adminjs/hapi';
+
+const componentLoader = new ComponentLoader();
+const Components = {
+  ExportComponent: componentLoader.add('ExportComponent', './components/ExportComponent.jsx'),
+};
 
 export const options = {
+  componentLoader,
   resources: [
     {
       resource: User,
@@ -41,7 +45,26 @@ export const options = {
         },
       },
     },
-    Release,
+    {
+      resource: Release,
+    },
+    {
+      resource: Translations,
+      options: {
+        actions: {
+          export: {
+            actionType: 'resource',
+            component: Components.ExportComponent,
+          },
+        },
+      },
+    },
   ],
-  auth: { strategy: 'simple' },
+  auth: {
+    strategy: 'session',
+    cookiePassword: process.env.ADMIN_COOKIE_PASSWORD,
+    cookieName: 'adminCookie',
+    authenticate: (email, password) => ({ email, password }),
+  },
 };
+

--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -5,7 +5,7 @@ import { checkUserIsAuthenticatedViaBasicAndAdmin } from '../../../application/s
 
 AdminJS.registerAdapter(AdminJSSequelize);
 
-export { default as plugin } from '@adminjs/hapi';
+export { default as plugin } from '@1024pix/adminjs-hapijs';
 
 const componentLoader = new ComponentLoader();
 const Components = {

--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -62,7 +62,7 @@ export const options = {
   ],
   auth: {
     strategy: 'session',
-    cookiePassword: process.env.ADMIN_COOKIE_PASSWORD,
+    cookiePassword: process.env.ADMIN_COOKIE_PASSWORD || 'very-long-password-for-tests-only',
     cookieName: 'adminCookie',
     authenticate: (email, password) => ({ email, password }),
   },

--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -1,6 +1,7 @@
 import { AdminJS, ComponentLoader } from 'adminjs';
 import AdminJSSequelize from '@adminjs/sequelize';
 import { User, Release, Translations } from './models.js';
+import { checkUserIsAuthenticatedViaBasicAndAdmin } from '../../../application/security-pre-handlers.js';
 
 AdminJS.registerAdapter(AdminJSSequelize);
 
@@ -64,7 +65,7 @@ export const options = {
     strategy: 'session',
     cookiePassword: process.env.ADMIN_COOKIE_PASSWORD || 'very-long-password-for-tests-only',
     cookieName: 'adminCookie',
-    authenticate: (email, password) => ({ email, password }),
+    authenticate: (email) => checkUserIsAuthenticatedViaBasicAndAdmin(email),
   },
 };
 

--- a/api/lib/infrastructure/plugins/adminjs/models.js
+++ b/api/lib/infrastructure/plugins/adminjs/models.js
@@ -35,3 +35,24 @@ export const Release = sequelize.define(
     timestamps: false,
   }
 );
+
+export const Translations = sequelize.define(
+  'translation',
+  {
+    key: {
+      type: DataTypes.TEXT,
+      primaryKey: true,
+    },
+    locale : {
+      type: DataTypes.TEXT,
+      primaryKey: true,
+    },
+    value: {
+      type: DataTypes.TEXT,
+    },
+  },
+  {
+    timestamps: false,
+  },
+);
+

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -8,6 +8,7 @@ import * as replicationDataRoute from './application/replication-data.js';
 import * as staticCoursesRoute from './application/static-courses/index.js';
 import * as staticRoute from './application/static/index.js';
 import * as usersRoute from './application/users.js';
+import * as translationsRoute from './application/translations.js';
 
 export const routes = [
   airtableProxyRoute,
@@ -20,4 +21,5 @@ export const routes = [
   staticCoursesRoute,
   staticRoute,
   usersRoute,
+  translationsRoute,
 ];

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -40,6 +40,7 @@
         "oppsy": "https://github.com/1024pix/oppsy#main",
         "p-map": "^6.0.0",
         "pg": "^8.9.0",
+        "pg-query-stream": "^4.5.3",
         "pino": "^8.0.0",
         "pino-pretty": "^10.2.0",
         "prom-client": "^14.0.0",
@@ -8998,6 +8999,14 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
       "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
     },
+    "node_modules/pg-cursor": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.10.3.tgz",
+      "integrity": "sha512-rDyBVoqPVnx/PTmnwQAYgusSeAKlTL++gmpf5klVK+mYMFEqsOc6VHHZnPKc/4lOvr4r6fiMuoxSFuBF1dx4FQ==",
+      "peerDependencies": {
+        "pg": "^8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -9018,6 +9027,17 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
       "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.5.3.tgz",
+      "integrity": "sha512-ufa94r/lHJdjAm3+zPZEO0gXAmCb4tZPaOt7O76mjcxdL/HxwTuryy76km+u0odBBgtfdKFYq/9XGfiYeQF0yA==",
+      "dependencies": {
+        "pg-cursor": "^2.10.3"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/pg-types": {
       "version": "2.2.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "@adminjs/hapi": "^7.0.0",
         "@adminjs/sequelize": "^4.0.0",
-        "@hapi/basic": "^7.0.0",
         "@hapi/boom": "^10.0.0",
         "@hapi/cookie": "^12.0.0",
         "@hapi/hapi": "^21.3.0",
@@ -2569,15 +2568,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.1.tgz",
       "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
       "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
-    "node_modules/@hapi/basic": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/basic/-/basic-7.0.2.tgz",
-      "integrity": "sha512-kdpsmCEHVDlIYStRbszSyy/9+dq5KkfWLX5AjuHGPwtzuuZopZnhkVvMZV45hQ8hA8V/weCoMs0nzXJ7JCA2ow==",
-      "dependencies": {
-        "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
     },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -27,6 +27,7 @@
         "blipp": "4.0.2",
         "bull": "^4.10.4",
         "dotenv": "^16.0.0",
+        "fast-csv": "4.3.6",
         "googleapis": "^126.0.0",
         "hapi-pino": "^8.4.0",
         "hapi-sentry": "^4.0.0-0",
@@ -2484,6 +2485,43 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.59.tgz",
+      "integrity": "sha512-NWJMpBL2Xs3MY93yrD6YrrTKep8eIA6iMnfG4oIc6LrTRlBZgiSCGiY3V/Owlp6umIBLyKb4F8Q7hxWatjYH5A=="
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.59.tgz",
+      "integrity": "sha512-NWJMpBL2Xs3MY93yrD6YrrTKep8eIA6iMnfG4oIc6LrTRlBZgiSCGiY3V/Owlp6umIBLyKb4F8Q7hxWatjYH5A=="
     },
     "node_modules/@floating-ui/core": {
       "version": "1.4.1",
@@ -6163,6 +6201,18 @@
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
       "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
     },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7850,16 +7900,51 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7881,6 +7966,11 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
       "integrity": "sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww=="
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
     "node_modules/log-symbols": {
       "version": "5.1.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@adminjs/hapi": "^7.0.0",
+        "@1024pix/adminjs-hapijs": "^7.0.1",
         "@adminjs/sequelize": "^4.0.0",
         "@hapi/boom": "^10.0.0",
         "@hapi/cookie": "^12.0.0",
@@ -67,6 +67,26 @@
         "node": "^v18.17.1"
       }
     },
+    "node_modules/@1024pix/adminjs-hapijs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/adminjs-hapijs/-/adminjs-hapijs-7.0.1.tgz",
+      "integrity": "sha512-0TrbgdGA1uT6qkCSIUoRz2A5RY+qr0cLC+kPVqhx0YKcs/2uCenETu6USAtFhV2YEzcGl2hTD3fAucnOWWOueQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@hapi/boom": "^9.1.4 || ^10.0.0",
+        "@hapi/cookie": "^11.0.2 || ^12.0.0",
+        "@hapi/hapi": "^20.2.1 || ^21.0.0",
+        "@hapi/inert": "^6.0.5 || ^7.0.0",
+        "adminjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@hapi/inert": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -119,26 +139,6 @@
       "peerDependencies": {
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
-      }
-    },
-    "node_modules/@adminjs/hapi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@adminjs/hapi/-/hapi-7.0.0.tgz",
-      "integrity": "sha512-AMbvbJ3XUpZUeWgzdT4x9iuXhXMLjP6Yfdj9SGdQZD3Nd6qgJ7hLMGVhHUKErCN+DLbrPL8z00dtKcSacz/+Pg==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "peerDependencies": {
-        "@hapi/boom": "^9.1.4 || ^10.0.0",
-        "@hapi/cookie": "^11.0.2 || ^12.0.0",
-        "@hapi/hapi": "^20.2.1 || ^21.0.0",
-        "@hapi/inert": "^6.0.5 || ^7.0.0",
-        "adminjs": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@hapi/inert": {
-          "optional": true
-        }
       }
     },
     "node_modules/@adminjs/sequelize": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -28,6 +28,7 @@
         "bull": "^4.10.4",
         "dotenv": "^16.0.0",
         "fast-csv": "4.3.6",
+        "file-saver": "2.0.5",
         "googleapis": "^126.0.0",
         "hapi-pino": "^8.4.0",
         "hapi-sentry": "^4.0.0-0",
@@ -6264,6 +6265,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -59,6 +59,7 @@
     "bull": "^4.10.4",
     "dotenv": "^16.0.0",
     "fast-csv": "4.3.6",
+    "file-saver": "2.0.5",
     "googleapis": "^126.0.0",
     "hapi-pino": "^8.4.0",
     "hapi-sentry": "^4.0.0-0",

--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "eslint .js,.cjs lib tests --fix",
     "preinstall": "npx check-engine && git config core.hooksPath .githooks || true",
     "start": "node index.js",
-    "start:watch": "nodemon --signal SIGTERM index.js",
+    "start:watch": "nodemon --ext js,cjs,json,jsx --signal SIGTERM index.js",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
     "test:api": "NODE_ENV=test vitest run",
     "test:api:unit": "NODE_ENV=test vitest run tests/unit/",

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
   "author": "GIP Pix",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@adminjs/hapi": "^7.0.0",
+    "@1024pix/adminjs-hapijs": "^7.0.1",
     "@adminjs/sequelize": "^4.0.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/cookie": "^12.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -71,6 +71,7 @@
     "oppsy": "https://github.com/1024pix/oppsy#main",
     "p-map": "^6.0.0",
     "pg": "^8.9.0",
+    "pg-query-stream": "^4.5.3",
     "pino": "^8.0.0",
     "pino-pretty": "^10.2.0",
     "prom-client": "^14.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -58,6 +58,7 @@
     "blipp": "4.0.2",
     "bull": "^4.10.4",
     "dotenv": "^16.0.0",
+    "fast-csv": "4.3.6",
     "googleapis": "^126.0.0",
     "hapi-pino": "^8.4.0",
     "hapi-sentry": "^4.0.0-0",

--- a/api/package.json
+++ b/api/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@adminjs/hapi": "^7.0.0",
     "@adminjs/sequelize": "^4.0.0",
-    "@hapi/basic": "^7.0.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/cookie": "^12.0.0",
     "@hapi/hapi": "^21.3.0",

--- a/api/sample.env
+++ b/api/sample.env
@@ -7,6 +7,7 @@
 #   3. uncomment the lines to activate or configure associated features
 #
 # Sections (displayed in sorted in alphabtic order):
+#   - server
 #   - databases
 #   - learning content
 #   - logging
@@ -25,6 +26,13 @@
 # type: Boolean
 # default: `undefined` (`false`)
 # ENABLE_REQUEST_MONITORING=true
+
+# Admin session cookie password
+#
+# presence: required
+# type: 32 length min String
+# default: none
+ADMIN_COOKIE_PASSWORD=aMoreThan32CharLongStringForExample
 
 # =========
 # DATABASES

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,5 @@
 import * as config from './lib/config.js';
 import Hapi from '@hapi/hapi';
-import HapiBasic from '@hapi/basic';
 import Oppsy from 'oppsy';
 
 import { catchDomainAndInfrastructureErrors } from './lib/infrastructure/utils/pre-response-utils.js';
@@ -36,8 +35,6 @@ export async function createServer() {
   server.auth.scheme('api-token', security.scheme);
   server.auth.strategy('default', 'api-token');
   server.auth.default('default');
-  await server.register(HapiBasic);
-  server.auth.strategy('simple', 'basic', { validate: (request, username) => securityPreHandlers.checkUserIsAuthenticatedViaBasicAndAdmin(username) });
 
   const configuration = [].concat(plugins, routes);
 
@@ -46,7 +43,7 @@ export async function createServer() {
   await server.register(configuration);
 
   return server;
-};
+}
 
 const enableOpsMetrics = async function(server) {
 

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -1,0 +1,35 @@
+import { expect, databaseBuilder, generateAuthorizationHeader } from '../../test-helper';
+import createServer from '../../../server';
+
+describe('Acceptance | Controller | translations-controller', () => {
+
+  describe('GET /translations.csv - export all translations in CSV file', () => {
+
+    it('should return a csv file', async () => {
+      // Given
+      const user = databaseBuilder.factory.buildAdminUser();
+      databaseBuilder.factory.buildTranslation({
+        key: 'some-key',
+        locale: 'fr-fr',
+        value: 'La clé !'
+      });
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+      const getTranslationsOptions = {
+        method: 'GET',
+        url: '/api/translations.csv',
+        headers: generateAuthorizationHeader(user)
+      };
+
+      // When
+      const response = await server.inject(getTranslationsOptions);
+
+      // Then
+      expect(response.statusCode).to.equal(200);
+    });
+
+  });
+
+});
+

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -1,5 +1,6 @@
-import { expect, databaseBuilder, generateAuthorizationHeader } from '../../test-helper';
-import createServer from '../../../server';
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader } from '../../test-helper';
+import { createServer } from '../../../server';
 
 describe('Acceptance | Controller | translations-controller', () => {
 
@@ -27,6 +28,8 @@ describe('Acceptance | Controller | translations-controller', () => {
 
       // Then
       expect(response.statusCode).to.equal(200);
+      expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
+      expect(response.payload).to.equal('key,locale,value\nsome-key,fr-fr,La clé !');
     });
 
   });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -79,14 +79,20 @@ export function catchErr(promiseFn, ctx) {
   };
 }
 
-export function streamToPromise(stream) {
+export async function streamToPromise(stream) {
+  return streamToPromiseArray(stream).then((array) => {
+    return array.join('');
+  });
+}
+
+export function streamToPromiseArray(stream) {
   return new Promise((resolve, reject) => {
-    let totalData = '';
+    const result = [];
     stream.on('data', (data) => {
-      totalData += data;
+      result.push(data);
     });
     stream.on('end', () => {
-      resolve(totalData);
+      resolve(result);
     });
     stream.on('error', reject);
   });

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -73,7 +73,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
 
     context('Successful case', () => {
 
-      it('should allow access to resource - with "credentials" property filled with authenticated user - when the request contains the authorization header with a valid api key', async () => {
+      it('should allow access to resource - returning apiKey as email - when the request contains the authorization header with a valid api key', async () => {
       // given
         const apiKey = 'valid.api.key';
         const authenticatedUser = new User({
@@ -91,7 +91,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         const response = await checkUserIsAuthenticatedViaBasicAndAdmin(apiKey);
 
         // then
-        expect(response).to.deep.equal({ isValid: true, credentials: { user: authenticatedUser } });
+        expect(response).to.deep.equal({ email: apiKey });
       });
 
     });
@@ -110,7 +110,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         const response = await checkUserIsAuthenticatedViaBasicAndAdmin(apiKey);
 
         // then
-        expect(response).to.be.deep.equal({ isValid: false });
+        expect(response).to.be.false;
       });
 
       it('should disallow access to resource when the user is not an admin', async () => {
@@ -131,7 +131,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         const response = await checkUserIsAuthenticatedViaBasicAndAdmin(apiKey);
 
         // then
-        expect(response).to.deep.equal({ isValid: false });
+        expect(response).to.deep.equal(false);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/export-translations_test.js
+++ b/api/tests/unit/domain/usecases/export-translations_test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { streamToPromise } from '../../../test-helper';
+import { Translation } from '../../../../lib/domain/models/Translation';
+import {
+  exportTranslations
+} from '../../../../lib/domain/usecases/export-translations';
+
+describe('Unit | Domain | Usecases | export-translations', function() {
+  it('write the translations as a csv to a stream', async function() {
+    const translationRepository = {
+      list() {
+        return [
+          new Translation({
+            key: 'some.key',
+            locale: 'fr',
+            value: 'Bonjour'
+          }),
+          new Translation({
+            key: 'some.key',
+            locale: 'en',
+            value: 'Hello,'
+          }),
+        ];
+      }
+    };
+    const stream = new PassThrough();
+    const promise = streamToPromise(stream);
+    await exportTranslations(stream, { translationRepository });
+    const result =  await promise;
+    expect(result).to.equal('key,locale,value\nsome.key,fr,Bonjour\nsome.key,en,"Hello,"');
+  });
+});

--- a/api/tests/unit/domain/usecases/export-translations_test.js
+++ b/api/tests/unit/domain/usecases/export-translations_test.js
@@ -8,26 +8,35 @@ import {
 
 describe('Unit | Domain | Usecases | export-translations', function() {
   it('write the translations as a csv to a stream', async function() {
+    const streamListStream = new PassThrough({
+      readableObjectMode: true,
+      writableObjectMode: true,
+    });
+    function writeTranslationStream() {
+      streamListStream.write(new Translation({
+        key: 'some.key',
+        locale: 'fr',
+        value: 'Bonjour'
+      }));
+      streamListStream.write(new Translation({
+        key: 'some.key',
+        locale: 'en',
+        value: 'Hello,'
+      }));
+      streamListStream.end();
+    }
     const translationRepository = {
-      list() {
-        return [
-          new Translation({
-            key: 'some.key',
-            locale: 'fr',
-            value: 'Bonjour'
-          }),
-          new Translation({
-            key: 'some.key',
-            locale: 'en',
-            value: 'Hello,'
-          }),
-        ];
+      streamList() {
+        return streamListStream;
       }
     };
     const stream = new PassThrough();
     const promise = streamToPromise(stream);
-    await exportTranslations(stream, { translationRepository });
-    const result =  await promise;
+
+    exportTranslations(stream, { translationRepository });
+    writeTranslationStream();
+
+    const result = await promise;
     expect(result).to.equal('key,locale,value\nsome.key,fr,Bonjour\nsome.key,en,"Hello,"');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible d'exporter les traductions pour ensuite les fournir à un outil de traduction.

## :robot: Solution

Les outils de traduction acceptant en général les fichiers CSV et JSON on regarde la possibilité de le faire directement avec un plugin d'adminJS qui gère notre interface d'administration.
On utilise le plugin `adminjs/import-export`.

Le plugin n'est pas satisfaisant et demande beaucoup d'adaptations.

On décide donc :
 - d'ajouter une route `/api/translations.csv`
 - d'ajouter une action et un composant custom AdminJS permettant l'export au format CSV depuis l'interface d'administration


## :rainbow: Remarques

Pour authentifier l'appel depuis le composant custom AdminJS, il a fallu changer la stratégie d'authentification de `simple` à `session` en fournissant les options de cookie (name et password).

Egalement, on a du créer un fork de `@adminjs/hapi` et le publier car celui-ci comportait un bug sur la lecture des credentials.

## :100: Pour tester

Se connecter à l'interface d'admin.
Se rendre sur la page des traductions `/translations`.
Cliquer sur export puis sur `Exporter les traductions au format CSV`.
Vérifier que le fichier téléchargé contient les traductions.


Pour tester la route uniquement, appeler la route `/api/translations.csv` et vérifier que le retour est bien un export au format csv de toutes les traductions.
