### PR TITLE
[FEATURE] Modifier la release et la réplication pour supporter l'ancien et le nouveau format des données traduisibles des épreuves (PIX-9315)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -45,6 +45,7 @@ export class Challenge {
     alpha,
     delta,
     skillId,
+    translations,
   } = {}) {
     this.id = id;
     this.instruction = instruction;
@@ -91,5 +92,6 @@ export class Challenge {
     this.alpha = alpha;
     this.delta = delta;
     this.skillId = skillId;
+    this.translations = translations;
   }
 }

--- a/api/lib/domain/models/release/ChallengeForRelease.js
+++ b/api/lib/domain/models/release/ChallengeForRelease.js
@@ -29,7 +29,8 @@ export class ChallengeForRelease {
     illustrationAlt,
     illustrationUrl,
     shuffled,
-    alternativeVersion
+    alternativeVersion,
+    translations,
   }) {
     this.id = id;
     this.instruction = instruction;
@@ -61,5 +62,6 @@ export class ChallengeForRelease {
     this.illustrationUrl = illustrationUrl;
     this.shuffled = shuffled;
     this.alternativeVersion = alternativeVersion;
+    this.translations = translations;
   }
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -61,9 +61,15 @@ function toDomainList(challengeDtos, translations) {
 }
 
 function toDomain(challengeDto, translations) {
-  const formattedTranslations = translations.map(({ key, value }) => [key.split('.').at(-1), value]);
+  const translatedFields = Object.fromEntries(
+    translations.map(({ key, value }) => [key.split('.').at(-1), value]),
+  );
+  const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
   return new Challenge({
     ...challengeDto,
-    ...Object.fromEntries(formattedTranslations),
+    ...translatedFields,
+    translations: {
+      [challengeLocale] : translatedFields
+    }
   });
 }

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -35,7 +35,8 @@ function _filterChallengeFields(challenge) {
     'timer',
     'type',
     'shuffled',
-    'alternativeVersion'
+    'alternativeVersion',
+    'translations',
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -19,6 +19,7 @@ const {
 } = airtableBuilder.factory;
 
 async function mockCurrentContent() {
+  const challenge = domainBuilder.buildChallengeDatasourceObject({ locales: ['fr'], });
   const expectedCurrentContent = {
     attachments: [domainBuilder.buildAttachment()],
     areas: [domainBuilder.buildAreaDatasourceObject()],
@@ -34,9 +35,18 @@ async function mockCurrentContent() {
     })],
     tubes: [domainBuilder.buildTubeDatasourceObject()],
     skills: [domainBuilder.buildSkillDatasourceObject()],
-    challenges: [domainBuilder.buildChallengeDatasourceObject({
-      locales: ['fr'],
-    })],
+    challenges: [{
+      ...challenge,
+      translations: {
+        fr: {
+          instruction: challenge.instruction,
+          alternativeInstruction: challenge.alternativeInstruction,
+          proposals: challenge.proposals,
+          solution: challenge.solution,
+          solutionToDisplay: challenge.solutionToDisplay,
+        }
+      }
+    }],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
     thematics: [domainBuilder.buildThematicDatasourceObject()],
     courses: [{

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -103,11 +103,20 @@ async function mockCurrentContent() {
     }],
     challenges: [{
       id: 'recChallenge0',
-      instruction: 'Consigne du Challenge',
-      proposals: 'Propositions du Challenge',
+      instruction: 'Consigne du Challenge - fr-fr',
+      proposals: 'Propositions du Challenge - fr-fr',
+      translations: {
+        'fr-fr': {
+          instruction: 'Consigne du Challenge - fr-fr',
+          proposals: 'Propositions du Challenge - fr-fr',
+          solution: 'Bonnes réponses du Challenge - fr-fr',
+          solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
+          alternativeInstruction: 'Consigne alternative - fr-fr',
+        }
+      },
       type: 'Type d\'épreuve',
-      solution: 'Bonnes réponses du Challenge',
-      solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+      solution: 'Bonnes réponses du Challenge - fr-fr',
+      solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
       t1Status: false,
       t2Status: true,
       t3Status: false,
@@ -124,7 +133,7 @@ async function mockCurrentContent() {
       format: 'mots',
       autoReply: false,
       locales: ['fr-fr'],
-      alternativeInstruction: 'Consigne alternative',
+      alternativeInstruction: 'Consigne alternative - fr-fr',
       focusable: false,
       delta: 0.5,
       alpha: 0.9,
@@ -199,6 +208,31 @@ async function mockCurrentContent() {
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].instruction,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.alternativeInstruction`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].alternativeInstruction,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.proposals`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].proposals,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.solution`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solution,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solutionToDisplay,
   });
 
   await databaseBuilder.commit();
@@ -289,11 +323,20 @@ async function mockContentForRelease() {
     }],
     challenges: [{
       id: 'recChallenge0',
-      instruction: 'Consigne du Challenge',
-      proposals: 'Propositions du Challenge',
+      instruction: 'Consigne du Challenge - fr-fr',
+      proposals: 'Propositions du Challenge - fr-fr',
+      translations: {
+        'fr-fr': {
+          instruction: 'Consigne du Challenge - fr-fr',
+          proposals: 'Propositions du Challenge - fr-fr',
+          solution: 'Bonnes réponses du Challenge - fr-fr',
+          solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
+          alternativeInstruction: 'Consigne alternative - fr-fr',
+        }
+      },
       type: 'Type d\'épreuve',
-      solution: 'Bonnes réponses du Challenge',
-      solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+      solution: 'Bonnes réponses du Challenge - fr-fr',
+      solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
       t1Status: false,
       t2Status: true,
       t3Status: false,
@@ -307,7 +350,7 @@ async function mockContentForRelease() {
       format: 'mots',
       autoReply: false,
       locales: ['fr-fr'],
-      alternativeInstruction: 'Consigne alternative',
+      alternativeInstruction: 'Consigne alternative - fr-fr',
       focusable: false,
       delta: 0.5,
       alpha: 0.9,
@@ -387,6 +430,31 @@ async function mockContentForRelease() {
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].instruction,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.alternativeInstruction`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].alternativeInstruction,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.proposals`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].proposals,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.solution`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solution,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solutionToDisplay,
   });
 
   await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it } from 'vitest';
 import { databaseBuilder, knex, domainBuilder, airtableBuilder } from '../../../test-helper.js';
-import { create, getLatestRelease, getRelease, getCurrentContent } from '../../../../lib/infrastructure/repositories/release-repository.js';
+import {
+  create,
+  getLatestRelease,
+  getRelease,
+  getCurrentContent
+} from '../../../../lib/infrastructure/repositories/release-repository.js';
 
 describe('Integration | Repository | release-repository', function() {
   describe('#create', function() {
@@ -163,7 +168,7 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getCurrentContent', function() {
 
     beforeEach(function() {
-      const { competences } = _mockRichAirtableContent();
+      const { competences, challenges } = _mockRichAirtableContent();
 
       for (const competence of competences) {
         if (competence.name_i18n?.fr) {
@@ -192,6 +197,37 @@ describe('Integration | Repository | release-repository', function() {
             key: `competence.${competence.id}.description`,
             locale: 'en',
             value: competence.description_i18n.en,
+          });
+        }
+      }
+
+      for (const challenge of challenges) {
+        const locales = Object.keys(challenge.translations);
+        for (const locale of locales) {
+          databaseBuilder.factory.buildTranslation({
+            key: `challenge.${challenge.id}.instruction`,
+            locale,
+            value: challenge.translations[locale].instruction,
+          });
+          databaseBuilder.factory.buildTranslation({
+            key: `challenge.${challenge.id}.alternativeInstruction`,
+            locale,
+            value: challenge.translations[locale].alternativeInstruction,
+          });
+          databaseBuilder.factory.buildTranslation({
+            key: `challenge.${challenge.id}.proposals`,
+            locale,
+            value: challenge.translations[locale].proposals,
+          });
+          databaseBuilder.factory.buildTranslation({
+            key: `challenge.${challenge.id}.solution`,
+            locale,
+            value: challenge.translations[locale].solution,
+          });
+          databaseBuilder.factory.buildTranslation({
+            key: `challenge.${challenge.id}.solutionToDisplay`,
+            locale,
+            value: challenge.translations[locale].solutionToDisplay,
           });
         }
       }
@@ -492,8 +528,17 @@ function _mockRichAirtableContent() {
     internationalisation: 'skill21111 internationalisation',
     version: 'skill21111 version',
   });
-  const airtableChallenge121211 = airtableBuilder.factory.buildChallenge({
+  const challenge121211 = {
     id: 'challenge121211',
+    translations: {
+      'fr-fr': {
+        instruction: 'challenge121211 instruction',
+        proposals: 'challenge121211 proposals',
+        solution: 'challenge121211 solution',
+        solutionToDisplay: 'challenge121211 solutionToDisplay',
+        alternativeInstruction: 'challenge121211 alternativeInstruction',
+      },
+    },
     instruction: 'challenge121211 instruction',
     proposals: 'challenge121211 proposals',
     type: 'challenge121211 type',
@@ -533,9 +578,19 @@ function _mockRichAirtableContent() {
     alpha: 2.2,
     updatedAt: 'challenge121211 updatedAt',
     shuffled: false,
-  });
-  const airtableChallenge121212 = airtableBuilder.factory.buildChallenge({
+  };
+  const airtableChallenge121211 = airtableBuilder.factory.buildChallenge(challenge121211);
+  const challenge121212 = {
     id: 'challenge121212',
+    translations: {
+      en: {
+        instruction: 'challenge121212 instruction',
+        proposals: 'challenge121212 proposals',
+        solution: 'challenge121212 solution',
+        solutionToDisplay: 'challenge121212 solutionToDisplay',
+        alternativeInstruction: 'challenge121212 alternativeInstruction',
+      },
+    },
     instruction: 'challenge121212 instruction',
     proposals: 'challenge121212 proposals',
     type: 'challenge121212 type',
@@ -575,9 +630,19 @@ function _mockRichAirtableContent() {
     alpha: 456,
     updatedAt: 'challenge121212 updatedAt',
     shuffled: true,
-  });
-  const airtableChallenge211111 = airtableBuilder.factory.buildChallenge({
+  };
+  const airtableChallenge121212 = airtableBuilder.factory.buildChallenge(challenge121212);
+  const challenge211111 = {
     id: 'challenge211111',
+    translations: {
+      fr: {
+        instruction: 'challenge211111 instruction',
+        proposals: 'challenge211111 proposals',
+        solution: 'challenge211111 solution',
+        solutionToDisplay: 'challenge211111 solutionToDisplay',
+        alternativeInstruction: 'challenge211111 alternativeInstruction',
+      },
+    },
     instruction: 'challenge211111 instruction',
     proposals: 'challenge211111 proposals',
     type: 'challenge211111 type',
@@ -617,9 +682,19 @@ function _mockRichAirtableContent() {
     alpha: 200,
     updatedAt: 'challenge211111 updatedAt',
     shuffled: false,
-  });
-  const airtableChallenge211112 = airtableBuilder.factory.buildChallenge({
+  };
+  const airtableChallenge211111 = airtableBuilder.factory.buildChallenge(challenge211111);
+  const challenge211112 = {
     id: 'challenge211112',
+    translations: {
+      fr: {
+        instruction: 'challenge211112 instruction',
+        proposals: 'challenge211112 proposals',
+        solution: 'challenge211112 solution',
+        solutionToDisplay: 'challenge211112 solutionToDisplay',
+        alternativeInstruction: 'challenge211112 alternativeInstruction',
+      },
+    },
     instruction: 'challenge211112 instruction',
     proposals: 'challenge211112 proposals',
     type: 'challenge211112 type',
@@ -659,9 +734,19 @@ function _mockRichAirtableContent() {
     alpha: 200,
     updatedAt: 'challenge211112 updatedAt',
     shuffled: false,
-  });
-  const airtableChallenge211113 = airtableBuilder.factory.buildChallenge({
+  };
+  const airtableChallenge211112 = airtableBuilder.factory.buildChallenge(challenge211112);
+  const challenge211113 = {
     id: 'challenge211113',
+    translations: {
+      'fr': {
+        instruction: 'challenge211113 instruction',
+        proposals: 'challenge211113 proposals',
+        solution: 'challenge211113 solution',
+        solutionToDisplay: 'challenge211113 solutionToDisplay',
+        alternativeInstruction: 'challenge211113 alternativeInstruction',
+      },
+    },
     instruction: 'challenge211113 instruction',
     proposals: 'challenge211113 proposals',
     type: 'challenge211113 type',
@@ -701,7 +786,8 @@ function _mockRichAirtableContent() {
     alpha: 200,
     updatedAt: 'challenge211113 updatedAt',
     shuffled: false,
-  });
+  };
+  const airtableChallenge211113 = airtableBuilder.factory.buildChallenge(challenge211113);
   const airtableTutorial1 = airtableBuilder.factory.buildTutorial({
     id: 'tutorial1',
     title: 'tutorial1 title',
@@ -760,6 +846,7 @@ function _mockRichAirtableContent() {
 
   return {
     competences: [competence11, competence12, competence21],
+    challenges: [challenge121211, challenge121212, challenge211111, challenge211112, challenge211113],
   };
 }
 
@@ -1090,6 +1177,15 @@ function _getRichCurrentContentDTO() {
   const expectedChallengeDTOs = [
     {
       id: 'challenge121211',
+      translations: {
+        'fr-fr': {
+          instruction: 'challenge121211 instruction',
+          proposals: 'challenge121211 proposals',
+          solution: 'challenge121211 solution',
+          solutionToDisplay: 'challenge121211 solutionToDisplay',
+          alternativeInstruction: 'challenge121211 alternativeInstruction',
+        },
+      },
       instruction: 'challenge121211 instruction',
       proposals: 'challenge121211 proposals',
       type: 'challenge121211 type',
@@ -1122,6 +1218,15 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge121212',
+      translations: {
+        en: {
+          instruction: 'challenge121212 instruction',
+          proposals: 'challenge121212 proposals',
+          solution: 'challenge121212 solution',
+          solutionToDisplay: 'challenge121212 solutionToDisplay',
+          alternativeInstruction: 'challenge121212 alternativeInstruction',
+        },
+      },
       instruction: 'challenge121212 instruction',
       proposals: 'challenge121212 proposals',
       type: 'challenge121212 type',
@@ -1153,6 +1258,15 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge211111',
+      translations: {
+        'fr': {
+          instruction: 'challenge211111 instruction',
+          proposals: 'challenge211111 proposals',
+          solution: 'challenge211111 solution',
+          solutionToDisplay: 'challenge211111 solutionToDisplay',
+          alternativeInstruction: 'challenge211111 alternativeInstruction',
+        },
+      },
       instruction: 'challenge211111 instruction',
       proposals: 'challenge211111 proposals',
       type: 'challenge211111 type',
@@ -1185,6 +1299,15 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge211112',
+      translations: {
+        'fr': {
+          instruction: 'challenge211112 instruction',
+          proposals: 'challenge211112 proposals',
+          solution: 'challenge211112 solution',
+          solutionToDisplay: 'challenge211112 solutionToDisplay',
+          alternativeInstruction: 'challenge211112 alternativeInstruction',
+        },
+      },
       instruction: 'challenge211112 instruction',
       proposals: 'challenge211112 proposals',
       type: 'challenge211112 type',
@@ -1216,6 +1339,15 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge211113',
+      translations: {
+        'fr': {
+          instruction: 'challenge211113 instruction',
+          proposals: 'challenge211113 proposals',
+          solution: 'challenge211113 solution',
+          solutionToDisplay: 'challenge211113 solutionToDisplay',
+          alternativeInstruction: 'challenge211113 alternativeInstruction',
+        },
+      },
       instruction: 'challenge211113 instruction',
       proposals: 'challenge211113 proposals',
       type: 'challenge211113 type',


### PR DESCRIPTION
## :unicorn: Problème
Le format de la release et de la réplication ne permet pas de véhiculer plusieurs traductions pour un même challenge.

## :robot: Solution
Modifier le format afin de pouvoir véhiculer plusieurs traductions pour un même challenge.

## :rainbow: Remarques
N/A

## :100: Pour tester
 - Créer/lire une release sur la RA et vérifier que les challenges contiennent bien un objet `translations` avec un sous-objet portant le nom de la locale du challenge et contenant les champs traduisibles
 - Appeler le endpoint de la réplication sur la RA et faire la même vérification