### PR TITLE
[FEATURE] Ajoute les épreuves traduites à la réplication (PIX-10761)

### DIFF
--- a/api/lib/domain/services/translate-challenge.js
+++ b/api/lib/domain/services/translate-challenge.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
-import { Challenge } from '../../domain/models/Challenge.js';
+import { Challenge } from '../models/Challenge.js';
 import { fields as challengeLocalizedFields } from '../../infrastructure/translations/challenge.js';
 
-export function translateChallenges({ localizedChallenges }) {
+export function createChallengeTranslator({ localizedChallenges }) {
   const localizedChallengesByChallengeId = _.groupBy(localizedChallenges, 'challengeId');
   return (challenge) => localizedChallengesByChallengeId[challenge.id]
     .map((localizedChallenge) => translateChallenge(challenge, localizedChallenge));

--- a/api/lib/domain/services/translate-challenges.js
+++ b/api/lib/domain/services/translate-challenges.js
@@ -1,9 +1,11 @@
+import _ from 'lodash';
 import { Challenge } from '../../domain/models/Challenge.js';
 import { fields as challengeLocalizedFields } from '../../infrastructure/translations/challenge.js';
 
 export function translateChallenges({ localizedChallenges }) {
-  return (challenge) => localizedChallenges
-    .filter((localizedChallenge) => localizedChallenge.challengeId === challenge.id)
+  const localizedChallengesByChallengeId = _.groupBy(localizedChallenges, 'challengeId');
+
+  return (challenge) => localizedChallengesByChallengeId[challenge.id]
     .map((localizedChallenge) => translateChallenge(challenge, localizedChallenge));
 }
 

--- a/api/lib/domain/services/translate-challenges.js
+++ b/api/lib/domain/services/translate-challenges.js
@@ -4,7 +4,6 @@ import { fields as challengeLocalizedFields } from '../../infrastructure/transla
 
 export function translateChallenges({ localizedChallenges }) {
   const localizedChallengesByChallengeId = _.groupBy(localizedChallenges, 'challengeId');
-
   return (challenge) => localizedChallengesByChallengeId[challenge.id]
     .map((localizedChallenge) => translateChallenge(challenge, localizedChallenge));
 }

--- a/api/lib/domain/services/translate-challenges.js
+++ b/api/lib/domain/services/translate-challenges.js
@@ -1,0 +1,41 @@
+import { Challenge } from '../../domain/models/Challenge.js';
+import { fields as challengeLocalizedFields } from '../../infrastructure/translations/challenge.js';
+
+export function translateChallenges({ localizedChallenges }) {
+  return (challenge) => localizedChallenges
+    .filter((localizedChallenge) => localizedChallenge.challengeId === challenge.id)
+    .map((localizedChallenge) => translateChallenge(challenge, localizedChallenge));
+}
+
+export function translateChallenge(challenge, localizedChallenge) {
+  const primaryLocale = Challenge.getPrimaryLocale(challenge.locales) ?? 'fr';
+  const isPrimaryLocale = primaryLocale === localizedChallenge.locale;
+  const clearedLocalizedFields = challengeLocalizedFields.reduce((acc, field) => {
+    acc[field] = '';
+    return acc;
+  }, {});
+  return {
+    ...challenge,
+    ...clearedLocalizedFields,
+    ...challenge.translations[localizedChallenge.locale],
+    id: localizedChallenge.id,
+    status: isPrimaryLocale ? challenge.status : getLocalizedChallengeStatus(challenge, localizedChallenge),
+    embedUrl: localizedChallenge.embedUrl ?? _replaceLangParamsInUrl(localizedChallenge.locale, challenge.embedUrl),
+    locales: isPrimaryLocale ? challenge.locales : [localizedChallenge.locale],
+  };
+}
+
+function getLocalizedChallengeStatus(challenge, localizedChallenge) {
+  if (['proposé', 'périmé'].includes(challenge.status) || localizedChallenge.status === 'validé') {
+    return challenge.status;
+  }
+  return localizedChallenge.status;
+}
+
+function _replaceLangParamsInUrl(locale, embedUrl) {
+  if (!embedUrl) return undefined;
+  const url = new URL(embedUrl);
+  url.searchParams.set('lang', locale);
+  return url.href;
+}
+

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -7,7 +7,7 @@ import {
 } from '../../infrastructure/datasources/airtable/index.js';
 import { challengeRepository, localizedChallengeRepository, competenceRepository, skillRepository } from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { translateChallenges } from '../services/translate-challenges.js';
+import { createChallengeTranslator } from '../services/translate-challenge.js';
 
 export async function getLearningContentForReplication() {
   const [
@@ -33,9 +33,9 @@ export async function getLearningContentForReplication() {
     thematicDatasource.list(),
     _getCoursesFromPGForReplication(),
   ]);
-  const translate = translateChallenges({ localizedChallenges });
+  const translateChallenge = createChallengeTranslator({ localizedChallenges });
 
-  const translatedChallenges = challenges.flatMap((challenge) => translate(challenge)).map(normalizeChallenge);
+  const translatedChallenges = challenges.flatMap(translateChallenge).map(normalizeChallenge);
 
   return {
     areas,

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -1,12 +1,12 @@
 import _ from 'lodash';
-import { translateChallenges, translateChallenge } from '../../domain/services/translate-challenges.js';
+import { createChallengeTranslator, translateChallenge } from '../../domain/services/translate-challenge.js';
 
 export function createChallengeTransformer({ attachments, localizedChallenges, localizedChallenge }) {
 
   if (localizedChallenges) {
     return _.flow(
       _addAttachmentsToChallenge({ attachments }),
-      translateChallenges({ localizedChallenges }),
+      createChallengeTranslator({ localizedChallenges }),
       _filterChallengesFields,
     );
   }

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -1,13 +1,12 @@
 import _ from 'lodash';
-import { Challenge } from '../../domain/models/Challenge.js';
-import { fields as challengeLocalizedFields } from '../../infrastructure/translations/challenge.js';
+import { translateChallenges, translateChallenge } from '../../domain/services/translate-challenges.js';
 
 export function createChallengeTransformer({ attachments, localizedChallenges, localizedChallenge }) {
 
   if (localizedChallenges) {
     return _.flow(
       _addAttachmentsToChallenge({ attachments }),
-      _challengeToTranslatedChallenges({ localizedChallenges }),
+      translateChallenges({ localizedChallenges }),
       _filterChallengesFields,
     );
   }
@@ -15,7 +14,7 @@ export function createChallengeTransformer({ attachments, localizedChallenges, l
   if (localizedChallenge) {
     return _.flow(
       _addAttachmentsToChallenge({ attachments }),
-      (challenge) => _translateChallenge(challenge, localizedChallenge),
+      (challenge) => translateChallenge(challenge, localizedChallenge),
       _filterChallengeFields,
     );
   }
@@ -24,44 +23,6 @@ export function createChallengeTransformer({ attachments, localizedChallenges, l
     _addAttachmentsToChallenge({ attachments }),
     _filterChallengeFields,
   );
-}
-
-function _challengeToTranslatedChallenges({ localizedChallenges }) {
-  return (challenge) => localizedChallenges
-    .filter((localizedChallenge) => localizedChallenge.challengeId === challenge.id)
-    .map((localizedChallenge) => _translateChallenge(challenge, localizedChallenge));
-}
-
-function _translateChallenge(challenge, localizedChallenge) {
-  const primaryLocale = Challenge.getPrimaryLocale(challenge.locales) ?? 'fr';
-  const isPrimaryLocale = primaryLocale === localizedChallenge.locale;
-  const clearedLocalizedFields = challengeLocalizedFields.reduce((acc, field) => {
-    acc[field] = '';
-    return acc;
-  }, {});
-  return {
-    ...challenge,
-    ...clearedLocalizedFields,
-    ...challenge.translations[localizedChallenge.locale],
-    id: localizedChallenge.id,
-    status: isPrimaryLocale ? challenge.status : getLocalizedChallengeStatus(challenge, localizedChallenge),
-    embedUrl: localizedChallenge.embedUrl ?? _replaceLangParamsInUrl(localizedChallenge.locale, challenge.embedUrl),
-    locales: isPrimaryLocale ? challenge.locales : [localizedChallenge.locale],
-  };
-}
-
-function getLocalizedChallengeStatus(challenge, localizedChallenge) {
-  if (['proposé', 'périmé'].includes(challenge.status) || localizedChallenge.status === 'validé') {
-    return challenge.status;
-  }
-  return localizedChallenge.status;
-}
-
-function _replaceLangParamsInUrl(locale, embedUrl) {
-  if (!embedUrl) return undefined;
-  const url = new URL(embedUrl);
-  url.searchParams.set('lang', locale);
-  return url.href;
 }
 
 function _filterChallengesFields(challenges) {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -20,6 +20,24 @@ const {
 
 async function mockCurrentContent() {
   const challenge = domainBuilder.buildChallenge();
+  const challengeNl = domainBuilder.buildChallenge({
+    id: 'localized-challenge-id',
+    locales: ['nl'],
+    embedUrl: 'https://github.io/page/epreuve.html?lang=nl',
+    translations: {
+      nl: {
+        instruction: 'Consigne en nl',
+      },
+    },
+  });
+  const expectedChallenge = { ...challenge };
+  delete expectedChallenge.localizedChallenges;
+  delete expectedChallenge.translations;
+
+  const expectedChallengeNl = { ...challengeNl };
+  delete expectedChallengeNl.localizedChallenges;
+  delete expectedChallengeNl.translations;
+
   const expectedCurrentContent = {
     attachments: [domainBuilder.buildAttachment()],
     areas: [domainBuilder.buildAreaDatasourceObject()],
@@ -35,7 +53,7 @@ async function mockCurrentContent() {
     })],
     tubes: [domainBuilder.buildTubeDatasourceObject()],
     skills: [domainBuilder.buildSkill()],
-    challenges: [challenge],
+    challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
     thematics: [domainBuilder.buildThematicDatasourceObject()],
     courses: [{
@@ -53,7 +71,7 @@ async function mockCurrentContent() {
     competences: [buildCompetence(expectedCurrentContent.competences[0])],
     tubes: [buildTube(expectedCurrentContent.tubes[0])],
     skills: [buildSkill(expectedCurrentContent.skills[0])],
-    challenges: [buildChallenge(expectedCurrentContent.challenges[0])],
+    challenges: [buildChallenge(expectedChallenge)],
     tutorials: [buildTutorial(expectedCurrentContent.tutorials[0])],
     thematics: [buildThematic(expectedCurrentContent.thematics[0])],
     attachments: [buildAttachment(expectedCurrentContent.attachments[0])],
@@ -78,6 +96,18 @@ async function mockCurrentContent() {
     challengeId: challenge.id,
     locale: 'fr',
     embedUrl: challenge.embedUrl,
+    status: 'validé',
+  });
+  databaseBuilder.factory.buildLocalizedChallenge({
+    id: 'localized-challenge-id',
+    challengeId: challenge.id,
+    locale: 'nl',
+    status: 'validé',
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${challenge.id}.instruction`,
+    locale: 'nl',
+    value: 'Consigne en nl',
   });
   databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
@@ -112,34 +142,34 @@ async function mockCurrentContent() {
   });
 
   databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedCurrentContent.challenges[0].id}.instruction`,
+    key: `challenge.${expectedChallenge.id}.instruction`,
     locale: 'fr',
-    value: expectedCurrentContent.challenges[0].translations.fr.instruction,
+    value: expectedChallenge.instruction,
   });
   databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedCurrentContent.challenges[0].id}.alternativeInstruction`,
+    key: `challenge.${expectedChallenge.id}.alternativeInstruction`,
     locale: 'fr',
-    value: expectedCurrentContent.challenges[0].translations.fr.alternativeInstruction,
+    value: expectedChallenge.alternativeInstruction,
   });
   databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedCurrentContent.challenges[0].id}.proposals`,
+    key: `challenge.${expectedChallenge.id}.proposals`,
     locale: 'fr',
-    value: expectedCurrentContent.challenges[0].translations.fr.proposals,
+    value: expectedChallenge.proposals,
   });
   databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedCurrentContent.challenges[0].id}.solution`,
+    key: `challenge.${expectedChallenge.id}.solution`,
     locale: 'fr',
-    value: expectedCurrentContent.challenges[0].translations.fr.solution,
+    value: expectedChallenge.solution,
   });
   databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedCurrentContent.challenges[0].id}.solutionToDisplay`,
+    key: `challenge.${expectedChallenge.id}.solutionToDisplay`,
     locale: 'fr',
-    value: expectedCurrentContent.challenges[0].translations.fr.solutionToDisplay,
+    value: expectedChallenge.solutionToDisplay,
   });
   databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedCurrentContent.challenges[0].id}.embedTitle`,
+    key: `challenge.${expectedChallenge.id}.embedTitle`,
     locale: 'fr',
-    value: expectedCurrentContent.challenges[0].translations.fr.embedTitle,
+    value: expectedChallenge.embedTitle,
   });
 
   await databaseBuilder.commit();


### PR DESCRIPTION
## :christmas_tree: Problème

Les épreuves traduites (localized challenges) ne sont pas envoyées dans la réplication.
Il n'est donc pas possible de faire du traitement de données en les prenant en compte.

## :gift: Proposition

On extrait du `challenge-transformer` la création des épreuves traduites dans un service dédié.
On utilise de service `translate-challenges` lors de la création de la réplication.

## :socks: Remarques

Le test d'acceptance est compliqué à maintenir, il faut envisager la création de modèles dédiés à la réplication pour essayer de le simplifier.

## :santa: Pour tester

Appeler la route `GET /api/replication-data`.
Vérifier que la clé `challenges` contient des épreuves traduites.
