### PR TITLE
[FEATURE] Autorise les épreuves traduites dans les tests statiques (PIX-10848).

### DIFF
--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -91,3 +91,4 @@ export async function deleteByKeyPrefixAndLocales({ prefix, locales, transaction
     await translationDatasource.delete(recordIds);
   }
 }
+

--- a/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
@@ -31,10 +31,6 @@ const serializer = new Serializer('static-courses', {
   },
   typeForAttribute(attribute) {
     if (attribute === 'challengeSummaries') return 'challenge-summaries';
-  },
-  transform(staticCourse) {
-    staticCourse.challengeSummaries?.forEach((challenge) => challenge.previewUrl = `/api/challenges/${challenge.id}/preview`);
-    return staticCourse;
   }
 });
 

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -149,7 +149,6 @@ async function mockCurrentContent() {
       name: 'Nom du Course',
       description: 'Description du Course',
       isActive: true,
-      competences: ['recCompetence0'],
       challenges: ['recChallenge0'],
     }],
     missions: [new Mission({
@@ -414,7 +413,6 @@ async function mockContentForRelease() {
       name: 'Nom du Course',
       description: 'Description du Course',
       isActive: true,
-      competences: ['recCompetence0'],
       challenges: ['recChallenge0'],
     }],
     missions: [new Mission({

--- a/api/tests/acceptance/application/static-courses/get_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course_test.js
@@ -31,6 +31,16 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
       locale: 'fr',
       value: 'instruction for challengeid2',
     });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid1',
+      challengeId: 'challengeid1',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid2',
+      challengeId: 'challengeid2',
+      locale: 'fr',
+    });
     await databaseBuilder.commit();
     const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid1',
@@ -63,7 +73,10 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
     const response = await server.inject({
       method: 'GET',
       url: '/api/static-courses/courseid1',
-      headers: generateAuthorizationHeader(user),
+      headers: {
+        ...generateAuthorizationHeader(user),
+        host: 'host.site',
+      },
     });
 
     // Then
@@ -104,7 +117,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid1',
             'skill-name': '@skillid1',
             status: 'status for challengeid1',
-            'preview-url': '/api/challenges/challengeid1/preview',
+            'preview-url': 'http://host.site/api/challenges/challengeid1/preview',
           },
         },
         {
@@ -115,7 +128,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid2',
             'skill-name': '@skillid2',
             status: 'status for challengeid2',
-            'preview-url': '/api/challenges/challengeid2/preview',
+            'preview-url': 'http://host.site/api/challenges/challengeid2/preview',
           },
         }
       ],

--- a/api/tests/acceptance/application/static-courses/post_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/post_static-course_test.js
@@ -16,20 +16,51 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
       toFake: ['Date'],
     });
     user = databaseBuilder.factory.buildAdminUser();
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid1',
+      challengeId: 'challengeid1',
+      locale: 'fr',
+    });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid1.instruction',
       locale: 'fr',
       value: 'instruction for challengeid1',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid1nl',
+      challengeId: 'challengeid1',
+      locale: 'nl',
+      status: 'proposé',
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: 'challenge.challengeid1.instruction',
+      locale: 'nl',
+      value: 'instruction for challengeid1 in nl',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid2',
+      challengeId: 'challengeid2',
+      locale: 'fr',
     });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid2.instruction',
       locale: 'fr',
       value: 'instruction for challengeid2',
     });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid3',
+      challengeId: 'challengeid3',
+      locale: 'fr',
+    });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid3.instruction',
       locale: 'fr',
       value: 'instruction for challengeid3',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid4',
+      challengeId: 'challengeid4',
+      locale: 'fr',
     });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid4.instruction',
@@ -41,7 +72,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid1',
       skillId: 'skillid1',
