### PR TITLE
[FEATURE] Adapter la réplication pour utiliser les traductions PG des Acquis (PIX-9403) 

### DIFF
--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -9,6 +9,7 @@ export class Skill {
     learningMoreTutorialIds,
     pixValue,
     competenceId,
+    internationalisation,
     status,
     tubeId,
     version,
@@ -27,5 +28,6 @@ export class Skill {
     this.tubeId = tubeId;
     this.version = version;
     this.level = level;
+    this.internationalisation = internationalisation;
   }
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,12 +1,11 @@
 import {
   areaDatasource,
   attachmentDatasource,
-  skillDatasource,
   thematicDatasource,
   tubeDatasource,
   tutorialDatasource,
 } from '../../infrastructure/datasources/airtable/index.js';
-import { challengeRepository, competenceRepository } from '../../infrastructure/repositories/index.js';
+import { challengeRepository, competenceRepository, skillRepository } from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 export async function getLearningContentForReplication() {
@@ -24,7 +23,7 @@ export async function getLearningContentForReplication() {
     areaDatasource.list(),
     competenceRepository.list(),
     tubeDatasource.list(),
-    skillDatasource.list(),
+    skillRepository.list(),
     challengeRepository.list(),
     tutorialDatasource.list(),
     attachmentDatasource.list(),

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -92,7 +92,16 @@ async function mockCurrentContent() {
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
   });
-
+  databaseBuilder.factory.buildTranslation({
+    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+    locale: 'fr',
+    value: expectedCurrentContent.skills[0].hint_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+    locale: 'en',
+    value: expectedCurrentContent.skills[0].hint_i18n.en,
+  });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr',


### PR DESCRIPTION
## :unicorn: Problème
LCMS fournit un référentiel pour la réplication qui utilise encore les traductions d'acquis depuis Airtable.

## :robot: Solution
Utiliser les traductions de la table PG `translations` dans le référentiel fourni à la réplication.

## :rainbow: Remarques
Le champ `internationalisation` avait été oublié dans le modèle `Skill` car il ne ressort pas dans la release.

## :100: Pour tester
Appeler la route : `/api/replication-data` et vérifier que les traductions d'acquis sont bien présentes.
Faire la même chose pour la route `/api/databases/airtable`.