### PR TITLE
[FEATURE] Pouvoir rechercher une épreuve localisée par identifiant (PIX-10680)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -1,4 +1,3 @@
-import qs from 'qs';
 import Boom from '@hapi/boom';
 import _ from 'lodash';
 import Joi from 'joi';
@@ -12,15 +11,7 @@ import { createChallengeTransformer } from '../../infrastructure/transformers/in
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import { previewChallenge } from '../../domain/usecases/index.js';
-
-function _parseQueryParams(search) {
-  const paramsParsed = qs.parse(search, { ignoreQueryPrefix: true });
-  const params = _.defaults(paramsParsed, { filter: {}, page: { size: 100 } });
-  if (params.page.size) {
-    params.page.size = parseInt(params.page.size);
-  }
-  return params;
-}
+import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 
 const challengeIdType = Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+$/).required();
 
@@ -51,7 +42,7 @@ export async function register(server) {
       path: '/api/challenges',
       config: {
         handler: async function(request) {
-          const params = _parseQueryParams(request.url.search);
+          const params = extractParameters(request.query, { page: { size: 100 } });
           const challenges = await challengeRepository.filter(params);
           return challengeSerializer.serialize(challenges);
         },

--- a/api/lib/application/localized-challenges.js
+++ b/api/lib/application/localized-challenges.js
@@ -1,6 +1,8 @@
+import _ from 'lodash';
 import { localizedChallengeRepository } from '../infrastructure/repositories/index.js';
 import { localizedChallengeSerializer } from '../infrastructure/serializers/jsonapi/index.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
+import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
 
 export async function register(server) {
   server.route([
@@ -12,6 +14,17 @@ export async function register(server) {
           const localizedChallengeId = request.params.id;
           const localizedChallenge = await localizedChallengeRepository.get({ id: localizedChallengeId });
           return localizedChallengeSerializer.serialize(localizedChallenge);
+        }
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/localized-challenges',
+      config: {
+        handler: async function(request) {
+          const params = extractParameters(request.query);
+          const localizedChallenges = await localizedChallengeRepository.getMany({ ids: params.filter.ids });
+          return localizedChallengeSerializer.serialize(localizedChallenges);
         }
       },
     },

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -22,7 +22,7 @@ export async function create(localizedChallenges = [], generateId = _generateId)
       id: localizedChallenge.id ?? generateId(),
     };
   });
-  await knex('localized_challenges').insert(localizedChallengesWithId).onConflict().ignore() ;
+  await knex('localized_challenges').insert(localizedChallengesWithId).onConflict().ignore();
 }
 
 export async function getByChallengeIdAndLocale({ challengeId, locale }) {
@@ -46,8 +46,16 @@ export async function get({ id, transaction: knexConnection = knex }) {
   return _toDomain(dto);
 }
 
+export async function getMany({ ids, transaction: knexConnection = knex }) {
+  const dtos = await knexConnection('localized_challenges').whereIn('id', ids).select();
+  return dtos.map(_toDomain);
+}
+
 export async function update({ localizedChallenge: { id, locale, embedUrl }, transaction: knexConnection = knex }) {
-  const [dto] = await knexConnection('localized_challenges').where('id', id).update({ locale, embedUrl }).returning('*');
+  const [dto] = await knexConnection('localized_challenges').where('id', id).update({
+    locale,
+    embedUrl
+  }).returning('*');
 
   if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');
 

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -13,14 +13,16 @@ const serializer = new Serializer('localized-challenges', {
     ref: 'id',
     included: false,
   },
+  transform: function({ challengeId, ...localizedChallenge }) {
+    return {
+      ...localizedChallenge,
+      challenge: { id: challengeId },
+    };
+  }
 });
 
 export function serialize(localizedChallenge) {
-  const { challengeId, ...props } = localizedChallenge;
-  return serializer.serialize({
-    ...props,
-    challenge: { id: challengeId },
-  });
+  return serializer.serialize(localizedChallenge);
 }
 
 const deserializer = new Deserializer({

--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -2,13 +2,17 @@ import _ from 'lodash';
 
 // query example: 'filter[organizationId]=4&page[size]=30$page[number]=3&sort=createdAt[desc]&include=user'
 // Warning: there is not any order between sort parameters
-export function extractParameters(query) {
-  return {
+export function extractParameters(query, defaultQuery) {
+  return _.mapValues({
     filter: _extractFilter(query),
     page: _extractPage(query),
     sort: _extractSort(query, 'sort'),
     include: _extractArrayParameter(query, 'include'),
-  };
+  }, (value, key) => {
+    if (Array.isArray(value)) return value;
+    if (defaultQuery?.[key] == undefined) return value;
+    return _.defaults(value, defaultQuery[key]);
+  });
 }
 
 function _extractFilter(query) {
@@ -24,7 +28,6 @@ function _extractSort(query) {
 function _extractPage(query) {
   const regex = /page\[([a-zA-Z]*)\]/;
   const params = _extractObjectParameter(query, regex);
-
   return _convertObjectValueToInt(params);
 }
 

--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -34,7 +34,11 @@ function _extractObjectParameter(query, regex) {
     (result, queryFilterValue, queryFilterKey) => {
       const parameter = queryFilterKey.match(regex);
       if (parameter && parameter[1]) {
-        result[parameter[1]] = queryFilterValue;
+        if (queryFilterKey.endsWith('[]')) {
+          result[parameter[1]] = Array.isArray(queryFilterValue) ? queryFilterValue : [queryFilterValue];
+        } else {
+          result[parameter[1]] = queryFilterValue;
+        }
       }
       return result;
     },

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -51,6 +51,126 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
     });
   });
 
+  describe('GET /localized-challenges', () => {
+    it('should find a localized challenge by ID', async () => {
+      // given
+      const user = databaseBuilder.factory.buildAdminUser();
+      const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
+        challengeId: 'recChallenge0',
+        id: 'localizedChallengeId',
+        locale: 'nl',
+        embedUrl: 'https://choucroute.com/',
+      });
+
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+      const getLocalizedChallengeOptions = {
+        method: 'GET',
+        url: '/api/localized-challenges?filter[ids][]=localizedChallengeId',
+        headers: generateAuthorizationHeader(user),
+      };
+
+      const expectedLocalizedChallenges = {
+        data: [{
+          type: 'localized-challenges',
+          id: localizedChallenge.id,
+          attributes: {
+            'locale': localizedChallenge.locale,
+            'embed-url': localizedChallenge.embedUrl,
+          },
+          relationships: {
+            challenge: {
+              data: {
+                id: localizedChallenge.challengeId,
+                type: 'challenges',
+              },
+            },
+          },
+        }]
+      };
+
+      // When
+      const response = await server.inject(getLocalizedChallengeOptions);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedLocalizedChallenges);
+    });
+
+    it('should filter several localized challenges by IDs', async () => {
+      // given
+      const user = databaseBuilder.factory.buildAdminUser();
+      const localizedChallenges = [
+        databaseBuilder.factory.buildLocalizedChallenge({
+          challengeId: 'recChallenge0',
+          id: 'localizedChallengeId0',
+          locale: 'nl',
+          embedUrl: 'https://choucroute.com/',
+        }),
+        databaseBuilder.factory.buildLocalizedChallenge({
+          challengeId: 'recChallenge1',
+          id: 'localizedChallengeId1',
+          locale: 'de',
+          embedUrl: 'https://raclette.com/',
+        }),
+      ];
+
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+      const getLocalizedChallengeOptions = {
+        method: 'GET',
+        url: '/api/localized-challenges?filter[ids][]=localizedChallengeId0&filter[ids][]=localizedChallengeId1',
+        headers: generateAuthorizationHeader(user),
+      };
+
+      const expectedLocalizedChallenges = {
+        data: [
+          {
+            type: 'localized-challenges',
+            id: localizedChallenges[0].id,
+            attributes: {
+              'locale': localizedChallenges[0].locale,
+              'embed-url': localizedChallenges[0].embedUrl,
+            },
+            relationships: {
+              challenge: {
+                data: {
+                  id: localizedChallenges[0].challengeId,
+                  type: 'challenges',
+                },
+              },
+            },
+          },
+          {
+            type: 'localized-challenges',
+            id: localizedChallenges[1].id,
+            attributes: {
+              'locale': localizedChallenges[1].locale,
+              'embed-url': localizedChallenges[1].embedUrl,
+            },
+            relationships: {
+              challenge: {
+                data: {
+                  id: localizedChallenges[1].challengeId,
+                  type: 'challenges',
+                },
+              },
+            },
+          }
+        ]
+      };
+
+      // When
+      const response = await server.inject(getLocalizedChallengeOptions);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedLocalizedChallenges);
+    });
+  });
+
   describe('PATCH /localized-challenges/{id}', () => {
     it('should modify localized challenge of given ID', async () => {
       // given

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -338,6 +338,44 @@ describe('Integration | Repository | localized-challenge-repository', function()
     });
   });
 
+  context('#getMany', () => {
+    it('should return localized challenges by ids', async () => {
+      // given
+      const ids = ['localizedChallengeId1', 'localizedChallengeId2'];
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: ids[0],
+        challengeId: 'challengeId1',
+        embedUrl: 'mon-url.com',
+        locale: 'bz',
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: ids[1],
+        challengeId: 'challengeId2',
+        locale: 'ur',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const localizedChallenges = await localizedChallengeRepository.getMany({ ids });
+
+      // then
+      expect(localizedChallenges).to.deep.equal([
+        domainBuilder.buildLocalizedChallenge({
+          id: ids[0],
+          challengeId: 'challengeId1',
+          embedUrl: 'mon-url.com',
+          locale: 'bz',
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: ids[1],
+          challengeId: 'challengeId2',
+          embedUrl:  null,
+          locale: 'ur',
+        }),
+      ]);
+    });
+  });
+
   context('#update', () => {
     it('should change localized challenge locale and embedUrl', async () => {
       // given

--- a/api/tests/unit/infrastructure/utils/query-params-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/query-params-utils_test.js
@@ -56,5 +56,36 @@ describe('Unit | Utils | Query Params Utils', function() {
         include: [],
       });
     });
+
+    it('should support default values for objects', function() {
+      // given
+      const query = {
+        'page[number]': '1',
+      };
+      const defaultQuery = {
+        page: {
+          size: 100,
+        },
+        sort: {
+          participationCount: 'asc',
+        }
+      };
+
+      // when
+      const result = extractParameters(query, defaultQuery);
+
+      // then
+      expect(result).to.deep.equal({
+        filter: {},
+        page: {
+          number: 1,
+          size: 100,
+        },
+        sort: {
+          participationCount: 'asc',
+        },
+        include: [],
+      });
+    });
   });
 });