-      status: 'status for challengeid1',
+      status: 'validé',
       locales: ['fr'],
     });
     const airtableSkill1 = airtableBuilder.factory.buildSkill({
@@ -52,7 +83,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     const airtableChallenge2 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid2',
       skillId: 'skillid2',
-      status: 'status for challengeid2',
+      status: 'proposé',
       locales: ['fr'],
     });
     const airtableSkill2 = airtableBuilder.factory.buildSkill({
@@ -63,7 +94,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     const airtableChallenge3 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid3',
       skillId: 'skillid3',
-      status: 'status for challengeid3',
+      status: 'proposé',
       locales: ['fr'],
     });
     const airtableSkill3 = airtableBuilder.factory.buildSkill({
@@ -74,7 +105,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     const airtableChallenge4 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid4',
       skillId: 'skillid4',
-      status: 'status for challengeid4',
+      status: 'proposé',
       locales: ['fr'],
     });
     const airtableSkill4 = airtableBuilder.factory.buildSkill({
@@ -100,7 +131,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
         attributes: {
           name: 'static course 1',
           description: 'static course description',
-          'challenge-ids': ['challengeid3', 'challengeid1'],
+          'challenge-ids': ['challengeid3', 'challengeid1', 'challengeid1nl'],
         },
       },
     };
@@ -110,7 +141,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     const response = await server.inject({
       method: 'POST',
       url: '/api/static-courses',
-      headers: generateAuthorizationHeader(user),
+      headers: { ...generateAuthorizationHeader(user), host: 'test.site' },
       payload,
     });
 
@@ -140,6 +171,10 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
                 type: 'challenge-summaries',
                 id: 'challengeid1',
               },
+              {
+                type: 'challenge-summaries',
+                id: 'challengeid1nl',
+              },
             ],
           },
         },
@@ -152,8 +187,8 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
             index: 0,
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
-            status: 'status for challengeid3',
-            'preview-url': '/api/challenges/challengeid3/preview',
+            status: 'proposé',
+            'preview-url': 'http://test.site/api/challenges/challengeid3/preview',
           },
         },
         {
@@ -163,10 +198,21 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
             index: 1,
             instruction: 'instruction for challengeid1',
             'skill-name': '@skillid1',
-            status: 'status for challengeid1',
-            'preview-url': '/api/challenges/challengeid1/preview',
+            status: 'validé',
+            'preview-url': 'http://test.site/api/challenges/challengeid1/preview',
           },
-        }
+        },
+        {
+          type: 'challenge-summaries',
+          id: 'challengeid1nl',
+          attributes: {
+            index: 2,
+            instruction: 'instruction for challengeid1 in nl',
+            'skill-name': '@skillid1',
+            status: 'proposé',
+            'preview-url': 'http://test.site/api/challenges/challengeid1/preview?locale=nl',
+          },
+        },
       ],
     });
   });

--- a/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
@@ -26,6 +26,21 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       createdAt: new Date('2020-01-01T00:00:10Z'),
       updatedAt: new Date('2020-01-01T00:00:10Z'),
     });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid2',
+      challengeId: 'challengeid2',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid3',
+      challengeId: 'challengeid3',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid4',
+      challengeId: 'challengeid4',
+      locale: 'fr',
+    });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid2.instruction',
       locale: 'fr',
@@ -101,7 +116,10 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
     const response = await server.inject({
       method: 'PUT',
       url: `/api/static-courses/${staticCourseId}/deactivate`,
-      headers: generateAuthorizationHeader(user),
+      headers: {
+        ...generateAuthorizationHeader(user),
+        host: 'test.site'
+      },
       payload,
     });
 
@@ -147,7 +165,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid2',
             'skill-name': '@skillid2',
             status: 'status for challengeid2',
-            'preview-url': '/api/challenges/challengeid2/preview',
+            'preview-url': 'http://test.site/api/challenges/challengeid2/preview',
           },
         },
         {
@@ -158,7 +176,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
             status: 'status for challengeid3',
-            'preview-url': '/api/challenges/challengeid3/preview',
+            'preview-url': 'http://test.site/api/challenges/challengeid3/preview',
           },
         },
         {
@@ -169,7 +187,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid4',
             'skill-name': '@skillid4',
             status: 'status for challengeid4',
-            'preview-url': '/api/challenges/challengeid4/preview',
+            'preview-url': 'http://test.site/api/challenges/challengeid4/preview',
           },
         }
       ],

