### PR TITLE
[FEATURE] Ecrire et mettre à jour l'embed-url dans localized_challenge (PIX-10435)

### DIFF
--- a/api/db/migrations/20231213154717_add-embedurl-to-localizedchallenge.js
+++ b/api/db/migrations/20231213154717_add-embedurl-to-localizedchallenge.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'localized_challenges';
+const EMBED_URL_COLUMN = 'embedUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function up(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.text(EMBED_URL_COLUMN);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function down(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(EMBED_URL_COLUMN);
+  });
+}

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -3,9 +3,11 @@ export class LocalizedChallenge {
     id,
     challengeId,
     locale,
+    embedUrl,
   } = {}) {
     this.id = id;
     this.challengeId = challengeId;
     this.locale = locale;
+    this.embedUrl = embedUrl;
   }
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -71,14 +71,16 @@ export async function update(challenge) {
     const primaryLocalizedChallenge = await localizedChallengeRepository.get({ id: challenge.id, transaction });
 
     const oldPrimaryLocale = primaryLocalizedChallenge.locale;
-
     if (oldPrimaryLocale !== challenge.primaryLocale) {
       primaryLocalizedChallenge.locale = challenge.primaryLocale;
-      await localizedChallengeRepository.update({
-        localizedChallenge: primaryLocalizedChallenge,
-        transaction,
-      });
     }
+
+    primaryLocalizedChallenge.embedUrl = challenge.embedUrl;
+
+    await localizedChallengeRepository.update({
+      localizedChallenge: primaryLocalizedChallenge,
+      transaction,
+    });
 
     const translations = extractTranslationsFromChallenge(challenge);
     await translationRepository.deleteByKeyPrefixAndLocales({

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -58,7 +58,8 @@ export async function create(challenge) {
   await localizedChallengeRepository.create([{
     id: challenge.id,
     challengeId: challenge.id,
-    locale: challenge.primaryLocale
+    locale: challenge.primaryLocale,
+    embedUrl: challenge.embedUrl,
   }]);
   return toDomain(createdChallengeDto, translations);
 }

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -47,7 +47,7 @@ export async function get({ id, transaction: knexConnection = knex }) {
 }
 
 export async function update({ localizedChallenge: { id, locale, embedUrl }, transaction: knexConnection = knex }) {
- await knexConnection('localized_challenges').where('id', id).update({ locale, embedUrl });
+  await knexConnection('localized_challenges').where('id', id).update({ locale, embedUrl });
 }
 
 function _toDomain(dto) {

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -46,8 +46,8 @@ export async function get({ id, transaction: knexConnection = knex }) {
   return _toDomain(dto);
 }
 
-export async function update({ localizedChallenge: { id, locale }, transaction: knexConnection = knex }) {
-  await knexConnection('localized_challenges').where('id', id).update({ locale });
+export async function update({ localizedChallenge: { id, locale, embedUrl }, transaction: knexConnection = knex }) {
+ await knexConnection('localized_challenges').where('id', id).update({ locale, embedUrl });
 }
 
 function _toDomain(dto) {

--- a/api/scripts/fill-localized-challenge-embed-url/index.js
+++ b/api/scripts/fill-localized-challenge-embed-url/index.js
@@ -1,0 +1,56 @@
+import { localizedChallengeRepository } from '../../lib/infrastructure/repositories/index.js';
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import { knex, disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export function fillLocalizedChallengesEmbedUrl({ airtableClient }) {
+  return knex.transaction(async (transaction) => {
+    const localizedChallenges = await fetchLocalizedChallenges({ airtableClient });
+    for (const localizedChallenge of localizedChallenges) {
+      await localizedChallengeRepository.update({ localizedChallenge, transaction });
+    }
+  });
+}
+
+export async function fetchLocalizedChallenges({ airtableClient }) {
+  const allChallenges = await airtableClient
+    .table('Epreuves')
+    .select({
+      fields: [
+        'id persistant',
+        'Embed URL',
+      ],
+    })
+    .all();
+
+  return allChallenges.map((challenge) => {
+    const idPersistant = challenge.get('id persistant');
+    const embedUrl = challenge.get('Embed URL');
+    return {
+      id: idPersistant,
+      embedUrl,
+    };
+  });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await fillLocalizedChallengesEmbedUrl({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/scripts/fill-localized-challenge-embed-url/index.js
+++ b/api/scripts/fill-localized-challenge-embed-url/index.js
@@ -23,12 +23,16 @@ export async function fetchLocalizedChallenges({ airtableClient }) {
         'id persistant',
         'Embed URL',
       ],
+      filterByFormula: 'NOT({Embed URL} = \'\')',
     })
     .all();
 
   return allChallenges.map((challenge) => {
     const idPersistant = challenge.get('id persistant');
     const embedUrl = challenge.get('Embed URL');
+    if (!embedUrl) {
+      console.error(`Embed URL is empty ! (challenge id ${idPersistant})`);
+    }
     return {
       id: idPersistant,
       embedUrl,

--- a/api/scripts/fill-localized-challenges/index.js
+++ b/api/scripts/fill-localized-challenges/index.js
@@ -7,7 +7,7 @@ import { disconnect } from '../../db/knex-database-connection.js';
 const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
 export async function fillLocalizedChallenges({ airtableClient }) {
-  const localizedChallenges = await fetchLocalizedChallenges({ airtableClient })
+  const localizedChallenges = await fetchLocalizedChallenges({ airtableClient });
   await localizedChallengeRepository.create(localizedChallenges);
 }
 
@@ -42,6 +42,7 @@ async function main() {
     }).base(process.env.AIRTABLE_BASE);
 
     await fillLocalizedChallenges({ airtableClient });
+    console.log('Embed url of localized challenge filled !');
   } catch (e) {
     console.error(e);
     process.exitCode = 1;

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -915,7 +915,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           id: 'challengeId',
           challengeId: 'challengeId',
           locale: 'fr',
-          embedUrl: null,
+          embedUrl: challenge.embedUrl,
         }
       ]);
       const translations = await knex('translations').select().orderBy('key');

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -915,6 +915,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           id: 'challengeId',
           challengeId: 'challengeId',
           locale: 'fr',
+          embedUrl: null,
         }
       ]);
       const translations = await knex('translations').select().orderBy('key');

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1165,6 +1165,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       databaseBuilder.factory.buildLocalizedChallenge({
         id: challengeId,
         challengeId,
+        embedUrl: 'old_url',
         locale,
       });
       databaseBuilder.factory.buildTranslation({
@@ -1339,6 +1340,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
         },
       });
+      const localizedChallenge =  await knex('localized_challenges').select('embedUrl').where('id', challengeId).pluck('embedUrl');
+      expect(localizedChallenge).to.deep.equal([challenge.embedUrl]);
       await expect(knex('translations').orderBy('key').select()).resolves.to.deep.equal([
         {
           key: 'challenge.recChallengeId.alternativeInstruction',
@@ -1563,6 +1566,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
         {
           id: challengeId,
           challengeId,
+          embedUrl: challenge.embedUrl,
           locale: 'fr',
         },
       ]);

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -11,7 +11,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'challengeNewid',
         challengeId: 'challengeId',
-        locale: 'fr-fr'
+        locale: 'fr-fr',
+        embedUrl: 'https://site.com/embed.html',
       });
       await databaseBuilder.commit();
 
@@ -23,6 +24,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         id: 'challengeNewid',
         challengeId: 'challengeId',
         locale: 'fr-fr',
+        embedUrl: 'https://site.com/embed.html',
       }]);
     });
   });
