### PR TITLE
[BUGFIX] Import des traductions ne créé qu'une seule épreuve virtuelle (PIX-10218)

### DIFF
--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -55,5 +55,5 @@ const extractChallengesLocales = fp.flow(
       locale: challengeTranslation.locale,
     });
   }),
-  fp.uniqBy(['locale', 'challengeId']),
+  fp.uniqBy(({ challengeId, locale }) => `${challengeId}:${locale}`),
 );

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -63,7 +63,7 @@ describe('Unit | Domain | Usecases | import-translations', function() {
   it('should create a localized challenge when a new locale is added', async () => {
     // when
     const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
-    csvStream.write('key_name,nl,comment\nchallenge.id.key,Hallo,\nchallenge.id.key2,Hallo2,');
+    csvStream.write('key_name,nl,comment\nchallenge.id.key,Hallo,\nchallenge.id.key2,Hallo2,\nchallenge.id2.key,Hallo3,');
     csvStream.end();
 
     // then
@@ -80,12 +80,23 @@ describe('Unit | Domain | Usecases | import-translations', function() {
         key: 'challenge.id.key2',
         locale: 'nl',
         value: 'Hallo2'
+      }),
+      new Translation({
+        key: 'challenge.id2.key',
+        locale: 'nl',
+        value: 'Hallo3'
       })
     ]);
     expect(localizedChallengeRepository.create).toHaveBeenCalledOnce();
-    expect(localizedChallengeRepository.create).toHaveBeenCalledWith([new LocalizedChallenge({
-      challengeId: 'id',
-      locale: 'nl',
-    })]);
+    expect(localizedChallengeRepository.create).toHaveBeenCalledWith([
+      new LocalizedChallenge({
+        challengeId: 'id',
+        locale: 'nl',
+      }),
+      new LocalizedChallenge({
+        challengeId: 'id2',
+        locale: 'nl',
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Une seule épreuve virtuelle est créée pour le premier challenge du CSV.

## :robot: Solution
Corriger l'import pour créer une épreuve virtuelle par épreuve.

## :rainbow: Remarques
N/A

## :100: Pour tester
Importer un CSV sur la RA et vérifier que ça créé plusieurs épreuves virtuelles.