### PR TITLE
[FEATURE] Adapter la release pour utiliser les traductions d'acquis de PG (PIX-9402)

### DIFF
--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -24,6 +24,7 @@ import * as competenceTranslations from '../translations/competence.js';
 import { Content, Release } from '../../domain/models/release/index.js';
 
 import { knex } from '../../../db/knex-database-connection.js';
+import * as skillTranslations from "../translations/skill.js";
 
 export function getCurrentContent() {
   return _getCurrentContent();
@@ -118,7 +119,8 @@ async function _getCurrentContentFromAirtable(challenges) {
     thematics,
     tubes,
     tutorials,
-    translations,
+    translationsForCompetence,
+    translationsForSkill,
   ] = await Promise.all([
     areaDatasource.list(),
     attachmentDatasource.list(),
@@ -129,6 +131,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     tubeDatasource.list(),
     tutorialDatasource.list(),
     translationRepository.listByPrefix(competenceTranslations.prefix),
+    translationRepository.listByPrefix(skillTranslations.prefix),
   ]);
   const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments });
   const transformedChallenges = challenges.map(transformChallenge);
@@ -137,7 +140,8 @@ async function _getCurrentContentFromAirtable(challenges) {
   const filteredSkills = skillTransformer.filterSkillsFields(skills);
   const filteredTutorials = tutorialTransformer.filterTutorialsFields(tutorials);
 
-  filteredCompetences.forEach((competence) => competenceTranslations.hydrateReleaseObject(competence, translations));
+  filteredCompetences.forEach((competence) => competenceTranslations.hydrateReleaseObject(competence, translationsForCompetence));
+  filteredSkills.forEach((skill) => skillTranslations.hydrateReleaseObject(skill, translationsForSkill));
 
   return {
     frameworks,

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -24,7 +24,7 @@ import * as competenceTranslations from '../translations/competence.js';
 import { Content, Release } from '../../domain/models/release/index.js';
 
 import { knex } from '../../../db/knex-database-connection.js';
-import * as skillTranslations from "../translations/skill.js";
+import * as skillTranslations from '../translations/skill.js';
 
 export function getCurrentContent() {
   return _getCurrentContent();
@@ -119,8 +119,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     thematics,
     tubes,
     tutorials,
-    translationsForCompetence,
-    translationsForSkill,
+    translations,
   ] = await Promise.all([
     areaDatasource.list(),
     attachmentDatasource.list(),
@@ -130,8 +129,8 @@ async function _getCurrentContentFromAirtable(challenges) {
     thematicDatasource.list(),
     tubeDatasource.list(),
     tutorialDatasource.list(),
-    translationRepository.listByPrefix(competenceTranslations.prefix),
-    translationRepository.listByPrefix(skillTranslations.prefix),
+    translationRepository.listByPrefixes([competenceTranslations.prefix, skillTranslations.prefix]),
+
   ]);
   const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments });
   const transformedChallenges = challenges.map(transformChallenge);
@@ -140,8 +139,8 @@ async function _getCurrentContentFromAirtable(challenges) {
   const filteredSkills = skillTransformer.filterSkillsFields(skills);
   const filteredTutorials = tutorialTransformer.filterTutorialsFields(tutorials);
 
-  filteredCompetences.forEach((competence) => competenceTranslations.hydrateReleaseObject(competence, translationsForCompetence));
-  filteredSkills.forEach((skill) => skillTranslations.hydrateReleaseObject(skill, translationsForSkill));
+  filteredCompetences.forEach((competence) => competenceTranslations.hydrateReleaseObject(competence, translations));
+  filteredSkills.forEach((skill) => skillTranslations.hydrateReleaseObject(skill, translations));
 
   return {
     frameworks,

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -30,6 +30,17 @@ export async function listByPrefix(prefix, { transaction = knex } = {}) {
   return translationDtos.map(_toDomain);
 }
 
+export async function listByPrefixes(prefixes, { transaction = knex } = {}) {
+  if (prefixes.length === 0) return [];
+  const queryBuilder = transaction('translations')
+    .whereLike('key', `${prefixes[0]}%`);
+  for (const prefix of prefixes.slice(1)) {
+    queryBuilder.orWhereLike('key', `${prefix}%`);
+  }
+  const translationDtos = await queryBuilder.select().orderBy('key');
+  return translationDtos.map(_toDomain);
+}
+
 export async function list() {
   const translationDtos = await knex('translations').select();
   return translationDtos.map(_toDomain);

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -51,3 +51,17 @@ export function prefixFor(skill) {
   return `${prefix}${id}.`;
 }
 
+export function hydrateReleaseObject(skill, translations) {
+  for (const { field } of fields) {
+    skill[`${field}_i18n`] = {};
+    for (const { locale } of locales) {
+      const translation = translations.find(
+        (translation) =>
+          translation.key === `${prefix}${skill.id}.${field}` &&
+          translation.locale === locale
+      );
+      skill[`${field}_i18n`][locale] = translation?.value ?? null;
+    }
+  }
+}
+

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -210,6 +210,16 @@ async function mockCurrentContent() {
     value: expectedCurrentContent.competences[0].description_i18n.en,
   });
   databaseBuilder.factory.buildTranslation({
+    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+    locale: 'fr',
+    value: expectedCurrentContent.skills[0].hint_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+    locale: 'en',
+    value: expectedCurrentContent.skills[0].hint_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr-fr',
     value: expectedCurrentContent.challenges[0].translations['fr-fr'].instruction,
@@ -430,6 +440,16 @@ async function mockContentForRelease() {
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+    locale: 'fr',
+    value: expectedCurrentContent.skills[0].hint_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+    locale: 'en',
+    value: expectedCurrentContent.skills[0].hint_i18n.en,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -168,7 +168,7 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getCurrentContent', function() {
 
     beforeEach(function() {
-      const { competences, challenges } = _mockRichAirtableContent();
+      const { competences, challenges, skills } = _mockRichAirtableContent();
 
       for (const competence of competences) {
         databaseBuilder.factory.buildTranslation({
@@ -219,6 +219,19 @@ describe('Integration | Repository | release-repository', function() {
           key: `challenge.${challenge.id}.solutionToDisplay`,
           locale,
           value: `${challenge.id} solutionToDisplay`,
+        });
+      }
+
+      for (const skill of skills) {
+        databaseBuilder.factory.buildTranslation({
+          key: `skill.${skill.id}.hint`,
+          locale: 'fr',
+          value: `${skill.id} fr indice`,
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: `skill.${skill.id}.hint`,
+          locale: 'en',
+          value: `${skill.id} en hint`,
         });
       }
 
@@ -426,7 +439,7 @@ function _mockRichAirtableContent() {
     },
     competenceId: 'competence21',
   });
-  const airtableSkill11111 = airtableBuilder.factory.buildSkill({
+  const skill11111 = {
     id: 'skill11111',
     name: 'skill11111 name',
     hint_i18n: {
@@ -444,8 +457,9 @@ function _mockRichAirtableContent() {
     level: 4,
     internationalisation: 'skill11111 internationalisation',
     version: 'skill11111 version',
-  });
-  const airtableSkill11112 = airtableBuilder.factory.buildSkill({
+  };
+  const airtableSkill11111 = airtableBuilder.factory.buildSkill(skill11111);
+  const skill11112 = {
     id: 'skill11112',
     name: 'skill11112 name',
     hint_i18n: {
@@ -463,8 +477,9 @@ function _mockRichAirtableContent() {
     level: 3,
     internationalisation: 'skill11112 internationalisation',
     version: 'skill11112 version',
-  });
-  const airtableSkill12121 = airtableBuilder.factory.buildSkill({
+  };
+  const airtableSkill11112 = airtableBuilder.factory.buildSkill(skill11112);
+  const skill12121 = {
     id: 'skill12121',
     name: 'skill12121 name',
     hint_i18n: {
@@ -482,8 +497,9 @@ function _mockRichAirtableContent() {
     level: 2,
     internationalisation: 'skill12121 internationalisation',
     version: 'skill12121 version',
-  });
-  const airtableSkill21111 = airtableBuilder.factory.buildSkill({
+  };
+  const airtableSkill12121 = airtableBuilder.factory.buildSkill(skill12121);
+  const skill21111 = {
     id: 'skill21111',
     name: 'skill21111 name',
     hint_i18n: {
@@ -501,7 +517,8 @@ function _mockRichAirtableContent() {
     level: 1,
     internationalisation: 'skill21111 internationalisation',
     version: 'skill21111 version',
-  });
+  };
+  const airtableSkill21111 = airtableBuilder.factory.buildSkill(skill21111);
   const challenge121211 = {
     id: 'challenge121211',
     type: 'challenge121211 type',
@@ -751,6 +768,7 @@ function _mockRichAirtableContent() {
   return {
     competences: [competence11, competence12, competence21],
     challenges: [challenge121211, challenge121212, challenge211111, challenge211112, challenge211113],
+    skills: [skill11111, skill11112, skill12121, skill21111],
   };
 }
 
@@ -1013,8 +1031,8 @@ function _getRichCurrentContentDTO() {
       id: 'skill11111',
       name: 'skill11111 name',
       hint_i18n: {
-        fr: 'skill11111 hintFrFr',
-        en: 'skill11111 hintEnUs',
+        fr: 'skill11111 fr indice',
+        en: 'skill11111 en hint',
       },
       hintStatus: 'skill11111 hintStatus',
       tutorialIds: ['tutorial2'],
@@ -1030,8 +1048,8 @@ function _getRichCurrentContentDTO() {
       id: 'skill11112',
       name: 'skill11112 name',
       hint_i18n: {
-        fr: 'skill11112 hintFrFr',
-        en: 'skill11112 hintEnUs',
+        fr: 'skill11112 fr indice',
+        en: 'skill11112 en hint',
       },
       hintStatus: 'skill11112 hintStatus',
       learningMoreTutorialIds: [],
@@ -1047,8 +1065,8 @@ function _getRichCurrentContentDTO() {
       id: 'skill12121',
       name: 'skill12121 name',
       hint_i18n: {
-        fr: 'skill12121 hintFrFr',
-        en: 'skill12121 hintEnUs',
+        fr: 'skill12121 fr indice',
+        en: 'skill12121 en hint',
       },
       hintStatus: 'skill12121 hintStatus',
       tutorialIds: [],
@@ -1064,8 +1082,8 @@ function _getRichCurrentContentDTO() {
       id: 'skill21111',
       name: 'skill21111 name',
       hint_i18n: {
-        fr: 'skill21111 hintFrFr',
-        en: 'skill21111 hintEnUs',
+        fr: 'skill21111 fr indice',
+        en: 'skill21111 en hint',
       },
       hintStatus: 'skill21111 hintStatus',
       tutorialIds: [],

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -335,6 +335,71 @@ describe('Integration | Repository | translation-repository', function() {
       });
     });
   });
+
+  context('#listByPrefixes', function() {
+    beforeEach(async function() {
+      databaseBuilder.factory.buildTranslation({
+        key: 'prefixa.key',
+        locale: 'fr',
+        value: 'prefixa'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'prefixb.key',
+        locale: 'fr',
+        value: 'prefixb'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'prefixc.key',
+        locale: 'fr',
+        value: 'prefixc'
+      });
+      await databaseBuilder.commit();
+
+    });
+    context('when no prefixes are specified', () => {
+      it('should return empty translations', async () => {
+        // when
+        const translations = await translationRepository.listByPrefixes([]);
+
+        //then
+        expect(translations).toEqual([]);
+      });
+    });
+
+    context('when one prefix is specified', () => {
+      it('should return translations of this prefix', async () => {
+        // when
+        const translations = await translationRepository.listByPrefixes(['prefixa']);
+
+        //then
+        expect(translations).toEqual([{
+          key: 'prefixa.key',
+          locale: 'fr',
+          value: 'prefixa'
+        }]);
+      });
+    });
+
+    context('when multiple prefixes are specified', () => {
+      it('should return translations of all prefixes', async () => {
+        // when
+        const translations = await translationRepository.listByPrefixes(['prefixa', 'prefixc']);
+
+        //then
+        expect(translations).toEqual([{
+          key: 'prefixa.key',
+          locale: 'fr',
+          value: 'prefixa'
+        },
+        {
+          key: 'prefixc.key',
+          locale: 'fr',
+          value: 'prefixc'
+        }
+        ]);
+      });
+    });
+  });
 });
 
 async function _setShouldDuplicateToAirtable(value) {

--- a/api/tests/unit/infrastructure/translations/skill_test.js
+++ b/api/tests/unit/infrastructure/translations/skill_test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractFromAirtableObject,
   hydrateToAirtableObject,
+  hydrateReleaseObject,
   prefixFor,
 } from '../../../../lib/infrastructure/translations/skill.js';
 
@@ -97,6 +98,61 @@ describe('Unit | Infrastructure | Skill translations', () => {
         'id persistant': 'test',
         'Indice fr-fr': 'indice fr-fr',
         'Indice en-us': null,
+      });
+    });
+  });
+
+  describe('#hydrateReleaseObject', () => {
+    it('should set translated fields into the object', () => {
+      // given
+      const skill = {
+        id: 'test',
+        otherField: 'foo',
+      };
+      const translations = [
+        { key: 'skill.test.hint', locale: 'fr', value: 'indice fr-fr' },
+        {
+          key: 'skill.test.hint',
+          locale: 'en',
+          value: 'hint en-us',
+        },
+      ];
+
+      // when
+      hydrateReleaseObject(skill, translations);
+
+      // then
+      expect(skill).to.deep.equal({
+        id: 'test',
+        hint_i18n: {
+          fr: 'indice fr-fr',
+          en: 'hint en-us',
+        },
+        otherField: 'foo',
+      });
+    });
+
+    it('should set null value for missing translations', () => {
+      // given
+      const skill = {
+        id: 'test',
+        otherField: 'foo',
+      };
+      const translations = [
+        { key: 'skill.test.hint', locale: 'en', value: 'my english hint' },
+      ];
+
+      // when
+      hydrateReleaseObject(skill, translations);
+
+      // then
+      expect(skill).to.deep.equal({
+        id: 'test',
+        hint_i18n: {
+          fr: null,
+          en: 'my english hint',
+        },
+        otherField: 'foo',
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La release n'inclut pas les translations venant de PG pour les acquis.

## :robot: Solution
On inclut les translations des acquis dans notre Release.

## :rainbow: Remarques
RAS

## :100: Pour tester
Lancer le script de migration pour seeder la DB,
(facultatif) changer un champ sur Airtable (pour vérifier que nos traductions viennent bien de PG et non plus de Airtable)
créer une release et vérifier que les champs traduits existent bien et sont bien renseignés.
