### PR TITLE
[FEATURE] Ajoute la langue "nl" dans les tutoriels (PIX-10167).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { LOCALE_TO_LANGUAGE_MAP } from './domain/constants.js';
+import { LOCALE_TO_LANGUAGE_MAP, TUTORIAL_LOCALE_TO_LANGUAGE_MAP } from './domain/constants.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -53,7 +53,7 @@ export const pixApp = {
   baseUrl: process.env.PIX_APP_BASEURL
 };
 
-export let pixEditor = {
+export const pixEditor = {
   airtableUrl: process.env.AIRTABLE_URL,
   airtableBase: process.env.AIRTABLE_BASE,
   tableChallenges: process.env.TABLE_CHALLENGES,
@@ -62,6 +62,7 @@ export let pixEditor = {
   storagePost: process.env.STORAGE_POST,
   storageBucket: process.env.STORAGE_BUCKET,
   localeToLanguageMap: LOCALE_TO_LANGUAGE_MAP,
+  tutorialLocaleToLanguageMap: TUTORIAL_LOCALE_TO_LANGUAGE_MAP,
 };
 
 export let storage = {
@@ -126,15 +127,6 @@ if (process.env.NODE_ENV === 'test') {
   };
 
   pixApp.baseUrl = 'https://app.test.pix.fr';
-
-  pixEditor = {
-    airtableUrl: 'airtableUrlValue',
-    tableChallenges: 'tableChallengesValue',
-    tableSkills: 'tableSkillsValue',
-    tableTubes: 'tableTubesValue',
-    storagePost: 'storagePostValue',
-    storageBucket: 'storageBucketValue',
-  };
 
   storage = {
     authUrl: 'https://storage.auth.example.net/api/auth',

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -6,6 +6,7 @@ export const LOCALE = {
   DEUTSCH_SPOKEN: 'de',
   PORTUGUESE_SPOKEN: 'pt',
   SPANISH_SPOKEN: 'es',
+  DUTCH_SPOKEN: 'nl',
 };
 
 export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
@@ -16,4 +17,10 @@ export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
   [LOCALE.ITALIAN_SPOKEN]: 'Italie',
   [LOCALE.SPANISH_SPOKEN]: 'Espagnol',
   [LOCALE.PORTUGUESE_SPOKEN]: 'Portugais',
+});
+
+export const TUTORIAL_LOCALE_TO_LANGUAGE_MAP = Object.freeze({
+  [LOCALE.ENGLISH_SPOKEN]: 'Anglais',
+  [LOCALE.FRENCH_SPOKEN]: 'Français',
+  [LOCALE.DUTCH_SPOKEN]: 'Néerlandais',
 });

--- a/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
@@ -10,13 +10,9 @@ const serializer = new Serializer('config', {
     'tableSkills',
     'tableTubes',
     'storagePost',
-    'storageTenant',
-    'storageUser',
-    'storagePassword',
-    'storageKey',
-    'storageAuth',
     'storageBucket',
     'localeToLanguageMap',
+    'tutorialLocaleToLanguageMap',
   ],
 });
 

--- a/api/tests/acceptance/application/config/config-controller_test.js
+++ b/api/tests/acceptance/application/config/config-controller_test.js
@@ -1,6 +1,7 @@
-import { beforeEach, describe, describe as context, expect, it } from 'vitest';
+import { beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
+import * as config from '../../../../lib/config.js';
 
 describe('Acceptance | Controller | config', () => {
 
@@ -30,6 +31,17 @@ describe('Acceptance | Controller | config', () => {
 
       it('should return config', async () => {
         // Given
+        vi.spyOn(config, 'pixEditor', 'get').mockReturnValue({
+          'airtableUrl': 'airtableUrlValue',
+          'tableChallenges': 'tableChallengesValue',
+          'tableSkills': 'tableSkillsValue',
+          'tableTubes': 'tableTubesValue',
+          'storagePost': 'storagePostValue',
+          'storageBucket': 'storageBucketValue',
+          'localeToLanguageMap': 'localeToLanguageMap',
+          'tutorialLocaleToLanguageMap': 'tutorialLocaleToLanguageMap',
+        });
+
         const expectedConfig = {
           data: {
             type: 'configs',
@@ -40,6 +52,8 @@ describe('Acceptance | Controller | config', () => {
               'table-tubes': 'tableTubesValue',
               'storage-post': 'storagePostValue',
               'storage-bucket': 'storageBucketValue',
+              'locale-to-language-map': 'localeToLanguageMap',
+              'tutorial-locale-to-language-map': 'tutorialLocaleToLanguageMap',
             },
           }
         };

--- a/pix-editor/app/components/form/tutorial.hbs
+++ b/pix-editor/app/components/form/tutorial.hbs
@@ -4,8 +4,8 @@
       <label for="title_tutorial">Titre *</label>
       <Input id="title_tutorial" @type="text" @value={{@tutorial.title}} placeholder="Titre" />
     </div>
-    <div class="four wide field">
-      <Field::Select @title="Langue *" @defaultText="Langue" @value={{this.tutorialLanguage}} @options={{this.options.language}} @edition={{true}} @setValue={{this.setTutorialLanguage}}/>
+    <div class="six wide field">
+      <Field::Select @title="Langue *" @defaultText="Langue" @value={{this.tutorialLanguage}} @options={{this.tutorialLanguageOptions}} @edition={{true}} @setValue={{this.setTutorialLanguage}}/>
     </div>
   </div>
   <div class="three fields">

--- a/pix-editor/app/components/form/tutorial.js
+++ b/pix-editor/app/components/form/tutorial.js
@@ -4,11 +4,11 @@ import { inject as service } from '@ember/service';
 
 export default class TutorialForm extends Component {
 
+  @service config;
   @service store;
   @service idGenerator;
 
   options = {
-    'language': [{ value:'en-us',label:'Anglais' }, { value:'fr-fr',label:'Français' }],
     'format': ['audio', 'frise', 'image', 'jeu', 'outil', 'page', 'pdf', 'site', 'slide', 'son', 'vidéo'],
     'level': ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
     'license': ['CC-BY-SA', '(c)', 'Youtube']
@@ -19,7 +19,11 @@ export default class TutorialForm extends Component {
   }
 
   get tutorialLanguage() {
-    return this.options.language.find(language=>language.value === this.args.tutorial.language);
+    return this.config.tutorialLocaleToLanguageMap[this.args.tutorial.language];
+  }
+
+  get tutorialLanguageOptions() {
+    return Object.entries(this.config.tutorialLocaleToLanguageMap).map(([value, label]) => ({ value, label }));
   }
 
   @action

--- a/pix-editor/app/models/config.js
+++ b/pix-editor/app/models/config.js
@@ -9,4 +9,5 @@ export default class ConfigModel extends Model {
   @attr storagePost;
   @attr storageBucket;
   @attr localeToLanguageMap;
+  @attr tutorialLocaleToLanguageMap;
 }

--- a/pix-editor/app/services/config.js
+++ b/pix-editor/app/services/config.js
@@ -17,6 +17,7 @@ export default class ConfigService extends Service {
   @tracked storagePost;
   @tracked storageBucket;
   @tracked localeToLanguageMap;
+  @tracked tutorialLocaleToLanguageMap;
 
   async load() {
     const currentUser = await this.store.queryRecord('user', { me: true });
@@ -32,6 +33,7 @@ export default class ConfigService extends Service {
     this.storagePost = config.storagePost;
     this.storageBucket = config.storageBucket;
     this.localeToLanguageMap = config.localeToLanguageMap;
+    this.tutorialLocaleToLanguageMap = config.tutorialLocaleToLanguageMap;
     this.intl.setLocale(['fr']);
 
     Sentry.setUser({ userName: this.author });

--- a/pix-editor/tests/integration/components/form/tutorial-test.js
+++ b/pix-editor/tests/integration/components/form/tutorial-test.js
@@ -1,21 +1,29 @@
 import { module, test } from 'qunit';
+import Service from '@ember/service';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | tutorial-form', function(hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('it renders tutorial languages from config', async function(assert) {
+    class ConfigService extends Service {
+      get tutorialLocaleToLanguageMap() {
+        return {
+          lang: 'Première langue',
+          otherLang: 'Autre Langue',
+        };
+      }
+    }
+    this.owner.register('service:config', ConfigService);
 
-    this.set('tutorial', { license:false, format:false, level:false });
+    this.set('tutorial', { license: false, format: false, level: false });
 
-    await render(hbs`<Form::Tutorial @tutorial={{this.tutorial}} />`);
+    const screen = await render(hbs`<Form::Tutorial @tutorial={{this.tutorial}} />`);
 
-    assert.dom('.ui.form').exists();
-
-
+    await clickByName('Langue');
+    assert.ok(screen.getByRole('listbox', { option: 'Première Langue' }));
+    assert.ok(screen.getByRole('listbox', { option: 'Autre Langue' }));
   });
 });

--- a/pix-editor/tests/integration/components/pop-in/tutorial-test.js
+++ b/pix-editor/tests/integration/components/pop-in/tutorial-test.js
@@ -6,6 +6,13 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | pop-in/tutorial', function(hooks) {
   setupIntlRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    const configService = this.owner.lookup('service:config');
+    configService.tutorialLocaleToLanguageMap = {
+      lang: 'Première langue',
+    };
+  });
+
   test('save input should be disabled if mandatory field are empty', async function(assert) {
     //given
     this.set('close', () => {});
@@ -21,8 +28,8 @@ module('Integration | Component | pop-in/tutorial', function(hooks) {
       level:'',
       tags:[]
     });
-    //when
 
+    //when
     await render(hbs`<PopIn::Tutorial @close={{this.close}} @tutorial={{this.tutorial}} @saveTutorial={{this.saveTutorial}}/>`);
 
     //then


### PR DESCRIPTION
## :christmas_tree: Problème

Dans Pix Editor, il n'est pas possible de spécifier qu'un tutoriel est en langue néerlandaise.

## :gift: Proposition

On crée une configuration spécifique aux langues des tutoriels et on expose cette configuration dans la route de config.
On modifie le composant de formulaire qui affiche et permet la modification d'un tutoriel pour que le sélecteur de langue se base sur cette configuration.

## :socks: Remarques

Le champ `Langues` de la table `Tutoriels` de `Airtable` a été modifié pour accepter tout type de string.

## :santa: Pour tester

Se rendre sur un acquis.
Cliquer sur modifier.
Dans la section _Pour en savoir plus_ ou la section _Pour réussir la prochaine fois_, ajouter un tutoriel.
Vérifier que la liste déroulante des langues propose le néerlandais, en plus du français et de l'anglais.
