### PR TITLE
[BUGFIX] Patch du challenge quand on modifie l'illustration (PIX-9770)

### DIFF
--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -61,7 +61,7 @@ export async function serializeEntity({ type, entity, translations }) {
   });
 
   if (model === attachmentDatasource.path()) {
-    const rawChallenge = await challengeDatasource.filterById(updatedRecord.challengeId);
+    const [rawChallenge] = await challengeRepository.filter({ filter: { ids: [updatedRecord.challengeId] } });
     const attachments = await attachmentDatasource.filterByChallengeId(updatedRecord.challengeId);
     const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments });
     const challenge = transformChallenge(rawChallenge);

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { domainBuilder, airtableBuilder } from '../../test-helper.js';
 import { attachmentDatasource, challengeDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import { serializeEntity } from '../../../lib/infrastructure/repositories/release-repository.js';
+import { challengeRepository } from '../../../lib/infrastructure/repositories/index.js';
 
 describe('Unit | Repository | release-repository', () => {
   describe('#serializeEntity', () => {
@@ -107,7 +108,7 @@ describe('Unit | Repository | release-repository', () => {
         }),
       ];
 
-      const challenge = domainBuilder.buildChallengeDatasourceObject({
+      const challenge = domainBuilder.buildChallenge({
         id: 'recChallenge',
         type : 'QCM',
         t1Status : 'Activé',
@@ -125,8 +126,8 @@ describe('Unit | Repository | release-repository', () => {
       });
       const type = 'Attachments';
 
-      vi.spyOn(challengeDatasource, 'filterById').mockImplementation(async (spyId) => {
-        if (spyId === 'recChallenge') return challenge;
+      vi.spyOn(challengeRepository, 'filter').mockImplementation(async ({ filter: { ids } }) => {
+        if (ids.length === 1 && ids[0] === 'recChallenge') return [challenge];
       });
       vi.spyOn(attachmentDatasource, 'filterByChallengeId').mockImplementation(async (spyId) => {
         if (spyId === 'recChallenge') return attachmentRecords;


### PR DESCRIPTION
## :unicorn: Problème
Quand on modifie l'illustration ou pièce jointe d'une épreuve, l'épreuve envoyée au cache de recette ne contient pas les champs traduisibles.

## :robot: Solution
Hydrater correctement l'épreuve avant de l'envoyer à la recette.

## :rainbow: Remarques
Ce bug explique le problème remonté par le métier d'épreuve s'affichant avec une illustration mais sans consigne ni propositions.

## :100: Pour tester
On a fait un test utilisateur concluant en local.