--- a/api/tests/unit/infrastructure/utils/query-params-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/query-params-utils_test.js
@@ -8,6 +8,8 @@ describe('Unit | Utils | Query Params Utils', function() {
       const query = {
         'filter[courseId]': '26',
         'filter[userId]': '1',
+        'filter[skillIds][]': '123',
+        'filter[tubeIds][]': ['456', '789'],
         'page[number]': '1',
         'page[size]': '200',
         'sort[participationCount]': 'asc',
@@ -22,6 +24,8 @@ describe('Unit | Utils | Query Params Utils', function() {
         filter: {
           courseId: '26',
           userId: '1',
+          skillIds: ['123'],
+          tubeIds: ['456', '789'],
         },
         page: {
           number: 1,

--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -13,7 +13,6 @@ export default class SidebarSearchComponent extends Component {
   async getSearchResults(query) {
     query = query.trim();
     if (query.startsWith('@')) {
-      this.routeModel = 'authenticated.skill';
       const skills = await this.store.query('skill', {
         filterByFormula: `FIND('${query.toLowerCase()}', LOWER(Nom))`,
         maxRecords: 20,
@@ -22,13 +21,13 @@ export default class SidebarSearchComponent extends Component {
       return skills.map(skill => ({
         isSkill: true,
         title: skill.name,
-        name: skill.name,
+        id: skill.name,
         status: skill.status,
         statusCSS: skill.statusCSS,
-        version: skill.version
+        version: skill.version,
+        route: 'authenticated.skill',
       }));
     } else if (query.startsWith('rec') || query.startsWith('challenge')) {
-      this.routeModel = 'authenticated.challenge';
       const challenges = await this.store.query('challenge', {
         filter: {
           ids: [query],
@@ -36,10 +35,10 @@ export default class SidebarSearchComponent extends Component {
       });
       return challenges.map(challenge => ({
         title: challenge.id,
-        id: challenge.id
+        id: challenge.id,
+        route: 'authenticated.challenge',
       }));
     } else {
-      this.routeModel = 'authenticated.challenge';
       const challenges = await this.store.query('challenge', {
         filter: {
           search: query.toLowerCase(),
@@ -50,7 +49,8 @@ export default class SidebarSearchComponent extends Component {
       });
       return challenges.map(challenge => ({
         title: challenge.instruction.substr(0, 100),
-        id: challenge.id
+        route: 'authenticated.challenge',
+        id: challenge.id,
       }));
     }
   }
@@ -61,9 +61,9 @@ export default class SidebarSearchComponent extends Component {
     const router = this.router;
     this.args.close();
     if (route === 'authenticated.skill') {
-      router.transitionTo(route, item.name);
+      router.transitionTo(item.route, item.id);
     } else {
-      router.transitionTo(route, item.id);
+      router.transitionTo(item.route, item.id);
     }
   }
 

--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -43,6 +43,21 @@ export default class SidebarSearchComponent extends Component {
     }));
   }
 
+  async searchLocalizedChallengesById(localizedChallengeId) {
+    const results = await this.store.query('localized-challenge', {
+      filter: {
+        ids: [localizedChallengeId],
+      },
+    });
+    return results.map(result => ({
+      title: result.id,
+      transition: {
+        route: 'authenticated.challenge',
+        model: result.id,
+      },
+    }));
+  }
+
   async searchChallengesByText(text) {
     const challenges = await this.store.query('challenge', {
       filter: {
@@ -67,7 +82,9 @@ export default class SidebarSearchComponent extends Component {
     if (query.startsWith('@')) {
       return this.searchSkillsByName(query);
     } else if (query.startsWith('rec') || query.startsWith('challenge')) {
-      return this.searchChallengesById(query);
+      const challenges = await this.searchChallengesById(query);
+      const localizedChallenges = await this.searchLocalizedChallengesById(query);
+      return [...challenges, ...localizedChallenges];
     }
     return this.searchChallengesByText(query);
   }

--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -9,62 +9,74 @@ export default class SidebarSearchComponent extends Component {
   @service store;
   @service router;
 
+  async searchSkillsByName(skillName) {
+    const skills = await this.store.query('skill', {
+      filterByFormula: `FIND('${skillName.toLowerCase()}', LOWER(Nom))`,
+      maxRecords: 20,
+      sort: [{ field: 'Nom', direction: 'asc' }]
+    });
+    return skills.map(skill => ({
+      isSkill: true,
+      title: skill.name,
+      status: skill.status,
+      statusCSS: skill.statusCSS,
+      version: skill.version,
+      transition: {
+        route: 'authenticated.skill',
+        model: skill.name,
+      },
+    }));
+  }
+
+  async searchChallengesById(challengeId) {
+    const challenges = await this.store.query('challenge', {
+      filter: {
+        ids: [challengeId],
+      },
+    });
+    return challenges.map(challenge => ({
+      title: challenge.id,
+      transition: {
+        route: 'authenticated.challenge',
+        model: challenge.id,
+      },
+    }));
+  }
+
+  async searchChallengesByText(text) {
+    const challenges = await this.store.query('challenge', {
+      filter: {
+        search: text.toLowerCase(),
+      },
+      page: {
+        size: 20,
+      },
+    });
+    return challenges.map(challenge => ({
+      title: challenge.instruction.substr(0, 100),
+      transition: {
+        route: 'authenticated.challenge',
+        model: challenge.id,
+      },
+    }));
+  }
+
   @action
   async getSearchResults(query) {
     query = query.trim();
     if (query.startsWith('@')) {
-      const skills = await this.store.query('skill', {
-        filterByFormula: `FIND('${query.toLowerCase()}', LOWER(Nom))`,
-        maxRecords: 20,
-        sort: [{ field: 'Nom', direction: 'asc' }]
-      });
-      return skills.map(skill => ({
-        isSkill: true,
-        title: skill.name,
-        id: skill.name,
-        status: skill.status,
-        statusCSS: skill.statusCSS,
-        version: skill.version,
-        route: 'authenticated.skill',
-      }));
+      return this.searchSkillsByName(query);
     } else if (query.startsWith('rec') || query.startsWith('challenge')) {
-      const challenges = await this.store.query('challenge', {
-        filter: {
-          ids: [query],
-        },
-      });
-      return challenges.map(challenge => ({
-        title: challenge.id,
-        id: challenge.id,
-        route: 'authenticated.challenge',
-      }));
-    } else {
-      const challenges = await this.store.query('challenge', {
-        filter: {
-          search: query.toLowerCase(),
-        },
-        page: {
-          size: 20,
-        },
-      });
-      return challenges.map(challenge => ({
-        title: challenge.instruction.substr(0, 100),
-        route: 'authenticated.challenge',
-        id: challenge.id,
-      }));
+      return this.searchChallengesById(query);
     }
+    return this.searchChallengesByText(query);
   }
 
   @action
-  linkTo(item) {
-    const route = this.routeModel;
+  linkTo({ transition }) {
     const router = this.router;
     this.args.close();
-    if (route === 'authenticated.skill') {
-      router.transitionTo(item.route, item.id);
-    } else {
-      router.transitionTo(item.route, item.id);
-    }
+    router.transitionTo(transition.route, transition.model);
   }
 
 }

--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { uniqBy } from 'lodash';
 
 export default class SidebarSearchComponent extends Component {
 
@@ -84,7 +85,7 @@ export default class SidebarSearchComponent extends Component {
     } else if (query.startsWith('rec') || query.startsWith('challenge')) {
       const challenges = await this.searchChallengesById(query);
       const localizedChallenges = await this.searchLocalizedChallengesById(query);
-      return [...challenges, ...localizedChallenges];
+      return uniqBy([...challenges, ...localizedChallenges], 'id');
     }
     return this.searchChallengesByText(query);
   }

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -5,4 +5,8 @@ export default class LocalizedChallengeModel extends Model {
   @attr locale;
 
   @belongsTo('challenge') challenge;
+
+  get isPrimaryChallenge() {
+    return this.challenge.get('id') === this.id;
+  }
 }

--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -25,18 +25,14 @@ export default class ChallengeRoute extends Route {
       await skill.challenges; // in order to load model.relatedPrototype later on
       const tube = await skill.tube;
       const competence = await tube.competence;
-      if (challenge.get('isPrototype')) {
-        if (localizedChallenge.isPrimaryChallenge) {
-          return this.router.transitionTo('authenticated.competence.prototypes.single', competence, challenge);
-        } else {
-          return this.router.transitionTo('authenticated.competence.prototypes.localized', competence, challenge.get('id'), localizedChallenge.get('id'));
-        }
+      if (challenge.get('isPrototype') && localizedChallenge.isPrimaryChallenge) {
+        return this.router.transitionTo('authenticated.competence.prototypes.single', competence, challenge);
+      } else if (challenge.get('isPrototype')) {
+        return this.router.transitionTo('authenticated.competence.prototypes.localized', competence, challenge.get('id'), localizedChallenge.get('id'));
+      } else if (localizedChallenge.isPrimaryChallenge) {
+        return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', competence, challenge.get('relatedPrototype'), challenge);
       } else {
-        if (localizedChallenge.isPrimaryChallenge) {
-          return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', competence, challenge.get('relatedPrototype'), challenge);
-        } else {
-          return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.localized', competence, challenge.get('relatedPrototype'), challenge.get('id'), localizedChallenge.get('id'));
-        }
+        return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.localized', competence, challenge.get('relatedPrototype'), challenge.get('id'), localizedChallenge.get('id'));
       }
     } catch (e) {
       this.router.transitionTo('authenticated');

--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -6,27 +6,40 @@ export default class ChallengeRoute extends Route {
   @service router;
   @service store;
 
-  model(params) {
-    return this.store.findRecord('challenge', params.challenge_id);
+  async model(params) {
+    try {
+      return this.store.findRecord('localized-challenge', params.challenge_id);
+    } catch {
+      return;
+    }
   }
 
-  async afterModel(model) {
-    if (model) {
-      try {
-        const skill = await model.skill;
-        await skill.challenges; // in order to load model.relatedPrototype later on
-        const tube = await skill.tube;
-        const competence = await tube.competence;
-        if (model.isPrototype) {
-          return this.router.transitionTo('authenticated.competence.prototypes.single', competence, model);
-        } else {
-          return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', competence, model.relatedPrototype, model);
-        }
-      } catch (e) {
-        this.router.transitionTo('authenticated');
-      }
-    } else {
+  async afterModel(localizedChallenge) {
+    if (!localizedChallenge) {
       return this.router.transitionTo('authenticated');
+    }
+
+    try {
+      const challenge = await localizedChallenge.challenge;
+      const skill = await challenge.get('skill');
+      await skill.challenges; // in order to load model.relatedPrototype later on
+      const tube = await skill.tube;
+      const competence = await tube.competence;
+      if (challenge.get('isPrototype')) {
+        if (localizedChallenge.isPrimaryChallenge) {
+          return this.router.transitionTo('authenticated.competence.prototypes.single', competence, challenge);
+        } else {
+          return this.router.transitionTo('authenticated.competence.prototypes.localized', competence, challenge.get('id'), localizedChallenge.get('id'));
+        }
+      } else {
+        if (localizedChallenge.isPrimaryChallenge) {
+          return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', competence, challenge.get('relatedPrototype'), challenge);
+        } else {
+          return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.localized', competence, challenge.get('relatedPrototype'), challenge.get('id'), localizedChallenge.get('id'));
+        }
+      }
+    } catch (e) {
+      this.router.transitionTo('authenticated');
     }
   }
 }

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -1,5 +1,5 @@
 import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
-import { createServer } from 'miragejs';
+import { Response, createServer } from 'miragejs';
 import { getDsModels, getDsSerializers } from 'ember-cli-mirage/ember-data';
 import slice from 'lodash/slice';
 
@@ -189,7 +189,7 @@ function routes() {
     const search = request.queryParams['filter[search]'];
     let records = null;
     if (ids) {
-      records = schema.challenges.find(ids);
+      records = schema.challenges.where((challenge)=> ids.includes(challenge.id));
     } else if (search) {
       records = schema.challenges.where((challenge) => challenge.instruction.includes(search));
     } else {
@@ -199,13 +199,17 @@ function routes() {
   });
 
   this.get('/challenges/:id', (schema, request) => {
-    return schema.challenges.find(request.params.id);
+    try {
+      return schema.challenges.find(request.params.id);
+    } catch (e) {
+      return new Response(404);
+    }
   });
 
   this.get('/localized-challenges', (schema, request) => {
     const ids = request.queryParams['filter[ids]'];
     if (ids) {
-      return schema.localizedChallenges.find(ids);
+      return schema.localizedChallenges.where((localizedChallenge)=> ids.includes(localizedChallenge.id));
     }
     return schema.localizedChallenges.all();
   });
@@ -213,7 +217,6 @@ function routes() {
   this.get('/localized-challenges/:id', (schema, request) => {
     return schema.localizedChallenges.find(request.params.id);
   });
-
 
   this.post('/challenges', (schema, request) => {
     const challenge = JSON.parse(request.requestBody);

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -186,10 +186,12 @@ function routes() {
 
   this.get('/challenges', (schema, request) => {
     const ids = request.queryParams['filter[ids]'];
+    const search = request.queryParams['filter[search]'];
     let records = null;
-
     if (ids) {
       records = schema.challenges.find(ids);
+    } else if (search) {
+      records = schema.challenges.where((challenge) => challenge.instruction.includes(search));
     } else {
       records = schema.challenges.all();
     }
@@ -198,6 +200,14 @@ function routes() {
 
   this.get('/challenges/:id', (schema, request) => {
     return schema.challenges.find(request.params.id);
+  });
+
+  this.get('/localized-challenges', (schema, request) => {
+    const ids = request.queryParams['filter[ids]'];
+    if (ids) {
+      return schema.localizedChallenges.find(ids);
+    }
+    return schema.localizedChallenges.all();
   });
 
   this.get('/localized-challenges/:id', (schema, request) => {

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -4,32 +4,43 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
-module('Acceptance | Search', function(hooks) {
+// eslint-disable-next-line qunit/no-only
+module.only('Acceptance | Search', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
-    this.server.create('challenge', { id: 'recChallenge1', airtableId: 'REC_RECHERCHE1' });
+    this.server.create('challenge', { id: 'recChallenge1', instruction: 'test', airtableId: 'REC_RECHERCHE1' });
     this.server.create('challenge', { id: 'challengeChallenge1', airtableId: 'REC_RECHERCHE2' });
+    this.server.create('localized-challenge', { id: 'localizedChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1', 'challengeChallenge1'] });
     this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
-    this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawTubeIds: ['recTube1'] });
-    this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
+    this.server.create('competence', {
+      id: 'recCompetence1.1',
+      pixId: 'pixId recCompetence1.1',
+      rawTubeIds: ['recTube1']
+    });
+    this.server.create('area', {
+      id: 'recArea1',
+      name: '1. Information et données',
+      code: '1',
+      competenceIds: ['recCompetence1.1']
+    });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     return authenticateSession();
   });
 
-  test('search a challenge by rec id', async function(assert) {
+  test('search a challenge by rec id', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1';
     // when
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
     await fillIn('[data-test-sidebar-search] input', '  recChallenge1  ');
-    await waitUntil(function() {
+    await waitUntil(function () {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
     await click(find('[data-test-sidebar-search] li'));
@@ -38,14 +49,14 @@ module('Acceptance | Search', function(hooks) {
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by challenge id', async function(assert) {
+  test('search a challenge by challenge id', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1';
     // when
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
     await fillIn('[data-test-sidebar-search] input', '  challengeChallenge1  ');
-    await waitUntil(function() {
+    await waitUntil(function () {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
     await click(find('[data-test-sidebar-search] li'));
@@ -54,14 +65,30 @@ module('Acceptance | Search', function(hooks) {
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by text', async function(assert) {
+  test('search a challenge by localized challenge id', async function (assert) {
+    // given
+    const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/localizedChallenge1';
+    // when
+    await visit('/');
+    await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
+    await fillIn('[data-test-sidebar-search] input', '  localizedChallenge1  ');
+    await waitUntil(function () {
+      return find('[data-test-sidebar-search] li');
+    }, { timeout: 1000 });
+    await click(find('[data-test-sidebar-search] li'));
+
+    // then
+    assert.strictEqual(currentURL(), expectedUrl);
+  });
+
+  test('search a challenge by text', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1';
     // when
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
     await fillIn('[data-test-sidebar-search] input', 'test');
-    await waitUntil(function() {
+    await waitUntil(function () {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
     await click(find('[data-test-sidebar-search] li'));

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -15,8 +15,8 @@ module.only('Acceptance | Search', function (hooks) {
 
     this.server.create('challenge', { id: 'recChallenge1', instruction: 'test', airtableId: 'REC_RECHERCHE1' });
     this.server.create('challenge', { id: 'challengeChallenge1', airtableId: 'REC_RECHERCHE2' });
-    this.server.create('localized-challenge', { id: 'localizedChallenge1', challengeId: 'challengeChallenge1' });
-    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1', 'challengeChallenge1'] });
+    this.server.create('localized-challenge', { id: 'challengeLocalizedChallenge1', challengeId: 'challengeChallenge1' });
+    this.server.create('skill', { id: 'recSkill1', name: '@skill1', challengeIds: ['recChallenge1', 'challengeChallenge1'] });
     this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
     this.server.create('competence', {
       id: 'recCompetence1.1',
@@ -67,11 +67,11 @@ module.only('Acceptance | Search', function (hooks) {
 
   test('search a challenge by localized challenge id', async function (assert) {
     // given
-    const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/localizedChallenge1';
+    const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/challengeLocalizedChallenge1';
     // when
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
-    await fillIn('[data-test-sidebar-search] input', '  localizedChallenge1  ');
+    await fillIn('[data-test-sidebar-search] input', '  challengeLocalizedChallenge1  ');
     await waitUntil(function () {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
@@ -88,6 +88,22 @@ module.only('Acceptance | Search', function (hooks) {
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
     await fillIn('[data-test-sidebar-search] input', 'test');
+    await waitUntil(function () {
+      return find('[data-test-sidebar-search] li');
+    }, { timeout: 1000 });
+    await click(find('[data-test-sidebar-search] li'));
+
+    // then
+    assert.strictEqual(currentURL(), expectedUrl);
+  });
+
+  test('search a skill by name - starting with @', async function (assert) {
+    // given
+    const expectedUrl = '/competence/recCompetence1.1/skills/recSkill1';
+    // when
+    await visit('/');
+    await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
+    await fillIn('[data-test-sidebar-search] input', '@skill1');
     await waitUntil(function () {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -4,8 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
-// eslint-disable-next-line qunit/no-only
-module.only('Acceptance | Search', function (hooks) {
+module('Acceptance | Search', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -15,7 +14,9 @@ module.only('Acceptance | Search', function (hooks) {
 
     this.server.create('challenge', { id: 'recChallenge1', instruction: 'test', airtableId: 'REC_RECHERCHE1' });
     this.server.create('challenge', { id: 'challengeChallenge1', airtableId: 'REC_RECHERCHE2' });
+    this.server.create('localized-challenge', { id: 'challengeChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', { id: 'challengeLocalizedChallenge1', challengeId: 'challengeChallenge1' });
+    this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1' });
     this.server.create('skill', { id: 'recSkill1', name: '@skill1', challengeIds: ['recChallenge1', 'challengeChallenge1'] });
     this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
     this.server.create('competence', {


### PR DESCRIPTION
## :christmas_tree: Problème
Si on copie-colle un identifiant d'épreuve localisée dans le champ de recherche, on a aucun résultat.

## :gift: Proposition
Implémenter la recherche d'épreuve localisée par identifiant.

## :socks: Remarques
BONUS: Le endpoint https://editor.pix.fr/challenge/{id} devrait maintenant supporter les épreuves localisées

## :santa: Pour tester
Rechercher une épreuve localisée par identifiant dans le champ de recherche.