### PR TITLE
[FEATURE] Ajout d'une table de jointure entre localized challenges et attachments pour gérer ces derniers côté PG (PIX-10978)

### DIFF
--- a/api/db/migrations/20240131143146_add-joint-table-of-localizedChallenges-and-attachment.js
+++ b/api/db/migrations/20240131143146_add-joint-table-of-localizedChallenges-and-attachment.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'localized_challenges-attachments';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.string('attachmentId').notNullable();
+    table.string('localizedChallengeId').references('localized_challenges.id');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema
+    .dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/localized-challenges-attachments.js
+++ b/api/db/seeds/data/localized-challenges-attachments.js
@@ -1,0 +1,30 @@
+import Airtable from 'airtable';
+export async function localizedChallengesAttachmentsBuilder(databaseBuilder) {
+  const {
+    AIRTABLE_API_KEY: airtableApiKey,
+    AIRTABLE_BASE: airtableBase,
+  } = process.env;
+
+  const airtableClient = new Airtable({ apiKey: airtableApiKey }).base(airtableBase);
+
+  const attachments = await airtableClient
+    .table('Attachments')
+    .select({
+      fields: [
+        'Record ID',
+        'localizedChallengeId',
+      ],
+    })
+    .all();
+
+  const localizedChallengesAttachments = attachments.map((attachment) => {
+    const attachmentId = attachment.get('Record ID');
+    const localizedChallengeId = attachment.get('localizedChallengeId');
+    return {
+      attachmentId,
+      localizedChallengeId,
+    };
+  });
+
+  localizedChallengesAttachments.forEach(databaseBuilder.factory.buildLocalizedChallengeAttachment);
+}

