### PR TITLE
[FEATURE] Ajouter le néerlandais des compétences/acquis dans la release (PIX-10240)

### DIFF
--- a/api/lib/infrastructure/translations/utils.js
+++ b/api/lib/infrastructure/translations/utils.js
@@ -53,12 +53,15 @@ function toDomain({ fields, locales }) {
   return (translations) => {
     return Object.fromEntries(fields.map(({ field }) => [
       `${field}_i18n`,
-      Object.fromEntries(locales.map(({ locale }) => [
-        locale,
-        translations.find(
-          (translation) => translation.key.endsWith(`.${field}`) && translation.locale === locale,
-        )?.value ?? null,
-      ]))
+      Object.fromEntries([
+        ...locales.map(({ locale }) => [locale, null]),
+        ...translations
+          .filter((translation) => translation.key.endsWith(`.${field}`))
+          .map((translation) => [
+            translation.locale,
+            translation.value
+          ]),
+      ]),
     ]));
   };
 }
@@ -92,7 +95,7 @@ export function buildTranslationsUtils({ locales, fields, prefix, idField }) {
     extractFromProxyObject: extractFromProxyObject({ localizedFields, prefixFor }),
     airtableObjectToProxyObject: airtableObjectToProxyObject({ localizedFields, prefixFor }),
     proxyObjectToAirtableObject: proxyObjectToAirtableObject({ localizedFields }),
-    toDomain: toDomain({ fields ,locales }),
+    toDomain: toDomain({ fields, locales }),
     extractFromReleaseObject: extractFromReleaseObject({ localizedFields, prefix }),
   };
 }

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -45,6 +45,7 @@ async function mockCurrentContent() {
       name_i18n: {
         fr: 'Nom de la Compétence - fr',
         en: 'Nom de la Compétence - en',
+        nl: 'Nom de la Compétence - nl',
       },
       areaId: '1',
       origin: 'Pix',
@@ -53,6 +54,7 @@ async function mockCurrentContent() {
       description_i18n: {
         fr: 'Description de la compétence - fr',
         en: 'Description de la compétence - en',
+        nl: 'Nom de la Compétence - nl',
       }
     }],
     thematics: [{
@@ -90,6 +92,7 @@ async function mockCurrentContent() {
       hint_i18n: {
         fr: 'Indice - fr',
         en: 'Indice - en',
+        nl: 'Indice - nl',
       },
       hintStatus: 'Statut de l‘indice',
       tutorialIds: ['recTutorial0'],
@@ -180,36 +183,25 @@ async function mockCurrentContent() {
     challengeIds: 'recChallenge0',
   });
 
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
-    locale: 'fr',
-    value: expectedCurrentContent.competences[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
-    locale: 'en',
-    value: expectedCurrentContent.competences[0].name_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
-    locale: 'fr',
-    value: expectedCurrentContent.competences[0].description_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
-    locale: 'en',
-    value: expectedCurrentContent.competences[0].description_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
-    locale: 'fr',
-    value: expectedCurrentContent.skills[0].hint_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
-    locale: 'en',
-    value: expectedCurrentContent.skills[0].hint_i18n.en,
-  });
+  for (const locale of ['fr', 'en', 'nl']) {
+    databaseBuilder.factory.buildTranslation({
+      key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+      locale,
+      value: expectedCurrentContent.competences[0].name_i18n[locale],
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+      locale,
+      value: expectedCurrentContent.competences[0].description_i18n[locale],
+    });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+      locale,
+      value: expectedCurrentContent.skills[0].hint_i18n[locale],
+    });
+  }
+
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr-fr',
@@ -276,10 +268,12 @@ async function mockContentForRelease() {
       name_i18n: {
         en: 'Nom de la Compétence - en',
         fr: 'Nom de la Compétence - fr',
+        nl: 'Nom de la Compétence - nl',
       },
       description_i18n: {
         en: 'Description de la compétence - en',
         fr: 'Description de la compétence - fr',
+        nl: 'Description de la compétence - nl',
       },
     }],
     thematics: [{
@@ -326,6 +320,7 @@ async function mockContentForRelease() {
       hint_i18n: {
         en: 'Indice - en',
         fr: 'Indice - fr',
+        nl: 'Indice - nl',
       },
     }],
     challenges: [{
@@ -409,36 +404,25 @@ async function mockContentForRelease() {
     imageUrl: 'Image du Course',
   });
 
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
-    locale: 'fr',
-    value: expectedCurrentContent.competences[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.name`,
-    locale: 'en',
-    value: expectedCurrentContent.competences[0].name_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
-    locale: 'fr',
-    value: expectedCurrentContent.competences[0].description_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `competence.${expectedCurrentContent.competences[0].id}.description`,
-    locale: 'en',
-    value: expectedCurrentContent.competences[0].description_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
-    locale: 'fr',
-    value: expectedCurrentContent.skills[0].hint_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
-    key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
-    locale: 'en',
-    value: expectedCurrentContent.skills[0].hint_i18n.en,
-  });
+  for (const locale of ['fr', 'en', 'nl']) {
+    databaseBuilder.factory.buildTranslation({
+      key: `competence.${expectedCurrentContent.competences[0].id}.name`,
+      locale,
+      value: expectedCurrentContent.competences[0].name_i18n[locale],
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `competence.${expectedCurrentContent.competences[0].id}.description`,
+      locale,
+      value: expectedCurrentContent.competences[0].description_i18n[locale],
+    });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
+      locale,
+      value: expectedCurrentContent.skills[0].hint_i18n[locale],
+    });
+  }
+
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
     locale: 'fr-fr',

--- a/api/tests/unit/infrastructure/translations/utils_test.js
+++ b/api/tests/unit/infrastructure/translations/utils_test.js
@@ -185,6 +185,8 @@ describe('Unit | Infrastructure | Entity translations', () => {
           locale: 'en',
           value: 'value2 en-us',
         },
+        { key: 'entity.test.attribute', locale: 'nl', value: 'value nl-be' },
+        { key: 'entity.test.attribute2', locale: 'nl', value: 'value2 nl-be' },
       ];
 
       // when
@@ -195,15 +197,17 @@ describe('Unit | Infrastructure | Entity translations', () => {
         attribute_i18n: {
           fr: 'value fr-fr',
           en: 'value en-us',
+          nl: 'value nl-be',
         },
         attribute2_i18n: {
           fr: 'value2 fr-fr',
           en: 'value2 en-us',
+          nl: 'value2 nl-be',
         },
       });
     });
 
-    it('should return null fields for missing translations', () => {
+    it('should return null fields for missing translations in given locales', () => {
       // given
       const translations = [
         { key: 'entity.test.attribute', locale: 'en', value: 'value en-us' },


### PR DESCRIPTION
## :christmas_tree: Problème
Le néerlandais des compétences et des acquis n'est pas dans la release.

## :gift: Proposition
Inclure toutes les traductions disponibles pour les compétences et acquis dans la release.

## :socks: Remarques
Dans le `toDomain` pour le fr et le en on force la présence des champs avec une valeur `null`, afin de garantir qu'on écrase toute donnée en provenance de Airtable.

## :santa: Pour tester
Télécharger la dernière release de la RA et vérifier qu'on a du néerlandais pour la compétence `competence2fk3toLdUqgUCS` et l'acquis `skillPxyUssXm23jJz`.

Si tu as `jq`, c'est ton jour de chance :
```
jq '.content.competences[] | select(.id == "competence2fk3toLdUqgUCS")'
jq '.content.skills[] | select(.id == "skillPxyUssXm23jJz")'
```