### PR TITLE
[WORKAROUND] Solution de contournement pour pouvoir importer `\"` dans Phrase (PIX-10120)

### DIFF
--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -32,6 +32,7 @@ export async function exportTranslations(stream, dependencies) {
   const csvLinesStream = translationsStreams
     .filter(({ translation }) => translation.locale === 'fr')
     .filter(keepPixFramework)
+    .map(replaceAntislashDoubleQuotes)
     .map(translationAndTagsToCSVLine);
 
   pipeline(
@@ -82,6 +83,17 @@ function extractMetadataFromObject(extractMetadataFn, releaseContent, typeTag) {
       description,
       object,
     };
+  };
+}
+
+function replaceAntislashDoubleQuotes({ translation, tags, description }) {
+  return {
+    translation: {
+      ...translation,
+      value: translation.value.replace(/\\"/g, '[NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]'),
+    },
+    tags,
+    description,
   };
 }
 

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -40,6 +40,7 @@ export async function exportTranslations(stream, dependencies) {
     csv.format({ headers: true }),
     stream,
     (error) => {
+      if (!error) return;
       logger.error({ error }, 'Error while exporting translations from release');
     },
   );

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -28,7 +28,10 @@ export function importTranslations(csvStream, dependencies = { translationReposi
         reject(new InvalidFileError(`Invalid data: ${JSON.stringify(invalidData)}`));
       })
       .on('data', (row) => {
-        translations.push(new Translation({ ...row, locale }));
+        translations.push(new Translation({
+          ...replaceAntislashDoubleQuotes(row),
+          locale,
+        }));
       })
       .on('end', async () => {
         if (translations.length === 0) {
@@ -43,6 +46,13 @@ export function importTranslations(csvStream, dependencies = { translationReposi
         resolve();
       });
   });
+}
+
+function replaceAntislashDoubleQuotes(row) {
+  return {
+    ...row,
+    value: row.value.replaceAll('[antislashdoublequote]', '\\"'),
+  };
 }
 
 const extractChallengesLocales = fp.flow(

--- a/api/server.js
+++ b/api/server.js
@@ -7,7 +7,6 @@ import { catchDomainAndInfrastructureErrors } from './lib/infrastructure/utils/p
 import { routes } from './lib/routes.js';
 import { plugins } from './lib/infrastructure/plugins/index.js';
 import * as security from './lib/infrastructure/security.js';
-import * as securityPreHandlers from './lib/application/security-pre-handlers.js';
 import * as monitoringTools from './lib/infrastructure/monitoring-tools.js';
 
 monitoringTools.installHapiHook();

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -475,6 +475,247 @@ describe('Acceptance | Controller | translations-controller', () => {
         await expect(response).rejects.toHaveProperty('isBoom', true);
       });
     });