@@ -38,6 +40,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         id: 'localizedChallengeId',
         challengeId: 'challengeId',
         locale: 'locale',
+        embedUrl: 'https://site.com/embed.html',
       }]);
 
       // then
@@ -47,6 +50,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         id: 'localizedChallengeId',
         challengeId: 'challengeId',
         locale: 'locale',
+        embedUrl: 'https://site.com/embed.html',
       }]);
     });
 
@@ -68,6 +72,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         await localizedChallengeRepository.create([{
           challengeId: 'challengeId',
           locale: 'locale',
+          embedUrl: 'https://site.com/embed.html',
         }], () => 'generated-id');
 
         // then
@@ -77,6 +82,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
           id: 'generated-id',
           challengeId: 'challengeId',
           locale: 'locale',
+          embedUrl: 'https://site.com/embed.html',
         }]);
       });
 
@@ -131,6 +137,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
           id: 'id',
           challengeId: 'challengeId',
           locale: 'en',
+          embedUrl: null,
         });
       });
     });
@@ -167,6 +174,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         id: 'localizedChallengeIdNl',
         challengeId,
         locale,
+        embedUrl: null,
       }));
     });
 
@@ -244,26 +252,31 @@ describe('Integration | Repository | localized-challenge-repository', function()
           id: `${challengeId1}En`,
           challengeId: challengeId1,
           locale: 'en',
+          embedUrl: null,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: challengeId1,
           challengeId: challengeId1,
           locale: 'fr-fr',
+          embedUrl: null,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: `${challengeId1}Nl`,
           challengeId: challengeId1,
           locale: 'nl',
+          embedUrl: null,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: `${challengeId2}En`,
           challengeId: challengeId2,
           locale: 'en',
+          embedUrl: null,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: challengeId2,
           challengeId: challengeId2,
           locale: 'fr-fr',
+          embedUrl: null,
         }),
       ]);
     });

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -289,6 +289,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
       databaseBuilder.factory.buildLocalizedChallenge({
         id,
         challengeId: 'challengeId',
+        embedUrl: 'mon-url.com',
         locale: 'bz',
       });
       await databaseBuilder.commit();