--- a/api/tests/acceptance/application/static-courses/put_static-course-reactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-reactivate_test.js
@@ -72,6 +72,21 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       createdAt: new Date('2020-01-01T00:00:10Z'),
       updatedAt: new Date('2020-01-02T00:00:10Z'),
     });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid2',
+      challengeId: 'challengeid2',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid3',
+      challengeId: 'challengeid3',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid4',
+      challengeId: 'challengeid4',
+      locale: 'fr',
+    });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid2.instruction',
       locale: 'fr',
@@ -101,7 +116,10 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
     const response = await server.inject({
       method: 'PUT',
       url: `/api/static-courses/${staticCourseId}/reactivate`,
-      headers: generateAuthorizationHeader(user),
+      headers: {
+        ...generateAuthorizationHeader(user),
+        host: 'test.site',
+      },
     });
 
     // then
@@ -146,7 +164,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid2',
             'skill-name': '@skillid2',
             status: 'status for challengeid2',
-            'preview-url': '/api/challenges/challengeid2/preview',
+            'preview-url': 'http://test.site/api/challenges/challengeid2/preview',
           },
         },
         {
@@ -157,7 +175,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
             status: 'status for challengeid3',
-            'preview-url': '/api/challenges/challengeid3/preview',
+            'preview-url': 'http://test.site/api/challenges/challengeid3/preview',
           },
         },
         {
@@ -168,7 +186,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
             instruction: 'instruction for challengeid4',
             'skill-name': '@skillid4',
             status: 'status for challengeid4',
-            'preview-url': '/api/challenges/challengeid4/preview',
+            'preview-url': 'http://test.site/api/challenges/challengeid4/preview',
           },
         }
       ],

--- a/api/tests/acceptance/application/static-courses/put_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course_test.js
@@ -37,6 +37,32 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       createdAt: new Date('2020-01-01T00:00:10Z'),
       updatedAt: new Date('2020-01-01T00:00:10Z'),
     });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid2',
+      challengeId: 'challengeid2',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid3',
+      challengeId: 'challengeid3',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeid1',
+      challengeId: 'challengeid1',
+      locale: 'fr',
+    });
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeidnl1',
+      challengeId: 'challengeid1',
+      locale: 'nl',
+      status: 'validé',
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: 'challenge.challengeid1.instruction',
+      locale: 'nl',
+      value: 'instruction for challengeidnl1',
+    });
     databaseBuilder.factory.buildTranslation({
       key: 'challenge.challengeid1.instruction',
       locale: 'fr',
@@ -113,6 +139,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
     return knex('static_courses').delete();
   });
 
+  // Add some localized challenge and make the test pass
   it('updates and returns the static course', async function() {
     // given
     const payload = {
@@ -120,7 +147,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
         attributes: {
           name: 'static course 1',
           description: 'static course description',
-          'challenge-ids': ['challengeid3', 'challengeid1'],
+          'challenge-ids': ['challengeid3', 'challengeid1', 'challengeidnl1'],
         },
       },
     };
@@ -130,7 +157,10 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
     const response = await server.inject({
       method: 'PUT',
       url: `/api/static-courses/${activeCourseId}`,
-      headers: generateAuthorizationHeader(user),
+      headers: {
+        ...generateAuthorizationHeader(user),
+        host: 'host.site',
+      },
       payload,
     });
 
@@ -159,6 +189,10 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
                 type: 'challenge-summaries',
                 id: 'challengeid1',
               },
+              {
+                type: 'challenge-summaries',
+                id: 'challengeidnl1',
+              },
             ],
           },
         },
@@ -172,7 +206,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid3',
             'skill-name': '@skillid3',
             status: 'status for challengeid3',