+
+    describe('when a translation contains \\"', () => {
+      it('should replace these by [NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]', async () => {
+        // Given
+        const user = databaseBuilder.factory.buildAdminUser();
+        const releaseContent = {
+          frameworks: [{
+            id: 'recFramework0',
+            name: 'Pix'
+          }, {
+            id: 'recFramework1',
+            name: 'Pix+'
+          }],
+          areas: [{
+            id: 'recArea0',
+            name: 'Nom du Domaine',
+            code: '1',
+            title_i18n: {
+              fr: 'Titre du Domaine - fr',
+              en: 'Titre du Domaine - en',
+            },
+            competenceIds: ['recCompetence0'],
+            color: 'jaffa',
+            frameworkId: 'recFramework0',
+          },
+          {
+            id: 'recArea1',
+            name: 'Nom du Domaine pix+',
+            code: '1',
+            title_i18n: {
+              fr: 'Titre du Domaine - fr',
+              en: 'Titre du Domaine - en',
+            },
+            competenceIds: ['recCompetence1'],
+            color: 'jaffa',
+            frameworkId: 'recFramework1',
+          }],
+          competences: [{
+            id: 'recCompetence0',
+            index: '1.1',
+            name_i18n: {
+              fr: 'Nom de la Compétence - fr',
+              en: 'Nom de la Compétence - en',
+            },
+            areaId: 'recArea0',
+            origin: 'Pix',
+            skillIds: ['recSkill0'],
+            thematicIds: ['recThematic0'],
+            description_i18n: {
+              fr: 'Description de la compétence - fr',
+              en: 'Description de la compétence - en',
+            }
+          },
+          {
+            id: 'recCompetence1',
+            index: '1.1',
+            name_i18n: {
+              fr: 'Nom de la Compétence - fr',
+              en: 'Nom de la Compétence - en',
+            },
+            areaId: 'recArea1',
+            origin: 'Pix+',
+            skillIds: [],
+            thematicIds: [],
+            description_i18n: {
+              fr: 'Description de la compétence - fr',
+              en: 'Description de la compétence - en',
+            }
+          }],
+          thematics: [{
+            id: 'recThematic0',
+            name_i18n: {
+              fr: 'Nom',
+              en: 'name',
+            },
+            competenceId: 'recCompetence0',
+            tubeIds: ['recTube0'],
+            index: 0
+          }],
+          tubes: [{
+            id: 'recTube0',
+            name: '@acquis',
+            title: 'Titre du Tube',
+            description: 'Description du Tube',
+            practicalTitle_i18n: {
+              fr: 'Titre pratique du Tube - fr',
+              en: 'Titre pratique du Tube - en',
+            },
+            practicalDescription_i18n: {
+              fr: 'Description pratique du Tube - fr',
+              en: 'Description pratique du Tube - en',
+            },
+            competenceId: 'recCompetence0',
+            thematicId: 'recThematic0',
+            skillIds: ['recSkill0'],
+            isMobileCompliant: true,
+            isTabletCompliant: false,
+          }],
+          skills: [{
+            id: 'recSkill0',
+            name: '@acquis1',
+            hint_i18n: {
+              fr: '\\"Indice\\" - fr',
+              en: 'Indice - en',
+            },
+            hintStatus: 'Statut de l‘indice',
+            tutorialIds: ['recTutorial0'],
+            learningMoreTutorialIds: ['recTutorial1'],
+            pixValue: 8,
+            competenceId: 'recCompetence0',
+            status: 'validé',
+            tubeId: 'recTube0',
+            version: 1,
+            level: 1,
+          }],
+          challenges: [{
+            id: 'recChallenge0',
+            instruction: 'Consigne du \\"Challenge\\"',
+            proposals: 'Propositions du \\"Challenge\\"',
+            type: 'Type d\'épreuve',
+            solution: 'Bonnes réponses du Challenge',
+            solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+            t1Status: false,
+            t2Status: true,
+            t3Status: false,
+            status: 'validé',
+            skillId: 'recSkill0',
+            embedUrl: 'Embed URL',
+            embedTitle: 'Embed title',
+            embedHeight: 'Embed height',
+            timer: 12,
+            illustrationUrl: 'url de l‘illustration',
+            attachments: ['url de la pièce jointe'],
+            competenceId: 'recCompetence0',
+            illustrationAlt: 'Texte alternatif illustration',
+            format: 'mots',
+            autoReply: false,
+            locales: ['fr'],
+            alternativeInstruction: 'Consigne alternative',
+            focusable: false,
+            delta: 0.5,
+            alpha: 0.9,
+            responsive: ['Smartphone'],
+            genealogy: 'Prototype 1',
+          }],
+        };
+        databaseBuilder.factory.buildRelease({
+          content: releaseContent
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          challengeId: 'recChallenge0',
+          id: 'recChallenge0',
+          locale: 'fr',
+        });
+
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+        const getTranslationsOptions = {
+          method: 'GET',
+          url: '/api/translations.csv',
+          headers: {
+            ...generateAuthorizationHeader(user),
+            host: 'test.site',
+          },
+        };
+
+        // When
+        const response = await server.inject(getTranslationsOptions);
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
+
+        const [headers, ...data] = await new Promise((resolve, reject) => {
+          const stream = parseCSVString(response.payload);
+          const data = [];
+          stream.on('data', (chunk) => data.push(chunk));
+          stream.on('end', () => resolve(data));
+          stream.on('error', (error) => reject(error));
+        });
+
+        expect(headers).to.deep.equal(['key', 'fr', 'tags', 'description']);
+        expect(_.orderBy(data, '0')).to.deep.equal([
+          [
+            'challenge.recChallenge0.alternativeInstruction',
+            'Consigne alternative',
+            'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPix Editor: http://test.site/challenge/recChallenge0'
+          ],
+          [
+            'challenge.recChallenge0.embedTitle',
+            'Embed title',
+            'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPix Editor: http://test.site/challenge/recChallenge0'
+          ],
+          [
+            'challenge.recChallenge0.instruction',
+            'Consigne du [NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]Challenge[NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]',
+            'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPix Editor: http://test.site/challenge/recChallenge0'
+          ],
+          [
+            'challenge.recChallenge0.proposals',
+            'Propositions du [NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]Challenge[NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]',
+            'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPix Editor: http://test.site/challenge/recChallenge0'
+          ],
+          [
+            'challenge.recChallenge0.solution',
+            'Bonnes réponses du Challenge',
+            'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPix Editor: http://test.site/challenge/recChallenge0'
+          ],
+          [
+            'challenge.recChallenge0.solutionToDisplay',
+            'Bonnes réponses du Challenge à afficher',
+            'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPix Editor: http://test.site/challenge/recChallenge0'
+          ],
+          [
+            'competence.recCompetence0.description',
+            'Description de la compétence - fr',
+            'competence,Pix-1-1.1,Pix-1,Pix',
+            ''
+          ],
+          [
+            'competence.recCompetence0.name',
+            'Nom de la Compétence - fr',
+            'competence,Pix-1-1.1,Pix-1,Pix',
+            ''
+          ],
+          [
+            'skill.recSkill0.hint',
+            '[NOTRANSLATE][antislashdoublequote][/NOTRANSLATE]Indice[NOTRANSLATE][antislashdoublequote][/NOTRANSLATE] - fr',
+            'acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+            ''
+          ],
+        ]);
+      });
+    });
   });
 
   describe('PATCH /translations.csv - import translations from a CSV file', () => {

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -891,5 +891,59 @@ describe('Acceptance | Controller | translations-controller', () => {
       expect(await knex('translations').where({ key: 'some-key' }).select('value').first()).to.deep.equal({ value: 'plop' });
     });
 
+    describe('when the file contains [antislashdoublequote] occurences', () => {
+      it('should replace these by \\"', async () => {
+        // Given
+        const user = databaseBuilder.factory.buildAdminUser();
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.challengeId.some-key',
+          locale: 'fr',
+          value: 'La clé !'
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: 'challengeId',
+          challengeId: 'challengeId',
+          locale: 'fr',
+        });
+
+        await databaseBuilder.commit();
+        const formData = new FormData();
+        formData.append('file', 'key_name,nl,comment\nchallenge.challengeId.some-key,[antislashdoublequote]plop[antislashdoublequote],commentaire\nchallenge.challengeId.key,[antislashdoublequote]blip[antislashdoublequote],', 'test.csv');
+
+        const server = await createServer();
+        const putTranslationsOptions = {
+          method: 'PATCH',
+          url: '/api/translations.csv',
+          headers: {
+            ...generateAuthorizationHeader(user),
+            ...formData.getHeaders(),
+          },
+          payload: formData.getBuffer()
+        };
+
+        // When
+        const response = await server.inject(putTranslationsOptions);
+
+        // Then
+        expect(response.statusCode).to.equal(204);
+        await expect(knex('translations').count()).resolves.to.deep.equal([{ count: 3 }]);
+        await expect(knex('translations')
+          .where({ key: 'challenge.challengeId.some-key' })
+          .select('locale', 'value')
+          .orderBy('locale'))
+          .resolves.to.deep.equal([{ locale: 'fr', value: 'La clé !' }, { locale: 'nl', value: '\\"plop\\"' }]);
+        await expect(knex('translations')
+          .where({ key: 'challenge.challengeId.key' })
+          .select('locale', 'value')
+          .first())
+          .resolves.to.deep.equal({ locale: 'nl', value: '\\"blip\\"' });
+        await expect(knex('localized_challenges').count()).resolves.to.deep.equal([{ count: 2 }]);
+        await expect(knex('localized_challenges')
+          .where({ locale: 'nl' })
+          .select(['challengeId', 'locale'])
+          .first())
+          .resolves.to.deep.equal({ challengeId: 'challengeId', locale: 'nl' });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Certaines épreuves contiennent `\"` dans leurs phrases à traduire, et la présence de ces caractères dans l'export CSV des traductions fait planter l'import dans Phrase.

## :gift: Proposition
En attendant un bugfix de leur part, on choisit de transformer `\"` par `[antislashquote]` pour importer dans Phrase
et on fait l'action inverse pour la réimportation dans Pix Editor.

## :socks: Remarques
RAS

## :santa: Pour tester
### Dans Pix Editor (/admin)
- Exporter un .csv à partir d'AdminJs (dans pix-editor) contenant une phrase à traduire avec `\"`

### Dans Phrase.com
- L'importer dans Phrase
- S'assurer que Phrase a bien importé cette phrase critique.
- Faire une traduction nl
- Exporter la traduction nl en .csv

### Dans Pix-Editor (/admin)
- Réimporter ce .csv dans AdminJs
- S'assurer que la traduction a bien toujours cette phrase avec son `\"`
- 🎉 
