### PR TITLE
[TECH] Fixer la versions des addons de BDD pour les reviews APP

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -10,8 +10,18 @@
     "first-deploy": "npm run scalingo-post-ra-creation"
   },
   "addons": [
-    "postgresql:postgresql-sandbox",
-    "redis:redis-sandbox"
+    {
+      "plan": "postgresql:postgresql-sandbox",
+      "options": {
+        "version": "14.10"
+      }
+    },
+    {
+      "plan": "redis:redis-sandbox",
+      "options": {
+        "version": "7.2.3"
+      }
+    }
   ],
   "formation": {
     "web": {


### PR DESCRIPTION
## :christmas_tree: Problème

La version de postgres proposée par Scalingo pour les nouvelles review app n'est pas définie, et peut donc évoluer sans que nous puissions tester le code dessus avant

## :gift: Proposition

Définir les versions des addons postgres et redis dans le scalingo.json pour fixer les versions démarrées dans les RA 

## :socks: Remarques

Cela permettra également de profiter de l'upgrade automatique des addons par Renovate : https://github.com/1024pix/renovate-config/pull/46

## :santa: Pour tester

La RA doit démarrer avec les bonnes versions d'addons (cf dashboard scalingo) :) 