--- a/api/db/seeds/data/localized-challenges.js
+++ b/api/db/seeds/data/localized-challenges.js
@@ -36,7 +36,7 @@ export async function localizedChallengesBuilder(databaseBuilder, translations) 
       ...challengesLocales[challengeId]
         ?.filter((locale) => locale !== primaryLocale)
         .map((locale) => ({
-          id: generateNewId('challenge'),
+          id: `${challengeId}-${locale}`,
           challengeId,
           locale,
           status: 'proposé'

--- a/api/db/seeds/data/localized-challenges.js
+++ b/api/db/seeds/data/localized-challenges.js
@@ -1,7 +1,6 @@
 import Airtable from 'airtable';
 import fp from 'lodash/fp.js';
 import { convertLanguagesToLocales } from '../../../lib/domain/services/convert-locales.js';
-import { generateNewId } from '../../../lib/infrastructure/utils/id-generator.js';
 
 export async function localizedChallengesBuilder(databaseBuilder, translations) {
   const {

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -1,5 +1,6 @@
 import { DatabaseBuilder } from '../../tests/tooling/database-builder/database-builder.js';
 import { localizedChallengesBuilder } from './data/localized-challenges.js';
+import { localizedChallengesAttachmentsBuilder } from './data/localized-challenges-attachments.js';
 import { staticCoursesBuilder } from './data/static-courses.js';
 import { translationsBuilder } from './data/translations.js';
 import { buildMissions } from './data/missions.js';
@@ -37,6 +38,8 @@ export async function seed(knex) {
   const translations = await translationsBuilder(databaseBuilder);
 
   await localizedChallengesBuilder(databaseBuilder, translations);
+
+  await localizedChallengesAttachmentsBuilder(databaseBuilder);
 
   staticCoursesBuilder(databaseBuilder);
 

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -63,6 +63,7 @@ export async function register(server) {
           }
         }],
         handler: async function(request, h) {
+          const tableName = request.params.path.split('/')[0];
           const response = await usecases.proxyDeleteRequestToAirtable(request, config.airtable.base, tableName, {
             proxyRequestToAirtable: _proxyRequestToAirtable,
           });

--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -63,7 +63,9 @@ export async function register(server) {
           }
         }],
         handler: async function(request, h) {
-          const response = await _proxyRequestToAirtable(request, config.airtable.base);
+          const response = await usecases.proxyDeleteRequestToAirtable(request, config.airtable.base, tableName, {
+            proxyRequestToAirtable: _proxyRequestToAirtable,
+          });
           return h.response(response.data).code(response.status);
         }
       },

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -3,14 +3,14 @@ export class LocalizedChallenge {
     id,
     challengeId,
     embedUrl,
-    fileIds = [],
+    fileIds,
     locale,
     status,
   } = {}) {
     this.id = id;
     this.challengeId = challengeId;
     this.embedUrl = embedUrl;
-    this.fileIds = fileIds;
+    this.fileIds = fileIds ?? [];
     this.locale = locale;
     this.status = status;
   }

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -2,14 +2,16 @@ export class LocalizedChallenge {
   constructor({
     id,
     challengeId,
-    locale,
     embedUrl,
+    fileIds = [],
+    locale,
     status,
   } = {}) {
     this.id = id;
     this.challengeId = challengeId;
-    this.locale = locale;
     this.embedUrl = embedUrl;
+    this.fileIds = fileIds;
+    this.locale = locale;
     this.status = status;
   }
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -4,6 +4,7 @@ export * from './find-all-missions.js';
 export * from './import-translations.js';
 export * from './modify-localized-challenge.js';
 export * from './preview-challenge.js';
+export * from './proxy-delete-request-to-airtable.js';
 export * from './proxy-read-request-to-airtable.js';
 export * from './proxy-write-request-to-airtable.js';
 export * from './update-mission.js';

--- a/api/lib/domain/usecases/proxy-delete-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-delete-request-to-airtable.js
@@ -1,0 +1,13 @@
+import * as repositories from '../../infrastructure/repositories/index.js';
+
+export async function proxyDeleteRequestToAirtable(request, airtableBase, tableName, {
+  proxyRequestToAirtable,
+  localizedChallengesAttachmentsRepository = repositories.localizedChallengesAttachmentsRepository,
+}) {
+  const response = await proxyRequestToAirtable(request, airtableBase);
+  if (tableName === 'Attachments') {
+    const attachmentId  = request.params.path.split('/')[1];
+    await localizedChallengesAttachmentsRepository.deleteByAttachmentId(attachmentId);
+  }
+  return response;
+}

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -4,7 +4,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   proxyRequestToAirtable,
   tableTranslations,
   translationRepository = repositories.translationRepository,
-  localizedChallengesAttachmentsRepository, //= repositories.localizedChallengesAttachmentsRepository,
+  localizedChallengesAttachmentsRepository = repositories.localizedChallengesAttachmentsRepository,
   updateStagingPixApiCache,
 }) {
   const requestFields = request.payload.fields;

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -4,6 +4,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   proxyRequestToAirtable,
   tableTranslations,
   translationRepository = repositories.translationRepository,
+  localizedChallengesAttachmentsRepository, //= repositories.localizedChallengesAttachmentsRepository,
   updateStagingPixApiCache,
 }) {
   const requestFields = request.payload.fields;
@@ -16,6 +17,17 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
 
   if (!_isResponseOK(response)) {
     return response;
+  }
+
+  const isCreatingAttachment = tableName === 'Attachments' && request.method === 'post';
+
+  if (isCreatingAttachment) {
+    const localizedChallengeId = response.data.fields.localizedChallengeId;
+    const attachmentId = response.data.id;
+    await localizedChallengesAttachmentsRepository.save({
+      localizedChallengeId,
+      attachmentId
+    });
   }
 
   let translations;

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -2,6 +2,7 @@ export * as areaRepository from './area-repository.js';
 export * as challengeRepository from './challenge-repository.js';
 export * as competenceRepository from './competence-repository.js';
 export * as fileStorageTokenRepository from './file-storage-token-repository.js';
+export * as localizedChallengesAttachmentsRepository from './localized-challenges-attachments-repository.js';
 export * as localizedChallengeRepository from './localized-challenge-repository.js';
 export * as missionRepository from './mission-repository.js';
 export * as releaseRepository from './release-repository.js';

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -41,7 +41,9 @@ export async function getByChallengeIdAndLocale({ challengeId, locale }) {
 }
 
 export async function listByChallengeIds({ challengeIds, transaction: knexConnection = knex }) {
-  const dtos = await knexConnection('localized_challenges').select().whereIn('challengeId', challengeIds).orderBy(['challengeId', 'locale']);
+  const dtos = await _queryLocalizedChallengeWithAttachment(knexConnection)
+    .whereIn('challengeId', challengeIds)
+    .orderBy(['challengeId', 'locale']);
   return dtos.map(_toDomain);
 }
 

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -62,7 +62,7 @@ export async function getMany({ ids, transaction: knexConnection = knex }) {
 }
 
 export async function update({
-  localizedChallenge: { id, locale, embedUrl, status },
+  localizedChallenge: { id, locale, embedUrl, status, fileIds },
   transaction: knexConnection = knex
 }) {
   const [dto] = await knexConnection('localized_challenges').where('id', id).update({
@@ -73,7 +73,7 @@ export async function update({
 
   if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');
 
-  return _toDomain(dto);
+  return _toDomain({ ...dto, fileIds });
 }
 
 function _toDomain(dto) {

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -56,7 +56,8 @@ export async function get({ id, transaction: knexConnection = knex }) {
 }
 
 export async function getMany({ ids, transaction: knexConnection = knex }) {
-  const dtos = await knexConnection('localized_challenges').whereIn('id', ids).select();
+  const dtos = await _queryLocalizedChallengeWithAttachment(knexConnection).whereIn('id', ids).select().orderBy('id');
+
   return dtos.map(_toDomain);
 }
 

--- a/api/lib/infrastructure/repositories/localized-challenges-attachments-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenges-attachments-repository.js
@@ -1,0 +1,6 @@
+import { knex } from '../../../db/knex-database-connection.js';
+
+export async function save({attachmentId, localizedChallengeId}) {
+  await knex('localized_challenges-attachments')
+    .insert({attachmentId, localizedChallengeId});
+}

--- a/api/lib/infrastructure/repositories/localized-challenges-attachments-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenges-attachments-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../../db/knex-database-connection.js';
 
-export async function save({ attachmentId, localizedChallengeId }) {
-  await knex('localized_challenges-attachments')
+export async function save({ attachmentId, localizedChallengeId, transaction: knexConnection = knex }) {
+  await knexConnection('localized_challenges-attachments')
     .insert({ attachmentId, localizedChallengeId });
 }
 

--- a/api/lib/infrastructure/repositories/localized-challenges-attachments-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenges-attachments-repository.js
@@ -1,6 +1,10 @@
 import { knex } from '../../../db/knex-database-connection.js';
 
-export async function save({attachmentId, localizedChallengeId}) {
+export async function save({ attachmentId, localizedChallengeId }) {
   await knex('localized_challenges-attachments')
-    .insert({attachmentId, localizedChallengeId});
+    .insert({ attachmentId, localizedChallengeId });
+}
+
+export async function deleteByAttachmentId(attachmentId) {
+  await knex('localized_challenges-attachments').delete().where({ attachmentId });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -1,5 +1,5 @@
 import JsonapiSerializer from 'jsonapi-serializer';
-import { dasherize, underscore } from 'inflected';
+import Inflector from 'inflected';
 import { LocalizedChallenge } from '../../../domain/models/index.js';
 
 const { Serializer, Deserializer } = JsonapiSerializer;
@@ -17,7 +17,7 @@ const serializer = new Serializer('localized-challenges', {
   },
   keyForAttribute(attribute) {
     if (attribute === 'fileIds') return 'files';
-    return dasherize(underscore(attribute));
+    return Inflector.dasherize(Inflector.underscore(attribute));
   },
   challenge: {
     ref: 'id',
@@ -47,11 +47,17 @@ const deserializer = new Deserializer({
       return challenge.id;
     },
   },
+  attachments: {
+    valueForRelationship(attachment) {
+      return attachment.id;
+    }
+  },
   transform: function({ challenge, embedUrl, ...localizedChallenge }) {
     return new LocalizedChallenge({
       ...localizedChallenge,
       challengeId: challenge,
       embedUrl: embedUrl === '' ? null : embedUrl,
+      fileIds: localizedChallenge.files,
     });
   }
 });

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -1,4 +1,5 @@
 import JsonapiSerializer from 'jsonapi-serializer';
+import { dasherize, underscore } from 'inflected';
 import { LocalizedChallenge } from '../../../domain/models/index.js';
 
 const { Serializer, Deserializer } = JsonapiSerializer;
@@ -9,10 +10,23 @@ const serializer = new Serializer('localized-challenges', {
     'locale',
     'embedUrl',
     'status',
+    'fileIds',
   ],
+  typeForAttribute(attribute) {
+    if (attribute === 'fileIds') return 'attachments';
+  },
+  keyForAttribute(attribute) {
+    if (attribute === 'fileIds') return 'files';
+    return dasherize(underscore(attribute));
+  },
   challenge: {
     ref: 'id',
     included: false,
+  },
+  fileIds: {
+    ref(_, fileId) {
+      return fileId;
+    }
   },
   transform: function({ challengeId, ...localizedChallenge }) {
     return {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -43,6 +43,7 @@
         "pg-query-stream": "^4.5.3",
         "pino": "^8.0.0",
         "pino-pretty": "^10.2.0",
+        "progress": "2.0.3",
         "qs": "^6.10.1",
         "sequelize": "^6.29.0",
         "showdown": "^2.0.0",
@@ -9686,6 +9687,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/api/package.json
+++ b/api/package.json
@@ -75,6 +75,7 @@
     "pg-query-stream": "^4.5.3",
     "pino": "^8.0.0",
     "pino-pretty": "^10.2.0",
+    "progress": "2.0.3",
     "qs": "^6.10.1",
     "sequelize": "^6.29.0",
     "showdown": "^2.0.0",

--- a/api/scripts/fill-localized-challenges-attachments/index.js
+++ b/api/scripts/fill-localized-challenges-attachments/index.js
@@ -1,0 +1,70 @@
+import { localizedChallengesAttachmentsRepository } from '../../lib/infrastructure/repositories/index.js';
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import ProgressBar from 'progress';
+import { knex, disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export function fillLocalizedChallengesAttachments({ airtableClient }) {
+  return knex.transaction(async (transaction) => {
+    const attachments = await fetchAttachments({ airtableClient });
+
+    const bar = new ProgressBar('[:bar] :percent', {
+      total: attachments.length,
+      width: 50,
+    });
+
+    for (const attachment of attachments) {
+      await localizedChallengesAttachmentsRepository.save({
+        attachmentId: attachment.id,
+        localizedChallengeId: attachment.localizedChallengeId,
+        transaction
+      });
+      bar.tick();
+    }
+    return { count: attachments.length };
+  });
+}
+
+export async function fetchAttachments({ airtableClient }) {
+  const allAttachments = await airtableClient
+    .table('Attachments')
+    .select({
+      fields: [
+        'Record ID',
+        'localizedChallengeId',
+      ],
+    })
+    .all();
+
+  return allAttachments.map((attachment) => {
+    const id = attachment.get('Record ID');
+    const localizedChallengeId = attachment.get('localizedChallengeId');
+    return {
+      id,
+      localizedChallengeId,
+    };
+  });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    const { count } = await fillLocalizedChallengesAttachments({ airtableClient });
+    console.log(`${count} attachments inserted successfully`);
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -876,7 +876,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
     });
     afterEach(async function() {
       await knex('translations').truncate();
-      await knex('localized_challenges').truncate();
+      await knex('localized_challenges').delete();
     });
 
     it('should create a challenge', async () => {

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -40,6 +40,9 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
                 type: 'challenges',
               },
             },
+            files: {
+              data: [],
+            },
           },
         }
       };
@@ -88,6 +91,9 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
                 id: localizedChallenge.challengeId,
                 type: 'challenges',
               },
+            },
+            files: {
+              data: [],
             },
           },
         }]
@@ -145,6 +151,9 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
                   type: 'challenges',
                 },
               },
+              files: {
+                data: [],
+              },
             },
           },
           {
@@ -161,6 +170,9 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
                   id: localizedChallenges[1].challengeId,
                   type: 'challenges',
                 },
