### PR TITLE
[FEATURE] Épreuves : Alimenter la release avec la table translations (PIX-9518)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -42,6 +42,9 @@ export class Challenge {
     createdAt,
     shuffled,
     contextualizedFields,
+    alpha,
+    delta,
+    skillId,
   } = {}) {
     this.id = id;
     this.instruction = instruction;
@@ -85,5 +88,8 @@ export class Challenge {
     this.createdAt = createdAt;
     this.shuffled = shuffled;
     this.contextualizedFields = contextualizedFields;
+    this.alpha = alpha;
+    this.delta = delta;
+    this.skillId = skillId;
   }
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -2,7 +2,7 @@ import { knex } from '../../../db/knex-database-connection.js';
 import { Challenge } from '../../domain/models/Challenge.js';
 import { challengeDatasource } from '../datasources/airtable/index.js';
 import { translationRepository } from './index.js';
-import { getPrimaryLocaleFromChallenge } from '../translations/challenge.js';
+import { prefix, prefixFor, getPrimaryLocaleFromChallenge } from '../translations/challenge.js';
 
 function _getChallengesFromParams(params) {
   if (params.filter && params.filter.ids) {
@@ -14,11 +14,23 @@ function _getChallengesFromParams(params) {
   return challengeDatasource.list(params);
 }
 
+export async function list() {
+  const [challenges, translations] = await Promise.all([
+    challengeDatasource.list(),
+    translationRepository.listByPrefix(prefix),
+  ]);
+  return challenges.map((challengeDto) => {
+    const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
+    const filteredTranslations = translations.filter(({ key, locale }) => key.startsWith(prefixFor(challengeDto)) && locale === challengeLocale);
+    return toDomain(challengeDto, filteredTranslations);
+  });
+}
+
 export async function filter(params = {}) {
   let challengeDtos = await _getChallengesFromParams(params);
   return knex.transaction(async (transaction) => {
     return Promise.all(challengeDtos.map(async (challengeDto) => {
-      const translations = await translationRepository.listByPrefix(`challenge.${challengeDto.id}.`, { transaction });
+      const translations = await translationRepository.listByPrefix(prefixFor(challengeDto), { transaction });
       const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
       const filteredTranslations = translations.filter(({ locale }) => locale === challengeLocale);
       return toDomain(challengeDto, filteredTranslations);

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -27,7 +27,7 @@ export async function list() {
 }
 
 export async function filter(params = {}) {
-  let challengeDtos = await _getChallengesFromParams(params);
+  const challengeDtos = await _getChallengesFromParams(params);
   return knex.transaction(async (transaction) => {
     return Promise.all(challengeDtos.map(async (challengeDto) => {
       const translations = await translationRepository.listByPrefix(prefixFor(challengeDto), { transaction });

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -4,15 +4,18 @@ import { challengeDatasource } from '../datasources/airtable/index.js';
 import { translationRepository } from './index.js';
 import { getPrimaryLocaleFromChallenge } from '../translations/challenge.js';
 
-export async function filter(params = {}) {
-  let challengeDtos;
+function _getChallengesFromParams(params) {
   if (params.filter && params.filter.ids) {
-    challengeDtos = await challengeDatasource.filter(params);
-  } else if (params.filter && params.filter.search) {
-    challengeDtos = await challengeDatasource.search(params);
-  } else {
-    challengeDtos = await challengeDatasource.list(params);
+    return challengeDatasource.filter(params);
   }
+  if (params.filter && params.filter.search) {
+    return challengeDatasource.search(params);
+  }
+  return challengeDatasource.list(params);
+}
+
+export async function filter(params = {}) {
+  let challengeDtos = await _getChallengesFromParams(params);
   return knex.transaction(async (transaction) => {
     return Promise.all(challengeDtos.map(async (challengeDto) => {
       const translations = await translationRepository.listByPrefix(`challenge.${challengeDto.id}.`, { transaction });

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -10,6 +10,7 @@ import {
   tutorialDatasource,
 } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
+import * as challengeRepository from './challenge-repository.js';
 import * as airtableSerializer from '../serializers/airtable-serializer.js';
 import {
   challengeTransformer,
@@ -96,10 +97,10 @@ function _toDomain(releaseDTO) {
 }
 
 async function _getCurrentContent() {
-  const airtableChallenges = await challengeDatasource.list();
+  const challenges = await challengeRepository.filter();
   const [currentContentFromAirtable, currentContentFromPG] = await Promise.all([
-    _getCurrentContentFromAirtable(airtableChallenges),
-    _getCurrentContentFromPG(airtableChallenges),
+    _getCurrentContentFromAirtable(challenges),
+    _getCurrentContentFromPG(challenges),
   ]);
   return {
     ...currentContentFromAirtable,

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -97,7 +97,7 @@ function _toDomain(releaseDTO) {
 }
 
 async function _getCurrentContent() {
-  const challenges = await challengeRepository.filter();
+  const challenges = await challengeRepository.list();
   const [currentContentFromAirtable, currentContentFromPG] = await Promise.all([
     _getCurrentContentFromAirtable(challenges),
     _getCurrentContentFromPG(challenges),

--- a/api/lib/infrastructure/translations/challenge.js
+++ b/api/lib/infrastructure/translations/challenge.js
@@ -11,7 +11,7 @@ const fields = [
 ];
 
 export function getPrimaryLocaleFromChallenge(locales) {
-  return locales.sort()[0];
+  return [...locales].sort()[0];
 }
 
 export function extractFromChallenge(challenge) {

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -1,9 +1,46 @@
 import { describe, expect, it, vi } from 'vitest';
-import { create, filter } from '../../../../lib/infrastructure/repositories/challenge-repository.js';
+import { create, filter, list } from '../../../../lib/infrastructure/repositories/challenge-repository.js';
 import { challengeDatasource } from '../../../../lib/infrastructure/datasources/airtable/challenge-datasource.js';
 import { translationRepository } from '../../../../lib/infrastructure/repositories/index.js';
 
 describe('Unit | Repository | challenge-repository', () => {
+
+  describe('#list', () => {
+    it('should return all challenges',  async () => {
+      // given
+      vi.spyOn(translationRepository, 'listByPrefix')
+        .mockResolvedValueOnce([{
+          key: 'challenge.1.instruction',
+          value: 'instruction',
+          locale: 'fr'
+        },{
+          key: 'challenge.1.proposals',
+          value: 'proposals',
+          locale: 'fr'
+        }, {
+          key: 'challenge.2.instruction',
+          value: 'instruction 2',
+          locale: 'fr'
+        },{
+          key: 'challenge.2.proposals',
+          value: 'proposals 2',
+          locale: 'fr'
+        }]);
+      vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{ id: 1, locales: [] },{ id: 2, locales: [] }]);
+
+      // when
+      const challenges = await list();
+
+      // then
+      expect(challenges.length).equal(2);
+      expect(challengeDatasource.list).toHaveBeenCalled();
+      expect(translationRepository.listByPrefix).toHaveBeenCalledWith('challenge.');
+      expect(challenges[0].instruction).to.equal('instruction');
+      expect(challenges[0].proposals).to.equal('proposals');
+      expect(challenges[1].instruction).to.equal('instruction 2');
+      expect(challenges[1].proposals).to.equal('proposals 2');
+    });
+  });
 
   describe('#filter', () => {
     describe('when ids are specified', () => {


### PR DESCRIPTION
## :unicorn: Problème
La release ne lit pas la table translations pour les épreuves.

## :robot: Solution
Lire les champs traduisible des épreuves depuis la table translations.

## :rainbow: Remarques
N/A

## :100: Pour tester
 - Modifier les traductions d'une épreuve manuellement dans la table translations
 - Faire un POST sur /api/releases pour créer une release
 - Vérifier que l'épreuve contient les bonnes valeurs