### PR TITLE
[BUGFIX] Réparation des fichiers de challenges qui n'étaient pas supprimés (PIX-11213)

### DIFF
--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -145,7 +145,7 @@
     @baseName={{@challenge.attachmentBaseName}}
     @addAttachment={{this.addAttachment}}
     @edition={{@edition}}
-    @removeAttachment={{this.removeAttachment}}
+    @removeAttachment={{@removeAttachment}}
     data-test-file-input-attachment
   />
   <Field::Input

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -127,7 +127,7 @@
     @value={{@challenge.illustration}}
     @edition={{@edition}}
     @addIllustration={{this.addIllustration}}
-    @removeIllustration={{this.removeIllustration}}
+    @removeIllustration={{@removeIllustration}}
     @display={{@showIllustration}}
     data-test-file-input-illustration
   />

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -185,15 +185,6 @@ export default class ChallengeForm extends Component {
   }
 
   @action
-  async removeAttachment(removedAttachment) {
-    await this.args.challenge.files;
-    const removedFile = this.args.challenge.files.findBy('filename', removedAttachment.filename);
-    if (removedFile) {
-      removedFile.deleteRecord();
-    }
-  }
-
-  @action
   setLocales(selectedOptions) {
     this.args.challenge.locales = selectedOptions.map(({ value }) => value);
   }

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -172,16 +172,6 @@ export default class ChallengeForm extends Component {
   }
 
   @action
