### PR TITLE
[TECH] Retrouve les `alternative-locales` depuis les traductions présentes.

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -8,7 +8,7 @@ import { challengeRepository, localizedChallengeRepository } from '../../infrast
 import { challengeSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import * as securityPreHandlers from '../security-pre-handlers.js';
 import { attachmentDatasource } from '../../infrastructure/datasources/airtable/index.js';
-import { challengeTransformer } from '../../infrastructure/transformers/index.js';
+import { createChallengeTransformer } from '../../infrastructure/transformers/index.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import { previewChallenge } from '../../domain/usecases/index.js';
@@ -29,7 +29,7 @@ async function _refreshCache({ challenge, localizedChallenge }) {
 
   try {
     const attachments = await attachmentDatasource.filterByChallengeId(challenge.id);
-    const transformChallenge = challengeTransformer.createChallengeTransformer({
+    const transformChallenge = createChallengeTransformer({
       attachments,
       localizedChallenge,
     });

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -101,4 +101,8 @@ export class Challenge {
   get primaryLocale() {
     return this.locales[0];
   }
+
+  get alternativeLocales() {
+    return Object.keys(this.translations).filter((locale) => locale !== this.primaryLocale);
+  }
 }

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -15,7 +15,7 @@ import {
 } from './index.js';
 import * as airtableSerializer from '../serializers/airtable-serializer.js';
 import {
-  challengeTransformer,
+  createChallengeTransformer,
   competenceTransformer,
   skillTransformer,
   tubeTransformer,
@@ -64,7 +64,7 @@ export async function serializeEntity({ type, entity, translations }) {
   if (model === attachmentDatasource.path()) {
     const [rawChallenge] = await challengeRepository.filter({ filter: { ids: [updatedRecord.challengeId] } });
     const attachments = await attachmentDatasource.filterByChallengeId(updatedRecord.challengeId);
-    const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments });
+    const transformChallenge = createChallengeTransformer({ attachments });
     const challenge = transformChallenge(rawChallenge);
 
     return { updatedRecord: challenge, model: challengeDatasource.path() };
@@ -126,7 +126,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     tutorialDatasource.list(),
     localizedChallengeRepository.list(),
   ]);
-  const transformChallenge = challengeTransformer.createChallengeTransformer({ attachments, localizedChallenges });
+  const transformChallenge = createChallengeTransformer({ attachments, localizedChallenges });
   const transformedChallenges = challenges.flatMap(transformChallenge);
   const transformedTubes = tubeTransformer.transform({ tubes, skills, challenges: transformedChallenges, thematics });
   const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);

--- a/api/lib/infrastructure/transformers/index.js
+++ b/api/lib/infrastructure/transformers/index.js
@@ -1,4 +1,4 @@
-export * as challengeTransformer from './challenge-transformer.js';
+export * from './challenge-transformer.js';
 export * as competenceTransformer from './competence-transformer.js';
 export * as skillTransformer from './skill-transformer.js';
 export * as tubeTransformer from './tube-transformer.js';

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -120,16 +120,10 @@ describe('Acceptance | Controller | challenges-controller', () => {
         locale: 'fr',
         value: '- 1\n- 2\n- 3\n- 4\n- 5',
       });
-
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: 'my id',
-        challengeId: 'my id',
-        locale: 'fr',
-      });
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: 'my id Nl',
-        challengeId: 'my id',
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.my id.instruction',
         locale: 'nl',
+        value: 'Hallo',
       });
 
       await databaseBuilder.commit();
@@ -280,21 +274,10 @@ describe('Acceptance | Controller | challenges-controller', () => {
         locale: 'fr',
         value: '- 1\n- 2\n- 3\n- 4\n- 5',
       });
-
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: '1',
-        challengeId: '1',
-        locale: 'fr',
-      });
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: '2',
-        challengeId: '2',
-        locale: 'fr',
-      });
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: '2 nl',
-        challengeId: '2',
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.2.proposals',
         locale: 'nl',
+        value: '- 1\n- 2\n- 3\n- 4\n- 5',
       });
 
       await databaseBuilder.commit();
@@ -547,15 +530,10 @@ describe('Acceptance | Controller | challenges-controller', () => {
         value: '- 1\n- 2\n- 3\n- 4\n- 5',
       });
 
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: 'recChallengeId1',
-        challengeId: 'recChallengeId1',
-        locale: 'fr',
-      });
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: 'recChallengeId1Nl',
-        challengeId: 'recChallengeId1',
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.recChallengeId1.proposals',
         locale: 'nl',
+        value: '- 1\n- 2\n- 3\n- 4\n- 5',
       });
 
       await databaseBuilder.commit();
@@ -901,6 +879,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             accessibility2: 'RAS',
             spoil: 'Non Sp',
             responsive: 'non',
+            'alternative-locales': [],
             locales: ['fr'],
             area: 'France',
             'auto-reply': false,
@@ -1322,6 +1301,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             accessibility2: 'RAS',
             spoil: 'Non Sp',
             responsive: 'non',
+            'alternative-locales': [],
             locales: ['fr'],
             area: 'France',
             'auto-reply': false,

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import * as challengeTransformer from '../../../../lib/infrastructure/transformers/challenge-transformer.js';
+import { createChallengeTransformer } from '../../../../lib/infrastructure/transformers/challenge-transformer.js';
 import { LocalizedChallenge } from '../../../../lib/domain/models/LocalizedChallenge.js';
 import { domainBuilder } from '../../../test-helper.js';
 
@@ -44,7 +44,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         });
 
         // when
-        const transform = challengeTransformer.createChallengeTransformer({ attachments, localizedChallenges });
+        const transform = createChallengeTransformer({ attachments, localizedChallenges });
         const result = transform(challenge);
 
         // then
@@ -96,7 +96,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         });
 
         // when
-        const transform = challengeTransformer.createChallengeTransformer({ attachments, localizedChallenge });
+        const transform = createChallengeTransformer({ attachments, localizedChallenge });
         const result = transform(challenge);
 
         // then
@@ -130,7 +130,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         });
 
         // when
-        const transform = challengeTransformer.createChallengeTransformer({ attachments });
+        const transform = createChallengeTransformer({ attachments });
         const result = transform(challenge);
 
         // then
@@ -161,7 +161,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         });
 
         // when
-        const transform = challengeTransformer.createChallengeTransformer({ attachments });
+        const transform = createChallengeTransformer({ attachments });
         const result = transform(challenge);
 
         // then
@@ -207,7 +207,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         });
 
         // when
-        const transform = challengeTransformer.createChallengeTransformer({ attachments });
+        const transform = createChallengeTransformer({ attachments });
         const result = transform(challenge);
 
         // then


### PR DESCRIPTION
## :unicorn: Problème

Le champ `alternative-locales` est actuellement construit à partir des `localized-challenges` associés au `challenge`.
Cette construction est inutilement complexe car le challenge contient l'information à travers les traductions.

## :robot: Solution

Utiliser le champ `translations` pour fournir les `alternative-locales`.

## :rainbow: Remarques

RIP la PR de Refacto.

## :100: Pour tester

Tout doit rester au vert.
