### PR TITLE
[FEATURE] Ajout d'un champ dans les prototypes des épreuves pour sélectionner les champs à contextualiser (PIX-9287)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -54,6 +54,7 @@ export const challengeDatasource = datasource.extend({
     'archived_at',
     'made_obsolete_at',
     'shuffled',
+    'contextualizedFields'
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -113,6 +114,7 @@ export const challengeDatasource = datasource.extend({
       madeObsoleteAt: airtableRecord.get('made_obsolete_at'),
       createdAt: airtableRecord.get('created_at'),
       shuffled: airtableRecord.get('shuffled'),
+      contextualizedFields: airtableRecord.get('contextualizedFields'),
     };
   },
 
@@ -155,6 +157,7 @@ export const challengeDatasource = datasource.extend({
         'archived_at': model.archivedAt,
         'made_obsolete_at': model.madeObsoleteAt,
         'shuffled': model.shuffled,
+        'contextualizedFields': model.contextualizedFields,
       }
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -42,6 +42,7 @@ const serializer = new Serializer('challenges', {
     'archivedAt',
     'madeObsoleteAt',
     'shuffled',
+    'contextualizedFields',
   ],
   typeForAttribute(attribute) {
     if (attribute === 'files') return 'attachments';

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -49,6 +49,7 @@ const challengeAirtableFields = [
   'archived_at',
   'made_obsolete_at',
   'shuffled',
+  'contextualizedFields',
 ];
 
 describe('Acceptance | Controller | challenges-controller', () => {
@@ -147,6 +148,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
               shuffled: false,
+              'contextualized-fields': ['instruction', 'illustration'],
             },
             relationships: {
               skill: {
@@ -242,6 +244,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
               shuffled: false,
+              'contextualized-fields': ['instruction', 'illustration'],
             },
             relationships: {
               skill: {
@@ -300,6 +303,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
               shuffled: false,
+              'contextualized-fields': ['instruction', 'illustration'],
             },
             relationships: {
               skill: {
@@ -457,6 +461,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             shuffled: false,
+            'contextualized-fields': ['instruction', 'illustration'],
           },
           relationships: {
             skill: {
@@ -573,6 +578,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
               shuffled: false,
+              'contextualized-fields': ['instruction', 'illustration'],
             },
             relationships: {
               skill: {
@@ -638,6 +644,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             shuffled: false,
+            'contextualized-fields': ['instruction', 'illustration'],
           },
           relationships: {
             skill: {
@@ -740,6 +747,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'archived-at': challenge.archivedAt,
               'made-obsolete-at': challenge.madeObsoleteAt,
               shuffled: false,
+              'contextualized-fields': ['instruction', 'illustration'],
             },
             relationships: {
               skill: {
@@ -830,6 +838,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'archived-at': '2023-03-03T10:47:05.555Z',
               'made-obsolete-at': '2023-04-04T10:47:05.555Z',
               shuffled: false,
+              'contextualized-fields': ['instruction', 'illustration'],
             },
             relationships: {
               skill: {
@@ -895,6 +904,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             shuffled: false,
+            'contextualized-fields': ['instruction', 'illustration'],
           },
           relationships: {
             skill: {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -72,6 +72,27 @@ async function mockCurrentContent() {
     challengeIds: 'recChallenge0',
   });
 
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+    locale: 'fr',
+    value: expectedCurrentContent.competences[0].name_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+    locale: 'en',
+    value: expectedCurrentContent.competences[0].name_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+    locale: 'fr',
+    value: expectedCurrentContent.competences[0].description_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+    locale: 'en',
+    value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+
   await databaseBuilder.commit();
 
   return expectedCurrentContent;
@@ -90,28 +111,6 @@ describe('Acceptance | Controller | replication-data-controller', () => {
     it('should return data for replication', async function() {
       const expectedCurrentContent = await mockCurrentContent();
 
-      databaseBuilder.factory.buildTranslation({
-        key: `competence.${expectedCurrentContent.competences[0].id}.name`,
-        locale: 'fr',
-        value: expectedCurrentContent.competences[0].name_i18n.fr,
-      });
-      databaseBuilder.factory.buildTranslation({
-        key: `competence.${expectedCurrentContent.competences[0].id}.name`,
-        locale: 'en',
-        value: expectedCurrentContent.competences[0].name_i18n.en,
-      });
-      databaseBuilder.factory.buildTranslation({
-        key: `competence.${expectedCurrentContent.competences[0].id}.description`,
-        locale: 'fr',
-        value: expectedCurrentContent.competences[0].description_i18n.fr,
-      });
-      databaseBuilder.factory.buildTranslation({
-        key: `competence.${expectedCurrentContent.competences[0].id}.description`,
-        locale: 'en',
-        value: expectedCurrentContent.competences[0].description_i18n.en,
-      });
-
-      await databaseBuilder.commit();
       const server = await createServer();
       const currentContentOptions = {
         method: 'GET',
@@ -123,7 +122,7 @@ describe('Acceptance | Controller | replication-data-controller', () => {
       const response = await server.inject(currentContentOptions);
 
       // then
-      expect(JSON.parse(response.result)).to.deep.equal(JSON.parse(JSON.stringify(expectedCurrentContent)));
+      expect(JSON.parse(response.result)).to.deep.equal(expectedCurrentContent);
     });
   });
 });

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -43,6 +43,7 @@ export function buildChallenge({
   madeObsoleteAt,
   createdAt = '1986-14-07',
   shuffled,
+  contextualizedFields,
 } = {}) {
   return {
     id: airtableId,
@@ -91,6 +92,7 @@ export function buildChallenge({
       'made_obsolete_at': madeObsoleteAt,
       'created_at': createdAt,
       'shuffled': shuffled,
+      'contextualizedFields': contextualizedFields,
     },
   };
 }

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-challenge-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-challenge-datasource-object.js
@@ -43,6 +43,7 @@ export function buildChallengeDatasourceObject({
   archivedAt = '2023-03-03T10:47:05.555Z',
   madeObsoleteAt = '2023-04-04T10:47:05.555Z',
   shuffled = false,
+  contextualizedFields = ['instruction', 'illustration'],
 } = {}) {
   return {
     id,
@@ -89,5 +90,6 @@ export function buildChallengeDatasourceObject({
     archivedAt,
     madeObsoleteAt,
     shuffled,
+    contextualizedFields,
   };
 }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -48,6 +48,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             shuffled: false,
+            'contextualized-fields': ['instruction', 'illustration'],
           },
           relationships: {
             skill: {
@@ -124,6 +125,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'archived-at': '2023-03-03T10:47:05.555Z',
             'made-obsolete-at': '2023-04-04T10:47:05.555Z',
             'shuffled': false,
+            'contextualizedFields': ['instruction', 'illustration'],
           },
           relationships: {
             skill: {

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -224,6 +224,18 @@
         />
       </div>
     </div>
+    {{#if @challenge.isPrototype}}
+      <div class="field">
+        <Field::Select
+          @title="Champs contextualisés"
+          @value={{this.contextualizedFields}}
+          @edition={{@edition}}
+          @multiple={{true}}
+          @options={{this.options.contextualizedFields}}
+          @setValue={{this.setContextualizedFields}}
+        />
+      </div>
+    {{/if}}
   </div>
   {{#unless @edition}}
     <Field::Input @value={{@challenge.id}} @title="Id" @edition={{false}} />

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -41,7 +41,15 @@ export default class ChallengeForm extends Component {
     'responsive':['Tablette', 'Smartphone', 'Tablette/Smartphone', 'Non'],
     'spoil':['Non Sp', 'Difficilement Sp', 'Facilement Sp'],
     'locales': this.languageOptions,
-    'area':['Afghanistan','Afrique du Sud','Albanie','Algérie','Allemagne','Andorre','Angola','Antigua-et-Barbuda','Arabie saoudite','Argentine','Arménie','Australie','Autriche','Azerbaïdjan','Bahamas','Bahreïn','Bangladesh','Barbade','Belgique','Belize','Bénin','Bhoutan','Biélorussie','Birmanie','Bolivie','Bosnie-Herzégovine','Botswana','Brésil','Brunei','Bulgarie','Burkina Faso','Burundi','Cambodge','Cameroun','Canada','Cap-Vert','Chili','Chine','Chypre','Colombie','Les Comores','Congo','Îles Cook','Corée du Nord','Corée du Sud','Costa Rica','Côte d\'ivoire','Croatie','Cuba','Danemark','Djibouti','République dominicaine','Dominique','Égypte','Émirats arabes unis','Équateur','Érythrée','Espagne','Estonie','Eswatini','Éthiopie','Fidji','Finlande','France','Gabon','Gambie','Géorgie','Ghana','Grèce','Grenade','Guinée','Guatémala','Guinée équatoriale','Guinée-Bissao','Guyana','Haïti','Honduras','Hongrie','Inde','Indonésie','Institutions internationales','Irak','Iran','Irlande','Islande','Israël','Italie','Jamaïque','Japon','Jordanie','Kazakhstan','Kenya','Kirghizstan','Kiribati','Kosovo','Koweït','Laos','Lésotho','Lettonie','Liban','Libéria','Libye','Liechtenstein','Lituanie','Luxembourg','Macédoine du Nord','Madagascar','Malaisie','Malawi','Maldives','Mali','Malte','Maroc','Îles Marshall','Maurice','Mauritanie','Mexique','Micronésie','Moldavie','Monaco','Mongolie','Monténégro','Mozambique','Namibie','Nauru','Népal','Neutre','Nicaragua','Niger','Nigéria','Niue','Norvège','Nouvelle-Zélande','Oman','Ouganda','Ouzbékistan','Pakistan','Palaos','La Palestine','Panama','Papouasie-Nouvelle-Guinée','Paraguay','Pays-Bas','Pérou','Philippines','Pologne','Portugal','Qatar','République centrafricaine','Roumanie','Russie','Rwanda','Saint-Christophe-et-Niévès','Sainte-Lucie','Saint-Marin','Saint-Vincent-et-les-Grenadines','Salomon','Salvador','Samoa','Sao Tomé-et-Principe','Sénégal','Serbie','Sierra Leone','Singapour','Slovaquie','Slovénie','Somalie','Soudan','Soudan du Sud','Sri Lanka','Suède','Suisse','Suriname','Syrie','Tadjikistan','Tanzanie','Tchad','Tchéquie','Thaïlande','Timor oriental','Togo','Tonga','Trinité-et-Tobago','Tunisie','Turkménistan','Turquie','Tuvalu','UK','Ukraine','Uruguay','USA','Vanuatu','Vatican','Vénézuéla','Vietnam','Yémen','Zambie','Zimbabwé']
+    'area':['Afghanistan','Afrique du Sud','Albanie','Algérie','Allemagne','Andorre','Angola','Antigua-et-Barbuda','Arabie saoudite','Argentine','Arménie','Australie','Autriche','Azerbaïdjan','Bahamas','Bahreïn','Bangladesh','Barbade','Belgique','Belize','Bénin','Bhoutan','Biélorussie','Birmanie','Bolivie','Bosnie-Herzégovine','Botswana','Brésil','Brunei','Bulgarie','Burkina Faso','Burundi','Cambodge','Cameroun','Canada','Cap-Vert','Chili','Chine','Chypre','Colombie','Les Comores','Congo','Îles Cook','Corée du Nord','Corée du Sud','Costa Rica','Côte d\'ivoire','Croatie','Cuba','Danemark','Djibouti','République dominicaine','Dominique','Égypte','Émirats arabes unis','Équateur','Érythrée','Espagne','Estonie','Eswatini','Éthiopie','Fidji','Finlande','France','Gabon','Gambie','Géorgie','Ghana','Grèce','Grenade','Guinée','Guatémala','Guinée équatoriale','Guinée-Bissao','Guyana','Haïti','Honduras','Hongrie','Inde','Indonésie','Institutions internationales','Irak','Iran','Irlande','Islande','Israël','Italie','Jamaïque','Japon','Jordanie','Kazakhstan','Kenya','Kirghizstan','Kiribati','Kosovo','Koweït','Laos','Lésotho','Lettonie','Liban','Libéria','Libye','Liechtenstein','Lituanie','Luxembourg','Macédoine du Nord','Madagascar','Malaisie','Malawi','Maldives','Mali','Malte','Maroc','Îles Marshall','Maurice','Mauritanie','Mexique','Micronésie','Moldavie','Monaco','Mongolie','Monténégro','Mozambique','Namibie','Nauru','Népal','Neutre','Nicaragua','Niger','Nigéria','Niue','Norvège','Nouvelle-Zélande','Oman','Ouganda','Ouzbékistan','Pakistan','Palaos','La Palestine','Panama','Papouasie-Nouvelle-Guinée','Paraguay','Pays-Bas','Pérou','Philippines','Pologne','Portugal','Qatar','République centrafricaine','Roumanie','Russie','Rwanda','Saint-Christophe-et-Niévès','Sainte-Lucie','Saint-Marin','Saint-Vincent-et-les-Grenadines','Salomon','Salvador','Samoa','Sao Tomé-et-Principe','Sénégal','Serbie','Sierra Leone','Singapour','Slovaquie','Slovénie','Somalie','Soudan','Soudan du Sud','Sri Lanka','Suède','Suisse','Suriname','Syrie','Tadjikistan','Tanzanie','Tchad','Tchéquie','Thaïlande','Timor oriental','Togo','Tonga','Trinité-et-Tobago','Tunisie','Turkménistan','Turquie','Tuvalu','UK','Ukraine','Uruguay','USA','Vanuatu','Vatican','Vénézuéla','Vietnam','Yémen','Zambie','Zimbabwé'],
+    'contextualizedFields': [
+      { value: 'instruction', label: 'Consigne' },
+      { value: 'proposals', label: 'Propositions' },
+      { value: 'solution', label: 'Réponse' },
+      { value: 'illustration', label: 'Illustration' },
+      { value: 'embed', label: 'Embed' },
+      { value: 'attachments', label: 'Pièces jointes' },
+    ],
   };
 
   helpInstructions = '<u>Style d’écriture :</u><br>*Écriture en italique*<br>**Écriture en gras**<br>***Écriture en italique et gras***<br><br><u>Aller à la ligne :</u><br>Phrase 1<br><br>Phrase 2<br><br><u>Liste :</u><br>- texte item 1<br>- texte item 2<br><br><u>Paragraphe avec retrait précédé d’un trait vertical gris :</u><br>> texte 1ere ligne<br>><br>> texte 3e ligne<br><br><u>Lien vers une page web :</u><br>[mot cliquable](url avec protocole)';
@@ -121,6 +129,10 @@ export default class ChallengeForm extends Component {
     return this.options.locales.filter(locale=> this.args.challenge.locales.includes(locale.value));
   }
 
+  get contextualizedFields() {
+    return this.options.contextualizedFields.filter(({ value }) => this.args.challenge.contextualizedFields?.includes(value));
+  }
+
   @action
   setChallengeType({ value }) {
     this.args.challenge.type = value;
@@ -190,9 +202,12 @@ export default class ChallengeForm extends Component {
   }
 
   @action
-  setLocales(results) {
-    this.args.challenge.locales = results.map(localeObject => {
-      return localeObject.value;
-    });
+  setLocales(selectedOptions) {
+    this.args.challenge.locales = selectedOptions.map(({ value }) => value);
+  }
+
+  @action
+  setContextualizedFields(selectedOptions) {
+    this.args.challenge.contextualizedFields = selectedOptions.map(({ value }) => value);
   }
 }

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -40,6 +40,7 @@ export default class ChallengeModel extends Model {
   @attr('date') archivedAt;
   @attr('date') madeObsoleteAt;
   @attr('boolean') shuffled;
+  @attr ({ defaultValue: function() { return []; } }) contextualizedFields;
 
   @belongsTo('skill') skill;
   @hasMany('attachment', { inverse: 'challenge' }) files;

--- a/pix-editor/mirage/factories/challenge.js
+++ b/pix-editor/mirage/factories/challenge.js
@@ -31,6 +31,7 @@ export default Factory.extend({
   area: 'area',
   autoReply: 'autoReply',
   files: null,
-  updatedAt: '2021-10-02T14:00:00.000Z'
+  updatedAt: '2021-10-02T14:00:00.000Z',
+  contextualizedFields() { return ['illustration', 'instruction']; },
 });
 


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile de connaître pour le pôle contenu les épreuves à contextualiser dans l'optique de l'internationalisation du référentiel à grande échelle.

## :robot: Solution
Rajout d'un champ sur les prototypes pour spécifier quels champs sont à contextualiser.

## :rainbow: Remarques
L'internationalisation sera le genre humain.

## :100: Pour tester
1. Se rendre sur un prototype d'une épreuve
2. Voir le champ "Champs contextualisés"
3. Modifier l'épreuve et rajouter/modifier une valeur dans le champ contextualisé.
4. Enregistrer
5. Vérifier que le champ a bien été sauvegardé
