### PR TITLE
[FEATURE] Ecrire dans la base PG les données traduites des domaines (PIX-9479)

### DIFF
--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -1,0 +1,19 @@
+import { buildTranslationsUtils } from './utils.js';
+
+export const prefix = 'area.';
+
+const locales = [
+  { airtableLocale: 'fr-fr', locale: 'fr' },
+  { airtableLocale: 'en-us', locale: 'en' },
+];
+
+const fields = [
+  { airtableField: 'Titre', field: 'title' },
+];
+
+const idField = 'id persistant';
+
+export const {
+  extractFromProxyObject,
+  prefixFor,
+} = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/lib/infrastructure/translations/index.js
+++ b/api/lib/infrastructure/translations/index.js
@@ -1,2 +1,3 @@
 export * as Competences from './competence.js';
 export * as Acquis from './skill.js';
+export * as Domaines from './area.js';

--- a/api/scripts/migrate-areas-translations-from-airtable/index.js
+++ b/api/scripts/migrate-areas-translations-from-airtable/index.js
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import * as areaTranslations from '../../lib/infrastructure/translations/area.js';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateAreasTranslationsFromAirtable({ airtableClient }) {
+  const areas = await airtableClient
+    .table('Domaines')
+    .select({
+      fields: [
+        'id persistant',
+        'Titre fr-fr',
+        'Titre en-us',
+      ],
+    })
+    .all();
+
+  const translations = areas.flatMap((area) =>
+    areaTranslations.extractFromProxyObject(area.fields)
+  );
+
+  await translationRepository.save({ translations });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateAreasTranslationsFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import nock from 'nock';
+import {
+  airtableBuilder,
+  inputOutputDataBuilder,
+  databaseBuilder,
+  domainBuilder,
+  generateAuthorizationHeader,
+  knex,
+} from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+
+describe('Acceptance | Controller | airtable-proxy-controller | create area translations', () => {
+  beforeEach(() => {
+    nock('https://api.test.pix.fr').post(/.*/).reply(200);
+
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+  });
+
+  afterEach(async () => {
+    try {
+      expect(nock.isDone()).to.be.true;
+    } finally {
+      await knex('translations').truncate();
+    }
+  });
+
+  describe('POST /api/airtable/content/Domaines', () => {
+    let airtableRawArea;
+    let areaToSave;
+    let user;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+      await databaseBuilder.commit();
+      const area = domainBuilder.buildAreaDatasourceObject({ id: 'mon_id_persistant' });
+      airtableRawArea = airtableBuilder.factory.buildArea({
+        ...area,
+        title_i18n: {
+          fr: 'Domaine titre',
+          en: 'Area title',
+        }
+      });
+      areaToSave = inputOutputDataBuilder.factory.buildArea({
+        ...area,
+        title_i18n: {
+          fr: 'Domaine titre',
+          en: 'Area title',
+        }
+      });
+    });
+
+    describe('nominal cases', () => {
+      it('should proxy request to airtable and add translations to the PG table', async () => {
+        // Given
+        nock('https://api.airtable.com')
+          .post('/v0/airtableBaseValue/Domaines', airtableRawArea)
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableRawArea);
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/airtable/content/Domaines',
+          headers: generateAuthorizationHeader(user),
+          payload: areaToSave,
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        const translations = await knex('translations').select().orderBy([{
+          column: 'key',
+          order: 'asc'
+        }, { column: 'locale', order: 'asc' }]);
+
+        expect(translations).to.deep.equal([{
+          key: 'area.mon_id_persistant.title',
+          locale: 'en',
+          value: 'Area title'
+        }, {
+          key: 'area.mon_id_persistant.title',
+          locale: 'fr',
+          value: 'Domaine titre'
+        }]);
+      });
+    });
+  });
+});
+
+describe('Acceptance | Controller | airtable-proxy-controller | Retrieve area translations', () => {
+
+  afterEach(() => {
+    expect(nock.isDone()).to.be.true;
+  });
+
+  afterEach(function() {
+    return knex('translations').truncate();
+  });
+
+  describe('GET /api/airtable/content/Domaines', () => {
+    let areaDataObject;
+    let airtableArea;
+    let user;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+
+      areaDataObject = domainBuilder.buildAreaDatasourceObject({
+        id: 'mon_id_persistant',
+      });
+      airtableArea = airtableBuilder.factory.buildArea(areaDataObject);
+
+      databaseBuilder.factory.buildTranslation({
+        locale: 'fr',
+        key: 'area.mon_id_persistant.title',
+        value: 'AAA'
+      });
+      databaseBuilder.factory.buildTranslation({
+        locale: 'en',
+        key: 'area.mon_id_persistant.title',
+        value: 'BBB'
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    describe('nominal cases', () => {
+      it('should proxy request to airtable and retrieve all areas', async () => {
+        // Given
+        const expectedAreaDataObject = domainBuilder.buildAreaDatasourceObject({
+          id: 'mon_id_persistant'
+        });
+        const expectedArea = inputOutputDataBuilder.factory.buildArea({
+          ...expectedAreaDataObject,
+          title_i18n: {
+            fr: 'Information et données',
+            en: 'Information and data',
+          }
+        });
+        nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/Domaines')
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, { records: [airtableArea] });
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/airtable/content/Domaines',
+          headers: generateAuthorizationHeader(user)
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal({ records: [expectedArea] });
+      });
+    });
+  });
+
+  describe('GET /api/airtable/content/Domaines/id', () => {
+    let areaDataObject;
+    let airtableArea;
+    let user;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+
+      areaDataObject = domainBuilder.buildAreaDatasourceObject({
+        id: 'mon_id_persistant',
+      });
+      airtableArea = airtableBuilder.factory.buildArea(areaDataObject);
+
+      databaseBuilder.factory.buildTranslation({
+        locale: 'fr',
+        key: 'area.mon_id_persistant.title',
+        value: 'Prout'
+      });
+      databaseBuilder.factory.buildTranslation({
+        locale: 'en',
+        key: 'area.mon_id_persistant.title',
+        value: 'Fart'
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    describe('nominal case', () => {
+      it('should proxy request to airtable and retrieve area by id', async () => {
+        // Given
+        const expectedAreaDataObject = domainBuilder.buildAreaDatasourceObject({
+          id: 'mon_id_persistant',
+        });
+        const expectedArea = inputOutputDataBuilder.factory.buildArea({
+          ...expectedAreaDataObject,
+          hint_i18n: {
+            fr: 'Information et données',
+            en: 'Information and data',
+          },
+        });
+        nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/Domaines/recId')
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableArea);
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/airtable/content/Domaines/recId',
+          headers: generateAuthorizationHeader(user)
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal(expectedArea);
+      });
+    });
+  });
+});

--- a/api/tests/scripts/migrate-areas-translations-from-airtable_test.js
+++ b/api/tests/scripts/migrate-areas-translations-from-airtable_test.js
@@ -1,0 +1,89 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { airtableBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+
+import { migrateAreasTranslationsFromAirtable } from '../../scripts/migrate-areas-translations-from-airtable/index.js';
+
+describe('Script | Migrate areas translations from Airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const areas = [
+      airtableBuilder.factory.buildArea({
+        id: 'recArea51',
+        code: '51',
+        name: '51. La zone 51',
+        title_i18n: {
+          fr: 'La zone 51',
+          en: 'The 51 area',
+        },
+      }),
+      airtableBuilder.factory.buildArea({
+        id: 'recArea52',
+        code: '52',
+        name: '52. La zone 52',
+        title_i18n: {
+          fr: 'La zone 52',
+          en: 'The 52 area',
+        },
+      }),
+    ];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Domaines')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: areas });
+
+    // when
+    await migrateAreasTranslationsFromAirtable({ airtableClient });
+
+    // then
+    await expect(
+      knex('translations').select().orderBy([
+        { column: 'key', order: 'asc' },
+        { column: 'locale', order: 'asc' },
+      ]),
+    ).resolves.toEqual([
+      {
+        key: 'area.recArea51.title',
+        locale: 'en',
+        value: areas[0].fields['Titre en-us'],
+      },
+      {
+        key: 'area.recArea51.title',
+        locale: 'fr',
+        value: areas[0].fields['Titre fr-fr'],
+      },
+      {
+        key: 'area.recArea52.title',
+        locale: 'en',
+        value: areas[1].fields['Titre en-us'],
+      },
+      {
+        key: 'area.recArea52.title',
+        locale: 'fr',
+        value: areas[1].fields['Titre fr-fr'],
+      },
+    ]);
+  });
+});

