### PR TITLE
[FEATURE] Pouvoir mettre à jour une mission (Pix-10274)

### DIFF
--- a/api/lib/application/missions/index.js
+++ b/api/lib/application/missions/index.js
@@ -8,6 +8,12 @@ export async function register(server) {
       config: {
         handler: missionController.findMissions,
       },
+    },{
+      method: 'GET',
+      path: '/api/missions/{id}',
+      config: {
+        handler: missionController.getMission,
+      },
     },
     {
       method: 'POST',
@@ -18,7 +24,7 @@ export async function register(server) {
       },
     },
     {
-      method: 'PUT',
+      method: 'PATCH',
       path: '/api/missions/{id}',
       config: {
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],

--- a/api/lib/application/missions/index.js
+++ b/api/lib/application/missions/index.js
@@ -17,6 +17,14 @@ export async function register(server) {
         handler: missionController.create,
       },
     },
+    {
+      method: 'PUT',
+      path: '/api/missions/{id}',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
+        handler: missionController.update,
+      },
+    },
   ]);
 }
 

--- a/api/lib/application/missions/mission-controller.js
+++ b/api/lib/application/missions/mission-controller.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import { findAllMissions, createMission, updateMission } from '../../domain/usecases/index.js';
 import { missionSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
-
+import * as missionRepository  from '../../infrastructure/repositories/mission-repository.js';
 //TODO Faire éventuellement un refacto pour mutualiser la gestion de la pagination
 const DEFAULT_PAGE = {
   number: 1,
@@ -14,6 +14,11 @@ export async function findMissions(request, h) {
   const { filter, page } = extractParameters(request.query);
   const { missions, meta } = await findAllMissions({ filter: normalizeFilter(filter), page: normalizePage(page) });
   return h.response(missionSerializer.serializeMissionSummary(missions, meta));
+}
+
+export async function getMission(request, h) {
+  const mission = await missionRepository.getById(request.params.id);
+  return h.response(missionSerializer.serializeMission(mission));
 }
 
 export async function create(request, h) {

--- a/api/lib/application/missions/mission-controller.js
+++ b/api/lib/application/missions/mission-controller.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
-import { findAllMissions, createMission } from '../../domain/usecases/index.js';
+import { findAllMissions, createMission, updateMission } from '../../domain/usecases/index.js';
 import { missionSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 
 //TODO Faire éventuellement un refacto pour mutualiser la gestion de la pagination
@@ -21,6 +21,13 @@ export async function create(request, h) {
   const mission = missionSerializer.deserializeMission(attributes);
   const savedMission = await createMission(mission);
   return h.response(missionSerializer.serializeMissionId(savedMission.id)).created();
+}
+export async function update(request, h) {
+  const attributes = request?.payload?.data?.attributes;
+  const missionId = request?.params?.id;
+  const mission = missionSerializer.deserializeMission({ ...attributes, id: missionId });
+  const updatedMission = await updateMission(mission);
+  return h.response(missionSerializer.serializeMissionId(updatedMission.id)).created();
 }
 
 function normalizePage(page) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -6,4 +6,5 @@ export * from './modify-localized-challenge.js';
 export * from './preview-challenge.js';
 export * from './proxy-read-request-to-airtable.js';
 export * from './proxy-write-request-to-airtable.js';
+export * from './update-mission.js';
 export * from './validate-urls-from-release.js';

--- a/api/lib/domain/usecases/update-mission.js
+++ b/api/lib/domain/usecases/update-mission.js
@@ -1,0 +1,6 @@
+import { missionRepository } from '../../infrastructure/repositories/index.js';
+
+export async function updateMission(mission, dependencies = { missionRepository }) {
+  await missionRepository.getById(mission.id);
+  return await dependencies.missionRepository.save(mission);
+}

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -57,13 +57,14 @@ export async function save(mission) {
 }
 
 function _toDomain(mission, translations) {
+  const translationsByMissionId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
   return new Mission({
     id: mission.id,
     createdAt: mission.createdAt,
     status: mission.status,
     competenceId: mission.competenceId,
     thematicId: mission.thematicId,
-    ...missionTranslations.toDomain(translations)
+    ...missionTranslations.toDomain(translationsByMissionId[mission.id])
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -24,6 +24,7 @@ export function serializeMissionId(id) {
 
 export function deserializeMission(attributes) {
   return new Mission({
+    id: attributes.id,
     name_i18n: { fr: attributes.name  },
     competenceId: attributes['competence-id'],
     thematicId: attributes['thematic-id'],

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -17,6 +17,28 @@ export function serializeMissionSummary(mission, meta) {
     meta,
   }).serialize(mission);
 }
+export function serializeMission(mission) {
+  return new Serializer('mission', {
+    transform: (mission) => {
+      return {
+        ...mission,
+        name: mission.name_i18n.fr,
+        learningObjectives: mission.learningObjectives_i18n.fr,
+        validatedObjectives: mission.validatedObjectives_i18n.fr
+      };
+    },
+    attributes: [
+      'name',
+      'competenceId',
+      'thematicId',
+      'learningObjectives',
+      'validatedObjectives',
+      'createdAt',
+      'status'
+    ],
+
+  }).serialize(mission);
+}
 
 export function serializeMissionId(id) {
   return new Serializer('mission', {}).serialize({ id });

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  databaseBuilder,
+  generateAuthorizationHeader,
+  knex,
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { Mission } from '../../../../lib/domain/models/index.js';
+
+describe('Acceptance | API | mission | GET /api/missions', function() {
+
+  afterEach(async function() {
+    await knex('missions').delete();
+    await knex('translations').delete();
+  });
+
+  it('Should return an object of serialized missions', async function() {
+
+    //given
+    const user = databaseBuilder.factory.buildAdminUser();
+    const mission = databaseBuilder.factory.buildMission({ name: 'Condor', status: Mission.status.ACTIVE, competenceId: 'recCompetence0', thematicId: null, validatedObjectives: 'Être forte', learningObjectives: 'Être imbattable', createdAt: new Date('2024-01-01') });
+    await databaseBuilder.commit();
+
+    //when
+    const server = await createServer();
+    const response = await server.inject({
+      method: 'GET',
+      url: `/api/missions/${mission.id}`,
+      headers: generateAuthorizationHeader(user),
+    });
+
+    //then
+    expect(response.result).to.deep.equal({
+      data: {
+        type: 'missions',
+        id: mission.id.toString(),
+        attributes: {
+          name: 'Condor',
+          status: Mission.status.ACTIVE,
+          'competence-id': 'recCompetence0',
+          'thematic-id': null,
+          'validated-objectives': 'Être forte',
+          'learning-objectives': 'Être imbattable',
+          'created-at': new Date('2024-01-01')
+        },
+      },
+    });
+  });
+
+});

--- a/api/tests/acceptance/application/mission/put_mission_test.js
+++ b/api/tests/acceptance/application/mission/put_mission_test.js
@@ -1,0 +1,93 @@
+import { afterEach, describe, describe as context, expect, it } from 'vitest';
+import {
+  databaseBuilder,
+  generateAuthorizationHeader,
+  knex,
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { Mission } from '../../../../lib/domain/models/index.js';
+
+describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
+
+  afterEach(async function() {
+    await knex('missions').delete();
+    await knex('translations').delete();
+  });
+
+  context('when user has rights to update a mission', function() {
+    it('updates the mission and returns its id', async function() {
+      // given
+      const user = databaseBuilder.factory.buildAdminUser();
+      const missionToUpdateId = databaseBuilder.factory.buildMission().id;
+      await databaseBuilder.commit();
+
+      const payload = {
+        data: {
+          attributes: {
+            name: 'Mission à mettre à jour',
+            'competence-id': 'TYUI',
+            'thematic-id': null,
+            status: Mission.status.ACTIVE,
+            'learning-objectives': 'Une chose',
+            'validated-objectives': null
+          },
+        },
+      };
+
+      // when
+      const server = await createServer();
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/missions/${missionToUpdateId}`,
+        headers: generateAuthorizationHeader(user),
+        payload,
+      });
+
+      // then
+      const { id: missionId } = await knex('missions').select('id').first();
+
+      expect(response.statusCode).to.equal(201);
+      expect(response.result).to.deep.equal({
+        data: {
+          type: 'missions',
+          id: missionId.toString(),
+        },
+      });
+    });
+  });
+
+  context('when user no has rights to update a mission', function() {
+    it('does not allow the update', async function() {
+      // given
+      const user = databaseBuilder.factory.buildReadonlyUser();
+      const missionId = databaseBuilder.factory.buildMission().id;
+      await databaseBuilder.commit();
+
+      const payload = {
+        data: {
+          attributes: {
+            name: 'Mission impossible',
+            'competence-id': 'AZERTY',
+            'thematic-id': null,
+            status: Mission.status.INACTIVE,
+            'learning-objectives': 'Autre chose',
+            'validated-objectives': 'Très bien'
+          },
+          id: missionId.toString()
+        },
+      };
+
+      // when
+      const server = await createServer();
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/missions/${missionId}`,
+        headers: generateAuthorizationHeader(user),
+        payload,
+      });
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -1,0 +1,45 @@
+import { describe, describe as context, expect, it, expectTypeOf } from 'vitest';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+import { updateMission } from '../../../../lib/domain/usecases/index.js';
+import { databaseBuilder } from '../../../test-helper.js';
+import { Mission } from '../../../../lib/domain/models/index.js';
+describe('Integration | Usecases | Update mission', function() {
+  context('When the mission to update does not exist', function() {
+    it('should return a not found error', async () => {
+      // given
+      const id = 1;
+
+      // when
+      const promise = updateMission({ id });
+
+      // then
+      await expect(promise).rejects.to.deep.equal(new NotFoundError('Mission introuvable'));
+    });
+  });
+  context('When the mission exists', function() {
+    it('should return the updated mission', async () => {
+      // given
+      const mission = databaseBuilder.factory.buildMission({ createdAt: new Date('2023-12-25') });
+      await databaseBuilder.commit();
+
+      const missionToUpdate = new Mission({
+        id: mission.id,
+        name_i18n: { fr: 'Updated mission'  },
+        competenceId: 'QWERTY',
+        thematicId: 'Thematic',
+        learningObjectives_i18n:  { fr: null },
+        validatedObjectives_i18n: { fr: 'Très bien' },
+        status: Mission.status.INACTIVE,
+        createdAt: new Date('2023-12-25')
+      });
+
+      // when
+      const updatedMission = await updateMission(missionToUpdate);
+
+      // then
+      expectTypeOf(updatedMission).toEqualTypeOf('Mission');
+      await expect(updatedMission).to.deep.equal(missionToUpdate);
+
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -1,8 +1,14 @@
 import { omit } from 'lodash';
 import { describe, describe as context, beforeEach, expect, expectTypeOf, it } from 'vitest';
 import { databaseBuilder, knex } from '../../../test-helper.js';
-import { findAllMissions, save, list } from '../../../../lib/infrastructure/repositories/mission-repository.js';
+import {
+  findAllMissions,
+  save,
+  list,
+  getById,
+} from '../../../../lib/infrastructure/repositories/mission-repository.js';
 import { Mission } from '../../../../lib/domain/models/index.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | mission-repository', function() {
 
@@ -11,6 +17,33 @@ describe('Integration | Repository | mission-repository', function() {
     await knex('missions').delete();
   });
 
+  describe('#get', function() {
+    context('When mission does not exists', function() {
+      it('should throw a NotFoundError', async function() {
+        const promise = getById(1);
+        await expect(promise).rejects.to.deep.equal(new NotFoundError('Mission introuvable'));
+      });
+    });
+    context('When mission exists', function() {
+      it('should return the mission', async function() {
+        databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.ACTIVE });
+        await databaseBuilder.commit();
+
+        const result = await getById(1);
+
+        expect(result).to.deep.equal(new Mission({
+          id: 1,
+          name_i18n: { fr: 'Ma première mission' },
+          competenceId: 'competenceId',
+          thematicId: 'thematicId',
+          learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
+          validatedObjectives_i18n: { fr: 'Rien' },
+          status: Mission.status.ACTIVE,
+          createdAt: new Date('2010-01-04'),
+        }));
+      });
+    });
+  });
   describe('#findAllMissions', function() {
     context('When there are missions', function() {
       it('should return all missions', async function() {
@@ -106,7 +139,7 @@ describe('Integration | Repository | mission-repository', function() {
     });
   });
 
-  describe('list', function()  {
+  describe('#list', function()  {
 
     it('Should return all missions', async function() {
 
@@ -151,64 +184,134 @@ describe('Integration | Repository | mission-repository', function() {
   });
 
   describe('#save', function() {
+    context('Mission creation', function() {
+      it('should store mission', async function() {
+        const mission = new Mission({
+          name_i18n: { fr: 'Mission impossible'  },
+          competenceId: 'AZERTY',
+          thematicId: 'QWERTY',
+          learningObjectives_i18n:  { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          status: Mission.status.INACTIVE,
+        });
 
-    it('should store mission', async function() {
-      const mission = new Mission({
-        name_i18n: { fr: 'Mission impossible'  },
-        competenceId: 'AZERTY',
-        thematicId: 'QWERTY',
-        learningObjectives_i18n:  { fr: null },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        status: Mission.status.INACTIVE,
+        const savedMission = await save(mission);
+        expectTypeOf(savedMission).toEqualTypeOf('Mission');
+        await expect(omit(savedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...mission, id: savedMission.id }), ['createdAt']));
+
+        const expectedMission = {
+          id: savedMission.id,
+          competenceId: 'AZERTY',
+          thematicId: 'QWERTY',
+          status: Mission.status.INACTIVE,
+        };
+
+        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicId', 'status', 'id');
+        await expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
-      const savedMission = await save(mission);
-      expectTypeOf(savedMission).toEqualTypeOf('Mission');
-      await expect(omit(savedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...mission, id: savedMission.id }), ['createdAt']));
+      it('should store I18n for mission', async function() {
 
-      const expectedMission = {
-        id: savedMission.id,
-        competenceId: 'AZERTY',
-        thematicId: 'QWERTY',
-        status: Mission.status.INACTIVE,
-      };
+        const mission = new Mission({
+          name_i18n: { fr: 'Mission impossible'  },
+          competenceId: 'AZERTY',
+          thematicId: 'QWERTY',
+          learningObjectives_i18n:  { fr: 'au boulot' },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          status: Mission.status.INACTIVE,
+        });
 
-      const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicId', 'status', 'id');
-      await expect(missionFromDb).to.deep.equal(expectedMission);
+        const savedMission = await save(mission);
+
+        const translations = [
+          {
+            key: `mission.${savedMission.id}.name`,
+            locale: 'fr',
+            value: 'Mission impossible'
+          },
+          {
+            key: `mission.${savedMission.id}.learningObjectives`,
+            locale: 'fr',
+            value: 'au boulot',
+          },
+          {
+            key: `mission.${savedMission.id}.validatedObjectives`,
+            locale: 'fr',
+            value: 'Très bien'
+          }
+        ];
+
+        expect(await knex('translations').select('*')).to.deep.equal(translations);
+      });
     });
 
-    it('should store I18n for mission', async function() {
+    context('Update mission', function() {
+      it('should update the mission', async function() {
+        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.ACTIVE });
+        await databaseBuilder.commit();
 
-      const mission = new Mission({
-        name_i18n: { fr: 'Mission impossible'  },
-        competenceId: 'AZERTY',
-        thematicId: 'QWERTY',
-        learningObjectives_i18n:  { fr: 'au boulot' },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        status: Mission.status.INACTIVE,
+        const missionToUpdate = new Mission({
+          id: savedMission.id,
+          name_i18n: { fr: 'Updated mission'  },
+          competenceId: 'QWERTY',
+          thematicId: 'Thematic',
+          learningObjectives_i18n:  { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          status: Mission.status.INACTIVE,
+        });
+
+        const updatedMission = await save(missionToUpdate);
+
+        expectTypeOf(updatedMission).toEqualTypeOf('Mission');
+        await expect(omit(updatedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...missionToUpdate, id: updatedMission.id }), ['createdAt']));
+
+        const expectedMission = {
+          id: updatedMission.id,
+          competenceId: 'QWERTY',
+          thematicId: 'Thematic',
+          status: Mission.status.INACTIVE,
+        };
+
+        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicId', 'status', 'id');
+        await expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
-      const savedMission = await save(mission);
+      it('should store I18n for mission', async function() {
+        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.ACTIVE });
+        await databaseBuilder.commit();
 
-      const translations = [
-        {
-          key: `mission.${savedMission.id}.name`,
-          locale: 'fr',
-          value: 'Mission impossible'
-        },
-        {
-          key: `mission.${savedMission.id}.learningObjectives`,
-          locale: 'fr',
-          value: 'au boulot',
-        },
-        {
-          key: `mission.${savedMission.id}.validatedObjectives`,
-          locale: 'fr',
-          value: 'Très bien'
-        }
-      ];
+        const missionToUpdate = new Mission({
+          id: savedMission.id,
+          name_i18n: { fr: 'Updated mission'  },
+          competenceId: 'QWERTY',
+          thematicId: 'Thematic',
+          learningObjectives_i18n:  { fr: 'Etre la boss' },
+          validatedObjectives_i18n: { fr: 'intermédiaire' },
+          status: Mission.status.INACTIVE,
+        });
 
-      expect(await knex('translations').select('*')).to.deep.equal(translations);
+        const updatedMission = await save(missionToUpdate);
+
+        const translations = [
+          {
+            key: `mission.${updatedMission.id}.name`,
+            locale: 'fr',
+            value: 'Updated mission'
+          },
+          {
+            key: `mission.${updatedMission.id}.learningObjectives`,
+            locale: 'fr',
+            value: 'Etre la boss',
+          },
+          {
+            key: `mission.${updatedMission.id}.validatedObjectives`,
+            locale: 'fr',
+            value: 'intermédiaire'
+          }
+        ];
+
+        expect(await knex('translations').select('*')).to.deep.equal(translations);
+      });
     });
   });
 });

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -199,7 +199,7 @@ describe('Unit | Controller | missions controller', function() {
 
     it('should call the usecase with a domain object', async function() {
       // given
-     
+
       // when
       await missionsController.create(request, hFake);
 
@@ -218,6 +218,59 @@ describe('Unit | Controller | missions controller', function() {
     it('should return the serialized mission id', async function() {
       // when
       const result = await missionsController.create(request, hFake);
+
+      // then
+      expect(result.source.data).to.deep.equal(
+        {
+          type: 'missions',
+          id: '1',
+        }
+      );
+    });
+  });
+  describe('updateMission', function() {
+    let updateMissionMock;
+    const attributes = {
+      name: 'Mission possible',
+      'competence-id': 'QWERTY',
+      status: Mission.status.ACTIVE,
+      'learning-objectives': 'apprendre à éviter les lasers',
+      'validated-objectives': 'Très bien',
+      'thematic-id': null
+    };
+
+    const missionId = 1;
+    const request = { payload: { data: { attributes } }, params: { id: missionId } };
+
+    beforeEach(function() {
+      updateMissionMock = vi.spyOn(usecases, 'updateMission');
+      updateMissionMock.mockResolvedValue(new Mission({
+        id: missionId
+      }));
+    });
+
+    it('should call the usecase with a domain object', async function() {
+      // given
+
+      // when
+      await missionsController.update(request, hFake);
+
+      const deserializedMission = new Mission({
+        id: missionId,
+        name_i18n: { fr: 'Mission possible' },
+        competenceId: 'QWERTY',
+        thematicId: null,
+        learningObjectives_i18n: { fr: 'apprendre à éviter les lasers' },
+        validatedObjectives_i18n: { fr: 'Très bien' },
+        status: Mission.status.ACTIVE,
+      });
+      // then
+      expect(updateMissionMock).toHaveBeenCalledWith(deserializedMission);
+    });
+
+    it('should return the serialized mission id', async function() {
+      // when
+      const result = await missionsController.update(request, hFake);
 
       // then
       expect(result.source.data).to.deep.equal(

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -1,8 +1,9 @@
 <form {{on "submit" this.onSubmitClicked}} class="new-mission-form">
-  <Card class="new-mission-form__card" @title="Création d'une mission">
+  <Card class="new-mission-form__card" @title={{@submitButtonText}}>
     <PixInput
       @id="mission-name"
       @label="Nom de la mission"
+      @value={{this.name.value}}
       @errorMessage="{{this.name.errorMessage}}"
       @requiredLabel="{{this.name.errorMessage}}"
       @validationStatus={{this.name.state}}
@@ -45,6 +46,7 @@
     <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de début de mission.</p>
     <PixTextarea
       @id="mission-learning-objectives"
+      @value={{this.learningObjectives}}
       {{on "change" this.updateLearningObjectives}}
     />
 
@@ -52,6 +54,7 @@
     <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de fin de mission.<br>Attention, cet élément est pour le moment utilisé que pour de l’affichage dans Pix 1D</p>
     <PixTextarea
       @id="mission-validated-objectives"
+      @value={{this.validatedObjectives}}
       {{on "change" this.updateValidatedObjectives}}
     />
    </Card>

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -19,6 +19,27 @@ export default class MissionForm extends Component {
   @tracked isSubmitting = false;
   @tracked isFormValid = false;
 
+  constructor(...args) {
+    super(...args);
+    if (this.args.mission.name?.length > 0) {
+      this.name.setValue(this.args.mission.name);
+      this.name.validate();
+      this.selectedStatus = this.args.mission.status;
+      this.validatedObjectives = this.args.mission.validatedObjectives;
+      this.learningObjectives = this.args.mission.learningObjectives;
+      this.isFormValid = true;
+    }
+    if (this.args.mission.competenceId?.length > 0) {
+      this.selectedCompetenceId.setValue(this.args.mission.competenceId);
+      this.selectedCompetenceId.validate();
+      this.updateThemes(this.args.mission.competenceId);
+      if (this.args.mission.thematicId?.length > 0) {
+        this.selectedThematicId = this.args.mission.thematicId;
+      }
+    }
+  }
+
+
   get statusOptions() {
     return [{ value: 'ACTIVE', label: 'ACTIVE' }, { value: 'INACTIVE', label: 'INACTIVE' }];
   }

--- a/pix-editor/app/controllers/authenticated/missions/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/edit.js
@@ -1,0 +1,31 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class MissionEditController extends Controller {
+  @service router;
+  @service notifications;
+
+  @action
+  async editMission(formData) {
+    try {
+      this.model.mission.name = formData.name;
+      this.model.mission.competenceId = formData.competenceId;
+      this.model.mission.status = formData.status;
+      this.model.mission.thematicId = formData.thematicId;
+      this.model.mission.validatedObjectives = formData.validatedObjectives;
+      this.model.mission.learningObjectives = formData.learningObjectives;
+      await this.model.mission.save();
+      this.notifications.success('Mission mise à jour avec succès.');
+      this.router.transitionTo('authenticated.missions.list');
+    } catch (err) {
+      this.model.mission.rollbackAttributes();
+      await this.notifications.error('Une erreur est survenue lors de la mise à jour de la mission.');
+    }
+  }
+
+  @action
+  async goBackToList() {
+    this.router.transitionTo('authenticated.missions.list');
+  }
+}

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -70,6 +70,7 @@ Router.map(function () {
     this.route('missions', function() {
       this.route('list', { path: '/' });
       this.route('new');
+      this.route('edit', { path: '/:mission_id' });
     });
   });
 });

--- a/pix-editor/app/routes/authenticated/missions/edit.js
+++ b/pix-editor/app/routes/authenticated/missions/edit.js
@@ -1,0 +1,36 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import FrameworkModel from '../../../models/framework';
+
+export default class MissionNewRoute extends Route {
+  @service access;
+  @service router;
+  @service store;
+  @service currentData;
+
+
+  beforeModel() {
+    if (!this.access.mayCreateOrEditStaticCourse()) {
+      this.router.transitionTo('authenticated.missions.list');
+    }
+  }
+
+  async model(params) {
+    const frameworks = this.currentData.getFrameworks().filter((framework) => framework.name === FrameworkModel.pix1DFrameworkName);
+    const getAreas = frameworks.map(framework => framework.areas);
+
+    const frameworkAreas = await Promise.all(getAreas);
+    const getCompetences = frameworkAreas.map(areas => areas.map(area => area.competences)).flat();
+    const areaCompetences = await Promise.all(getCompetences);
+    const mission = await this.store.findRecord('mission', params.mission_id);
+    return {
+      mission,
+      competences: areaCompetences.flatMap((competences) => competences.toArray()),
+    };
+  }
+
+  afterModel(model) {
+    const getThemes = model.competences.map(competence => competence.rawThemes);
+    return Promise.all(getThemes);
+  }
+}

--- a/pix-editor/app/routes/authenticated/static-courses/static-course.js
+++ b/pix-editor/app/routes/authenticated/static-courses/static-course.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class StaticCoursesRoute extends Route {
+export default class StaticCourseRoute extends Route {
   @service store;
 
   model(params) {

--- a/pix-editor/app/styles/globals/table.scss
+++ b/pix-editor/app/styles/globals/table.scss
@@ -86,6 +86,10 @@
          height: 100%;
          margin: auto;
 
+         &__edit-mission {
+           height: inherit;
+         }
+
          a {
            padding: 8px 10px;
            border-radius: 50%;
@@ -94,6 +98,14 @@
              background-color: $pix-neutral-20;
            }
          }
+        &__edit-mission{
+          a {
+            border-radius: 0;
+            &:hover {
+              background-color: var(--pix-primary-700);
+            }
+          }
+        }
       }
 
       > a {

--- a/pix-editor/app/templates/authenticated/missions/edit.hbs
+++ b/pix-editor/app/templates/authenticated/missions/edit.hbs
@@ -1,0 +1,14 @@
+<header class="page-header">
+  <h1 class="page-title">Modification d'une mission</h1>
+</header>
+<main class="page-body">
+  <section class="page-section">
+    <Form::Mission
+      @mission={{this.model.mission}}
+      @competences={{this.model.competences}}
+      @onFormCancelled={{this.goBackToList}}
+      @submitButtonText="Modifier la mission"
+      @onFormSubmitted={{this.editMission}}
+    />
+  </section>
+</main>

--- a/pix-editor/app/templates/authenticated/missions/list.hbs
+++ b/pix-editor/app/templates/authenticated/missions/list.hbs
@@ -1,6 +1,6 @@
 <header class="page-header">
   <h1 class="page-title">Missions</h1>
-  {{!-- {{#if this.model.mayCreateOrEditMissions}} --}}
+  {{#if this.model.mayCreateOrEditMissions}}
     <div class="page-actions">
       <PixButtonLink
         @backgroundColor="blue"
@@ -13,7 +13,7 @@
         Créer une nouvelle mission
       </PixButtonLink>
     </div>
-  {{!-- {{/if}}   --}}
+  {{/if}}
 </header>
 <main class="page-body">
   <section class="page-section">
@@ -65,7 +65,20 @@
                 {{if mission.isActive "Actif" "Inactif"}}
               </PixTag>
             </td>
-            <td class="actions">
+            <td class="actions actions__edit-mission">
+              {{#if this.model.mayCreateOrEditMissions}}
+                <PixButtonLink
+                  @backgroundColor="blue"
+                  @route="authenticated.missions.edit"
+                  class="pix-button-link-with-icon white-font"
+                  @model={{mission.id}}
+                >
+                  <FaIcon
+                    @icon="plus"
+                    @prefix="fas"></FaIcon>
+                  Modifier
+                </PixButtonLink>
+              {{/if}}
             </td>
           </tr>
         {{/each}}

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -285,6 +285,27 @@ function routes() {
     return mission;
   });
 
+  this.get('/missions/:id', function(schema, request) {
+    const id = request.params.id;
+    return schema.create('mission', {
+      id,
+      name: 'Mission impossible',
+      competenceId: 'recCompetence1.1',
+      thematicId: null, status: 'ACTIVE',
+      learningObjectives: null,
+      validatedObjectives: null
+    });
+  });
+
+  this.patch('/missions/:id', function(schema, request) {
+    const attributes = JSON.parse(request.requestBody).data.attributes;
+    const id = request.params.id;
+    const mission = schema.missions.find(id);
+    mission.update({ ...attributes });
+    schema.create('mission-summary', { ...attributes, id });
+    return mission;
+  });
+
   this.get('/static-course-summaries', function(schema, request) {
     const queryParams = request.queryParams;
     const {

--- a/pix-editor/mirage/factories/competence.js
+++ b/pix-editor/mirage/factories/competence.js
@@ -1,7 +1,6 @@
 import { Factory } from 'miragejs';
 
 export default Factory.extend({
-
   title: 'Title',
   titleEn: 'TitleEn',
   code: 'Code',

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { click, currentURL, find, triggerEvent } from '@ember/test-helpers';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+
+module('Acceptance | Missions | Edit', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('theme', { id: 'recTheme1' });
+    this.server.create('competence', { id:  'recCompetence1.1', pixId: 'recCompetence1.1', rawThemeIds: ['recTheme1'], title: 'Notre compétence' });
+    this.server.create('area', {
+      id: 'recArea1',
+      name: '1. Information et données',
+      code: '1',
+      competenceIds: ['recCompetence1.1']
+    });
+    this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D', areaIds: ['recArea1'] });
+    this.server.create('mission-summary', {
+      id: 2,
+      name: 'Mission 1',
+      competence: 'Mirage',
+      createdAt: '2023/12/11',
+      status: 'ACTIVE'
+    });
+  });
+
+  module('when user has write access', function (hooks) {
+    hooks.beforeEach(function () {
+      this.server.create('config', 'default');
+      this.server.create('user', { trigram: 'ABC', access: 'admin' });
+      return authenticateSession();
+    });
+
+    test('should be able to edit a mission', async function (assert) {
+      // given
+      await visit('/missions');
+
+      // when
+      await clickByName('Modifier');
+
+      // then
+      assert.strictEqual(currentURL(), '/missions/2');
+    });
+
+    test('should save updated informations', async function (assert) {
+      // given
+      this.server.create('mission', {
+        id: 3,
+        name: 'Mission',
+        competenceId: 'Mirage',
+        createdAt: '2023/12/11',
+        status: 'ACTIVE'
+      });
+      const screen = await visit('/missions/3');
+
+      // when
+      await fillByLabel('* Nom de la mission', 'Nouvelle mission de test');
+      await triggerEvent(find('#mission-name'), 'keyup', '');
+
+      await clickByName('Compétence');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Notre compétence' }));
+      await click(screen.getByRole('button', { name: 'Modifier la mission' }));
+
+      // then
+      assert.strictEqual(currentURL(), '/missions');
+      assert.dom(screen.getByText('Nouvelle mission de test')).exists();
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Après la création, on souhaite pouvoir mettre à jour une mission

## :gift: Proposition
Mettre en place un bouton pour accéder au formulaire de modification d'une mission

## :socks: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
**en tant qu'admin**
- aller sur scalingo récupérer la `adminUserApiKey` et se connecter à pix editor.
- Aller sur l'url `/missions`
- cliquer sur le bouton modifier d'une mission, changer un ou plusieurs champs et valider

**avec read-only**
- - aller sur scalingo récupérer la `readPixOnlyUserApiKey` et se connecter à pix editor.
- Aller sur l'url `/missions`
- voir que le bouton 'modifer' n'est pas visible