-  async removeIllustration() {
-    await this.args.challenge.files;
-    const removedFile = this.args.challenge.illustration;
-    if (removedFile) {
-      removedFile.deleteRecord();
-      return removedFile.alt;
-    }
-  }
-
-  @action
   addAttachment(file) {
     const attachment = {
       filename: file.name,

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -116,6 +116,7 @@ export default class LocalizedController extends Controller {
     this.model.rollbackAttributes();
     await this.model.files;
     this.model.files.forEach((file) => file.rollbackAttributes());
+    this.deletedFiles = [];
     if (!this.wasMaximized) {
       this.minimize();
     }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -36,6 +36,8 @@ export default class SingleController extends Controller {
   @service storage;
   @service store;
 
+  deletedFiles = [];
+
   get maximized() {
     return this.parentController.leftMaximized;
   }
@@ -401,6 +403,16 @@ export default class SingleController extends Controller {
     await Promise.all(updateChallenges);
   }
 
+  @action
+  async removeIllustration() {
+    await this.challenge.files;
+    const removedFile = this.challenge.illustration;
+    if (removedFile) {
+      removedFile.deleteRecord();
+      this.deletedFiles.push(removedFile);
+    }
+  }
+
   _saveCheck(challenge) {
     if (challenge.autoReply && !challenge.embedURL) {
       this._errorMessage('Le mode "Réponse automatique" à été activé alors que l\'épreuve ne contient pas d\'embed');
@@ -622,6 +634,7 @@ export default class SingleController extends Controller {
 
   _saveChallenge(challenge) {
     this._loadingMessage('Enregistrement...');
+
     return challenge.save();
   }
 
@@ -634,6 +647,10 @@ export default class SingleController extends Controller {
       }
       await file.save();
     }
+    for (const deletedFile of this.deletedFiles) {
+      await deletedFile.save();
+    }
+    this.deletedFiles = [];
     return challenge;
   }
 

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -413,6 +413,16 @@ export default class SingleController extends Controller {
     }
   }
 
+  @action
+  async removeAttachment(removedAttachment) {
+    await this.challenge.files;
+    const removedFile = this.challenge.attachments.findBy('filename', removedAttachment.filename);
+    if (removedFile) {
+      removedFile.deleteRecord();
+      this.deletedFiles.push(removedFile);
+    }
+  }
+
   _saveCheck(challenge) {
     if (challenge.autoReply && !challenge.embedURL) {
       this._errorMessage('Le mode "Réponse automatique" à été activé alors que l\'épreuve ne contient pas d\'embed');

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -61,7 +61,9 @@
                      @displayAlternativeInstructionsField={{this.displayAlternativeInstructionsField}}
                      @setDisplayAlternativeInstructionsField={{this.setDisplayAlternativeInstructionsField}}
                      @displaySolutionToDisplayField={{this.displaySolutionToDisplayField}}
-                     @setDisplaySolutionToDisplayField={{this.setDisplaySolutionToDisplayField}}/>
+                     @setDisplaySolutionToDisplayField={{this.setDisplaySolutionToDisplayField}}
+                     @removeIllustration={{this.removeIllustration}}
+    />
   </div>
 <div class="ui vertical compact labeled icon menu challenge-menu">
   {{#if this.edition}}

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -63,6 +63,7 @@
                      @displaySolutionToDisplayField={{this.displaySolutionToDisplayField}}
                      @setDisplaySolutionToDisplayField={{this.setDisplaySolutionToDisplayField}}
                      @removeIllustration={{this.removeIllustration}}
+                     @removeAttachment={{this.removeAttachment}}
     />
   </div>
 <div class="ui vertical compact labeled icon menu challenge-menu">

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -252,6 +252,12 @@ function routes() {
     const skill = schema.skills.find(skillId);
     challenge.skill = skill;
 
+    const files = body.data.relationships.files.data.map(({id}) => {
+      return schema.attachments.find(id);
+    });
+    challenge.files = files;
+    challenge.save();
+
     return challenge;
   });
 

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -252,7 +252,7 @@ function routes() {
     const skill = schema.skills.find(skillId);
     challenge.skill = skill;
 
-    const files = body.data.relationships.files.data.map(({id}) => {
+    const files = body.data.relationships.files.data.map(({ id }) => {
       return schema.attachments.find(id);
     });
     challenge.files = files;

--- a/pix-editor/tests/unit/component/form/challenge-test.js
+++ b/pix-editor/tests/unit/component/form/challenge-test.js
@@ -48,32 +48,6 @@ module('unit | Component | form/challenge', function(hooks) {
     assert.ok(createRecordStub.calledWith('attachment', expectedAttachment));
   });
 
-  test('it should remove illustration', async function(assert) {
-    // given
-    const deleteRecordStub = sinon.stub();
-    const challenge = {
-      id: 'recchallenge_1',
-      name: 'challenge',
-      files: [],
-      illustration: {
-        filename: 'file_name',
-        size: 123,
-        mimeType: 'image/png',
-        type: 'illustration',
-        deleteRecord: deleteRecordStub,
-        alt: 'alternative text',
-      }
-    };
-    component.args.challenge = challenge;
-
-    // when
-    const alternativeText = await component.removeIllustration();
-
-    // then
-    assert.ok(deleteRecordStub.calledOnce);
-    assert.strictEqual(alternativeText, 'alternative text');
-  });
-
   test('it should add attachment', async function(assert) {
     //given
     const createRecordStub = sinon.stub();

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -363,6 +363,34 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
     assert.ok(messageStub.calledWith('Modification annulée'));
   });
 
+  module('#removeIllustration', function() {
+    test('it should remove illustration', async function(assert) {
+      // given
+      const deleteRecordStub = sinon.stub();
+      const challenge = {
+        id: 'recchallenge_1',
+        name: 'challenge',
+        files: [],
+        illustration: {
+          filename: 'file_name',
+          size: 123,
+          mimeType: 'image/png',
+          type: 'illustration',
+          deleteRecord: deleteRecordStub,
+          alt: 'alternative text',
+        }
+      };
+      controller.model = challenge;
+
+      // when
+      await controller.removeIllustration();
+
+      // then
+      assert.ok(deleteRecordStub.calledOnce);
+      assert.equal(controller.deletedFiles.length, 1);
+    });
+  });
+
   module('_saveCheck', function(hooks) {
     let challenge;
 

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -387,7 +387,39 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
 
       // then
       assert.ok(deleteRecordStub.calledOnce);
-      assert.equal(controller.deletedFiles.length, 1);
+      assert.strictEqual(controller.deletedFiles.length, 1);
+    });
+  });
+
+  module('#removeAttachment', function() {
+    test('it should remove the attachment', async function(assert) {
+      // given
+      const deleteRecordStub = sinon.stub();
+      const challenge = {
+        id: 'recchallenge_1',
+        name: 'challenge',
+        files: [],
+        attachments: [
+          {
+            filename: 'file_name.pdf',
+            size: 123,
+            mimeType: 'application/pdf',
+            type: 'attachment',
+            deleteRecord: deleteRecordStub,
+          }
+        ]
+
+      };
+      controller.model = challenge;
+
+      // when
+      await controller.removeAttachment({
+        filename: 'file_name.pdf'
+      });
+
+      // then
+      assert.ok(deleteRecordStub.calledOnce);
+      assert.strictEqual(controller.deletedFiles.length, 1);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les fichiers liés à des challenges originaux n'étaient pas supprimés, juste décorrélés.

## :robot: Proposition
On ajoute la suppression des fichiers pour les challenges. (Comme ça a été fait pour les localized challenges)

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller sur @SourceImage3, ajouter et enlever des illustrations, des pièces jointes, rechargez, testez un peu tout comme ça et assurez-vous que tout se déroule comme prévu.
