### PR TITLE
[FEATURE] Ajout des options "lien externe" et "indice" dans la liste des champs à contextualiser d'une épreuve (PIX-9287).

### DIFF
--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -44,11 +44,13 @@ export default class ChallengeForm extends Component {
     'area':['Afghanistan','Afrique du Sud','Albanie','Algérie','Allemagne','Andorre','Angola','Antigua-et-Barbuda','Arabie saoudite','Argentine','Arménie','Australie','Autriche','Azerbaïdjan','Bahamas','Bahreïn','Bangladesh','Barbade','Belgique','Belize','Bénin','Bhoutan','Biélorussie','Birmanie','Bolivie','Bosnie-Herzégovine','Botswana','Brésil','Brunei','Bulgarie','Burkina Faso','Burundi','Cambodge','Cameroun','Canada','Cap-Vert','Chili','Chine','Chypre','Colombie','Les Comores','Congo','Îles Cook','Corée du Nord','Corée du Sud','Costa Rica','Côte d\'ivoire','Croatie','Cuba','Danemark','Djibouti','République dominicaine','Dominique','Égypte','Émirats arabes unis','Équateur','Érythrée','Espagne','Estonie','Eswatini','Éthiopie','Fidji','Finlande','France','Gabon','Gambie','Géorgie','Ghana','Grèce','Grenade','Guinée','Guatémala','Guinée équatoriale','Guinée-Bissao','Guyana','Haïti','Honduras','Hongrie','Inde','Indonésie','Institutions internationales','Irak','Iran','Irlande','Islande','Israël','Italie','Jamaïque','Japon','Jordanie','Kazakhstan','Kenya','Kirghizstan','Kiribati','Kosovo','Koweït','Laos','Lésotho','Lettonie','Liban','Libéria','Libye','Liechtenstein','Lituanie','Luxembourg','Macédoine du Nord','Madagascar','Malaisie','Malawi','Maldives','Mali','Malte','Maroc','Îles Marshall','Maurice','Mauritanie','Mexique','Micronésie','Moldavie','Monaco','Mongolie','Monténégro','Mozambique','Namibie','Nauru','Népal','Neutre','Nicaragua','Niger','Nigéria','Niue','Norvège','Nouvelle-Zélande','Oman','Ouganda','Ouzbékistan','Pakistan','Palaos','La Palestine','Panama','Papouasie-Nouvelle-Guinée','Paraguay','Pays-Bas','Pérou','Philippines','Pologne','Portugal','Qatar','République centrafricaine','Roumanie','Russie','Rwanda','Saint-Christophe-et-Niévès','Sainte-Lucie','Saint-Marin','Saint-Vincent-et-les-Grenadines','Salomon','Salvador','Samoa','Sao Tomé-et-Principe','Sénégal','Serbie','Sierra Leone','Singapour','Slovaquie','Slovénie','Somalie','Soudan','Soudan du Sud','Sri Lanka','Suède','Suisse','Suriname','Syrie','Tadjikistan','Tanzanie','Tchad','Tchéquie','Thaïlande','Timor oriental','Togo','Tonga','Trinité-et-Tobago','Tunisie','Turkménistan','Turquie','Tuvalu','UK','Ukraine','Uruguay','USA','Vanuatu','Vatican','Vénézuéla','Vietnam','Yémen','Zambie','Zimbabwé'],
     'contextualizedFields': [
       { value: 'instruction', label: 'Consigne' },
+      { value: 'embed', label: 'Embed' },
+      { value: 'illustration', label: 'Illustration' },
+      { value: 'skillHint', label: 'Indice' },
+      { value: 'externalLink', label: 'Lien externe' },
+      { value: 'attachments', label: 'Pièces jointes' },
       { value: 'proposals', label: 'Propositions' },
       { value: 'solution', label: 'Réponse' },
-      { value: 'illustration', label: 'Illustration' },
-      { value: 'embed', label: 'Embed' },
-      { value: 'attachments', label: 'Pièces jointes' },
     ],
   };
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'implémentation de l'information des champs à contextualiser sur une épreuve (voir #302), nous avons oublié les options "lien externe" et "indice".

## :robot: Solution
On ajoute les deux options manquantes, à la fois dans l'interface de Pix Editor et dans la liste des possibilités dans Airtable.

## :rainbow: Remarques
On en profite pour afficher la liste des options par ordre alphabétique.

## :100: Pour tester
Se rendre sur le prototype d'une épreuve et vérifier que les options "Lien externe" et "Indice" sont sélectionnables lors de l'édition des champs à contextualiser.
