### PR TITLE
[FEATURE] Ajouter les épreuves localisées dans la release (PIX-10017).

### DIFF
--- a/api/db/migrations/20231120095724_create-localized-challenges-table.js
+++ b/api/db/migrations/20231120095724_create-localized-challenges-table.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable('localized_challenges', (t) => {
+    t.string('id').notNullable().primary();
+    t.string('challengeId').notNullable();
+    t.string('locale', 20).notNullable();
+    t.unique(['challengeId', 'locale']);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable('localized_challenges');
+}

--- a/api/db/seeds/data/localized-challenges.js
+++ b/api/db/seeds/data/localized-challenges.js
@@ -1,0 +1,16 @@
+import Airtable from 'airtable';
+
+import { fetchLocalizedChallenges } from '../../../scripts/fill-localized-challenges/index.js';
+
+export async function localizedChallengesBuilder(databaseBuilder) {
+  const {
+    AIRTABLE_API_KEY: airtableApiKey,
+    AIRTABLE_BASE: airtableBase,
+  } = process.env;
+
+  const airtableClient = new Airtable({ apiKey: airtableApiKey }).base(airtableBase);
+
+  const localizedChallenges = await fetchLocalizedChallenges({ airtableClient });
+
+  localizedChallenges.forEach(databaseBuilder.factory.buildLocalizedChallenge);
+}

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,4 +1,5 @@
 import { DatabaseBuilder } from '../../tests/tooling/database-builder/database-builder.js';
+import { localizedChallengesBuilder } from './data/localized-challenges.js';
 import { staticCoursesBuilder } from './data/static-courses.js';
 import { translationsBuilder } from './data/translations.js';
 
@@ -31,6 +32,8 @@ export async function seed(knex) {
     access: 'readonly',
     apiKey: process.env.REVIEW_APP_READ_ONLY_USER_API_KEY || readOnlyUserApiKey,
   });
