### PR TITLE
[REFACTOR] Ajout du bandeau sur la page de version d'un challenge (PIX-10534)

### DIFF
--- a/pix-editor/app/components/competence/prototypes/challenge-header.hbs
+++ b/pix-editor/app/components/competence/prototypes/challenge-header.hbs
@@ -1,0 +1,18 @@
+<div class={{concat "challenge-header " @class}}>
+  <div class="ui menu">
+    <div class="ui left menu">
+     {{yield to="actions"}}
+    </div>
+    <div class="item header">
+      {{yield}}
+    </div>
+    <div class="ui right menu">
+      {{#if @maximized}}
+        <button class="ui icon button item" {{on "click" @minimize}} type="button"><i class="window minimize icon"></i></button>
+      {{else}}
+        <button class="ui icon button item" {{on "click" @maximize}} type="button"><i class="window maximize outline icon"></i></button>
+      {{/if}}
+      <button class="ui icon button item" {{on "click" @close}} type="button"><i class="icon window close"></i></button>
+    </div>
+  </div>
+</div>

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -1,18 +1,74 @@
-import Controller from '@ember/controller';
+import Controller, { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class LocalizedController extends Controller {
+
+  @service router;
+
+  @controller('authenticated.competence') competenceController;
+  @controller('authenticated.competence.prototypes.single.alternatives') alternativesController;
 
   get previewUrl() {
     return new URL(`${this.model.challenge.get('preview')}?locale=${this.model.locale}`, window.location).href;
   }
 
   get challengeRoute() {
-    return this.model.challenge.get('isPrototype') ? 'authenticated.competence.prototypes.single' : 'authenticated.competence.prototypes.single.alternatives.single';
+    return this.isPrototype ? 'authenticated.competence.prototypes.single' : 'authenticated.competence.prototypes.single.alternatives.single';
   }
 
   get challengeModels() {
-    return this.model.challenge.get('isPrototype')
+    return this.isPrototype
       ? [this.model.challenge]
       : [this.model.challenge.get('relatedPrototype'), this.model.challenge];
+  }
+
+  get isPrototype() {
+    return this.model.challenge.get('isPrototype');
+  }
+
+  get prototypeMaximized() {
+    return this.competenceController.leftMaximized;
+  }
+
+  get alternativeMaximized() {
+    return this.alternativesController.rightMaximized;
+  }
+
+  get maximized() {
+    return this.isPrototype ? this.prototypeMaximized : this.alternativeMaximized;
+  }
+
+  @action maximize() {
+    if (this.isPrototype) {
+      this.competenceController.maximizeLeft(true);
+    } else {
+      this.alternativesController.maximizeRight(true);
+    }
+  }
+
+  @action minimize() {
+    if (this.isPrototype) {
+      this.competenceController.maximizeLeft(false);
+    } else {
+      this.alternativesController.maximizeRight(false);
+    }
+  }
+
+  @action close() {
+    if (this.isPrototype) {
+      this.router.transitionTo(
+        'authenticated.competence.prototypes',
+        this.competenceController.competence,
+        { queryParams: { leftMaximized: false } },
+      );
+    } else {
+      this.router.transitionTo(
+        'authenticated.competence.prototypes.single.alternatives',
+        this.competenceController.competence,
+        this.alternativesController.challenge,
+        { queryParams: { rightMaximized: false } },
+      );
+    }
   }
 }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -23,6 +23,12 @@ export default class LocalizedController extends Controller {
       : [this.model.challenge.get('relatedPrototype'), this.model.challenge];
   }
 
+  get challengeTitle() {
+    return this.isPrototype
+      ? this.model.challenge.get('skillName')
+      : `Déclinaison n°${this.model.challenge.get('alternativeVersion')}`;
+  }
+
   get isPrototype() {
     return this.model.challenge.get('isPrototype');
   }

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -7,6 +7,7 @@
 >
   <:default>
     <i class="{{convert-language-as-flag this.model.locale}} flag" title={{this.model.locale}}></i>
+    {{this.challengeTitle}}
   </:default>
 </Competence::Prototypes::ChallengeHeader>
 <div class="challenge">
@@ -23,7 +24,7 @@
   <div class="ui vertical compact labeled icon menu challenge-menu">
     <a class="ui button item" href={{this.previewUrl}} target="_blank" rel="noopener noreferrer">
       <i class="eye icon"></i>
-      Prévisualiser {{ this.model.locale }}
+      Prévisualiser
     </a>
     <Buttons::CopyLink @link={{this.previewUrl}} />
     <LinkTo @route={{this.challengeRoute}} @models={{this.challengeModels}} class="ui button item">

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -1,3 +1,14 @@
+<Competence::Prototypes::ChallengeHeader
+  @class=""
+  @maximized={{this.maximized}}
+  @minimize={{this.minimize}}
+  @maximize={{this.maximize}}
+  @close={{this.close}}
+>
+  <:default>
+    <i class="{{convert-language-as-flag this.model.locale}} flag" title={{this.model.locale}}></i>
+  </:default>
+</Competence::Prototypes::ChallengeHeader>
 <div class="challenge">
   <div class="challenge-data {{this.elementClass}}" {{scroll-top false}}>
     <form action="" class="ui form">

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -1,35 +1,40 @@
-<div class={{concat "challenge-header " this.challenge.statusCSS}}>
-  <div class="ui menu">
-      <div class="ui left menu">
+<Competence::Prototypes::ChallengeHeader
+  @class={{this.challenge.statusCSS}}
+  @maximized={{this.maximized}}
+  @minimize={{this.minimize}}
+  @maximize={{this.maximize}}
+  @close={{this.close}}
+>
+  <:actions>
     {{#if this.mayAccessLog}}
-        <button class="ui button icon item" {{on "click" this.challengeLog}} type="button"><i class="icon window chat"></i></button>
+      <button class="ui button icon item" {{on "click" this.challengeLog}} type="button"><i class="icon window chat"></i></button>
     {{/if}}
     {{#unless this.edition}}
       {{#if (and this.challenge.isPrototype (not this.challenge.isWorkbench))}}
-          <button class="ui button icon item" {{on "click" this.showVersions}} type="button"><i class="clone icon"></i>&nbsp;v{{this.challenge.version}}</button>
+        <button class="ui button icon item" {{on "click" this.showVersions}} type="button"><i class="clone icon"></i>&nbsp;v{{this.challenge.version}}</button>
       {{/if}}
       {{#if (or this.mayValidate this.mayArchive this.mayObsolete)}}
-        <BasicDropdown @id="testdd" @renderInPlace={{true}} @class="icon ui dropdown " @horizontalPosition="left" as |dd|>
+        <BasicDropdown @renderInPlace={{true}} @class="icon ui dropdown" @horizontalPosition="left" as |dd|>
           <dd.Trigger><button class="ui icon button item" type="button"><i class="bolt icon"></i></button></dd.Trigger>
           <dd.Content @class="dropdown-content dropdown-content-challenge slide-fade">
-              {{#if this.mayValidate}}
-                <button class="ui button validate item"  {{on "click" (fn this.validate dd)}} type="button">
-                  <i class="checkmark icon"></i>
-                  {{t 'common.validate'}}
-                </button>
-              {{/if}}
-              {{#if this.mayArchive}}
-                <button class="ui button archive item"  {{on "click" (fn this.archive dd)}} type="button">
-                  <i class="archive icon"></i>
-                  {{t 'competence.prototypes.archive'}}
-                </button>
-              {{/if}}
-              {{#if this.mayObsolete}}
+            {{#if this.mayValidate}}
+              <button class="ui button validate item"  {{on "click" (fn this.validate dd)}} type="button">
+                <i class="checkmark icon"></i>
+                {{t 'common.validate'}}
+              </button>
+            {{/if}}
+            {{#if this.mayArchive}}
+              <button class="ui button archive item"  {{on "click" (fn this.archive dd)}} type="button">
+                <i class="archive icon"></i>
+                {{t 'competence.prototypes.archive'}}
+              </button>
+            {{/if}}
+            {{#if this.mayObsolete}}
               <button class="ui button archive item"  {{on "click" (fn this.obsolete dd)}} type="button">
-                  <i class="trash alternate icon"></i>
-                  {{t 'competence.prototypes.obsolete'}}
-                </button>
-              {{/if}}
+                <i class="trash alternate icon"></i>
+                {{t 'competence.prototypes.obsolete'}}
+              </button>
+            {{/if}}
           </dd.Content>
         </BasicDropdown>
       {{/if}}
@@ -37,24 +42,17 @@
         <button data-test-move-button class="ui icon button item" {{on "click" this.movePrototype}} type="button"><i class="icon random"></i></button>
       {{/if}}
     {{/unless}}
-      </div>
-    <div class={{concat "item header" (if this.creation " creation" "")}}>
+  </:actions>
+  <:default>
+    <div class={{(if this.creation " creation" "")}}>
       {{this.challengeTitle}}
-      <div class="ui circular label {{this.challenge.statusCSS}}">{{this.challenge.status}}</div>
-      {{#unless this.challenge.isNew}}
-        <time class="ui colored label" title="Dernière modification" datetime="{{this.lastUpdatedAtISO}}">{{format-date this.challenge.updatedAt}}</time>
-      {{/unless}}
     </div>
-    <div class="ui right menu">
-      {{#if this.maximized}}
-        <button class="ui icon button item" {{on "click" this.minimize}} type="button"><i class="window minimize icon"></i></button>
-      {{else}}
-        <button class="ui icon button item" {{on "click" this.maximize}} type="button"><i class="window maximize outline icon"></i></button>
-      {{/if}}
-      <button class="ui icon button item" {{on "click" this.close}} type="button"><i class="icon window close"></i></button>
-    </div>
-  </div>
-</div>
+    <div class="ui circular label {{this.challenge.statusCSS}}">{{this.challenge.status}}</div>
+    {{#unless this.challenge.isNew}}
+      <time class="ui colored label" title="Dernière modification" datetime="{{this.lastUpdatedAtISO}}">{{format-date this.challenge.updatedAt}}</time>
+    {{/unless}}
+  </:default>
+</Competence::Prototypes::ChallengeHeader>
 <div class="challenge">
   <div class="challenge-data {{this.elementClass}}" {{scroll-top this.edition}}>
     <Form::Challenge @challenge={{this.challenge}}

--- a/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
@@ -35,7 +35,7 @@ module('Acceptance | Controller | Get Localized Challenge', function(hooks) {
     const embedUrlInput = await screen.getByRole('textbox', { name: 'Embed URL :' });
     assert.deepEqual(embedUrlInput.value, 'https://my-embed.com/en.html');
 
-    const link = await screen.findByText('Prévisualiser en');
+    const link = await screen.findByText('Prévisualiser');
     assert.ok(link.getAttribute('href').endsWith('/preview?locale=en'), 'href ends with /preview?locale=en');
   });
 
@@ -47,7 +47,6 @@ module('Acceptance | Controller | Get Localized Challenge', function(hooks) {
     await click(findAll('[data-test-skill-cell-link]')[0]);
     await click(screen.getByText('Version en'));
 
-    await clickByText('Prévisualiser en');
     await clickByText('Version originale');
     assert.dom(screen.getByText('Version en')).exists();
   });


### PR DESCRIPTION
## :christmas_tree: Problème
On a pas le bandeau de l'acquis/déclinaison quand on est sur la version nl d'un challenge.

## :gift: Proposition
Ajouter le bandeau.

## :socks: Remarques
N/A

## :santa: Pour tester
Aller sur la version nl d'un proto ou d'une décli.