### PR TITLE
[BUGFIX] Bouton "Copier le lien" copie une URL sans protocole ni host (PIX-10284)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -111,6 +111,10 @@ export default class SingleController extends Controller {
     return this.challenge.updatedAt.toISOString();
   }
 
+  get absolutePreviewUrl() {
+    return new URL(this.challenge.preview, window.location).href;
+  }
+
   @action
   getPreviewUrl(locale) {
     return locale ? `${this.challenge.preview}?locale=${locale}` : this.challenge.preview;

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -65,7 +65,7 @@
                      @displaySolutionToDisplayField={{this.displaySolutionToDisplayField}}
                      @setDisplaySolutionToDisplayField={{this.setDisplaySolutionToDisplayField}}/>
     {{#if this.copyOperation}}
-      <Field::Copy @value={{this.challenge.preview}} @onCopied={{this.linkCopied}}/>
+      <Field::Copy @value={{this.absolutePreviewUrl}} @onCopied={{this.linkCopied}}/>
     {{/if}}
   </div>
 <div class="ui vertical compact labeled icon menu challenge-menu">
@@ -109,7 +109,7 @@
     {{/if}}
     <button class="ui button item" {{on "click" this.copyLink}} type="button">
       <i class="linkify icon"></i>
-      Copier lien
+      Copier le lien
     </button>
     {{#if this.mayAccessAlternatives}}
       <button class="ui button item alternatives"  {{on "click" this.showAlternatives}} type="button">


### PR DESCRIPTION
## :christmas_tree: Problème
Le bouton "Copier le lien" de l'épreuve copie une chaîne ne contenant que le path `"/api/..."` sans le protocole ni le host.

## :gift: Proposition
Compléter l'URL en utilisant le protocole et le host de la page.

## :socks: Remarques
N/A

## :santa: Pour tester
Aller sur n'importe quelle épreuve de la RA et tester le bouton "Copier le lien"