### PR TITLE
[FEATURE] Permettre l'ajout d'une piece jointe ou d'une illustration sur une épreuve traduite (PIX-10934).

### DIFF
--- a/pix-editor/app/components/field/files.hbs
+++ b/pix-editor/app/components/field/files.hbs
@@ -1,12 +1,14 @@
 <div class="field" ...attributes>
   {{#if (or @value.length @edition)}}
-    <label>{{@title}}</label>
+    <h3 class="field-title">{{@title}}</h3>
   {{/if}}
   {{#if @value.length}}
     {{#each @value as |file|}}
-      <a href={{file.url}} download={{file.filename}} target="_blank" rel="noopener noreferrer"><i class="file icon"></i> {{file.filename}}</a>
+      <a href={{file.url}} download={{file.filename}} target="_blank" rel="noopener noreferrer"><i
+        class="file icon"></i> {{file.filename}}</a>
       {{#if @edition}}
-        <button {{on "click" (fn this.remove file)}} class="ui button file-remove" data-test-delete-attachment-button type="button"><i class="remove icon"></i></button>
+        <button {{on "click" (fn this.remove file)}} class="ui button file-remove" data-test-delete-attachment-button
+                                                     type="button"><i class="remove icon"></i></button>
       {{/if}}
     {{/each}}
   {{/if}}
@@ -19,8 +21,8 @@
     {{/let}}
     {{#if @value.length}}
       <div class="ui input">
-          <label class="label-input" for="name">Nom :</label>
-          <Input id="name" @value={{@baseName}} />
+        <label class="label-input" for="name">Nom :</label>
+        <Input id="name" @value={{@baseName}} />
       </div>
     {{/if}}
   {{/if}}

--- a/pix-editor/app/components/field/illustration.hbs
+++ b/pix-editor/app/components/field/illustration.hbs
@@ -1,6 +1,6 @@
 <div class="field" ...attributes>
   {{#if (or @value @edition)}}
-    <label>{{@title}}</label>
+    <h3 class="field-title">{{@title}}</h3>
   {{/if}}
   {{#if @value}}
     {{#if @value.url}}

--- a/pix-editor/app/components/pop-in/image.hbs
+++ b/pix-editor/app/components/pop-in/image.hbs
@@ -2,6 +2,7 @@
     @title="Illustration"
     @onCloseButtonClick={{@close}}
     @showModal={{@showModal}}
+    ...attributes
 >
   <:content>
     <img class="image-modal" src={{@imageSrc}} alt="illustration">

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -86,7 +86,7 @@ export default class LocalizedController extends Controller {
 
   @action
   showIllustration() {
-    const illustration = this.challenge.illustration;
+    const illustration = this.model.illustration;
     this.popInImageSrc = illustration.url;
     this.displayImage = true;
   }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -120,23 +120,22 @@ export default class LocalizedController extends Controller {
     this.notify.message('Modification annulée');
   }
 
-  @action save() {
+  @action async save() {
     this.loader.start();
-    return this._handleIllustration(this.model)
-      .then(challenge => this._handleAttachments(challenge))
-      .then(challenge => this._saveChallenge(challenge))
-      .then(challenge => this._saveAttachments(challenge))
-      .then(()=> {
-        this.edition = false;
-        this.loader.stop();
-        this.notify.message('Épreuve mise à jour');
-      })
-      .catch((error) => {
-        console.error(error);
-        Sentry.captureException(error);
-        this.loader.stop();
-        this.notify.error('Erreur lors de la mise à jour de l\'épreuve');
-      });
+    try {
+      const localizedChallenge = await this._handleIllustration(this.model);
+      this._handleAttachments(localizedChallenge);
+      this._saveChallenge(localizedChallenge);
+      this._saveAttachments(localizedChallenge);
+      this.edition = false;
+      this.loader.stop();
+      this.notify.message('Épreuve mise à jour');
+    } catch (error) {
+      console.error(error);
+      Sentry.captureException(error);
+      this.loader.stop();
+      this.notify.error('Erreur lors de la mise à jour de l\'épreuve');
+    }
   }
 
   @action maximize() {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -175,6 +175,7 @@ export default class SingleController extends Controller {
     this.challenge.rollbackAttributes();
     await this.challenge.files;
     this.challenge.files.forEach((file) => file.rollbackAttributes());
+    this.deletedFiles = [];
     if (!this.wasMaximized) {
       this.minimize();
     }

--- a/pix-editor/app/models/attachment.js
+++ b/pix-editor/app/models/attachment.js
@@ -11,6 +11,6 @@ export default class Attachment extends Model {
 
   @tracked cloneBeforeSave;
 
-  @belongsTo('challenge') challenge;
+  @belongsTo('challenge', { inverse: 'files' }) challenge;
   @belongsTo('localized-challenge',  { inverse: 'files' }) localizedChallenge;
 }

--- a/pix-editor/app/models/attachment.js
+++ b/pix-editor/app/models/attachment.js
@@ -12,4 +12,5 @@ export default class Attachment extends Model {
   @tracked cloneBeforeSave;
 
   @belongsTo('challenge') challenge;
+  @belongsTo('localized-challenge',  { inverse: 'files' }) localizedChallenge;
 }

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -40,4 +40,28 @@ export default class LocalizedChallengeModel extends Model {
   get isStatusEditable() {
     return ['validé', 'archivé'].includes(this.challenge.get('status'));
   }
+
+  get _firstAttachmentBaseName() {
+    const attachments = this.attachments;
+    if (attachments && attachments.length > 0) {
+      return attachments[0].filename.replace(/\.[^/.]+$/, '');
+    }
+    return null;
+  }
+
+  get attachmentBaseName() {
+    if (this._definedBaseName) {
+      return this._definedBaseName;
+    }
+    return this._firstAttachmentBaseName;
+  }
+
+  set attachmentBaseName(value) {
+    this._definedBaseName = value;
+    return value;
+  }
+
+  baseNameUpdated() {
+    return this._firstAttachmentBaseName !== this.attachmentBaseName;
+  }
 }

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -10,7 +10,7 @@ export default class LocalizedChallengeModel extends Model {
   @attr locale;
   @attr status;
 
-  @belongsTo('challenge') challenge;
+  @belongsTo('challenge', { inverse: 'localizedChallenges' }) challenge;
   @hasMany('attachment', { inverse: 'localizedChallenge' }) files;
 
   get isPrimaryChallenge() {

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -1,4 +1,4 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 const inProductionCombinations = [
   'validé:validé',
@@ -11,9 +11,18 @@ export default class LocalizedChallengeModel extends Model {
   @attr status;
 
   @belongsTo('challenge') challenge;
+  @hasMany('attachment', { inverse: 'localizedChallenge' }) files;
 
   get isPrimaryChallenge() {
     return this.challenge.get('id') === this.id;
+  }
+
+  get illustration() {
+    return this.files.find((file) => file.type === 'illustration' && !file.isDeleted);
+  }
+
+  get attachments() {
+    return this.files.filter((file) => file.type === 'attachment' && !file.isDeleted);
   }
 
   get statusCSS() {

--- a/pix-editor/app/serializers/airtable.js
+++ b/pix-editor/app/serializers/airtable.js
@@ -36,7 +36,6 @@ export default class AirtableSerializer extends RESTSerializer {
       delete payload.id;
       delete payload.deleted;
     }
-
     return super.normalizeResponse(...arguments);
   }
 

--- a/pix-editor/app/serializers/application.js
+++ b/pix-editor/app/serializers/application.js
@@ -1,3 +1,8 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 
-export default class ApplicationSerializer extends JSONAPISerializer {}
+export default class ApplicationSerializer extends JSONAPISerializer {
+  shouldSerializeHasMany() {
+    return true;
+  }
+
+}

--- a/pix-editor/app/serializers/attachment.js
+++ b/pix-editor/app/serializers/attachment.js
@@ -9,18 +9,30 @@ export default class AttachmentSerializer extends AirtableSerializer {
     mimeType: 'mimeType',
     size: 'size',
     type: 'type',
+    localizedChallenge: 'localizedChallengeId',
   };
 
   payloadKeyFromModelName() {
     return 'Attachments';
   }
 
-  serializeBelongsTo(snapshot, json) {
-    const challenge = snapshot.belongsTo('challenge');
-    const localizedChallenge = snapshot.belongsTo('localizedChallenge');
-    const { airtableId } = challenge.attributes();
+  serializeBelongsTo(snapshot, json, relationship) {
+    if (relationship.key === 'localizedChallenge') {
+      const localizedChallenge = snapshot.belongsTo('localizedChallenge');
+      if (localizedChallenge) {
+        json.localizedChallengeId = localizedChallenge.id;
+      }
+    }
 
-    json.challengeId = [airtableId];
-    json.localizedChallengeId = localizedChallenge?.id ? localizedChallenge.id : challenge.id;
+    if (relationship.key === 'challenge') {
+      const challenge = snapshot.belongsTo('challenge');
+      if (!challenge) return;
+
+      json.challengeId = [challenge.attributes().airtableId];
+      if (!json.localizedChallengeId) {
+        json.localizedChallengeId = challenge.id;
+      }
+
+    }
   }
 }

--- a/pix-editor/app/serializers/attachment.js
+++ b/pix-editor/app/serializers/attachment.js
@@ -15,13 +15,12 @@ export default class AttachmentSerializer extends AirtableSerializer {
     return 'Attachments';
   }
 
-  serializeBelongsTo(snapshot, json, relationship) {
-    if (relationship.key !== 'challenge') return;
-
+  serializeBelongsTo(snapshot, json) {
     const challenge = snapshot.belongsTo('challenge');
+    const localizedChallenge = snapshot.belongsTo('localizedChallenge');
     const { airtableId } = challenge.attributes();
 
     json.challengeId = [airtableId];
-    json.localizedChallengeId = challenge.id;
+    json.localizedChallengeId = localizedChallenge?.id ? localizedChallenge.id : challenge.id;
   }
 }

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -30,6 +30,7 @@
 @import 'authenticated/static-courses/static-course';
 @import 'components/card';
 @import 'components/login-form';
+@import 'components/field';
 @import 'globals/global';
 @import 'globals/notification';
 @import 'globals/page';

--- a/pix-editor/app/styles/components/field.scss
+++ b/pix-editor/app/styles/components/field.scss
@@ -1,0 +1,4 @@
+.ui.form .field-title {
+  font-size: 0.92857143em;
+  font-weight: bold;
+}

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -100,8 +100,9 @@
     data-testid='change-status-confirm-popin'
   />
   <PopIn::Image
-    @imageSrc={{this.popinImageSrc}}
+    @imageSrc={{this.popInImageSrc}}
     @close={{this.closeIllustration}}
     @showModal={{this.displayImage}}
+    data-testid='display-illustration-pop-in'
   />
 </div>

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -14,6 +14,32 @@
 <div class="challenge">
   <div class="challenge-data {{this.elementClass}}" {{scroll-top false}}>
     <form action="" class="ui form">
+      <Field::Illustration
+        @title="Illustration"
+        @value={{this.model.illustration}}
+        @edition={{this.edition}}
+        @addIllustration={{this.addIllustration}}
+        @removeIllustration={{this.removeIllustration}}
+        @display={{this.showIllustration}}
+        data-test-file-input-illustration
+      />
+      {{#if this.model.illustration}}
+        <Field::Textarea
+          @value={{this.model.illustration.alt}}
+          @title="Texte alternatif"
+          @edition={{false}}
+          @id="challenge-illustration-alt"
+        />
+      {{/if}}
+      <Field::Files
+        @title="Pièces jointes"
+        @value={{this.model.attachments}}
+        @baseName={{this.model.attachmentBaseName}}
+        @addAttachment={{this.addAttachment}}
+        @edition={{this.edition}}
+        @removeAttachment={{this.removeAttachment}}
+        data-test-file-input-attachment
+      />
       <Field::Input
         @id="localized-challenge-embed-url"
         @label="Embed URL"
@@ -72,5 +98,10 @@
     @onDeny={{this.confirmDeny}}
     @showModal={{this.displayConfirm}}
     data-testid='change-status-confirm-popin'
+  />
+  <PopIn::Image
+    @imageSrc={{this.popinImageSrc}}
+    @close={{this.closeIllustration}}
+    @showModal={{this.displayImage}}
   />
 </div>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -24,6 +24,9 @@ function routes() {
   this.post('/airtable/content/Attachments', (schema, request) => {
     const payload = JSON.parse(request.requestBody);
     const attachment = _deserializePayload(payload, 'attachment');
+    if (attachment.localizedChallenge) {
+      attachment.localizedChallenge = schema.localizedChallenges.find(attachment.localizedChallenge);
+    }
     const createdAttachment = schema.attachments.create(attachment);
     return _serializeModel(createdAttachment, 'attachment');
   });

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
@@ -1,0 +1,157 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { visit, clickByText } from '@1024pix/ember-testing-library';
+import { findAll, click, find } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { runTask } from 'ember-lifeline';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
+import Service from '@ember/service';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1' });
+    this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl' });
+    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'] });
+    this.server.create('skill', { id: 'recSkill2', challengeIds: [] });
+    this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+    this.server.create('tube', { id: 'recTube2', rawSkillIds: ['recSkill2'] });
+    this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+    this.server.create('theme', { id: 'recTheme2', name: 'theme2', rawTubeIds: ['recTube2'] });
+    this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds:['recTheme1'], rawTubeIds: ['recTube1'] });
+    this.server.create('competence', { id: 'recCompetence2.1', pixId: 'pixId recCompetence2.1', rawThemeIds:['recTheme2'], rawTubeIds: ['recTube2'] });
+    this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
+    this.server.create('area', { id: 'recArea2', name: '2. Communication et collaboration', code: '2', competenceIds: ['recCompetence2.1'] });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1', 'recArea2'] });
+    return authenticateSession();
+  });
+
+  test('adding attachments', async function(assert) {
+    // given
+    class StorageServiceStub extends Service {
+      uploadFile() {}
+    }
+
+    this.owner.register('service:storage', StorageServiceStub);
+    const storageServiceStub = this.owner.lookup('service:storage');
+    sinon.stub(storageServiceStub, 'uploadFile').resolves({ url: 'data:,', filename: 'attachment-name' });
+
+    // when
+    const screen = await visit('/');
+    await click(findAll('[data-test-area-item]')[0]);
+    await click(findAll('[data-test-competence-item]')[0]);
+    await click(findAll('[data-test-skill-cell-link]')[0]);
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+
+    const file = new File([], 'challenge-illustration.png', { type: 'image/png' });
+    await selectFiles('[data-test-file-input-attachment] input', file);
+
+    await runTask(this, async () => {}, 400);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.ok(storageServiceStub.uploadFile.calledOnce);
+    assert.ok(attachments.every(record => !record.isNew));
+    assert.strictEqual(attachments.length, 1);
+  });
+
+  test('delete attachment', async function(assert) {
+    // given
+    this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      skillId: 'recSkill2',
+    });
+    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+    this.server.create('localized-challenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      attachments: [{
+        'id': 'attd74YR8ga7IOfWp',
+        'url': 'https://dl.airtable.com/.attachments/b60304a44214d5b6f94d63df59d3516a/d1f1b65b/attachment.png',
+        'filename': 'attachment.png',
+        'size': 178629,
+        'type': 'image/png'
+      }],
+      filesIds: ['recAttachment1'],
+      locale: 'nl'
+    });
+    this.server.create('attachment', { id: 'recAttachment1', type: 'attachment', challengeId: 'recChallenge2', filename: 'attachment.png', localizedChallengeId: 'recChallenge2NL' });
+
+    // when
+    const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+
+    await click(find('[data-test-delete-attachment-button]'));
+
+    await runTask(this, async () => {}, 200);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.strictEqual(attachments.length, 0);
+    assert.ok(attachments.every(record => !record.isDeleted));
+  });
+
+  test('cancel adding an attachment', async function(assert) {
+    // given
+    this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      skillId: 'recSkill2',
+    });
+    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+    this.server.create('localized-challenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      attachments: [{
+        'id': 'attd74YR8ga7IOfWp',
+        'url': 'https://dl.airtable.com/.attachments/b60304a44214d5b6f94d63df59d3516a/d1f1b65b/attachment.png',
+        'filename': 'attachment.png',
+        'size': 178629,
+        'type': 'image/png'
+      }],
+      filesIds: ['recAttachment1'],
+      locale: 'nl'
+    });
+    this.server.create('attachment', { id: 'recAttachment1', type: 'attachment', challengeId: 'recChallenge2', filename: 'attachment.png', localizedChallengeId: 'recChallenge2NL' });
+
+    // when
+    const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+    await click(find('[data-test-delete-attachment-button]'));
+
+    await runTask(this, async () => {}, 200);
+    const cancelButton = await screen.findByRole('button', { name: 'Annuler' });
+    await click(cancelButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Modification annulée');
+    assert.strictEqual(attachments.length, 1);
+    assert.ok(attachments.every(record => !record.isDeleted));
+  });
+});
+

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
@@ -9,11 +9,11 @@ import { selectFiles } from 'ember-file-upload/test-support';
 import Service from '@ember/service';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
-module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
+module('Acceptance | Modify-Localized-Challenge-Attachment', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -26,18 +26,39 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     this.server.create('tube', { id: 'recTube2', rawSkillIds: ['recSkill2'] });
     this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
     this.server.create('theme', { id: 'recTheme2', name: 'theme2', rawTubeIds: ['recTube2'] });
-    this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds:['recTheme1'], rawTubeIds: ['recTube1'] });
-    this.server.create('competence', { id: 'recCompetence2.1', pixId: 'pixId recCompetence2.1', rawThemeIds:['recTheme2'], rawTubeIds: ['recTube2'] });
-    this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
-    this.server.create('area', { id: 'recArea2', name: '2. Communication et collaboration', code: '2', competenceIds: ['recCompetence2.1'] });
+    this.server.create('competence', {
+      id: 'recCompetence1.1',
+      pixId: 'pixId recCompetence1.1',
+      rawThemeIds: ['recTheme1'],
+      rawTubeIds: ['recTube1']
+    });
+    this.server.create('competence', {
+      id: 'recCompetence2.1',
+      pixId: 'pixId recCompetence2.1',
+      rawThemeIds: ['recTheme2'],
+      rawTubeIds: ['recTube2']
+    });
+    this.server.create('area', {
+      id: 'recArea1',
+      name: '1. Information et données',
+      code: '1',
+      competenceIds: ['recCompetence1.1']
+    });
+    this.server.create('area', {
+      id: 'recArea2',
+      name: '2. Communication et collaboration',
+      code: '2',
+      competenceIds: ['recCompetence2.1']
+    });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1', 'recArea2'] });
     return authenticateSession();
   });
 
-  test('adding attachments', async function(assert) {
+  test('adding attachments', async function (assert) {
     // given
     class StorageServiceStub extends Service {
-      uploadFile() {}
+      uploadFile() {
+      }
     }
 
     this.owner.register('service:storage', StorageServiceStub);
@@ -52,10 +73,11 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     await clickByText('Version nl');
     await clickByText('Modifier');
 
-    const file = new File([], 'challenge-illustration.png', { type: 'image/png' });
+    const file = new File([], 'challenge-attachment.png', { type: 'image/png' });
     await selectFiles('[data-test-file-input-attachment] input', file);
 
-    await runTask(this, async () => {}, 400);
+    await runTask(this, async () => {
+    }, 400);
     const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
     await click(saveButton);
 
@@ -69,7 +91,57 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     assert.strictEqual(attachments.length, 1);
   });
 
-  test('delete attachment', async function(assert) {
+  test('adding attachments on localized challenge with illustration', async function (assert) {
+    // given
+    this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      skillId: 'recSkill2',
+    });
+    this.server.create('localizedChallenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      illustration: [{
+        'id': 'attd74YR8ga7IOfWp',
+        'url': 'https://dl.airtable.com/.attachments/b60304a44214d5b6f94d63df59d3516a/d1f1b65b/CertificatGUL2020.png',
+        'filename': 'Certificat GUL 2020.png',
+        'size': 178629,
+        'type': 'image/png'
+      }],
+      filesIds: ['recAttachment1'],
+      locale: 'nl'
+    });
+    this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge2', localizedChallengeId: 'recChallenge2NL' });
+
+    class StorageServiceStub extends Service {
+      uploadFile() {
+      }
+    }
+
+    this.owner.register('service:storage', StorageServiceStub);
+    const storageServiceStub = this.owner.lookup('service:storage');
+    sinon.stub(storageServiceStub, 'uploadFile').resolves({ url: 'data:,', filename: 'attachment-name' });
+
+    // when
+    const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+
+    const file = new File([], 'challenge-attachment.png', { type: 'image/png' });
+    await selectFiles('[data-test-file-input-attachment] input', file);
+
+    await runTask(this, async () => {
+    }, 400);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.dom(screen.getByRole('heading', { name: 'Pièces jointes' })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Illustration' })).exists();
+  });
+
+  test('delete attachment', async function (assert) {
     // given
     this.server.create('challenge', {
       id: 'recChallenge2',
@@ -90,7 +162,13 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
       filesIds: ['recAttachment1'],
       locale: 'nl'
     });
-    this.server.create('attachment', { id: 'recAttachment1', type: 'attachment', challengeId: 'recChallenge2', filename: 'attachment.png', localizedChallengeId: 'recChallenge2NL' });
+    this.server.create('attachment', {
+      id: 'recAttachment1',
+      type: 'attachment',
+      challengeId: 'recChallenge2',
+      filename: 'attachment.png',
+      localizedChallengeId: 'recChallenge2NL'
+    });
 
     // when
     const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
@@ -99,7 +177,8 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
 
     await click(find('[data-test-delete-attachment-button]'));
 
-    await runTask(this, async () => {}, 200);
+    await runTask(this, async () => {
+    }, 200);
     const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
     await click(saveButton);
 
@@ -112,7 +191,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     assert.ok(attachments.every(record => !record.isDeleted));
   });
 
-  test('cancel adding an attachment', async function(assert) {
+  test('cancel adding an attachment', async function (assert) {
     // given
     this.server.create('challenge', {
       id: 'recChallenge2',
@@ -133,7 +212,13 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
       filesIds: ['recAttachment1'],
       locale: 'nl'
     });
-    this.server.create('attachment', { id: 'recAttachment1', type: 'attachment', challengeId: 'recChallenge2', filename: 'attachment.png', localizedChallengeId: 'recChallenge2NL' });
+    this.server.create('attachment', {
+      id: 'recAttachment1',
+      type: 'attachment',
+      challengeId: 'recChallenge2',
+      filename: 'attachment.png',
+      localizedChallengeId: 'recChallenge2NL'
+    });
 
     // when
     const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
@@ -141,7 +226,8 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     await clickByText('Modifier');
     await click(find('[data-test-delete-attachment-button]'));
 
-    await runTask(this, async () => {}, 200);
+    await runTask(this, async () => {
+    }, 200);
     const cancelButton = await screen.findByRole('button', { name: 'Annuler' });
     await click(cancelButton);
 

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { visit, clickByText } from '@1024pix/ember-testing-library';
+import { visit, clickByText, within } from '@1024pix/ember-testing-library';
 import { findAll, click, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { runTask } from 'ember-lifeline';
@@ -59,14 +59,19 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
     await click(saveButton);
 
+    const showImageButton = await screen.findByRole('presentation');
+    await click(showImageButton);
+
     const store = this.owner.lookup('service:store');
     const attachments = await store.peekAll('attachment');
+    const popIn = await screen.findByTestId('display-illustration-pop-in');
 
     // then
     assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
     assert.ok(storageServiceStub.uploadFile.calledOnce);
     assert.ok(attachments.every(record => !record.isNew));
     assert.strictEqual(attachments.length, 1);
+    assert.dom(await within(popIn).findByRole('img')).hasAttribute('src', 'data:,');
   });
 
   test('delete illustration', async function(assert) {

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
@@ -1,0 +1,229 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { visit, clickByText } from '@1024pix/ember-testing-library';
+import { findAll, click, find } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { runTask } from 'ember-lifeline';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { selectFiles } from 'ember-file-upload/test-support';
+import Service from '@ember/service';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    this.server.create('challenge', { id: 'recChallenge1' });
+    this.server.create('localizedChallenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
+    this.server.create('localizedChallenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl' });
+    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'] });
+    this.server.create('skill', { id: 'recSkill2', challengeIds: [] });
+    this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+    this.server.create('tube', { id: 'recTube2', rawSkillIds: ['recSkill2'] });
+    this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+    this.server.create('theme', { id: 'recTheme2', name: 'theme2', rawTubeIds: ['recTube2'] });
+    this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds:['recTheme1'], rawTubeIds: ['recTube1'] });
+    this.server.create('competence', { id: 'recCompetence2.1', pixId: 'pixId recCompetence2.1', rawThemeIds:['recTheme2'], rawTubeIds: ['recTube2'] });
+    this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
+    this.server.create('area', { id: 'recArea2', name: '2. Communication et collaboration', code: '2', competenceIds: ['recCompetence2.1'] });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1', 'recArea2'] });
+    return authenticateSession();
+  });
+
+  test('adding illustration', async function(assert) {
+    // given
+    class StorageServiceStub extends Service {
+      uploadFile() {}
+    }
+
+    this.owner.register('service:storage', StorageServiceStub);
+    const storageServiceStub = this.owner.lookup('service:storage');
+    sinon.stub(storageServiceStub, 'uploadFile').resolves({ url: 'data:,', filename: 'attachment-name' });
+
+    // when
+    const screen = await visit('/');
+    await click(findAll('[data-test-area-item]')[0]);
+    await click(findAll('[data-test-competence-item]')[0]);
+    await click(findAll('[data-test-skill-cell-link]')[0]);
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+
+    const file = new File([], 'challenge-illustration.png', { type: 'image/png' });
+    await selectFiles('[data-test-file-input-illustration] input', file);
+
+    await runTask(this, async () => {}, 200);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.ok(storageServiceStub.uploadFile.calledOnce);
+    assert.ok(attachments.every(record => !record.isNew));
+    assert.strictEqual(attachments.length, 1);
+  });
+
+  test('delete illustration', async function(assert) {
+    // given
+    this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      skillId: 'recSkill2',
+    });
+    this.server.create('localizedChallenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      illustration: [{
+        'id': 'attd74YR8ga7IOfWp',
+        'url': 'https://dl.airtable.com/.attachments/b60304a44214d5b6f94d63df59d3516a/d1f1b65b/CertificatGUL2020.png',
+        'filename': 'Certificat GUL 2020.png',
+        'size': 178629,
+        'type': 'image/png'
+      }],
+      filesIds: ['recAttachment1'],
+      locale: 'nl'
+    });
+    this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge2', localizedChallengeId: 'recChallenge2NL' });
+    class StorageServiceStub extends Service {
+      uploadFile() {}
+    }
+
+    this.owner.register('service:storage', StorageServiceStub);
+    const storageServiceStub = this.owner.lookup('service:storage');
+    sinon.stub(storageServiceStub, 'uploadFile').resolves({ url: 'data:,', filename: 'attachment-name' });
+
+    // when
+    const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+    await click(find('[data-test-delete-illustration-button]'));
+
+    await runTask(this, async () => {}, 200);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.strictEqual(attachments.length, 0);
+    assert.ok(attachments.every(record => !record.isDeleted));
+  });
+
+  test('update illustration', async function(assert) {
+    // given
+    this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      skillId: 'recSkill2',
+    });
+    this.server.create('localizedChallenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      illustration: [{
+        'id': 'attd74YR8ga7IOfWp',
+        'url': 'https://dl.airtable.com/.attachments/b60304a44214d5b6f94d63df59d3516a/d1f1b65b/CertificatGUL2020.png',
+        'filename': 'Certificat GUL 2020.png',
+        'size': 178629,
+        'type': 'image/png'
+      }],
+      filesIds: ['recAttachment1'],
+      locale: 'nl'
+    });
+    this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge2', localizedChallengeId: 'recChallenge2NL' });
+    class StorageServiceStub extends Service {
+      uploadFile() {}
+    }
+
+    this.owner.register('service:storage', StorageServiceStub);
+    const storageServiceStub = this.owner.lookup('service:storage');
+    sinon.stub(storageServiceStub, 'uploadFile').resolves({ url: 'data:,', filename: 'attachment-name' });
+
+    // when
+    const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+
+    const file = new File([], 'challenge-illustration.png', { type: 'image/png' });
+    await selectFiles('[data-test-file-input-illustration] input', file);
+
+    await runTask(this, async () => {}, 200);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+    const localizedChallenge = await store.peekRecord('localized-challenge', 'recChallenge2NL');
+    await localizedChallenge.files;
+    const newIllustration  = localizedChallenge.files.findBy('type', 'illustration');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.ok(storageServiceStub.uploadFile.calledOnce);
+    assert.ok(attachments.every(record => !record.isModified));
+    assert.strictEqual(newIllustration.url, 'data:,');
+  });
+
+  test('delete and upload a new illustration', async function(assert) {
+    // given
+    this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      skillId: 'recSkill2',
+    });
+    this.server.create('localizedChallenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      illustration: [{
+        'id': 'attd74YR8ga7IOfWp',
+        'url': 'https://dl.airtable.com/.attachments/b60304a44214d5b6f94d63df59d3516a/d1f1b65b/CertificatGUL2020.png',
+        'filename': 'Certificat GUL 2020.png',
+        'size': 178629,
+        'type': 'image/png'
+      }],
+      filesIds: ['recAttachment1'],
+      locale: 'nl'
+    });
+    this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge2', localizedChallengeId: 'recChallenge2NL' });
+
+    class StorageServiceStub extends Service {
+      uploadFile() {}
+    }
+    this.owner.register('service:storage', StorageServiceStub);
+    const storageServiceStub = this.owner.lookup('service:storage');
+    sinon.stub(storageServiceStub, 'uploadFile').resolves({ url: 'data:,', filename: 'attachment-name' });
+
+    // when
+    const screen = await visit('/competence/recCompetence2.1/prototypes/recChallenge2');
+    await clickByText('Version nl');
+    await clickByText('Modifier');
+
+    const file = new File([], 'challenge-illustration.png', { type: 'image/png' });
+    await selectFiles('[data-test-file-input-illustration] input', file);
+
+    await runTask(this, async () => {}, 200);
+    const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
+    await click(saveButton);
+
+    const store = this.owner.lookup('service:store');
+    const attachments = await store.peekAll('attachment');
+    const localizedChallenge = await store.peekRecord('localized-challenge', 'recChallenge2NL');
+    await localizedChallenge.files;
+    const newIllustration = localizedChallenge.files.findBy('type', 'illustration');
+
+    // then
+    assert.dom('[data-test-main-message]').hasText('Épreuve mise à jour');
+    assert.ok(storageServiceStub.uploadFile.calledOnce);
+    assert.ok(attachments.every(record => !record.isModified));
+    assert.strictEqual(newIllustration.url, 'data:,');
+  });
+
+});
+