+              },
+              files: {
+                data: [],
               },
             },
           }

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -382,6 +382,37 @@ describe('Integration | Repository | localized-challenge-repository', function()
       }));
     });
 
+    context('when there is one attachment joined to localized challenge', () => {
+      it('should return localized challenge with fileIds', async () => {
+        // given
+        const id = 'localizedChallengeId';
+        const localizedChallengeBz = databaseBuilder.factory.buildLocalizedChallenge({
+          id,
+          challengeId: 'challengeId',
+          embedUrl: 'mon-url.com',
+          locale: 'bz',
+        });
+
+        const localizedChallengeAttachment = databaseBuilder.factory.buildLocalizedChallengeAttachment({
+          localizedChallengeId: localizedChallengeBz.id,
+          attachmentId: 'attachment-id-0',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const localizedChallenge = await localizedChallengeRepository.get({ id });
+
+        // then
+        expect(localizedChallenge).to.deep.equal(domainBuilder.buildLocalizedChallenge({
+          id,
+          challengeId: 'challengeId',
+          embedUrl: 'mon-url.com',
+          locale: 'bz',
+          fileIds: [localizedChallengeAttachment.attachmentId],
+        }));
+      });
+    });
+
     context('when id does not exist', () => {
       it('should throw a NotFoundError', async () => {
         // given

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -603,5 +603,52 @@ describe('Integration | Repository | localized-challenge-repository', function()
           status: null,
         }));
     });
+    context('when there is one attachment joined to localized challenge', ()=> {
+      it('should change localized challenge locale and embedUrl with attachmentId', async () => {
+        // given
+        const id = 'localizedChallengeId';
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id,
+          challengeId: 'challengeId',
+          embedUrl: 'my-url.html',
+          locale: 'bz',
+        });
+
+        await databaseBuilder.commit();
+
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id,
+          challengeId: 'differentChallengeId should not be updated',
+          embedUrl: 'my-new-url.html',
+          locale: 'ar',
+          status: null,
+          files: ['attachmentId']
+        });
+
+        // when
+        const localizedUpdatedChallenge = await localizedChallengeRepository.update({ localizedChallenge });
+
+        // then
+        await expect(knex('localized_challenges').select()).resolves.to.deep.equal([
+          {
+            id,
+            challengeId: 'challengeId',
+            embedUrl: 'my-new-url.html',
+            locale: 'ar',
+            status: null,
+          },
+        ]);
+
+        expect(localizedUpdatedChallenge).to.deep.equal(
+          domainBuilder.buildLocalizedChallenge({
+            id,
+            challengeId: 'challengeId',
+            embedUrl: 'my-new-url.html',
+            locale: 'ar',
+            status: null,
+            files: ['attachmentId']
+          }));
+      });
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -32,6 +32,57 @@ describe('Integration | Repository | localized-challenge-repository', function()
     });
   });
 
