### PR TITLE
[BUGFIX] Ordre des domaines dans le panneau de navigation (PIX-10264)

### DIFF
--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -3,7 +3,7 @@
   <h1 class="header">Pix Editor</h1>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
   <Sidebar::Search @displaySearch={{this.maySearch}} @close={{@close}} />
-  <Sidebar::Navigation @displayFrameworkList={{this.maySwitchFramework}} @areas={{this.areas}} @close={{@close}}/>
+  <Sidebar::Navigation @displayFrameworkList={{this.maySwitchFramework}} @close={{@close}}/>
   <div class="secondary-links">
     {{#if this.mayAccessStaticCourses}}
       <LinkTo @route="authenticated.static-courses" {{on "click" @close}}>

--- a/pix-editor/app/models/framework.js
+++ b/pix-editor/app/models/framework.js
@@ -8,6 +8,6 @@ export default class FrameworkModel extends Model {
   get sortedAreas() {
     return this.areas
       .toArray()
-      .sort((areaA, areaB) => parseInt(areaA.code) > parseInt(areaB.code));
+      .sort((areaA, areaB) => parseInt(areaA.code) - parseInt(areaB.code));
   }
 }

--- a/pix-editor/tests/unit/models/framework-test.js
+++ b/pix-editor/tests/unit/models/framework-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | framework', function(hooks) {
+  setupTest(hooks);
+  let store;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#sortedAreas', function() {
+    test('it should return areas sorted by code', function(assert) {
+      // given
+      const framework = run(() => store.createRecord('framework', {
+        areas: [
+          store.createRecord('area', { code: '10' }),
+          store.createRecord('area', { code: '9' }),
+        ]
+      }));
+
+      // when
+      const sortedAreas = framework.sortedAreas;
+
+      // then
+      assert.strictEqual(sortedAreas.length, 2);
+      assert.strictEqual(sortedAreas[0].code, '9');
+      assert.strictEqual(sortedAreas[1].code, '10');
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
L'ordre des domaines n'est pas correct dans le panneau de navigation, exemple en prod sur le référentiel "Professionnels de Santé".

## :gift: Proposition
Corriger l'ordre.

## :socks: Remarques
N/A

## :santa: Pour tester
Sur la RA aller sur le référentiel "Droit", si c'est dans le bon ordre alors c'est bon.