### PR TITLE
[TECH] Refactoring gestion des traductions dans proxy Airtable (PIX-10085)

### DIFF
--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -123,7 +123,7 @@ export function getTableTranslations(tablesTranslations, tableName) {
   const writeToPgEnabled = tableTranslations?.extractFromProxyObject !== undefined;
 
   // Lecture dans PG possible seulement si écriture dans PG activée
-  const readFromPgEnabled = writeToPgEnabled && tableTranslations?.hydrateProxyObject !== undefined;
+  const readFromPgEnabled = writeToPgEnabled && tableTranslations?.airtableObjectToProxyObject !== undefined;
 
   // Arrêt de l'écriture dans Airtable possible seulement si écriture et lecture dans PG activées
   const writeToAirtableDisabled = readFromPgEnabled && tableTranslations?.proxyObjectToAirtableObject !== undefined;

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -19,7 +19,7 @@ export async function register(server) {
       config: {
         handler: async function(request, h) {
           const tableName = request.params.path.split('/')[0];
-          const tableTranslations = getTableTranslations(tableName);
+          const tableTranslations = getTableTranslations(tablesTranslations, tableName);
 
           const response = await usecases.proxyReadRequestToAirtable(request, config.airtable.base, {
             tableTranslations,
@@ -41,7 +41,7 @@ export async function register(server) {
         }],
         handler: async function(request, h) {
           const tableName = request.params.path.split('/')[0];
-          const tableTranslations = getTableTranslations(tableName);
+          const tableTranslations = getTableTranslations(tablesTranslations, tableName);
 
           const response = await usecases.proxyWriteRequestToAirtable(request, config.airtable.base, tableName, {
             proxyRequestToAirtable: _proxyRequestToAirtable,
@@ -117,7 +117,7 @@ async function _updateStagingPixApiCache(type, entity, translations) {
   }
 }
 
-function getTableTranslations(tableName) {
+export function getTableTranslations(tablesTranslations, tableName) {
   const tableTranslations = tablesTranslations[tableName];
 
   const writeToPgEnabled = tableTranslations?.extractFromAirtableObject !== undefined;

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -120,10 +120,10 @@ async function _updateStagingPixApiCache(type, entity, translations) {
 export function getTableTranslations(tablesTranslations, tableName) {
   const tableTranslations = tablesTranslations[tableName];
 
-  const writeToPgEnabled = tableTranslations?.extractFromAirtableObject !== undefined;
+  const writeToPgEnabled = tableTranslations?.extractFromProxyObject !== undefined;
 
   // Lecture dans PG possible seulement si écriture dans PG activée
-  const readFromPgEnabled = writeToPgEnabled && tableTranslations?.hydrateToAirtableObject !== undefined;
+  const readFromPgEnabled = writeToPgEnabled && tableTranslations?.hydrateProxyObject !== undefined;
 
   // Arrêt de l'écriture dans Airtable possible seulement si écriture et lecture dans PG activées
   const writeToAirtableDisabled = readFromPgEnabled && tableTranslations?.dehydrateAirtableObject !== undefined;

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -126,7 +126,7 @@ export function getTableTranslations(tablesTranslations, tableName) {
   const readFromPgEnabled = writeToPgEnabled && tableTranslations?.hydrateProxyObject !== undefined;
 
   // Arrêt de l'écriture dans Airtable possible seulement si écriture et lecture dans PG activées
-  const writeToAirtableDisabled = readFromPgEnabled && tableTranslations?.dehydrateAirtableObject !== undefined;
+  const writeToAirtableDisabled = readFromPgEnabled && tableTranslations?.proxyObjectToAirtableObject !== undefined;
 
   return {
     ...tableTranslations,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -2,3 +2,4 @@ export * from './export-translations.js';
 export * from './import-translations.js';
 export * from './validate-urls-from-release.js';
 export * from './proxy-read-request-to-airtable.js';
+export * from './proxy-write-request-to-airtable.js';

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,3 +1,4 @@
 export * from './export-translations.js';
 export * from './import-translations.js';
 export * from './validate-urls-from-release.js';
+export * from './proxy-read-request-to-airtable.js';

--- a/api/lib/domain/usecases/proxy-read-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-read-request-to-airtable.js
@@ -14,11 +14,11 @@ export async function proxyReadRequestToAirtable(request, airtableBase, {
   if (response.data.records) {
     const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
     response.data.records.forEach((entity) => {
-      tableTranslations.hydrateToAirtableObject(entity.fields, translations);
+      tableTranslations.hydrateProxyObject(entity.fields, translations);
     });
   } else {
     const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
-    tableTranslations.hydrateToAirtableObject(response.data.fields, translations);
+    tableTranslations.hydrateProxyObject(response.data.fields, translations);
   }
 
   return response;

--- a/api/lib/domain/usecases/proxy-read-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-read-request-to-airtable.js
@@ -13,12 +13,13 @@ export async function proxyReadRequestToAirtable(request, airtableBase, {
 
   if (response.data.records) {
     const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
-    response.data.records.forEach((entity) => {
-      tableTranslations.hydrateProxyObject(entity.fields, translations);
-    });
+    response.data.records = response.data.records.map((entity) => ({
+      ...entity,
+      fields: tableTranslations.airtableObjectToProxyObject(entity.fields, translations),
+    }));
   } else {
     const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
-    tableTranslations.hydrateProxyObject(response.data.fields, translations);
+    response.data.fields = tableTranslations.airtableObjectToProxyObject(response.data.fields, translations);
   }
 
   return response;

--- a/api/lib/domain/usecases/proxy-read-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-read-request-to-airtable.js
@@ -1,0 +1,29 @@
+import * as repositories from '../../infrastructure/repositories/index.js';
+
+export async function proxyReadRequestToAirtable(request, airtableBase, {
+  proxyRequestToAirtable,
+  tableTranslations,
+  translationRepository = repositories.translationRepository
+}) {
+  const response = await proxyRequestToAirtable(request, airtableBase);
+
+  if (!_isResponseOK(response)) return response;
+
+  if (!tableTranslations.readFromPgEnabled) return response;
+
+  if (response.data.records) {
+    const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
+    response.data.records.forEach((entity) => {
+      tableTranslations.hydrateToAirtableObject(entity.fields, translations);
+    });
+  } else {
+    const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
+    tableTranslations.hydrateToAirtableObject(response.data.fields, translations);
+  }
+
+  return response;
+}
+
+function _isResponseOK(response) {
+  return response.status >= 200 && response.status < 300;
+}

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -1,0 +1,42 @@
+import * as repositories from '../../infrastructure/repositories/index.js';
+
+export async function proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+  proxyRequestToAirtable,
+  tableTranslations,
+  translationRepository = repositories.translationRepository,
+  updateStagingPixApiCache,
+}) {
+  let translations;
+  if (tableTranslations.writeToPgEnabled) {
+    translations = tableTranslations.extractFromAirtableObject(request.payload.fields);
+  }
+
+  if (tableTranslations.writeToAirtableDisabled) {
+    tableTranslations.dehydrateAirtableObject(request.payload?.fields);
+  }
+
+  const response = await proxyRequestToAirtable(request, airtableBase);
+
+  if (!_isResponseOK(response)) {
+    return response;
+  }
+
+  if (tableTranslations.writeToPgEnabled) {
+    if (request.method === 'patch') {
+      await translationRepository.deleteByKeyPrefix(tableTranslations.prefixFor(response.data.fields));
+    }
+    await translationRepository.save(translations);
+  }
+
+  if (tableTranslations.readFromPgEnabled) {
+    tableTranslations.hydrateToAirtableObject(response.data.fields, translations);
+  }
+
+  await updateStagingPixApiCache(tableName, response.data, translations);
+
+  return response;
+}
+
+function _isResponseOK(response) {
+  return response.status >= 200 && response.status < 300;
+}

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -30,7 +30,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   }
 
   if (tableTranslations.readFromPgEnabled) {
-    tableTranslations.hydrateProxyObject(response.data.fields, translations);
+    response.data.fields = tableTranslations.airtableObjectToProxyObject(response.data.fields, translations);
   }
 
   await updateStagingPixApiCache(tableName, response.data, translations);

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -8,7 +8,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
 }) {
   let translations;
   if (tableTranslations.writeToPgEnabled) {
-    translations = tableTranslations.extractFromAirtableObject(request.payload.fields);
+    translations = tableTranslations.extractFromProxyObject(request.payload.fields);
   }
 
   if (tableTranslations.writeToAirtableDisabled) {
@@ -29,7 +29,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   }
 
   if (tableTranslations.readFromPgEnabled) {
-    tableTranslations.hydrateToAirtableObject(response.data.fields, translations);
+    tableTranslations.hydrateProxyObject(response.data.fields, translations);
   }
 
   await updateStagingPixApiCache(tableName, response.data, translations);

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -17,7 +17,7 @@ const idField = 'id persistant';
 export const {
   extractFromProxyObject,
   hydrateProxyObject,
-  dehydrateAirtableObject,
+  proxyObjectToAirtableObject,
   hydrateReleaseObject,
   extractFromReleaseObject,
   prefixFor,

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -16,7 +16,7 @@ const idField = 'id persistant';
 
 export const {
   extractFromProxyObject,
-  hydrateProxyObject,
+  airtableObjectToProxyObject,
   proxyObjectToAirtableObject,
   hydrateReleaseObject,
   extractFromReleaseObject,

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -15,8 +15,8 @@ const fields = [
 const idField = 'id persistant';
 
 export const {
-  extractFromAirtableObject,
-  hydrateToAirtableObject,
+  extractFromProxyObject,
+  hydrateProxyObject,
   dehydrateAirtableObject,
   hydrateReleaseObject,
   extractFromReleaseObject,

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -14,7 +14,7 @@ const fields = [
 const idField = 'id persistant';
 
 export const {
-  extractFromAirtableObject,
-  hydrateToAirtableObject,
+  extractFromProxyObject,
+  hydrateProxyObject,
   prefixFor,
 } = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -15,6 +15,6 @@ const idField = 'id persistant';
 
 export const {
   extractFromProxyObject,
-  hydrateProxyObject,
+  airtableObjectToProxyObject,
   prefixFor,
 } = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/lib/infrastructure/translations/utils.js
+++ b/api/lib/infrastructure/translations/utils.js
@@ -41,15 +41,13 @@ function hydrateProxyObject({ localizedFields, prefixFor }) {
   };
 }
 
-function dehydrateAirtableObject({ localizedFields }) {
-  return (entity) => {
-    for (const {
-      airtableLocale,
-      airtableField,
-    } of localizedFields) {
-      delete entity[`${airtableField} ${airtableLocale}`];
-    }
-  };
+function proxyObjectToAirtableObject({ localizedFields }) {
+  const airtableLocalizedFields = localizedFields
+    .map(({ airtableLocale, airtableField }) => `${airtableField} ${airtableLocale}`);
+
+  return (proxyObject) => Object.fromEntries(
+    Object.entries(proxyObject).filter(([field]) => !airtableLocalizedFields.includes(field)),
+  );
 }
 
 function hydrateReleaseObject({ fields, locales, prefix }) {
@@ -96,7 +94,7 @@ export function buildTranslationsUtils({ locales, fields, prefix, idField }) {
     prefixFor,
     extractFromProxyObject: extractFromProxyObject({ localizedFields, prefixFor }),
     hydrateProxyObject: hydrateProxyObject({ localizedFields, prefixFor }),
-    dehydrateAirtableObject: dehydrateAirtableObject({ localizedFields }),
+    proxyObjectToAirtableObject: proxyObjectToAirtableObject({ localizedFields }),
     hydrateReleaseObject: hydrateReleaseObject({ fields, locales, prefix }),
     extractFromReleaseObject: extractFromReleaseObject({ localizedFields, prefix }),
   };

--- a/api/lib/infrastructure/translations/utils.js
+++ b/api/lib/infrastructure/translations/utils.js
@@ -21,23 +21,22 @@ function extractFromProxyObject({ localizedFields, prefixFor }) {
   };
 }
 
-function hydrateProxyObject({ localizedFields, prefixFor }) {
-  return (entity, translations) => {
-    for (const {
-      airtableLocale,
-      locale,
-      airtableField,
-      field,
-    } of localizedFields) {
-      const translation = translations.find(
-        (translation) =>
-          translation.key === `${prefixFor(entity)}${field}` &&
-          translation.locale === locale
-      );
+function airtableObjectToProxyObject({ localizedFields, prefixFor }) {
+  return (airtableObject, translations) => {
+    return {
+      ...airtableObject,
+      ...Object.fromEntries(
+        localizedFields.map(({ airtableLocale, locale, airtableField, field }) => {
+          const translation = translations.find(
+            (translation) =>
+              translation.key === `${prefixFor(airtableObject)}${field}` &&
+              translation.locale === locale
+          );
 
-      entity[`${airtableField} ${airtableLocale}`] =
-        translation?.value ?? null;
-    }
+          return [`${airtableField} ${airtableLocale}`, translation?.value ?? null];
+        }),
+      ),
+    };
   };
 }
 
@@ -93,7 +92,7 @@ export function buildTranslationsUtils({ locales, fields, prefix, idField }) {
     localizedFields,
     prefixFor,
     extractFromProxyObject: extractFromProxyObject({ localizedFields, prefixFor }),
-    hydrateProxyObject: hydrateProxyObject({ localizedFields, prefixFor }),
+    airtableObjectToProxyObject: airtableObjectToProxyObject({ localizedFields, prefixFor }),
     proxyObjectToAirtableObject: proxyObjectToAirtableObject({ localizedFields }),
     hydrateReleaseObject: hydrateReleaseObject({ fields, locales, prefix }),
     extractFromReleaseObject: extractFromReleaseObject({ localizedFields, prefix }),

--- a/api/lib/infrastructure/translations/utils.js
+++ b/api/lib/infrastructure/translations/utils.js
@@ -9,7 +9,7 @@ function buildLocalizedFields(locales, fields) {
   );
 }
 
-function extractFromAirtableObject({ localizedFields, prefixFor }) {
+function extractFromProxyObject({ localizedFields, prefixFor }) {
   return (entity) => {
     return localizedFields
       .filter(({ airtableField, airtableLocale }) => entity[`${airtableField} ${airtableLocale}`])
@@ -21,7 +21,7 @@ function extractFromAirtableObject({ localizedFields, prefixFor }) {
   };
 }
 
-function hydrateToAirtableObject({ localizedFields, prefixFor }) {
+function hydrateProxyObject({ localizedFields, prefixFor }) {
   return (entity, translations) => {
     for (const {
       airtableLocale,
@@ -94,8 +94,8 @@ export function buildTranslationsUtils({ locales, fields, prefix, idField }) {
   return {
     localizedFields,
     prefixFor,
-    extractFromAirtableObject: extractFromAirtableObject({ localizedFields, prefixFor }),
-    hydrateToAirtableObject: hydrateToAirtableObject({ localizedFields, prefixFor }),
+    extractFromProxyObject: extractFromProxyObject({ localizedFields, prefixFor }),
+    hydrateProxyObject: hydrateProxyObject({ localizedFields, prefixFor }),
     dehydrateAirtableObject: dehydrateAirtableObject({ localizedFields }),
     hydrateReleaseObject: hydrateReleaseObject({ fields, locales, prefix }),
     extractFromReleaseObject: extractFromReleaseObject({ localizedFields, prefix }),

--- a/api/scripts/migrate-competences-translation-from-airtable/index.js
+++ b/api/scripts/migrate-competences-translation-from-airtable/index.js
@@ -22,7 +22,7 @@ export async function migrateCompetencesTranslationFromAirtable({ airtableClient
     .all();
 
   const translations = allCompetences.flatMap((competence) =>
-    competenceTranslations.extractFromAirtableObject(competence.fields)
+    competenceTranslations.extractFromProxyObject(competence.fields)
   );
 
   await translationRepository.save(translations);

--- a/api/scripts/migrate-skills-translation-from-airtable/index.js
+++ b/api/scripts/migrate-skills-translation-from-airtable/index.js
@@ -20,7 +20,7 @@ export async function migrateSkillsTranslationFromAirtable({ airtableClient }) {
     .all();
 
   const translations = allSkills.flatMap((skill) =>
-    skillTranslations.extractFromAirtableObject(skill.fields)
+    skillTranslations.extractFromProxyObject(skill.fields)
   );
 
   await translationRepository.save(translations);

--- a/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-competence_test.js
@@ -41,7 +41,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
       const competence = domainBuilder.buildCompetenceDatasourceObject({ id: 'mon_id_persistant' });
       airtableRawCompetence = airtableBuilder.factory.buildCompetence(competence);
       competenceToSave = inputOutputDataBuilder.factory.buildCompetence({
-        ... competence,
+        ...competence,
         name_i18n: {
           fr: 'Pouet',
           en: 'Toot'
@@ -187,54 +187,6 @@ describe('Acceptance | Controller | airtable-proxy-controller | create competenc
           key: 'competence.mon_id_persistant.description',
           locale: 'en',
           value: 'DDDDDDDDDDDDDDDD'
-        });
-      });
-    });
-
-    describe('when some fields are emptied', () => {
-      it('should delete translation keys', async () => {
-        // Given
-        const competenceDataObject = domainBuilder.buildCompetenceDatasourceObject({
-          id: 'mon_id_persistant',
-        });
-        airtableRawCompetence = airtableBuilder.factory.buildCompetence(competenceDataObject);
-        competence = inputOutputDataBuilder.factory.buildCompetence({
-          ...competenceDataObject,
-          name_i18n: {
-            fr: 'AAA',
-          },
-          description_i18n: {
-            fr: 'CCCCCCCCCCCCCCCC',
-          },
-        });
-
-        nock('https://api.airtable.com')
-          .patch('/v0/airtableBaseValue/Competences/id_airtable', airtableRawCompetence)
-          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, airtableRawCompetence);
-        const server = await createServer();
-
-        // When
-        const response = await server.inject({
-          method: 'PATCH',
-          url: '/api/airtable/content/Competences/id_airtable',
-          headers: generateAuthorizationHeader(user),
-          payload: competence,
-        });
-
-        // Then
-        expect(response.statusCode).to.equal(200);
-        const translations = await knex('translations').select('key', 'locale', 'value');
-        expect(translations.length).to.equal(2);
-        expect(translations[0]).to.deep.equal({
-          key: 'competence.mon_id_persistant.name',
-          locale: 'fr',
-          value: 'AAA'
-        });
-        expect(translations[1]).to.deep.equal({
-          key: 'competence.mon_id_persistant.description',
-          locale: 'fr',
-          value: 'CCCCCCCCCCCCCCCC'
         });
       });
     });

--- a/api/tests/acceptance/application/airtable-proxy-controller-skill_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-skill_test.js
@@ -150,45 +150,6 @@ describe('Acceptance | Controller | airtable-proxy-controller | create skill tra
         }]);
       });
     });
-
-    describe('when some fields are emptied', () => {
-      it('should delete translation keys', async () => {
-        // Given
-        const skillDataObject = domainBuilder.buildSkillDatasourceObject({
-          id: 'mon_id_persistant',
-        });
-        skillToUpdate = inputOutputDataBuilder.factory.buildSkill({
-          ...skillDataObject,
-          hint_i18n: {
-            fr: 'AAA',
-          },
-        });
-
-        nock('https://api.airtable.com')
-          .patch('/v0/airtableBaseValue/Acquis/id_airtable', skillToUpdate)
-          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, skillToUpdate);
-        const server = await createServer();
-
-        // When
-        const response = await server.inject({
-          method: 'PATCH',
-          url: '/api/airtable/content/Acquis/id_airtable',
-          headers: generateAuthorizationHeader(user),
-          payload: skillToUpdate,
-        });
-
-        // Then
-        expect(response.statusCode).to.equal(200);
-        const translations = await knex('translations').select('key', 'locale', 'value');
-        expect(translations.length).to.equal(1);
-        expect(translations[0]).to.deep.equal({
-          key: 'skill.mon_id_persistant.hint',
-          locale: 'fr',
-          value: 'AAA'
-        });
-      });
-    });
   });
 });
 

--- a/api/tests/acceptance/application/airtable-proxy-controller_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller_test.js
@@ -1,17 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import nock from 'nock';
 import {
-  airtableBuilder,
   databaseBuilder,
-  inputOutputDataBuilder,
-  domainBuilder,
   generateAuthorizationHeader
 } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller', () => {
 
-  describe('GET/POST/PUT/DELETE /api/airtable/content/Competences', () => {
+  describe('POST /api/airtable/content/{Table}', () => {
 
     async function createAdminUser() {
       const user = databaseBuilder.factory.buildAdminUser();
@@ -25,73 +22,13 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
       return user;
     }
 
-    describe('nominal cases', () => {
-
-      it('should proxy request to airtable', async () => {
-        // Given
-        const user = await createReadonlyUser();
-        const competenceDataObject = domainBuilder.buildCompetenceDatasourceObject();
-        const competence = airtableBuilder.factory.buildCompetence(competenceDataObject);
-        const inputOutputCompetence = inputOutputDataBuilder.factory.buildCompetence({
-          ...competenceDataObject,
-          name_i18n: {
-            en: null,
-            fr: null,
-          },
-          description_i18n: {
-            en: null,
-            fr: null,
-          },
-        });
-        nock('https://api.airtable.com')
-          .get('/v0/airtableBaseValue/Competences?key=value')
-          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, competence);
-        const server = await createServer();
-
-        // When
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/airtable/content/Competences?key=value',
-          headers: generateAuthorizationHeader(user)
-        });
-
-        // Then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result).to.deep.equal(inputOutputCompetence);
-      });
-
-      it('should proxy post request to airtable', async () => {
-        // Given
-        const user = await createAdminUser();
-        nock('https://api.airtable.com')
-          .post('/v0/airtableBaseValue/Epreuves?key=value', { param: 'value' })
-          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .matchHeader('content-type', 'application/json')
-          .reply(200, 'ok');
-        const server = await createServer();
-
-        // When
-        const response = await server.inject({
-          method: 'POST',
-          url: '/api/airtable/content/Epreuves?key=value',
-          headers: generateAuthorizationHeader(user),
-          payload: { param: 'value' }
-        });
-
-        // Then
-        expect(response.statusCode).to.equal(200);
-        expect(response.result).to.equal('ok');
-      });
-    });
-
     describe('error cases', () => {
 
       it('should return airtable error status code', async () => {
         // Given
         const user = await createAdminUser();
         nock('https://api.airtable.com')
-          .post('/v0/airtableBaseValue/Epreuves?key=value', { param: 'value' })
+          .post('/v0/airtableBaseValue/Entites', { param: 'value' })
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .matchHeader('content-type', 'application/json')
           .reply(401, 'Unauthorized');
@@ -100,7 +37,7 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
         // When
         const response = await server.inject({
           method: 'POST',
-          url: '/api/airtable/content/Epreuves?key=value',
+          url: '/api/airtable/content/Entites',
           headers: generateAuthorizationHeader(user),
           payload: { param: 'value' }
         });
@@ -118,7 +55,7 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
         // When
         const response = await server.inject({
           method: 'POST',
-          url: '/api/airtable/content/Epreuves?key=value',
+          url: '/api/airtable/content/Entites',
           headers: generateAuthorizationHeader(user),
           payload: { param: 'value' }
         });
@@ -127,7 +64,5 @@ describe('Acceptance | Controller | airtable-proxy-controller', () => {
         expect(response.statusCode).to.equal(403);
       });
     });
-
   });
-
 });

--- a/api/tests/unit/application/airtable-proxy_test.js
+++ b/api/tests/unit/application/airtable-proxy_test.js
@@ -5,12 +5,12 @@ describe('Unit | Application | airtable proxy', function() {
   describe('#getTableTranslation', function() {
     const tableName = 'Entites';
 
-    describe('when table translations implements extractFromAirtableObject', () => {
+    describe('when table translations implements extractFromProxyObject', () => {
       it('should enable Write to Pg', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            extractFromAirtableObject: vi.fn(),
+            extractFromProxyObject: vi.fn(),
           },
         };
 
@@ -24,13 +24,13 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements extractFromAirtableObject and hydrateToAirtableObject', () => {
+    describe('when table translations implements extractFromProxyObject and hydrateProxyObject', () => {
       it('should enable Read to Pg', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            extractFromAirtableObject: vi.fn(),
-            hydrateToAirtableObject: vi.fn(),
+            extractFromProxyObject: vi.fn(),
+            hydrateProxyObject: vi.fn(),
           },
         };
 
@@ -44,13 +44,13 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements extractFromAirtableObject, hydrateToAirtableObject and dehydrateAirtableObject', () => {
+    describe('when table translations implements extractFromProxyObject, hydrateProxyObject and dehydrateAirtableObject', () => {
       it('shoud enable Write to Airtable', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            extractFromAirtableObject: vi.fn(),
-            hydrateToAirtableObject: vi.fn(),
+            extractFromProxyObject: vi.fn(),
+            hydrateProxyObject: vi.fn(),
             dehydrateAirtableObject: vi.fn(),
           },
         };
@@ -65,12 +65,12 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only hydrateToAirtableObject', () => {
+    describe('when table translations implements only hydrateProxyObject', () => {
       it('should not enable Read to Pg', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            hydrateToAirtableObject: vi.fn(),
+            hydrateProxyObject: vi.fn(),
           },
         };
 
@@ -84,12 +84,12 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only hydrateToAirtableObject and dehydrateAirtableObject', () => {
+    describe('when table translations implements only hydrateProxyObject and dehydrateAirtableObject', () => {
       it('should not enable Read to Pg or disable write to Airtable', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            hydrateToAirtableObject: vi.fn(),
+            hydrateProxyObject: vi.fn(),
             dehydrateAirtableObject: vi.fn(),
           },
         };
@@ -104,12 +104,12 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only extractFromAirtableObject and dehydrateAirtableObject', () => {
+    describe('when table translations implements only extractFromProxyObject and dehydrateAirtableObject', () => {
       it('should enable only write to PG', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            extractFromAirtableObject: vi.fn(),
+            extractFromProxyObject: vi.fn(),
             dehydrateAirtableObject: vi.fn(),
           },
         };

--- a/api/tests/unit/application/airtable-proxy_test.js
+++ b/api/tests/unit/application/airtable-proxy_test.js
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as airtableProxy from '../../../lib/application/airtable-proxy.js';
+
+describe('Unit | Application | airtable proxy', function() {
+  describe('#getTableTranslation', function() {
+    const tableName = 'Entites';
+
+    describe('when table translations implements extractFromAirtableObject', () => {
+      it('should enable Write to Pg', async function() {
+        // Given
+        const tablesTranslations = {
+          [tableName]: {
+            extractFromAirtableObject: vi.fn(),
+          },
+        };
+
+        // When
+        const tableTranslations = airtableProxy.getTableTranslations(tablesTranslations, tableName);
+
+        // Then
+        expect(tableTranslations.writeToPgEnabled).toBe(true);
+        expect(tableTranslations.readFromPgEnabled).toBe(false);
+        expect(tableTranslations.writeToAirtableDisabled).toBe(false);
+      });
+    });
+
+    describe('when table translations implements extractFromAirtableObject and hydrateToAirtableObject', () => {
+      it('should enable Read to Pg', async function() {
+        // Given
+        const tablesTranslations = {
+          [tableName]: {
+            extractFromAirtableObject: vi.fn(),
+            hydrateToAirtableObject: vi.fn(),
+          },
+        };
+
+        // When
+        const tableTranslations = airtableProxy.getTableTranslations(tablesTranslations, tableName);
+
+        // Then
+        expect(tableTranslations.writeToPgEnabled).toBe(true);
+        expect(tableTranslations.readFromPgEnabled).toBe(true);
+        expect(tableTranslations.writeToAirtableDisabled).toBe(false);
+      });
+    });
+
+    describe('when table translations implements extractFromAirtableObject, hydrateToAirtableObject and dehydrateAirtableObject', () => {
+      it('shoud enable Write to Airtable', async function() {
+        // Given
+        const tablesTranslations = {
+          [tableName]: {
+            extractFromAirtableObject: vi.fn(),
+            hydrateToAirtableObject: vi.fn(),
+            dehydrateAirtableObject: vi.fn(),
+          },
+        };
+
+        // When
+        const tableTranslations = airtableProxy.getTableTranslations(tablesTranslations, tableName);
+
+        // Then
+        expect(tableTranslations.writeToPgEnabled).toBe(true);
+        expect(tableTranslations.readFromPgEnabled).toBe(true);
+        expect(tableTranslations.writeToAirtableDisabled).toBe(true);
+      });
+    });
+
+    describe('when table translations implements only hydrateToAirtableObject', () => {
+      it('should not enable Read to Pg', async function() {
+        // Given
+        const tablesTranslations = {
+          [tableName]: {
+            hydrateToAirtableObject: vi.fn(),
+          },
+        };
+
+        // When
+        const tableTranslations = airtableProxy.getTableTranslations(tablesTranslations, tableName);
+
+        // Then
+        expect(tableTranslations.writeToPgEnabled).toBe(false);
+        expect(tableTranslations.readFromPgEnabled).toBe(false);
+        expect(tableTranslations.writeToAirtableDisabled).toBe(false);
+      });
+    });
+
+    describe('when table translations implements only hydrateToAirtableObject and dehydrateAirtableObject', () => {
+      it('should not enable Read to Pg or disable write to Airtable', async function() {
+        // Given
+        const tablesTranslations = {
+          [tableName]: {
+            hydrateToAirtableObject: vi.fn(),
+            dehydrateAirtableObject: vi.fn(),
+          },
+        };
+
+        // When
+        const tableTranslations = airtableProxy.getTableTranslations(tablesTranslations, tableName);
+
+        // Then
+        expect(tableTranslations.writeToPgEnabled).toBe(false);
+        expect(tableTranslations.readFromPgEnabled).toBe(false);
+        expect(tableTranslations.writeToAirtableDisabled).toBe(false);
+      });
+    });
+
+    describe('when table translations implements only extractFromAirtableObject and dehydrateAirtableObject', () => {
+      it('should enable only write to PG', async function() {
+        // Given
+        const tablesTranslations = {
+          [tableName]: {
+            extractFromAirtableObject: vi.fn(),
+            dehydrateAirtableObject: vi.fn(),
+          },
+        };
+
+        // When
+        const tableTranslations = airtableProxy.getTableTranslations(tablesTranslations, tableName);
+
+        // Then
+        expect(tableTranslations.writeToPgEnabled).toBe(true);
+        expect(tableTranslations.readFromPgEnabled).toBe(false);
+        expect(tableTranslations.writeToAirtableDisabled).toBe(false);
+      });
+    });
+  });
+});
+

--- a/api/tests/unit/application/airtable-proxy_test.js
+++ b/api/tests/unit/application/airtable-proxy_test.js
@@ -24,13 +24,13 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements extractFromProxyObject and hydrateProxyObject', () => {
+    describe('when table translations implements extractFromProxyObject and airtableObjectToProxyObject', () => {
       it('should enable Read to Pg', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
             extractFromProxyObject: vi.fn(),
-            hydrateProxyObject: vi.fn(),
+            airtableObjectToProxyObject: vi.fn(),
           },
         };
 
@@ -44,13 +44,13 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements extractFromProxyObject, hydrateProxyObject and proxyObjectToAirtableObject', () => {
+    describe('when table translations implements extractFromProxyObject, airtableObjectToProxyObject and proxyObjectToAirtableObject', () => {
       it('shoud enable Write to Airtable', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
             extractFromProxyObject: vi.fn(),
-            hydrateProxyObject: vi.fn(),
+            airtableObjectToProxyObject: vi.fn(),
             proxyObjectToAirtableObject: vi.fn(),
           },
         };
@@ -65,12 +65,12 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only hydrateProxyObject', () => {
+    describe('when table translations implements only airtableObjectToProxyObject', () => {
       it('should not enable Read to Pg', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            hydrateProxyObject: vi.fn(),
+            airtableObjectToProxyObject: vi.fn(),
           },
         };
 
@@ -84,12 +84,12 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only hydrateProxyObject and proxyObjectToAirtableObject', () => {
+    describe('when table translations implements only airtableObjectToProxyObject and proxyObjectToAirtableObject', () => {
       it('should not enable Read to Pg or disable write to Airtable', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
-            hydrateProxyObject: vi.fn(),
+            airtableObjectToProxyObject: vi.fn(),
             proxyObjectToAirtableObject: vi.fn(),
           },
         };

--- a/api/tests/unit/application/airtable-proxy_test.js
+++ b/api/tests/unit/application/airtable-proxy_test.js
@@ -44,14 +44,14 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements extractFromProxyObject, hydrateProxyObject and dehydrateAirtableObject', () => {
+    describe('when table translations implements extractFromProxyObject, hydrateProxyObject and proxyObjectToAirtableObject', () => {
       it('shoud enable Write to Airtable', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
             extractFromProxyObject: vi.fn(),
             hydrateProxyObject: vi.fn(),
-            dehydrateAirtableObject: vi.fn(),
+            proxyObjectToAirtableObject: vi.fn(),
           },
         };
 
@@ -84,13 +84,13 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only hydrateProxyObject and dehydrateAirtableObject', () => {
+    describe('when table translations implements only hydrateProxyObject and proxyObjectToAirtableObject', () => {
       it('should not enable Read to Pg or disable write to Airtable', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
             hydrateProxyObject: vi.fn(),
-            dehydrateAirtableObject: vi.fn(),
+            proxyObjectToAirtableObject: vi.fn(),
           },
         };
 
@@ -104,13 +104,13 @@ describe('Unit | Application | airtable proxy', function() {
       });
     });
 
-    describe('when table translations implements only extractFromProxyObject and dehydrateAirtableObject', () => {
+    describe('when table translations implements only extractFromProxyObject and proxyObjectToAirtableObject', () => {
       it('should enable only write to PG', async function() {
         // Given
         const tablesTranslations = {
           [tableName]: {
             extractFromProxyObject: vi.fn(),
-            dehydrateAirtableObject: vi.fn(),
+            proxyObjectToAirtableObject: vi.fn(),
           },
         };
 

--- a/api/tests/unit/domain/usecases/proxy-read-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-read-request-to-airtable_test.js
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { proxyReadRequestToAirtable } from '../../../../lib/domain/usecases/proxy-read-request-to-airtable.js';
+
+describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
+  let proxyRequestToAirtable;
+  let tableTranslations;
+  let translationRepository;
+  let response;
+
+  const request = Symbol('request');
+  const airtableBase = Symbol('airtableBase');
+  const translations = Symbol('translations');
+
+  beforeEach(() => {
+    proxyRequestToAirtable = vi.fn();
+    tableTranslations = {
+      prefix: 'entity.',
+      prefixFor: vi.fn(),
+      hydrateToAirtableObject: vi.fn(),
+      readFromPgEnabled: false,
+    };
+    translationRepository = {
+      listByPrefix: vi.fn(),
+    };
+  });
+
+  describe('when reading a single entity', () => {
+    const entity = Symbol('entity');
+
+    beforeEach(() => {
+      response = { status: 200, data: { fields: entity } };
+      proxyRequestToAirtable.mockResolvedValue(response);
+    });
+
+    it('should proxy request to airtable', async () => {
+      // when
+      const actualResponse = await proxyReadRequestToAirtable(request, airtableBase, {
+        proxyRequestToAirtable,
+        tableTranslations,
+      });
+
+      // then
+      expect(actualResponse).toBe(response);
+
+      expect(proxyRequestToAirtable).toHaveBeenCalledOnce();
+      expect(proxyRequestToAirtable).toHaveBeenCalledWith(request, airtableBase);
+    });
+
+    describe('when reading translations from PG is enabled', () => {
+      beforeEach(() => {
+        tableTranslations.readFromPgEnabled = true;
+        tableTranslations.prefixFor.mockReturnValue('entity.id.');
+        translationRepository.listByPrefix.mockResolvedValue(translations);
+      });
+
+      it('should hydrate response with translations from PG', async () => {
+        // when
+        const actualResponse = await proxyReadRequestToAirtable(request, airtableBase, {
+          proxyRequestToAirtable,
+          tableTranslations,
+          translationRepository,
+        });
+
+        // then
+        expect(actualResponse).toBe(response);
+
+        expect(tableTranslations.prefixFor).toHaveBeenCalledOnce();
+        expect(tableTranslations.prefixFor).toHaveBeenCalledWith(entity);
+
+        expect(translationRepository.listByPrefix).toHaveBeenCalledOnce();
+        expect(translationRepository.listByPrefix).toHaveBeenCalledWith('entity.id.');
+
+        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledOnce();
+        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledWith(entity, translations);
+      });
+    });
+  });
+
+  describe('when reading several entities', () => {
+    const entity1 = Symbol('entity1');
+    const entity2 = Symbol('entity2');
+
+    beforeEach(() => {
+      response = { status: 200, data: { records: [{ fields: entity1 }, { fields: entity2 }] } };
+      proxyRequestToAirtable.mockResolvedValue(response);
+    });
+
+    it('should proxy request to airtable', async () => {
+      // when
+      const actualResponse = await proxyReadRequestToAirtable(request, airtableBase, {
+        proxyRequestToAirtable,
+        tableTranslations,
+      });
+
+      // then
+      expect(actualResponse).toBe(response);
+
+      expect(proxyRequestToAirtable).toHaveBeenCalledOnce();
+      expect(proxyRequestToAirtable).toHaveBeenCalledWith(request, airtableBase);
+    });
+
+    describe('when reading translations from PG is enabled', () => {
+      beforeEach(() => {
+        tableTranslations.readFromPgEnabled = true;
+        translationRepository.listByPrefix.mockResolvedValue(translations);
+      });
+
+      it('should hydrate response with translations from PG', async () => {
+        // when
+        const actualResponse = await proxyReadRequestToAirtable(request, airtableBase, {
+          proxyRequestToAirtable,
+          tableTranslations,
+          translationRepository,
+        });
+
+        // then
+        expect(actualResponse).toBe(response);
+
+        expect(translationRepository.listByPrefix).toHaveBeenCalledOnce();
+        expect(translationRepository.listByPrefix).toHaveBeenCalledWith(tableTranslations.prefix);
+
+        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledTimes(2);
+        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenNthCalledWith(1, entity1, translations);
+        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenNthCalledWith(2, entity2, translations);
+      });
+    });
+  });
+
+  describe('when response is not OK', () => {
+    beforeEach(() => {
+      response = { status: 400 };
+      proxyRequestToAirtable.mockResolvedValue(response);
+    });
+
+    it('should return response as is', async () => {
+      // when
+      const actualResponse = await proxyReadRequestToAirtable(request, airtableBase, {
+        proxyRequestToAirtable,
+      });
+
+      // then
+      expect(actualResponse).toBe(response);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/proxy-read-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-read-request-to-airtable_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
     tableTranslations = {
       prefix: 'entity.',
       prefixFor: vi.fn(),
-      hydrateToAirtableObject: vi.fn(),
+      hydrateProxyObject: vi.fn(),
       readFromPgEnabled: false,
     };
     translationRepository = {
@@ -70,8 +70,8 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
         expect(translationRepository.listByPrefix).toHaveBeenCalledOnce();
         expect(translationRepository.listByPrefix).toHaveBeenCalledWith('entity.id.');
 
-        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledOnce();
-        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledWith(entity, translations);
+        expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledOnce();
+        expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledWith(entity, translations);
       });
     });
   });
@@ -119,9 +119,9 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
         expect(translationRepository.listByPrefix).toHaveBeenCalledOnce();
         expect(translationRepository.listByPrefix).toHaveBeenCalledWith(tableTranslations.prefix);
 
-        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledTimes(2);
-        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenNthCalledWith(1, entity1, translations);
-        expect(tableTranslations.hydrateToAirtableObject).toHaveBeenNthCalledWith(2, entity2, translations);
+        expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledTimes(2);
+        expect(tableTranslations.hydrateProxyObject).toHaveBeenNthCalledWith(1, entity1, translations);
+        expect(tableTranslations.hydrateProxyObject).toHaveBeenNthCalledWith(2, entity2, translations);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -21,9 +21,9 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
     tableTranslations = {
       prefix: 'entity.',
       prefixFor: vi.fn(),
-      extractFromAirtableObject: vi.fn(),
+      extractFromProxyObject: vi.fn(),
       dehydrateAirtableObject: vi.fn(),
-      hydrateToAirtableObject: vi.fn(),
+      hydrateProxyObject: vi.fn(),
       writeToPgEnabled: false,
       readFromPgEnabled: false,
       writeToAirtableDisabled: false,
@@ -85,7 +85,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
         request = { method: 'post', payload: { fields: requestFields } };
 
         tableTranslations.writeToPgEnabled = true;
-        tableTranslations.extractFromAirtableObject.mockReturnValue(translations);
+        tableTranslations.extractFromProxyObject.mockReturnValue(translations);
       });
 
       it('should save extracted translations to PG', async () => {
@@ -100,8 +100,8 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
         // then
         expect(actualResponse).toBe(response);
 
-        expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledOnce();
-        expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledWith(requestFields);
+        expect(tableTranslations.extractFromProxyObject).toHaveBeenCalledOnce();
+        expect(tableTranslations.extractFromProxyObject).toHaveBeenCalledWith(requestFields);
 
         expect(translationRepository.save).toHaveBeenCalledOnce();
         expect(translationRepository.save).toHaveBeenCalledWith(translations);
@@ -126,8 +126,8 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
           // then
           expect(actualResponse).toBe(response);
 
-          expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledOnce();
-          expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledWith(requestFields);
+          expect(tableTranslations.extractFromProxyObject).toHaveBeenCalledOnce();
+          expect(tableTranslations.extractFromProxyObject).toHaveBeenCalledWith(requestFields);
 
           expect(tableTranslations.prefixFor).toHaveBeenCalledOnce();
           expect(tableTranslations.prefixFor).toHaveBeenCalledWith(responseFields);
@@ -157,8 +157,8 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
           // then
           expect(actualResponse).toBe(response);
 
-          expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledOnce();
-          expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledWith(responseFields, translations);
+          expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledOnce();
+          expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledWith(responseFields, translations);
 
           expect(updateStagingPixApiCache).toHaveBeenCalledOnce();
           expect(updateStagingPixApiCache).toHaveBeenCalledWith(tableName, responseEntity, translations);

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { proxyWriteRequestToAirtable } from '../../../../lib/domain/usecases/proxy-write-request-to-airtable.js';
+
+describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
+  let proxyRequestToAirtable;
+  let tableTranslations;
+  let translationRepository;
+  let updateStagingPixApiCache;
+  let responseEntity;
+  let response;
+  let request;
+
+  const requestFields = Symbol('requestFields');
+  const airtableBase = Symbol('airtableBase');
+  const tableName = Symbol('tableName');
+  const translations = Symbol('translations');
+  const responseFields = Symbol('responseFields');
+
+  beforeEach(() => {
+    proxyRequestToAirtable = vi.fn();
+    tableTranslations = {
+      prefix: 'entity.',
+      prefixFor: vi.fn(),
+      extractFromAirtableObject: vi.fn(),
+      dehydrateAirtableObject: vi.fn(),
+      hydrateToAirtableObject: vi.fn(),
+      writeToPgEnabled: false,
+      readFromPgEnabled: false,
+      writeToAirtableDisabled: false,
+    };
+    translationRepository = {
+      deleteByKeyPrefix: vi.fn(),
+      save: vi.fn(),
+    };
+    updateStagingPixApiCache = vi.fn();
+  });
+
+  it('should proxy request to airtable', async () => {
+    // given
+    request = Symbol('request');
+    response = { status: 200, data: {} };
+
+    proxyRequestToAirtable.mockResolvedValue(response);
+
+    // when
+    const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+      proxyRequestToAirtable,
+      tableTranslations,
+      updateStagingPixApiCache,
+    });
+
+    // then
+    expect(actualResponse).toBe(response);
+
+    expect(proxyRequestToAirtable).toHaveBeenCalledOnce();
+    expect(proxyRequestToAirtable).toHaveBeenCalledWith(request, airtableBase);
+  });
+
+  describe('when response is OK', () => {
+    beforeEach(() => {
+      request = Symbol('request');
+      responseEntity = { fields: responseFields };
+      response = { status: 200, data: responseEntity };
+
+      proxyRequestToAirtable.mockResolvedValue(response);
+    });
+
+    it('should update staging Pix API cache', async () => {
+      // when
+      const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+        proxyRequestToAirtable,
+        tableTranslations,
+        updateStagingPixApiCache,
+      });
+
+      // then
+      expect(actualResponse).toBe(response);
+
+      expect(updateStagingPixApiCache).toHaveBeenCalledOnce();
+      expect(updateStagingPixApiCache).toHaveBeenCalledWith(tableName, responseEntity, undefined);
+    });
+
+    describe('when writing translations to PG is enabled', () => {
+      beforeEach(() => {
+        request = { method: 'post', payload: { fields: requestFields } };
+
+        tableTranslations.writeToPgEnabled = true;
+        tableTranslations.extractFromAirtableObject.mockReturnValue(translations);
+      });
+
+      it('should save extracted translations to PG', async () => {
+        // when
+        const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+          proxyRequestToAirtable,
+          tableTranslations,
+          updateStagingPixApiCache,
+          translationRepository,
+        });
+
+        // then
+        expect(actualResponse).toBe(response);
+
+        expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledOnce();
+        expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledWith(requestFields);
+
+        expect(translationRepository.save).toHaveBeenCalledOnce();
+        expect(translationRepository.save).toHaveBeenCalledWith(translations);
+      });
+
+      describe('when updating an existing entity', () => {
+        beforeEach(() => {
+          request.method = 'patch';
+
+          tableTranslations.prefixFor.mockReturnValue('entity.id');
+        });
+
+        it('should delete translations before saving these', async () => {
+          // when
+          const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+            proxyRequestToAirtable,
+            tableTranslations,
+            updateStagingPixApiCache,
+            translationRepository,
+          });
+
+          // then
+          expect(actualResponse).toBe(response);
+
+          expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledOnce();
+          expect(tableTranslations.extractFromAirtableObject).toHaveBeenCalledWith(requestFields);
+
+          expect(tableTranslations.prefixFor).toHaveBeenCalledOnce();
+          expect(tableTranslations.prefixFor).toHaveBeenCalledWith(responseFields);
+
+          expect(translationRepository.deleteByKeyPrefix).toHaveBeenCalledOnce();
+          expect(translationRepository.deleteByKeyPrefix).toHaveBeenCalledWith('entity.id');
+
+          expect(translationRepository.save).toHaveBeenCalledOnce();
+          expect(translationRepository.save).toHaveBeenCalledWith(translations);
+        });
+      });
+
+      describe('when reading translations from PG is enabled', () => {
+        beforeEach(() => {
+          tableTranslations.readFromPgEnabled = true;
+        });
+
+        it('should hydrate response and update staging Pix API cache using translations from PG', async () => {
+          // when
+          const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+            proxyRequestToAirtable,
+            tableTranslations,
+            updateStagingPixApiCache,
+            translationRepository,
+          });
+
+          // then
+          expect(actualResponse).toBe(response);
+
+          expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledOnce();
+          expect(tableTranslations.hydrateToAirtableObject).toHaveBeenCalledWith(responseFields, translations);
+
+          expect(updateStagingPixApiCache).toHaveBeenCalledOnce();
+          expect(updateStagingPixApiCache).toHaveBeenCalledWith(tableName, responseEntity, translations);
+        });
+
+        describe('when writing translations to Airtable is disabled', () => {
+          beforeEach(() => {
+            tableTranslations.writeToAirtableDisabled = true;
+          });
+
+          it('should dehydrate request before proxying to Airtable', async () => {
+            // when
+            const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+              proxyRequestToAirtable,
+              tableTranslations,
+              updateStagingPixApiCache,
+              translationRepository,
+            });
+
+            // then
+            expect(actualResponse).toBe(response);
+
+            expect(tableTranslations.dehydrateAirtableObject).toHaveBeenCalledOnce();
+            expect(tableTranslations.dehydrateAirtableObject).toHaveBeenCalledWith(requestFields);
+          });
+        });
+      });
+    });
+  });
+
+  describe('when response is not OK', () => {
+    beforeEach(() => {
+      request = Symbol('request');
+      response = { status: 400 };
+
+      proxyRequestToAirtable.mockResolvedValue(response);
+    });
+
+    it('should return response as is', async () => {
+      // when
+      const actualResponse = await proxyWriteRequestToAirtable(request, airtableBase, tableName, {
+        proxyRequestToAirtable,
+        tableTranslations,
+      });
+
+      // then
+      expect(actualResponse).toBe(response);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -22,7 +22,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
       prefix: 'entity.',
       prefixFor: vi.fn(),
       extractFromProxyObject: vi.fn(),
-      dehydrateAirtableObject: vi.fn(),
+      proxyObjectToAirtableObject: vi.fn(),
       hydrateProxyObject: vi.fn(),
       writeToPgEnabled: false,
       readFromPgEnabled: false,
@@ -37,7 +37,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
 
   it('should proxy request to airtable', async () => {
     // given
-    request = Symbol('request');
+    request = { payload: { fields: requestFields } };
     response = { status: 200, data: {} };
 
     proxyRequestToAirtable.mockResolvedValue(response);
@@ -58,7 +58,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
 
   describe('when response is OK', () => {
     beforeEach(() => {
-      request = Symbol('request');
+      request = { payload: { fields: requestFields } };
       responseEntity = { fields: responseFields };
       response = { status: 200, data: responseEntity };
 
@@ -165,8 +165,11 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
         });
 
         describe('when writing translations to Airtable is disabled', () => {
+          const airtableRequestFields = Symbol('airtableRequestFields');
+
           beforeEach(() => {
             tableTranslations.writeToAirtableDisabled = true;
+            tableTranslations.proxyObjectToAirtableObject.mockReturnValue(airtableRequestFields);
           });
 
           it('should dehydrate request before proxying to Airtable', async () => {
@@ -181,8 +184,10 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
             // then
             expect(actualResponse).toBe(response);
 
-            expect(tableTranslations.dehydrateAirtableObject).toHaveBeenCalledOnce();
-            expect(tableTranslations.dehydrateAirtableObject).toHaveBeenCalledWith(requestFields);
+            expect(request.payload.fields).toBe(airtableRequestFields);
+
+            expect(tableTranslations.proxyObjectToAirtableObject).toHaveBeenCalledOnce();
+            expect(tableTranslations.proxyObjectToAirtableObject).toHaveBeenCalledWith(requestFields);
           });
         });
       });
@@ -191,7 +196,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
 
   describe('when response is not OK', () => {
     beforeEach(() => {
-      request = Symbol('request');
+      request = { payload: { fields: requestFields } };
       response = { status: 400 };
 
       proxyRequestToAirtable.mockResolvedValue(response);

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -22,8 +22,8 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
       prefix: 'entity.',
       prefixFor: vi.fn(),
       extractFromProxyObject: vi.fn(),
+      airtableObjectToProxyObject: vi.fn(),
       proxyObjectToAirtableObject: vi.fn(),
-      hydrateProxyObject: vi.fn(),
       writeToPgEnabled: false,
       readFromPgEnabled: false,
       writeToAirtableDisabled: false,
@@ -141,8 +141,11 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
       });
 
       describe('when reading translations from PG is enabled', () => {
+        const proxyResponseFields = Symbol('proxyResponseFields');
+
         beforeEach(() => {
           tableTranslations.readFromPgEnabled = true;
+          tableTranslations.airtableObjectToProxyObject.mockReturnValue(proxyResponseFields);
         });
 
         it('should hydrate response and update staging Pix API cache using translations from PG', async () => {
@@ -156,9 +159,10 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
 
           // then
           expect(actualResponse).toBe(response);
+          expect(response.data.fields).toBe(proxyResponseFields);
 
-          expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledOnce();
-          expect(tableTranslations.hydrateProxyObject).toHaveBeenCalledWith(responseFields, translations);
+          expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenCalledOnce();
+          expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenCalledWith(responseFields, translations);
 
           expect(updateStagingPixApiCache).toHaveBeenCalledOnce();
           expect(updateStagingPixApiCache).toHaveBeenCalledWith(tableName, responseEntity, translations);

--- a/api/tests/unit/infrastructure/translations/utils_test.js
+++ b/api/tests/unit/infrastructure/translations/utils_test.js
@@ -130,10 +130,10 @@ describe('Unit | Infrastructure | Entity translations', () => {
     });
   });
 
-  describe('#dehydrateAirtableObject', () => {
-    it('should set translated fields into the object', () => {
+  describe('#proxyObjectToAirtableObject', () => {
+    it('should return an airtable object', () => {
       // given
-      const entity = {
+      const proxyObject = {
         'mon id': 'test',
         'Attribut fr-fr': 'value fr-fr initial',
         'Attribut2 fr-fr': 'value2 fr-fr initial',
@@ -141,11 +141,18 @@ describe('Unit | Infrastructure | Entity translations', () => {
       };
 
       // when
-      translationsUtils.dehydrateAirtableObject(entity);
+      const airtableObject = translationsUtils.proxyObjectToAirtableObject(proxyObject);
 
       // then
-      expect(entity).to.deep.equal({
+      expect(airtableObject).to.deep.equal({
         'mon id': 'test',
+        otherField: 'foo',
+      });
+
+      expect(proxyObject).to.deep.equal({
+        'mon id': 'test',
+        'Attribut fr-fr': 'value fr-fr initial',
+        'Attribut2 fr-fr': 'value2 fr-fr initial',
         otherField: 'foo',
       });
     });

--- a/api/tests/unit/infrastructure/translations/utils_test.js
+++ b/api/tests/unit/infrastructure/translations/utils_test.js
@@ -64,10 +64,10 @@ describe('Unit | Infrastructure | Entity translations', () => {
     });
   });
 
-  describe('#hydrateAirtableObject', () => {
+  describe('#airtableObjectToProxyObject', () => {
     it('should set translated fields into the object', () => {
       // given
-      const entity = {
+      const airtableObject = {
         'mon id': 'test',
         'Attribut fr-fr': 'value fr-fr initial',
         otherField: 'foo',
@@ -88,10 +88,10 @@ describe('Unit | Infrastructure | Entity translations', () => {
       ];
 
       // when
-      translationsUtils.hydrateProxyObject(entity, translations);
+      const proxyObject = translationsUtils.airtableObjectToProxyObject(airtableObject, translations);
 
       // then
-      expect(entity).to.deep.equal({
+      expect(proxyObject).to.deep.equal({
         'mon id': 'test',
         'Attribut fr-fr': 'value fr-fr',
         'Attribut en-us': 'value en-us',
@@ -99,11 +99,17 @@ describe('Unit | Infrastructure | Entity translations', () => {
         'Attribut2 en-us': 'value2 en-us',
         otherField: 'foo',
       });
+
+      expect(airtableObject).to.deep.equal({
+        'mon id': 'test',
+        'Attribut fr-fr': 'value fr-fr initial',
+        otherField: 'foo',
+      });
     });
 
     it('should set null value for missing translations', () => {
       // given
-      const entity = {
+      const airtableObject = {
         'mon id': 'test',
         'Attribut fr-fr': 'value fr-fr initial',
       };
@@ -117,15 +123,20 @@ describe('Unit | Infrastructure | Entity translations', () => {
       ];
 
       // when
-      translationsUtils.hydrateProxyObject(entity, translations);
+      const proxyObject = translationsUtils.airtableObjectToProxyObject(airtableObject, translations);
 
       // then
-      expect(entity).to.deep.equal({
+      expect(proxyObject).to.deep.equal({
         'mon id': 'test',
         'Attribut fr-fr': null,
         'Attribut en-us': 'value en-us',
         'Attribut2 fr-fr': null,
         'Attribut2 en-us': 'value2 en-us',
+      });
+
+      expect(airtableObject).to.deep.equal({
+        'mon id': 'test',
+        'Attribut fr-fr': 'value fr-fr initial',
       });
     });
   });

--- a/api/tests/unit/infrastructure/translations/utils_test.js
+++ b/api/tests/unit/infrastructure/translations/utils_test.js
@@ -22,7 +22,7 @@ describe('Unit | Infrastructure | Entity translations', () => {
     translationsUtils = buildTranslationsUtils({ fields, locales, prefix, idField });
   });
 
-  describe('#extractFromAirtableObject', () => {
+  describe('#extractFromProxyObject', () => {
     it('should return the list of translations', () => {
       // given
       const entity = {
@@ -34,7 +34,7 @@ describe('Unit | Infrastructure | Entity translations', () => {
       };
 
       // when
-      const translations = translationsUtils.extractFromAirtableObject(entity);
+      const translations = translationsUtils.extractFromProxyObject(entity);
 
       // then
       expect(translations).to.deep.equal([
@@ -54,7 +54,7 @@ describe('Unit | Infrastructure | Entity translations', () => {
       };
 
       // when
-      const translations = translationsUtils.extractFromAirtableObject(entity);
+      const translations = translationsUtils.extractFromProxyObject(entity);
 
       // then
       expect(translations).to.deep.equal([
@@ -88,7 +88,7 @@ describe('Unit | Infrastructure | Entity translations', () => {
       ];
 
       // when
-      translationsUtils.hydrateToAirtableObject(entity, translations);
+      translationsUtils.hydrateProxyObject(entity, translations);
 
       // then
       expect(entity).to.deep.equal({
@@ -117,7 +117,7 @@ describe('Unit | Infrastructure | Entity translations', () => {
       ];
 
       // when
-      translationsUtils.hydrateToAirtableObject(entity, translations);
+      translationsUtils.hydrateProxyObject(entity, translations);
 
       // then
       expect(entity).to.deep.equal({


### PR DESCRIPTION
## :unicorn: Problème

On souhaite améliorer le code de gestion des traductions dans le proxy Airtable :

 - mieux mettre en évidence les comportements suivants :
   - L'écriture des traductions dans PG est-elle sactivée ?
   - La lecture des traductions dans PG est-elle activée ?
   - L'écriture des champs traduisibles dans Airtable est-elle désactivée ?
 - mieux tester ces comportements
 - clarifier le rôle de certaines méthodes des utilitaires de traduction

## :robot: Solution

 - Extraire et tester un usecase pour les requêtes de lecture (GET) et un usecase pour les requêtes d'écriture (POST/PATCH).
 - Dans ces usescases, s'appuyer sur des flags pour savoir quels comportements doivent être activés pour la gestion des traductions
 - Renommer certains utilitaires des traductions
 - Éviter de faire de la mutation des paramètres d'entrée dans certains utilitaires de traductions

## :rainbow: Remarques

On supprime quelques tests d'acceptances qui n'ont plus vraiment de sens à l'heure actuelle.

## :100: Pour tester

Faire de la non régression sur la lecture/modification des acquis et compétences.
