### PR TITLE
[TECH] Monter la version de l'image postgresql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:14.6-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -47,7 +47,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
-      - image: postgres:14.6-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -61,7 +61,7 @@ executors:
         type: string
     docker:
       - image: mcr.microsoft.com/playwright:v<<parameters.playwright-version>>-focal
-      - image: postgres:14.6-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   postgres:
-    image: postgres:14.6-alpine
+    image: postgres:14.10-alpine
     ports:
       - "5444:5432"
     environment:


### PR DESCRIPTION
## :christmas_tree: Problème
Une nouvelle version des addons postgresql et redis est proposée par Scalingo et la montée de version va être effectuée. Cependant, les images docker sont encore sur les anciennes versions.

## :gift: Proposition
- Mettre à jour la version de l'image postgresql de la version 14.6 à la version 14.10
- La version de l'image redis est déjà à jour