### PR TITLE
[FEATURE] Migre les traductions des textes alternatifs des illustrations vers la table `translations`  (PIX-9505).

### DIFF
--- a/api/scripts/migrate-attachments-translation-from-airtable/index.js
+++ b/api/scripts/migrate-attachments-translation-from-airtable/index.js
@@ -1,0 +1,54 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import _ from 'lodash';
+import { extractFromProxyObject } from '../../lib/infrastructure/translations/attachment.js';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateAttachmentsTranslationFromAirtable({ airtableClient }) {
+  const allAttachments = await airtableClient
+    .table('Attachments')
+    .select({
+      fields: [
+        'alt',
+        'localizedChallengeId',
+      ],
+    })
+    .all();
+
+  const translations = [];
+
+  for (const attachment of allAttachments) {
+    const objectTranslations = await extractFromProxyObject({
+      alt: attachment.get('alt'),
+      localizedChallengeId: attachment.get('localizedChallengeId')
+    });
+    translations.push(...objectTranslations);
+  }
+
+  for (const translationsChunk of _.chunk(translations, 5000)) {
+    await translationRepository.save({ translations: translationsChunk });
+  }
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateAttachmentsTranslationFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/scripts/migrate-attachments-translation-from-airtable_test.js
+++ b/api/tests/scripts/migrate-attachments-translation-from-airtable_test.js
@@ -1,0 +1,76 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+import {
+  migrateAttachmentsTranslationFromAirtable
+} from '../../scripts/migrate-attachments-translation-from-airtable/index.js';
+
+describe('Migrate translation from airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(async () => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: 'localizedChallengeId',
+      challengeId: 'monChallengeId',
+      locale: 'fr'
+    });
+    databaseBuilder.factory.buildLocalizedChallengeAttachment({
+      localizedChallengeId: 'localizedChallengeId',
+      attachmentId: 'airtableAttachmentId'
+    });
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const attachment = {
+      id: 'airtableAttachmentId',
+      fields: {
+        alt: 'Mon alt',
+        localizedChallengeId: 'localizedChallengeId',
+      }
+    };
+
+    const attachments = [attachment];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Attachments')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: attachments });
+
+    // when
+    await migrateAttachmentsTranslationFromAirtable({ airtableClient });
+
+    // then
+    const translations = await knex('translations').select().orderBy([{
+      column: 'key',
+      order: 'asc'
+    }, { column: 'locale', order: 'asc' }]);
+
+    expect(translations).to.have.lengthOf(1);
+    expect(translations).to.deep.equal([
+      {
+        key: 'challenge.monChallengeId.illustrationAlt',
+        locale: 'fr',
+        value: 'Mon alt'
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## :egg: Problème

Les textes alternatifs des illustrations sont désormais écrits à la fois dans Airtable (table `Attachments`) et dans postgres (table `translations`).
Les textes existants avant cettte double écriture ne sont pas présents dans postgres.

## :bowl_with_spoon: Proposition

Migrer les textes alternatifs avec un script dédié.

## :milk_glass: Remarques

RAS.

## :butter: Pour tester

Executer le script `node ./scripts/migrate-attachments-translation-from-airtable/index.js`.
Vérifier que la table `translations` de postgres contient les textets alternatifs des illustrations.
-> 133 clés de traductions doivent contenir le suffixe `illustrationAlt`.
