### PR TITLE
[TECH] Spécifier le buildpack utilisé par Scalingo.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/Scalingo/nodejs-buildpack


### PR DESCRIPTION
## :unicorn: Problème
Lorsque le buildpack n'est pas spécifié, Scalingo utilise un buildpack interne qui fait de la détection du runtime à utiliser.
Ce buildpack n'étant pas open source, il est difficile de savoir quelles sont les versions de nodejs qu'il supporte.

## :robot: Solution
On ajoute un fichier `.buildpacks` qui spécifie l'utilisation du buildpack opensource nodejs.

## :rainbow: Remarques
On préfère cette solution à l'utilisation d'une variable d'environnement qui nécessitent une définition manuelle sur tous les environnements.

## :100: Pour tester
Vérifier que l'application se déploie correctement sur Scalingo.
