### PR TITLE
[FEATURE] Déprécier les colonnes traduites des domaines de airtable (PIX-9484)

### DIFF
--- a/api/lib/domain/models/Area.js
+++ b/api/lib/domain/models/Area.js
@@ -2,6 +2,7 @@ export class Area {
   constructor({
     id,
     code,
+    name,
     title_i18n,
     competenceIds,
     competenceAirtableIds,
@@ -10,12 +11,11 @@ export class Area {
   }) {
     this.id = id;
     this.code = code;
+    this.name = name;
     this.title_i18n = title_i18n;
     this.competenceIds = competenceIds;
     this.competenceAirtableIds = competenceAirtableIds;
     this.color = color;
     this.frameworkId = frameworkId;
-
-    this.name = `${code}. ${title_i18n.fr}`;
   }
 }

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -9,10 +9,6 @@ export const areaDatasource = datasource.extend({
   usedFields: [
     'id persistant',
     'Code',
-    'Nom',
-    'Titre',
-    'Titre fr-fr',
-    'Titre en-us',
     'Competences (identifiants) (id persistant)',
     'Competences (identifiants)',
     'Couleur',
@@ -23,11 +19,6 @@ export const areaDatasource = datasource.extend({
     return {
       id: airtableRecord.get('id persistant'),
       code: airtableRecord.get('Code'),
-      title_i18n: {
-        fr: airtableRecord.get('Titre fr-fr') || airtableRecord.get('Titre'),
-        en: airtableRecord.get('Titre en-us') || airtableRecord.get('Titre'),
-      },
-      name: airtableRecord.get('Nom'),
       competenceIds: airtableRecord.get('Competences (identifiants) (id persistant)'),
       competenceAirtableIds: airtableRecord.get('Competences (identifiants)'),
       color: airtableRecord.get('Couleur'),

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -20,6 +20,6 @@ function toDomainList(datasourceAreas, translations) {
 export function toDomain(datasourceArea, translations = []) {
   return new Area({
     ...datasourceArea,
-    ...areaTranslations.toDomain(translations),
+    ...areaTranslations.toDomain(translations, datasourceArea),
   });
 }

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -76,7 +76,7 @@ export async function serializeEntity({ type, entity, translations }) {
   return {
     updatedRecord: {
       ...updatedRecord,
-      ...tablesTranslations[type].toDomain(translations),
+      ...tablesTranslations[type].toDomain(translations, updatedRecord),
     },
     model,
   };

--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -18,12 +18,18 @@ const areaTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, i
 export const {
   extractFromProxyObject,
   extractFromReleaseObject,
+  proxyObjectToAirtableObject,
   prefixFor,
-  toDomain,
 } = areaTranslationUtils;
 
 export function airtableObjectToProxyObject(airtableObject, translations) {
   const areaProxyObject = areaTranslationUtils.airtableObjectToProxyObject(airtableObject, translations);
   areaProxyObject.Nom = `${areaProxyObject.Code}. ${areaProxyObject['Titre fr-fr']}`;
   return areaProxyObject;
+}
+
+export function toDomain(translations, datasourceArea) {
+  const domainArea = areaTranslationUtils.toDomain(translations);
+  domainArea.name = `${datasourceArea.code}. ${domainArea.title_i18n.fr}`;
+  return domainArea;
 }

--- a/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-area_test.js
@@ -38,13 +38,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create area tran
       user = databaseBuilder.factory.buildAdminUser();
       await databaseBuilder.commit();
       const area = domainBuilder.buildAreaDatasourceObject({ id: 'mon_id_persistant' });
-      airtableRawArea = airtableBuilder.factory.buildArea({
-        ...area,
-        title_i18n: {
-          fr: 'Domaine titre',
-          en: 'Area title',
-        }
-      });
+      airtableRawArea = airtableBuilder.factory.buildArea(area);
       areaToSave = inputOutputDataBuilder.factory.buildArea({
         ...area,
         title_i18n: {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -46,15 +46,27 @@ async function mockCurrentContent() {
   const expectedChallengeNl = { ...challengeNl };
   delete expectedChallengeNl.localizedChallenges;
 
-  const expectedAttachment = { id: 'attid1', challengeId: challenge.id, url: 'http://example.fr', type: 'lol', alt: 'stop' };
-  const expectedAttachmentNl = { id: 'attid2', challengeId: challengeNl.id, url: 'http://example.nl', type: 'haha', alt: 'arrête' };
+  const expectedAttachment = {
+    id: 'attid1',
+    challengeId: challenge.id,
+    url: 'http://example.fr',
+    type: 'lol',
+    alt: 'stop'
+  };
+  const expectedAttachmentNl = {
+    id: 'attid2',
+    challengeId: challengeNl.id,
+    url: 'http://example.nl',
+    type: 'haha',
+    alt: 'arrête'
+  };
 
   const expectedCurrentContent = {
     attachments: [
       domainBuilder.buildAttachment(expectedAttachment),
       domainBuilder.buildAttachment({ ...expectedAttachmentNl, challengeId: challengeNl.id }),
     ],
-    areas: [domainBuilder.buildAreaDatasourceObject()],
+    areas: [domainBuilder.buildArea()],
     competences: [domainBuilder.buildCompetence({
       name_i18n: {
         fr: 'Français',

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -15,11 +15,6 @@ describe('Integration | Repository | area-repository', () => {
           competenceAirtableIds: ['competenceAirtableId11', 'competenceAirtableId12'],
           competenceIds: ['competenceId11', 'competenceId12'],
           frameworkId: 'frameworkId1',
-          name: '1. Premier domaine airtable',
-          title_i18n: {
-            fr: 'Premier domaine airtable',
-            en: 'First area airtable',
-          },
         }),
         airtableBuilder.factory.buildArea({
           id: 'areaId2',
@@ -28,11 +23,6 @@ describe('Integration | Repository | area-repository', () => {
           competenceAirtableIds: ['competenceAirtableId21', 'competenceAirtableId22'],
           competenceIds: ['competenceId21', 'competenceId22'],
           frameworkId: 'frameworkId1',
-          name: '2. Second domaine airtable',
-          title_i18n: {
-            fr: 'Second domaine airtable',
-            en: 'Second area airtable',
-          },
         }),
       ]).activate().nockScope;
 

--- a/api/tests/scripts/migrate-areas-translations-from-airtable_test.js
+++ b/api/tests/scripts/migrate-areas-translations-from-airtable_test.js
@@ -31,22 +31,19 @@ describe('Script | Migrate areas translations from Airtable', function() {
       airtableBuilder.factory.buildArea({
         id: 'recArea51',
         code: '51',
-        name: '51. La zone 51',
-        title_i18n: {
-          fr: 'La zone 51',
-          en: 'The 51 area',
-        },
       }),
       airtableBuilder.factory.buildArea({
         id: 'recArea52',
         code: '52',
-        name: '52. La zone 52',
-        title_i18n: {
-          fr: 'La zone 52',
-          en: 'The 52 area',
-        },
       }),
     ];
+
+    areas[0].fields['Titre fr-fr'] = 'La zone 51';
+    areas[0].fields['Titre en-us'] = 'The 51 area';
+    areas[0].fields['Name'] = '51. La zone 51';
+    areas[1].fields['Titre fr-fr'] = 'La zone 52';
+    areas[1].fields['Titre en-us'] = 'The 52 area';
+    areas[1].fields['Name'] = '52. La zone 52';
 
     nock('https://api.airtable.com')
       .get('/v0/airtableBaseValue/Domaines')

--- a/api/tests/tooling/airtable-builder/factory/build-area.js
+++ b/api/tests/tooling/airtable-builder/factory/build-area.js
@@ -3,10 +3,8 @@ export function buildArea({
   competenceIds,
   competenceAirtableIds,
   code,
-  name,
   color,
   frameworkId,
-  title_i18n: { fr: titleFrFr, en: titleEnUs },
 } = {}) {
   return {
     id,
@@ -14,10 +12,7 @@ export function buildArea({
       'id persistant': id,
       'Competences (identifiants) (id persistant)': competenceIds,
       'Competences (identifiants)': competenceAirtableIds,
-      'Titre fr-fr': titleFrFr,
-      'Titre en-us': titleEnUs,
       'Code': code,
-      'Nom': name,
       'Couleur': color,
       'Referentiel': [frameworkId],
     },

--- a/api/tests/tooling/domain-builder/factory/build-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-area.js
@@ -11,6 +11,7 @@ export function buildArea({
 } = {}) {
   return new Area({
     id,
+    name: `${code}. ${title_i18n.fr}`,
     code,
     title_i18n,
     competenceIds,

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-area-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-area-datasource-object.js
@@ -1,11 +1,6 @@
 export function buildAreaDatasourceObject({
   id = 'recvoGdo7z2z7pXWa',
   code = '1',
-  name = '1. Information et données',
-  title_i18n = {
-    fr: 'Information et données',
-    en: 'Information and data',
-  },
   competenceIds = [
     'recsvLz0W2ShyfD63',
     'recNv8qhaY887jQb2',
@@ -21,8 +16,6 @@ export function buildAreaDatasourceObject({
   return {
     id,
     code,
-    name,
-    title_i18n,
     competenceIds,
     competenceAirtableIds,
     color,

--- a/api/tests/unit/infrastructure/serializers/airtable-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/airtable-serializer_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { domainBuilder, airtableBuilder } from '../../../test-helper.js';
+import { airtableBuilder, domainBuilder } from '../../../test-helper.js';
 import { serialize } from '../../../../lib/infrastructure/serializers/airtable-serializer.js';
 
 describe('Unit | Infrastructure | Serializers | Airtable Serializer', () => {
@@ -8,23 +8,7 @@ describe('Unit | Infrastructure | Serializers | Airtable Serializer', () => {
     it('should create a Area from the AirtableRecord', () => {
       // given
       const expectedArea = domainBuilder.buildAreaDatasourceObject();
-      const airtableObject = airtableBuilder.factory.buildArea({
-        id: 'recvoGdo7z2z7pXWa',
-        competenceIds: [
-          'recsvLz0W2ShyfD63',
-          'recNv8qhaY887jQb2',
-          'recIkYm646lrGvLNT',
-        ],
-        competenceAirtableIds: ['recChallenge0'],
-        code: '1',
-        name: '1. Information et données',
-        title_i18n: {
-          fr: 'Information et données',
-          en: 'Information and data',
-        },
-        color: 'jaffa',
-        frameworkId: 'recFramework0'
-      });
+      const airtableObject = airtableBuilder.factory.buildArea(expectedArea);
       const tableName = 'Domaines';
 
       // when

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -12,13 +12,8 @@ describe('Unit | Repository | release-repository', () => {
         id: '1',
         code: 1,
         color: 'blue',
-        name: '1',
         competenceIds: [],
         competenceAirtableIds: [],
-        title_i18n: {
-          fr: 'Bonjour',
-          en: 'Hello',
-        },
         frameworkId: 'recFramework0',
       });
       const type = 'Domaines';
@@ -44,7 +39,7 @@ describe('Unit | Repository | release-repository', () => {
         id: '1',
         code: 1,
         color: 'blue',
-        name: '1',
+        name: '1. Bonjour',
         competenceIds: [],
         competenceAirtableIds: [],
         title_i18n: {


### PR DESCRIPTION
## :unicorn: Problème
Les colonnes traduites des domaines sur airtable sont encore utilisées

## :robot: Proposition
Les retirer du code

## :rainbow: Remarques

## :100: Pour tester
Vérifier qu'une fois les colonnes taggées en [DEPRECATED], il est toujours possible de créer/éditer un domaine et que la release/réplication peut être générée