### PR TITLE
[FEATURE] Faire la recherche d'épreuve à partir des traductions (PIX-9659)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -171,6 +171,9 @@ export const challengeDatasource = datasource.extend({
       fields: this.usedFields,
       filterByFormula: `FIND('${_escapeQuery(params.filter.search)}', LOWER(CONCATENATE({Embed URL})))`
     };
+    if (params.filter.ids && params.filter.ids.length > 0) {
+      options.filterByFormula = 'OR(' + options.filterByFormula + ', ' + params.filter.ids.map((id) => `'${id}' = {id persistant}`).join(',') + ')';
+    }
     if (params.page && params.page.size) {
       options.maxRecords = params.page.size;
     }
@@ -186,7 +189,6 @@ export const challengeDatasource = datasource.extend({
     return this.fromAirTableObject(airtableRawObjects[0]);
   },
 
-  // OR('recChallenge1' = {id persistant}, 'recChallenge2' = {id persistant}, FIND('toto', LOWER(CONCATENATE({Embed URL})))
   async getAllIdsIn(challengeIds) {
     const options = {
       fields: ['id persistant'],

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -169,7 +169,7 @@ export const challengeDatasource = datasource.extend({
   async search(params) {
     const options = {
       fields: this.usedFields,
-      filterByFormula : `AND(FIND('${_escapeQuery(params.filter.search)}', LOWER(CONCATENATE(Consigne,Propositions,{Embed URL}))) , Statut != 'archive')`
+      filterByFormula: `FIND('${_escapeQuery(params.filter.search)}', LOWER(CONCATENATE({Embed URL})))`
     };
     if (params.page && params.page.size) {
       options.maxRecords = params.page.size;
@@ -180,12 +180,13 @@ export const challengeDatasource = datasource.extend({
 
   async filterById(id) {
     const airtableRawObjects = await findRecords(this.tableName, {
-      filterByFormula : `{id persistant} = '${id}'`,
+      filterByFormula: `{id persistant} = '${id}'`,
       maxRecords: 1,
     });
     return this.fromAirTableObject(airtableRawObjects[0]);
   },
 
+  // OR('recChallenge1' = {id persistant}, 'recChallenge2' = {id persistant}, FIND('toto', LOWER(CONCATENATE({Embed URL})))
   async getAllIdsIn(challengeIds) {
     const options = {
       fields: ['id persistant'],

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -13,7 +13,8 @@ async function _getChallengesFromParams(params) {
     params.filter.ids = await translationRepository.search({
       entity: 'challenge',
       fields: ['instruction', 'proposals'],
-      search: params.filter.search
+      search: params.filter.search,
+      limit: params.page?.size,
     });
     return challengeDatasource.search(params);
   }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -5,11 +5,16 @@ import { challengeDatasource } from '../datasources/airtable/index.js';
 import { translationRepository } from './index.js';
 import { prefix, prefixFor, getPrimaryLocaleFromChallenge } from '../translations/challenge.js';
 
-function _getChallengesFromParams(params) {
+async function _getChallengesFromParams(params) {
   if (params.filter && params.filter.ids) {
     return challengeDatasource.filter(params);
   }
   if (params.filter && params.filter.search) {
+    params.filter.ids = await translationRepository.search({
+      entity: 'challenge',
+      fields: ['instruction', 'proposals'],
+      search: params.filter.search
+    });
     return challengeDatasource.search(params);
   }
   return challengeDatasource.list(params);
@@ -51,7 +56,10 @@ async function loadTranslationsForChallenges(challengeDtos) {
 }
 
 function toDomainList(challengeDtos, translations) {
-  const translationsByLocaleAndChallengeId = _.groupBy(translations, ({ locale, key }) => `${locale}:${key.split('.')[1]}`);
+  const translationsByLocaleAndChallengeId = _.groupBy(translations, ({
+    locale,
+    key
+  }) => `${locale}:${key.split('.')[1]}`);
 
   return challengeDtos.map((challengeDto) => {
     const challengeLocale = getPrimaryLocaleFromChallenge(challengeDto.locales) ?? 'fr';
@@ -69,7 +77,7 @@ function toDomain(challengeDto, translations) {
     ...challengeDto,
     ...translatedFields,
     translations: {
-      [challengeLocale] : translatedFields
+      [challengeLocale]: translatedFields
     }
   });
 }

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -38,7 +38,7 @@ export async function list() {
 export async function search({ entity, fields, search, limit }) {
   const query = knex('translations')
     .pluck('key')
-    .whereLike('value', `%${search}%`)
+    .whereLike('value', `%${escapeWildcardCharacters(search)}%`)
     .andWhere(function() {
       for (const field of fields) {
         this.orWhereLike('key', `${entity}.%.${field}`);
@@ -53,6 +53,10 @@ export async function search({ entity, fields, search, limit }) {
   return _.sortedUniq(keys.map((key) => {
     return key.split('.')[1];
   }));
+}
+
+function escapeWildcardCharacters(s) {
+  return s.replace(/(%|_)/g, '\\$1');
 }
 
 export async function checkIfShouldDuplicateToAirtable() {

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -35,14 +35,20 @@ export async function list() {
   return translationDtos.map(_toDomain);
 }
 
-export async function search({ entity, fields, search }) {
-  const keys = await knex('translations').pluck('key')
+export async function search({ entity, fields, search, limit }) {
+  const query = knex('translations')
+    .pluck('key')
     .whereLike('value', `%${search}%`)
     .andWhere(function() {
       for (const field of fields) {
         this.orWhereLike('key', `${entity}.%.${field}`);
       }
-    }).orderBy('key');
+    })
+    .orderBy('key');
+
+  if (limit) query.limit(limit);
+
+  const keys = await query;
 
   return _.sortedUniq(keys.map((key) => {
     return key.split('.')[1];

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { translationDatasource } from '../datasources/airtable/index.js';
 import { Translation } from '../../domain/models/index.js';
+import _ from 'lodash';
 
 let _shouldDuplicateToAirtable;
 let _shouldDuplicateToAirtablePromise;
@@ -34,6 +35,20 @@ export async function list() {
   return translationDtos.map(_toDomain);
 }
 
+export async function search({ entity, fields, search }) {
+  const keys = await knex('translations').pluck('key')
+    .whereLike('value', `%${search}%`)
+    .andWhere(function() {
+      for (const field of fields) {
+        this.orWhereLike('key', `${entity}.%.${field}`);
+      }
+    }).orderBy('key');
+
+  return _.sortedUniq(keys.map((key) => {
+    return key.split('.')[1];
+  }));
+}
+
 export async function checkIfShouldDuplicateToAirtable() {
   _shouldDuplicateToAirtablePromise = translationDatasource.exists();
   _shouldDuplicateToAirtable = await _shouldDuplicateToAirtablePromise;
@@ -53,9 +68,11 @@ export async function deleteByKeyPrefix(prefix) {
   }
 
   if (_shouldDuplicateToAirtable) {
-    const records = await translationDatasource.filter({ filter: {
-      formula: `REGEX_MATCH(key, "^${prefix.replace(/(\.)/g, '\\$1')}")`,
-    } });
+    const records = await translationDatasource.filter({
+      filter: {
+        formula: `REGEX_MATCH(key, "^${prefix.replace(/(\.)/g, '\\$1')}")`,
+      }
+    });
     const recordIds = records.map(({ airtableId }) => airtableId);
     await translationDatasource.delete(recordIds);
   }

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -38,7 +38,7 @@ export async function list() {
 export async function search({ entity, fields, search, limit }) {
   const query = knex('translations')
     .pluck('key')
-    .whereLike('value', `%${escapeWildcardCharacters(search)}%`)
+    .whereILike('value', `%${escapeWildcardCharacters(search)}%`)
     .andWhere(function() {
       for (const field of fields) {
         this.orWhereLike('key', `${entity}.%.${field}`);

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -342,7 +342,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             '': challengeAirtableFields,
           },
           maxRecords: 100,
-          filterByFormula: 'AND(FIND(\'query term\', LOWER(CONCATENATE(Consigne,Propositions,{Embed URL}))) , Statut != \'archive\')',
+          filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))',
         })
         .reply(200, {
           records: []
@@ -369,7 +369,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           fields: {
             '': challengeAirtableFields,
           },
-          filterByFormula: 'AND(FIND(\'query term\', LOWER(CONCATENATE(Consigne,Propositions,{Embed URL}))) , Statut != \'archive\')',
+          filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))',
           maxRecords: 20,
         })
         .reply(200, {

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -255,6 +255,58 @@ describe('Integration | Repository | translation-repository', function() {
       // then
       expect(entityIds).to.deep.equal(['entityId1']);
     });
+
+    describe('when search string contains wildcard characters', () => {
+
+      beforeEach(async () => {
+        databaseBuilder.factory.buildTranslation({
+          key: 'entity.entityId1.key',
+          locale: 'fr',
+          value: 'aaa N_n aaa',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'entity.entityId2.key',
+          locale: 'fr',
+          value: 'On est sur de nous à 80% à peu près',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'entity.entityId3.key',
+          locale: 'fr',
+          value: 'aaa Non aaa',
+        });
+        await databaseBuilder.commit();
+      });
+
+      it('should escape % character', async () => {
+        // given
+        const searchString = '%';
+
+        // when
+        const entityIds = await search({
+          entity: 'entity',
+          fields: ['key'],
+          search: searchString,
+        });
+
+        // then
+        expect(entityIds).to.deep.equal(['entityId2']);
+      });
+
+      it('should escape _ character', async () => {
+        // given
+        const searchString = 'N_n';
+
+        // when
+        const entityIds = await search({
+          entity: 'entity',
+          fields: ['key'],
+          search: searchString,
+        });
+
+        // then
+        expect(entityIds).to.deep.equal(['entityId1']);
+      });
+    });
   });
 });
 

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, describe as context, expect, it } from
 import { knex, databaseBuilder } from '../../../test-helper.js';
 import {
   checkIfShouldDuplicateToAirtable,
-  save, search
+  save,
+  search,
 } from '../../../../lib/infrastructure/repositories/translation-repository.js';
 import nock from 'nock';
 import { translationRepository } from '../../../../lib/infrastructure/repositories/index.js';
@@ -254,6 +255,32 @@ describe('Integration | Repository | translation-repository', function() {
 
       // then
       expect(entityIds).to.deep.equal(['entityId1']);
+    });
+
+    it('should perform a case-insensitive search', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'Coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await search({
+        entity: 'entity',
+        fields: ['key'],
+        search: 'coucou',
+        limit: 2,
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1', 'entityId2']);
     });
 
     describe('when search string contains wildcard characters', () => {

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -151,6 +151,7 @@ describe('Integration | Repository | translation-repository', function() {
       });
     });
   });
+
   context('#search', function() {
     it('should search for fields in entities', async function() {
       // given
@@ -227,6 +228,32 @@ describe('Integration | Repository | translation-repository', function() {
 
       // then
       expect(entityIds).to.deep.equal(['entityId1', 'entityId2']);
+    });
+
+    it('should return a limited number of ids', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await search({
+        entity: 'entity',
+        fields: ['key'],
+        search: 'coucou',
+        limit: 1,
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1']);
     });
   });
 });

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -52,7 +52,11 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
     it('should convert Airtable t1, t2, t3 status to boolean', () => {
       // given
-      const airtableChallenge = airtableBuilder.factory.buildChallenge({ t1Status: true, t2Status: false, t3Status: true });
+      const airtableChallenge = airtableBuilder.factory.buildChallenge({
+        t1Status: true,
+        t2Status: false,
+        t3Status: true
+      });
       const challengeRecord = new AirtableRecord('Epreuves', airtableChallenge.id, airtableChallenge);
 
       // when
@@ -126,9 +130,13 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(challenge).to.deep.equal(airtableChallenge);
     });
 
-    it('should transform boolean to `activer/désactiver` for t1, t2 and t3',() => {
+    it('should transform boolean to `activer/désactiver` for t1, t2 and t3', () => {
       // given
-      const createdChallenge = domainBuilder.buildChallengeDatasourceObject({ t1Status: true, t2Status: false, t3Status: null });
+      const createdChallenge = domainBuilder.buildChallengeDatasourceObject({
+        t1Status: true,
+        t2Status: false,
+        t3Status: null
+      });
 
       // when
       const challenge = challengeDatasource.toAirTableObject(createdChallenge);
@@ -185,12 +193,15 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       const newChallenge = await challengeDatasource.filterById('recChallenge');
 
       expect(newChallenge.id).to.equal('recChallenge');
-      expect(airtableFindRecordsSpy).toHaveBeenCalledWith('Epreuves', { filterByFormula: '{id persistant} = \'recChallenge\'', maxRecords: 1 });
+      expect(airtableFindRecordsSpy).toHaveBeenCalledWith('Epreuves', {
+        filterByFormula: '{id persistant} = \'recChallenge\'',
+        maxRecords: 1
+      });
     });
   });
 
   describe('#search', () => {
-    it('should search challenges with a query',  async () => {
+    it('should search challenges with a query', async () => {
       const challenge = airtableBuilder.factory.buildChallenge({
         id: 'recChallenge',
         skillIds: [],
@@ -200,12 +211,15 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       const challengeRecord = new AirtableRecord('Epreuves', challenge.id, challenge);
 
       vi.spyOn(airtable, 'findRecords')
-        .mockResolvedValue([ challengeRecord ]);
+        .mockResolvedValue([challengeRecord]);
 
       challengeDatasource.usedFields = Symbol('used fields');
       const challenges = await challengeDatasource.search({ filter: { search: 'query term' } });
 
-      expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', { fields: challengeDatasource.usedFields, filterByFormula: 'AND(FIND(\'query term\', LOWER(CONCATENATE(Consigne,Propositions,{Embed URL}))) , Statut != \'archive\')' });
+      expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
+        fields: challengeDatasource.usedFields,
+        filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))'
+      });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');
     });
@@ -217,7 +231,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       challengeDatasource.usedFields = Symbol('used fields');
       await challengeDatasource.search({ filter: { search: 'query \' term' } });
 
-      expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', { fields: challengeDatasource.usedFields, filterByFormula: 'AND(FIND(\'query \\\' term\', LOWER(CONCATENATE(Consigne,Propositions,{Embed URL}))) , Statut != \'archive\')' });
+      expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
+        fields: challengeDatasource.usedFields,
+        filterByFormula: 'FIND(\'query \\\' term\', LOWER(CONCATENATE({Embed URL})))'
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -214,11 +214,38 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
         .mockResolvedValue([challengeRecord]);
 
       challengeDatasource.usedFields = Symbol('used fields');
-      const challenges = await challengeDatasource.search({ filter: { search: 'query term' } });
+      const challenges = await challengeDatasource.search({
+        filter: { search: 'query term', ids: [] },
+      });
 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))'
+      });
+      expect(challenges.length).to.equal(1);
+      expect(challenges[0].id).to.equal('recChallenge');
+    });
+
+    it('should search challenges with a query or in ids', async () => {
+      const challenge = airtableBuilder.factory.buildChallenge({
+        id: 'recChallenge',
+        skillIds: [],
+        skills: [],
+        attachments: [],
+      });
+      const challengeRecord = new AirtableRecord('Epreuves', challenge.id, challenge);
+
+      vi.spyOn(airtable, 'findRecords')
+        .mockResolvedValue([challengeRecord]);
+
+      challengeDatasource.usedFields = Symbol('used fields');
+      const challenges = await challengeDatasource.search({
+        filter: { search: 'query term', ids: ['challengeId1'] },
+      });
+
+      expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
+        fields: challengeDatasource.usedFields,
+        filterByFormula: 'OR(FIND(\'query term\', LOWER(CONCATENATE({Embed URL}))), \'challengeId1\' = {id persistant})'
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -144,7 +144,7 @@ describe('Unit | Repository | challenge-repository', () => {
         vi.spyOn(translationRepository, 'search').mockResolvedValueOnce(['challengeId1']);
 
         // when
-        const challenges = await filter({ filter: { search: 'toto' } });
+        const challenges = await filter({ filter: { search: 'toto' }, page: { size: 'limit' } });
 
         // then
         expect(challenges.length).equal(2);
@@ -153,10 +153,11 @@ describe('Unit | Repository | challenge-repository', () => {
         expect(translationRepository.search).toHaveBeenCalledWith({
           entity: 'challenge',
           fields: ['instruction', 'proposals'],
-          search: 'toto'
+          search: 'toto',
+          limit: 'limit',
         });
 
-        expect(challengeDatasource.search).toHaveBeenCalledWith({ filter: { search: 'toto', ids: ['challengeId1'] } });
+        expect(challengeDatasource.search).toHaveBeenCalledWith({ filter: { search: 'toto', ids: ['challengeId1'] }, page: { size: 'limit' } });
       });
     });
   });

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -6,14 +6,14 @@ import { translationRepository } from '../../../../lib/infrastructure/repositori
 describe('Unit | Repository | challenge-repository', () => {
 
   describe('#list', () => {
-    it('should return all challenges',  async () => {
+    it('should return all challenges', async () => {
       // given
       vi.spyOn(translationRepository, 'listByPrefix')
         .mockResolvedValueOnce([{
           key: 'challenge.1.instruction',
           value: 'instruction',
           locale: 'fr'
-        },{
+        }, {
           key: 'challenge.1.proposals',
           value: 'proposals',
           locale: 'fr'
@@ -21,12 +21,12 @@ describe('Unit | Repository | challenge-repository', () => {
           key: 'challenge.2.instruction',
           value: 'instruction 2',
           locale: 'fr'
-        },{
+        }, {
           key: 'challenge.2.proposals',
           value: 'proposals 2',
           locale: 'fr'
         }]);
-      vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{ id: 1, locales: [] },{ id: 2, locales: [] }]);
+      vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{ id: 1, locales: [] }, { id: 2, locales: [] }]);
 
       // when
       const challenges = await list();
@@ -44,15 +44,15 @@ describe('Unit | Repository | challenge-repository', () => {
 
   describe('#filter', () => {
     describe('when ids are specified', () => {
-      it('should return challenges with given ids',  async () => {
+      it('should return challenges with given ids', async () => {
         // given
-        vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{ id: 1, locales: [] },{ id: 2, locales: [] }]);
+        vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{ id: 1, locales: [] }, { id: 2, locales: [] }]);
         vi.spyOn(translationRepository, 'listByPrefix')
           .mockResolvedValueOnce([{
             key: 'challenge.1.instruction',
             value: 'instruction',
             locale: 'fr'
-          },{
+          }, {
             key: 'challenge.1.proposals',
             value: 'proposals',
             locale: 'fr'
@@ -61,7 +61,7 @@ describe('Unit | Repository | challenge-repository', () => {
             key: 'challenge.2.instruction',
             value: 'instruction 2',
             locale: 'fr'
-          },{
+          }, {
             key: 'challenge.2.proposals',
             value: 'proposals 2',
             locale: 'fr'
@@ -81,7 +81,7 @@ describe('Unit | Repository | challenge-repository', () => {
         expect(translationRepository.listByPrefix).toHaveBeenCalledWith('challenge.2.', { transaction: expect.anything() });
       });
 
-      it('should return challenges with empty fields when have no translation',  async () => {
+      it('should return challenges with empty fields when have no translation', async () => {
         // given
         vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{ id: 1, locales: [] }]);
         vi.spyOn(translationRepository, 'listByPrefix')
@@ -120,10 +120,10 @@ describe('Unit | Repository | challenge-repository', () => {
     });
 
     describe('when ids and search are not specified', () => {
-      it('should return all challenges',  async () => {
+      it('should return all challenges', async () => {
         // given
-        vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{},{}]);
-        vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{ locales: [] },{ locales: [] }]);
+        vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{}, {}]);
+        vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{ locales: [] }, { locales: [] }]);
 
         // when
         const challenges = await filter({ page: { size: 20 } });
@@ -136,11 +136,12 @@ describe('Unit | Repository | challenge-repository', () => {
     });
 
     describe('when search is specified', () => {
-      it('should search challenges according to filters',  async () => {
+      it('should search challenges according to filters', async () => {
         // given
-        vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{},{}]);
-        vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{},{}]);
-        vi.spyOn(challengeDatasource, 'search').mockResolvedValue([{ locales: [] },{ locales: [] }]);
+        vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([{}, {}]);
+        vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{}, {}]);
+        vi.spyOn(challengeDatasource, 'search').mockResolvedValue([{ locales: [] }, { locales: [] }]);
+        vi.spyOn(translationRepository, 'search').mockResolvedValueOnce(['challengeId1']);
 
         // when
         const challenges = await filter({ filter: { search: 'toto' } });
@@ -149,13 +150,19 @@ describe('Unit | Repository | challenge-repository', () => {
         expect(challenges.length).equal(2);
         expect(challengeDatasource.filter).not.toHaveBeenCalled();
         expect(challengeDatasource.list).not.toHaveBeenCalled();
-        expect(challengeDatasource.search).toHaveBeenCalledWith({ filter: { search: 'toto' } });
+        expect(translationRepository.search).toHaveBeenCalledWith({
+          entity: 'challenge',
+          fields: ['instruction', 'proposals'],
+          search: 'toto'
+        });
+
+        expect(challengeDatasource.search).toHaveBeenCalledWith({ filter: { search: 'toto', ids: ['challengeId1'] } });
       });
     });
   });
 
   describe('#create', () => {
-    it('should call the datasource', async() => {
+    it('should call the datasource', async () => {
       // given
       const createdChallenge = 'new challenge';
       vi.spyOn(challengeDatasource, 'create').mockResolvedValue(createdChallenge);


### PR DESCRIPTION
## :unicorn: Problème
La recherche d'épreuves ne va plus pouvoir s'appuyer entièrement sur Airtable.

## :robot: Solution
Faire la recherche d'épreuves à partir des traductions.

## :rainbow: Remarques
N/A

## :100: Pour tester
Tester le champ de recherche sur la RA.