### PR TITLE
[BUGFIX] Augmente la taille maximale autorisée du fichier de traductions importé (PIX-10718).

### DIFF
--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -5,6 +5,7 @@ import { exportTranslations } from '../domain/usecases/export-translations.js';
 import { importTranslations, InvalidFileError } from '../domain/usecases/import-translations.js';
 import { logger } from '../infrastructure/logger.js';
 import { releaseRepository, localizedChallengeRepository } from '../infrastructure/repositories/index.js';
+import * as config from '../config.js';
 
 export async function register(server) {
   server.route([
@@ -28,6 +29,7 @@ export async function register(server) {
         payload: {
           multipart: true,
           output: 'file',
+          maxBytes: config.importTranslationsFileMaxSize,
         },
         handler: importTranslationsHandler
       },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -110,6 +110,8 @@ export const checkUrlsJobs = {
   tutorialsSheetName: process.env.CHECK_URLS_TUTORIALS_SHEET_NAME,
 };
 
+export const importTranslationsFileMaxSize = process.env.IMPORT_TRANSLATIONS_FILE_MAX_SIZE || 2097152;
+
 if (process.env.NODE_ENV === 'test') {
   port = 0;
   hapi.publicDir = 'tests/public-tests/';

--- a/api/sample.env
+++ b/api/sample.env
@@ -34,6 +34,13 @@
 # default: none
 ADMIN_COOKIE_PASSWORD=aMoreThan32CharLongStringForExample
 
+# Maximum size allowed for translations import file
+#
+# presence: optional
+# type: Number (in bytes)
+# default: 209715200 bytes
+# IMPORT_TRANSLATIONS_FILE_MAX_SIZE=2097152
+
 # =========
 # DATABASES
 # =========


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de l'import d'un fichier de traductions au format CSV (généré par Phrase), l'utilisateur est confronté à une erreur 413.
Cette erreur est levée par HapiJS dans le cas où le fichier importé dépasse 1MB.
Cette valeur de seuil est la valeur par défaut de HapiJS.

## :gift: Proposition

On ajoute une variable d'environnement permettant de configurer la taille maximum autorisée du fichier d'import.
Par défaut, on configure cette variable à 2MB.

## :socks: Remarques

RAS

## :santa: Pour tester

Se connecter sur l'admin de la review app : https://pix-lcms-review-pr461.osc-fr1.scalingo.io/admin.
Dans la partie Translations, sélection Import/Export.
Sélectionner un fichier CSV de plus de 1MB.
Valider.
Constater qu'il n'y a pas d'erreur 413.

Refaire l'opération avec un fichier de plus de 2MB.
Constater qu'il y a une erreur 413.
