### PR TITLE
[FEATURE] Suppression des translations dans PG et Airtable (PIX-9441)

### DIFF
--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -29,8 +29,7 @@ export async function register(server) {
                 tableTranslations.hydrateToAirtableObject(entity.fields, translations) ;
               });
             } else {
-              const id = response.data.fields['id persistant'];
-              const translations = await translationRepository.listByPrefix(`${tableTranslations.prefix}${id}.`);
+              const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
               tableTranslations.hydrateToAirtableObject(response.data.fields, translations);
             }
           }
@@ -62,6 +61,10 @@ export async function register(server) {
 
           if (_isResponseOK(response)) {
             if (translations) {
+              if (request.method === 'patch') {
+                await translationRepository.deleteByKeyPrefix(tableTranslations.prefixFor(response.data.fields));
+              }
+
               await translationRepository.save(translations);
 
               tableTranslations.hydrateToAirtableObject(response.data.fields, translations);

--- a/api/lib/domain/usecases/update-challenge.js
+++ b/api/lib/domain/usecases/update-challenge.js
@@ -4,7 +4,7 @@ import * as challengeTranslations from '../../infrastructure/translations/challe
 export async function updateChallenge(challenge, dependencies = { challengeRepository, translationRepository }) {
   const translations = challengeTranslations.extractFromChallenge(challenge);
   const updatedChallenge = dependencies.challengeRepository.update(challenge);
-  await dependencies.translationRepository.deleteByKeyPrefix(`${challengeTranslations.prefix}${challenge.id}.`);
+  await dependencies.translationRepository.deleteByKeyPrefix(challengeTranslations.prefixFor(challenge));
   await dependencies.translationRepository.save(translations);
 
   return updatedChallenge;

--- a/api/lib/domain/usecases/update-challenge.js
+++ b/api/lib/domain/usecases/update-challenge.js
@@ -4,7 +4,7 @@ import * as challengeTranslations from '../../infrastructure/translations/challe
 export async function updateChallenge(challenge, dependencies = { challengeRepository, translationRepository }) {
   const translations = challengeTranslations.extractFromChallenge(challenge);
   const updatedChallenge = dependencies.challengeRepository.update(challenge);
-  await dependencies.translationRepository.deleteByKeyPrefix(`${challengeTranslations.prefix}${challenge.id}`);
+  await dependencies.translationRepository.deleteByKeyPrefix(`${challengeTranslations.prefix}${challenge.id}.`);
   await dependencies.translationRepository.save(translations);
 
   return updatedChallenge;

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -29,7 +29,7 @@ export async function updateRecord(tableName, body) {
 }
 
 export async function upsertRecords(tableName, records, fieldsToMergeOn) {
-  logger.info({ tableName }, 'Upserting Airtable');
+  logger.info({ tableName }, 'Upserting redords in Airtable');
   return _airtableClient().table(tableName).update(
     records,
     {
@@ -41,6 +41,6 @@ export async function upsertRecords(tableName, records, fieldsToMergeOn) {
 }
 
 export async function deleteRecords(tableName, recordIds) {
-  logger.info({ tableName }, 'Deleting Airtable');
+  logger.info({ tableName }, 'Deleting records in Airtable');
   return _airtableClient().table(tableName).destroy(recordIds);
 }

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -39,3 +39,8 @@ export async function upsertRecords(tableName, records, fieldsToMergeOn) {
     },
   );
 }
+
+export async function deleteRecords(tableName, recordIds) {
+  logger.info({ tableName }, 'Deleting Airtable');
+  return _airtableClient().table(tableName).destroy(recordIds);
+}

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -15,12 +15,15 @@ const _DatasourcePrototype = {
     return airtableRawObjects.map(this.fromAirTableObject);
   },
 
-  async filter({ filter: { ids } }) {
+  async filter({ filter: { ids, formula } }) {
+    const filterByFormula = ids ? (
+      'OR(' + ids.map((id) => `'${id}' = {id persistant}`).join(',') + ')'
+    ) : formula;
     const airtableRawObjects = await airtable.findRecords(
       this.tableName,
       {
         fields: this.usedFields,
-        filterByFormula: 'OR(' + ids.map((id) => `'${id}' = {id persistant}`).join(',') + ')'
+        filterByFormula,
       },
     );
     return airtableRawObjects.map(this.fromAirTableObject);
@@ -46,7 +49,11 @@ const _DatasourcePrototype = {
       allAirtableRawObjects.push(...airtableRawObjects.map((airtableRawObject) => this.fromAirTableObject(airtableRawObject)));
     }
     return allAirtableRawObjects;
-  }
+  },
+
+  async delete(ids) {
+    return airtable.deleteRecords(this.tableName, ids);
+  },
 };
 
 function* chunks(array, chunkSize) {

--- a/api/lib/infrastructure/datasources/airtable/translation-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/translation-datasource.js
@@ -25,6 +25,7 @@ export const translationDatasource = datasource.extend({
       key: airtableRecord.get('key'),
       locale: airtableRecord.get('locale'),
       value: airtableRecord.get('value'),
+      airtableId: airtableRecord.id,
     };
   },
 

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -62,4 +62,16 @@ export async function deleteByKeyPrefix(prefix) {
   await knex('translations')
     .whereLike('key', `${prefix}%`)
     .delete();
+
+  if (_shouldDuplicateToAirtable == null && _shouldDuplicateToAirtablePromise == null) {
+    await checkIfShouldDuplicateToAirtable();
+  }
+
+  if (_shouldDuplicateToAirtable) {
+    const records = await translationDatasource.filter({ filter: {
+      formula: `REGEX_MATCH(key, "^${prefix.replace(/(\.)/g, '\\$1')}")`,
+    } });
+    const recordIds = records.map(({ airtableId }) => airtableId);
+    await translationDatasource.delete(recordIds);
+  }
 }

--- a/api/lib/infrastructure/translations/challenge.js
+++ b/api/lib/infrastructure/translations/challenge.js
@@ -16,14 +16,17 @@ function getPrimaryLocaleFromChallenge(locales) {
 
 export function extractFromChallenge(challenge) {
   const locale = getPrimaryLocaleFromChallenge(challenge.locales);
-  const id = challenge.id;
   return fields
     .filter((field) => challenge[field])
     .map((field) => {
       return new Translation({
-        key: `${prefix}${id}.${field}`,
+        key: `${prefixFor(challenge)}${field}`,
         locale: locale,
         value: challenge[field],
       });
     });
+}
+
+export function prefixFor(challenge) {
+  return `${prefix}${challenge.id}.`;
 }

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -20,19 +20,16 @@ const localizedFields = locales.flatMap((locale) =>
 );
 
 export function extractFromAirtableObject(competence) {
-  const id = competence['id persistant'];
   return localizedFields
     .filter(({ airtableField, airtableLocale }) => competence[`${airtableField} ${airtableLocale}`])
     .map(({ field, locale, airtableField, airtableLocale }) => new Translation({
-      key: `${prefix}${id}.${field}`,
+      key: `${prefixFor(competence)}${field}`,
       value: competence[`${airtableField} ${airtableLocale}`],
       locale,
     }));
 }
 
 export function hydrateToAirtableObject(competence, translations) {
-  const id = competence['id persistant'];
-
   for (const {
     airtableLocale,
     locale,
@@ -41,7 +38,7 @@ export function hydrateToAirtableObject(competence, translations) {
   } of localizedFields) {
     const translation = translations.find(
       (translation) =>
-        translation.key === `${prefix}${id}.${field}` &&
+        translation.key === `${prefixFor(competence)}${field}` &&
         translation.locale === locale
     );
 
@@ -71,4 +68,9 @@ export function hydrateReleaseObject(competence, translations) {
       competence[`${field}_i18n`][locale] = translation?.value ?? null;
     }
   }
+}
+
+export function prefixFor(competence) {
+  const id = competence['id persistant'];
+  return `${prefix}${id}.`;
 }

--- a/api/lib/infrastructure/translations/index.js
+++ b/api/lib/infrastructure/translations/index.js
@@ -1,2 +1,1 @@
 export * as Competences from './competence.js';
-export * as Challenge from './challenge.js';

--- a/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
@@ -190,8 +190,55 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
         });
       });
     });
-  });
 
