### PR TITLE
[FEATURE] Importer les traductions des épreuves dans PG depuis Airtable (PIX-9416)

### DIFF
--- a/api/scripts/migrate-challenges-translation-from-airtable/index.js
+++ b/api/scripts/migrate-challenges-translation-from-airtable/index.js
@@ -1,0 +1,52 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import * as challengeTranslations from '../../lib/infrastructure/translations/challenge.js';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+import { challengeDatasource } from '../../lib/infrastructure/datasources/airtable/index.js';
+import { Challenge } from '../../lib/domain/models/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateChallengesTranslationFromAirtable({ airtableClient }) {
+  const allChallenges = await airtableClient
+    .table('Epreuves')
+    .select({
+      fields: [
+        'id persistant',
+        'Consigne',
+        'Consigne alternative',
+        'Propositions',
+        'Bonnes réponses',
+        'Bonnes réponses à afficher',
+      ],
+    })
+    .all();
+
+  const translations = allChallenges.flatMap((challenge) => {
+    const challengeModel = new Challenge(challengeDatasource.fromAirTableObject(challenge));
+    return challengeTranslations.extractFromChallenge(challengeModel);
+  });
+
+  await translationRepository.save(translations);
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateChallengesTranslationFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/scripts/migrate-challenges-translation-from-airtable/index.js
+++ b/api/scripts/migrate-challenges-translation-from-airtable/index.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import Airtable from 'airtable';
+import _ from 'lodash';
 import * as challengeTranslations from '../../lib/infrastructure/translations/challenge.js';
 import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
 import { disconnect } from '../../db/knex-database-connection.js';
@@ -29,7 +30,9 @@ export async function migrateChallengesTranslationFromAirtable({ airtableClient 
     return challengeTranslations.extractFromChallenge(challengeModel);
   });
 
-  await translationRepository.save(translations);
+  for (const translationsChunk of _.chunk(translations, 5000)) {
+    await translationRepository.save(translationsChunk);
+  }
 }
 
 async function main() {

--- a/api/scripts/migrate-challenges-translation-from-airtable/index.js
+++ b/api/scripts/migrate-challenges-translation-from-airtable/index.js
@@ -21,6 +21,7 @@ export async function migrateChallengesTranslationFromAirtable({ airtableClient 
         'Propositions',
         'Bonnes réponses',
         'Bonnes réponses à afficher',
+        'Langues',
       ],
     })
     .all();

--- a/api/tests/scripts/migrate-challenges-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-challenges-translation-from-airtable_test.js
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { airtableBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+import {
+  migrateChallengesTranslationFromAirtable
+} from '../../scripts/migrate-challenges-translation-from-airtable/index.js';
+
+describe('Migrate translation from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const challenge = airtableBuilder.factory.buildChallenge({
+      id: 'challengeid1',
+      instruction: 'instruction',
+      alternativeInstruction: 'alternativeInstruction',
+      proposals: 'proposals',
+      solution: 'solution',
+      solutionToDisplay: 'solutionToDisplay',
+      locales: ['fr-fr']
+    });
+
+    const challenges = [challenge];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Epreuves')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: challenges });
+
+    // when
+    await migrateChallengesTranslationFromAirtable({ airtableClient });
+
+    // then
+    const translations = await knex('translations').select().orderBy([{
+      column: 'key',
+      order: 'asc'
+    }, { column: 'locale', order: 'asc' }]);
+
+    expect(translations).to.have.lengthOf(5);
+    expect(translations).to.deep.equal([
+      {
+        key: 'challenge.challengeid1.alternativeInstruction',
+        locale: 'fr-fr',
+        value: 'alternativeInstruction'
+      },
+      {
+        key: 'challenge.challengeid1.instruction',
+        locale: 'fr-fr',
+        value: 'instruction'
+      },
+      {
+        key: 'challenge.challengeid1.proposals',
+        locale: 'fr-fr',
+        value: 'proposals'
+      },
+      {
+        key: 'challenge.challengeid1.solution',
+        locale: 'fr-fr',
+        value: 'solution'
+      },
+      {
+        key: 'challenge.challengeid1.solutionToDisplay',
+        locale: 'fr-fr',
+        value: 'solutionToDisplay'
+      }
+    ]);
+  });
+});

--- a/api/tests/scripts/migrate-challenges-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-challenges-translation-from-airtable_test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 import { airtableBuilder, knex } from '../test-helper.js';
 import Airtable from 'airtable';
 import nock from 'nock';
@@ -20,6 +20,10 @@ describe('Migrate translation from airtable', function() {
     airtableClient = new Airtable({
       apiKey: 'airtableApiKeyValue',
     }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
   });
 
   it('fills translations table', async function() {

--- a/api/tests/scripts/migrate-challenges-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-challenges-translation-from-airtable_test.js
@@ -43,7 +43,19 @@ describe('Migrate translation from airtable', function() {
     nock('https://api.airtable.com')
       .get('/v0/airtableBaseValue/Epreuves')
       .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-      .query(true)
+      .query({
+        fields: {
+          '': [
+            'id persistant',
+            'Consigne',
+            'Consigne alternative',
+            'Propositions',
+            'Bonnes réponses',
+            'Bonnes réponses à afficher',
+            'Langues',
+          ]
+        }
+      })
       .reply(200, { records: challenges });
 
     // when

--- a/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-competences-translation-from-airtable_test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 import { airtableBuilder, knex } from '../test-helper.js';
 import Airtable from 'airtable';
 import nock from 'nock';
@@ -19,6 +19,10 @@ describe('Migrate translation from airtable', function() {
     airtableClient = new Airtable({
       apiKey: 'airtableApiKeyValue',
     }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
   });
 
   it('fills translations table', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Avec la double écriture des traduction des épreuves depuis #315 nous ne pouvons encore basculer la lecture de celles-ci sans avoir importer les textes actuels.

## :robot: Solution
Créer les entrées dans la table traduction a partir des épreuves existantes.

## :rainbow: Remarques
Il y a beaucoup d'épreuves sur nos différents environnements, et cela prend du temps.

## :100: Pour tester
1. Lancer le script `node api/scripts/migrate-challenges-translation-from-airtable/`
2. Regarder la table translations en se connectant au pg `select * from translations`;