+  context('when there is one attachment joined to localized challenges', () => {
+    it('should return a list of localized challenges with fileIds', async () => {
+      // given
+      const id = 'localizedChallengeId';
+      const id2 = 'localizedChallengeId2';
+      const localizedChallengeBz = databaseBuilder.factory.buildLocalizedChallenge({
+        id,
+        challengeId: 'challengeId',
+        embedUrl: 'mon-url.com',
+        locale: 'bz',
+      });
+      const localizedChallengeNl = databaseBuilder.factory.buildLocalizedChallenge({
+        id: id2,
+        challengeId: 'challengeId',
+        embedUrl: 'mon-url-nl.com',
+        locale: 'nl',
+      });
+      const localizedChallengeFr = databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challengeId',
+        challengeId: 'challengeId',
+        embedUrl: 'mon-url-fr.com',
+        locale: 'fr',
+      });
+
+      const localizedChallengeAttachment = databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: localizedChallengeBz.id,
+        attachmentId: 'attachment-id-0',
+      });
+      await databaseBuilder.commit();
+
+      const expectedFrenchChallenge = domainBuilder.buildLocalizedChallenge({
+        ...localizedChallengeFr,
+        fileIds: [],
+      });
+      const expectedBzChallenge = domainBuilder.buildLocalizedChallenge({
+        ...localizedChallengeBz,
+        fileIds: [localizedChallengeAttachment.attachmentId],
+      });
+      const expectedNlChallenge = domainBuilder.buildLocalizedChallenge({
+        ...localizedChallengeNl,
+        fileIds: [],
+      });
+
+      // when
+      const localizedChallenges = await localizedChallengeRepository.list();
+
+      // then
+      expect(localizedChallenges).to.deep.equal([expectedFrenchChallenge, expectedBzChallenge, expectedNlChallenge]);
+    });
+  });
+
   context('#create', function() {
     afterEach(async () => {
       await knex('localized_challenges').delete();

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -407,66 +407,66 @@ describe('Integration | Repository | localized-challenge-repository', function()
         }),
       ]);
     });
