### PR TITLE
[BUGFIX] Afficher les versions traduites d'une épreuve périmée ou archivée (PIX-10770).

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -1,5 +1,4 @@
 import Boom from '@hapi/boom';
-import _ from 'lodash';
 import Joi from 'joi';
 import Sentry from '@sentry/node';
 import { logger } from '../../infrastructure/logger.js';

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -12,4 +12,8 @@ export class LocalizedChallenge {
     this.embedUrl = embedUrl;
     this.status = status;
   }
+
+  get isPrimary() {
+    return this.id === this.challengeId;
+  }
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -76,7 +76,7 @@ export async function update(challenge) {
     const updatedChallengeDto = await challengeDatasource.update(challenge);
 
     const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds: [challenge.id], transaction });
-    const primaryLocalizedChallenge = localizedChallenges.find(({ id })=> id === challenge.id);
+    const primaryLocalizedChallenge = localizedChallenges.find(({ isPrimary })=> isPrimary);
 
     const oldPrimaryLocale = primaryLocalizedChallenge.locale;
     if (oldPrimaryLocale !== challenge.primaryLocale) {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -10,7 +10,6 @@ import {
   prefixFor
 } from '../translations/challenge.js';
 import { NotFoundError } from '../../domain/errors.js';
-import { listByChallengeIds } from './localized-challenge-repository.js';
 
 async function _getChallengesFromParams(params) {
   if (params.filter && params.filter.ids) {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1292,6 +1292,12 @@ describe('Acceptance | Controller | challenges-controller', () => {
         embedUrl: 'old_url',
         locale,
       });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challenge_localized_nl',
+        challengeId,
+        embedUrl: 'url_nl',
+        locale: 'nl',
+      });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.instruction`,
         locale,
@@ -1399,13 +1405,6 @@ describe('Acceptance | Controller | challenges-controller', () => {
                   };
                 }),
               },
-              'localized-challenges': {
-                data: [
-                  {
-                    id: 'recChallengeId',
-                  }
-                ]
-              },
             },
           },
         },
@@ -1446,7 +1445,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             accessibility2: 'RAS',
             spoil: 'Non Sp',
             responsive: 'non',
-            'alternative-locales': [],
+            'alternative-locales': ['nl'],
             locales: ['fr'],
             area: 'France',
             'auto-reply': false,
@@ -1477,6 +1476,10 @@ describe('Acceptance | Controller | challenges-controller', () => {
               data: [
                 {
                   id: 'recChallengeId',
+                  type: 'localized-challenges',
+                },
+                {
+                  id: 'challenge_localized_nl',
                   type: 'localized-challenges',
                 }
               ]

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
+
+describe('Unit | Domain | LocalizedChallenge', () => {
+  describe('#isPrimary', () => {
+    it('should return true if id is the same as challengeId, false otherwise', () => {
+      // given
+      const primaryLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
+        id: 'challengeId',
+        challengeId: 'challengeId',
+      });
+      const alternativeLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
+        id: 'alternativeId',
+        challengeId: 'challengeId',
+      });
+
+      // then
+      expect(primaryLocalizedChallenge.isPrimary).toBe(true);
+      expect(alternativeLocalizedChallenge.isPrimary).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Lors du changement de statut d'une épreuve ou d'une déclinaison les versions traduites ne sont plus affichées. 

## :gift: Proposition

Ajouter tous les localized challenges à la réponse d'API du changement de statut. 

## :socks: Remarques

RAS

## :santa: Pour tester

Se rendre sur une épreuve validée qui possède une version traduite.
Archiver l'épreuve.
Vérifier que la version traduite est toujours accessible.
