### PR TITLE
[FEATURE] Seeds : Créer des épreuves virtuelles pour les épreuves ayant des traductions supplémentaires (PIX-10311)

### DIFF
--- a/api/db/seeds/data/translations.js
+++ b/api/db/seeds/data/translations.js
@@ -19,13 +19,11 @@ export async function translationsBuilder(databaseBuilder) {
     throw err;
   }
 
-  const translations = airtableTranslations.map((translation) => {
-    return {
-      key: translation.get('key'),
-      locale: translation.get('locale'),
-      value: translation.get('value'),
-    };
-  });
+  const translations = airtableTranslations.map((translation) => ({
+    key: translation.get('key'),
+    locale: translation.get('locale'),
+    value: translation.get('value'),
+  }));
 
-  translations.forEach(databaseBuilder.factory.buildTranslation);
+  return translations.map(databaseBuilder.factory.buildTranslation);
 }

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -33,11 +33,11 @@ export async function seed(knex) {
     apiKey: process.env.REVIEW_APP_READ_ONLY_USER_API_KEY || readOnlyUserApiKey,
   });
 
-  await localizedChallengesBuilder(databaseBuilder);
+  const translations = await translationsBuilder(databaseBuilder);
+
+  await localizedChallengesBuilder(databaseBuilder, translations);
 
   staticCoursesBuilder(databaseBuilder);
-
-  await translationsBuilder(databaseBuilder);
 
   return databaseBuilder.commit();
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Quand on seed un environnement, les épreuves ayant des traductions dans une locale autre que leur locale principale n'ont pas d'épreuve virtuelle associée à cette locale supplémentaire.

## :gift: Proposition
Modifier les seeds pour créer des épreuves virtuelles en fonction des traductions présentes.

## :socks: Remarques
N/A

## :santa: Pour tester
Aller sur la RA et vérifier qu'il y a des épreuves virtuelles néerlandaises qui ont été créées par les seeds (exemple sur le challenge `rec1WAPS3HcvM1zxa`).