### PR TITLE
[BUGFIX] Résolution de problème d'import des traductions venant de Phrase. (PIX-10169)

### DIFF
--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import Boom from '@hapi/boom';
 import { exportTranslations } from '../domain/usecases/export-translations.js';
 import { importTranslations, InvalidFileError } from '../domain/usecases/import-translations.js';
+import { logger } from '../infrastructure/logger.js';
 
 export async function register(server) {
   server.route([
@@ -43,6 +44,7 @@ export async function importTranslationsHandler(request, h) {
     await importTranslations(stream);
   } catch (error) {
     if (error instanceof InvalidFileError) {
+      logger.error(error);
       return Boom.badRequest('Invalid CSV file');
     }
     throw error;

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -2,6 +2,7 @@ import { translationRepository, localizedChallengeRepository } from '../../infra
 import { LocalizedChallenge, Translation } from '../models/index.js';
 import { parseStream } from 'fast-csv';
 import fp from 'lodash/fp.js';
+
 export class InvalidFileError extends Error {}
 
 export function importTranslations(csvStream, dependencies = { translationRepository, localizedChallengeRepository }) {
@@ -12,7 +13,9 @@ export function importTranslations(csvStream, dependencies = { translationReposi
       strictColumnHandling: true,
     }).validate((data) => data.key && data.locale && data.value)
       .on('error', reject)
-      .on('data-invalid', reject)
+      .on('data-invalid', (invalidData) => {
+        reject(new InvalidFileError(`Invalid data: ${JSON.stringify(invalidData)}`));
+      })
       .on('data', (row) => {
         translations.push(new Translation(row));
       })

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -8,16 +8,27 @@ export class InvalidFileError extends Error {}
 export function importTranslations(csvStream, dependencies = { translationRepository, localizedChallengeRepository }) {
   return new Promise((resolve, reject) => {
     const translations = [];
+    let locale;
     parseStream(csvStream, {
-      headers: true,
+      headers: (headers) => {
+        if (headers[0] !== 'key_name') throw new InvalidFileError('Expected first column to be key_name');
+        locale = headers[1];
+        try {
+          new Intl.Locale(locale);
+        } catch {
+          throw new InvalidFileError('Expected second column to be a valid locale');
+        }
+        return ['key', 'value', ...Array(headers.length - 2)];
+      },
+      objectMode: true,
       strictColumnHandling: true,
-    }).validate((data) => data.key && data.locale && data.value)
+    }).validate((data) => data.key && data.value)
       .on('error', reject)
       .on('data-invalid', (invalidData) => {
         reject(new InvalidFileError(`Invalid data: ${JSON.stringify(invalidData)}`));
       })
       .on('data', (row) => {
-        translations.push(new Translation(row));
+        translations.push(new Translation({ ...row, locale }));
       })
       .on('end', async () => {
         if (translations.length === 0) {


### PR DESCRIPTION
## :unicorn: Problème
Le csv conçu par Phrase s'importe mal à cause de champs renommés non gérés.

## :robot: Solution
On gère les champs renommés du csv importé pour pouvoir valider notre import dans Pix Editor.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Importer un fichier csv de Phrase via l'admin de Pix-Editor (A trouver sur chat-team-dev-contenu sur Slack)
- S'assurer que l'import a bien eu lieu.