-  context('when there are attachments', () => {
-    it('should return the list of localized challenges with attachment for a list of challenge IDs', async () => {
-      const challengeId1 = 'challengeId1';
-      const challengeId2 = 'challengeId2';
-      const embedUrl = 'url.com';
+    context('when there are attachments', () => {
+      it('should return the list of localized challenges with attachment for a list of challenge IDs', async () => {
+        const challengeId1 = 'challengeId1';
+        const challengeId2 = 'challengeId2';
+        const embedUrl = 'url.com';
 
-      // given
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: challengeId1,
-        challengeId: challengeId1,
-        locale: 'fr-fr',
-        embedUrl,
-      });
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: `${challengeId1}En`,
-        challengeId: challengeId1,
-        locale: 'en',
-        embedUrl,
-      });
-      databaseBuilder.factory.buildLocalizedChallenge({
-        id: `${challengeId2}Nl`,
-        challengeId: challengeId2,
-        locale: 'nl',
-        embedUrl,
-      });
-
-      databaseBuilder.factory.buildLocalizedChallengeAttachment({
-        localizedChallengeId: `${challengeId2}Nl`,
-        attachmentId: 'attachment-nl',
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds: [challengeId1, challengeId2] });
-
-      // then
-      expect(localizedChallenges).to.deep.equal([
-        domainBuilder.buildLocalizedChallenge({
-          id: `${challengeId1}En`,
-          challengeId: challengeId1,
-          locale: 'en',
-          embedUrl,
-        }),
-        domainBuilder.buildLocalizedChallenge({
+        // given
+        databaseBuilder.factory.buildLocalizedChallenge({
           id: challengeId1,
           challengeId: challengeId1,
           locale: 'fr-fr',
           embedUrl,
-        }),
-        domainBuilder.buildLocalizedChallenge({
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: `${challengeId1}En`,
+          challengeId: challengeId1,
+          locale: 'en',
+          embedUrl,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
           id: `${challengeId2}Nl`,
           challengeId: challengeId2,
           locale: 'nl',
-          fileIds: ['attachment-nl'],
           embedUrl,
-        })
-      ])
-    })
-  })
+        });
+
+        databaseBuilder.factory.buildLocalizedChallengeAttachment({
+          localizedChallengeId: `${challengeId2}Nl`,
+          attachmentId: 'attachment-nl',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds: [challengeId1, challengeId2] });
+
+        // then
+        expect(localizedChallenges).to.deep.equal([
+          domainBuilder.buildLocalizedChallenge({
+            id: `${challengeId1}En`,
+            challengeId: challengeId1,
+            locale: 'en',
+            embedUrl,
+          }),
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeId1,
+            challengeId: challengeId1,
+            locale: 'fr-fr',
+            embedUrl,
+          }),
+          domainBuilder.buildLocalizedChallenge({
+            id: `${challengeId2}Nl`,
+            challengeId: challengeId2,
+            locale: 'nl',
+            fileIds: ['attachment-nl'],
+            embedUrl,
+          })
+        ]);
+      });
+    });
   });
 
   context('#get', () => {

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -478,7 +478,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
     });
   });
 
-  context('#getMany', () => {
+  context('#getMany', () =>   {
     it('should return localized challenges by ids', async () => {
       // given
       const ids = ['localizedChallengeId1', 'localizedChallengeId2'];
@@ -493,6 +493,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         challengeId: 'challengeId2',
         locale: 'ur',
       });
+
       await databaseBuilder.commit();
 
       // when
@@ -513,6 +514,49 @@ describe('Integration | Repository | localized-challenge-repository', function()
           locale: 'ur',
         }),
       ]);
+    });
+    context('when there is one attachment joined to localized challenge', ()=> {
+      it('should return localized challenges by ids with attachment', async () => {
+        // given
+        const ids = ['localizedChallengeId1', 'localizedChallengeId2'];
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: ids[0],
+          challengeId: 'challengeId1',
+          embedUrl: 'mon-url.com',
+          locale: 'bz',
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: ids[1],
+          challengeId: 'challengeId2',
+          locale: 'ur',
+        });
+        databaseBuilder.factory.buildLocalizedChallengeAttachment({
+          localizedChallengeId: ids[0],
+          attachmentId: 'attachmentId',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const localizedChallenges = await localizedChallengeRepository.getMany({ ids });
+
+        // then
+        expect(localizedChallenges).to.deep.equal([
+          domainBuilder.buildLocalizedChallenge({
+            id: ids[0],
+            challengeId: 'challengeId1',
+            embedUrl: 'mon-url.com',
+            locale: 'bz',
+            fileIds: ['attachmentId']
+          }),
+          domainBuilder.buildLocalizedChallenge({
+            id: ids[1],
+            challengeId: 'challengeId2',
+            embedUrl:  null,
+            locale: 'ur',
+          }),
+        ]);
+      });
+
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -407,6 +407,66 @@ describe('Integration | Repository | localized-challenge-repository', function()
         }),
       ]);
     });
