### PR TITLE
[TECH] Chargement des épreuves en lazy (PIX-9586)

### DIFF
--- a/pix-editor/app/components/competence/grid/cell-i18n.hbs
+++ b/pix-editor/app/components/competence/grid/cell-i18n.hbs
@@ -4,9 +4,13 @@
       {{@skill.name}}
     </div>
     <div class="flags">
-      {{#each this.languagesAndFlags as |languageAndFlag| }}
-        <i class="{{languageAndFlag.flag}} flag" title="{{languageAndFlag.language}}"></i>
-      {{/each}}
+      {{#if this.loadingChallenges}}
+        <span class="loading">...</span>
+      {{else}}
+        {{#each this.languagesAndFlags as |languageAndFlag| }}
+          <i class="{{languageAndFlag.flag}} flag" title="{{languageAndFlag.language}}"></i>
+        {{/each}}
+      {{/if}}
     </div>
   </LinkTo>
 </td>

--- a/pix-editor/app/components/competence/grid/cell-i18n.js
+++ b/pix-editor/app/components/competence/grid/cell-i18n.js
@@ -10,4 +10,8 @@ export default class CompetenceGridCellI18nComponent extends Component {
       return { language, flag: convertLanguageAsFlag([language]) };
     });
   }
+
+  get loadingChallenges() {
+    return this.args.skill.challenges.isPending;
+  }
 }

--- a/pix-editor/app/components/competence/grid/cell-production.hbs
+++ b/pix-editor/app/components/competence/grid/cell-production.hbs
@@ -1,13 +1,23 @@
 <td data-test-skill-cell class="skill-cell production {{this.alertCSS}}">
-  <LinkTo data-test-skill-cell-link @route={{@link}} @model={{@skill.productionPrototype}} class="skill-cell__link">
+  <LinkTo
+    data-test-skill-cell-link
+    @route={{@link}}
+    @model={{@skill.productionPrototype}}
+    class="skill-cell__link"
+    @disabled={{this.loadingChallenges}}
+  >
     {{@skill.name}}
     <div class="alternative">
-      <span data-test-production-alternative-length class="production" title="Nombre d'épreuves en production">{{this.productionChallengesFilteredByLanguage}}</span>
-      {{#if this.draftAlternativesFilteredByLanguage}}
-        <span data-test-draft-alternative-length class="draft" title="Nombre d'épreuves en cours de construction">({{this.draftAlternativesFilteredByLanguage}})</span>
-      {{/if}}
-      {{#if @skill.productionPrototype.notDeclinable}}
-        <span class="not-declinable">NR</span>
+      {{#if this.loadingChallenges}}
+        ...
+      {{else}}
+        <span data-test-production-alternative-length class="production" title="Nombre d'épreuves en production">{{this.productionChallengesFilteredByLanguage}}</span>
+        {{#if this.draftAlternativesFilteredByLanguage}}
+          <span data-test-draft-alternative-length class="draft" title="Nombre d'épreuves en cours de construction">({{this.draftAlternativesFilteredByLanguage}})</span>
+        {{/if}}
+        {{#if @skill.productionPrototype.notDeclinable}}
+          <span class="not-declinable">NR</span>
+        {{/if}}
       {{/if}}
     </div>
   </LinkTo>

--- a/pix-editor/app/components/competence/grid/cell-production.js
+++ b/pix-editor/app/components/competence/grid/cell-production.js
@@ -3,14 +3,19 @@ import Component from '@glimmer/component';
 export default class CellProduction extends Component {
 
   get productionChallengesFilteredByLanguage() {
+    if (this.loadingChallenges) return null;
     const productionAlternatives = this.args.skill.productionPrototype.productionAlternatives;
     const productionChallenges = [...productionAlternatives, this.args.skill.productionPrototype];
     return this._filterChallengesByLanguage(productionChallenges);
   }
 
   get draftAlternativesFilteredByLanguage() {
-    const draftAlternatives = this.args.skill.productionPrototype.draftAlternatives;
-    return this._filterChallengesByLanguage(draftAlternatives);
+    if (this.loadingChallenges) return null;
+    return this._filterChallengesByLanguage(this.args.skill.productionPrototype.draftAlternatives);
+  }
+
+  get loadingChallenges() {
+    return this.args.skill.challenges.isPending;
   }
 
   _filterChallengesByLanguage(challenges) {
@@ -25,7 +30,7 @@ export default class CellProduction extends Component {
   }
 
   get alertCSS() {
-    if (this.productionChallengesFilteredByLanguage > 0) {
+    if (this.loadingChallenges || this.productionChallengesFilteredByLanguage > 0) {
       return '';
     }
     if (this.draftAlternativesFilteredByLanguage > 0) {

--- a/pix-editor/app/components/competence/grid/cell-quality.hbs
+++ b/pix-editor/app/components/competence/grid/cell-quality.hbs
@@ -1,16 +1,24 @@
 <td class="skill-cell quality-skill-cell">
-  <EmberTooltip @tooltipClass="custom-tooltip quality-tooltip" @arrowClass="custom-arrow" @side="right-start">
-    <table class="quality-indication-details">
-      <tbody>
-        {{this.popupBuild}}
-      </tbody>
-    </table>
-  </EmberTooltip >
+  {{#unless this.loadingChallenges}}
+    <EmberTooltip @tooltipClass="custom-tooltip quality-tooltip" @arrowClass="custom-arrow" @side="right-start">
+      <table class="quality-indication-details">
+        <tbody>
+          {{this.popupBuild}}
+        </tbody>
+      </table>
+    </EmberTooltip>
+  {{/unless}}
   <LinkTo @route="authenticated.competence.quality.single" @model={{@skill}} class="skill-cell__link">
     <div class="quality {{this.qualityClassColor}}">
       <div class=" quality-indication">
         <span>{{@skill.name}}</span>
-        <span>{{this.qualityIndication}}</span>
+        <span>
+          {{#if this.loadingChallenges}}
+            ...
+          {{else}}
+            {{this.qualityIndication}}
+          {{/if}}
+        </span>
       </div>
       {{#if this.classTutorial}}
         <i class="lab icon {{this.classTutorial}}"></i>

--- a/pix-editor/app/components/competence/grid/cell-quality.js
+++ b/pix-editor/app/components/competence/grid/cell-quality.js
@@ -4,6 +4,7 @@ import { htmlSafe } from '@ember/template';
 export default class CellQuality extends Component {
 
   get qualityIndication() {
+    if (this.loadingChallenges) return null;
     const productionPrototype = this.args.skill.productionPrototype;
     const allWeight = 19;
     const spoil = this._spoilWeight(productionPrototype.spoil);
@@ -16,7 +17,14 @@ export default class CellQuality extends Component {
     return Math.round(result * 100);
   }
 
+  get loadingChallenges() {
+    return this.args.skill.challenges.isPending;
+  }
+
   get qualityClassColor() {
+    if (this.loadingChallenges) {
+      return 'quality loading';
+    }
     const qualityIndication = this.qualityIndication;
     if (qualityIndication < 50) {
       return 'quality bad-quality';

--- a/pix-editor/app/components/competence/grid/cell-workbench.hbs
+++ b/pix-editor/app/components/competence/grid/cell-workbench.hbs
@@ -2,17 +2,21 @@
   <LinkTo @route="authenticated.competence.prototypes.list" @models={{array @tube.id @skill.id}} class="skill-cell__link">
     {{@skill.name}}
     <div class="workbench__status">
-      {{#if this.hasDraftPrototypes}}
-        <span data-test-draft-prototype-count class="draft-prototype ui tiny label" title="Proposé">{{this.draftPrototypesCount}}</span>
-      {{/if}}
-      {{#if this.validatedPrototype}}
-        <span data-test-validated-prototype-count class="validated-prototype ui tiny label" title="Validé">1</span>
-      {{/if}}
-      {{#if this.hasArchivedPrototypes}}
-        <span data-test-archived-prototype-count class="archived-prototype ui tiny label" title="Archivé">{{this.archivedPrototypesCount}}</span>
-      {{/if}}
-      {{#if this.hasObsoletePrototypes}}
-        <span data-test-obsolete-prototype-count class="obsolete-prototype ui tiny label" title="Périmé"> {{this.obsoletePrototypesCount}}</span>
+      {{#if this.loadingChallenges}}
+        <span class="loading">...</span>
+      {{else}}
+        {{#if this.hasDraftPrototypes}}
+          <span data-test-draft-prototype-count class="draft-prototype ui tiny label" title="Proposé">{{this.draftPrototypesCount}}</span>
+        {{/if}}
+        {{#if this.validatedPrototype}}
+          <span data-test-validated-prototype-count class="validated-prototype ui tiny label" title="Validé">1</span>
+        {{/if}}
+        {{#if this.hasArchivedPrototypes}}
+          <span data-test-archived-prototype-count class="archived-prototype ui tiny label" title="Archivé">{{this.archivedPrototypesCount}}</span>
+        {{/if}}
+        {{#if this.hasObsoletePrototypes}}
+          <span data-test-obsolete-prototype-count class="obsolete-prototype ui tiny label" title="Périmé"> {{this.obsoletePrototypesCount}}</span>
+        {{/if}}
       {{/if}}
     </div>
   </LinkTo>

--- a/pix-editor/app/components/competence/grid/cell-workbench.js
+++ b/pix-editor/app/components/competence/grid/cell-workbench.js
@@ -6,6 +6,10 @@ export default class CellWorkbench extends Component {
     return this.args.skills.map(skill => skill.prototypes).flat();
   }
 
+  get loadingChallenges() {
+    return this.args.skills.some(skill => skill.challenges.isPending);
+  }
+
   get validatedPrototype() {
     return this.prototypes.find(prototype => prototype.isValidated);
   }

--- a/pix-editor/app/routes/authenticated/competence.js
+++ b/pix-editor/app/routes/authenticated/competence.js
@@ -20,13 +20,12 @@ export default class CompetenceRoute extends Route {
       const themes = await model.hasMany('rawThemes').reload();
       const themesTubes = await Promise.all(themes.map(theme => theme.hasMany('rawTubes').reload()));
       const tubesSkills = await Promise.all(themesTubes.flatMap(tubes => tubes.map(tube => tube.hasMany('rawSkills').reload())));
-      await Promise.all(tubesSkills.flatMap(skills => skills.map(skill => skill.hasMany('challenges').reload())));
+      Promise.all(tubesSkills.flatMap(skills => skills.map(skill => skill.hasMany('challenges').reload()))).catch(console.error);
       model.needsRefresh = false;
     } else {
       const themes = await model.rawThemes;
       const themesTubes = await Promise.all(themes.map(theme => theme.rawTubes));
-      const skillsStubes = await Promise.all(themesTubes.flatMap(tubes => tubes.map(tube => tube.rawSkills)));
-      await Promise.all(skillsStubes.flatMap(skills => skills.map(skill => skill.challenges)));
+      await Promise.all(themesTubes.flatMap(tubes => tubes.map(tube => tube.rawSkills)));
     }
   }
 

--- a/pix-editor/app/styles/_competence.scss
+++ b/pix-editor/app/styles/_competence.scss
@@ -113,8 +113,11 @@
       .skill-cell__link {
         color: black;
         cursor: pointer;
-      }
 
+        &.disabled {
+          cursor: not-allowed;
+        }
+      }
 
       &.production {
         &.warning {
@@ -172,6 +175,10 @@
             &.not-declinable {
               color: black;
               background: white;
+            }
+
+            &.loading {
+              height: 25px;
             }
           }
         }
@@ -314,6 +321,10 @@
 
           &.good-quality {
             background: #0DC600;
+          }
+
+          &.loading {
+            background-color: #aaaaaa;
           }
 
           .half-tutorial {

--- a/pix-editor/tests/e2e/challenge.spec.js
+++ b/pix-editor/tests/e2e/challenge.spec.js
@@ -6,13 +6,13 @@ test.describe('Épreuves', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 10000 });
   });
 
   test('accéder au détail d\'une épreuve', async function({ page }) {
     await page.getByRole('button', { name: '1. Information et données' }).click();
-    await page.getByRole('link', { name: '1.1' }).click(); // FIXME add title
-    await page.getByRole('link', { name: '@Moteur1' }).click();
+    await page.getByRole('link', { name: '1.1 Mener une recherche et une veille d’information' }).click();
+    await page.getByRole('link', { name: '@Moteur1 2 NR' }).click({ timeout: 10000 });
 
     await expect(page.getByText('Citer le numéro d\'une des applications permettant d\'aller sur le web (navigateur web).')).toBeVisible();
   });

--- a/pix-editor/tests/e2e/login.spec.js
+++ b/pix-editor/tests/e2e/login.spec.js
@@ -19,7 +19,7 @@ test.describe('Login', () => {
       await page.getByRole('textbox', { name: 'Clé API' }).fill('8d03a893-3967-4501-9dc4-e0aa6c6dc442');
       await page.getByRole('button', { name: 'Se connecter' }).click();
 
-      await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 10000 });
       await expect(page.getByText(/DEV\s+-\s+Version\s+\d+\.\d+\.\d+/)).toBeVisible();
     });
 
@@ -43,7 +43,7 @@ test.describe('Login', () => {
       await page.getByRole('textbox', { name: 'Clé API' }).fill('adaf3eee-09dc-4f9a-a504-ff92e74c9d0f');
       await page.getByRole('button', { name: 'Se connecter' }).click();
 
-      await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 10000 });
       await expect(page.getByText(/EDI\s+-\s+Version\s+\d+\.\d+\.\d+/)).toBeVisible();
     });
   });

--- a/pix-editor/tests/e2e/static-course.spec.js
+++ b/pix-editor/tests/e2e/static-course.spec.js
@@ -6,7 +6,7 @@ test.describe('Tests statiques', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 10000 });
   });
 
   test('accéder au détail d\'un test statique', async function({ page }) {

--- a/pix-editor/tests/integration/components/competence/grid/cell-i18n-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-i18n-test.js
@@ -13,7 +13,8 @@ module('Integration | Component | competence/grid/cell-i18n', function(hooks) {
     const skill = {
       id: 'rec123456',
       name: 'skillName',
-      languages: ['Anglais','Franco Français','Francophone']
+      languages: ['Anglais','Franco Français','Francophone'],
+      challenges: [],
     };
     this.set('section', section);
     this.set('skill', skill);

--- a/pix-editor/tests/integration/components/competence/grid/cell-production-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-production-test.js
@@ -34,8 +34,9 @@ module('Integration | Component | competence/grid/cell-production', function(hoo
         id: 'challenge6',
         locales: ['Francophone', 'Franco Français'],
         productionAlternatives: [challenge1, challenge2, challenge3],
-        draftAlternatives: [challenge4, challenge5]
-      }
+        draftAlternatives: [challenge4, challenge5],
+      },
+      challenges: [challenge1, challenge2, challenge3, challenge4, challenge5],
     });
   });
 

--- a/pix-editor/tests/integration/components/competence/grid/cell-quality-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-quality-test.js
@@ -11,7 +11,8 @@ module('Integration | Component | quality-view', function(hooks) {
     const skill = {
       productionPrototype: {},
       tutoSolution: [],
-      tutoMore: []
+      tutoMore: [],
+      challenges: [],
     };
 
     this.skill = skill;

--- a/pix-editor/tests/integration/components/competence/grid/grid-cell-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/grid-cell-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | competence/grid/grid-cell', function (hooks) {
       productionPrototypes: [challenge],
       validatedChallenges: [challenge],
       languages: ['Francophone'],
-
+      challenges: [challenge],
     };
     this.set('section', section);
     this.set('skill', skill);


### PR DESCRIPTION
## :unicorn: Problème
Le chargement des épreuves retarde beaucoup l'affichage de la page compétence.

## :robot: Solution
Charger les épreuves en lazy et adapter l'affichage des différentes vues quand les épreuves ne sont pas encore chargées.

## :rainbow: Remarques
C'est un essai, pas sur que ce soit ce qu'on veut.

## :100: Pour tester
Aller sur la RA et afficher différentes compétences et les différentes vues.