-            'preview-url': '/api/challenges/challengeid3/preview',
+            'preview-url': 'http://host.site/api/challenges/challengeid3/preview',
           },
         },
         {
@@ -183,9 +217,20 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
             instruction: 'instruction for challengeid1',
             'skill-name': '@skillid1',
             status: 'status for challengeid1',
-            'preview-url': '/api/challenges/challengeid1/preview',
+            'preview-url': 'http://host.site/api/challenges/challengeid1/preview',
           },
-        }
+        },
+        {
+          type: 'challenge-summaries',
+          id: 'challengeidnl1',
+          attributes: {
+            index: 2,
+            instruction: 'instruction for challengeidnl1',
+            'skill-name': '@skillid1',
+            status: 'status for challengeid1',
+            'preview-url': 'http://host.site/api/challenges/challengeid1/preview?locale=nl',
+          },
+        },
       ],
     });
   });

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1310,7 +1310,6 @@ function _getRichCurrentContentDTO() {
       name: 'course1PG name',
       description: 'course1PG description',
       isActive: false,
-      competences: ['competence12', 'competence21'],
       challenges: ['challenge121212', 'challenge211113', 'challengeNl'],
     },
   ];

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -181,7 +181,7 @@ describe('Integration | Repository | release-repository', function() {
         name: 'course1PG name',
         description: 'course1PG description',
         isActive: false,
-        challengeIds: 'challenge121212,challenge211113',
+        challengeIds: 'challenge121212,challenge211113,challengeNl',
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2020-01-02'),
       });
@@ -255,7 +255,7 @@ function buildChallengesTranslationsAndLocalizedChallenges(challenges) {
     buildChallengeTranslationsAndLocalizedChallenge(challenge, challenge.locales[0]);
   }
 