+  context('when there are attachments', () => {
+    it('should return the list of localized challenges with attachment for a list of challenge IDs', async () => {
+      const challengeId1 = 'challengeId1';
+      const challengeId2 = 'challengeId2';
+      const embedUrl = 'url.com';
+
+      // given
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeId1,
+        challengeId: challengeId1,
+        locale: 'fr-fr',
+        embedUrl,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: `${challengeId1}En`,
+        challengeId: challengeId1,
+        locale: 'en',
+        embedUrl,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: `${challengeId2}Nl`,
+        challengeId: challengeId2,
+        locale: 'nl',
+        embedUrl,
+      });
+
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: `${challengeId2}Nl`,
+        attachmentId: 'attachment-nl',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds: [challengeId1, challengeId2] });
+
+      // then
+      expect(localizedChallenges).to.deep.equal([
+        domainBuilder.buildLocalizedChallenge({
+          id: `${challengeId1}En`,
+          challengeId: challengeId1,
+          locale: 'en',
+          embedUrl,
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: challengeId1,
+          challengeId: challengeId1,
+          locale: 'fr-fr',
+          embedUrl,
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: `${challengeId2}Nl`,
+          challengeId: challengeId2,
+          locale: 'nl',
+          fileIds: ['attachment-nl'],
+          embedUrl,
+        })
+      ])
+    })
+  })
   });
 
   context('#get', () => {

--- a/api/tests/integration/infrastructure/repositories/localized-challenges-attachments-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenges-attachments-repository_test.js
@@ -3,29 +3,59 @@ import { databaseBuilder, knex } from '../../../test-helper.js';
 import { localizedChallengesAttachmentsRepository } from '../../../../lib/infrastructure/repositories/index.js';
 
 describe('Integration | Repository | localized-challenges-attachments-repository', function() {
-  afterEach(async function() {
-    await knex('localized_challenges-attachments').delete();
-  });
-  it('should save attachment and localized challenge ids', async function() {
-    // given
-    const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
-      id: 'challengeNewid',
-      challengeId: 'challengeId',
-      locale: 'fr-fr',
-      embedUrl: 'https://example.com/embed.html',
-      status: 'proposé'
+  describe('#save', () => {
+    afterEach(async function() {
+      await knex('localized_challenges-attachments').delete();
     });
-    await databaseBuilder.commit();
+    it('should save attachment and localized challenge ids', async function() {
+      // given
+      const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challengeNewid',
+        challengeId: 'challengeId',
+        locale: 'fr-fr',
+        embedUrl: 'https://example.com/embed.html',
+        status: 'proposé'
+      });
+      await databaseBuilder.commit();
 
-    // when
-    await localizedChallengesAttachmentsRepository.save({ localizedChallengeId: localizedChallenge.id, attachmentId: 'attachment-id' });
+      // when
+      await localizedChallengesAttachmentsRepository.save({ localizedChallengeId: localizedChallenge.id, attachmentId: 'attachment-id' });
 
-    // then
-    const localizedChallengesAttachments = await knex('localized_challenges-attachments').select();
+      // then
+      const localizedChallengesAttachments = await knex('localized_challenges-attachments').select();
 
-    expect(localizedChallengesAttachments).to.deep.equal([{
-      localizedChallengeId: localizedChallenge.id,
-      attachmentId: 'attachment-id',
-    }]);
+      expect(localizedChallengesAttachments).to.deep.equal([{
+        localizedChallengeId: localizedChallenge.id,
+        attachmentId: 'attachment-id',
+      }]);
+    });
+  });
+  describe('#deleteByAttachmentId', () => {
+    it('should delete localizedChallengeAttachment', async () => {
+      // given
+      const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'localized-challenge-id',
+        challengeId: 'challengeId',
+        locale: 'fr',
+        embedUrl: 'https://example.com/embed.html',
+        status: 'proposé'
+      });
+      const localizedChallengeAttachment = databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: localizedChallenge.id,
+        attachmentId: 'attachment-id',
+      });
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: localizedChallenge.id,
+        attachmentId: 'attachment-id2',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await localizedChallengesAttachmentsRepository.deleteByAttachmentId(localizedChallengeAttachment.attachmentId);
+
+      // then
+      const localizedChallengeAttachments = await knex('localized_challenges-attachments').select();
+      expect(localizedChallengeAttachments).toHaveLength(1);
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/localized-challenges-attachments-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenges-attachments-repository_test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+import { localizedChallengesAttachmentsRepository } from '../../../../lib/infrastructure/repositories/index.js';
+
+describe('Integration | Repository | localized-challenges-attachments-repository', function() {
+  afterEach(async function() {
+    await knex('localized_challenges-attachments').delete();
+  });
+  it('should save attachment and localized challenge ids', async function() {
+    // given
+    const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'challengeNewid',
+      challengeId: 'challengeId',
+      locale: 'fr-fr',
+      embedUrl: 'https://example.com/embed.html',
+      status: 'proposé'
+    });
+    await databaseBuilder.commit();
+
+    // when
+    await localizedChallengesAttachmentsRepository.save({ localizedChallengeId: localizedChallenge.id, attachmentId: 'attachment-id' });
+
+    // then
+    const localizedChallengesAttachments = await knex('localized_challenges-attachments').select();
+
+    expect(localizedChallengesAttachments).to.deep.equal([{
+      localizedChallengeId: localizedChallenge.id,
+      attachmentId: 'attachment-id',
+    }]);
+  });
+});

--- a/api/tests/scripts/fill-localized-challenges-attachments_test.js
+++ b/api/tests/scripts/fill-localized-challenges-attachments_test.js
@@ -1,0 +1,63 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+import {
+  fillLocalizedChallengesAttachments
+} from '../../scripts/fill-localized-challenges-attachments/index.js';
+
+describe('Fill localized challenges attachments from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('localized_challenges-attachments').delete();
+  });
+
+  it('fills localized_challenges-attachments table from airtable', async function() {
+    // given
+    databaseBuilder.factory.buildLocalizedChallenge({ id: 'localizedChallenge1' });
+    await databaseBuilder.commit();
+    const attachment1 = {
+      fields: {
+        'Record ID': 'attachment1',
+        localizedChallengeId: 'localizedChallenge1',
+      }
+    };
+
+    const attachments = [attachment1];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Attachments')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query({
+        fields: {
+          '': [
+            'Record ID',
+            'localizedChallengeId',
+          ]
+        }
+      })
+      .reply(200, { records: attachments });
+
+    // when
+    await fillLocalizedChallengesAttachments({ airtableClient });
+
+    // then
+    const localizedChallengesAttachments = await knex('localized_challenges-attachments').select().orderBy('attachmentId');
+
+    expect(localizedChallengesAttachments).to.have.lengthOf(1);
+    expect(localizedChallengesAttachments).to.deep.equal([
+      {
+        attachmentId: 'attachment1',
+        localizedChallengeId: 'localizedChallenge1',
+      },
+    ]);
+  });
+});