@@ -300,6 +301,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
       expect(localizedChallenge).to.deep.equal(domainBuilder.buildLocalizedChallenge({
         id,
         challengeId: 'challengeId',
+        embedUrl: 'mon-url.com',
         locale: 'bz',
       }));
     });
@@ -319,12 +321,13 @@ describe('Integration | Repository | localized-challenge-repository', function()
   });
 
   context('#update', () => {
-    it('should change localized challenge locale', async () => {
+    it('should change localized challenge locale and embedUrl', async () => {
       // given
       const id = 'localizedChallengeId';
       databaseBuilder.factory.buildLocalizedChallenge({
         id,
         challengeId: 'challengeId',
+        embedUrl: "my-url.html",
         locale: 'bz',
       });
       await databaseBuilder.commit();
@@ -332,6 +335,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
       const localizedChallenge = domainBuilder.buildLocalizedChallenge({
         id,
         challengeId: 'differentChallengeId should not be updated',
+        embedUrl: 'my-new-url.html',
         locale: 'ar',
       });
 
@@ -343,6 +347,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         {
           id,
           challengeId: 'challengeId',
+          embedUrl: 'my-new-url.html',
           locale: 'ar',
         },
       ]);

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -327,7 +327,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
       databaseBuilder.factory.buildLocalizedChallenge({
         id,
         challengeId: 'challengeId',
-        embedUrl: "my-url.html",
+        embedUrl: 'my-url.html',
         locale: 'bz',
       });
       await databaseBuilder.commit();

--- a/api/tests/scripts/fill-localized-challenge-embed-url_test.js
+++ b/api/tests/scripts/fill-localized-challenge-embed-url_test.js
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import Airtable from 'airtable';
 import nock from 'nock';
 import { knex, databaseBuilder } from '../test-helper.js';
@@ -8,12 +8,6 @@ describe('Fill `embedUrl` localized challenges from airtable', function() {
   let airtableClient;
 
   beforeEach(() => {
-    nock('https://api.airtable.com')
-      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
-      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-      .optionally()
-      .reply(404);
-
     airtableClient = new Airtable({
       apiKey: 'airtableApiKeyValue',
     }).base('airtableBaseValue');
@@ -52,7 +46,8 @@ describe('Fill `embedUrl` localized challenges from airtable', function() {
             'id persistant',
             'Embed URL',
           ]
-        }
+        },
+        filterByFormula: 'NOT({Embed URL} = \'\')'
       })
       .reply(200, { records: [challenge1] });
 

--- a/api/tests/scripts/fill-localized-challenge-embed-url_test.js
+++ b/api/tests/scripts/fill-localized-challenge-embed-url_test.js
@@ -1,0 +1,80 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import Airtable from 'airtable';
+import nock from 'nock';
+import { knex, databaseBuilder } from '../test-helper.js';
+import { fillLocalizedChallengesEmbedUrl } from '../../scripts/fill-localized-challenge-embed-url';
+
+describe('Fill `embedUrl` localized challenges from airtable', function() {
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  it('should fill `embedUrl` localized challenges from airtable ', async () => {
+    // given
+    const challenge1 = {
+      id: 'airtableChallengeId',
+      fields: {
+        'id persistant': 'challengeid1',
+        'Embed URL': 'my-embed-url-challengeid1',
+      }
+    };
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid1',
+      challengeId: 'challengeid1',
+      embedUrl: '',
+    });
+
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid2',
+      challengeId: 'challengeid1',
+      locale: 'nl',
+      embedUrl: '',
+    });
+
+    await databaseBuilder.commit();
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Epreuves')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query({
+        fields: {
+          '': [
+            'id persistant',
+            'Embed URL',
+          ]
+        }
+      })
+      .reply(200, { records: [challenge1] });
+
+    // when
+    await fillLocalizedChallengesEmbedUrl({ airtableClient });
+
+    // then
+    const localizedChallenges = await knex('localized_challenges').select('id', 'locale', 'challengeId', 'embedUrl').orderBy('id');
+
+    expect(localizedChallenges).to.deep.equal([
+      {
+        id: 'challengeid1',
+        challengeId: 'challengeid1',
+        locale: 'fr',
+        embedUrl: 'my-embed-url-challengeid1',
+      },
+      {
+        id: 'challengeid2',
+        challengeId: 'challengeid1',
+        locale: 'nl',
+        embedUrl: '',
+      },
+    ]);
+  });
+});