+
+  await localizedChallengesBuilder(databaseBuilder);
 
   staticCoursesBuilder(databaseBuilder);
 

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -84,11 +84,11 @@ export class Challenge {
     this.skillId = skillId;
     this.translations = translations;
 
-    this.instruction = this.translations[this.locales[0]].instruction ?? '';
-    this.alternativeInstruction = this.translations[this.locales[0]].alternativeInstruction ?? '';
-    this.proposals = this.translations[this.locales[0]].proposals ?? '';
-    this.solution = this.translations[this.locales[0]].solution ?? '';
-    this.solutionToDisplay = this.translations[this.locales[0]].solutionToDisplay ?? '';
+    this.instruction = this.translations[this.locales[0]]?.instruction ?? '';
+    this.alternativeInstruction = this.translations[this.locales[0]]?.alternativeInstruction ?? '';
+    this.proposals = this.translations[this.locales[0]]?.proposals ?? '';
+    this.solution = this.translations[this.locales[0]]?.solution ?? '';
+    this.solutionToDisplay = this.translations[this.locales[0]]?.solutionToDisplay ?? '';
   }
 
   static defaultLocales(locales) {

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -99,4 +99,8 @@ export class Challenge {
   static getPrimaryLocale(locales) {
     return Challenge.defaultLocales(locales)[0];
   }
+
+  get primaryLocale() {
+    return this.locales[0];
+  }
 }

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -1,0 +1,11 @@
+export class LocalizedChallenge {
+  constructor({
+    id,
+    challengeId,
+    locale,
+  } = {}) {
+    this.id = id;
+    this.challengeId = challengeId;
+    this.locale = locale;
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -1,4 +1,5 @@
 export * from './Challenge.js';
+export * from './LocalizedChallenge.js';
 export * from './StaticCourse.js';
 export * from './Translation.js';
 export * from './User.js';

--- a/api/lib/domain/services/convert-locales.js
+++ b/api/lib/domain/services/convert-locales.js
@@ -1,0 +1,26 @@
+import { LOCALE_TO_LANGUAGE_MAP } from '../constants.js';
+import _ from 'lodash';
+
+export function convertLanguagesToLocales(languages) {
+  return languages.map((language) => convertLanguageToLocale(language));
+}
+
+export function convertLanguageToLocale(language) {
+  const locale = _.findKey(LOCALE_TO_LANGUAGE_MAP, (lang) => language === lang);
+  if (!locale) {
+    throw new Error('Langue inconnue');
+  }
+  return locale;
+}
+
+export function convertLocalesToLanguages(locales) {
+  return locales.map((locale) => convertLocaleToLanguage(locale));
+}
+
+export function convertLocaleToLanguage(locale) {
+  const language = LOCALE_TO_LANGUAGE_MAP[locale];
+  if (!language) {
+    throw new Error('Locale inconnue');
+  }
+  return language;
+}

--- a/api/lib/domain/services/convert-locales.js
+++ b/api/lib/domain/services/convert-locales.js
@@ -2,7 +2,7 @@ import { LOCALE_TO_LANGUAGE_MAP } from '../constants.js';
 import _ from 'lodash';
 
 export function convertLanguagesToLocales(languages) {
-  return languages.map((language) => convertLanguageToLocale(language));
+  return languages?.map((language) => convertLanguageToLocale(language));
 }
 
 export function convertLanguageToLocale(language) {

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -1,10 +1,10 @@
-import { translationRepository } from '../../infrastructure/repositories/index.js';
-import { Translation } from '../models/index.js';
+import { translationRepository, localizedChallengeRepository } from '../../infrastructure/repositories/index.js';
+import {LocalizedChallenge, Translation} from '../models/index.js';
 import { parseStream } from 'fast-csv';
-
+import fp from 'lodash/fp';
 export class InvalidFileError extends Error {}
 
-export function importTranslations(csvStream, dependencies = { translationRepository }) {
+export function importTranslations(csvStream, dependencies = { translationRepository, localizedChallengeRepository }) {
   return new Promise((resolve, reject) => {
     const translations = [];
     parseStream(csvStream, {
@@ -20,8 +20,27 @@ export function importTranslations(csvStream, dependencies = { translationReposi
         if (translations.length === 0) {
           return reject(new InvalidFileError());
         }
+
+        const challengesLocales = extractChallengesLocales(translations);
+
+        await dependencies.localizedChallengeRepository.create(challengesLocales);
+
         await dependencies.translationRepository.save(translations);
+
         resolve();
       });
   });
 }
+
+const extractChallengesLocales = fp.flow(
+  fp.filter((translation) => {
+    return translation.key.startsWith('challenge.');
+  }),
+  fp.map((challengeTranslation) => {
+    return new LocalizedChallenge({
+      challengeId: challengeTranslation.key.split('.')[1],
+      locale: challengeTranslation.locale,
+    })
+  }),
+  fp.uniqBy(['locale', 'challengeId']),
+);

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -1,7 +1,7 @@
 import { translationRepository, localizedChallengeRepository } from '../../infrastructure/repositories/index.js';
-import {LocalizedChallenge, Translation} from '../models/index.js';
+import { LocalizedChallenge, Translation } from '../models/index.js';
 import { parseStream } from 'fast-csv';
-import fp from 'lodash/fp';
+import fp from 'lodash/fp.js';
 export class InvalidFileError extends Error {}
 
 export function importTranslations(csvStream, dependencies = { translationRepository, localizedChallengeRepository }) {
@@ -22,7 +22,6 @@ export function importTranslations(csvStream, dependencies = { translationReposi
         }
 
         const challengesLocales = extractChallengesLocales(translations);
-
         await dependencies.localizedChallengeRepository.create(challengesLocales);
 
         await dependencies.translationRepository.save(translations);
@@ -40,7 +39,7 @@ const extractChallengesLocales = fp.flow(
     return new LocalizedChallenge({
       challengeId: challengeTranslation.key.split('.')[1],
       locale: challengeTranslation.locale,
-    })
+    });
   }),
   fp.uniqBy(['locale', 'challengeId']),
 );

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,7 +1,7 @@
 import { datasource } from './datasource.js';
 import { findRecords } from '../../airtable.js';
 import { LOCALE_TO_LANGUAGE_MAP } from '../../../domain/constants.js';
-import _ from 'lodash';
+import { convertLanguagesToLocales, convertLocalesToLanguages } from '../../../domain/services/convert-locales.js';
 
 export const challengeDatasource = datasource.extend({
 
@@ -81,7 +81,7 @@ export const challengeDatasource = datasource.extend({
       format: airtableRecord.get('Format') || 'mots',
       files: airtableRecord.get('files'),
       autoReply: Boolean(airtableRecord.get('Réponse automatique')) || false,
-      locales: _convertLanguagesToLocales(airtableRecord.get('Langues') || []),
+      locales: convertLanguagesToLocales(airtableRecord.get('Langues') || []),
       focusable: airtableRecord.get('Focalisée'),
       airtableId: airtableRecord.get('Record ID'),
       genealogy: airtableRecord.get('Généalogie'),
@@ -123,7 +123,7 @@ export const challengeDatasource = datasource.extend({
         'Timer': model.timer,
         'Format': model.format,
         'Réponse automatique': model.autoReply,
-        'Langues': _convertLocalesToLanguages(model.locales),
+        'Langues': convertLocalesToLanguages(model.locales),
         'Focalisée': model.focusable,
         'Acquix': model.skills,
         'Généalogie': model.genealogy,
@@ -197,30 +197,4 @@ function _convertBooleanToAirtableValue(value) {
 
 function _convertAirtableValueToBoolean(value) {
   return value === 'Activé';
-}
-
-function _convertLanguagesToLocales(languages) {
-  return languages.map((language) => _convertLanguageToLocale(language));
-}
-
-function _convertLanguageToLocale(language) {
-  const locale = _.findKey(LOCALE_TO_LANGUAGE_MAP, (lang) => language === lang);
-  if (!locale) {
-    throw new Error('Langue inconnue');
-  }
-
-  return locale;
-}
-
-function _convertLocalesToLanguages(locales) {
-  return locales.map((locale) => _convertLocaleToLanguage(locale));
-}
-
-function _convertLocaleToLanguage(locale) {
-  const language = LOCALE_TO_LANGUAGE_MAP[locale];
-  if (!language) {
-    throw new Error('Locale inconnue');
-  }
-
-  return language;
 }

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,6 +1,5 @@
 import { datasource } from './datasource.js';
 import { findRecords } from '../../airtable.js';
-import { LOCALE_TO_LANGUAGE_MAP } from '../../../domain/constants.js';
 import { convertLanguagesToLocales, convertLocalesToLanguages } from '../../../domain/services/convert-locales.js';
 
 export const challengeDatasource = datasource.extend({

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -3,6 +3,7 @@ import { knex } from '../../../db/knex-database-connection.js';
 import { Challenge } from '../../domain/models/Challenge.js';
 import { challengeDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
+import * as localizedChallengeRepository from './localized-challenge-repository.js';
 import { extractFromChallenge as extractTranslationsFromChallenge, prefix, prefixFor } from '../translations/challenge.js';
 
 async function _getChallengesFromParams(params) {
@@ -39,6 +40,7 @@ export async function create(challenge) {
   const createdChallengeDto = await challengeDatasource.create(challenge);
   const translations = extractTranslationsFromChallenge(challenge);
   await translationRepository.save(translations);
+  await localizedChallengeRepository.create({ id: challenge.id, challengeId: challenge.id, locale: challenge.primaryLocale });
   return toDomain(createdChallengeDto, translations);
 }
 

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -40,7 +40,7 @@ export async function create(challenge) {
   const createdChallengeDto = await challengeDatasource.create(challenge);
   const translations = extractTranslationsFromChallenge(challenge);
   await translationRepository.save(translations);
-  await localizedChallengeRepository.create({ id: challenge.id, challengeId: challenge.id, locale: challenge.primaryLocale });
+  await localizedChallengeRepository.create([{ id: challenge.id, challengeId: challenge.id, locale: challenge.primaryLocale }]);
   return toDomain(createdChallengeDto, translations);
 }
 

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -1,5 +1,6 @@
 export * as challengeRepository from './challenge-repository.js';
 export * as fileStorageTokenRepository from './file-storage-token-repository.js';
+export * as localizedChallengeRepository from './localized-challenge-repository.js';
 export * as releaseRepository from './release-repository.js';
 export * as staticCourseRepository from './static-course-repository.js';
 export * as translationRepository from './translation-repository.js';

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -1,13 +1,27 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { LocalizedChallenge } from '../../domain/models/index.js';
+import { generateNewId } from '../utils/id-generator.js';
 
 export async function list() {
   const localizedChallengeDtos = await knex('localized_challenges').select();
   return localizedChallengeDtos.map(_toDomain);
 }
 
-export async function create(...localizedChallenges) {
-  await knex('localized_challenges').insert(localizedChallenges);
+function _generateId() {
+  return generateNewId('challenge');
+}
+
+export async function create(localizedChallenges = [], generateId = _generateId) {
+  if (localizedChallenges.length === 0) {
+    return;
+  }
+  const localizedChallengesWithId = localizedChallenges.map((localizedChallenge) => {
+    return {
+      id: localizedChallenge.id ?? generateId(),
+      ...localizedChallenge,
+    };
+  });
+  await knex('localized_challenges').insert(localizedChallengesWithId).onConflict().ignore() ;
 }
 
 function _toDomain(dto) {

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -1,10 +1,17 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { LocalizedChallenge } from '../../domain/models/index.js';
-import _ from 'lodash';
 
 export async function list() {
   const localizedChallengeDtos = await knex('localized_challenges').select();
   return localizedChallengeDtos.map(_toDomain);
+}
+
+export async function create({ id, challengeId, locale }) {
+  await knex('localized_challenges').insert({
+    id,
+    challengeId,
+    locale,
+  });
 }
 
 function _toDomain(dto) {

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -17,8 +17,8 @@ export async function create(localizedChallenges = [], generateId = _generateId)
   }
   const localizedChallengesWithId = localizedChallenges.map((localizedChallenge) => {
     return {
-      id: localizedChallenge.id ?? generateId(),
       ...localizedChallenge,
+      id: localizedChallenge.id ?? generateId(),
     };
   });
   await knex('localized_challenges').insert(localizedChallengesWithId).onConflict().ignore() ;

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -6,12 +6,8 @@ export async function list() {
   return localizedChallengeDtos.map(_toDomain);
 }
 
-export async function create({ id, challengeId, locale }) {
-  await knex('localized_challenges').insert({
-    id,
-    challengeId,
-    locale,
-  });
+export async function create(...localizedChallenges) {
+  await knex('localized_challenges').insert(localizedChallenges);
 }
 
 function _toDomain(dto) {

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -1,0 +1,12 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { LocalizedChallenge } from '../../domain/models/index.js';
+import _ from 'lodash';
+
+export async function list() {
+  const localizedChallengeDtos = await knex('localized_challenges').select();
+  return localizedChallengeDtos.map(_toDomain);
+}
+
+function _toDomain(dto) {
+  return new LocalizedChallenge(dto);
+}

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -9,8 +9,11 @@ import {
   tubeDatasource,
   tutorialDatasource,
 } from '../datasources/airtable/index.js';
-import * as translationRepository from './translation-repository.js';
-import * as challengeRepository from './challenge-repository.js';
+import {
+  challengeRepository,
+  translationRepository,
+  localizedChallengeRepository,
+} from './index.js';
 import * as airtableSerializer from '../serializers/airtable-serializer.js';
 import {
   challengeTransformer,
@@ -108,6 +111,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     tubes,
     tutorials,
     translations,
+    localizedChallenges,
   ] = await Promise.all([
     areaDatasource.list(),
     attachmentDatasource.list(),
@@ -118,8 +122,9 @@ async function _getCurrentContentFromAirtable(challenges) {
     tubeDatasource.list(),
     tutorialDatasource.list(),
     translationRepository.listByPrefix(competenceTranslations.prefix),
+    localizedChallengeRepository.list(),
   ]);
-  const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments, withLocalizedChallenges: true });
+  const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments, localizedChallenges });
   const transformedChallenges = challenges.flatMap(transformChallenge);
   const transformedTubes = tubeTransformer.transform({ tubes, skills, challenges: transformedChallenges, thematics });
   const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -24,14 +24,12 @@ function _localizeChallenge({ localizedChallenges }) {
       .filter((localizedChallenge) => localizedChallenge.challengeId === challenge.id)
       .map(({ locale, id }) => {
         const isPrimaryLocale = primaryLocale === locale;
-        const localizedChallenge = {
+        return  {
           ...challenge,
           ...challenge.translations[locale],
           id,
           locales: isPrimaryLocale ? challenge.locales : [locale],
         };
-        delete localizedChallenge.translations;
-        return localizedChallenge;
       });
   };
 
@@ -73,7 +71,6 @@ function _filterChallengeFields(challenge) {
     'type',
     'shuffled',
     'alternativeVersion',
-    'translations',
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { Challenge } from '../../domain/models/Challenge.js';
+import { fields as challengeLocalizedFields } from '../../infrastructure/translations/challenge.js';
 
 export function createChallengeTransformer({ attachments, localizedChallenges }) {
 
@@ -24,8 +25,13 @@ function _localizeChallenge({ localizedChallenges }) {
       .filter((localizedChallenge) => localizedChallenge.challengeId === challenge.id)
       .map(({ locale, id }) => {
         const isPrimaryLocale = primaryLocale === locale;
-        return  {
+        const clearedLocalizedFields = challengeLocalizedFields.reduce((acc, field) => {
+          acc[field] = '';
+          return acc;
+        }, {});
+        return {
           ...challenge,
+          ...clearedLocalizedFields,
           ...challenge.translations[locale],
           id,
           locales: isPrimaryLocale ? challenge.locales : [locale],

--- a/api/lib/infrastructure/translations/challenge.js
+++ b/api/lib/infrastructure/translations/challenge.js
@@ -2,7 +2,7 @@ import { Challenge, Translation } from '../../domain/models/index.js';
 
 export const prefix = 'challenge.';
 
-const fields = [
+export const fields = [
   'instruction',
   'alternativeInstruction',
   'proposals',

--- a/api/scripts/fill-localized-challenges/index.js
+++ b/api/scripts/fill-localized-challenges/index.js
@@ -7,6 +7,11 @@ import { disconnect } from '../../db/knex-database-connection.js';
 const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
 export async function fillLocalizedChallenges({ airtableClient }) {
+  const localizedChallenges = await fetchLocalizedChallenges({ airtableClient })
+  await localizedChallengeRepository.create(...localizedChallenges);
+}
+
+export async function fetchLocalizedChallenges({ airtableClient }) {
   const allChallenges = await airtableClient
     .table('Epreuves')
     .select({
@@ -17,7 +22,7 @@ export async function fillLocalizedChallenges({ airtableClient }) {
     })
     .all();
 
-  const localizedChallenges = allChallenges.map((challenge) => {
+  return allChallenges.map((challenge) => {
     const locale = convertLanguagesToLocales(challenge.get('Langues'))?.sort()?.[0] ?? 'fr';
     const idPersistant = challenge.get('id persistant');
     return {
@@ -26,7 +31,6 @@ export async function fillLocalizedChallenges({ airtableClient }) {
       locale,
     };
   });
-  await localizedChallengeRepository.create(...localizedChallenges);
 }
 
 async function main() {

--- a/api/scripts/fill-localized-challenges/index.js
+++ b/api/scripts/fill-localized-challenges/index.js
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
 export async function fillLocalizedChallenges({ airtableClient }) {
   const localizedChallenges = await fetchLocalizedChallenges({ airtableClient })
-  await localizedChallengeRepository.create(...localizedChallenges);
+  await localizedChallengeRepository.create(localizedChallenges);
 }
 
 export async function fetchLocalizedChallenges({ airtableClient }) {

--- a/api/scripts/fill-localized-challenges/index.js
+++ b/api/scripts/fill-localized-challenges/index.js
@@ -1,0 +1,51 @@
+import { localizedChallengeRepository } from '../../lib/infrastructure/repositories/index.js';
+import { convertLanguagesToLocales } from '../../lib/domain/services/convert-locales.js';
+import {fileURLToPath} from "node:url";
+import Airtable from "airtable";
+import {disconnect} from "../../db/knex-database-connection.js";
+import {migrateSkillsTranslationFromAirtable} from "../migrate-skills-translation-from-airtable/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+export async function fillLocalizedChallenges({ airtableClient }) {
+  const allChallenges = await airtableClient
+        .table('Epreuves')
+        .select({
+          fields: [
+            'id persistant',
+            'Langues',
+          ],
+        })
+        .all();
+
+  for (const challenge of allChallenges) {
+    const locale = convertLanguagesToLocales(challenge.get('Langues')).sort()[0];
+    const idPersistant = challenge.get('id persistant');
+    await localizedChallengeRepository.create([
+      {
+        id: idPersistant,
+        challengeId: idPersistant,
+        locale,
+      }
+    ]);
+  }
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await fillLocalizedChallenges({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/scripts/migrate-challenges-translation-from-airtable/index.js
+++ b/api/scripts/migrate-challenges-translation-from-airtable/index.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import * as challengeTranslations from '../../lib/infrastructure/translations/challenge.js';
 import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
 import { disconnect } from '../../db/knex-database-connection.js';
-import { LOCALE_TO_LANGUAGE_MAP } from '../../lib/domain/constants.js';
+import { convertLanguagesToLocales } from '../../lib/domain/services/convert-locales.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
@@ -33,26 +33,13 @@ export async function migrateChallengesTranslationFromAirtable({ airtableClient 
       proposals: challenge.get('Propositions'),
       solution: challenge.get('Bonnes réponses'),
       solutionToDisplay: challenge.get('Bonnes réponses à afficher'),
-      locales: _convertLanguagesToLocales(challenge.get('Langues')),
+      locales: convertLanguagesToLocales(challenge.get('Langues')),
     });
   });
 
   for (const translationsChunk of _.chunk(translations, 5000)) {
     await translationRepository.save(translationsChunk);
   }
-}
-
-function _convertLanguagesToLocales(languages) {
-  return languages.map((language) => _convertLanguageToLocale(language));
-}
-
-function _convertLanguageToLocale(language) {
-  const locale = _.findKey(LOCALE_TO_LANGUAGE_MAP, (lang) => language === lang);
-  if (!locale) {
-    throw new Error('Langue inconnue');
-  }
-
-  return locale;
 }
 
 async function main() {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -629,6 +629,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
     });
     afterEach(async function() {
       await knex('translations').truncate();
+      await knex('localized_challenges').truncate();
     });
 
     it('should create a challenge', async () => {
@@ -783,6 +784,14 @@ describe('Acceptance | Controller | challenges-controller', () => {
           }
         },
       });
+      const localizedChallenges = await knex('localized_challenges').select();
+      expect(localizedChallenges).to.deep.equal([
+        {
+          id: 'challengeId',
+          challengeId: 'challengeId',
+          locale: 'fr',
+        }
+      ])
       const translations = await knex('translations').select().orderBy('key');
       expect(translations).to.deep.equal([
         {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -828,15 +828,6 @@ describe('Acceptance | Controller | challenges-controller', () => {
         ...challenge,
         illustrationUrl: null,
         illustrationAlt: null,
-        translations: {
-          fr: {
-            instruction: challenge.instruction,
-            alternativeInstruction: challenge.alternativeInstruction,
-            proposals: challenge.proposals,
-            solution: challenge.solution,
-            solutionToDisplay: challenge.solutionToDisplay,
-          },
-        },
       });
       const expectedBodyChallenge = _removeReadonlyFields(airtableBuilder.factory.buildChallenge(challenge), true);
       const expectedBody = { records: [expectedBodyChallenge] };

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -791,7 +791,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           challengeId: 'challengeId',
           locale: 'fr',
         }
-      ])
+      ]);
       const translations = await knex('translations').select().orderBy('key');
       expect(translations).to.deep.equal([
         {

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -226,6 +226,12 @@ async function mockCurrentContent() {
     value: expectedCurrentContent.challenges[0].solutionToDisplay,
   });
 
+  databaseBuilder.factory.buildLocalizedChallenge({
+    id: expectedCurrentContent.challenges[0].id,
+    challengeId: expectedCurrentContent.challenges[0].id,
+    locale: 'fr-fr',
+  });
+
   await databaseBuilder.commit();
 
   return expectedCurrentContent;
@@ -437,6 +443,12 @@ async function mockContentForRelease() {
     key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
     locale: 'fr-fr',
     value: expectedCurrentContent.challenges[0].solutionToDisplay,
+  });
+
+  databaseBuilder.factory.buildLocalizedChallenge({
+    id: expectedCurrentContent.challenges[0].id,
+    challengeId: expectedCurrentContent.challenges[0].id,
+    locale: 'fr-fr',
   });
 
   await databaseBuilder.commit();

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -105,15 +105,6 @@ async function mockCurrentContent() {
       id: 'recChallenge0',
       instruction: 'Consigne du Challenge - fr-fr',
       proposals: 'Propositions du Challenge - fr-fr',
-      translations: {
-        'fr-fr': {
-          instruction: 'Consigne du Challenge - fr-fr',
-          proposals: 'Propositions du Challenge - fr-fr',
-          solution: 'Bonnes réponses du Challenge - fr-fr',
-          solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
-          alternativeInstruction: 'Consigne alternative - fr-fr',
-        }
-      },
       type: 'Type d\'épreuve',
       solution: 'Bonnes réponses du Challenge - fr-fr',
       solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
@@ -212,27 +203,27 @@ async function mockCurrentContent() {
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].instruction,
+    value: expectedCurrentContent.challenges[0].instruction,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.alternativeInstruction`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].alternativeInstruction,
+    value: expectedCurrentContent.challenges[0].alternativeInstruction,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.proposals`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].proposals,
+    value: expectedCurrentContent.challenges[0].proposals,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.solution`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solution,
+    value: expectedCurrentContent.challenges[0].solution,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solutionToDisplay,
+    value: expectedCurrentContent.challenges[0].solutionToDisplay,
   });
 
   await databaseBuilder.commit();
@@ -325,15 +316,6 @@ async function mockContentForRelease() {
       id: 'recChallenge0',
       instruction: 'Consigne du Challenge - fr-fr',
       proposals: 'Propositions du Challenge - fr-fr',
-      translations: {
-        'fr-fr': {
-          instruction: 'Consigne du Challenge - fr-fr',
-          proposals: 'Propositions du Challenge - fr-fr',
-          solution: 'Bonnes réponses du Challenge - fr-fr',
-          solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
-          alternativeInstruction: 'Consigne alternative - fr-fr',
-        }
-      },
       type: 'Type d\'épreuve',
       solution: 'Bonnes réponses du Challenge - fr-fr',
       solutionToDisplay: 'Bonnes réponses du Challenge à afficher - fr-fr',
@@ -434,27 +416,27 @@ async function mockContentForRelease() {
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].instruction,
+    value: expectedCurrentContent.challenges[0].instruction,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.alternativeInstruction`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].alternativeInstruction,
+    value: expectedCurrentContent.challenges[0].alternativeInstruction,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.proposals`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].proposals,
+    value: expectedCurrentContent.challenges[0].proposals,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.solution`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solution,
+    value: expectedCurrentContent.challenges[0].solution,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
     locale: 'fr-fr',
-    value: expectedCurrentContent.challenges[0].translations['fr-fr'].solutionToDisplay,
+    value: expectedCurrentContent.challenges[0].solutionToDisplay,
   });
 
   await databaseBuilder.commit();

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -411,6 +411,8 @@ describe('Acceptance | Controller | translations-controller', () => {
 
       expect(await knex('translations').count()).to.deep.equal([{ count: 1 }]);
       expect(await knex('translations').where({ key: 'some-key' }).select('value').first()).to.deep.equal({ value: 'plop' });
+
+      // FIXME expect localized challenges when there are challenge translations
     });
 
     it('should fail when the file is not a CSV', async () => {

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -388,9 +388,15 @@ describe('Acceptance | Controller | translations-controller', () => {
         locale: 'fr-fr',
         value: 'La clé !'
       });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challengeId',
+        challengeId: 'challengeId',
+        locale: 'fr',
+      });
+
       await databaseBuilder.commit();
       const formData = new FormData();
-      formData.append('file', 'key,locale,value\nsome-key,fr-fr,plop', 'test.csv');
+      formData.append('file', 'key,locale,value\nsome-key,fr-fr,plop\nchallenge.challengeId.key,en,blip', 'test.csv');
 
       const server = await createServer();
       const putTranslationsOptions = {
@@ -407,12 +413,16 @@ describe('Acceptance | Controller | translations-controller', () => {
       const response = await server.inject(putTranslationsOptions);
 
       // Then
+      const expectedLocalizedChallenge = await knex('localized_challenges')
+        .where({ locale: 'en' })
+        .select(['challengeId', 'locale'])
+        .first();
       expect(response.statusCode).to.equal(204);
-
-      expect(await knex('translations').count()).to.deep.equal([{ count: 1 }]);
+      expect(await knex('translations').count()).to.deep.equal([{ count: 2 }]);
       expect(await knex('translations').where({ key: 'some-key' }).select('value').first()).to.deep.equal({ value: 'plop' });
+      expect(await knex('localized_challenges').count()).to.deep.equal([{ count: 2 }]);
+      expect(expectedLocalizedChallenge).to.deep.equal({ challengeId: 'challengeId', locale: 'en' });
 
-      // FIXME expect localized challenges when there are challenge translations
     });
 
     it('should fail when the file is not a CSV', async () => {

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -1,0 +1,29 @@
+import { describe, describe as context, expect, it } from 'vitest';
+import {  databaseBuilder } from '../../../test-helper.js';
+import { localizedChallengeRepository } from '../../../../lib/infrastructure/repositories/index.js';
+
+describe('Integration | Repository | localized-challenge-repository', function() {
+
+  context('#list', function() {
+    it('should returns all localized challenges ', async function() {
+      // given
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challengeNewid',
+        challengeId: 'challengeId',
+        locale: 'fr-fr'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await localizedChallengeRepository.list();
+
+      // then
+      expect(result).to.deep.equal([{
+        id: 'challengeNewid',
+        challengeId: 'challengeId',
+        locale: 'fr-fr',
+      }]);
+    });
+
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -33,11 +33,11 @@ describe('Integration | Repository | localized-challenge-repository', function()
 
     it('should create a localized challenge', async function() {
       // when
-      await localizedChallengeRepository.create({
+      await localizedChallengeRepository.create([{
         id: 'localizedChallengeId',
         challengeId: 'challengeId',
         locale: 'locale',
-      });
+      }]);
 
       // then
       const localizedChallenge = await knex('localized_challenges').select();
@@ -47,6 +47,91 @@ describe('Integration | Repository | localized-challenge-repository', function()
         challengeId: 'challengeId',
         locale: 'locale',
       }]);
+    });
+
+    context('when there is no arg', function() {
+      it('should do nothing', async function() {
+        // when
+        await localizedChallengeRepository.create();
+
+        // then
+        const localizedChallenge = await knex('localized_challenges').select();
+
+        expect(localizedChallenge).to.deep.equal([]);
+      });
+    });
+
+    context('when there is no id', function() {
+      it('should generate an id and create a localized challenge', async function() {
+        // when
+        await localizedChallengeRepository.create([{
+          challengeId: 'challengeId',
+          locale: 'locale',
+        }], () => 'generated-id');
+
+        // then
+        const localizedChallenge = await knex('localized_challenges').select();
+
+        expect(localizedChallenge).to.deep.equal([{
+          id: 'generated-id',
+          challengeId: 'challengeId',
+          locale: 'locale',
+        }]);
+      });
+
+      it('should generate multiple unique ids and create localized challenges', async function() {
+
+        // when
+        await localizedChallengeRepository.create([
+          {
+            challengeId: 'challengeId',
+            locale: 'en',
+          },
+          {
+            challengeId: 'challengeId',
+            locale: 'fr',
+          }
+        ]);
+
+        // then
+        const localizedChallenges = await knex('localized_challenges').select();
+
+        expect(localizedChallenges.length).to.equal(2);
+        expect(localizedChallenges[0].id).not.to.equal(localizedChallenges[1].id);
+      });
+
+      it('should not create duplicated localizedChallenges when already exist', async () => {
+        // given
+        await knex('localized_challenges').insert(
+          {
+            id: 'id',
+            challengeId: 'challengeId',
+            locale: 'en',
+          }
+        );
+
+        // when
+        await localizedChallengeRepository.create([
+          {
+            challengeId: 'challengeId',
+            locale: 'en',
+          },
+          {
+            challengeId: 'challengeId',
+            locale: 'fr',
+          }
+        ]);
+
+        // then
+        const localizedChallenges = await knex('localized_challenges').select().orderBy('locale');
+
+        expect(localizedChallenges.length).to.equal(2);
+        expect(localizedChallenges[0]).to.deep.equal({
+          id: 'id',
+          challengeId: 'challengeId',
+          locale: 'en',
+        });
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -1,11 +1,11 @@
-import { describe, describe as context, expect, it } from 'vitest';
-import {  databaseBuilder } from '../../../test-helper.js';
+import { describe, describe as context, expect, it, afterEach } from 'vitest';
+import { databaseBuilder, knex } from '../../../test-helper.js';
 import { localizedChallengeRepository } from '../../../../lib/infrastructure/repositories/index.js';
 
 describe('Integration | Repository | localized-challenge-repository', function() {
 
   context('#list', function() {
-    it('should returns all localized challenges ', async function() {
+    it('should returns all localized challenges', async function() {
       // given
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'challengeNewid',
@@ -24,6 +24,29 @@ describe('Integration | Repository | localized-challenge-repository', function()
         locale: 'fr-fr',
       }]);
     });
+  });
 
+  context('#create', function() {
+    afterEach(async () => {
+      await knex('localized_challenges').truncate();
+    });
+
+    it('should create a localized challenge', async function() {
+      // when
+      await localizedChallengeRepository.create({
+        id: 'localizedChallengeId',
+        challengeId: 'challengeId',
+        locale: 'locale',
+      });
+
+      // then
+      const localizedChallenge = await knex('localized_challenges').select();
+
+      expect(localizedChallenge).to.deep.equal([{
+        id: 'localizedChallengeId',
+        challengeId: 'challengeId',
+        locale: 'locale',
+      }]);
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -220,6 +220,12 @@ describe('Integration | Repository | release-repository', function() {
           locale,
           value: `${challenge.id} solutionToDisplay`,
         });
+
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: challenge.id,
+          challengeId: challenge.id,
+          locale,
+        });
       }
 
       const otherLocale = 'nl-be';
@@ -248,6 +254,12 @@ describe('Integration | Repository | release-repository', function() {
         key: `challenge.${challengeWithTranslation.id}.solutionToDisplay`,
         locale: otherLocale,
         value: `${challengeWithTranslation.id} solutionToDisplay ${otherLocale}`,
+      });
+
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challenge129803721984',
+        challengeId: challengeWithTranslation.id,
+        locale: otherLocale,
       });
 
       databaseBuilder.factory.buildStaticCourse({
@@ -1140,7 +1152,7 @@ function _getRichCurrentContentDTO() {
       alternativeVersion: 'challenge121211 alternativeVersion',
     },
     {
-      id: 'challenge121211-nl-be',
+      id: 'challenge129803721984',
       instruction: 'challenge121211 instruction nl-be',
       proposals: 'challenge121211 proposals nl-be',
       type: 'challenge121211 type',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -222,6 +222,34 @@ describe('Integration | Repository | release-repository', function() {
         });
       }
 
+      const otherLocale = 'nl-be';
+      const challengeWithTranslation = challenges[0];
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeWithTranslation.id}.instruction`,
+        locale: otherLocale,
+        value: `${challengeWithTranslation.id} instruction ${otherLocale}`,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeWithTranslation.id}.alternativeInstruction`,
+        locale: otherLocale,
+        value: `${challengeWithTranslation.id} alternativeInstruction ${otherLocale}`,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeWithTranslation.id}.proposals`,
+        locale: otherLocale,
+        value: `${challengeWithTranslation.id} proposals ${otherLocale}`,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeWithTranslation.id}.solution`,
+        locale: otherLocale,
+        value: `${challengeWithTranslation.id} solution ${otherLocale}`,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeWithTranslation.id}.solutionToDisplay`,
+        locale: otherLocale,
+        value: `${challengeWithTranslation.id} solutionToDisplay ${otherLocale}`,
+      });
+
       databaseBuilder.factory.buildStaticCourse({
         id: 'course1PG',
         name: 'course1PG name',
@@ -594,7 +622,7 @@ function _mockRichAirtableContent() {
     format: 'challenge211111 format',
     files: 'challenge211111 files',
     autoReply: 'challenge211111 autoReply',
-    locales: ['fr'],
+    locales: ['fr', 'fr-fr'],
     airtableId: 'challenge211111',
     skills: 'challenge211111 skills',
     genealogy: 'Prototype 1',
@@ -1081,15 +1109,6 @@ function _getRichCurrentContentDTO() {
   const expectedChallengeDTOs = [
     {
       id: 'challenge121211',
-      translations: {
-        'fr-fr': {
-          instruction: 'challenge121211 instruction',
-          proposals: 'challenge121211 proposals',
-          solution: 'challenge121211 solution',
-          solutionToDisplay: 'challenge121211 solutionToDisplay',
-          alternativeInstruction: 'challenge121211 alternativeInstruction',
-        },
-      },
       instruction: 'challenge121211 instruction',
       proposals: 'challenge121211 proposals',
       type: 'challenge121211 type',
@@ -1121,16 +1140,39 @@ function _getRichCurrentContentDTO() {
       alternativeVersion: 'challenge121211 alternativeVersion',
     },
     {
+      id: 'challenge121211-nl-be',
+      instruction: 'challenge121211 instruction nl-be',
+      proposals: 'challenge121211 proposals nl-be',
+      type: 'challenge121211 type',
+      solution: 'challenge121211 solution nl-be',
+      solutionToDisplay: 'challenge121211 solutionToDisplay nl-be',
+      t1Status: true,
+      t2Status: true,
+      t3Status: true,
+      status: 'validé',
+      skillId: 'skill12121',
+      embedUrl: 'challenge121211 embedUrl',
+      embedTitle: 'challenge121211 embedTitle',
+      embedHeight: 'challenge121211 embedHeight',
+      timer: 1,
+      competenceId: 'competence12',
+      format: 'challenge121211 format',
+      autoReply: true,
+      locales: ['nl-be'],
+      alternativeInstruction: 'challenge121211 alternativeInstruction nl-be',
+      genealogy: 'Prototype 1',
+      responsive: ['Smartphone', 'Tablet'],
+      focusable: 'challenge121211 focusable',
+      delta: 1.1,
+      alpha: 2.2,
+      attachments: ['attachment1 url', 'attachment2 url'],
+      illustrationUrl: null,
+      illustrationAlt: null,
+      shuffled: false,
+      alternativeVersion: 'challenge121211 alternativeVersion',
+    },
+    {
       id: 'challenge121212',
-      translations: {
-        en: {
-          instruction: 'challenge121212 instruction',
-          proposals: 'challenge121212 proposals',
-          solution: 'challenge121212 solution',
-          solutionToDisplay: 'challenge121212 solutionToDisplay',
-          alternativeInstruction: 'challenge121212 alternativeInstruction',
-        },
-      },
       instruction: 'challenge121212 instruction',
       proposals: 'challenge121212 proposals',
       type: 'challenge121212 type',
@@ -1162,15 +1204,6 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge211111',
-      translations: {
-        fr: {
-          instruction: 'challenge211111 instruction',
-          proposals: 'challenge211111 proposals',
-          solution: 'challenge211111 solution',
-          solutionToDisplay: 'challenge211111 solutionToDisplay',
-          alternativeInstruction: 'challenge211111 alternativeInstruction',
-        },
-      },
       instruction: 'challenge211111 instruction',
       proposals: 'challenge211111 proposals',
       type: 'challenge211111 type',
@@ -1188,7 +1221,7 @@ function _getRichCurrentContentDTO() {
       competenceId: 'competence21',
       format: 'challenge211111 format',
       autoReply: true,
-      locales: ['fr'],
+      locales: ['fr', 'fr-fr'],
       alternativeInstruction: 'challenge211111 alternativeInstruction',
       genealogy: 'Prototype 1',
       responsive: ['Tablet'],
@@ -1203,15 +1236,6 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge211112',
-      translations: {
-        'fr': {
-          instruction: 'challenge211112 instruction',
-          proposals: 'challenge211112 proposals',
-          solution: 'challenge211112 solution',
-          solutionToDisplay: 'challenge211112 solutionToDisplay',
-          alternativeInstruction: 'challenge211112 alternativeInstruction',
-        },
-      },
       instruction: 'challenge211112 instruction',
       proposals: 'challenge211112 proposals',
       type: 'challenge211112 type',
@@ -1243,15 +1267,6 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'challenge211113',
-      translations: {
-        'fr': {
-          instruction: 'challenge211113 instruction',
-          proposals: 'challenge211113 proposals',
-          solution: 'challenge211113 solution',
-          solutionToDisplay: 'challenge211113 solutionToDisplay',
-          alternativeInstruction: 'challenge211113 alternativeInstruction',
-        },
-      },
       instruction: 'challenge211113 instruction',
       proposals: 'challenge211113 proposals',
       type: 'challenge211113 type',

--- a/api/tests/scripts/fill-localized-challenges_test.js
+++ b/api/tests/scripts/fill-localized-challenges_test.js
@@ -1,0 +1,85 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+import {
+  fillLocalizedChallenges
+} from '../../scripts/fill-localized-challenges/index.js';
+
+describe.only('Fill localized challenges from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('localized_challenges').truncate();
+  });
+
+  it('fills localized_challenges table from airtable', async function() {
+    // given
+    const challenge1 = {
+      id: 'airtableChallengeId',
+      fields: {
+        'id persistant': 'challengeid1',
+        Langues: ['Franco Français'],
+      }
+    };
+
+    const challenge2 = {
+      id: 'airtableChallengeId2',
+      fields: {
+        'id persistant': 'challengeid2',
+        Langues: ['Franco Français', 'Francophone'],
+      }
+    };
+
+    const challenges = [challenge1, challenge2];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Epreuves')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query({
+        fields: {
+          '': [
+            'id persistant',
+            'Langues',
+          ]
+        }
+      })
+      .reply(200, { records: challenges });
+
+    // when
+    await fillLocalizedChallenges({ airtableClient });
+
+    // then
+    const localizedChallenges = await knex('localized_challenges').select().orderBy([{
+      column: 'id',
+      order: 'asc'
+    }, { column: 'locale', order: 'asc' }]);
+
+    expect(localizedChallenges).to.have.lengthOf(2);
+    expect(localizedChallenges).to.deep.equal([
+      {
+        id: 'challengeid1',
+        challengeId: 'challengeid1',
+        locale: 'fr-fr',
+      },
+      {
+        id: 'challengeid2',
+        challengeId: 'challengeid2',
+        locale: 'fr',
+      }
+    ]);
+  });
+});

--- a/api/tests/scripts/fill-localized-challenges_test.js
+++ b/api/tests/scripts/fill-localized-challenges_test.js
@@ -6,7 +6,7 @@ import {
   fillLocalizedChallenges
 } from '../../scripts/fill-localized-challenges/index.js';
 
-describe.only('Fill localized challenges from airtable', function() {
+describe('Fill localized challenges from airtable', function() {
 
   let airtableClient;
 

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -1,3 +1,5 @@
+import { convertLocalesToLanguages } from '../../../../lib/domain/services/convert-locales.js';
+
 export function buildChallenge({
   id = 'challid1',
   type,
@@ -56,7 +58,7 @@ export function buildChallenge({
       'Acquix (id persistant)': [skillId],
       'Format': format,
       'files': files,
-      'Langues': _convertLocalesToLanguages(locales || []),
+      'Langues': convertLocalesToLanguages(locales || []),
       'Réponse automatique': autoReply,
       'Compétences (via tube) (id persistant)': [competenceId],
       'Record ID': airtableId,
@@ -89,18 +91,4 @@ export function buildChallenge({
 
 function _convertStatusFromBoolToString(status) {
   return status ? 'Activé' : 'Désactivé';
-}
-
-function _convertLocalesToLanguages(locales) {
-  return locales.map((locale) => {
-    if (locale === 'fr') {
-      return 'Francophone';
-    }
-    if (locale === 'fr-fr') {
-      return 'Franco Français';
-    }
-    if (locale === 'en') {
-      return 'Anglais';
-    }
-  });
 }

--- a/api/tests/tooling/database-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-challenge.js
@@ -1,0 +1,12 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildLocalizedChallenge({
+  id = 'i18nChallenge123',
+  challengeId = 'challenge123',
+  locale = 'fr',
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'localized_challenges',
+    values: { id, challengeId, locale },
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -1,4 +1,5 @@
-export * from './build-user.js';
+export * from './build-localized-challenge.js';
 export * from './build-release.js';
 export * from './build-static-course.js';
 export * from './build-translation.js';
+export * from './build-user.js';

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -47,15 +47,15 @@ export function buildChallenge({
   skillId = 'recSkillId',
   alpha = 0.5,
   delta = 0.2,
-   translations= {
-     [Challenge.getPrimaryLocale(locales)]: {
-       instruction,
-       alternativeInstruction,
-       proposals,
-       solution,
-       solutionToDisplay,
-     },
-   },
+  translations = {
+    [Challenge.getPrimaryLocale(locales)]: {
+      instruction,
+      alternativeInstruction,
+      proposals,
+      solution,
+      solutionToDisplay,
+    },
+  },
 } = {}, fieldsToOmit = []) {
   const data = {
     id,

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -47,6 +47,15 @@ export function buildChallenge({
   skillId = 'recSkillId',
   alpha = 0.5,
   delta = 0.2,
+   translations= {
+     [Challenge.getPrimaryLocale(locales)]: {
+       instruction,
+       alternativeInstruction,
+       proposals,
+       solution,
+       solutionToDisplay,
+     },
+   },
 } = {}, fieldsToOmit = []) {
   const data = {
     id,
@@ -86,15 +95,7 @@ export function buildChallenge({
     createdAt,
     shuffled,
     contextualizedFields,
-    translations: {
-      [Challenge.getPrimaryLocale(locales)]: {
-        instruction,
-        alternativeInstruction,
-        proposals,
-        solution,
-        solutionToDisplay,
-      },
-    },
+    translations,
     skillId,
     alpha,
     delta,

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Usecases | import-translations', function() {
     translationRepository = {
       save: vi.fn(),
     };
-  })
+  });
 
   it('should write in database translation from CSV', async () => {
     // when

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -1,20 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
-import { Translation } from '../../../../lib/domain/models/index.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Translation, LocalizedChallenge } from '../../../../lib/domain/models/index.js';
 import {
   importTranslations
 } from '../../../../lib/domain/usecases/import-translations';
 import { PassThrough } from 'node:stream';
 
 describe('Unit | Domain | Usecases | import-translations', function() {
-  it('should write in database translation from CSV', async () => {
-    // given
-    const csvStream = new PassThrough();
-    const translationRepository = {
+  let csvStream;
+  let localizedChallengeRepository;
+  let translationRepository;
+
+  beforeEach(() => {
+    csvStream = new PassThrough();
+    localizedChallengeRepository = {
+      create: vi.fn()
+    };
+    translationRepository = {
       save: vi.fn(),
     };
+  })
 
+  it('should write in database translation from CSV', async () => {
     // when
-    const promise = importTranslations(csvStream, { translationRepository });
+    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
     csvStream.write('key,locale,value\nsome.key,fr-FR,coucou');
     csvStream.end();
 
@@ -30,14 +38,8 @@ describe('Unit | Domain | Usecases | import-translations', function() {
   });
 
   it('should return an error when the CSV doesnt contain valid translations', async () => {
-    // given
-    const csvStream = new PassThrough();
-    const translationRepository = {
-      save: vi.fn(),
-    };
-
     // when
-    const promise = importTranslations(csvStream, { translationRepository });
+    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
     csvStream.write('one invalid header,locale\navalue,anotherone');
     csvStream.end();
 
@@ -47,19 +49,42 @@ describe('Unit | Domain | Usecases | import-translations', function() {
   });
 
   it('should return an error when its the CSV doesnt contain valid translations', async () => {
-    // given
-    const csvStream = new PassThrough();
-    const translationRepository = {
-      save: vi.fn(),
-    };
-
     // when
-    const promise = importTranslations(csvStream, { translationRepository });
+    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
     csvStream.write('some data');
     csvStream.end();
 
     // then
     await expect(promise).rejects.toThrow();
     expect(translationRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should create a localized challenge when a new locale is added', async () => {
+    // when
+    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
+    csvStream.write('key,locale,value\nchallenge.id.key,fr-FR,coucou\nchallenge.id.key2,fr-FR,coucou2');
+    csvStream.end();
+
+    // then
+    await promise;
+
+    expect(translationRepository.save).toHaveBeenCalledOnce();
+    expect(translationRepository.save).toHaveBeenCalledWith([
+      new Translation({
+        key: 'challenge.id.key',
+        locale: 'fr-FR',
+        value: 'coucou'
+      }),
+      new Translation({
+        key: 'challenge.id.key2',
+        locale: 'fr-FR',
+        value: 'coucou2'
+      })
+    ]);
+    expect(localizedChallengeRepository.create).toHaveBeenCalledOnce();
+    expect(localizedChallengeRepository.create).toHaveBeenCalledWith([new LocalizedChallenge({
+      challengeId: 'id',
+      locale: 'fr-FR',
+    })]);
   });
 });

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -33,6 +33,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             fr: {
               instruction: 'Consigne',
               alternativeInstruction: 'Consigne alternative',
+              proposals: 'Propositions',
             },
             en: {
               instruction: 'English instructions',
@@ -54,6 +55,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             locales: ['fr', 'fr-fr'],
             instruction: 'Consigne',
             alternativeInstruction: 'Consigne alternative',
+            proposals: 'Propositions',
           }),
           _buildReleaseChallenge({
             ...challenge,
@@ -61,6 +63,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             locales: ['en'],
             instruction: 'English instructions',
             alternativeInstruction: 'Alternative english instructions',
+            proposals: '',
           })
         ]);
       });

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import * as challengeTransformer from '../../../../lib/infrastructure/transformers/challenge-transformer.js';
+import { LocalizedChallenge } from '../../../../lib/domain/models/LocalizedChallenge.js';
+import { domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Infrastructure | Challenge Transformer', function() {
+
+  describe('#createChallengeTransformer', function() {
+    describe('when there are several localized challenges', () => {
+      it('should return transformed challenges', async function() {
+        // given
+        const attachments = [];
+        const localizedChallenges = [
+          new LocalizedChallenge({
+            id: 'challenge-id',
+            challengeId: 'challenge-id',
+            locale: 'fr',
+          }),
+          new LocalizedChallenge({
+            id: 'localized-challenge-en-id',
+            challengeId: 'challenge-id',
+            locale: 'en',
+          }),
+          new LocalizedChallenge({
+            id: 'other-challenge-id',
+            challengeId: 'other-challenge-id',
+            locale: 'nl-be',
+          }),
+        ];
+        const challenge = domainBuilder.buildChallenge({
+          id: 'challenge-id',
+          translations: {
+            fr: {
+              instruction: 'Consigne',
+              alternativeInstruction: 'Consigne alternative',
+            },
+            en: {
+              instruction: 'English instructions',
+              alternativeInstruction: 'Alternative english instructions',
+            },
+          },
+          locales: ['fr', 'fr-fr'],
+        });
+
+        // when
+        const transform = challengeTransformer.createChallengeTransformer({ attachments, localizedChallenges });
+        const result = transform(challenge);
+
+        // then
+        expect(result).to.deep.equal([
+          _buildReleaseChallenge({
+            ...challenge,
+            id: 'challenge-id',
+            locales: ['fr', 'fr-fr'],
+            instruction: 'Consigne',
+            alternativeInstruction: 'Consigne alternative',
+          }),
+          _buildReleaseChallenge({
+            ...challenge,
+            id: 'localized-challenge-en-id',
+            locales: ['en'],
+            instruction: 'English instructions',
+            alternativeInstruction: 'Alternative english instructions',
+          })
+        ]);
+      });
+    });
+  });
+});
+
+function _buildReleaseChallenge({
+  id,
+  instruction,
+  proposals,
+  type,
+  solution,
+  solutionToDisplay,
+  t1Status,
+  t2Status,
+  t3Status,
+  status,
+  skillId,
+  embedUrl,
+  embedTitle,
+  embedHeight,
+  timer,
+  competenceId,
+  format,
+  autoReply,
+  locales,
+  alternativeInstruction,
+  genealogy,
+  responsive,
+  focusable,
+  delta,
+  alpha,
+  attachments,
+  illustrationUrl = null,
+  illustrationAlt = null,
+  shuffled,
+  alternativeVersion,
+}) {
+  const releaseChallenge = {
+    id,
+    instruction,
+    proposals,
+    type,
+    solution,
+    solutionToDisplay,
+    t1Status,
+    t2Status,
+    t3Status,
+    status,
+    skillId,
+    embedUrl,
+    embedTitle,
+    embedHeight,
+    timer,
+    competenceId,
+    format,
+    autoReply,
+    locales,
+    alternativeInstruction,
+    genealogy,
+    responsive,
+    focusable,
+    delta,
+    alpha,
+    illustrationUrl,
+    illustrationAlt,
+    shuffled,
+    alternativeVersion,
+  };
+  if (attachments) {
+    releaseChallenge.attachments = attachments;
+  }
+  return releaseChallenge;
+}

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -6,47 +6,7 @@ import { challengeRepository } from '../../../lib/infrastructure/repositories/in
 
 describe('Unit | Repository | release-repository', () => {
   describe('#serializeEntity', () => {
-    it('serialize a challenge and fetch attachments', async () => {
-      const challengeDataObject = domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge' });
-      const entity = airtableBuilder.factory.buildChallenge({
-        id: 'recChallenge',
-        type: challengeDataObject.type,
-        t1Status: challengeDataObject.t1Status,
-        t2Status: challengeDataObject.t2Status,
-        t3Status: challengeDataObject.t3Status,
-        status: challengeDataObject.status,
-        skillId: challengeDataObject.skillId,
-        timer: challengeDataObject.timer,
-        illustrationUrl: challengeDataObject.illustrationUrl,
-        attachments: challengeDataObject.attachments || [],
-        competenceId: challengeDataObject.competenceId,
-        embedUrl: challengeDataObject.embedUrl,
-        embedTitle: challengeDataObject.embedTitle,
-        embedHeight: challengeDataObject.embedHeight,
-        illustrationAlt: challengeDataObject.illustrationAlt,
-        format: challengeDataObject.format,
-        autoReply: challengeDataObject.autoReply,
-      });
-      const attachment = domainBuilder.buildAttachment({
-        id: '1',
-        alt: '',
-        type: 'illustration',
-        url: 'http://example.com/test',
-        challengeId: 'recChallenge',
-      });
-      const type = 'Epreuves';
-
-      vi.spyOn(attachmentDatasource, 'filterByChallengeId').mockImplementation(async (spyId) => {
-        if (spyId === 'recChallenge') return [attachment];
-      });
-
-      const { updatedRecord, model } = await serializeEntity({ entity, type });
-
-      expect(updatedRecord.illustrationUrl).to.equal('http://example.com/test');
-      expect(model).to.equal('challenges');
-    });
-
-    it('serialize an area', async () => {
+    it('serializes an area', async () => {
       const entity = airtableBuilder.factory.buildArea({
         id: '1',
         code: 1,
@@ -84,7 +44,7 @@ describe('Unit | Repository | release-repository', () => {
       expect(model).to.equal('areas');
     });
 
-    it('serialize attachment', async () => {
+    it('serializes attachment', async () => {
       const entity = airtableBuilder.factory.buildAttachment({
         id: 'recAttachment',
         alt: 'texte alternatif à l\'image',


### PR DESCRIPTION
## :unicorn: Problème
Les épreuves sur pix-editor possèdent plusieurs langues or sur pix-app nous voulons une épreuve par langue

## :robot: Solution
Lors de la release générer des épreuves depuis leur traductions.
Une table permet d'enregistré la correspondance entre l'id  de ces épreuves localisées avec l'id de l'épreuve mère

## :rainbow: Remarques
RAS

## :100: Pour tester

1. Créer une release
1. Vérifier qu'il n'y a aucune épreuves 
1. Lancer le script d'import des épreuves localisées: `node api/scripts/fill-localized-challenges/index.js`
1. Créer une release
1. Vérifier qu'il y a des épreuves
1. Créer une épreuve
1. vérifier sa présence dans la release
1. importer des nouvelles traductions
1. vérifier leur présence dans la release
