### PR TITLE
[FEATURE] Exporter les traductions au format CSV compatible avec Phrase (PIX-9538).

### DIFF
--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -2,7 +2,7 @@ import csv from 'fast-csv';
 import { translationRepository } from '../../infrastructure/repositories/index.js';
 
 export async function exportTranslations(stream, dependencies = { translationRepository }) {
-  const translationsStream = dependencies.translationRepository.streamList();
+  const translationsStream = dependencies.translationRepository.streamList({ locale: 'fr' });
   const csvStream = csv.format({ headers: true });
   csvStream.pipe(stream);
   translationsStream
@@ -10,7 +10,7 @@ export async function exportTranslations(stream, dependencies = { translationRep
       return {
         key,
         fr: value,
-      }
+      };
     })
     .pipe(csvStream);
 }

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -5,5 +5,12 @@ export async function exportTranslations(stream, dependencies = { translationRep
   const translationsStream = dependencies.translationRepository.streamList();
   const csvStream = csv.format({ headers: true });
   csvStream.pipe(stream);
-  translationsStream.pipe(csvStream);
+  translationsStream
+    .map(({ key, value }) => {
+      return {
+        key,
+        fr: value,
+      }
+    })
+    .pipe(csvStream);
 }

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -35,8 +35,8 @@ export async function list() {
   return translationDtos.map(_toDomain);
 }
 
-export function streamList() {
-  const stream = knex('translations').select().stream();
+export function streamList({ locale }) {
+  const stream = knex('translations').select().where({ locale }).stream();
 
   const toDomainTransform = new Transform({
     writableObjectMode: true,

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -30,7 +30,7 @@ describe('Acceptance | Controller | translations-controller', () => {
       // Then
       expect(response.statusCode).to.equal(200);
       expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
-      expect(response.payload).to.equal('key,locale,value\nsome-key,fr-fr,La clé !');
+      expect(response.payload).to.equal('key,fr\nsome-key,La clé !');
     });
 
   });

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -15,6 +15,11 @@ describe('Acceptance | Controller | translations-controller', () => {
         locale: 'fr-fr',
         value: 'La clé !'
       });
+      databaseBuilder.factory.buildTranslation({
+        key: 'some-key',
+        locale: 'fr',
+        value: 'La clé de la France !'
+      });
       await databaseBuilder.commit();
 
       const server = await createServer();
@@ -30,7 +35,7 @@ describe('Acceptance | Controller | translations-controller', () => {
       // Then
       expect(response.statusCode).to.equal(200);
       expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
-      expect(response.payload).to.equal('key,fr\nsome-key,La clé !');
+      expect(response.payload).to.equal('key,fr\nsome-key,La clé de la France !');
     });
 
   });

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -62,8 +62,13 @@ describe('Integration | Repository | translation-repository', function() {
   });
 
   context('#streamList', function() {
-    it('should stream a list', async function() {
+    it('should stream a list of translations of given locale', async function() {
       // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'some.key',
+        locale: 'fr-fr',
+        value: 'Bonjour, la mif de France'
+      });
       databaseBuilder.factory.buildTranslation({
         key: 'some.key',
         locale: 'fr',
@@ -72,7 +77,7 @@ describe('Integration | Repository | translation-repository', function() {
       await databaseBuilder.commit();
 
       // when
-      const stream = translationRepository.streamList();
+      const stream = translationRepository.streamList({ locale: 'fr' });
       const result = await streamToPromiseArray(stream);
 
       // then

--- a/api/tests/unit/domain/usecases/export-translations_test.js
+++ b/api/tests/unit/domain/usecases/export-translations_test.js
@@ -18,11 +18,6 @@ describe('Unit | Domain | Usecases | export-translations', function() {
         locale: 'fr',
         value: 'Bonjour'
       }));
-      streamListStream.write(new Translation({
-        key: 'some.key',
-        locale: 'en',
-        value: 'Hello,'
-      }));
       streamListStream.end();
     }
     const translationRepository = {
@@ -37,6 +32,6 @@ describe('Unit | Domain | Usecases | export-translations', function() {
     writeTranslationStream();
 
     const result = await promise;
-    expect(result).to.equal('key,locale,value\nsome.key,fr,Bonjour\nsome.key,en,"Hello,"');
+    expect(result).to.equal('key,fr\nsome.key,Bonjour');
   });
 });

--- a/api/tests/unit/domain/usecases/export-translations_test.js
+++ b/api/tests/unit/domain/usecases/export-translations_test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PassThrough } from 'node:stream';
 import { streamToPromise } from '../../../test-helper';
 import { Translation } from '../../../../lib/domain/models/Translation';
@@ -21,9 +21,9 @@ describe('Unit | Domain | Usecases | export-translations', function() {
       streamListStream.end();
     }
     const translationRepository = {
-      streamList() {
+      streamList: vi.fn(() => {
         return streamListStream;
-      }
+      })
     };
     const stream = new PassThrough();
     const promise = streamToPromise(stream);
@@ -33,5 +33,6 @@ describe('Unit | Domain | Usecases | export-translations', function() {
 
     const result = await promise;
     expect(result).to.equal('key,fr\nsome.key,Bonjour');
+    expect(translationRepository.streamList).toHaveBeenCalledWith({ locale: 'fr' });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

L'outil de traduction choisi (Phrase) permet d'importer des traductions via un fichier CSV.
Notre export CSV actuel n'est pas au bon format, car il contient une colonne `locale` alors que Phrase attend une colonne **par** locale (soit une colonne `fr`, une colonne `en`, etc).

## :robot: Solution

On exporte uniquement les traductions francophones (`locale=fr`) en adaptant le format à l'attendu de Phrase.

## :rainbow: Remarques

On a choisi d'exporter uniquement les traductions francophones car c'est ce qui nous a paru être la référence pour les autres locales.
A voir avec le métier si c'est bien le cas.

## :100: Pour tester

Se connecter à l'interface d'admin.
Dans la table `translations`, faire un export et vérifier le format du fichier CSV.
Le fichier ne doit contenir que les colonnes `key` et `fr`.