--- a/api/tests/tooling/input-output-data-builder/factory/build-area.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-area.js
@@ -1,0 +1,25 @@
+export function buildArea({
+  id = 'areaid1',
+  competenceIds,
+  competenceAirtableIds,
+  code,
+  name,
+  color,
+  frameworkId,
+  title_i18n: { fr: titleFrFr, en: titleEnUs },
+} = {}) {
+  return {
+    id,
+    'fields': {
+      'id persistant': id,
+      'Competences (identifiants) (id persistant)': competenceIds,
+      'Competences (identifiants)': competenceAirtableIds,
+      'Titre fr-fr': titleFrFr,
+      'Titre en-us': titleEnUs,
+      'Code': code,
+      'Nom': name,
+      'Couleur': color,
+      'Referentiel': [frameworkId],
+    },
+  };
+}

--- a/api/tests/tooling/input-output-data-builder/factory/index.js
+++ b/api/tests/tooling/input-output-data-builder/factory/index.js
@@ -1,2 +1,3 @@
 export * from './build-competence.js';
 export * from './build-skill.js';
+export * from './build-area.js';


### PR DESCRIPTION
## :unicorn: Problème
Les traductions des domaines ne sont pas dans PG 

## :robot: Proposition
Les rajouter via la double écriture

## :rainbow: Remarques

## :100: Pour tester
Vérifier à la création d'un domaine que le titre est ajouté dans PG