### PR TITLE
[FEATURE] Permettre l'affichage des bouton d'actions d'une épreuve (PIX-10288).

### DIFF
--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -26,12 +26,17 @@
   flex-direction: row;
   overflow: hidden;
 
-  .ui.labeled.icon.menu .item {
-    text-align: left;
+  .ui.labeled.icon.menu {
+    overflow-y: auto;
 
-    > .icon:not(.dropdown) {
-      display: inline;
-      margin-right: 10px !important;
+    .item {
+      text-align: left;
+
+      > .icon:not(.dropdown) {
+        display: inline;
+        margin-right: 10px !important;
+        font-size: 1.2em !important;
+      }
     }
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Avec l'ajout du bouton de prévisualisation des épreuves localisées certains boutons n'étaient plus accessibles pour certaine configuration d'écran.

## :gift: Proposition
Diminuer la taille des icones des boutons pour réduire leur taille.
Ajouter une barre de scroll lorsque les boutons dépassent leur conteneur.

## :socks: Remarques
RAS

## :santa: Pour tester
Se rendre sur la page d'un prototype ou d'une déclinaison : 
-  constaté la taille des boutons.
- Augmenter le zoom pour faire apparaitre la barre de scroll