--- a/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
@@ -29,14 +29,15 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
     this.owner.register('service:notify', NotifyService);
   });
 
-  module('It should save localized challenge', function(hooks) {
-    let handleIllustrationStub, handleAttachmentStub, localizedChallenge;
+  module('it should save localized challenge', function(hooks) {
+    let handleIllustrationStub, handleAttachmentStub, localizedChallenge, saveChallengeStub, saveAttachmentsStub;
 
     hooks.beforeEach(function () {
 
       localizedChallenge = {
         id: 'rec123456',
         save: sinon.stub().resolves(localizedChallenge),
+        files: [],
       };
       controller.model = localizedChallenge;
 
@@ -45,6 +46,12 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
 
       handleAttachmentStub = sinon.stub().resolves(localizedChallenge);
       controller._handleAttachments = handleAttachmentStub;
+
+      saveChallengeStub = sinon.stub().resolves(localizedChallenge);
+      controller._saveChallenge = saveChallengeStub;
+
+      saveAttachmentsStub = sinon.stub().resolves(localizedChallenge);
+      controller._saveAttachments = saveAttachmentsStub;
 
       controller.wasMaximized = true;
     });
@@ -55,10 +62,12 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
 
       // then
       assert.ok(startStub.calledOnce);
-      assert.ok(localizedChallenge.save.calledOnce);
+      assert.ok(handleIllustrationStub.calledWith(localizedChallenge));
+      assert.ok(handleAttachmentStub.calledWith(localizedChallenge));
+      assert.ok(saveChallengeStub.calledWith(localizedChallenge));
+      assert.ok(saveAttachmentsStub.calledWith(localizedChallenge));
       assert.ok(messageStub.calledWith('Épreuve mise à jour'));
       assert.ok(stopStub.calledOnce);
-
     });
 
     test('it should reinitialize edition',  async function(assert) {

--- a/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
@@ -89,7 +89,8 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
     const rollbackAttributesStub = sinon.stub();
     const localizedChallenge = EmberObject.create({
       id: 'recChallenge',
-      rollbackAttributes: rollbackAttributesStub
+      rollbackAttributes: rollbackAttributesStub,
+      files: [],
     });
     controller.model = localizedChallenge;
 


### PR DESCRIPTION
## :unicorn: Problème
Afin d'attacher des pièce jointe ou des illustration traduite nous avons besoin d'une IHM pour le faire.

## :robot: Proposition
Créer l'IHM afin d'ajouter des pièce jointe ou illustration à une épreuve traduite.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur une épreuve traduite avec un compte admin/editor et ajouter une illustration ou une pièce jointe.
Vérifier que l'ajout / suppression d'illustrations et attachments fonctionne pour une épreuve et épreuve traduite.
