### PR TITLE
[BUGFIX] Problème chargement de la vue Acquis après modif d'un sujet (PIX-9455)

### DIFF
--- a/pix-editor/app/components/sidebar/navigation.hbs
+++ b/pix-editor/app/components/sidebar/navigation.hbs
@@ -11,10 +11,27 @@
         <accordionItem.panel>
           <div class="content">
             {{#each area.sortedCompetences as |competence|}}
-              <LinkTo data-test-competence-item @route="authenticated.competence" @model={{competence.id}} class="item" {{on "click" @close}}>{{competence.name}}</LinkTo>
+              <LinkTo
+                data-test-competence-item
+                @route="authenticated.competence"
+                @model={{competence.id}}
+                class="item"
+                @query={{hash leftMaximized=false}}
+                {{on "click" @close}}
+              >
+                {{competence.name}}
+              </LinkTo>
             {{/each}}
             {{#if this.mayCreateCompetence}}
-              <LinkTo data-test-add-competence @route="authenticated.competence-management.new" @model={{area.id}} class="item" {{on "click" @close}}><i class="plus square icon"></i>Ajouter une compétence</LinkTo>
+              <LinkTo
+                data-test-add-competence
+                @route="authenticated.competence-management.new"
+                @model={{area.id}}
+                class="item"
+                {{on "click" @close}}
+              >
+                <i class="plus square icon"></i>Ajouter une compétence
+              </LinkTo>
             {{/if}}
           </div>
         </accordionItem.panel>


### PR DESCRIPTION
## :unicorn: Problème
Quand le panneau de modification/détail d'un sujet est maximisé, le menu de navigation vers une compétence arrive sur un écran vide.

## :robot: Solution
Réduire le panneau lors de la navigation vers une compétence.

## :rainbow: Remarques
N/A

## :100: Pour tester
- Je suis dans pixEditor et affiche une compétence.
- Je passe en vue Acquis et sélectionne un sujet
- Je maximise le panneau de détail du sujet
- Je retourne dans le menu de navigation et clique à nouveau pour afficher la compétence.
- Je vérifie que la compétence s'affiche bien