### PR TITLE
[FEATURE] Ecrire l'alternative textuel des illustrations dans la table de traduction (PIX-9296).  

### DIFF
--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -39,7 +39,7 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
       });
     }
 
-    translations = tableTranslations.extractFromProxyObject(requestFields);
+    translations = await tableTranslations.extractFromProxyObject(requestFields);
 
     await translationRepository.save({ translations });
   }
@@ -47,7 +47,6 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   if (tableTranslations.readFromPgEnabled) {
     response.data.fields = tableTranslations.airtableObjectToProxyObject(response.data.fields, translations);
   }
-
   await updateStagingPixApiCache(tableName, response.data, translations);
 
   return response;

--- a/api/lib/domain/usecases/proxy-write-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-write-request-to-airtable.js
@@ -33,8 +33,9 @@ export async function proxyWriteRequestToAirtable(request, airtableBase, tableNa
   let translations;
   if (tableTranslations.writeToPgEnabled) {
     if (request.method === 'patch') {
+      const prefix = await tableTranslations.prefixFor(response.data.fields);
       await translationRepository.deleteByKeyPrefixAndLocales({
-        prefix: tableTranslations.prefixFor(response.data.fields),
+        prefix,
         locales: ['fr', 'fr-fr', 'en'],
       });
     }

--- a/api/lib/infrastructure/translations/attachment.js
+++ b/api/lib/infrastructure/translations/attachment.js
@@ -1,0 +1,22 @@
+import { Translation } from '../../domain/models/index.js';
+import { localizedChallengeRepository } from '../repositories/index.js';
+import { prefixFor } from './challenge.js';
+
+export const prefix = 'challenge.';
+
+export async function extractFromProxyObject(airtableAttachment) {
+  const { alt: illustrationAlt, localizedChallengeId } = airtableAttachment;
+
+  if (!illustrationAlt || !localizedChallengeId) {
+    return [];
+  }
+
+  const localizedChallenge = await localizedChallengeRepository.get({ id: localizedChallengeId });
+
+  return new Translation({
+    key: `${prefixFor({ id: localizedChallenge.challengeId })}illustrationAlt`,
+    locale: localizedChallenge.locale,
+    value: illustrationAlt,
+  });
+}
+

--- a/api/lib/infrastructure/translations/attachment.js
+++ b/api/lib/infrastructure/translations/attachment.js
@@ -1,22 +1,31 @@
 import { Translation } from '../../domain/models/index.js';
 import { localizedChallengeRepository } from '../repositories/index.js';
-import { prefixFor } from './challenge.js';
+import { prefixFor as prefixForChallenge } from './challenge.js';
 
 export const prefix = 'challenge.';
 
-export async function extractFromProxyObject(airtableAttachment) {
-  const { alt: illustrationAlt, localizedChallengeId } = airtableAttachment;
+export async function prefixFor(airtableAttachment) {
+  const localizedChallenge = await getLocalizedChallenge(airtableAttachment);
 
-  if (!illustrationAlt || !localizedChallengeId) {
-    return [];
-  }
-
-  const localizedChallenge = await localizedChallengeRepository.get({ id: localizedChallengeId });
-
-  return new Translation({
-    key: `${prefixFor({ id: localizedChallenge.challengeId })}illustrationAlt`,
-    locale: localizedChallenge.locale,
-    value: illustrationAlt,
-  });
+  return `${prefixForChallenge({ id: localizedChallenge.challengeId })}illustrationAlt`;
 }
 
+export async function extractFromProxyObject(airtableAttachment) {
+  if (!airtableAttachment.alt) return [];
+
+  const localizedChallenge = await getLocalizedChallenge(airtableAttachment);
+
+  return [
+    new Translation({
+      key: `${prefixForChallenge({ id: localizedChallenge.challengeId })}illustrationAlt`,
+      locale: localizedChallenge.locale,
+      value: airtableAttachment.alt,
+    }),
+  ];
+}
+
+async function getLocalizedChallenge(airtableAttachment) {
+  const { localizedChallengeId } = airtableAttachment;
+
+  return localizedChallengeRepository.get({ id: localizedChallengeId });
+}

--- a/api/lib/infrastructure/translations/index.js
+++ b/api/lib/infrastructure/translations/index.js
@@ -1,3 +1,4 @@
-export * as Competences from './competence.js';
 export * as Acquis from './skill.js';
+export * as Attachments from './attachment.js';
+export * as Competences from './competence.js';
 export * as Domaines from './area.js';

--- a/api/tests/acceptance/application/airtable-proxy-controller-attachment_test.js
+++ b/api/tests/acceptance/application/airtable-proxy-controller-attachment_test.js
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import nock from 'nock';
+import {
+  airtableBuilder,
+  inputOutputDataBuilder,
+  databaseBuilder,
+  domainBuilder,
+  generateAuthorizationHeader,
+  knex,
+} from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+
+describe('Acceptance | Controller | airtable-proxy-controller | create area translations', () => {
+  beforeEach(() => {
+    nock('https://api.test.pix.fr').post(/.*/).reply(200);
+
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+  });
+
+  afterEach(async () => {
+    try {
+      expect(nock.isDone()).to.be.true;
+    } finally {
+      await knex('translations').truncate();
+    }
+  });
+
+  describe('POST /api/airtable/content/Attachments', () => {
+    let airtableRawChallenge;
+    let airtableRawAttachment;
+    let attachmentToSave;
+    let user;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+      const localizedChallenge = databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'recChallengeId',
+        challengeId: 'recChallengeId',
+        locale: 'fr',
+      });
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: localizedChallenge.id,
+        attachmentId: 'mon_id_persistant'
+      });
+
+      await databaseBuilder.commit();
+
+      const attachment = domainBuilder.buildAttachmentDatasourceObject({
+        id: 'mon_id_persistant',
+        alt: 'Alt en français',
+        challengeId: localizedChallenge.challengeId,
+        localizedChallengeId: localizedChallenge.id,
+      });
+
+      const challenge = domainBuilder.buildChallengeDatasourceObject({
+        id: localizedChallenge.challengeId,
+      });
+      airtableRawChallenge = airtableBuilder.factory.buildChallenge({
+        ...challenge,
+        files: [{
+          fileId: 'mon_id_persistant',
+          localizedChallengeId: localizedChallenge.id,
+        }]
+      });
+      airtableRawAttachment = airtableBuilder.factory.buildAttachment(attachment);
+      attachmentToSave = inputOutputDataBuilder.factory.buildAttachment(attachment);
+    });
+
+    describe('nominal cases', () => {
+      it('should proxy request to airtable and add translations to the PG table', async () => {
+        // Given
+        nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/Epreuves')
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .query(true)
+          .reply(200, {
+            records: [airtableRawChallenge],
+          });
+
+        nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/Attachments')
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .query(true)
+          .reply(200, {
+            records: [airtableRawAttachment],
+          });
+
+        nock('https://api.airtable.com')
+          .post('/v0/airtableBaseValue/Attachments', airtableRawAttachment)
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableRawAttachment);
+
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/airtable/content/Attachments',
+          headers: generateAuthorizationHeader(user),
+          payload: attachmentToSave,
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        const translations = await knex('translations').select().orderBy([{
+          column: 'key',
+          order: 'asc'
+        }, { column: 'locale', order: 'asc' }]);
+
+        expect(translations).to.deep.equal([{
+          key: 'challenge.recChallengeId.illustrationAlt',
+          locale: 'fr',
+          value: 'Alt en français'
+        }]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-attachment-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-attachment-datasource-object.js
@@ -1,0 +1,18 @@
+export function buildAttachmentDatasourceObject({
+  id = 'attachmentId',
+  url = 'http://',
+  alt = 'alt text',
+  type = 'image',
+  challengeId = 'recChallengeId',
+  localizedChallengeId = challengeId,
+} = {}) {
+
+  return {
+    id,
+    url,
+    alt,
+    type,
+    challengeId,
+    localizedChallengeId,
+  };
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -21,6 +21,7 @@ export * from './build-thematic-for-release.js';
 export * from './build-tube-for-release.js';
 export * from './build-tutorial-for-release.js';
 export * from './datasource-objects/build-area-datasource-object.js';
+export * from './datasource-objects/build-attachment-datasource-object.js';
 export * from './datasource-objects/build-challenge-datasource-object.js';
 export * from './datasource-objects/build-competence-datasource-object.js';
 export * from './datasource-objects/build-framework-datasource-object.js';

--- a/api/tests/tooling/input-output-data-builder/factory/build-attachment.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-attachment.js
@@ -1,0 +1,21 @@
+export function buildAttachment({
+  id = 'attachmentId',
+  url = 'http://',
+  alt = 'alt text',
+  type = 'image',
+  challengeId = 'recChallengeId',
+  localizedChallengeId = challengeId,
+} = {}) {
+
+  return {
+    id,
+    'fields': {
+      'Record ID': id,
+      'alt': alt,
+      'url': url,
+      'challengeId persistant': [challengeId],
+      'type': type,
+      localizedChallengeId
+    },
+  };
+}

--- a/api/tests/tooling/input-output-data-builder/factory/index.js
+++ b/api/tests/tooling/input-output-data-builder/factory/index.js
@@ -1,3 +1,4 @@
 export * from './build-competence.js';
 export * from './build-skill.js';
 export * from './build-area.js';
+export * from './build-attachment.js';


### PR DESCRIPTION
## :unicorn: Problème
Le champ alternative textuel doit être traduit.

## :robot: Proposition
Lors de l'enregistrement d'un attachment de type illustration, enregistrer l'alternative textuelle dans la table de traduction.

## :rainbow: Remarques
RAS

## :100: Pour tester
Ajouter une illustration à une épreuve avec une alternative textuelle et vérifier que cette traduction existe dans la table PG sous la clef : `challenge.challengeId.illustrationAlt`
