### PR TITLE
[BUGFIX] Fix des attachments pour les localized challenges dans la release (PIX-11138)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -28,7 +28,7 @@ export const attachmentDatasource = datasource.extend({
       type: airtableRecord.get('type'),
       mimeType: airtableRecord.get('mimeType'),
       alt: airtableRecord.get('alt'),
-      challengeId: airtableRecord.get('challengeId persistant')[0],
+      challengeId: airtableRecord.get('challengeId persistant')?.[0],
       localizedChallengeId: airtableRecord.get('localizedChallengeId'),
     };
   },

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -47,7 +47,7 @@ function _filterChallengeFields(challenge) {
 function _addAttachmentsToChallenge({ attachments }) {
   return (challenge) => {
     const newChallenge = { ...challenge, illustrationAlt: null, illustrationUrl: null };
-    const challengeAttachments = challenge.files.map((fileId) => attachments.find(({ id }) => id === fileId));
+    const challengeAttachments = attachments.filter(({ localizedChallengeId }) => localizedChallengeId === challenge.id);
     challengeAttachments.forEach((attachment) => _assignAttachmentToChallenge(newChallenge, attachment));
     return newChallenge;
   };

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -177,6 +177,11 @@ describe('Integration | Repository | release-repository', function() {
       buildSkillsTranslations(skills);
       buildChallengesTranslationsAndLocalizedChallenges(challenges);
 
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        attachmentId: 'attachment4',
+        localizedChallengeId: 'challengeNl',
+      });
+
       databaseBuilder.factory.buildStaticCourse({
         id: 'course1PG',
         name: 'course1PG name',
@@ -787,6 +792,14 @@ function _mockRichAirtableContent() {
     url: 'attachment3 url',
     challengeId: 'challenge211111',
   });
+  const airtableAttachment4 = airtableBuilder.factory.buildAttachmentForLocalizedChallenge({
+    id: 'attachment4',
+    alt: 'attachment4 alt',
+    type: 'attachment',
+    url: 'attachment4 url',
+    challengeId: '',
+    localizedChallengeId: 'challengeNl',
+  });
 
   airtableBuilder.mockLists({
     frameworks: [airtableFrameworkA],
@@ -797,7 +810,7 @@ function _mockRichAirtableContent() {
     skills: [airtableSkill11111, airtableSkill11112, airtableSkill12121, airtableSkill21111],
     challenges: [airtableChallenge121211, airtableChallenge121212, airtableChallenge211111, airtableChallenge211112, airtableChallenge211113],
     tutorials: [airtableTutorial1, airtableTutorial2],
-    attachments: [airtableAttachment1, airtableAttachment2, airtableAttachment3],
+    attachments: [airtableAttachment1, airtableAttachment2, airtableAttachment3, airtableAttachment4],
   });
 
   return {
@@ -1191,6 +1204,7 @@ function _getRichCurrentContentDTO() {
       focusable: 'challenge121211 focusable',
       delta: 1.1,
       alpha: 2.2,
+      attachments: ['attachment4 url'],
       illustrationUrl: null,
       illustrationAlt: null,
       shuffled: false,

--- a/api/tests/tooling/airtable-builder/factory/build-attachment-for-localized-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-attachment-for-localized-challenge.js
@@ -1,0 +1,19 @@
+export function buildAttachmentForLocalizedChallenge({
+  id = 'attid1',
+  alt = 'alt',
+  type = 'image/png',
+  url = 'url/to/attachment',
+  localizedChallengeId = 'localizedChallengeId',
+} = {}) {
+
+  return {
+    id,
+    'fields': {
+      'Record ID': id,
+      'alt': alt,
+      'url': url,
+      'type': type,
+      localizedChallengeId
+    },
+  };
+}

--- a/api/tests/tooling/airtable-builder/factory/index.js
+++ b/api/tests/tooling/airtable-builder/factory/index.js
@@ -1,5 +1,6 @@
 export * from './build-area.js';
 export * from './build-attachment.js';
+export * from './build-attachment-for-localized-challenge.js';
 export * from './build-challenge.js';
 export * from './build-competence.js';
 export * from './build-framework.js';


### PR DESCRIPTION
## :unicorn: Problème
On récupérait les id d'attachments en passant par les files de challenge (donc impossible de récupérer ceux des localized challenges)

## :robot: Proposition
On passe par la table localized Challenges attachments pour récupérer les id des attachments.

## :rainbow: Remarques
RAS (déso la répli, pardon data 😢 )

## :100: Pour tester
Créer une release et s'assurer qu'elle se passe bien.
