### PR TITLE
[BUGFIX] Changement de couleur des bordures d'un composant "SELECT"

### DIFF
--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -82,7 +82,6 @@
       color: rgba(255, 255, 255, 0.5);
       background-color: transparent;
       border-color: rgba(255, 255, 255, 0.9);
-      color: white;
       border-bottom: 1px solid rgba(255, 255, 255, 0.9);
       border-left: 1px solid rgba(255, 255, 255, 0.9);
       cursor: pointer;

--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -72,13 +72,19 @@
   }
 
   #select-framework {
+
+    .ember-power-select-status-icon {
+      border-color: rgba(255, 255, 255, 0.9) transparent transparent transparent;
+    }
+
     .ember-power-select-trigger {
       margin: 10px 5px;
       color: rgba(255, 255, 255, 0.5);
       background-color: transparent;
-      border-color: transparent;
-      border-bottom: 1px solid rgba(34, 36, 38, 0.15);
-      border-left: 1px solid rgba(34, 36, 38, 0.15);
+      border-color: rgba(255, 255, 255, 0.9);
+      color: white;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.9);
+      border-left: 1px solid rgba(255, 255, 255, 0.9);
       cursor: pointer;
     }
   }

--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -79,7 +79,7 @@
 
     .ember-power-select-trigger {
       margin: 10px 5px;
-      color: rgba(255, 255, 255, 0.5);
+      color: rgba(255, 255, 255, 0.9);
       background-color: transparent;
       border-color: rgba(255, 255, 255, 0.9);
       border-bottom: 1px solid rgba(255, 255, 255, 0.9);


### PR DESCRIPTION
## :unicorn: Problème
Dans le menu de navigation, le composant permettant de selectionner les frameworks était peu visible.

![Capture d’écran du 2024-02-01 10-34-19](https://github.com/1024pix/pix-editor/assets/62065031/8bbcebc0-8556-4155-8128-0bb92bc2fd90)


## :robot: Proposition
Changer les couleurs dans le css pour ressembler à l'input juste au dessus.

![Capture d’écran du 2024-02-07 18-08-24](https://github.com/1024pix/pix-editor/assets/62065031/5b34df81-a3bf-4344-9927-54644fe5374c)

## :100: Pour tester
- Se connecter à la Review App
- Cliquer sur la sideBar
- Vérifier que le "SELECT" qui permet de choisir les frameworks, possède bien des bordure blanche.