### PR TITLE
[FEATURE] Ecrire dans PG les traductions des Acquis (PIX-9399) 

### DIFF
--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -26,7 +26,7 @@ export async function register(server) {
             if (response.data.records) {
               const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
               response.data.records.forEach((entity) => {
-                tableTranslations.hydrateToAirtableObject(entity.fields, translations) ;
+                tableTranslations.hydrateToAirtableObject(entity.fields, translations);
               });
             } else {
               const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
@@ -54,7 +54,7 @@ export async function register(server) {
           let translations;
           if (tableTranslations) {
             translations = tableTranslations.extractFromAirtableObject(request.payload.fields);
-            tableTranslations.dehydrateAirtableObject(request.payload?.fields);
+            tableTranslations.dehydrateAirtableObject?.(request.payload?.fields);
           }
 
           const response = await _proxyRequestToAirtable(request, config.airtable.base);
@@ -116,7 +116,8 @@ export const name = 'airtable-proxy';
 
 async function _proxyRequestToAirtable(request, airtableBase) {
   return axios.request(`${AIRTABLE_BASE_URL}/${airtableBase}/${request.params.path}`,
-    { headers: { 'Authorization': `Bearer ${config.airtable.apiKey}`, 'Content-Type': 'application/json' },
+    {
+      headers: { 'Authorization': `Bearer ${config.airtable.apiKey}`, 'Content-Type': 'application/json' },
       params: request.query,
       method: request.method,
       data: request.payload ? request.payload : {},

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -80,7 +80,7 @@ export async function serializeEntity({ type, entity, translations }) {
     return { updatedRecord: challenge, model };
   }
 
-  tablesTranslations[type]?.hydrateReleaseObject(updatedRecord, translations);
+  tablesTranslations[type]?.hydrateReleaseObject?.(updatedRecord, translations);
 
   return { updatedRecord, model };
 }

--- a/api/lib/infrastructure/translations/index.js
+++ b/api/lib/infrastructure/translations/index.js
@@ -1,1 +1,2 @@
 export * as Competences from './competence.js';
+export * as Acquis from './skill.js';

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -46,16 +46,8 @@ export function hydrateToAirtableObject(skill, translations) {
   }
 }
 
-export function dehydrateAirtableObject() {
-}
-
-export function hydrateReleaseObject() {
-}
-
 export function prefixFor(skill) {
   const id = skill['id persistant'];
   return `${prefix}${id}.`;
 }
 
-export function extractFromReleaseObject() {
-}

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -1,0 +1,61 @@
+import { Translation } from '../../domain/models/index.js';
+
+export const prefix = 'skill.';
+
+const locales = [
+  { airtableLocale: 'fr-fr', locale: 'fr' },
+  { airtableLocale: 'en-us', locale: 'en' },
+];
+
+const fields = [
+  { airtableField: 'Indice', field: 'hint' },
+];
+
+const localizedFields = locales.flatMap((locale) =>
+  fields.map((field) => ({
+    ...locale,
+    ...field,
+  }))
+);
+
+export function extractFromAirtableObject(skill) {
+  return localizedFields
+    .filter(({ airtableField, airtableLocale }) => skill[`${airtableField} ${airtableLocale}`])
+    .map(({ field, locale, airtableField, airtableLocale }) => new Translation({
+      key: `${prefixFor(skill)}${field}`,
+      value: skill[`${airtableField} ${airtableLocale}`],
+      locale,
+    }));
+}
+
+export function hydrateToAirtableObject(skill, translations) {
+  for (const {
+    airtableLocale,
+    locale,
+    airtableField,
+    field,
+  } of localizedFields) {
+    const translation = translations.find(
+      (translation) =>
+        translation.key === `${prefixFor(skill)}${field}` &&
+        translation.locale === locale
+    );
+
+    skill[`${airtableField} ${airtableLocale}`] =
+      translation?.value ?? null;
+  }
+}
+
+export function dehydrateAirtableObject() {
+}
+
+export function hydrateReleaseObject() {
+}
+
+export function prefixFor(skill) {
+  const id = skill['id persistant'];
+  return `${prefix}${id}.`;
+}
+
+export function extractFromReleaseObject() {
+}

--- a/api/scripts/migrate-skills-translation-from-airtable/index.js
+++ b/api/scripts/migrate-skills-translation-from-airtable/index.js
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import * as skillTranslations from '../../lib/infrastructure/translations/skill.js';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateSkillsTranslationFromAirtable({ airtableClient }) {
+  const allSkills = await airtableClient
+    .table('Acquis')
+    .select({
+      fields: [
+        'id persistant',
+        'Indice fr-fr',
+        'Indice en-us',
+      ],
+    })
+    .all();
+
+  const translations = allSkills.flatMap((skill) =>
+    skillTranslations.extractFromAirtableObject(skill.fields)
+  );
+
+  await translationRepository.save(translations);
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateSkillsTranslationFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/scripts/migrate-skills-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-skills-translation-from-airtable_test.js
@@ -36,13 +36,12 @@ describe('Migrate translation from airtable', function() {
         en: 'clue',
       }
     });
-    const skills = [skill];
 
     nock('https://api.airtable.com')
       .get('/v0/airtableBaseValue/Acquis')
       .matchHeader('authorization', 'Bearer airtableApiKeyValue')
       .query(true)
-      .reply(200, { records: skills });
+      .reply(200, { records: [skill] });
 
     // when
     await migrateSkillsTranslationFromAirtable({ airtableClient });

--- a/api/tests/scripts/migrate-skills-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-skills-translation-from-airtable_test.js
@@ -1,0 +1,69 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { airtableBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+
+import {
+  migrateSkillsTranslationFromAirtable
+} from '../../scripts/migrate-skills-translation-from-airtable/index.js';
+
+describe('Migrate translation from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const skill = airtableBuilder.factory.buildSkill({
+      id: 'skillid1',
+      hint_i18n: {
+        fr: 'indice',
+        en: 'clue',
+      }
+    });
+    const skills = [skill];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Acquis')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: skills });
+
+    // when
+    await migrateSkillsTranslationFromAirtable({ airtableClient });
+
+    // then
+    const translations = await knex('translations').select().orderBy([{
+      column: 'key',
+      order: 'asc'
+    }, { column: 'locale', order: 'asc' }]);
+
+    expect(translations).to.have.lengthOf(2);
+    expect(translations).to.deep.equal([
+      {
+        key: 'skill.skillid1.hint',
+        locale: 'en',
+        value: 'clue'
+      },
+      {
+        key: 'skill.skillid1.hint',
+        locale: 'fr',
+        value: 'indice'
+      }]);
+  });
+});

--- a/api/tests/tooling/input-output-data-builder/factory/build-skill.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-skill.js
@@ -1,0 +1,37 @@
+export function buildSkill({
+  id = 'skillid1',
+  name,
+  hint_i18n: { fr: hintFrFr, en: hintEnUs },
+  hintStatus,
+  tutorialIds,
+  learningMoreTutorialIds,
+  pixValue,
+  competenceId,
+  status,
+  tubeId,
+  description,
+  level,
+  internationalisation,
+  version,
+} = {}) {
+  return {
+    id,
+    'fields': {
+      'id persistant': id,
+      'Indice fr-fr': hintFrFr,
+      'Indice en-us': hintEnUs,
+      'Statut de l\'indice': hintStatus,
+      'Comprendre (id persistant)': tutorialIds,
+      'En savoir plus (id persistant)': learningMoreTutorialIds,
+      'Tube (id persistant)': [tubeId],
+      'Status': status,
+      'Nom': name,
+      'Compétence (via Tube) (id persistant)': [competenceId],
+      'PixValue': pixValue,
+      'Description': description,
+      'Level': level,
+      'Internationalisation': internationalisation,
+      'Version': version,
+    },
+  };
+}

--- a/api/tests/tooling/input-output-data-builder/factory/index.js
+++ b/api/tests/tooling/input-output-data-builder/factory/index.js
@@ -1,1 +1,2 @@
 export * from './build-competence.js';
+export * from './build-skill.js';

--- a/api/tests/unit/infrastructure/translations/skill_test.js
+++ b/api/tests/unit/infrastructure/translations/skill_test.js
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractFromAirtableObject,
+  hydrateToAirtableObject,
+  prefixFor,
+} from '../../../../lib/infrastructure/translations/skill.js';
+
+describe('Unit | Infrastructure | Skill translations', () => {
+  describe('#extractFromAirtableObject', () => {
+    it('should return the list of translations', () => {
+      // given
+      const skill = {
+        'id persistant': 'test',
+        'Indice fr-fr': 'indice fr-fr',
+        'Indice en-us': 'hint en-us',
+      };
+
+      // when
+      const translations = extractFromAirtableObject(skill);
+
+      // then
+      expect(translations).to.deep.equal([
+        {
+          key: 'skill.test.hint',
+          locale: 'fr',
+          value: 'indice fr-fr',
+        },
+        {
+          key: 'skill.test.hint',
+          locale: 'en',
+          value: 'hint en-us',
+        },
+      ]);
+    });
+
+    it('should return translations only for field w/ values', () => {
+      // given
+      const skill = {
+        'id persistant': 'test',
+        'Indice fr-fr': 'indice fr-fr',
+      };
+
+      // when
+      const translations = extractFromAirtableObject(skill);
+
+      // then
+      expect(translations).to.deep.equal([
+        {
+          key: 'skill.test.hint',
+          locale: 'fr',
+          value: 'indice fr-fr',
+        }]);
+    });
+  });
+  describe('#hydrateAirtableObject', () => {
+    it('should set translated fields into the object', () => {
+      // given
+      const skill = {
+        'id persistant': 'test',
+        'Indice fr-fr': 'indice fr-fr initial',
+        otherField: 'foo',
+      };
+
+      const translations = [
+        { key: 'skill.test.hint', locale: 'fr', value: 'indice fr-fr' },
+        { key: 'skill.test.hint', locale: 'en', value: 'indice en-us' },
+
+      ];
+
+      // when
+      hydrateToAirtableObject(skill, translations);
+
+      // then
+      expect(skill).to.deep.equal({
+        'id persistant': 'test',
+        'Indice fr-fr': 'indice fr-fr',
+        'Indice en-us': 'indice en-us',
+        otherField: 'foo',
+      });
+    });
+
+    it('should set null value for missing translations', () => {
+      // given
+      const skill = {
+        'id persistant': 'test',
+        'Indice fr-fr': 'indice fr-fr initial',
+      };
+      const translations = [
+        { key: 'skill.test.hint', locale: 'fr', value: 'indice fr-fr' },
+      ];
+
+      // when
+      hydrateToAirtableObject(skill, translations);
+
+      // then
+      expect(skill).to.deep.equal({
+        'id persistant': 'test',
+        'Indice fr-fr': 'indice fr-fr',
+        'Indice en-us': null,
+      });
+    });
+  });
+
+  describe('#prefixFor', () => {
+    it('should return the prefix for skill fields keys', () => {
+      // given
+      const skill = {
+        'id persistant': 'recSkill123',
+      };
+
+      // when
+      const prefix = prefixFor(skill);
+
+      // then
+      expect(prefix).toBe('skill.recSkill123.');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'indice des acquis est traduit mais dans Airtable

## :robot: Solution
Ajouter les traductions d'acquis dans PG, permettre lors de l'ajout ou la modification d'acquis de mettre à jour les traductions dans PG.

## :rainbow: Remarques
le fichier api/lib/infrastructure/translations/skill.js contient des méthodes vides afin de préserver l'interface en vue des prochains développements qui aligneront leur comportement sur les méthodes de competences.

La partie export des traductions n'est pas encore géré dans cette PR.

## :100: Pour tester
- npm db:reset 
Vérifier que lors de l'ajout ou modification d'un acquis, l'indice est mis à jour dans airtable et dans PG.