### PR TITLE
[FEATURE] Rattacher l'attachment à un localized challenge (PIX-10879)

### DIFF
--- a/pix-editor/app/serializers/attachment.js
+++ b/pix-editor/app/serializers/attachment.js
@@ -16,9 +16,11 @@ export default class AttachmentSerializer extends AirtableSerializer {
   }
 
   serializeBelongsTo(snapshot, json, relationship) {
-    const payloadKey = 'challengeId';
-    const key = relationship.key;
+    if (relationship.key !== 'challenge') return;
 
-    json[payloadKey] = [snapshot.belongsTo(key).attributes().airtableId];
+    const challengeId = snapshot.belongsTo('challenge').attributes().airtableId;
+
+    json.challengeId = [challengeId];
+    json.localizedChallengeId = challengeId;
   }
 }

--- a/pix-editor/tests/unit/serializers/attachment-test.js
+++ b/pix-editor/tests/unit/serializers/attachment-test.js
@@ -26,6 +26,7 @@ module('Unit | Serializer | attachment', function(hooks) {
       type: 'type',
       alt: 'alt',
       challengeId: ['myAirtableId'],
+      localizedChallengeId: 'myAirtableId',
     };
 
     const serializedAttachment = attachment.serialize();


### PR DESCRIPTION
## :christmas_tree: Problème
Un attachment n'est rattaché à aucune langue.

## :gift: Proposition
Ajouter une colonne permettant de rattacher un attachment à une traduction précise du challenge.

## :socks: Remarques
N/A

## :santa: Pour tester
Vérifier que quand on créé un nouvel attachment, sa colonne localizedChallengeId porte la même valeur que sa colonne challenge id persistant.