### PR TITLE
[FEATURE] Lire les traductions des acquis côté front (PIX-9401)

### DIFF
--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -9,7 +9,7 @@ import * as securityPreHandlers from './security-pre-handlers.js';
 import * as tablesTranslations from '../infrastructure/translations/index.js';
 
 const AIRTABLE_BASE_URL = 'https://api.airtable.com/v0';
-const tablesTranslationsForReading = ['Competences'];
+const tablesTranslationsForReading = ['Competences', 'Acquis'];
 const tablesTranslationsForWriting = ['Competences', 'Acquis'];
 
 export async function register(server) {


### PR DESCRIPTION
## :unicorn: Problème
On veut pouvoir lire les traductions des acquis côté Front qui sont sur PG et non sur Airtable

## :robot: Solution
Implémenter la lecture des traductions de PG et plus d'Airtable

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix-Editor,
Créer un nouvel acquis,
Voir que les traductions sont bien dans la table Traduction de Airtable.
Se connecter en local, faire un npm run db:reset et vérifier sur PG que la traduction du nouvel acquis a bien été créée.
Faire une modif côté Airtable de la colonne Indice fr-fr de l'acquis qu'on vient de créer
Voir que la modif n'est pas répercutée sur le Front.
