### PR TITLE
[TECH] Vérifier que la version de node est disponible sur Scalingo avant de la mettre à jour

### DIFF
--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -1,0 +1,15 @@
+name: Check node version availability on Scalingo
+
+on: [push]
+
+jobs:
+  check-node-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0
+        with:
+          directory: 'api'
+


### PR DESCRIPTION
## :christmas_tree: Problème

Renovate propose des versions de node qui ne sont pas encore disponibles sur Scalingo

## :gift: Proposition

Faire un check de la disponibilité de la version de node sur Scalingo avant de merger la PR Renovate

## :santa: Pour tester

Vérifier que l'action passe pour cette PR, merger, rebase la PR de Renovate et vérifier que la nouvelle version ne passe pas
