### PR TITLE
[FEATURE] Ecrit le titre des embed dans la table translations (PIX-10615)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -48,7 +48,6 @@ export class Challenge {
     this.t3Status = t3Status;
     this.status = status;
     this.skills = skills;
-    this.embedTitle = embedTitle;
     this.embedHeight = embedHeight;
     this.timer = timer;
     this.competenceId = competenceId;
@@ -86,6 +85,7 @@ export class Challenge {
     this.proposals = this.translations[this.locales[0]]?.proposals ?? '';
     this.solution = this.translations[this.locales[0]]?.solution ?? '';
     this.solutionToDisplay = this.translations[this.locales[0]]?.solutionToDisplay ?? '';
+    this.embedTitle = this.translations[this.locales[0]]?.embedTitle ?? embedTitle;
     this.localizedChallenges = localizedChallenges ?? [];
     this.embedUrl = localizedChallenges
       ?.find(({ locale }) => Challenge.getPrimaryLocale(this.locales) === locale)

--- a/api/lib/infrastructure/translations/challenge.js
+++ b/api/lib/infrastructure/translations/challenge.js
@@ -10,9 +10,13 @@ export const fields = [
   'solutionToDisplay',
 ];
 
+const writableFields = [
+  'embedTitle',
+];
+
 export function extractFromChallenge(challenge) {
   const locale = Challenge.getPrimaryLocale(challenge.locales);
-  return fields
+  return [...fields, ...writableFields]
     .filter((field) => challenge[field])
     .map((field) => {
       return new Translation({

--- a/api/scripts/migrate-embed-title-translation-from-airtable/index.js
+++ b/api/scripts/migrate-embed-title-translation-from-airtable/index.js
@@ -1,0 +1,62 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import _ from 'lodash';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+import { convertLanguagesToLocales } from '../../lib/domain/services/convert-locales.js';
+import { prefixFor } from '../../lib/infrastructure/translations/challenge.js';
+import { Challenge, Translation } from '../../lib/domain/models/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateEmbedTitleTranslationFromAirtable({ airtableClient }) {
+  const allChallenges = await airtableClient
+    .table('Epreuves')
+    .select({
+      fields: [
+        'id persistant',
+        'Embed title',
+        'Langues',
+      ],
+    })
+    .all();
+
+  const translations = allChallenges.map((challenge) => {
+    return {
+      id: challenge.get('id persistant'),
+      embedTitle: challenge.get('Embed title'),
+      locales: convertLanguagesToLocales(challenge.get('Langues')),
+    };
+  }).filter((challenge) => {
+    return challenge.embedTitle;
+  }).map((challenge) => {
+    return new Translation({
+      key: `${prefixFor(challenge)}embedTitle`,
+      locale: Challenge.getPrimaryLocale(challenge.locales),
+      value: challenge.embedTitle,
+    });
+  });
+  for (const translationsChunk of _.chunk(translations, 5000)) {
+    await translationRepository.save({ translations: translationsChunk });
+  }
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateEmbedTitleTranslationFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1013,6 +1013,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
           value: 'consigne alternative'
         },
         {
+          key: 'challenge.challengeId.embedTitle',
+          locale: 'fr',
+          value: challenge.embedTitle,
+        },
+        {
           key: 'challenge.challengeId.instruction',
           locale: 'fr',
           value: 'consigne'
@@ -1451,6 +1456,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
           value: challenge.alternativeInstruction,
         },
         {
+          key: 'challenge.recChallengeId.embedTitle',
+          locale: 'fr',
+          value: challenge.embedTitle,
+        },
+        {
           key: 'challenge.recChallengeId.instruction',
           locale: 'fr',
           value: challenge.instruction,
@@ -1685,6 +1695,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
           key: 'challenge.recChallengeId.alternativeInstruction',
           locale: 'fr',
           value: challenge.alternativeInstruction,
+        },
+        {
+          key: 'challenge.recChallengeId.embedTitle',
+          locale: 'fr',
+          value: challenge.embedTitle,
         },
         {
           key: 'challenge.recChallengeId.instruction',

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -204,6 +204,12 @@ describe('Acceptance | Controller | translations-controller', () => {
           'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
         ],
         [
+          'challenge.recChallenge0.embedTitle',
+          'Embed title',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
           'challenge.recChallenge0.instruction',
           'Consigne du Challenge',
           'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',

--- a/api/tests/scripts/migrate-embed-title-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-embed-title-translation-from-airtable_test.js
@@ -1,0 +1,82 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+import {
+  migrateEmbedTitleTranslationFromAirtable
+} from '../../scripts/migrate-embed-title-translation-from-airtable/index.js';
+
+describe('Migrate translation from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const challenge = {
+      id: 'airtableChallengeId',
+      fields: {
+        'id persistant': 'challengeid1',
+        'Embed title': 'Embed title',
+        Langues: ['Franco Français'],
+      }
+    };
+    const challengeWithEmptyEmbedTitle = {
+      id: 'airtableChallengeId',
+      fields: {
+        'id persistant': 'challengeid2',
+        'Embed title': '',
+        Langues: ['Franco Français'],
+      }
+    };
+
+    const challenges = [challenge, challengeWithEmptyEmbedTitle];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Epreuves')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query({
+        fields: {
+          '': [
+            'id persistant',
+            'Embed title',
+            'Langues',
+          ]
+        }
+      })
+      .reply(200, { records: challenges });
+
+    // when
+    await migrateEmbedTitleTranslationFromAirtable({ airtableClient });
+
+    // then
+    const translations = await knex('translations').select().orderBy([{
+      column: 'key',
+      order: 'asc'
+    }, { column: 'locale', order: 'asc' }]);
+
+    expect(translations).to.have.lengthOf(1);
+    expect(translations).to.deep.equal([
+      {
+        key: 'challenge.challengeid1.embedTitle',
+        locale: 'fr-fr',
+        value: 'Embed title'
+      },
+    ]);
+  });
+});

--- a/api/tests/unit/infrastructure/translations/challenge_test.js
+++ b/api/tests/unit/infrastructure/translations/challenge_test.js
@@ -16,25 +16,43 @@ describe('Unit | Infrastructure | Challenge translations', () => {
             proposals: 'propositions en français',
             solution: 'bonnes réponses en français',
             solutionToDisplay: 'bonnes réponses à afficher en français',
+            embedTitle: 'titre du simulateur',
           }
         },
         locales: ['fr'],
       });
       const translations = extractFromChallenge(challenge);
       expect(translations).to.deep.equal([
-        { key: 'challenge.test.instruction', locale: 'fr', value: 'consigne en français' },
+        {
+          key: 'challenge.test.instruction',
+          locale: 'fr',
+          value: 'consigne en français',
+        },
         {
           key: 'challenge.test.alternativeInstruction',
           locale: 'fr',
           value: 'consigne alternative en français'
         },
-        { key: 'challenge.test.proposals', locale: 'fr', value: 'propositions en français' },
-        { key: 'challenge.test.solution', locale: 'fr', value: 'bonnes réponses en français' },
+        {
+          key: 'challenge.test.proposals',
+          locale: 'fr',
+          value: 'propositions en français',
+        },
+        {
+          key: 'challenge.test.solution',
+          locale: 'fr',
+          value: 'bonnes réponses en français',
+        },
         {
           key: 'challenge.test.solutionToDisplay',
           locale: 'fr',
           value: 'bonnes réponses à afficher en français'
         },
+        {
+          key: 'challenge.test.embedTitle',
+          locale: 'fr',
+          value: 'titre du simulateur',
+        }
       ]);
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Les titres des embeds sont utilisés côté Pix App pour définir le titre des iframe.
Ces titres sont importants pour l'accessibilité de notre application.
Actuellement, ces titres ne sont pas traduisibles, ce qui sera problématique pour des utilisateurs non francophones.

## :gift: Proposition

On crée un script qui ajoute les titres des embeds dans la table de traduction.
Lors de la création / mise à jour d'une épreuve, on maintient à jour la traduction du titre de l'embed.

## :socks: Remarques

RAS

## :santa: Pour tester

Exécuter le script `node migrate-embed-title-translation-from-airtable/index.js`.
Vérifier que la table traduction contient des titres d'embed.
Modifier le titre d'un embed depuis Pix Editor.
Vérifier que la table traduction a été mise à jour.