-  buildChallengeTranslationsAndLocalizedChallenge(challenges[0], 'nl-be', 'challenge129803721984');
+  buildChallengeTranslationsAndLocalizedChallenge(challenges[0], 'nl-be', 'challengeNl');
 }
 
 function buildChallengeTranslationsAndLocalizedChallenge(challenge, locale, localizedChallengeId = challenge.id) {
@@ -1147,7 +1147,7 @@ function _getRichCurrentContentDTO() {
       alternativeVersion: 'challenge121211 alternativeVersion',
     },
     {
-      id: 'challenge129803721984',
+      id: 'challengeNl',
       instruction: 'challenge121211 instruction nl-be',
       proposals: 'challenge121211 proposals nl-be',
       type: 'challenge121211 type',
@@ -1311,7 +1311,7 @@ function _getRichCurrentContentDTO() {
       description: 'course1PG description',
       isActive: false,
       competences: ['competence12', 'competence21'],
-      challenges: ['challenge121212', 'challenge211113'],
+      challenges: ['challenge121212', 'challenge211113', 'challengeNl'],
     },
   ];
   const expectedTutorialDTOs = [

--- a/api/tests/unit/application/static-courses/static-courses_test.js
+++ b/api/tests/unit/application/static-courses/static-courses_test.js
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import { hFake, domainBuilder, catchErr } from '../../../test-helper.js';
 import * as staticCourseController from '../../../../lib/application/static-courses/static-courses.js';
-import { challengeRepository, staticCourseRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import { localizedChallengeRepository, staticCourseRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
 import { InvalidStaticCourseCreationOrUpdateError } from '../../../../lib/domain/errors.js';
 
@@ -162,14 +162,14 @@ describe('Unit | Controller | static courses controller', function() {
   describe('create', function() {
 
     describe('creationCommand normalization', function() {
-      let saveStub, getReadStub, getAllIdsInStub, generateNewIdStub;
+      let saveStub, getReadStub, getManyStub, generateNewIdStub;
 
       beforeEach(function() {
         vi.useFakeTimers({
           now: new Date('2021-10-29T03:04:00Z'),
         });
-        getAllIdsInStub = vi.spyOn(challengeRepository, 'getAllIdsIn');
-        getAllIdsInStub.mockResolvedValue(['chalA']);
+        getManyStub = vi.spyOn(localizedChallengeRepository, 'getMany');
+        getManyStub.mockResolvedValue([{ id: 'chalA' }]);
         saveStub = vi.spyOn(staticCourseRepository, 'save');
         saveStub.mockResolvedValue('course123');
         getReadStub = vi.spyOn(staticCourseRepository, 'getRead');
@@ -184,11 +184,13 @@ describe('Unit | Controller | static courses controller', function() {
 
       it('should pass along creation command from attributes when all is valid', async function() {
         // given
-        const request = { payload: { data: { attributes: {
-          name: 'some valid name  ',
-          description: '  some valid description',
-          'challenge-ids': ['chalA'],
-        } } } };
+        const request = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name  ',
+            description: '  some valid description',
+            'challenge-ids': ['chalA'],
+          } } } };
 
         // when
         await staticCourseController.create(request, hFake);
@@ -207,20 +209,26 @@ describe('Unit | Controller | static courses controller', function() {
 
       it('should normalize name to an empty string when not a string, and thus throw an error', async function() {
         // given
-        const request0 = { payload: { data: { attributes: {
-          name: null,
-          description: '  some valid description',
-          'challenge-ids': ['chalA'],
-        } } } };
-        const request1 = { payload: { data: { attributes: {
-          description: '  some valid description',
-          'challenge-ids': ['chalA'],
-        } } } };
-        const request2 = { payload: { data: { attributes: {
-          name: 123,
-          description: '  some valid description',
-          'challenge-ids': ['chalA'],
-        } } } };
+        const request0 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: null,
+            description: '  some valid description',
+            'challenge-ids': ['chalA'],
+          } } } };
+        const request1 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            description: '  some valid description',
+            'challenge-ids': ['chalA'],
+          } } } };
+        const request2 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 123,
+            description: '  some valid description',
+            'challenge-ids': ['chalA'],
+          } } } };
 
         // when
         const error0 = await catchErr(staticCourseController.create)(request0, hFake);
@@ -239,20 +247,26 @@ describe('Unit | Controller | static courses controller', function() {
 
       it('should normalize description to an empty string when not a string', async function() {
         // given
-        const request0 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          description: null,
-          'challenge-ids': ['chalA'],
-        } } } };
-        const request1 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          'challenge-ids': ['chalA'],
-        } } } };
-        const request2 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          description: 123,
-          'challenge-ids': ['chalA'],
-        } } } };
+        const request0 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            description: null,
+            'challenge-ids': ['chalA'],
+          } } } };
+        const request1 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            'challenge-ids': ['chalA'],
+          } } } };
+        const request2 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            description: 123,
+            'challenge-ids': ['chalA'],
+          } } } };
 
         // when
         await staticCourseController.create(request0, hFake);
@@ -275,25 +289,33 @@ describe('Unit | Controller | static courses controller', function() {
 
       it('should normalize challengeIds to an empty array when not an array, and thus throw an error', async function() {
         // given
-        const request0 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          description: 'some valid description',
-          challengeIds: 'coucou',
-        } } } };
-        const request1 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          description: 'some valid description',
-          challengeIds: null,
-        } } } };
-        const request2 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          description: 'some valid description',
-        } } } };
-        const request3 = { payload: { data: { attributes: {
-          name: 'some valid name',
-          description: 'some valid description',
-          challengeIds: 123,
-        } } } };
+        const request0 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            description: 'some valid description',
+            challengeIds: 'coucou',
+          } } } };
+        const request1 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            description: 'some valid description',
+            challengeIds: null,
+          } } } };
+        const request2 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            description: 'some valid description',
+          } } } };
+        const request3 = {
+          url: { host: 'host.site', protocol: 'http:' },
+          payload: { data: { attributes: {
+            name: 'some valid name',
+            description: 'some valid description',
+            challengeIds: 123,
+          } } } };
 
         // when
         const error0 = await catchErr(staticCourseController.create)(request0, hFake);
