### PR TITLE
[BUGFIX] Maintient la relation Epreuves <-> Attachements à jour (PIX-11147).

### DIFF
--- a/api/lib/application/airtable-proxy.js
+++ b/api/lib/application/airtable-proxy.js
@@ -105,8 +105,6 @@ async function _proxyRequestToAirtable(request, airtableBase) {
 }
 
 async function _updateStagingPixApiCache(type, entity, translations) {
-  if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
-
   try {
     const { updatedRecord, model } = await releaseRepository.serializeEntity({
       type,

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -15,8 +15,6 @@ import { extractParameters } from '../../infrastructure/utils/query-params-utils
 const challengeIdType = Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+$/).required();
 
 async function _refreshCache({ challenge }) {
-  if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
-
   try {
     const attachments = await attachmentDatasource.filterByChallengeId(challenge.id);
     const transformChallenge = createChallengeTransformer({ attachments });

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -16,7 +16,7 @@ const challengeIdType = Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+$/).re
 
 async function _refreshCache({ challenge }) {
   try {
-    const attachments = await attachmentDatasource.filterByChallengeId(challenge.id);
+    const attachments = await attachmentDatasource.filterByLocalizedChallengeId(challenge.id);
     const transformChallenge = createChallengeTransformer({ attachments });
     const newChallenge = transformChallenge(challenge);
 

--- a/api/lib/domain/usecases/preview-challenge.js
+++ b/api/lib/domain/usecases/preview-challenge.js
@@ -4,15 +4,13 @@ import * as config from '../../config.js';
 export async function previewChallenge(
   { challengeId, locale },
   {
-    localizedChallengeRepository = repositories.localizedChallengeRepository,
     challengeRepository = repositories.challengeRepository,
     refreshCache,
   },
 ) {
   if (!locale) return new URL(`challenges/${challengeId}/preview`, config.pixApp.baseUrl).href;
-  const localizedChallenge = await localizedChallengeRepository.getByChallengeIdAndLocale({ challengeId, locale });
   const challenge = await challengeRepository.get(challengeId);
   const translatedChallenge = challenge.translate(locale);
   await refreshCache({ challenge: translatedChallenge });
-  return new URL(`challenges/${localizedChallenge.id}/preview`, config.pixApp.baseUrl).href;
+  return new URL(`challenges/${translatedChallenge.id}/preview`, config.pixApp.baseUrl).href;
 }

--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -33,9 +33,9 @@ export const attachmentDatasource = datasource.extend({
     };
   },
 
-  async filterByChallengeId(challengeId) {
+  async filterByLocalizedChallengeId(localizedChallengeId) {
     const airtableRawObjects = await findRecords(this.tableName, {
-      filterByFormula : `{challengeId persistant} = '${challengeId}'`,
+      filterByFormula : `{localizedChallengeId} = '${localizedChallengeId}'`,
     });
     return airtableRawObjects.map(this.fromAirTableObject);
   }

--- a/api/lib/infrastructure/event-notifier/updated-record-notifier.js
+++ b/api/lib/infrastructure/event-notifier/updated-record-notifier.js
@@ -1,3 +1,8 @@
+import { logger } from '../logger.js';
+
 export async function notify({ pixApiClient, updatedRecord, model }) {
-  return pixApiClient.request({ payload: updatedRecord, url: `/api/cache/${model}/${updatedRecord.id}` });
+  if (pixApiClient.isPixApiCachePatchingEnabled()) {
+    return pixApiClient.request({ payload: updatedRecord, url: `/api/cache/${model}/${updatedRecord.id}` });
+  }
+  logger.info(`Refreshing cache with ${JSON.stringify(updatedRecord)} for model ${model}`);
 }

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -64,7 +64,7 @@ export async function serializeEntity({ type, entity, translations }) {
 
   if (model === attachmentDatasource.path()) {
     const [rawChallenge] = await challengeRepository.filter({ filter: { ids: [updatedRecord.challengeId] } });
-    const attachments = await attachmentDatasource.filterByChallengeId(updatedRecord.challengeId);
+    const attachments = await attachmentDatasource.filterByLocalizedChallengeId(updatedRecord.challengeId);
     const transformChallenge = createChallengeTransformer({ attachments });
     const challenge = transformChallenge(rawChallenge);
 

--- a/api/scripts/fill-missing-attachments-challenge-ids/index.js
+++ b/api/scripts/fill-missing-attachments-challenge-ids/index.js
@@ -1,0 +1,91 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import _ from 'lodash';
+import { knex, disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function fillMissingAttachmentsChallengeIds({ airtableClient }) {
+  const attachmentsWithoutChallengeId = await fetchAttachmentsWithoutChallengeId({ airtableClient });
+
+  const attachments = [];
+
+  for (const attachment of attachmentsWithoutChallengeId) {
+    const challengeId = await knex('localized_challenges')
+      .pluck('challengeId')
+      .where({ id: attachment.localizedChallengeId });
+
+    attachments.push({
+      id: attachment.id,
+      challengeId: challengeId[0],
+    });
+  }
+
+  const formula = `OR(${attachments.map(({ challengeId }) => `{id persistant} = "${challengeId}"`).join(',')})`;
+
+  const airtableChallenges = await airtableClient
+    .table('Epreuves')
+    .select({
+      fields: [
+        'id persistant',
+      ],
+      filterByFormula: formula,
+    })
+    .all();
+
+  const attachmentsWithChallengeId = attachments.map((attachment) => {
+    const airtableChallenge = airtableChallenges.find((challenge) => challenge.get('id persistant') === attachment.challengeId);
+
+    return {
+      id: attachment.id,
+      fields: {
+        challengeId: [airtableChallenge.id],
+      }
+    };
+  });
+
+  for (const attachmentChunk of _.chunk(attachmentsWithChallengeId, 10)) {
+    await airtableClient.table('Attachments').update(attachmentChunk);
+  }
+}
+
+async function fetchAttachmentsWithoutChallengeId({ airtableClient }) {
+  const rawAttachments = await airtableClient
+    .table('Attachments')
+    .select({
+      fields: [
+        'Record ID',
+        'localizedChallengeId',
+      ],
+      filterByFormula: '{challengeId} = BLANK()'
+    })
+    .all();
+
+  return rawAttachments.map((rawAttachment) => {
+    return {
+      id: rawAttachment.get('Record ID'),
+      localizedChallengeId: rawAttachment.get('localizedChallengeId'),
+    };
+  });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await fillMissingAttachmentsChallengeIds({ airtableClient });
+    console.log('All attachments are now linked to a Challenge!');
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -756,6 +756,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
     const locale = 'nl';
     let airtableChallengeScope;
     let airtableAttachmentScope;
+    let attachment;
 
     beforeEach(async function() {
       airtableChallengeScope = airtableBuilder.mockList({ tableName: 'Epreuves' }).returns([
@@ -766,7 +767,12 @@ describe('Acceptance | Controller | challenges-controller', () => {
         })
       ]).activate().nockScope;
 
-      airtableAttachmentScope = airtableBuilder.mockList({ tableName: 'Attachments' }).returns([]).activate().nockScope;
+      attachment = airtableBuilder.factory.buildAttachment({
+        challengeId,
+        localizedChallengeId,
+        type: 'illustration',
+      });
+      airtableAttachmentScope = airtableBuilder.mockList({ tableName: 'Attachments' }).returns([attachment]).activate().nockScope;
 
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.instruction`,
@@ -833,8 +839,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             embedUrl: null,
             embedTitle: 'embed title for nl',
             format: 'mots',
-            illustrationAlt: null,
-            illustrationUrl: null,
+            illustrationAlt: attachment.fields.alt,
+            illustrationUrl: attachment.fields.url,
             instruction: 'instruction for nl',
             locales: ['nl'],
             proposals: 'proposals for nl',

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1122,7 +1122,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
       const attachmentsScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Attachments')
-        .query({ filterByFormula: '{challengeId persistant} = \'recChallengeId\'' })
+        .query({ filterByFormula: '{localizedChallengeId} = \'recChallengeId\'' })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [airtableAttachment] });
 

--- a/api/tests/scripts/fill-missing-attachments-challenge-ids_test.js
+++ b/api/tests/scripts/fill-missing-attachments-challenge-ids_test.js
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import Airtable from 'airtable';
+import nock from 'nock';
+import { databaseBuilder } from '../test-helper.js';
+import { fillMissingAttachmentsChallengeIds } from '../../scripts/fill-missing-attachments-challenge-ids/index.js';
+
+describe('Fill missing attachments challenge Ids in airtable', function() {
+  let airtableClient;
+
+  beforeEach(() => {
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  it('should retrieve attachments without challenge id', async () => {
+    // given
+    databaseBuilder.factory.buildLocalizedChallenge({
+      challengeId: 'challengeId',
+      id: 'localizedChallengeId',
+    });
+    await databaseBuilder.commit();
+
+    const airtableAttachment = {
+      id: 'attachmentId',
+      fields: {
+        'Record ID': 'attachmentId',
+        localizedChallengeId: 'localizedChallengeId',
+      }
+    };
+    const airtableChallenge = {
+      id: 'airtableChallengeId',
+      fields: {
+        'id persistant': 'challengeId',
+      },
+    };
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Attachments')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query({
+        fields: {
+          '': [
+            'Record ID',
+            'localizedChallengeId',
+          ]
+        },
+        filterByFormula: '{challengeId} = BLANK()'
+      })
+      .reply(200, { records: [airtableAttachment] });
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Epreuves')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query({
+        fields: {
+          '': 'id persistant',
+        },
+        filterByFormula: 'OR({id persistant} = "challengeId")',
+      })
+      .reply(200, { records: [airtableChallenge] });
+
+    const attachmentRecord = { id: 'attachmentId', fields: { challengeId: ['airtableChallengeId'] } };
+    nock('https://api.airtable.com')
+      .patch('/v0/airtableBaseValue/Attachments/?', { records: [attachmentRecord] })
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .reply(200, { records: [attachmentRecord] });
+
+    // when
+    await fillMissingAttachmentsChallengeIds({ airtableClient });
+
+    // then
+    expect(nock.isDone()).to.be.true;
+  });
+});

--- a/api/tests/unit/domain/usecases/preview-challenge_test.js
+++ b/api/tests/unit/domain/usecases/preview-challenge_test.js
@@ -19,7 +19,9 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
     const localizedChallengeRepository = {
       getByChallengeIdAndLocale: vi.fn().mockResolvedValueOnce(localizedChallenge),
     };
-    const challenge = domainBuilder.buildChallenge();
+    const challenge = domainBuilder.buildChallenge({
+      localizedChallenges: [localizedChallenge],
+    });
     const challengeRepository = {
       get: vi.fn().mockResolvedValueOnce(challenge),
     };
@@ -30,7 +32,6 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
 
     // then
     expect(url).to.equal(`https://preview.url.fr/challenges/${localizedChallengeId}/preview`);
-    expect(localizedChallengeRepository.getByChallengeIdAndLocale).toHaveBeenCalledWith({ locale, challengeId });
     expect(challengeRepository.get).toHaveBeenCalledWith(challengeId);
     expect(refreshCache).toHaveBeenCalledWith({ challenge });
   });

--- a/api/tests/unit/infrastructure/datasources/airtable/attachment-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/attachment-datasource_test.js
@@ -6,7 +6,7 @@ import airtableClient from 'airtable';
 
 describe('Unit | Infrastructure | Datasource | Airtable | AttachmentDatasource', () => {
 
-  describe('#filterByChallengeId', () => {
+  describe('#filterByLocalizedChallengeId', () => {
     it('calls airtable', async () => {
       const attachment = airtableBuilder.factory.buildAttachment({
         id: 'recAttachment',
@@ -17,11 +17,11 @@ describe('Unit | Infrastructure | Datasource | Airtable | AttachmentDatasource',
       const airtableFindRecordsSpy = vi.spyOn(airtable, 'findRecords')
         .mockResolvedValue([attachmentRecord]);
 
-      const newAttachments = await attachmentDatasource.filterByChallengeId('recChallenge');
+      const newAttachments = await attachmentDatasource.filterByLocalizedChallengeId('recChallenge');
 
       expect(newAttachments[0].id).to.equal('recAttachment');
       expect(newAttachments).to.have.length(1);
-      expect(airtableFindRecordsSpy).toHaveBeenCalledWith('Attachments', { filterByFormula: '{challengeId persistant} = \'recChallenge\'' });
+      expect(airtableFindRecordsSpy).toHaveBeenCalledWith('Attachments', { filterByFormula: '{localizedChallengeId} = \'recChallenge\'' });
     });
   });
 });

--- a/api/tests/unit/infrastructure/event-notifier/updated-record-notifier_test.js
+++ b/api/tests/unit/infrastructure/event-notifier/updated-record-notifier_test.js
@@ -10,7 +10,10 @@ describe('Unit | Infrastructure | EventNotifier | UpdatedRecordedNotifier', () =
       // given
       const updatedRecord = domainBuilder.buildAreaDatasourceObject();
       const model = 'Model';
-      const pixApiClient = { request: vi.fn() };
+      const pixApiClient = {
+        request: vi.fn(),
+        isPixApiCachePatchingEnabled: vi.fn().mockReturnValue(true),
+      };
 
       // when
       await notify({ pixApiClient, updatedRecord, model });

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -30,7 +30,7 @@ describe('Unit | Repository | release-repository', () => {
         }),
       ];
 
-      vi.spyOn(attachmentDatasource, 'filterByChallengeId');
+      vi.spyOn(attachmentDatasource, 'filterByLocalizedChallengeId');
       vi.spyOn(challengeDatasource, 'filterById');
 
       const { updatedRecord, model } = await serializeEntity({ entity, type, translations });
@@ -48,7 +48,7 @@ describe('Unit | Repository | release-repository', () => {
         },
         frameworkId: 'recFramework0',
       });
-      expect(attachmentDatasource.filterByChallengeId).not.toHaveBeenCalled();
+      expect(attachmentDatasource.filterByLocalizedChallengeId).not.toHaveBeenCalled();
       expect(challengeDatasource.filterById).not.toHaveBeenCalled();
       expect(model).to.equal('areas');
     });
@@ -106,7 +106,7 @@ describe('Unit | Repository | release-repository', () => {
       vi.spyOn(challengeRepository, 'filter').mockImplementation(async ({ filter: { ids } }) => {
         if (ids.length === 1 && ids[0] === 'recChallenge') return [challenge];
       });
-      vi.spyOn(attachmentDatasource, 'filterByChallengeId').mockImplementation(async (spyId) => {
+      vi.spyOn(attachmentDatasource, 'filterByLocalizedChallengeId').mockImplementation(async (spyId) => {
         if (spyId === 'recChallenge') return attachmentRecords;
       });
 

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -182,6 +182,7 @@ export default class LocalizedController extends Controller {
       file,
       type: 'illustration',
       localizedChallenge: this.model,
+      challenge: this.model.challenge,
       alt,
     };
     this.store.createRecord('attachment', attachment);
@@ -207,6 +208,7 @@ export default class LocalizedController extends Controller {
       file,
       type: 'attachment',
       localizedChallenge: this.model,
+      challenge: this.model.challenge,
     };
     this.store.createRecord('attachment', attachment);
   }


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors de l'implémentation de la fonctionnalité d'édition (ajout / modification / suppression) de pièces jointes et illustration pour les épreuves traduites, nous avons fait le choix de ne pas lier ces fichiers à l'épreuve d'origine, mais uniquement à l'épreuve traduite.
A l'origine, ce choix a été piloté par le fait qu'à terme, on aimerait conserver uniquement des épreuves traduites.
La mise en production de cette fonctionnalité a montré plusieurs limites à ce raisonnement : 
- La release et la réplication se basaient sur le lien `challenge.files` maintenu automatiquement par Airtable lorsqu'on valorise le `challengeId` d'un attachment.
Permettre une valeur vide pour le champ `challengeId` casse alors ce fonctionnement.
Une solution de contournement a été livrée avec la PR #514.
- La prévisualisation, et plus précisément la sérialisation de l'entité `attachment`, se base également sur ce lien.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On ajoute le lien vers l'épreuve d'origine lors de la création des atttachements, que ce soit une illustration ou une pièce jointe.


Il faut remplir le `challengeId` des `attachments` sur Airtable.
Pour cela, un script est créé : `scripts/fill-missing-attachments-challenge-ids/index.js`.

## :rainbow: Remarques

RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Ajouter des `attachments` sur une épreuve traduite.
Appeler les endpoints de création de release et de réplication.
Vérifier que les `attachments` sont bien présents (champs `illustrationUrl` et `attachments` du `challenge`).
Vérifier que la prévisualisation de l'épreuve traduite est fonctionnelle, en branchant la Review App sur une Review App de Pix Api.
