### PR TITLE
[TECH] Ajouter un template custom de migration Knex

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -15,6 +15,7 @@ function localPostgresEnv(databaseUrl) {
     migrations: {
       tableName: 'knex_migrations',
       directory: './migrations',
+      stub: './migration-template.js',
     },
     seeds: {
       directory: './seeds',

--- a/api/db/migration-template.js
+++ b/api/db/migration-template.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'example';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    // TODO Replace following line by actual up migration
+    table.increments('id').notNullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  // TODO Replace following line by actual down migration
+  await knex.schema.dropTable(TABLE_NAME);
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Le template de migration Knex par défaut est en CJS, alors qu'on est en ES.

## :gift: Proposition
Ajouter un template de mirgation custom en ES.

## :socks: Remarques
N/A

## :santa: Pour tester
Faire `npm run db:new-migration test` dans api et vérifier que le script créé est bien en ES.