--- a/api/tests/scripts/fill-localized-challenges_test.js
+++ b/api/tests/scripts/fill-localized-challenges_test.js
@@ -23,7 +23,7 @@ describe('Fill localized challenges from airtable', function() {
   });
 
   afterEach(async () => {
-    await knex('localized_challenges').truncate();
+    await knex('localized_challenges').delete();
   });
 
   it('fills localized_challenges table from airtable', async function() {

--- a/api/tests/tooling/database-builder/factory/build-localized-challenge-attachment.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-challenge-attachment.js
@@ -1,0 +1,12 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildLocalizedChallengeAttachment({
+  localizedChallengeId = 'challenge123',
+  attachmentId = 'attachment123'
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    autoId: false,
+    tableName: 'localized_challenges-attachments',
+    values: { localizedChallengeId, attachmentId },
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -1,4 +1,5 @@
 export * from './build-localized-challenge.js';
+export * from './build-localized-challenge-attachment.js';
 export * from './build-mission.js';
 export * from './build-release.js';
 export * from './build-static-course.js';

--- a/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
@@ -3,15 +3,17 @@ import { LocalizedChallenge } from '../../../../lib/domain/models';
 export function buildLocalizedChallenge({
   id = 'persistant id',
   challengeId = 'persistant id',
-  locale = 'fr',
   embedUrl = 'https://example.com/embed.html',
+  fileIds = [],
+  locale = 'fr',
   status = null,
 }) {
   return new LocalizedChallenge({
     id,
     challengeId,
-    locale,
     embedUrl,
+    fileIds,
+    locale,
     status
   });
 }

--- a/api/tests/unit/domain/usecases/proxy-delete-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-delete-request-to-airtable_test.js
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as usecases from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
+  let proxyRequestToAirtable;
+  let localizedChallengesAttachmentsRepository;
+  let tableName;
+  let request;
+
+  const response = Symbol('response');
+  const airtableBase = Symbol('airtableBase');
+
+  beforeEach(() => {
+    proxyRequestToAirtable = vi.fn();
+  });
+
+  it('should forward the request to Airtable API', async () => {
+    // given
+    tableName = Symbol('tableName');
+    request = Symbol('request');
+    proxyRequestToAirtable.mockResolvedValueOnce(response);
+
+    // when
+    const actualResponse = await usecases.proxyDeleteRequestToAirtable(request, airtableBase, tableName, { proxyRequestToAirtable });
+
+    // then
+    expect(actualResponse).toBe(response);
+    expect(proxyRequestToAirtable).toHaveBeenCalledWith(request, airtableBase);
+  });
+
+  describe('when tableName is Attachments', () => {
+    it('should delete relations between deleted attachments and localized challenges', async () => {
+      // given
+      tableName = 'Attachments';
+      proxyRequestToAirtable.mockResolvedValueOnce(response);
+      localizedChallengesAttachmentsRepository = {
+        deleteByAttachmentId: vi.fn().mockResolvedValueOnce(),
+      };
+      request = {
+        params: {
+          path: 'Attachments/attachmentId'
+        }
+      };
+
+      // when
+      const actualResponse = await usecases.proxyDeleteRequestToAirtable(request, airtableBase, tableName, { proxyRequestToAirtable, localizedChallengesAttachmentsRepository });
+
+      // then
+      expect(actualResponse).toBe(response);
+      expect(proxyRequestToAirtable).toHaveBeenCalledWith(request, airtableBase);
+      expect(localizedChallengesAttachmentsRepository.deleteByAttachmentId).toHaveBeenCalledWith('attachmentId');
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-write-request-to-airtable_test.js
@@ -80,6 +80,47 @@ describe('Unit | Domain | Usecases | proxy-write-request-to-airtable', () => {
       expect(updateStagingPixApiCache).toHaveBeenCalledWith(tableName, responseEntity, undefined);
     });
 
+    it('should write joint entry to localized_challenges-attachments', async () => {
+      // when
+      const createAttachmentAirtableResponse = {
+        status: 200,
+        data: {
+          id: 'created-attachement-id',
+          fields: {
+            localizedChallengeId: 'localizedChallengeId',
+          }
+        }
+      };
+      const localizedChallengesAttachmentsRepository = {
+        save: vi.fn(),
+      };
+
+      proxyRequestToAirtable.mockResolvedValue(createAttachmentAirtableResponse);
+
+      const createAttachmentRequest = {
+        method: 'post',
+        payload: {
+          fields: {
+            localizedChallengeId: 'localizedChallengeId',
+          },
+        }
+      };
+
+      const actualResponse = await proxyWriteRequestToAirtable(createAttachmentRequest, airtableBase, 'Attachments', {
+        proxyRequestToAirtable,
+        tableTranslations,
+        localizedChallengesAttachmentsRepository,
+        updateStagingPixApiCache,
+      });
+
+      // then
+      expect(actualResponse).toBe(createAttachmentAirtableResponse);
+      expect(localizedChallengesAttachmentsRepository.save).toHaveBeenCalledWith({
+        attachmentId: 'created-attachement-id',
+        localizedChallengeId: 'localizedChallengeId',
+      });
+    });
+
     describe('when writing translations to PG is enabled', () => {
       beforeEach(() => {
         request = { method: 'post', payload: { fields: requestFields } };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
@@ -34,6 +34,45 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
       expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
     });
 
+    it('should deserialize a Localized Challenge with files', async () => {
+      // Given
+      const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
+        fileIds: ['attachmentId']
+      });
+
+      const json = {
+        data: {
+          type: 'localized-challenges',
+          id: `${expectedLocalizedChallenge.id}`,
+          attributes: {
+            'embed-url': expectedLocalizedChallenge.embedUrl,
+            locale: expectedLocalizedChallenge.locale,
+            status: expectedLocalizedChallenge.status,
+          },
+          relationships: {
+            challenge: {
+              data: {
+                type: 'challenges',
+                id: expectedLocalizedChallenge.challengeId,
+              },
+            },
+            files: {
+              data: [{
+                type: 'attachments',
+                id: 'attachmentId'
+              }]
+            }
+          },
+        },
+      };
+
+      // When
+      const localizedChallenge = await deserialize(json);
+
+      // Then
+      expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
+    });
+
     it('should deserialize empty embed URL as null', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({

--- a/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { domainBuilder } from '../../../../test-helper.js';
-import { deserialize } from '../../../../../lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js';
+import { deserialize, serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
   describe('#deserialize', () => {
@@ -64,6 +64,53 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
 
       // Then
       expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
+    });
+  });
+  describe('#serialize', () => {
+    it('should serialize a localized challenge with its attachments', async () => {
+      // given
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+        embedUrl: null,
+        status: 'validé',
+        fileIds: ['attachment1', 'attachment2']
+      });
+      const expectedSerializedLocalizedChallenge = {
+        data: {
+          type: 'localized-challenges',
+          id: `${localizedChallenge.id}`,
+          attributes: {
+            locale: localizedChallenge.locale,
+            'embed-url': null,
+            status: localizedChallenge.status,
+          },
+          relationships: {
+            files: {
+              data: [
+                {
+                  type: 'attachments',
+                  id: 'attachment1',
+                },
+                {
+                  type: 'attachments',
+                  id: 'attachment2',
+                }
+              ],
+            },
+            challenge: {
+              data: {
+                id: 'persistant id',
+                type: 'challenges',
+              },
+            }
+          }
+        }
+      };
+
+      // When
+      const json = serialize(localizedChallenge);
+
+      // Then
+      expect(json).to.deep.equal(expectedSerializedLocalizedChallenge);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,17 @@
       "version": "3.126.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "inflected": "^2.1.0"
+      },
       "engines": {
         "node": "^20.11.0"
       }
+    },
+    "node_modules/inflected": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
+      "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/1024pix/pix-editor/issues"
   },
-  "homepage": "https://github.com/1024pix/pix-editor#readme"
+  "homepage": "https://github.com/1024pix/pix-editor#readme",
+  "dependencies": {
+    "inflected": "^2.1.0"
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas récupérer ni afficher les attachments des localized Challenges sans devoir faire une requête additionnelle sur Airtable.

## :robot: Proposition
Création d'une table de liaison permettant de récupérer les attachments Ids en fonction des localized Challenge Id.
On peut maintenant lister, afficher et supprimer les attachments des localized Challenges.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Ajouter un attachment dans un challenge dans pix-editor
- Vérifier dans la base PG que l'attachment Id a bien été ajouté dans la table `localized_challenges-attachments`