--- a/api/tests/scripts/fill-localized-challenges_test.js
+++ b/api/tests/scripts/fill-localized-challenges_test.js
@@ -63,7 +63,7 @@ describe('Fill localized challenges from airtable', function() {
     await fillLocalizedChallenges({ airtableClient });
 
     // then
-    const localizedChallenges = await knex('localized_challenges').select().orderBy([{
+    const localizedChallenges = await knex('localized_challenges').select('id', 'challengeId', 'locale').orderBy([{
       column: 'id',
       order: 'asc'
     }, { column: 'locale', order: 'asc' }]);

--- a/api/tests/tooling/database-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-challenge.js
@@ -4,9 +4,10 @@ export function buildLocalizedChallenge({
   id = 'i18nChallenge123',
   challengeId = 'challenge123',
   locale = 'fr',
+  embedUrl,
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'localized_challenges',
-    values: { id, challengeId, locale },
+    values: { id, challengeId, locale, embedUrl },
   });
 }

--- a/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
@@ -4,10 +4,12 @@ export function buildLocalizedChallenge({
   id = 'persistant id',
   challengeId = 'persistant id',
   locale = 'fr',
+  embedUrl = 'https://site.com/embed.html',
 }) {
   return new LocalizedChallenge({
     id,
     challengeId,
     locale,
+    embedUrl,
   });
 }


### PR DESCRIPTION
## :christmas_tree: Problème

L'embed url était portée jusque là par l'épreuve. On a maintenant une table `localized_challenges` dans laquelle on voudrait déplacer ce champ pour pouvoir personnaliser par locale a terme. 

## :gift: Proposition
Ecrire la propriété `embedUrl` de Challenge dans LocalizedChallenge en plus de airtable.
Copier les données depuis airtable avec un script.

## :socks: Remarques
N/A

## :santa: Pour tester
- Lancer le script: `node api/scripts/fill-localized-challenge-embed-url/` et compter le nombre d'épreuves avec embed url entre airtable et la table localized_challenge
- Créer une épreuve avec un embedUrl et vérifier que son localizedChallenge associé a bien un embedUrl rempli.
- Modifier une épreuve avec un embedUrl et vérifier que son localizedChallenge associé a bien un embedUrl modifié.

