### PR TITLE
[TECH] Utilise la version officielle de @adminjs/hapijs.

### DIFF
--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -5,7 +5,7 @@ import { checkUserIsAuthenticatedViaBasicAndAdmin } from '../../../application/s
 
 AdminJS.registerAdapter(AdminJSSequelize);
 
-export { default as plugin } from '@1024pix/adminjs-hapijs';
+export { default as plugin } from '@adminjs/hapi';
 
 const componentLoader = new ComponentLoader();
 const Components = {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@1024pix/adminjs-hapijs": "^7.0.1",
+        "@adminjs/hapi": "^7.0.1",
         "@adminjs/sequelize": "^4.0.0",
         "@hapi/boom": "^10.0.0",
         "@hapi/cookie": "^12.0.0",
@@ -67,26 +67,6 @@
         "node": "^20.9.0"
       }
     },
-    "node_modules/@1024pix/adminjs-hapijs": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/adminjs-hapijs/-/adminjs-hapijs-7.0.1.tgz",
-      "integrity": "sha512-0TrbgdGA1uT6qkCSIUoRz2A5RY+qr0cLC+kPVqhx0YKcs/2uCenETu6USAtFhV2YEzcGl2hTD3fAucnOWWOueQ==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "peerDependencies": {
-        "@hapi/boom": "^9.1.4 || ^10.0.0",
-        "@hapi/cookie": "^11.0.2 || ^12.0.0",
-        "@hapi/hapi": "^20.2.1 || ^21.0.0",
-        "@hapi/inert": "^6.0.5 || ^7.0.0",
-        "adminjs": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@hapi/inert": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -139,6 +119,26 @@
       "peerDependencies": {
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
+      }
+    },
+    "node_modules/@adminjs/hapi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@adminjs/hapi/-/hapi-7.0.1.tgz",
+      "integrity": "sha512-7ng11XCUZd0MgFKo4xIwuK0u9tBUTd2sHXY3EEhZF7B0ydDsgenEQxQTZdkQF2HM3eUo+RNwU+me45zwX2QxRA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "@hapi/boom": "^9.1.4 || ^10.0.0",
+        "@hapi/cookie": "^11.0.2 || ^12.0.0",
+        "@hapi/hapi": "^20.2.1 || ^21.0.0",
+        "@hapi/inert": "^6.0.5 || ^7.0.0",
+        "adminjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@hapi/inert": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adminjs/sequelize": {

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
   "author": "GIP Pix",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@1024pix/adminjs-hapijs": "^7.0.1",
+    "@adminjs/hapi": "^7.0.1",
     "@adminjs/sequelize": "^4.0.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/cookie": "^12.0.0",


### PR DESCRIPTION
## :unicorn: Problème

Le bug rencontré sur la lecture des credentials dans le plugin adminjs/hapijs a été corrigé et releasé dans la version 7.0.1.
Il n'est donc plus nécessaire d'utiliser notre fork.

## :robot: Solution
Utiliser de nouveau le plugin officiel.

## :rainbow: Remarques
RAS.

## :100: Pour tester
Se connecter à l'interface d'admin et faire un export des traductions.
