### PR TITLE
[FEATURE] Permettre la modification de l'embed URL d'une épreuve nl (PIX-10365).

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -38,7 +38,7 @@ rules:
     - { max: 1, maxEOF: 1 }
   no-unused-vars:
     - 2
-    - { argsIgnorePattern: "_" }
+    - { argsIgnorePattern: "_", varsIgnorePattern: "_" }
   no-var:
     - 2
   object-curly-spacing:

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -47,7 +47,11 @@ export async function get({ id, transaction: knexConnection = knex }) {
 }
 
 export async function update({ localizedChallenge: { id, locale, embedUrl }, transaction: knexConnection = knex }) {
-  await knexConnection('localized_challenges').where('id', id).update({ locale, embedUrl });
+  const [dto] = await knexConnection('localized_challenges').where('id', id).update({ locale, embedUrl }).returning('*');
+
+  if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');
+
+  return _toDomain(dto);
 }
 
 function _toDomain(dto) {

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -25,9 +25,20 @@ export function serialize(localizedChallenge) {
 
 const deserializer = new Deserializer({
   keyForAttribute: 'camelCase',
+  challenges: {
+    valueForRelationship(challenge) {
+      return challenge.id;
+    },
+  },
+  transform: function({ challenge, embedUrl, ...localizedChallenge }) {
+    return new LocalizedChallenge({
+      ...localizedChallenge,
+      challengeId: challenge,
+      embedUrl: embedUrl === '' ? null : embedUrl,
+    });
+  }
 });
 
 export async function deserialize(localizedChallengeBody) {
-  const dto = await deserializer.deserialize(localizedChallengeBody);
-  return new LocalizedChallenge(dto);
+  return deserializer.deserialize(localizedChallengeBody);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -1,6 +1,7 @@
 import JsonapiSerializer from 'jsonapi-serializer';
+import { LocalizedChallenge } from '../../../domain/models/index.js';
 
-const { Serializer } = JsonapiSerializer;
+const { Serializer, Deserializer } = JsonapiSerializer;
 
 const serializer = new Serializer('localized-challenges', {
   attributes: [
@@ -20,4 +21,13 @@ export function serialize(localizedChallenge) {
     ...props,
     challenge: { id: challengeId },
   });
+}
+
+const deserializer = new Deserializer({
+  keyForAttribute: 'camelCase',
+});
+
+export async function deserialize(localizedChallengeBody) {
+  const dto = await deserializer.deserialize(localizedChallengeBody);
+  return new LocalizedChallenge(dto);
 }

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -96,5 +96,22 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
         embedUrl: 'https://cassoulet.com/',
       });
     });
