### PR TITLE
[FEATURE] Adapter les noms des tags pour pouvoir utiliser les filtres de Phrase (PIX-9752).

### DIFF
--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -76,7 +76,10 @@ function extractTranslationsFromObject(extractFn) {
 }
 
 function extractTagsFromChallenge(challenge, releaseContent) {
-  return extractTagsFromSkill(releaseContent.skills[challenge.skillId], releaseContent);
+  return [
+    toTag(challenge.status),
+    ...extractTagsFromSkill(releaseContent.skills[challenge.skillId], releaseContent),
+  ];
 }
 
 function extractTagsFromSkill(skill, releaseContent) {

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -41,13 +41,19 @@ export async function exportTranslations(stream, dependencies = { releaseReposit
 }
 
 function toTag(tagName) {
-  return _(tagName).deburr().replaceAll(' ', '_').replaceAll('@', '-');
+  return _(tagName).deburr().replaceAll(' ', '_').replaceAll('@', '');
 }
 
 function extractTagsFromObject(extractTagsFn, releaseContent, typeTag) {
   return (object) => {
+    const hierarchyTags = extractTagsFn(object, releaseContent).reverse();
+    const tags = [];
+    while (hierarchyTags.length > 0) {
+      tags.push(hierarchyTags.join('-'));
+      hierarchyTags.pop();
+    }
     return {
-      tags: [typeTag, ...extractTagsFn(object, releaseContent)],
+      tags: [typeTag, ...tags],
       object,
     };
   };
@@ -70,37 +76,34 @@ function extractTranslationsFromObject(extractFn) {
 }
 
 function extractTagsFromChallenge(challenge, releaseContent) {
-  return [
-    ...extractTagsFromSkill(releaseContent.skills[challenge.skillId], releaseContent),
-    toTag(challenge.status),
-  ];
+  return extractTagsFromSkill(releaseContent.skills[challenge.skillId], releaseContent);
 }
 
 function extractTagsFromSkill(skill, releaseContent) {
   if (skill === undefined) return [];
   return [
-    toTag(`acquis${skill.name}`),
+    toTag(skill.name),
     ...extractTagsFromTube(releaseContent.tubes[skill.tubeId], releaseContent),
   ];
 }
 
 function extractTagsFromTube(tube, releaseContent) {
   return [
-    toTag(`sujet${tube.name}`),
+    toTag(tube.name),
     ...extractTagsFromCompetence(releaseContent.competences[tube.competenceId], releaseContent),
   ];
 }
 
 function extractTagsFromCompetence(competence, releaseContent) {
   return [
-    toTag(`competence-${competence.index}`),
+    toTag(competence.index),
     ...extractTagsFromArea(releaseContent.areas[competence.areaId], releaseContent),
   ];
 }
 
 function extractTagsFromArea(area, releaseContent) {
   return [
-    toTag(`domaine-${area.code}`),
-    toTag(`referentiel-${releaseContent.frameworks[area.frameworkId].name}`),
+    toTag(area.code),
+    toTag(releaseContent.frameworks[area.frameworkId].name),
   ];
 }

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -47,11 +47,10 @@ function toTag(tagName) {
 function extractTagsFromObject(extractTagsFn, releaseContent, typeTag) {
   return (object) => {
     const hierarchyTags = extractTagsFn(object, releaseContent).reverse();
-    const tags = [];
-    while (hierarchyTags.length > 0) {
-      tags.push(hierarchyTags.join('-'));
-      hierarchyTags.pop();
-    }
+    const tags = hierarchyTags.map((_, index) => {
+      return hierarchyTags.slice(0,hierarchyTags.length - index).join('-');
+    });
+
     return {
       tags: [typeTag, ...tags],
       object,

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -5,7 +5,7 @@ import { createServer } from '../../../server';
 
 describe('Acceptance | Controller | translations-controller', () => {
 
-  describe('GET /translations.csv - export all translations in CSV file', () => {
+  describe.only('GET /translations.csv - export all translations in CSV file', () => {
 
     it('should return a csv file', async () => {
       // Given
@@ -143,13 +143,13 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,acquis-acquis1,sujet-acquis,competence-1.1,domaine-1,referentiel-Nom_du_referentiel,valide"',
-        'competence.recCompetence0.description,Description de la compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
-        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'competence.recCompetence0.description,Description de la compétence - fr,"competence,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
       ]);
     });
 
@@ -289,11 +289,11 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,valide"',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,valide"',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,valide"',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,valide"',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,valide"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,epreuve',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,epreuve',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,epreuve',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,epreuve',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,epreuve',
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
       ]);

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -5,7 +5,7 @@ import { createServer } from '../../../server';
 
 describe('Acceptance | Controller | translations-controller', () => {
 
-  describe.only('GET /translations.csv - export all translations in CSV file', () => {
+  describe('GET /translations.csv - export all translations in CSV file', () => {
 
     it('should return a csv file', async () => {
       // Given
@@ -143,11 +143,11 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1-valide,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1-valide,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1-valide,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1-valide,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,Nom_du_referentiel-1-1.1-acquis-acquis1-valide,Nom_du_referentiel-1-1.1-acquis-acquis1,Nom_du_referentiel-1-1.1-acquis,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
       ]);
@@ -289,13 +289,13 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags');
       expect(payload).to.deep.equal([
-        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,epreuve',
-        'challenge.recChallenge0.instruction,Consigne du Challenge,epreuve',
-        'challenge.recChallenge0.proposals,Propositions du Challenge,epreuve',
-        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,epreuve',
-        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,epreuve',
-        'competence.recCompetence0.description,Description de la compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
-        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,competence-1.1,domaine-1,referentiel-Nom_du_referentiel"',
+        'challenge.recChallenge0.alternativeInstruction,Consigne alternative,"epreuve,valide"',
+        'challenge.recChallenge0.instruction,Consigne du Challenge,"epreuve,valide"',
+        'challenge.recChallenge0.proposals,Propositions du Challenge,"epreuve,valide"',
+        'challenge.recChallenge0.solution,Bonnes réponses du Challenge,"epreuve,valide"',
+        'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,valide"',
+        'competence.recCompetence0.description,Description de la compétence - fr,"competence,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
+        'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Nom_du_referentiel-1-1.1,Nom_du_referentiel-1,Nom_du_referentiel"',
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème

Phrase ne permet pas de filtrer sur plusieurs tags en faisant un "ET" (il applique un "OU" entre les différents tags sélectionnés).
Cela pose problème pour sélectionner par exemple uniquement les acquis d'un référentiel donné.

## :robot: Solution

On augmente tous les tags avec l'ensemble des objets dont ils font partie.
ie. 1.1 devient Nom_Du_Referentiel-Tube-Acquis-1.1

## :rainbow: Remarques
On applique le même principe pour les statuts d'épreuves.

## :100: Pour tester
Exporter les traductions et vérifier les tags dans le fichier csv.
