### PR TITLE
[FEATURE] Ajout des traductions des acquis dans l'export Phrase (PIX-10230)

### DIFF
--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -15,6 +15,7 @@ const idField = 'id persistant';
 
 export const {
   extractFromProxyObject,
+  extractFromReleaseObject,
   airtableObjectToProxyObject,
   proxyObjectToAirtableObject,
   prefixFor,

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -181,6 +181,7 @@ describe('Acceptance | Controller | translations-controller', () => {
         'challenge.recChallenge0.solutionToDisplay,Bonnes réponses du Challenge à afficher,"epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix"',
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix"',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix"',
+        'skill.recSkill0.hint,Indice - fr,"acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix"',
       ]);
     });
 
@@ -322,6 +323,7 @@ describe('Acceptance | Controller | translations-controller', () => {
       expect(payload).to.deep.equal([
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix"',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix"',
+        'skill.recSkill0.hint,Indice - fr,"acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix"',
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Les traductions des acquis ne sont pas présentes dans le fichier CSV exporté pour Phrase.

## :robot: Solution
Ajouter les traductions des acquis dans l'export.

## :rainbow: Remarques
N/A

## :100: Pour tester
~Créer une release sur la RA.~ C'est fait.
Aller dans AdminJS et exporter les traductions, vérifier que celles des acquis sont bien présentes.