+
+    it('should not update a challenge when i am a read-only user', async () => {
+      // Given
+      const readOnlyUser = databaseBuilder.factory.buildReadonlyUser();
+      await databaseBuilder.commit();
+      const server = await createServer();
+
+      // When
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/localized-challenges/123',
+        headers: generateAuthorizationHeader(readOnlyUser),
+        payload: {}
+      });
+      // Then
+      await expect(response.statusCode).to.equal(403);
+    });
   });
 });

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { databaseBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 
 describe('Acceptance | Controller | localized-challenges-controller', () => {
@@ -48,6 +48,53 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal(expectedLocalizedChallenges);
+    });
+  });
+
+  describe('PATCH /localized-challenges/{id}', () => {
+    it('should modify localized challenge of given ID', async () => {
+      // given
+      const user = databaseBuilder.factory.buildAdminUser();
+      const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
+        challengeId: 'recChallenge0',
+        id: 'localizedChallengeId',
+        locale: 'nl',
+        embedUrl: 'https://choucroute.com/',
+      });
+
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+      const patchLocalizedChallengeOptions = {
+        method: 'PATCH',
+        url: '/api/localized-challenges/localizedChallengeId',
+        headers: generateAuthorizationHeader(user),
+        payload: {
+          data: {
+            type: 'localized-challenges',
+            id: localizedChallenge.id,
+            attributes: {
+              'embed-url': 'https://cassoulet.com/',
+              locale: 'should-not-update',
+              'challenge-id': 'should-not-update',
+            },
+          },
+        },
+      };
+
+      // When
+      const response = await server.inject(patchLocalizedChallengeOptions);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+
+      const updatedLocalizedChallenge = await knex('localized_challenges').select().where({ id: localizedChallenge.id }).first();
+      expect(updatedLocalizedChallenge).to.deep.equal({
+        id: localizedChallenge.id,
+        challengeId: localizedChallenge.challengeId,
+        locale: 'nl',
+        embedUrl: 'https://cassoulet.com/',
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -358,7 +358,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
       });
 
       // when
-      await localizedChallengeRepository.update({ localizedChallenge });
+      const localizedUpdatedChallenge = await localizedChallengeRepository.update({ localizedChallenge });
 
       // then
       await expect(knex('localized_challenges').select()).resolves.to.deep.equal([
@@ -369,6 +369,14 @@ describe('Integration | Repository | localized-challenge-repository', function()
           locale: 'ar',
         },
       ]);
+
+      expect(localizedUpdatedChallenge).to.deep.equal(
+        domainBuilder.buildLocalizedChallenge({
+          id,
+          challengeId: 'challengeId',
+          embedUrl: 'my-new-url.html',
+          locale: 'ar'
+        }));
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../../test-helper.js';
+import { deserialize } from '../../../../../lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
+  describe('#deserialize', () => {
+    it('should deserialize a Localized Challenge', async () => {
+      // Given
+      const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({});
+      const json = {
+        data: {
+          type: 'localized-challenges',
+          id: `${expectedLocalizedChallenge.id}`,
+          attributes: {
+            'embed-url': expectedLocalizedChallenge.embedUrl,
+            locale: expectedLocalizedChallenge.locale,
+          },
+          relationships: {
+            challenge: {
+              data: {
+                type: 'challenges',
+                id: expectedLocalizedChallenge.challengeId,
+              },
+            },
+          },
+        },
+      };
+
+      // When
+      const localizedChallenge = await deserialize(json);
+
+      // Then
+      expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
+    });
+
+    it('should deserialize empty embed URL as null', async () => {
+      // Given
+      const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
+        embedUrl: null,
+      });
+      const json = {
+        data: {
+          type: 'localized-challenges',
+          id: `${expectedLocalizedChallenge.id}`,
+          attributes: {
+            'embed-url': '',
+            locale: expectedLocalizedChallenge.locale,
+          },
+          relationships: {
+            challenge: {
+              data: {
+                type: 'challenges',
+                id: expectedLocalizedChallenge.challengeId,
+              },
+            },
+          },
+        },
+      };
+
+      // When
+      const localizedChallenge = await deserialize(json);
+
+      // Then
+      expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
+    });
+  });
+});

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -53,9 +53,7 @@ export default class LocalizedController extends Controller {
   }
 
   get mayEdit() {
-    // model.challenge is a proxy object, thus we passed the content prop
-    // to access service
-    return this.access.mayEdit(this.model.challenge.content);
+    return this.access.mayEdit(this.model.challenge);
   }
 
   @action edit() {

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -88,9 +88,9 @@ export default class AccessService extends Service {
 
   mayEdit(challenge) {
     const level = this.config.accessLevel;
-    const production = challenge.isValidated;
-    const obsolete = challenge.isObsolete;
-    const prototype = challenge.isPrototype;
+    const production = challenge.get('isValidated');
+    const obsolete = challenge.get('isObsolete');
+    const prototype = challenge.get('isPrototype');
     if (obsolete) {
       return false;
     }

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -16,20 +16,37 @@
       <Field::Input
         @label="Embed URL"
         @value={{this.model.embedURL}}
-        @edition={{false}}
+        @edition={{this.edition}}
         @placeholder="Url de l'embed"
       />
     </form>
   </div>
   <div class="ui vertical compact labeled icon menu challenge-menu">
-    <a class="ui button item" href={{this.previewUrl}} target="_blank" rel="noopener noreferrer">
-      <i class="eye icon"></i>
-      Prévisualiser
-    </a>
-    <Buttons::CopyLink @link={{this.previewUrl}} />
-    <LinkTo @route={{this.challengeRoute}} @models={{this.challengeModels}} class="ui button item">
-      <i class="globe icon"></i>
-      Version originale
-    </LinkTo>
+    {{#if this.edition}}
+      <button class="ui button item important-action" {{on "click" this.save}} type="button">
+        <i class="save icon"></i>
+        Enregistrer
+      </button>
+      <button class="ui button item" {{on "click" this.cancelEdit}} type="button">
+        <i class="ban icon"></i>
+        Annuler
+      </button>
+    {{else}}
+      <a class="ui button item" href={{this.previewUrl}} target="_blank" rel="noopener noreferrer">
+        <i class="eye icon"></i>
+        Prévisualiser
+      </a>
+      <Buttons::CopyLink @link={{this.previewUrl}} />
+      <LinkTo @route={{this.challengeRoute}} @models={{this.challengeModels}} class="ui button item">
+        <i class="globe icon"></i>
+        Version originale
+      </LinkTo>
+      {{#if this.mayEdit}}
+        <button class="ui button item" {{on "click" this.edit}} type="button">
+          <i class="edit icon"></i>
+          Modifier
+        </button>
+      {{/if}}
+    {{/if}}
   </div>
 </div>

--- a/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
@@ -1,0 +1,96 @@
+import { module, test } from 'qunit';
+import Service from '@ember/service';
+import sinon from 'sinon';
+import EmberObject from '@ember/object';
+import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
+
+module('Unit | Controller | competence/prototypes/localized', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let controller, messageStub, startStub, stopStub, errorStub;
+
+  hooks.beforeEach(function () {
+    //given
+    controller = this.owner.lookup('controller:authenticated.competence/prototypes/localized');
+
+    startStub = sinon.stub();
+    stopStub = sinon.stub();
+    class LoaderService extends Service {
+      start = startStub;
+      stop = stopStub;
+    }
+    this.owner.register('service:loader', LoaderService);
+
+    errorStub = sinon.stub();
+    messageStub = sinon.stub();
+    class NotifyService extends Service {
+      error = errorStub;
+      message = messageStub;
+    }
+    this.owner.register('service:notify', NotifyService);
+  });
+
+  module('It should save localized challenge', function(hooks) {
+    let handleIllustrationStub, handleAttachmentStub, localizedChallenge;
+
+    hooks.beforeEach(function () {
+
+      localizedChallenge = {
+        id: 'rec123456',
+        save: sinon.stub().resolves(localizedChallenge),
+      };
+      controller.model = localizedChallenge;
+
+      handleIllustrationStub = sinon.stub().resolves(localizedChallenge);
+      controller._handleIllustration = handleIllustrationStub;
+
+      handleAttachmentStub = sinon.stub().resolves(localizedChallenge);
+      controller._handleAttachments = handleAttachmentStub;
+
+      controller.wasMaximized = true;
+    });
+
+    test('it should call handler with appropriate args', async function(assert) {
+      // when
+      await controller.save();
+
+      // then
+      assert.ok(startStub.calledOnce);
+      assert.ok(localizedChallenge.save.calledOnce);
+      assert.ok(messageStub.calledWith('Épreuve mise à jour'));
+      assert.ok(stopStub.calledOnce);
+
+    });
+
+    test('it should reinitialize edition',  async function(assert) {
+      // given
+      controller.edition = true;
+
+      // when
+      await controller.save();
+
+      // then
+      assert.notOk(controller.edition);
+    });
+  });
+
+  test('it should cancel edition', async function(assert) {
+    // given
+    controller.edition = true;
+    controller.wasMaximized = true;
+    const rollbackAttributesStub = sinon.stub();
+    const localizedChallenge = EmberObject.create({
+      id: 'recChallenge',
+      rollbackAttributes: rollbackAttributesStub
+    });
+    controller.model = localizedChallenge;
+
+    // when
+    await controller.cancelEdit();
+
+    // then
+    assert.notOk(controller.edition);
+    assert.ok(rollbackAttributesStub.calledOnce);
+    assert.ok(messageStub.calledWith('Modification annulée'));
+  });
+
+});

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
+import EmberObject from '@ember/object';
 
 module('Unit | Service | access', function(hooks) {
   setupTest(hooks);
@@ -28,12 +29,12 @@ module('Unit | Service | access', function(hooks) {
   module('mayEdit', function() {
 
     test('it should return `false` if challenge is obsolete', function (assert) {
-      //given
-      const challenge = {
+      // given
+      const challenge = EmberObject.create({
         id: 'rec123656',
         name: 'deletedChallenge',
         isObsolete: true
-      };
+      });
 
       //when
       const accessResult = accessService.mayEdit(challenge);
@@ -45,17 +46,17 @@ module('Unit | Service | access', function(hooks) {
     module('#liveChallenge', function(hooks) {
       let validatedChallenge, archivedChallenge;
       hooks.beforeEach(function () {
-        validatedChallenge = {
+        validatedChallenge = EmberObject.create({
           id: 'recChallenge1',
           name: 'challenge',
           isValidated: true,
-        };
+        });
 
-        archivedChallenge = {
+        archivedChallenge = EmberObject.create({
           id: 'recChallenge2',
           name: 'challenge',
           isArchived: true,
-        };
+        });
       });
       test('it should return `true` if challenge is live and level is `EDITOR`', function (assert) {
         //when
@@ -78,20 +79,20 @@ module('Unit | Service | access', function(hooks) {
 
     test('it should return `true` when level is `REPLICATOR` only if challenge is not in production and is not a prototype', function (assert) {
       //given
-      const validatedChallenge = {
+      const validatedChallenge = EmberObject.create({
         id: 'rec123655',
         name: 'validatedChallenge',
         isValidated: true,
-      };
-      const prototypeChallenge = {
+      });
+      const prototypeChallenge = EmberObject.create({
         id: 'rec123656',
         name: 'prototypeChallenge',
         isPrototype: true,
-      };
-      const challenge = {
+      });
+      const challenge = EmberObject.create({
         id: 'rec123657',
         name: 'challenge',
-      };
+      });
 
       //when
       _stubAccessLevel(REPLICATOR, this.owner);


### PR DESCRIPTION
## :christmas_tree: Problème

L'embed URL d'une épreuve est spécifique à chaque locale mais il n'est pas possible de la modifiée via Pix Editor.

## :gift: Proposition

Permettre la modification de cette URL via Pix Editor.

## :socks: Remarques

RAS

## :santa: Pour tester

Se connecter à la review app.
Aller sur une épreuve.
Afficher la version NL.
Cliquer sur modifier.
Modifier l'URL.
Cliquer sur Enregistrer.
Vérifier que l'embed URL de la version NL est à jour.

Deuxième test :
Sur la même épreuve, vider l'URL de l'embed et Enregistrer.
Vérifier que dans la DB l'embed URL est `NULL` ou bien vérifier que dans la release on a bien l'embed URL par défaut.