@@ -317,14 +339,14 @@ describe('Unit | Controller | static courses controller', function() {
   describe('update', function() {
 
     describe('updateCommand normalization', function() {
-      let saveStub, getReadStub, getAllIdsInStub, getStub;
+      let saveStub, getReadStub, getManyStub, getStub;
 
       beforeEach(function() {
         vi.useFakeTimers({
           now: new Date('2021-10-29T03:04:00Z'),
         });
-        getAllIdsInStub = vi.spyOn(challengeRepository, 'getAllIdsIn');
-        getAllIdsInStub.mockResolvedValue(['chalA']);
+        getManyStub = vi.spyOn(localizedChallengeRepository, 'getMany');
+        getManyStub.mockResolvedValue([{ id: 'chalA' }]);
         saveStub = vi.spyOn(staticCourseRepository, 'save');
         saveStub.mockResolvedValue();
         getStub = vi.spyOn(staticCourseRepository, 'get');
@@ -343,6 +365,7 @@ describe('Unit | Controller | static courses controller', function() {
       it('should pass along update command from attributes when all is valid', async function() {
         // given
         const request = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name  ',
             description: '  some valid description',
@@ -368,6 +391,7 @@ describe('Unit | Controller | static courses controller', function() {
       it('should normalize name to an empty string when not a string, and thus throw an error', async function() {
         // given
         const request0 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: null,
             description: '  some valid description',
@@ -375,12 +399,14 @@ describe('Unit | Controller | static courses controller', function() {
           } } },
           params: { id: 'someCourseId' } };
         const request1 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             description: '  some valid description',
             'challenge-ids': ['chalA'],
           } } },
           params: { id: 'someCourseId' } };
         const request2 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 123,
             description: '  some valid description',
@@ -406,6 +432,7 @@ describe('Unit | Controller | static courses controller', function() {
       it('should normalize description to an empty string when not a string', async function() {
         // given
         const request0 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             description: null,
@@ -413,12 +440,14 @@ describe('Unit | Controller | static courses controller', function() {
           } } },
           params: { id: 'someCourseId' } };
         const request1 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             'challenge-ids': ['chalA'],
           } } },
           params: { id: 'someCourseId' } };
         const request2 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             description: 123,
@@ -448,6 +477,7 @@ describe('Unit | Controller | static courses controller', function() {
       it('should normalize challengeIds to an empty array when not an array, and thus throw an error', async function() {
         // given
         const request0 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             description: 'some valid description',
@@ -455,6 +485,7 @@ describe('Unit | Controller | static courses controller', function() {
           } } },
           params: { id: 'someCourseId' } };
         const request1 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             description: 'some valid description',
@@ -462,12 +493,14 @@ describe('Unit | Controller | static courses controller', function() {
           } } },
           params: { id: 'someCourseId' } };
         const request2 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             description: 'some valid description',
           } } },
           params: { id: 'someCourseId' } };
         const request3 = {
+          url: { host: 'host.site', protocol: 'http:' },
           payload: { data: { attributes: {
             name: 'some valid name',
             description: 'some valid description',


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de la création ou mise à jour d'un test statique, on fait la vérification que les identifiants d'épreuves sont dans la table `Epreuve` de Airtable.
Cela ne permet pas d'ajouter des épreuves traduites qui sont stockées dans la table `localized-challenges` de PG.

## :gift: Proposition

On se base sur le `localizedChallengeRepository` pour valider les identifiants d'épreuve.
On en profite pour calculer les statuts et les url de prévisualisation correctement.

## :socks: Remarques

RAS.

## :santa: Pour tester

Se rendre sur la partie Test statique.
Modifier un test statique en ajoutant un identifiant d'épreuve traduite.
Créer un test statique incluant un identifiant d'épreuve traduite.
Créer une release.
Vérifier que les 2 tests statiques sont inclus dans la release et contiennent l'identifiant d'épreuve traduite.