+    describe('when some fields are emptied', () => {
+      it('should delete translation keys', async () => {
+        // Given
+        const competenceDataObject = domainBuilder.buildCompetenceDatasourceObject({
+          id: 'mon_id_persistant',
+        });
+        airtableRawCompetence = airtableBuilder.factory.buildCompetence(competenceDataObject);
+        competence = inputOutputDataBuilder.factory.buildCompetence({
+          ...competenceDataObject,
+          name_i18n: {
+            fr: 'AAA',
+          },
+          description_i18n: {
+            fr: 'CCCCCCCCCCCCCCCC',
+          },
+        });
+
+        nock('https://api.airtable.com')
+          .patch('/v0/airtableBaseValue/Competences/id_airtable', airtableRawCompetence)
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableRawCompetence);
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/airtable/content/Competences/id_airtable',
+          headers: generateAuthorizationHeader(user),
+          payload: competence,
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        const translations = await knex('translations').select('key', 'locale', 'value');
+        expect(translations.length).to.equal(2);
+        expect(translations[0]).to.deep.equal({
+          key: 'competence.mon_id_persistant.name',
+          locale: 'fr',
+          value: 'AAA'
+        });
+        expect(translations[1]).to.deep.equal({
+          key: 'competence.mon_id_persistant.description',
+          locale: 'fr',
+          value: 'CCCCCCCCCCCCCCCC'
+        });
+      });
+    });
+  });
 });
 
 describe('Acceptance | Controller | airtable-proxy-controller | retrieve competence translations', () => {

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -116,7 +116,17 @@ describe('Integration | Repository | translation-repository', function() {
       it('should delete keys in Airtable', async() => {
         // given
         nock('https://api.airtable.com')
-          .get('/v0/airtableBaseValue/translations?fields%5B%5D=key&fields%5B%5D=locale&fields%5B%5D=value&filterByFormula=REGEX_MATCH(key%2C+%22%5Esome%5C.prefix%5C.%22)')
+          .get('/v0/airtableBaseValue/translations')
+          .query({
+            fields: {
+              '': [
+                'key',
+                'locale',
+                'value',
+              ],
+            },
+            filterByFormula: 'REGEX_MATCH(key, "^some\\.prefix\\.")',
+          })
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .reply(200, { records: [
             {
@@ -138,7 +148,15 @@ describe('Integration | Repository | translation-repository', function() {
           ] });
 
         nock('https://api.airtable.com')
-          .delete('/v0/airtableBaseValue/translations?records%5B%5D=recTranslation1&records%5B%5D=recTranslation2')
+          .delete('/v0/airtableBaseValue/translations')
+          .query({
+            records: {
+              '': [
+                'recTranslation1',
+                'recTranslation2',
+              ]
+            }
+          })
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .reply(200, {
             records: [

--- a/api/tests/unit/domain/usecases/update-challenge_test.js
+++ b/api/tests/unit/domain/usecases/update-challenge_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Usecases | update-challenge', () => {
       const updatedChallenge = await updateChallenge(challenge, { translationRepository, challengeRepository });
 
       expect(updatedChallenge).to.deep.equal(expectedUpdatedChallenge);
-      expect(translationRepository.deleteByKeyPrefix).toHaveBeenCalledWith('challenge.recChallengeId');
+      expect(translationRepository.deleteByKeyPrefix).toHaveBeenCalledWith('challenge.recChallengeId.');
     });
   });
 });

--- a/api/tests/unit/infrastructure/translations/challenge_test.js
+++ b/api/tests/unit/infrastructure/translations/challenge_test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { extractFromChallenge } from '../../../../lib/infrastructure/translations/challenge.js';
+
+import { extractFromChallenge, prefixFor } from '../../../../lib/infrastructure/translations/challenge.js';
 import { Challenge } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Infrastructure | Challenge translations', () => {
@@ -85,4 +86,18 @@ describe('Unit | Infrastructure | Challenge translations', () => {
     });
   });
 
+  describe('#prefixFor', () => {
+    it('should return prefix for challenge fields keys', () => {
+      // given
+      const challenge = new Challenge({
+        id: 'recTestChallenge',
+      });
+
+      // when
+      const prefix = prefixFor(challenge);
+
+      // then
+      expect(prefix).toBe('challenge.recTestChallenge.');
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/translations/competence_test.js
+++ b/api/tests/unit/infrastructure/translations/competence_test.js
@@ -3,7 +3,8 @@ import {
   extractFromAirtableObject,
   hydrateReleaseObject,
   hydrateToAirtableObject,
-  dehydrateAirtableObject
+  dehydrateAirtableObject,
+  prefixFor,
 } from '../../../../lib/infrastructure/translations/competence.js';
 
 describe('Unit | Infrastructure | Competence translations', () => {
@@ -214,6 +215,21 @@ describe('Unit | Infrastructure | Competence translations', () => {
         },
         otherField: 'foo',
       });
+    });
+  });
+
+  describe('#prefixFor', () => {
+    it('should return the prefix for competence fields keys', () => {
+      // given
+      const competence = {
+        'id persistant': 'recCompetence123',
+      };
+
+      // when
+      const prefix = prefixFor(competence);
+
+      // then
+      expect(prefix).toBe('competence.recCompetence123.');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible de vider un champ d'une compétence (aller sur une compétence, vider un champ et enregistrer, recharcher la page, et voilà).

Quand la table `translations` existe dans Airtable, les traductions sont écrites en double dans PG et Airtable, mais quand une traduction est supprimée (quand un champ est vidé), elle n'est supprimée que dans PG.

## :robot: Solution
 - [x] Supprimer les translations d'une compétence quand des champs sont vidés (airtable-proxy)
 - [x] Supprimer les translations dans Airtable quand elles sont supprimées dans PG

## :rainbow: Remarques
N/A

## :100: Pour tester
Vidage de champ de compétence :
 - Modifier une compétence
 - Vider un champ
 - Enregistrer
 - Recharger la page
 - Le champ doit toujours être vide

Pour la suppression dans Airtable, se connecter à Airtable et vérifier que la clé de trad correspondant au champ est bien supprimée également.