### PR TITLE
[BUGFIX] Le localizedChallengeId doit se baser sur le challengeId Persistant (PIX-10884)

### DIFF
--- a/pix-editor/app/serializers/attachment.js
+++ b/pix-editor/app/serializers/attachment.js
@@ -18,9 +18,10 @@ export default class AttachmentSerializer extends AirtableSerializer {
   serializeBelongsTo(snapshot, json, relationship) {
     if (relationship.key !== 'challenge') return;
 
-    const challengeId = snapshot.belongsTo('challenge').attributes().airtableId;
+    const challenge = snapshot.belongsTo('challenge');
+    const { airtableId } = challenge.attributes();
 
-    json.challengeId = [challengeId];
-    json.localizedChallengeId = challengeId;
+    json.challengeId = [airtableId];
+    json.localizedChallengeId = challenge.id;
   }
 }

--- a/pix-editor/tests/unit/serializers/attachment-test.js
+++ b/pix-editor/tests/unit/serializers/attachment-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Serializer | attachment', function(hooks) {
+module('Unit | Serializer | attachment', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes attachments', function(assert) {
+  test('it serializes attachments', function (assert) {
     const store = this.owner.lookup('service:store');
     const challenge = run(() => store.createRecord('challenge', { id: 'challengeId', airtableId: 'myAirtableId' }));
     const attachment = run(() => store.createRecord('attachment', {
@@ -26,7 +26,7 @@ module('Unit | Serializer | attachment', function(hooks) {
       type: 'type',
       alt: 'alt',
       challengeId: ['myAirtableId'],
-      localizedChallengeId: 'myAirtableId',
+      localizedChallengeId: 'challengeId'
     };
 
     const serializedAttachment = attachment.serialize();


### PR DESCRIPTION
## :christmas_tree: Problème
Nos localizedChallengeId enregistrés dans airtable ne copiaient pas le bon id de challenge.

## :gift: Proposition
Ils doivent se baser sur l'id Persistant.

## :socks: Remarques
RAS

## :santa: Pour tester
Modifier un attachement d'un challenge nl
Vérifier que son id enregistré dans airtable soit le même que l'id persistant correspondant.
