### PR TITLE
[BUGFIX] Modifications depuis PixEditor : ne pas supprimer toutes les traductions (PIX-10004)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
 
       - run:
           name: Wait for Pix Editor API to be ready...
-          command: curl --fail --ipv4 --retry 6 --retry-connrefused --retry-delay 10 --silent http://localhost:3002/api > /dev/null
+          command: curl --fail --ipv4 --retry 9 --retry-connrefused --retry-delay 10 --silent http://localhost:3002/api > /dev/null
 
       - run:
           name: Wait for Pix Editor to be ready...

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ pix-editor/app/config-private-test.js
 /pix-editor/playwright-report/
 /pix-editor/playwright/.cache/
 *.storageState.json
+
+# VSCode
+.vscode/settings.json

--- a/.vscode/sample.settings.json
+++ b/.vscode/sample.settings.json
@@ -1,0 +1,6 @@
+{
+    "eslint.workingDirectories": [
+        "./api",
+        "./pix-editor"
+    ]
+}

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -21,7 +21,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   let translations;
   if (tableTranslations.writeToPgEnabled) {
     if (request.method === 'patch') {
-      await translationRepository.deleteByKeyPrefix(tableTranslations.prefixFor(response.data.fields));
+      await translationRepository.deleteByKeyPrefixAndLocales(tableTranslations.prefixFor(response.data.fields), ['fr', 'fr-fr', 'en']);
     }
 
     translations = tableTranslations.extractFromProxyObject(requestFields);

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -1,10 +1,14 @@
 import _ from 'lodash';
 import { knex } from '../../../db/knex-database-connection.js';
-import { Challenge } from '../../domain/models/Challenge.js';
+import { Challenge } from '../../domain/models/index.js';
 import { challengeDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as localizedChallengeRepository from './localized-challenge-repository.js';
-import { extractFromChallenge as extractTranslationsFromChallenge, prefix, prefixFor } from '../translations/challenge.js';
+import {
+  extractFromChallenge as extractTranslationsFromChallenge,
+  prefix,
+  prefixFor
+} from '../translations/challenge.js';
 
 async function _getChallengesFromParams(params) {
   if (params.filter && params.filter.ids) {
@@ -40,14 +44,18 @@ export async function create(challenge) {
   const createdChallengeDto = await challengeDatasource.create(challenge);
   const translations = extractTranslationsFromChallenge(challenge);
   await translationRepository.save(translations);
-  await localizedChallengeRepository.create([{ id: challenge.id, challengeId: challenge.id, locale: challenge.primaryLocale }]);
+  await localizedChallengeRepository.create([{
+    id: challenge.id,
+    challengeId: challenge.id,
+    locale: challenge.primaryLocale
+  }]);
   return toDomain(createdChallengeDto, translations);
 }
 
 export async function update(challenge) {
   const updatedChallengeDto = await challengeDatasource.update(challenge);
   const translations = extractTranslationsFromChallenge(challenge);
-  await translationRepository.deleteByKeyPrefix(prefixFor(challenge));
+  await translationRepository.deleteByKeyPrefixAndLocales(prefixFor(challenge), [challenge.primaryLocale]);
   await translationRepository.save(translations);
   return toDomain(updatedChallengeDto, translations);
 }

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -84,6 +84,7 @@ export async function deleteByKeyPrefixAndLocales(prefix, locales) {
         formula: `AND(REGEX_MATCH(key, '^${prefix.replace(/(\.)/g, '\\$1')}'), OR(${locales.map((locale) => `locale = '${locale}'`).join(', ')}))`,
       },
     });
+    if (records.length === 0) return;
     const recordIds = records.map(({ airtableId }) => airtableId);
     await translationDatasource.delete(recordIds);
   }

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -29,7 +29,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
       writeToAirtableDisabled: false,
     };
     translationRepository = {
-      deleteByKeyPrefix: vi.fn(),
+      deleteByKeyPrefixAndLocales: vi.fn(),
       save: vi.fn(),
     };
     updateStagingPixApiCache = vi.fn();
@@ -132,8 +132,8 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
           expect(tableTranslations.prefixFor).toHaveBeenCalledOnce();
           expect(tableTranslations.prefixFor).toHaveBeenCalledWith(responseFields);
 
-          expect(translationRepository.deleteByKeyPrefix).toHaveBeenCalledOnce();
-          expect(translationRepository.deleteByKeyPrefix).toHaveBeenCalledWith('entity.id');
+          expect(translationRepository.deleteByKeyPrefixAndLocales).toHaveBeenCalledOnce();
+          expect(translationRepository.deleteByKeyPrefixAndLocales).toHaveBeenCalledWith('entity.id', ['fr', 'fr-fr', 'en']);
 
           expect(translationRepository.save).toHaveBeenCalledOnce();
           expect(translationRepository.save).toHaveBeenCalledWith(translations);


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on fait des modifications sur une entité depuis PixEditor, on supprime toutes ses traductions, y compris celles importées par Phrase, il faut supprimer uniquement les traductions modifiables depuis PixEditor.

## :robot: Solution
Pour l'épreuve, supprimer uniquement les traductions de sa langue principale.
Pour les autres entités, supprimer uniquement les traductions fr et en.

## :rainbow: Remarques
N/A

## :100: Pour tester
Ajouter des traductions dans une autre langue que fr/en sur une compétence et modifier cette compétence depuis PE, vérifier que les traductions ajoutées sont tjrs là.

Faire le même test pour une épreuve et un acquis.