### PR TITLE
[TECH] Ne pas patcher le cache LCMS en RA/Intégration (PIX-9504)

### DIFF
--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -125,6 +125,8 @@ async function _proxyRequestToAirtable(request, airtableBase) {
 }
 
 async function _updateStagingPixApiCache(type, entity, translations) {
+  if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
+
   try {
     const { updatedRecord, model } = await releaseRepository.serializeEntity({
       type,

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -25,6 +25,8 @@ function _parseQueryParams(search) {
 const challengeIdType = Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+$/).required();
 
 async function _refreshCache(challenge) {
+  if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
+
   try {
     const attachments = await attachmentDatasource.filterByChallengeId(challenge.id);
     const learningContent = {

--- a/api/lib/infrastructure/pix-api-client.js
+++ b/api/lib/infrastructure/pix-api-client.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import qs from 'qs';
 import { cache } from './cache.js';
 import * as config from '../config.js';
+import { logger } from './logger.js';
 
 export async function request({ payload, url }) {
   return _callAPIWithRetry((token) => {
@@ -11,6 +12,16 @@ export async function request({ payload, url }) {
       { headers: { Authorization: `Bearer ${token}` } }
     );
   });
+}
+
+export function isPixApiCachePatchingEnabled() {
+  const enabled = config.pixApi.baseUrl !== undefined;
+
+  if (!enabled) {
+    logger.info('No base URL defined for Pix API, LCMS cache patching is disabled');
+  }
+
+  return enabled;
 }
 
 async function _callAPIWithRetry(fn, renewToken = false) {


### PR DESCRIPTION
## :unicorn: Problème
Les RAs patchent le cache LCMS de recette, et l'intégration essaient de patcher le cache LCMS mais échoue.

## :robot: Solution
Ne pas pas patcher le cache LCMS si aucune URL n'est définie pour l'API Pix.

## :rainbow: Remarques
Le template des RAs Pix Editor a été mis à jour pour enlever les variables d'environnements suivantes :
 - `PIX_API_BASEURL` 
 - `PIX_API_USER_EMAIL`
 - `PIX_API_USER_PASSWORD`

## :100: Pour tester
 - Modifier un challenge et enregistrer
 - Cliquer sur le lien de prévisualtion
 - Vérifier qu'on obtient une erreur 404
