### PR TITLE
[TECH] CircleCI: Lier la version de l'executor Playwright à celle de la dépendance avec Renovate.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,13 @@ executors:
       - image: redis:7.0.12-alpine
     resource_class: medium
   playwright-redis-postgres-docker:
+    parameters:
+      playwright-version:
+        # renovate datasource=npm depName=@playwright/test
+        default: 1.37.1
+        type: string
     docker:
-      - image: mcr.microsoft.com/playwright:v1.37.1-focal
+      - image: mcr.microsoft.com/playwright:v<<parameters.playwright-version>>-focal
       - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: circleci

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>1024pix/renovate-config"
+ ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "^@playwright/test$"
+      ],
+    "additionalBranchPrefix": "",
+    "commitMessageSuffix": ""
+   }
   ]
 }


### PR DESCRIPTION
## :unicorn: Problème
Les versions dans la config CircleCI ne sont pas celles de Renovate (pour Playwright).

## :robot: Solution
Utiliser des executors pour mutualiser la configuration des jobs, et mettre des commentaires pour Renovate respectants le matchString défini dans la configuration suivante : https://github.com/1024pix/renovate-config/blob/main/presets/detect-circleci-custom-dependencies.json

## :rainbow: Remarques
N/A

## :100: Pour tester
Vérifier que la CI est OK.
