### PR TITLE
[BUGFIX] Changement de la locale principale de l'épreuve (PIX-10424)

### DIFF
--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -38,7 +38,7 @@ export function importTranslations(csvStream, dependencies = { translationReposi
         const challengesLocales = extractChallengesLocales(translations);
         await dependencies.localizedChallengeRepository.create(challengesLocales);
 
-        await dependencies.translationRepository.save(translations);
+        await dependencies.translationRepository.save({ translations });
 
         resolve();
       });

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -21,7 +21,10 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   let translations;
   if (tableTranslations.writeToPgEnabled) {
     if (request.method === 'patch') {
-      await translationRepository.deleteByKeyPrefixAndLocales(tableTranslations.prefixFor(response.data.fields), ['fr', 'fr-fr', 'en']);
+      await translationRepository.deleteByKeyPrefixAndLocales({
+        prefix: tableTranslations.prefixFor(response.data.fields),
+        locales: ['fr', 'fr-fr', 'en'],
+      });
     }
 
     translations = tableTranslations.extractFromProxyObject(requestFields);

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -29,7 +29,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
 
     translations = tableTranslations.extractFromProxyObject(requestFields);
 
-    await translationRepository.save(translations);
+    await translationRepository.save({ translations });
   }
 
   if (tableTranslations.readFromPgEnabled) {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -66,7 +66,10 @@ export async function create(challenge) {
 export async function update(challenge) {
   const updatedChallengeDto = await challengeDatasource.update(challenge);
   const translations = extractTranslationsFromChallenge(challenge);
-  await translationRepository.deleteByKeyPrefixAndLocales(prefixFor(challenge), [challenge.primaryLocale]);
+  await translationRepository.deleteByKeyPrefixAndLocales({
+    prefix: prefixFor(challenge), locales:
+    [challenge.primaryLocale],
+  });
   await translationRepository.save(translations);
   return toDomain(updatedChallengeDto, translations);
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -54,7 +54,7 @@ export async function filter(params = {}) {
 export async function create(challenge) {
   const createdChallengeDto = await challengeDatasource.create(challenge);
   const translations = extractTranslationsFromChallenge(challenge);
-  await translationRepository.save(translations);
+  await translationRepository.save({ translations });
   await localizedChallengeRepository.create([{
     id: challenge.id,
     challengeId: challenge.id,
@@ -70,7 +70,7 @@ export async function update(challenge) {
     prefix: prefixFor(challenge), locales:
     [challenge.primaryLocale],
   });
-  await translationRepository.save(translations);
+  await translationRepository.save({ translations });
   return toDomain(updatedChallengeDto, translations);
 }
 

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -46,6 +46,10 @@ export async function get({ id, transaction: knexConnection = knex }) {
   return _toDomain(dto);
 }
 
+export async function update({ localizedChallenge: { id, locale }, transaction: knexConnection = knex }) {
+  await knexConnection('localized_challenges').where('id', id).update({ locale });
+}
+
 function _toDomain(dto) {
   return new LocalizedChallenge(dto);
 }

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -38,6 +38,14 @@ export async function listByChallengeIds(challengeIds) {
   return dtos.map(_toDomain);
 }
 
+export async function get({ id, transaction: knexConnection = knex }) {
+  const dto = await knexConnection('localized_challenges').select().where('id', id).first();
+
+  if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');
+
+  return _toDomain(dto);
+}
+
 function _toDomain(dto) {
   return new LocalizedChallenge(dto);
 }

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -6,10 +6,10 @@ import _ from 'lodash';
 let _shouldDuplicateToAirtable;
 let _shouldDuplicateToAirtablePromise;
 
-export async function save(translations) {
+export async function save({ translations, transaction: knexConnection = knex }) {
   if (translations.length === 0) return [];
 
-  await knex('translations')
+  await knexConnection('translations')
     .insert(translations)
     .onConflict(['key', 'locale'])
     .merge();

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -68,8 +68,8 @@ function _toDomain(dto) {
   return new Translation(dto);
 }
 
-export async function deleteByKeyPrefixAndLocales(prefix, locales) {
-  await knex('translations')
+export async function deleteByKeyPrefixAndLocales({ prefix, locales, transaction: knexConnection = knex }) {
+  await knexConnection('translations')
     .delete()
     .whereLike('key', `${prefix}%`)
     .whereIn('locale', locales);

--- a/api/scripts/fix-localized-challenges-locale/index.js
+++ b/api/scripts/fix-localized-challenges-locale/index.js
@@ -1,0 +1,72 @@
+import { convertLanguagesToLocales } from '../../lib/domain/services/convert-locales.js';
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+export async function fillLocalizedChallenges({ airtableClient }) {
+  const idealLocalizedChallenges = await fetchLocalizedChallenges({ airtableClient });
+  const idealLocales = Object.fromEntries(idealLocalizedChallenges.map(({ id, locale }) => [id, locale]));
+
+  await knex.transaction(async (transaction) => {
+    const localizedChallenges = await transaction('localized_challenges').where('id', knex.raw('"challengeId"')).select();
+
+    const brokenLocalizedChallenges = localizedChallenges.filter(({ id, locale }) => idealLocales[id] !== undefined && locale !== idealLocales[id]);
+
+    if (brokenLocalizedChallenges.length === 0) {
+      console.log('No localized challenges need to be fixed');
+      return;
+    }
+
+    console.log(`Fixing ${brokenLocalizedChallenges.length} localized challenges`);
+    brokenLocalizedChallenges.forEach(
+      ({ id, locale }) => console.log(`  will change ${id} from ${locale} to ${idealLocales[id]}`),
+    );
+
+    await Promise.all(brokenLocalizedChallenges.map(
+      ({ id }) => transaction('localized_challenges').where('id', id).update({ locale: idealLocales[id] }),
+    ));
+  });
+}
+
+export async function fetchLocalizedChallenges({ airtableClient }) {
+  const allChallenges = await airtableClient
+    .table('Epreuves')
+    .select({
+      fields: [
+        'id persistant',
+        'Langues',
+      ],
+    })
+    .all();
+
+  return allChallenges.map((challenge) => {
+    const locale = convertLanguagesToLocales(challenge.get('Langues'))?.sort()?.[0] ?? 'fr';
+    const idPersistant = challenge.get('id persistant');
+    return {
+      id: idPersistant,
+      challengeId: idPersistant,
+      locale,
+    };
+  });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await fillLocalizedChallenges({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/scripts/migrate-challenges-translation-from-airtable/index.js
+++ b/api/scripts/migrate-challenges-translation-from-airtable/index.js
@@ -38,7 +38,7 @@ export async function migrateChallengesTranslationFromAirtable({ airtableClient 
   });
 
   for (const translationsChunk of _.chunk(translations, 5000)) {
-    await translationRepository.save(translationsChunk);
+    await translationRepository.save({ translations: translationsChunk });
   }
 }
 

--- a/api/scripts/migrate-competences-translation-from-airtable/index.js
+++ b/api/scripts/migrate-competences-translation-from-airtable/index.js
@@ -25,7 +25,7 @@ export async function migrateCompetencesTranslationFromAirtable({ airtableClient
     competenceTranslations.extractFromProxyObject(competence.fields)
   );
 
-  await translationRepository.save(translations);
+  await translationRepository.save({ translations });
 }
 
 async function main() {

--- a/api/scripts/migrate-skills-translation-from-airtable/index.js
+++ b/api/scripts/migrate-skills-translation-from-airtable/index.js
@@ -23,7 +23,7 @@ export async function migrateSkillsTranslationFromAirtable({ airtableClient }) {
     skillTranslations.extractFromProxyObject(skill.fields)
   );
 
-  await translationRepository.save(translations);
+  await translationRepository.save({ translations });
 }
 
 async function main() {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1367,7 +1367,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       ]);
     });
 
-    it.fails('should change challenge\'s primary locale', async () => {
+    it('should change challenge\'s primary locale', async () => {
       // Given
       const challengeId = 'recChallengeId';
       const originalLocale = 'fr-fr';

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -304,4 +304,35 @@ describe('Integration | Repository | localized-challenge-repository', function()
       });
     });
   });
+
+  context('#update', () => {
+    it('should change localized challenge locale', async () => {
+      // given
+      const id = 'localizedChallengeId';
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id,
+        challengeId: 'challengeId',
+        locale: 'bz',
+      });
+      await databaseBuilder.commit();
+
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+        id,
+        challengeId: 'differentChallengeId should not be updated',
+        locale: 'ar',
+      });
+
+      // when
+      await localizedChallengeRepository.update({ localizedChallenge });
+
+      // then
+      await expect(knex('localized_challenges').select()).resolves.to.deep.equal([
+        {
+          id,
+          challengeId: 'challengeId',
+          locale: 'ar',
+        },
+      ]);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -268,4 +268,40 @@ describe('Integration | Repository | localized-challenge-repository', function()
       ]);
     });
   });
+
+  context('#get', () => {
+    it('should return localized challenge by id', async () => {
+      // given
+      const id = 'localizedChallengeId';
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id,
+        challengeId: 'challengeId',
+        locale: 'bz',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const localizedChallenge = await localizedChallengeRepository.get({ id });
+
+      // then
+      expect(localizedChallenge).to.deep.equal(domainBuilder.buildLocalizedChallenge({
+        id,
+        challengeId: 'challengeId',
+        locale: 'bz',
+      }));
+    });
+
+    context('when id does not exist', () => {
+      it('should throw a NotFoundError', async () => {
+        // given
+        const id = 'unknownLocalizedChallengeId';
+
+        // when
+        const promise = localizedChallengeRepository.get({ id });
+
+        // then
+        await expect(promise).rejects.to.deep.equal(new NotFoundError('Épreuve ou langue introuvable'));
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -16,6 +16,35 @@ describe('Integration | Repository | translation-repository', function() {
 
   context('#save', function() {
 
+    it('should create or update translations', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id.key1',
+        locale: 'fr',
+        value: 'key1 fr'
+      });
+      await databaseBuilder.commit();
+
+      const translations = [
+        {
+          key: 'entity.id.key1',
+          locale: 'fr',
+          value: 'key1 fr'
+        },
+        {
+          key: 'entity.id.key2',
+          locale: 'fr',
+          value: 'key2 fr'
+        }
+      ];
+
+      // when
+      await translationRepository.save({ translations });
+
+      // then
+      await expect(knex('translations').select().orderBy('key')).resolves.to.deep.equal(translations);
+    });
+
     context('when Airtable has a translations table', () => {
       beforeEach(async function() {
         await _setShouldDuplicateToAirtable(true);
@@ -49,14 +78,10 @@ describe('Integration | Repository | translation-repository', function() {
           .reply(200, { records: [] });
 
         // when
-        await save([{ key: 'entity.recordid.key', locale: 'fr', value: 'translationValue' }]);
+        await save({ translations: [{ key: 'entity.recordid.key', locale: 'fr', value: 'translationValue' }] });
 
         // then
         expect(nock.isDone()).to.be.true;
-      });
-
-      afterEach(async function() {
-        await _setShouldDuplicateToAirtable(false);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -85,7 +85,7 @@ describe('Integration | Repository | translation-repository', function() {
       const locales = ['fr', 'en'];
 
       // when
-      await translationRepository.deleteByKeyPrefixAndLocales(prefixToDelete, locales);
+      await translationRepository.deleteByKeyPrefixAndLocales({ prefix: prefixToDelete, locales });
 
       // then
       expect(await knex('translations').select()).to.deep.equal([
@@ -161,7 +161,7 @@ describe('Integration | Repository | translation-repository', function() {
         const locales = ['fr', 'en'];
 
         // when
-        await translationRepository.deleteByKeyPrefixAndLocales(prefixToDelete, locales);
+        await translationRepository.deleteByKeyPrefixAndLocales({ prefix: prefixToDelete, locales });
 
         expect(nock.isDone()).toBe(true);
       });

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -31,11 +31,13 @@ describe('Unit | Domain | Usecases | import-translations', function() {
     await promise;
 
     expect(translationRepository.save).toHaveBeenCalledOnce();
-    expect(translationRepository.save).toHaveBeenCalledWith([new Translation({
-      key: 'some.key',
-      locale: 'nl',
-      value: 'Hallo'
-    })]);
+    expect(translationRepository.save).toHaveBeenCalledWith({
+      translations: [new Translation({
+        key: 'some.key',
+        locale: 'nl',
+        value: 'Hallo'
+      })],
+    });
   });
 
   it('should return an error when the CSV doesn\'t have key_name as first column', async () => {
@@ -70,23 +72,25 @@ describe('Unit | Domain | Usecases | import-translations', function() {
     await promise;
 
     expect(translationRepository.save).toHaveBeenCalledOnce();
-    expect(translationRepository.save).toHaveBeenCalledWith([
-      new Translation({
-        key: 'challenge.id.key',
-        locale: 'nl',
-        value: 'Hallo'
-      }),
-      new Translation({
-        key: 'challenge.id.key2',
-        locale: 'nl',
-        value: 'Hallo2'
-      }),
-      new Translation({
-        key: 'challenge.id2.key',
-        locale: 'nl',
-        value: 'Hallo3'
-      })
-    ]);
+    expect(translationRepository.save).toHaveBeenCalledWith({
+      translations: [
+        new Translation({
+          key: 'challenge.id.key',
+          locale: 'nl',
+          value: 'Hallo'
+        }),
+        new Translation({
+          key: 'challenge.id.key2',
+          locale: 'nl',
+          value: 'Hallo2'
+        }),
+        new Translation({
+          key: 'challenge.id2.key',
+          locale: 'nl',
+          value: 'Hallo3'
+        })
+      ],
+    });
     expect(localizedChallengeRepository.create).toHaveBeenCalledOnce();
     expect(localizedChallengeRepository.create).toHaveBeenCalledWith([
       new LocalizedChallenge({

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -104,7 +104,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
         expect(tableTranslations.extractFromProxyObject).toHaveBeenCalledWith(requestFields);
 
         expect(translationRepository.save).toHaveBeenCalledOnce();
-        expect(translationRepository.save).toHaveBeenCalledWith(translations);
+        expect(translationRepository.save).toHaveBeenCalledWith({ translations });
       });
 
       describe('when updating an existing entity', () => {
@@ -136,7 +136,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
           expect(translationRepository.deleteByKeyPrefixAndLocales).toHaveBeenCalledWith({ prefix:'entity.id', locales: ['fr', 'fr-fr', 'en'] });
 
           expect(translationRepository.save).toHaveBeenCalledOnce();
-          expect(translationRepository.save).toHaveBeenCalledWith(translations);
+          expect(translationRepository.save).toHaveBeenCalledWith({ translations });
         });
       });
 

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -133,7 +133,7 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
           expect(tableTranslations.prefixFor).toHaveBeenCalledWith(responseFields);
 
           expect(translationRepository.deleteByKeyPrefixAndLocales).toHaveBeenCalledOnce();
-          expect(translationRepository.deleteByKeyPrefixAndLocales).toHaveBeenCalledWith('entity.id', ['fr', 'fr-fr', 'en']);
+          expect(translationRepository.deleteByKeyPrefixAndLocales).toHaveBeenCalledWith({ prefix:'entity.id', locales: ['fr', 'fr-fr', 'en'] });
 
           expect(translationRepository.save).toHaveBeenCalledOnce();
           expect(translationRepository.save).toHaveBeenCalledWith(translations);


### PR DESCRIPTION
## :christmas_tree: Problème
Le changement de la locale principale de l'épreuve n'est pas répercuté sur le localized challenge principal (celui ayant le même ID que le challenge).
La mise à jour des translations a également un problème : des nouvelles sont créées mais les anciennes (sur l'ancienne locale) ne sont pas supprimées.

## :gift: Proposition
Gérer le changement de locale principale dans le challengeRepository.

## :socks: Remarques
Un bon vendredi.

Ce serait bien d'utiliser également une transaction dans `challengeRepository.create`, dans une autre PR...

## :santa: Pour tester
Sur la RA, modifier la locale principale d'une épreuve, et enregistrer.
Recharger la page lol.
Vérifier qu'un 2ème bouton de "Prévisualiser xx" n'apparaît pas (cela valide que les translations sur l'ancienne locale sont bien supprimées étant donné que les alternativeLocales sont calculées à partir des translations).

Pas vraiment possible de valider que la locale du localizedChallenge est bien mise à jour depuis PixEditor, alors connecte toi à Postgres et vérifie avec cette requête :
```sql
select * from localized_challenges where "challengeId"= 'XXXXXXXXXXXXXX';
```