### PR TITLE
[FEATURE] Ajoute la locale `nl` aux locales possibles des déclinaisons (PIX-10735).

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -12,10 +12,11 @@ export const LOCALE = {
 export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
   [LOCALE.DEUTSCH_SPOKEN]: 'Allemand',
   [LOCALE.ENGLISH_SPOKEN]: 'Anglais',
+  [LOCALE.SPANISH_SPOKEN]: 'Espagnol',
   [LOCALE.FRENCH_FRANCE]: 'Franco Français',
   [LOCALE.FRENCH_SPOKEN]: 'Francophone',
   [LOCALE.ITALIAN_SPOKEN]: 'Italie',
-  [LOCALE.SPANISH_SPOKEN]: 'Espagnol',
+  [LOCALE.DUTCH_SPOKEN]: 'Néerlandais',
   [LOCALE.PORTUGUESE_SPOKEN]: 'Portugais',
 });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Il n'est pas possible d'ajouter des pièces jointes ou illustrations traduites par locale pour une épreuve donnée.
Afin de pouvoir créer un parcours néerlandais contenant des pièces jointes ou illustrations, on souhaite créer des déclinaisons d'épreuves dans la locale `nl`.
Cette liste de locales étant une configuration LCMS reçue par Pix Editor il faut ajouter la locale `nl` à cette configuration.

## :gift: Proposition

On ajoute la locale `nl` à la configuration `pixEditor`.

## :socks: Remarques

Dans Airtable, il faut également ajouter la valeur `Néerlandais` dans la liste des options possible de la colonne `Langues` de la table `Epreuves`.
Cela a été fait sur toutes les bases.

## :santa: Pour tester

Se rendre sur Pix Editor.
Modifier une épreuve et constater que le choix `Néerlandais` est disponible dans la liste déroulante des locales.
