### PR TITLE
[FEATURE] Personnaliser le titre de la page d'adminjs

### DIFF
--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -13,6 +13,9 @@ const Components = {
 };
 
 export const options = {
+  branding: {
+    companyName: 'Pix Editor',
+  },
   componentLoader,
   resources: [
     {


### PR DESCRIPTION
## :unicorn: Problème
Une fois connecter sur adminjs, le titre de la page est "Company". Ce n'est pas très joli ni explicite.

## :robot: Solution
Personnaliser le titre de la page en mettant "Pix Editor"

## :100: Pour tester
1. Se connecter sur adminjs via /admin
2. Voir le titre HTML de la page
