### PR TITLE
 [FEATURE] Alimenter la réplication avec la table translations (PIX-9519)

### DIFF
--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -7,7 +7,7 @@ import {
   tubeDatasource,
   tutorialDatasource,
 } from '../../infrastructure/datasources/airtable/index.js';
-import * as tablesTranslations from '../../infrastructure/translations/index.js';
+import * as competenceTranslations from '../../infrastructure/translations/competence.js';
 import { challengeRepository, translationRepository } from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
@@ -24,6 +24,7 @@ export async function getLearningContentForReplication(dependencies = { translat
     attachments,
     thematics,
     courses,
+    translations,
   ] = await Promise.all([
     areaDatasource.list(),
     competenceDatasource.list(),
@@ -34,13 +35,11 @@ export async function getLearningContentForReplication(dependencies = { translat
     attachmentDatasource.list(),
     thematicDatasource.list(),
     _getCoursesFromPGForReplication(),
+    translationRepository.listByPrefix(competenceTranslations.prefix),
   ]);
 
-  const translations = await translationRepository.list();
-
   competences.forEach((competence) => {
-    const tableTranslations = tablesTranslations['Competences'];
-    tableTranslations.hydrateReleaseObject(competence, translations);
+    competenceTranslations.hydrateReleaseObject(competence, translations);
   });
 
   return {

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,7 +1,6 @@
 import {
   areaDatasource,
   attachmentDatasource,
-  challengeDatasource,
   competenceDatasource,
   skillDatasource,
   thematicDatasource,
@@ -9,7 +8,7 @@ import {
   tutorialDatasource,
 } from '../../infrastructure/datasources/airtable/index.js';
 import * as tablesTranslations from '../../infrastructure/translations/index.js';
-import { translationRepository } from '../../infrastructure/repositories/index.js';
+import { challengeRepository, translationRepository } from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 export async function getLearningContentForReplication(dependencies = { translationRepository }) {
@@ -30,7 +29,7 @@ export async function getLearningContentForReplication(dependencies = { translat
     competenceDatasource.list(),
     tubeDatasource.list(),
     skillDatasource.list(),
-    challengeDatasource.list(),
+    challengeRepository.list(),
     tutorialDatasource.list(),
     attachmentDatasource.list(),
     thematicDatasource.list(),

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -53,17 +53,10 @@ async function loadTranslationsForChallenges(challengeDtos) {
 function toDomainList(challengeDtos, translations) {
   const translationsByLocaleAndChallengeId = _.groupBy(translations, ({ locale, key }) => `${locale}:${key.split('.')[1]}`);
 
-  return new Promise(async (resolve) => {
-    const challenges = [];
-    for (const chunkChallenges of _(challengeDtos).chunk(1000)) {
-      challenges.push(...chunkChallenges.map((challengeDto) => {
-        const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
-        const filteredTranslations = translationsByLocaleAndChallengeId[`${challengeLocale}:${challengeDto.id}`] ?? [];
-        return toDomain(challengeDto, filteredTranslations);
-      }));
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-    resolve(challenges);
+  return challengeDtos.map((challengeDto) => {
+    const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
+    const filteredTranslations = translationsByLocaleAndChallengeId[`${challengeLocale}:${challengeDto.id}`] ?? [];
+    return toDomain(challengeDto, filteredTranslations);
   });
 }
 

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -51,14 +51,14 @@ async function loadTranslationsForChallenges(challengeDtos) {
 }
 
 function toDomainList(challengeDtos, translations) {
+  const translationsByLocaleAndChallengeId = _.groupBy(translations, ({ locale, key }) => `${locale}:${key.split('.')[1]}`);
+
   return new Promise(async (resolve) => {
     const challenges = [];
     for (const chunkChallenges of _(challengeDtos).chunk(1000)) {
       challenges.push(...chunkChallenges.map((challengeDto) => {
         const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
-        const filteredTranslations = translations.filter(
-          ({ key, locale }) => key.startsWith(prefixFor(challengeDto)) && locale === challengeLocale
-        );
+        const filteredTranslations = translationsByLocaleAndChallengeId[`${challengeLocale}:${challengeDto.id}`] ?? [];
         return toDomain(challengeDto, filteredTranslations);
       }));
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -128,7 +128,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     thematicDatasource.list(),
     tubeDatasource.list(),
     tutorialDatasource.list(),
-    translationRepository.list(),
+    translationRepository.listByPrefix(competenceTranslations.prefix),
   ]);
   const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments });
   const transformedChallenges = challenges.map(transformChallenge);

--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -20,13 +20,12 @@ export function promiseStreamer(promise, writableStream = getWritableStream()) {
   }, 1000);
   promise.then((data) => {
     writableStream.write(JSON.stringify(data));
-    clearInterval(timer);
-    writableStream.end();
   }).catch((error) => {
     logger.error(error);
     Sentry.captureException(error);
-    clearInterval(timer);
     writableStream.write('error');
+  }).finally(() => {
+    clearInterval(timer);
     writableStream.end();
   });
   return writableStream;

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -34,7 +34,9 @@ async function mockCurrentContent() {
     })],
     tubes: [domainBuilder.buildTubeDatasourceObject()],
     skills: [domainBuilder.buildSkillDatasourceObject()],
-    challenges: [domainBuilder.buildChallengeDatasourceObject()],
+    challenges: [domainBuilder.buildChallengeDatasourceObject({
+      locales: ['fr'],
+    })],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
     thematics: [domainBuilder.buildThematicDatasourceObject()],
     courses: [{
@@ -91,6 +93,32 @@ async function mockCurrentContent() {
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
+    locale: 'fr',
+    value: expectedCurrentContent.challenges[0].instruction,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.alternativeInstruction`,
+    locale: 'fr',
+    value: expectedCurrentContent.challenges[0].alternativeInstruction,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.proposals`,
+    locale: 'fr',
+    value: expectedCurrentContent.challenges[0].proposals,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.solution`,
+    locale: 'fr',
+    value: expectedCurrentContent.challenges[0].solution,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
+    locale: 'fr',
+    value: expectedCurrentContent.challenges[0].solutionToDisplay,
   });
 
   await databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
La réplication ne lit pas les translations des challenges.

## :robot: Solution
Alimenter les champs traduisibles des challenges avec la table translations.

## :rainbow: Remarques
N/A

## :100: Pour tester
 - Modifier manuellement les translations d'un challenge en BdD PG
 - Appeler le endpoing de replication `/api/databases/airtable`
 - Vérifier que le challenge contient les bonnes valeurs