### PR TITLE
[FEATURE] i18n : Lecture hybride des domaines (PIX-9481)

### DIFF
--- a/api/lib/domain/models/Area.js
+++ b/api/lib/domain/models/Area.js
@@ -1,0 +1,21 @@
+export class Area {
+  constructor({
+    id,
+    code,
+    title_i18n,
+    competenceIds,
+    competenceAirtableIds,
+    color,
+    frameworkId,
+  }) {
+    this.id = id;
+    this.code = code;
+    this.title_i18n = title_i18n;
+    this.competenceIds = competenceIds;
+    this.competenceAirtableIds = competenceAirtableIds;
+    this.color = color;
+    this.frameworkId = frameworkId;
+
+    this.name = `${code}. ${title_i18n.fr}`;
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -6,3 +6,4 @@ export * from './Skill.js';
 export * from './StaticCourse.js';
 export * from './Translation.js';
 export * from './User.js';
+export * from './Area.js';

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { extractFromChallenge } from '../../infrastructure/translations/challenge.js';
 import * as competenceTranslations from '../../infrastructure/translations/competence.js';
 import * as skillTranslations from '../../infrastructure/translations/skill.js';
+import * as areaTranslations from '../../infrastructure/translations/area.js';
 import { mergeStreams } from '../../infrastructure/utils/merge-stream.js';
 import { logger } from '../../infrastructure/logger.js';
 
@@ -25,6 +26,7 @@ export async function exportTranslations(stream, dependencies) {
 
   const translationsStreams = mergeStreams(
     createTranslationsStream(release.content.competences, extractMetadataFromCompetence, releaseContent, 'competence', competenceTranslations.extractFromReleaseObject),
+    createTranslationsStream(release.content.areas, extractMetadataFromArea, releaseContent, 'domaine', areaTranslations.extractFromReleaseObject),
     createTranslationsStream(release.content.skills, extractMetadataFromSkill, releaseContent, 'acquis', skillTranslations.extractFromReleaseObject),
     createTranslationsStream(frenchChallenges, _.curry(extractMetadataFromChallenge)(dependencies.baseUrl, localizedChallenges), releaseContent, 'epreuve', extractFromChallenge),
   );
@@ -125,6 +127,13 @@ function extractMetadataFromChallenge(baseUrl, localizedChallenges, challenge, r
 function extractMetadataFromSkill(skill, releaseContent) {
   return {
     tags: extractTagsFromSkill(skill, releaseContent),
+    description: '',
+  };
+}
+
+function extractMetadataFromArea(area, releaseContent) {
+  return {
+    tags: extractTagsFromArea(area, releaseContent),
     description: '',
   };
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,11 +1,15 @@
 import {
-  areaDatasource,
   attachmentDatasource,
   thematicDatasource,
   tubeDatasource,
   tutorialDatasource,
 } from '../../infrastructure/datasources/airtable/index.js';
-import { challengeRepository, competenceRepository, skillRepository } from '../../infrastructure/repositories/index.js';
+import {
+  areaRepository,
+  challengeRepository,
+  competenceRepository,
+  skillRepository,
+} from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 export async function getLearningContentForReplication() {
@@ -20,7 +24,7 @@ export async function getLearningContentForReplication() {
     thematics,
     courses,
   ] = await Promise.all([
-    areaDatasource.list(),
+    areaRepository.list(),
     competenceRepository.list(),
     tubeDatasource.list(),
     skillRepository.list(),

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -1,0 +1,25 @@
+import { areaDatasource } from '../datasources/airtable/index.js';
+import * as translationRepository from './translation-repository.js';
+import * as areaTranslations from '../translations/area.js';
+import _ from 'lodash';
+import { Area } from '../../domain/models/index.js';
+
+export async function list() {
+  const datasourceAreas = await areaDatasource.list();
+  const translations = await translationRepository.listByPrefix(areaTranslations.prefix);
+  return toDomainList(datasourceAreas, translations);
+}
+
+function toDomainList(datasourceAreas, translations) {
+  const translationsByAreaId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  return datasourceAreas.map(
+    (datasourceArea) => toDomain(datasourceArea, translationsByAreaId[datasourceArea.id]),
+  );
+}
+
+export function toDomain(datasourceArea, translations = []) {
+  return new Area({
+    ...datasourceArea,
+    ...areaTranslations.toDomain(translations),
+  });
+}

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -1,3 +1,4 @@
+export * as areaRepository from './area-repository.js';
 export * as challengeRepository from './challenge-repository.js';
 export * as competenceRepository from './competence-repository.js';
 export * as fileStorageTokenRepository from './file-storage-token-repository.js';

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import {
-  areaDatasource,
   attachmentDatasource,
   challengeDatasource,
   frameworkDatasource,
@@ -9,6 +8,7 @@ import {
   tutorialDatasource,
 } from '../datasources/airtable/index.js';
 import {
+  areaRepository,
   challengeRepository,
   competenceRepository,
   missionRepository,
@@ -74,7 +74,7 @@ export async function serializeEntity({ type, entity, translations }) {
   if (!tablesTranslations[type]?.toDomain) return { updatedRecord, model };
 
   return {
-    updatedRecord:{
+    updatedRecord: {
       ...updatedRecord,
       ...tablesTranslations[type].toDomain(translations),
     },
@@ -116,7 +116,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     tubes,
     tutorials,
   ] = await Promise.all([
-    areaDatasource.list(),
+    areaRepository.list(),
     attachmentDatasource.list(),
     competenceRepository.list(),
     frameworkDatasource.list(),

--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -16,6 +16,7 @@ const idField = 'id persistant';
 export const {
   extractFromProxyObject,
   airtableObjectToProxyObject,
+  extractFromReleaseObject,
   prefixFor,
   toDomain,
 } = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -17,4 +17,5 @@ export const {
   extractFromProxyObject,
   airtableObjectToProxyObject,
   prefixFor,
+  toDomain,
 } = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -13,10 +13,17 @@ const fields = [
 
 const idField = 'id persistant';
 
+const areaTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, idField });
+
 export const {
   extractFromProxyObject,
-  airtableObjectToProxyObject,
   extractFromReleaseObject,
   prefixFor,
   toDomain,
-} = buildTranslationsUtils({ locales, fields, prefix, idField });
+} = areaTranslationUtils;
+
+export function airtableObjectToProxyObject(airtableObject, translations) {
+  const areaProxyObject = areaTranslationUtils.airtableObjectToProxyObject(airtableObject, translations);
+  areaProxyObject.Nom = `${areaProxyObject.Code}. ${areaProxyObject['Titre fr-fr']}`;
+  return areaProxyObject;
+}

--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -15,5 +15,6 @@ const idField = 'id persistant';
 
 export const {
   extractFromProxyObject,
+  airtableObjectToProxyObject,
   prefixFor,
 } = buildTranslationsUtils({ locales, fields, prefix, idField });

--- a/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
@@ -118,12 +118,12 @@ describe('Acceptance | Controller | airtable-proxy-controller | Retrieve area tr
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
         key: 'area.mon_id_persistant.title',
-        value: 'AAA'
+        value: 'Titre de domaine dans PG'
       });
       databaseBuilder.factory.buildTranslation({
         locale: 'en',
         key: 'area.mon_id_persistant.title',
-        value: 'BBB'
+        value: 'Area title in PG'
       });
 
       await databaseBuilder.commit();
@@ -138,8 +138,8 @@ describe('Acceptance | Controller | airtable-proxy-controller | Retrieve area tr
         const expectedArea = inputOutputDataBuilder.factory.buildArea({
           ...expectedAreaDataObject,
           title_i18n: {
-            fr: 'Information et données',
-            en: 'Information and data',
+            fr: 'Titre de domaine dans PG',
+            en: 'Area title in PG',
           }
         });
         nock('https://api.airtable.com')
@@ -197,10 +197,10 @@ describe('Acceptance | Controller | airtable-proxy-controller | Retrieve area tr
         });
         const expectedArea = inputOutputDataBuilder.factory.buildArea({
           ...expectedAreaDataObject,
-          hint_i18n: {
-            fr: 'Information et données',
-            en: 'Information and data',
-          },
+          title_i18n: {
+            fr: 'Prout',
+            en: 'Fart',
+          }
         });
         nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Domaines/recId')

--- a/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
@@ -137,6 +137,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | Retrieve area tr
         });
         const expectedArea = inputOutputDataBuilder.factory.buildArea({
           ...expectedAreaDataObject,
+          name: `${expectedAreaDataObject.code}. Titre de domaine dans PG`,
           title_i18n: {
             fr: 'Titre de domaine dans PG',
             en: 'Area title in PG',
@@ -197,6 +198,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | Retrieve area tr
         });
         const expectedArea = inputOutputDataBuilder.factory.buildArea({
           ...expectedAreaDataObject,
+          name: `${expectedAreaDataObject.code}. Prout`,
           title_i18n: {
             fr: 'Prout',
             en: 'Fart',

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -138,6 +138,18 @@ async function mockCurrentContent() {
     locale: 'nl',
     value: 'Consigne en nl',
   });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `area.${expectedCurrentContent.areas[0].id}.title`,
+    locale: 'fr',
+    value: expectedCurrentContent.areas[0].title_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `area.${expectedCurrentContent.areas[0].id}.title`,
+    locale: 'en',
+    value: expectedCurrentContent.areas[0].title_i18n.en,
+  });
+
   databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'fr',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -29,11 +29,12 @@ async function mockCurrentContent() {
     }],
     areas: [{
       id: 'recArea0',
-      name: 'Nom du Domaine',
+      name: '1. Titre du Domaine - fr',
       code: '1',
       title_i18n: {
         fr: 'Titre du Domaine - fr',
         en: 'Titre du Domaine - en',
+        nl: 'Titre du Domaine - nl',
       },
       competenceIds: ['recCompetence0'],
       competenceAirtableIds: ['recCompetence123'],
@@ -254,6 +255,12 @@ async function mockCurrentContent() {
       locale,
       value: expectedCurrentContent.skills[0].hint_i18n[locale],
     });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `area.${expectedCurrentContent.areas[0].id}.title`,
+      locale,
+      value: expectedCurrentContent.areas[0].title_i18n[locale],
+    });
   }
 
   databaseBuilder.factory.buildTranslation({
@@ -307,7 +314,7 @@ async function mockContentForRelease() {
     }],
     areas: [{
       id: 'recArea0',
-      name: 'Nom du Domaine',
+      name: '1. Titre du Domaine - fr',
       code: '1',
       competenceIds: ['recCompetence0'],
       competenceAirtableIds: ['recCompetence123'],
@@ -316,6 +323,7 @@ async function mockContentForRelease() {
       title_i18n: {
         en: 'Titre du Domaine - en',
         fr: 'Titre du Domaine - fr',
+        nl: 'Titre du Domaine - nl',
       },
     }],
     competences: [{
@@ -510,6 +518,12 @@ async function mockContentForRelease() {
       locale,
       value: expectedCurrentContent.skills[0].hint_i18n[locale],
     });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `area.${expectedCurrentContent.areas[0].id}.title`,
+      locale,
+      value: expectedCurrentContent.areas[0].title_i18n[locale],
+    });
   }
 
   databaseBuilder.factory.buildTranslation({
@@ -677,7 +691,7 @@ describe('Acceptance | Controller | release-controller', () => {
         const user = databaseBuilder.factory.buildAdminUser();
         databaseBuilder.factory.buildMission({
           id: 1,
-          name: 'Ma première mission' ,
+          name: 'Ma première mission',
           competenceId: 'competenceId',
           thematicId: 'thematicId',
           learningObjectives: 'Que tu sois le meilleur',

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | Controller | translations-controller', () => {
         }],
         areas: [{
           id: 'recArea0',
-          name: 'Nom du Domaine',
+          name: '1. Titre du Domaine - fr',
           code: '1',
           title_i18n: {
             fr: 'Titre du Domaine - fr',
@@ -34,11 +34,11 @@ describe('Acceptance | Controller | translations-controller', () => {
         },
         {
           id: 'recArea1',
-          name: 'Nom du Domaine pix+',
+          name: '1. Titre du Domaine Pix+ - fr',
           code: '1',
           title_i18n: {
-            fr: 'Titre du Domaine - fr',
-            en: 'Titre du Domaine - en',
+            fr: 'Titre du Domaine Pix+ - fr',
+            en: 'Titre du Domaine Pix+ - en',
           },
           competenceIds: ['recCompetence1'],
           color: 'jaffa',
@@ -198,6 +198,12 @@ describe('Acceptance | Controller | translations-controller', () => {
       expect(headers).to.deep.equal(['key', 'fr', 'tags', 'description']);
       expect(_.orderBy(data, '0')).to.deep.equal([
         [
+          'area.recArea0.title',
+          'Titre du Domaine - fr',
+          'domaine,Pix-1,Pix',
+          ''
+        ],
+        [
           'challenge.recChallenge0.alternativeInstruction',
           'Consigne alternative',
           'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
@@ -264,7 +270,7 @@ describe('Acceptance | Controller | translations-controller', () => {
         }],
         areas: [{
           id: 'recArea0',
-          name: 'Nom du Domaine',
+          name: '1. Titre du Domaine - fr',
           code: '1',
           title_i18n: {
             fr: 'Titre du Domaine - fr',
@@ -396,6 +402,7 @@ describe('Acceptance | Controller | translations-controller', () => {
       payload.sort();
       expect(headers).to.equal('key,fr,tags,description');
       expect(payload).to.deep.equal([
+        'area.recArea0.title,Titre du Domaine - fr,"domaine,Pix-1,Pix",',
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix",',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix",',
         'skill.recSkill0.hint,Indice - fr,"acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
@@ -490,7 +497,7 @@ describe('Acceptance | Controller | translations-controller', () => {
           }],
           areas: [{
             id: 'recArea0',
-            name: 'Nom du Domaine',
+            name: '1. Titre du Domaine - fr',
             code: '1',
             title_i18n: {
               fr: 'Titre du Domaine - fr',
@@ -502,10 +509,10 @@ describe('Acceptance | Controller | translations-controller', () => {
           },
           {
             id: 'recArea1',
-            name: 'Nom du Domaine pix+',
+            name: '1. Titre du Domaine pix+ - fr',
             code: '1',
             title_i18n: {
-              fr: 'Titre du Domaine - fr',
+              fr: 'Titre du Domaine pix+ - fr',
               en: 'Titre du Domaine - en',
             },
             competenceIds: ['recCompetence1'],
@@ -659,6 +666,12 @@ describe('Acceptance | Controller | translations-controller', () => {
 
         expect(headers).to.deep.equal(['key', 'fr', 'tags', 'description']);
         expect(_.orderBy(data, '0')).to.deep.equal([
+          [
+            'area.recArea0.title',
+            'Titre du Domaine - fr',
+            'domaine,Pix-1,Pix',
+            ''
+          ],
           [
             'challenge.recChallenge0.alternativeInstruction',
             'Consigne alternative',

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import * as areaRepository from '../../../../lib/infrastructure/repositories/area-repository.js';
+
+describe('Integration | Repository | area-repository', () => {
+
+  describe('#list', () => {
+    it('should return the list of all competences', async () => {
+      // given
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Domaines' }).returns([
+        airtableBuilder.factory.buildArea({
+          id: 'areaId1',
+          code: '1',
+          color: 'blue da ba di da ba da',
+          competenceAirtableIds: ['competenceAirtableId11', 'competenceAirtableId12'],
+          competenceIds: ['competenceId11', 'competenceId12'],
+          frameworkId: 'frameworkId1',
+          name: '1. Premier domaine airtable',
+          title_i18n: {
+            fr: 'Premier domaine airtable',
+            en: 'First area airtable',
+          },
+        }),
+        airtableBuilder.factory.buildArea({
+          id: 'areaId2',
+          code: '2',
+          color: 'caca d\'oie',
+          competenceAirtableIds: ['competenceAirtableId21', 'competenceAirtableId22'],
+          competenceIds: ['competenceId21', 'competenceId22'],
+          frameworkId: 'frameworkId1',
+          name: '2. Second domaine airtable',
+          title_i18n: {
+            fr: 'Second domaine airtable',
+            en: 'Second area airtable',
+          },
+        }),
+      ]).activate().nockScope;
+
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId1.title',
+        locale: 'fr',
+        value: 'Premier domaine',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId1.title',
+        locale: 'en',
+        value: 'First area',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId2.title',
+        locale: 'fr',
+        value: 'Second domaine',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId2.title',
+        locale: 'en',
+        value: 'Second area',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const areas = await areaRepository.list();
+
+      // then
+      expect(areas).toEqual([
+        domainBuilder.buildArea({
+          id: 'areaId1',
+          code: '1',
+          color: 'blue da ba di da ba da',
+          competenceAirtableIds: ['competenceAirtableId11', 'competenceAirtableId12'],
+          competenceIds: ['competenceId11', 'competenceId12'],
+          frameworkId: 'frameworkId1',
+          title_i18n: {
+            fr: 'Premier domaine',
+            en: 'First area',
+          },
+        }),
+        domainBuilder.buildArea({
+          id: 'areaId2',
+          code: '2',
+          color: 'caca d\'oie',
+          competenceAirtableIds: ['competenceAirtableId21', 'competenceAirtableId22'],
+          competenceIds: ['competenceId21', 'competenceId22'],
+          frameworkId: 'frameworkId1',
+          title_i18n: {
+            fr: 'Second domaine',
+            en: 'Second area',
+          },
+        }),
+      ]);
+
+      airtableScope.done();
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -170,8 +170,9 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getCurrentContent', function() {
 
     beforeEach(function() {
-      const { competences, skills, challenges } = _mockRichAirtableContent();
+      const { areas, competences, skills, challenges } = _mockRichAirtableContent();
 
+      buildAreasTranslations(areas);
       buildCompetencesTranslations(competences);
       buildSkillsTranslations(skills);
       buildChallengesTranslationsAndLocalizedChallenges(challenges);
@@ -209,6 +210,21 @@ describe('Integration | Repository | release-repository', function() {
     });
   });
 });
+
+function buildAreasTranslations(areas) {
+  for (const area of areas) {
+    databaseBuilder.factory.buildTranslation({
+      key: `area.${area.id}.title`,
+      locale: 'fr',
+      value: `${area.id} titleFrFr`,
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `area.${area.id}.title`,
+      locale: 'en',
+      value: `${area.id} titleEnUs`,
+    });
+  }
+}
 
 function buildCompetencesTranslations(competences) {
   for (const competence of competences) {
@@ -304,7 +320,7 @@ function _mockRichAirtableContent() {
     id: 'frameworkA',
     name: 'FrameworkA',
   });
-  const airtableArea1 = airtableBuilder.factory.buildArea({
+  const area1 = {
     id: 'area1',
     competenceIds: ['competence11', 'competence12'],
     competenceAirtableIds: ['competence11', 'competence12'],
@@ -312,12 +328,13 @@ function _mockRichAirtableContent() {
       fr: 'area1 titleFrFr',
       en: 'area1 titleEnUs',
     },
-    code: 'area1 code',
+    code: '1',
     name: 'area1 name',
     color: 'area1 color',
     frameworkId: 'frameworkA',
-  });
-  const airtableArea2 = airtableBuilder.factory.buildArea({
+  };
+  const airtableArea1 = airtableBuilder.factory.buildArea(area1);
+  const area2 = {
     id: 'area2',
     competenceIds: ['competence21'],
     competenceAirtableIds: ['competence21'],
@@ -325,11 +342,12 @@ function _mockRichAirtableContent() {
       fr: 'area2 titleFrFr',
       en: 'area2 titleEnUs',
     },
-    code: 'area2 code',
+    code: '2',
     name: 'area2 name',
     color: 'area2 color',
     frameworkId: 'frameworkA',
-  });
+  };
+  const airtableArea2 = airtableBuilder.factory.buildArea(area2);
   const competence11 = {
     id: 'competence11',
     index: 'competence11 index',
@@ -783,6 +801,7 @@ function _mockRichAirtableContent() {
   });
 
   return {
+    areas: [area1, area2],
     competences: [competence11, competence12, competence21],
     skills: [skill11111, skill11112, skill12121, skill21111],
     challenges: [challenge121211, challenge121212, challenge211111, challenge211112, challenge211113],
@@ -810,8 +829,8 @@ function _getRichCurrentContentDTO() {
       fr: 'area1 titleFrFr',
       en: 'area1 titleEnUs',
     },
-    code: 'area1 code',
-    name: 'area1 name',
+    code: '1',
+    name: '1. area1 titleFrFr',
     color: 'area1 color',
     frameworkId: 'frameworkA',
   }, {
@@ -826,8 +845,8 @@ function _getRichCurrentContentDTO() {
       fr: 'area2 titleFrFr',
       en: 'area2 titleEnUs',
     },
-    code: 'area2 code',
-    name: 'area2 name',
+    code: '2',
+    name: '2. area2 titleFrFr',
     color: 'area2 color',
     frameworkId: 'frameworkA',
   }];

--- a/api/tests/tooling/domain-builder/factory/build-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-area.js
@@ -1,0 +1,21 @@
+import { Area } from '../../../../lib/domain/models/Area';
+
+export function buildArea({
+  id = 'recArea1',
+  code = '1',
+  color = 'colorArea1',
+  competenceIds = ['recComp1', 'recComp2'],
+  competenceAirtableIds = ['recAirComp1', 'recAirComp2'],
+  frameworkId = 'recFramework1',
+  title_i18n = { fr: 'titreArea1', en: 'titleArea1' },
+} = {}) {
+  return new Area({
+    id,
+    code,
+    title_i18n,
+    competenceIds,
+    competenceAirtableIds,
+    color,
+    frameworkId,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,3 +1,4 @@
+export * from './build-area.js';
 export * from './build-area-for-release.js';
 export * from './build-attachment.js';
 export * from './build-challenge-for-release.js';

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -3,6 +3,7 @@ import { domainBuilder, airtableBuilder } from '../../test-helper.js';
 import { attachmentDatasource, challengeDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import { serializeEntity } from '../../../lib/infrastructure/repositories/release-repository.js';
 import { challengeRepository } from '../../../lib/infrastructure/repositories/index.js';
+import { Translation } from '../../../lib/domain/models/index.js';
 
 describe('Unit | Repository | release-repository', () => {
   describe('#serializeEntity', () => {
@@ -21,10 +22,23 @@ describe('Unit | Repository | release-repository', () => {
         frameworkId: 'recFramework0',
       });
       const type = 'Domaines';
+      const translations = [
+        new Translation({
+          key: 'area.1.title',
+          locale: 'fr',
+          value: 'Bonjour',
+        }),
+        new Translation({
+          key: 'area.1.title',
+          locale: 'en',
+          value: 'Hello',
+        }),
+      ];
+
       vi.spyOn(attachmentDatasource, 'filterByChallengeId');
       vi.spyOn(challengeDatasource, 'filterById');
 
-      const { updatedRecord, model } = await serializeEntity({ entity, type });
+      const { updatedRecord, model } = await serializeEntity({ entity, type, translations });
 
       expect(updatedRecord).to.deep.equal({
         id: '1',


### PR DESCRIPTION
## :unicorn: Problème
Les champs traduisibles des domaines sont lus depuis Airtable.

## :robot: Proposition
Lire les champs traduisibles depuis PG.

## :rainbow: Remarques
N/A

## :100: Pour tester
Modifier une traduction de domaine directement dans PG et vérifier que cela impacte toutes les lectures :
 - IHM PixEditor
 - Release
 - Repli
 - Export CSV des trads