### PR TITLE
[BUGFIX] Corrige le noms des tags a l'export

### DIFF
--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -78,28 +78,28 @@ function extractTagsFromChallenge(challenge, releaseContent) {
 function extractTagsFromSkill(skill, releaseContent) {
   if (skill === undefined) return [];
   return [
-    toTag(skill.name),
+    toTag(`acquis${skill.name}`),
     ...extractTagsFromTube(releaseContent.tubes[skill.tubeId], releaseContent),
   ];
 }
 
 function extractTagsFromTube(tube, releaseContent) {
   return [
-    toTag(tube.name),
+    toTag(`sujet${tube.name}`),
     ...extractTagsFromCompetence(releaseContent.competences[tube.competenceId], releaseContent),
   ];
 }
 
 function extractTagsFromCompetence(competence, releaseContent) {
   return [
-    toTag(competence.index),
+    toTag(`competence-${competence.index}`),
     ...extractTagsFromArea(releaseContent.areas[competence.areaId], releaseContent),
   ];
 }
 
 function extractTagsFromArea(area, releaseContent) {
   return [
-    toTag(area.code),
-    toTag(releaseContent.frameworks[area.frameworkId].name),
+    toTag(`domaine-${area.code}`),
+    toTag(`referentiel-${releaseContent.frameworks[area.frameworkId].name}`),
   ];
 }

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -1,5 +1,6 @@
 import { Readable, pipeline } from 'node:stream';
 import csv from 'fast-csv';
+import _ from 'lodash';
 import { releaseRepository } from '../../infrastructure/repositories/index.js';
 import { extractFromChallenge } from '../../infrastructure/translations/challenge.js';
 import { extractFromReleaseObject } from '../../infrastructure/translations/competence.js';
@@ -40,7 +41,7 @@ export async function exportTranslations(stream, dependencies = { releaseReposit
 }
 
 function toTag(tagName) {
-  return tagName.replaceAll('é', 'e').replaceAll(' ', '_').replaceAll('@', '-');
+  return _(tagName).deburr().replaceAll(' ', '_').replaceAll('@', '-');
 }
 
 function extractTagsFromObject(extractTagsFn, releaseContent, typeTag) {

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -19,12 +19,12 @@ export async function exportTranslations(stream, dependencies = { releaseReposit
 
   const challengesStream = Readable.from(release.content.challenges)
     .filter((challenge) => challenge.locales.includes('fr'))
-    .map(extractTagsFromObject(extractTagsFromChallenge, releaseContent, 'épreuve'))
+    .map(extractTagsFromObject(extractTagsFromChallenge, releaseContent, 'epreuve'))
     .flatMap(extractTranslationsFromObject(extractFromChallenge))
     .map(translationAndTagsToCSVLine);
 
   const competencesStream = Readable.from(release.content.competences)
-    .map(extractTagsFromObject(extractTagsFromCompetence, releaseContent, 'compétence'))
+    .map(extractTagsFromObject(extractTagsFromCompetence, releaseContent, 'competence'))
     .flatMap(extractTranslationsFromObject(extractFromReleaseObject))
     .filter(({ translation }) => translation.locale === 'fr')
     .map(translationAndTagsToCSVLine);
@@ -37,6 +37,10 @@ export async function exportTranslations(stream, dependencies = { releaseReposit
       logger.error({ error }, 'Error while exporting translations from release');
     },
   );
+}
+
+function toTag(tagName) {
+  return tagName.replaceAll('é', 'e').replaceAll(' ', '_').replaceAll('@', '-');
 }
 
 function extractTagsFromObject(extractTagsFn, releaseContent, typeTag) {
@@ -67,35 +71,35 @@ function extractTranslationsFromObject(extractFn) {
 function extractTagsFromChallenge(challenge, releaseContent) {
   return [
     ...extractTagsFromSkill(releaseContent.skills[challenge.skillId], releaseContent),
-    challenge.status,
+    toTag(challenge.status),
   ];
 }
 
 function extractTagsFromSkill(skill, releaseContent) {
   if (skill === undefined) return [];
   return [
-    skill.name,
+    toTag(skill.name),
     ...extractTagsFromTube(releaseContent.tubes[skill.tubeId], releaseContent),
   ];
 }
 
 function extractTagsFromTube(tube, releaseContent) {
   return [
-    tube.name,
+    toTag(tube.name),
     ...extractTagsFromCompetence(releaseContent.competences[tube.competenceId], releaseContent),
   ];
 }
 
 function extractTagsFromCompetence(competence, releaseContent) {
   return [
-    competence.index,
+    toTag(competence.index),
     ...extractTagsFromArea(releaseContent.areas[competence.areaId], releaseContent),
   ];
 }
 
 function extractTagsFromArea(area, releaseContent) {
   return [
-    area.code,
-    releaseContent.frameworks[area.frameworkId].name,
+    toTag(area.code),
+    toTag(releaseContent.frameworks[area.frameworkId].name),
   ];
 }

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -143,13 +143,13 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
-        'competence.recCompetence0.description,Description de la compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
-        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
+        'competence.recCompetence0.description,Description de la compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
+        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
       ]);
     });
 
@@ -294,8 +294,8 @@ describe('Acceptance | Controller | translations-controller', () => {
         'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,valide"',
         'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,valide"',
         'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,valide"',
-        'competence.recCompetence0.description,Description de la compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
-        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
+        'competence.recCompetence0.description,Description de la compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
+        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
       ]);
     });
 

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -143,13 +143,13 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"épreuve,@acquis1,@acquis,1.1,1,Nom du referentiel,validé"',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,"épreuve,@acquis1,@acquis,1.1,1,Nom du referentiel,validé"',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,"épreuve,@acquis1,@acquis,1.1,1,Nom du referentiel,validé"',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"épreuve,@acquis1,@acquis,1.1,1,Nom du referentiel,validé"',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"épreuve,@acquis1,@acquis,1.1,1,Nom du referentiel,validé"',
-        'competence.recCompetence0.description,Description de la compétence - fr,"compétence,1.1,1,Nom du referentiel"',
-        'competence.recCompetence0.name,Nom de la Compétence - fr,"compétence,1.1,1,Nom du referentiel"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,-acquis1,-acquis,1.1,1,Nom_du_referentiel,valide"',
+        'competence.recCompetence0.description,Description de la compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
+        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
       ]);
     });
 
@@ -289,13 +289,13 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"épreuve,validé"',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,"épreuve,validé"',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,"épreuve,validé"',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"épreuve,validé"',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"épreuve,validé"',
-        'competence.recCompetence0.description,Description de la compétence - fr,"compétence,1.1,1,Nom du referentiel"',
-        'competence.recCompetence0.name,Nom de la Compétence - fr,"compétence,1.1,1,Nom du referentiel"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,valide"',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,valide"',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,valide"',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,valide"',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,valide"',
+        'competence.recCompetence0.description,Description de la compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
+        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,1.1,1,Nom_du_referentiel"',
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Les tags sur phrase ne peuvent pas contenir d'accent ou d'arobase. Ils ont automatiquement converti en underscore.

## :robot: Solution
Remplacer les caractères:
- é => e
- @ -> -
- " " -> _

Le plus pénible est bien sur l'arobase qui était parfaite ici.

En plus un système pour préfixer les tags par le type d'objet a été rajouté.


## :100: Pour tester
1. Faire un export des traductions
2. Faire l'import sur phrase et vérifier les tags
