### PR TITLE
[BUGFIX] Autorise les modifications de Embed URL par un utilisateur non admin (PIX-10804).

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -52,3 +52,5 @@ export class InvalidStaticCourseCreationOrUpdateError extends DomainError {
     this.errors.push({ field, data: duplicates, code: 'DUPLICATES_FORBIDDEN' });
   }
 }
+
+export class ForbiddenError extends DomainError {}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -2,6 +2,7 @@ export * from './create-mission.js';
 export * from './export-translations.js';
 export * from './find-all-missions.js';
 export * from './import-translations.js';
+export * from './modify-localized-challenge.js';
 export * from './preview-challenge.js';
 export * from './proxy-read-request-to-airtable.js';
 export * from './proxy-write-request-to-airtable.js';

--- a/api/lib/domain/usecases/modify-localized-challenge.js
+++ b/api/lib/domain/usecases/modify-localized-challenge.js
@@ -1,0 +1,16 @@
+import { localizedChallengeRepository } from '../../infrastructure/repositories/index.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { ForbiddenError } from '../errors.js';
+
+export async function modifyLocalizedChallenge({ isAdmin, localizedChallenge }, dependencies = { localizedChallengeRepository }) {
+  return knex.transaction(async (transaction) => {
+    const originalLocalizedChallenge = await dependencies.localizedChallengeRepository.get({
+      id: localizedChallenge.id,
+      transaction
+    });
+    if (!isAdmin && localizedChallenge.status !== originalLocalizedChallenge.status) {
+      throw new ForbiddenError();
+    }
+    return dependencies.localizedChallengeRepository.update({ localizedChallenge, transaction });
+  });
+}

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -288,6 +288,13 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
     it('should return forbidden error if user is NOT admin and updates status', async() => {
       // given
       const user = databaseBuilder.factory.buildEditorUser();
+      databaseBuilder.factory.buildLocalizedChallenge({
+        challengeId: 'recChallenge0',
+        id: 'localizedChallengeId',
+        locale: 'nl',
+        status: 'proposé',
+        embedUrl: 'https://choucroute.com/',
+      });
       await databaseBuilder.commit();
 
       const server = await createServer();

--- a/api/tests/unit/domain/usecases/modify-localized-challenges_test.js
+++ b/api/tests/unit/domain/usecases/modify-localized-challenges_test.js
@@ -1,0 +1,104 @@
+import { expect, describe, vi, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { modifyLocalizedChallenge } from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | Domain | Usecases | modify localized challenge', () => {
+  describe('#modify', () => {
+    it('should modify embed URL', async () => {
+      const localizedChallengeRepository = {
+        update: vi.fn(),
+        get: vi.fn().mockResolvedValue(domainBuilder.buildLocalizedChallenge({
+          status: 'validé',
+        }))
+      };
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+        id: 'localized-challenge-id',
+        challengeId: 'challenge-id',
+        embedUrl: 'original-embed-url',
+        status: 'validé',
+        locale: 'nl',
+      });
+
+      await modifyLocalizedChallenge({ localizedChallenge }, { localizedChallengeRepository });
+
+      expect(localizedChallengeRepository.update).toHaveBeenCalledWith({
+        localizedChallenge,
+        transaction: expect.anything()
+      });
+    });
+    describe('when user is admin', () => {
+      it('should modify status', async () => {
+        const localizedChallengeRepository = {
+          update: vi.fn(),
+          get: vi.fn().mockResolvedValue(domainBuilder.buildLocalizedChallenge({
+            status: 'validé',
+          }))
+        };
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'localized-challenge-id',
+          challengeId: 'challenge-id',
+          embedUrl: 'original-embed-url',
+          status: 'validé',
+          locale: 'nl',
+        });
+
+        await modifyLocalizedChallenge({ isAdmin: true, localizedChallenge }, { localizedChallengeRepository });
+
+        expect(localizedChallengeRepository.update).toHaveBeenCalledWith({ localizedChallenge,  transaction: expect.anything() });
+      });
+    });
+    describe('when user is not admin', () => {
+      it('should not modify status', async () => {
+        const localizedChallengeRepository = {
+          update: vi.fn(),
+          get: vi.fn().mockResolvedValue(domainBuilder.buildLocalizedChallenge({
+            status: 'validé',
+          })),
+        };
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'localized-challenge-id',
+          challengeId: 'challenge-id',
+          embedUrl: 'original-embed-url',
+          status: 'proposé',
+          locale: 'nl',
+        });
+
+        expect(modifyLocalizedChallenge({
+          isAdmin: false,
+          localizedChallenge
+        }, { localizedChallengeRepository })).rejects.toThrow();
+        expect(localizedChallengeRepository.update).not.toHaveBeenCalledWith({ localizedChallenge,  transaction: expect.anything() });
+      });
+
+      it('should be able to modify when status is not modified', async () => {
+        const localizedChallengeRepository = {
+          update: vi.fn(),
+          get: vi.fn().mockResolvedValue(domainBuilder.buildLocalizedChallenge({
+            status: 'validé',
+          }))
+        };
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'localized-challenge-id',
+          challengeId: 'challenge-id',
+          embedUrl: 'original-embed-url',
+          status: 'validé',
+          locale: 'nl',
+        });
+
+        await modifyLocalizedChallenge({
+          isAdmin: false,
+          localizedChallenge
+        }, { localizedChallengeRepository });
+
+        expect(localizedChallengeRepository.update).toHaveBeenCalledWith({
+          localizedChallenge,
+          transaction: expect.anything()
+        });
+        expect(localizedChallengeRepository.get).toHaveBeenCalledWith({
+          id: 'localized-challenge-id',
+          transaction: expect.anything()
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Les utilisateurs non admin ne peuvent pas modifier l'embed URL d'une épreuve traduite.
Cela est du à la restriction de modification de statuts aux admins uniquement, qui empêche toute modification de l'épreuve par un utilisateur non admin.

## :gift: Proposition
On crée un usecase pour isoler le comportement métier de la modification d'une épreuve traduite.
La modification est autorisée uniquement aux admins ou aux autres utilisateurs *si* le statut est égal au statut existant.

## :socks: Remarques
RAS

## :santa: Pour tester
Se connecter en Editeur
Tenter de modifier un status du challenge nl.
Voir que la modification est un échec.

Tenter de modifier l'embed URL du challenge NL.
Voir que la modification est un succès.
