### PR TITLE
[FEATURE] Afficher l'identifiant de l'épreuve localisée (PIX-10604)

### DIFF
--- a/pix-editor/app/components/field/input.hbs
+++ b/pix-editor/app/components/field/input.hbs
@@ -2,8 +2,8 @@
   <p>{{@title}}</p>
   <div class="ui input">
     {{#if @label}}
-      <label class="label-input" for="input" >{{@label}} : </label>
+      <label class="label-input" for={{@id}} >{{@label}} : </label>
     {{/if}}
-    <Input id="input" @value={{@value}} placeholder={{@placeholder}} readonly={{not @edition}} />
+    <Input id={{@id}} @value={{@value}} placeholder={{@placeholder}} readonly={{not @edition}} />
   </div>
 </div>

--- a/pix-editor/app/components/field/textarea.hbs
+++ b/pix-editor/app/components/field/textarea.hbs
@@ -1,18 +1,24 @@
 <div class={{concat "field textArea" (if @edition "" " disabled") (if this.maximized " maximized" "")}} ...attributes>
-    <label for="textarea">
-        {{#if @edition}}
-            <button {{on "click" this.toggleMaximized}} class={{concat "ui compact icon right floated button" (if this.maximized " primary" " basic")}} type="button"><i class={{concat (if this.maximized "compress " "expand ")  "icon"}}></i></button>
-            {{#if @helpContent}}
-            <div class="ui compact icon right floated button basic">
-              <i class="help icon">
-                <EmberTooltip @side="left-start" @tooltipClass="custom-tooltip">
-                  {{this.safeHelpContent}}
-                </EmberTooltip>
-              </i>
-            </div>
-            {{/if}}
-        {{/if}}
-        {{@title}}
-    </label>
-    <Textarea id="textarea" @value={{@value}} rows="4" readonly={{not @edition}} class="attached" />
+  <label for={{@id}}>
+    {{#if @edition}}
+      <button
+        {{on "click" this.toggleMaximized}}
+        class={{concat "ui compact icon right floated button" (if this.maximized " primary" " basic")}}
+        type="button"
+      >
+        <i class={{concat (if this.maximized "compress " "expand ")  "icon"}}></i>
+      </button>
+      {{#if @helpContent}}
+        <div class="ui compact icon right floated button basic">
+          <i class="help icon">
+            <EmberTooltip @side="left-start" @tooltipClass="custom-tooltip">
+              {{this.safeHelpContent}}
+            </EmberTooltip>
+          </i>
+        </div>
+      {{/if}}
+    {{/if}}
+    {{@title}}
+  </label>
+  <Textarea id={{@id}} @value={{@value}} rows="4" readonly={{not @edition}} class="attached" />
 </div>

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -70,6 +70,7 @@
     @edition={{@edition}}
     @helpContent={{this.helpAnswers}}
     data-test-answers-field
+    @id="challenge-solution"
   />
   {{#if (and @challenge.isTextBased (not this.isAutoReply))}}
     <div
@@ -118,6 +119,7 @@
       @value={{@challenge.solutionToDisplay}}
       @edition={{@edition}}
       data-test-solution-to-display-field
+      @id="challenge-solution-to-display"
     />
   </Field::ToggleField>
   <Field::Illustration
@@ -134,6 +136,7 @@
       @value={{@challenge.illustration.alt}}
       @title="Texte alternatif"
       @edition={{@edition}}
+      @id="challenge-illustration-alt"
     />
   {{/if}}
   <Field::Files

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -150,16 +150,19 @@
     @value={{@challenge.embedURL}}
     @edition={{@edition}}
     @label="URL"
+    @id="challenge-embed-url"
   />
   <Field::Input
     @value={{@challenge.embedHeight}}
     @edition={{@edition}}
     @label="Hauteur"
+    @id="challenge-embed-height"
   />
   <Field::Input
     @value={{@challenge.embedTitle}}
     @edition={{@edition}}
     @label="Titre"
+    @id="challenge-embed-title"
   />
   {{#if @challenge.isPrototype}}
     <Field::Select

--- a/pix-editor/app/components/form/skill.hbs
+++ b/pix-editor/app/components/form/skill.hbs
@@ -1,9 +1,36 @@
 <form action="" class="ui form">
-  <Field::Textarea @title="Description" @value={{@skill.description}} @edition={{@edition}} />
-  <Field::Select @title="Statut de la description" @value={{@skill.descriptionStatus}} @options={{this.options.descriptionStatus}} @edition={{@edition}} @setValue={{fn (mut @skill.descriptionStatus)}}/>
-  <Field::Textarea @title="Indice (fr)" @value={{@skill.clue}} @edition={{@edition}} />
-  <Field::Textarea @title="Indice (en)" @value={{@skill.clueEn}} @edition={{@edition}} />
-  <Field::Select @title="Statut de l'indice" @value={{@skill.clueStatus}} @options={{this.options.clueStatus}} @edition={{@edition}} @setValue={{fn (mut @skill.clueStatus)}}/>
+  <Field::Textarea
+    @title="Description"
+    @value={{@skill.description}}
+    @edition={{@edition}}
+    @id="skill-description"
+  />
+  <Field::Select
+    @title="Statut de la description"
+    @value={{@skill.descriptionStatus}}
+    @options={{this.options.descriptionStatus}}
+    @edition={{@edition}}
+    @setValue={{fn (mut @skill.descriptionStatus)}}
+  />
+  <Field::Textarea
+    @title="Indice (fr)"
+    @value={{@skill.clue}}
+    @edition={{@edition}}
+    @id="skill-clue-fr"
+  />
+  <Field::Textarea
+    @title="Indice (en)"
+    @value={{@skill.clueEn}}
+    @edition={{@edition}}
+    @id="skill-clue-en"
+  />
+  <Field::Select
+    @title="Statut de l'indice"
+    @value={{@skill.clueStatus}}
+    @options={{this.options.clueStatus}}
+    @edition={{@edition}}
+    @setValue={{fn (mut @skill.clueStatus)}}
+  />
   {{#if @skill.productionPrototype}}
     <Field::Quality @title="Qualité" @challenge={{@skill.productionPrototype}} @edition={{@edition}} />
   {{/if}}
@@ -23,7 +50,13 @@
     @searchClass="more"
     @addTutorial={{fn this.addTutorial @skill.tutoMore}}
     @removeTutorial={{fn this.removeTutorial @skill.tutoMore}}/>
-  <Field::Select @title="Internationalisation" @value={{@skill.i18n}} @options={{this.options.i18n}} @edition={{@edition}} @setValue={{fn (mut @skill.i18n)}}/>
+  <Field::Select
+    @title="Internationalisation"
+    @value={{@skill.i18n}}
+    @options={{this.options.i18n}}
+    @edition={{@edition}}
+    @setValue={{fn (mut @skill.i18n)}}
+  />
   {{#unless @edition}}
     <Field::Input @value={{@skill.pixId}} @title="Id" @edition={{false}} />
   {{/unless}}

--- a/pix-editor/app/components/form/theme.hbs
+++ b/pix-editor/app/components/form/theme.hbs
@@ -1,4 +1,16 @@
 <form action="" class="ui form">
-  <Field::Input data-test-theme-name-field @value={{@theme.name}} @edition={{@edition}} @label="Nom fr-fr"/>
-  <Field::Input data-test-theme-name-en-us-field @value={{@theme.nameEnUs}} @edition={{@edition}} @label="Nom en-us"/>
+  <Field::Input
+    data-test-theme-name-field
+    @value={{@theme.name}}
+    @edition={{@edition}}
+    @label="Nom fr-fr"
+    @id="theme-name-fr"
+  />
+  <Field::Input
+    data-test-theme-name-en-us-field
+    @value={{@theme.nameEnUs}}
+    @edition={{@edition}}
+    @label="Nom en-us"
+    @id="theme-name-en"
+  />
 </form>

--- a/pix-editor/app/components/form/tube.hbs
+++ b/pix-editor/app/components/form/tube.hbs
@@ -1,16 +1,49 @@
 <form action="" class="ui form">
   {{#if @edition}}
-    <Field::Input data-test-name-field @value={{@tube.name}} @edition={{@edition}} @label="Nom"/>
+    <Field::Input
+      data-test-name-field
+      @value={{@tube.name}}
+      @edition={{@edition}}
+      @label="Nom"
+      @id="tube-name"
+    />
   {{/if}}
   <div class="ui raised segment">
-    <Field::Input data-test-practical-title-fr-field @value={{@tube.practicalTitleFr}} @edition={{@edition}} @label="Titre pratique (fr)"/>
-    <Field::Textarea data-test-practical-description-fr-field @title="Description pratique (fr) :" @value={{@tube.practicalDescriptionFr}} @edition={{@edition}} />
+    <Field::Input
+      data-test-practical-title-fr-field
+      @value={{@tube.practicalTitleFr}}
+      @edition={{@edition}}
+      @label="Titre pratique (fr)"
+      @id="tube-title-fr"
+    />
+    <Field::Textarea
+      data-test-practical-description-fr-field
+      @title="Description pratique (fr) :"
+      @value={{@tube.practicalDescriptionFr}}
+      @edition={{@edition}}
+    />
   </div>
   <div class="ui raised segment">
-    <Field::Input data-test-practical-title-en-field @value={{@tube.practicalTitleEn}} @edition={{@edition}} @label="Titre pratique (en)"/>
-    <Field::Textarea data-test-practical-description-en-field @title="Description pratique (en) :" @value={{@tube.practicalDescriptionEn}} @edition={{@edition}} />
+    <Field::Input
+      data-test-practical-title-en-field
+      @value={{@tube.practicalTitleEn}}
+      @edition={{@edition}}
+      @label="Titre pratique (en)"
+      @id="tube-title-en"
+    />
+    <Field::Textarea
+      data-test-practical-description-en-field
+      @title="Description pratique (en) :"
+      @value={{@tube.practicalDescriptionEn}}
+      @edition={{@edition}}
+    />
   </div>
   {{#unless @edition}}
-    <Field::Input data-test-pix-id-field @value={{@tube.pixId}} @title="Id" @edition={{false}} />
+    <Field::Input
+      data-test-pix-id-field
+      @value={{@tube.pixId}}
+      @title="Id"
+      @edition={{false}}
+    />
   {{/unless}}
 </form>

--- a/pix-editor/app/components/form/tube.hbs
+++ b/pix-editor/app/components/form/tube.hbs
@@ -21,6 +21,7 @@
       @title="Description pratique (fr) :"
       @value={{@tube.practicalDescriptionFr}}
       @edition={{@edition}}
+      @id="tube-description-fr"
     />
   </div>
   <div class="ui raised segment">
@@ -36,6 +37,7 @@
       @title="Description pratique (en) :"
       @value={{@tube.practicalDescriptionEn}}
       @edition={{@edition}}
+      @id="tube-description-en"
     />
   </div>
   {{#unless @edition}}

--- a/pix-editor/app/templates/authenticated/area-management/new.hbs
+++ b/pix-editor/app/templates/authenticated/area-management/new.hbs
@@ -1,26 +1,37 @@
 <div class="main-left area-management">
   <div class="ui main-title">
-      <h1 class="ui left floated header">Nouveau domaine du pix + {{this.framework.name}}</h1>
+    <h1 class="ui left floated header">Nouveau domaine du pix + {{this.framework.name}}</h1>
   </div>
   <div class="area-management__details">
     <div class="area-management__data">
       <form action="" class="ui form">
-        <Field::Input data-test-area-title-input @value={{this.area.titleFrFr}} @edition={{true}} @label="Titre"/>
+        <Field::Input
+          data-test-area-title-input
+          @value={{this.area.titleFrFr}}
+          @edition={{true}}
+          @label="Titre"
+          @id="area-title-fr"
+        />
         <div class="ui raised segment">
           <i class="flag gb uk"></i>
-          <Field::Input @value={{this.area.titleEnUs}} @edition={{true}} @label="Titre (en)"/>
+          <Field::Input
+            @value={{this.area.titleEnUs}}
+            @edition={{true}}
+            @label="Titre (en)"
+            @id="area-title-en"
+          />
         </div>
       </form>
     </div>
     <div class="ui vertical compact labeled icon menu area-management__menu">
-        <button data-test-save-button class="ui button item important-action" {{on "click" this.save}} type="button">
-          <i class="save icon"></i>
-          Enregistrer
-        </button>
-        <button data-test-cancel-button class="ui button item" {{on "click" this.cancelEdit}} type="button">
-          <i class="ban icon"></i>
-          Annuler
-        </button>
+      <button data-test-save-button class="ui button item important-action" {{on "click" this.save}} type="button">
+        <i class="save icon"></i>
+        Enregistrer
+      </button>
+      <button data-test-cancel-button class="ui button item" {{on "click" this.cancelEdit}} type="button">
+        <i class="ban icon"></i>
+        Annuler
+      </button>
     </div>
   </div>
 </div>

--- a/pix-editor/app/templates/authenticated/competence-management/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence-management/single.hbs
@@ -9,12 +9,31 @@
   <div class="competence-management__details">
     <div class="competence-management__data">
       <form action="" class="ui form">
-        <Field::Input data-test-competence-title-input @value={{this.competence.title}} @edition={{this.edition}} @label="Titre"/>
-        <Field::Textarea @title="Description :" @value={{this.competence.description}} @edition={{this.edition}} />
+        <Field::Input
+          data-test-competence-title-input
+          @value={{this.competence.title}}
+          @edition={{this.edition}}
+          @label="Titre"
+          @id="competence-title-fr"
+        />
+        <Field::Textarea
+          @title="Description :"
+          @value={{this.competence.description}}
+          @edition={{this.edition}}
+        />
         <div class="ui raised segment">
           <i class="flag gb uk"></i>
-          <Field::Input @value={{this.competence.titleEn}} @edition={{this.edition}} @label="Titre (en)"/>
-          <Field::Textarea @title="Description (en) :" @value={{this.competence.descriptionEn}} @edition={{this.edition}} />
+          <Field::Input
+            @value={{this.competence.titleEn}}
+            @edition={{this.edition}}
+            @label="Titre (en)"
+            @id="competence-title-en"
+          />
+          <Field::Textarea
+            @title="Description (en) :"
+            @value={{this.competence.descriptionEn}}
+            @edition={{this.edition}}
+          />
         </div>
         {{#unless this.edition}}
           <Field::Input @value={{this.competence.pixId}} @title="Id" @edition={{false}} />

--- a/pix-editor/app/templates/authenticated/competence-management/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence-management/single.hbs
@@ -20,6 +20,7 @@
           @title="Description :"
           @value={{this.competence.description}}
           @edition={{this.edition}}
+          @id="competence-description-fr"
         />
         <div class="ui raised segment">
           <i class="flag gb uk"></i>
@@ -33,6 +34,7 @@
             @title="Description (en) :"
             @value={{this.competence.descriptionEn}}
             @edition={{this.edition}}
+            @id="competence-description-en"
           />
         </div>
         {{#unless this.edition}}

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -14,11 +14,20 @@
   <div class="challenge-data {{this.elementClass}}" {{scroll-top false}}>
     <form action="" class="ui form">
       <Field::Input
+        @id="localized-challenge-embed-url"
         @label="Embed URL"
         @value={{this.model.embedURL}}
         @edition={{this.edition}}
         @placeholder="Url de l'embed"
       />
+      {{#unless this.edition}}
+        <Field::Input
+          @id="localized-challenge-id"
+          @value={{this.model.id}}
+          @label="Id"
+          @edition={{false}}
+        />
+      {{/unless}}
     </form>
   </div>
   <div class="ui vertical compact labeled icon menu challenge-menu">


### PR DESCRIPTION
## :christmas_tree: Problème
Sur les autres entités on a toujours l'identifiant affiché en bas du formulaire.

## :gift: Proposition
Afficher l'identifiant de l'épreuve localisée en bas de son formulaire.

## :socks: Remarques
N/A

## :santa: Pour tester
Aller voir la version NL d'une épreuve et vérifier que le champ est bien présent quand on est pas en édition.