### PR TITLE
[TECH] Modification de la config de Vitest pour être full ESM (PIX-9230)

### DIFF
--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -6,5 +6,8 @@ export default defineConfig({
     reporters: 'dot',
     restoreMocks: true,
     singleThread: true,
+    deps: {
+      interopDefault: false,
+    }
   },
 });


### PR DESCRIPTION
## :unicorn: Problème
Vitest "convertit" les import faits en mode CJS en imports faits en mode ESM. Ce qui signifie qu'il n'y aura pas d'erreur sur la lecture des tests, alors qu'on a un require qui ne devrait pas y être. 

## :robot: Solution
On change donc la configuration de Vitest afin qu'il lève une erreur quand il détecte un import de type `require` (donc en Common JS)

## :rainbow: Remarques
RAS

## :100: Pour tester
Dans un test, changez un 
`import MonTruc from 'mon-path/du-fichier.js`
en 
`const MonTruc = require 'mon-path/du-fichier.js';`
lancez le test correspondant, et voyez que Vitest lève une erreur disant qu'il détecte un "require".
