### PR TITLE
[FEATURE] Débrancher les champs traduisibles des acquis dans Airtable (PIX-9404)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -10,9 +10,6 @@ export const skillDatasource = datasource.extend({
   usedFields: [
     'id persistant',
     'Nom',
-    'Indice',
-    'Indice fr-fr',
-    'Indice en-us',
     'Statut de l\'indice',
     'Comprendre (id persistant)',
     'En savoir plus (id persistant)',
@@ -31,10 +28,6 @@ export const skillDatasource = datasource.extend({
     return {
       id: airtableRecord.get('id persistant'),
       name: airtableRecord.get('Nom'),
-      hint_i18n: {
-        fr: airtableRecord.get('Indice fr-fr'),
-        en: airtableRecord.get('Indice en-us'),
-      },
       hintStatus: airtableRecord.get('Statut de l\'indice') || 'no status',
       tutorialIds: airtableRecord.get('Comprendre (id persistant)') || [],
       learningMoreTutorialIds: airtableRecord.get('En savoir plus (id persistant)') || [],

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -16,6 +16,7 @@ const idField = 'id persistant';
 export const {
   extractFromProxyObject,
   airtableObjectToProxyObject,
+  proxyObjectToAirtableObject,
   prefixFor,
   toDomain,
 } = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/tests/acceptance/application/airtable-proxy-controller-skill_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-skill_test.js
@@ -41,7 +41,11 @@ describe('Acceptance | Controller | airtable-proxy-controller | create skill tra
       const skill = domainBuilder.buildSkillDatasourceObject({ id: 'mon_id_persistant' });
       airtableRawSkill = airtableBuilder.factory.buildSkill(skill);
       skillToSave = inputOutputDataBuilder.factory.buildSkill({
-        ...skill
+        ...skill,
+        hint_i18n: {
+          fr: 'Peut-on géo-localiser un téléphone lorsqu’il est éteint ?',
+          en: 'Can we geo-locate a rabbit on the ice floe?',
+        }
       });
     });
 
@@ -84,6 +88,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create skill tra
 
   describe('PATCH /api/airtable/content/Acquis/id_airtable', () => {
     let skillToUpdate;
+    let airtableSkill;
     let user;
 
     beforeEach(async function() {
@@ -92,12 +97,13 @@ describe('Acceptance | Controller | airtable-proxy-controller | create skill tra
       const skillDataObject = domainBuilder.buildSkillDatasourceObject({
         id: 'mon_id_persistant',
       });
+      airtableSkill = airtableBuilder.factory.buildSkill(skillDataObject);
       skillToUpdate = inputOutputDataBuilder.factory.buildSkill({
         ...skillDataObject,
         hint_i18n: {
           fr: 'AAA',
           en: 'BBB',
-        }
+        },
       });
 
       databaseBuilder.factory.buildTranslation({
@@ -119,9 +125,9 @@ describe('Acceptance | Controller | airtable-proxy-controller | create skill tra
       it('should proxy request to airtable and update translations to the PG table', async () => {
         // Given
         nock('https://api.airtable.com')
-          .patch('/v0/airtableBaseValue/Acquis/id_airtable', skillToUpdate)
+          .patch('/v0/airtableBaseValue/Acquis/id_airtable', airtableSkill)
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, skillToUpdate);
+          .reply(200, airtableSkill);
         const server = await createServer();
 
         // When
@@ -165,7 +171,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve skill t
 
   describe('GET /api/airtable/content/Acquis', () => {
     let skillDataObject;
-    let skill;
+    let airtableSkill;
     let user;
 
     beforeEach(async function() {
@@ -174,13 +180,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve skill t
       skillDataObject = domainBuilder.buildSkillDatasourceObject({
         id: 'mon_id_persistant',
       });
-      skill = inputOutputDataBuilder.factory.buildSkill({
-        ...skillDataObject,
-        hint_i18n: {
-          fr: 'CCC',
-          en: 'DDD',
-        }
-      });
+      airtableSkill = airtableBuilder.factory.buildSkill(skillDataObject);
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
@@ -212,7 +212,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve skill t
         nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Acquis')
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, { records: [skill] });
+          .reply(200, { records: [airtableSkill] });
         const server = await createServer();
 
         // When
@@ -231,7 +231,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve skill t
 
   describe('GET /api/airtable/content/Acquis/id', () => {
     let skillDataObject;
-    let skill;
+    let airtableSkill;
     let user;
 
     beforeEach(async function() {
@@ -240,13 +240,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve skill t
       skillDataObject = domainBuilder.buildSkillDatasourceObject({
         id: 'mon_id_persistant',
       });
-      skill = inputOutputDataBuilder.factory.buildSkill({
-        ...skillDataObject,
-        hint_i18n: {
-          fr: 'Pouet',
-          en: 'Toot',
-        },
-      });
+      airtableSkill = airtableBuilder.factory.buildSkill(skillDataObject);
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
@@ -278,7 +272,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | retrieve skill t
         nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Acquis/recId')
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, skill);
+          .reply(200, airtableSkill);
         const server = await createServer();
 
         // When

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -22,7 +22,7 @@ async function mockCurrentContent() {
   const expectedCurrentContent = {
     attachments: [domainBuilder.buildAttachment()],
     areas: [domainBuilder.buildAreaDatasourceObject()],
-    competences: [domainBuilder.buildCompetenceForRelease({
+    competences: [domainBuilder.buildCompetence({
       name_i18n: {
         fr: 'Français',
         en: 'English',
@@ -33,7 +33,7 @@ async function mockCurrentContent() {
       }
     })],
     tubes: [domainBuilder.buildTubeDatasourceObject()],
-    skills: [domainBuilder.buildSkillDatasourceObject()],
+    skills: [domainBuilder.buildSkill()],
     challenges: [domainBuilder.buildChallenge()],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
     thematics: [domainBuilder.buildThematicDatasourceObject()],
@@ -92,6 +92,7 @@ async function mockCurrentContent() {
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
   });
+
   databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'fr',
@@ -102,6 +103,7 @@ async function mockCurrentContent() {
     locale: 'en',
     value: expectedCurrentContent.skills[0].hint_i18n.en,
   });
+
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr',

--- a/api/tests/scripts/migrate-skills-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-skills-translation-from-airtable_test.js
@@ -31,11 +31,9 @@ describe('Migrate translation from airtable', function() {
     // given
     const skill = airtableBuilder.factory.buildSkill({
       id: 'skillid1',
-      hint_i18n: {
-        fr: 'indice',
-        en: 'clue',
-      }
     });
+    skill.fields['Indice fr-fr'] = 'indice';
+    skill.fields['Indice en-us'] = 'clue';
 
     nock('https://api.airtable.com')
       .get('/v0/airtableBaseValue/Acquis')

--- a/api/tests/tooling/airtable-builder/factory/build-skill.js
+++ b/api/tests/tooling/airtable-builder/factory/build-skill.js
@@ -1,10 +1,6 @@
 export function buildSkill({
   id,
   name,
-  hint_i18n: {
-    fr: hintFrFr,
-    en: hintEnUs,
-  } = {},
   hintStatus,
   tutorialIds,
   learningMoreTutorialIds,
@@ -22,8 +18,6 @@ export function buildSkill({
     id,
     'fields': {
       'id persistant': id,
-      'Indice fr-fr': hintFrFr,
-      'Indice en-us': hintEnUs,
       'Statut de l\'indice': hintStatus,
       'Comprendre (id persistant)': tutorialIds,
       'En savoir plus (id persistant)': learningMoreTutorialIds,

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-skill-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-skill-datasource-object.js
@@ -2,10 +2,6 @@ export function buildSkillDatasourceObject(
   {
     id = 'recTIddrkopID28Ep',
     name = '@accesDonnées1',
-    hint_i18n = {
-      fr: 'Peut-on géo-localiser un téléphone lorsqu’il est éteint ?',
-      en: 'Can we geo-locate a rabbit on the ice floe?',
-    },
     hintStatus = 'Validé',
     tutorialIds = ['receomyzL0AmpMFGw'],
     learningMoreTutorialIds = ['recQbjXNAPsVJthXh', 'rec3DkUX0a6RNi2Hz'],
@@ -21,7 +17,6 @@ export function buildSkillDatasourceObject(
   return {
     id,
     name,
-    hint_i18n,
     hintStatus,
     tutorialIds,
     learningMoreTutorialIds,


### PR DESCRIPTION
## :unicorn: Problème
On écrit et on lit toujours les champs traduisibles des acquis dans Airtable.

## :robot: Solution
Débrancher la lecture et l'écriture de ces champs.

## :rainbow: Remarques
N/A

## :100: Pour tester
Mettre à jour ou créer un acquis dans PixEditor et vérifier que les champs traduisibles ne sont pas valorisés dans Airtable.