### PR TITLE
[FEATURE] Lire le texte alternatif des illustrations depuis PG (PIX-9506)

### DIFF
--- a/api/lib/domain/models/Attachment.js
+++ b/api/lib/domain/models/Attachment.js
@@ -1,0 +1,17 @@
+export class Attachment {
+  constructor({
+    id,
+    url,
+    alt,
+    type,
+    challengeId,
+    localizedChallengeId,
+  }) {
+    this.id = id;
+    this.url = url;
+    this.alt = alt;
+    this.type = type;
+    this.challengeId = challengeId;
+    this.localizedChallengeId = localizedChallengeId;
+  }
+}

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -114,6 +114,7 @@ export class Challenge {
     this.solution = this.#translations[this.locale]?.solution ?? '';
     this.solutionToDisplay = this.#translations[this.locale]?.solutionToDisplay ?? '';
     this.embedTitle = this.#translations[this.locale]?.embedTitle ?? '';
+    this.illustrationAlt = this.#translations[this.locale]?.illustrationAlt ?? '';
 
     const localizedChallenge = this.localizedChallenges.find(({ locale }) => this.locale === locale);
 

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -114,7 +114,7 @@ export class Challenge {
     this.solution = this.#translations[this.locale]?.solution ?? '';
     this.solutionToDisplay = this.#translations[this.locale]?.solutionToDisplay ?? '';
     this.embedTitle = this.#translations[this.locale]?.embedTitle ?? '';
-    this.illustrationAlt = this.#translations[this.locale]?.illustrationAlt ?? '';
+    this.illustrationAlt = this.#translations[this.locale]?.illustrationAlt ?? null;
 
     const localizedChallenge = this.localizedChallenges.find(({ locale }) => this.locale === locale);
 

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -1,3 +1,5 @@
+export * from './Area.js';
+export * from './Attachment.js';
 export * from './Challenge.js';
 export * from './Competence.js';
 export * from './LocalizedChallenge.js';
@@ -6,4 +8,3 @@ export * from './Skill.js';
 export * from './StaticCourse.js';
 export * from './Translation.js';
 export * from './User.js';
-export * from './Area.js';

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,11 +1,11 @@
 import {
-  attachmentDatasource,
   thematicDatasource,
   tubeDatasource,
   tutorialDatasource,
 } from '../../infrastructure/datasources/airtable/index.js';
 import {
   areaRepository,
+  attachmentRepository,
   challengeRepository,
   competenceRepository,
   skillRepository,
@@ -30,7 +30,7 @@ export async function getLearningContentForReplication() {
     skillRepository.list(),
     challengeRepository.list(),
     tutorialDatasource.list(),
-    attachmentDatasource.list(),
+    attachmentRepository.list(),
     thematicDatasource.list(),
     _getCoursesFromPGForReplication(),
   ]);

--- a/api/lib/domain/usecases/proxy-read-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-read-request-to-airtable.js
@@ -13,13 +13,13 @@ export async function proxyReadRequestToAirtable(request, airtableBase, {
 
   if (response.data.records) {
     const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
-    response.data.records = response.data.records.map((entity) => ({
+    response.data.records = await Promise.all(response.data.records.map(async (entity) => ({
       ...entity,
-      fields: tableTranslations.airtableObjectToProxyObject(entity.fields, translations),
-    }));
+      fields: await tableTranslations.airtableObjectToProxyObject(entity.fields, translations),
+    })));
   } else {
-    const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
-    response.data.fields = tableTranslations.airtableObjectToProxyObject(response.data.fields, translations);
+    const translations = await translationRepository.listByPrefix(await tableTranslations.prefixFor(response.data.fields));
+    response.data.fields = await tableTranslations.airtableObjectToProxyObject(response.data.fields, translations);
   }
 
   return response;

--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -13,7 +13,6 @@ export const attachmentDatasource = datasource.extend({
     'size',
     'type',
     'mimeType',
-    'alt',
     'challengeId persistant',
     'localizedChallengeId',
   ],
@@ -27,7 +26,6 @@ export const attachmentDatasource = datasource.extend({
       size: airtableRecord.get('size'),
       type: airtableRecord.get('type'),
       mimeType: airtableRecord.get('mimeType'),
-      alt: airtableRecord.get('alt'),
       challengeId: airtableRecord.get('challengeId persistant')?.[0],
       localizedChallengeId: airtableRecord.get('localizedChallengeId'),
     };

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -17,9 +17,12 @@ function toDomainList(datasourceAttachments, translations, localizedChallenges) 
   const localizedChallengesById = _.groupBy(localizedChallenges, 'id');
 
   return datasourceAttachments.map((attachment) => {
+    if (attachment.type !== 'illustration') {
+      return toDomain(attachment);
+    }
     const challengeTranslations = translationsByChallengeId[attachment.challengeId];
     const locale = localizedChallengesById[attachment.localizedChallengeId][0].locale;
-    const translation = challengeTranslations.find((translation) => locale === translation.locale);
+    const translation = challengeTranslations?.find((translation) => locale === translation.locale);
 
     return toDomain(attachment, translation);
   });
@@ -28,6 +31,6 @@ function toDomainList(datasourceAttachments, translations, localizedChallenges) 
 export function toDomain(attachment, translation) {
   return new Attachment({
     ...attachment,
-    alt: attachment.type === 'illustration' ? translation.value : null,
+    alt: translation?.value ?? null,
   });
 }

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -1,0 +1,33 @@
+import { attachmentDatasource } from '../datasources/airtable/index.js';
+import * as translationRepository from './translation-repository.js';
+import * as localizedChallengeRepository from './localized-challenge-repository.js';
+import _ from 'lodash';
+import { Attachment } from '../../domain/models/index.js';
+
+export async function list() {
+  const datasourceAttachments = await attachmentDatasource.list();
+  const translations = await translationRepository.listByPattern('challenge.%.illustrationAlt');
+  const localizedChallenges = await localizedChallengeRepository.list();
+
+  return toDomainList(datasourceAttachments, translations, localizedChallenges);
+}
+
+function toDomainList(datasourceAttachments, translations, localizedChallenges) {
+  const translationsByChallengeId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const localizedChallengesById = _.groupBy(localizedChallenges, 'id');
+
+  return datasourceAttachments.map((attachment) => {
+    const challengeTranslations = translationsByChallengeId[attachment.challengeId];
+    const locale = localizedChallengesById[attachment.localizedChallengeId][0].locale;
+    const translation = challengeTranslations.find((translation) => locale === translation.locale);
+
+    return toDomain(attachment, translation);
+  });
+}
+
+export function toDomain(attachment, translation) {
+  return new Attachment({
+    ...attachment,
+    alt: attachment.type === 'illustration' ? translation.value : null,
+  });
+}

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -1,4 +1,5 @@
 export * as areaRepository from './area-repository.js';
+export * as attachmentRepository from './attachment-repository.js';
 export * as challengeRepository from './challenge-repository.js';
 export * as competenceRepository from './competence-repository.js';
 export * as fileStorageTokenRepository from './file-storage-token-repository.js';

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -32,6 +32,13 @@ export async function listByPrefix(prefix, { transaction = knex } = {}) {
   return translationDtos.map(_toDomain);
 }
 
+export async function listByPattern(pattern, { transaction = knex } = {}) {
+  const translationDtos = await transaction('translations')
+    .select()
+    .whereLike('key', `${pattern}`);
+  return translationDtos.map(_toDomain);
+}
+
 export async function list() {
   const translationDtos = await knex('translations').select();
   return translationDtos.map(_toDomain);

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -46,7 +46,7 @@ function _filterChallengeFields(challenge) {
 
 function _addAttachmentsToChallenge({ attachments }) {
   return (challenge) => {
-    const newChallenge = { ...challenge, illustrationAlt: null, illustrationUrl: null };
+    const newChallenge = { ...challenge, illustrationUrl: null };
     const challengeAttachments = attachments.filter(({ localizedChallengeId }) => localizedChallengeId === challenge.id);
     challengeAttachments.forEach((attachment) => _assignAttachmentToChallenge(newChallenge, attachment));
     return newChallenge;
@@ -55,7 +55,6 @@ function _addAttachmentsToChallenge({ attachments }) {
 
 function _assignAttachmentToChallenge(challenge, attachment) {
   if (attachment.type === 'illustration') {
-    challenge.illustrationAlt = attachment.alt;
     challenge.illustrationUrl = attachment.url;
   } else {
     if (!challenge.attachments) {

--- a/api/lib/infrastructure/translations/attachment.js
+++ b/api/lib/infrastructure/translations/attachment.js
@@ -24,6 +24,16 @@ export async function extractFromProxyObject(airtableAttachment) {
   ];
 }
 
+export async function airtableObjectToProxyObject(airtableObject, translations) {
+  const localizedChallenge = await localizedChallengeRepository.get({ id: airtableObject.localizedChallengeId });
+  const translation = translations.find(({ key, locale }) => key === `${prefixForChallenge({ id: localizedChallenge.challengeId })}illustrationAlt` && locale === localizedChallenge.locale);
+
+  return {
+    ...airtableObject,
+    alt: translation?.value ?? null,
+  };
+}
+
 async function getLocalizedChallenge(airtableAttachment) {
   const { localizedChallengeId } = airtableAttachment;
 

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-area_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-area_test.js
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
 import {
   airtableBuilder,
-  inputOutputDataBuilder,
   databaseBuilder,
   domainBuilder,
   generateAuthorizationHeader,
+  inputOutputDataBuilder,
   knex,
-} from '../../test-helper.js';
-import { createServer } from '../../../server.js';
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller | create area translations', () => {
   beforeEach(() => {

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-attachment_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-attachment_test.js
@@ -3,13 +3,13 @@ import { omit } from 'lodash';
 import nock from 'nock';
 import {
   airtableBuilder,
-  inputOutputDataBuilder,
   databaseBuilder,
   domainBuilder,
   generateAuthorizationHeader,
+  inputOutputDataBuilder,
   knex,
-} from '../../test-helper.js';
-import { createServer } from '../../../server.js';
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller | create attachment translations', () => {
   beforeEach(() => {

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-attachment_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-attachment_test.js
@@ -69,6 +69,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create attachmen
         }]
       });
       airtableRawAttachment = airtableBuilder.factory.buildAttachment(attachment);
+      airtableRawAttachment.fields.alt = attachment.alt;
       attachmentToSave = inputOutputDataBuilder.factory.buildAttachment(attachment);
     });
 
@@ -166,6 +167,7 @@ describe('Acceptance | Controller | airtable-proxy-controller | create attachmen
         }]
       });
       airtableRawAttachment = airtableBuilder.factory.buildAttachment(attachment);
+      airtableRawAttachment.fields.alt = attachment.alt;
       attachmentToUpdate = inputOutputDataBuilder.factory.buildAttachment(attachment);
     });
 

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-changelog_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-changelog_test.js
@@ -1,7 +1,7 @@
 import { describe, describe as context, expect, it } from 'vitest';
 import nock from 'nock';
-import { databaseBuilder, generateAuthorizationHeader } from '../../test-helper.js';
-import { createServer } from '../../../server.js';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller-changelog', () => {
   describe('PATCH /api/airtable/changelog/Notes', () => {

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-competence_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-competence_test.js
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
 import {
   airtableBuilder,
-  inputOutputDataBuilder,
   databaseBuilder,
   domainBuilder,
   generateAuthorizationHeader,
+  inputOutputDataBuilder,
   knex,
-} from '../../test-helper.js';
-import { createServer } from '../../../server.js';
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller | create competence translations', () => {
   beforeEach(() => {

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-refresh-cache_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-refresh-cache_test.js
@@ -4,12 +4,12 @@ import {
   airtableBuilder,
   databaseBuilder,
   domainBuilder,
-  inputOutputDataBuilder,
   generateAuthorizationHeader,
+  inputOutputDataBuilder,
   knex,
-} from '../../test-helper.js';
-import { createServer } from '../../../server.js';
-import * as config from '../../../lib/config.js';
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import * as config from '../../../../lib/config.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller-refresh-cache', () => {
 

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-skill_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-skill_test.js
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
 import {
   airtableBuilder,
-  inputOutputDataBuilder,
   databaseBuilder,
   domainBuilder,
   generateAuthorizationHeader,
+  inputOutputDataBuilder,
   knex,
-} from '../../test-helper.js';
-import { createServer } from '../../../server.js';
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller | create skill translations', () => {
   beforeEach(() => {

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller_test.js
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import nock from 'nock';
-import {
-  databaseBuilder,
-  generateAuthorizationHeader
-} from '../../test-helper.js';
-import { createServer } from '../../../server.js';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
 
 describe('Acceptance | Controller | airtable-proxy-controller', () => {
 

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -804,6 +804,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
         locale,
         value: 'embed title for nl',
       });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeId}.illustrationAlt`,
+        locale,
+        value: 'illustration alt for nl',
+      });
 
       databaseBuilder.factory.buildLocalizedChallenge({
         id: challengeId,
@@ -839,7 +844,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             embedUrl: null,
             embedTitle: 'embed title for nl',
             format: 'mots',
-            illustrationAlt: attachment.fields.alt,
+            illustrationAlt: 'illustration alt for nl',
             illustrationUrl: attachment.fields.url,
             instruction: 'instruction for nl',
             locales: ['nl'],

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -43,7 +43,7 @@ async function mockCurrentContent() {
   const expectedChallenge = { ...challenge, area: challenge.geography };
   delete expectedChallenge.localizedChallenges;
 
-  const expectedChallengeNl = { ...challengeNl, area: challenge.geography };
+  const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', area: challenge.geography };
   delete expectedChallengeNl.localizedChallenges;
 
   const expectedAttachment = {
@@ -51,14 +51,16 @@ async function mockCurrentContent() {
     challengeId: challenge.id,
     url: 'http://example.fr',
     type: 'lol',
-    alt: 'stop'
+    alt: null,
+    localizedChallenge: challenge.id,
   };
   const expectedAttachmentNl = {
     id: 'attid2',
-    challengeId: challengeNl.id,
+    challengeId: challenge.id,
     url: 'http://example.nl',
-    type: 'haha',
-    alt: 'arrête'
+    type: 'illustration',
+    alt: 'alt_nl',
+    localizedChallengeId: 'localized-challenge-id',
   };
 
   const expectedCurrentContent = {
@@ -223,6 +225,12 @@ async function mockCurrentContent() {
     key: `challenge.${expectedChallenge.id}.embedTitle`,
     locale: 'fr',
     value: expectedChallenge.embedTitle,
+  });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedChallenge.id}.illustrationAlt`,
+    locale: 'nl',
+    value: expectedAttachmentNl.alt,
   });
 
   await databaseBuilder.commit();

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -176,7 +176,6 @@ async function mockCurrentContent() {
   const attachments = [{
     id: 'attid1',
     url: 'url de l‘illustration',
-    alt: 'Texte alternatif illustration',
     type: 'illustration',
     challengeId: 'recChallenge0',
     localizedChallengeId: 'recChallenge0',
@@ -292,6 +291,11 @@ async function mockCurrentContent() {
     key: `challenge.${expectedCurrentContent.challenges[0].id}.embedTitle`,
     locale: 'fr-fr',
     value: expectedCurrentContent.challenges[0].embedTitle,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.illustrationAlt`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].illustrationAlt,
   });
 
   databaseBuilder.factory.buildLocalizedChallenge({
@@ -459,7 +463,6 @@ async function mockContentForRelease() {
   const attachments = [{
     id: 'attid1',
     url: 'url de l‘illustration',
-    alt: 'Texte alternatif illustration',
     type: 'illustration',
     challengeId: 'recChallenge0',
     localizedChallengeId: 'recChallenge0',
@@ -555,6 +558,11 @@ async function mockContentForRelease() {
     key: `challenge.${expectedCurrentContent.challenges[0].id}.embedTitle`,
     locale: 'fr-fr',
     value: expectedCurrentContent.challenges[0].embedTitle,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${expectedCurrentContent.challenges[0].id}.illustrationAlt`,
+    locale: 'fr-fr',
+    value: expectedCurrentContent.challenges[0].illustrationAlt,
   });
 
   databaseBuilder.factory.buildLocalizedChallenge({

--- a/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import * as attachmentRepository from '../../../../lib/infrastructure/repositories/attachment-repository.js';
+
+describe('Integration | Repository | attachment-repository', () => {
+
+  describe('#list', () => {
+    it('should return the list of all attachments with an alt illustration', async () => {
+      // given
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'localizedChallengeId1',
+        challengeId: 'challengeId1',
+        locale: 'fr',
+      });
+
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'localizedChallengeId1Nl',
+        challengeId: 'challengeId1',
+        locale: 'nl',
+      });
+
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'localizedChallengeId2',
+        challengeId: 'challengeId2',
+        locale: 'en',
+      });
+
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeId1.illustrationAlt',
+        locale: 'fr',
+        value: 'illustration text alt 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeId1.illustrationAlt',
+        locale: 'nl',
+        value: 'illustration text alt 1 nl',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeId2.illustrationAlt',
+        locale: 'en',
+        value: 'illustration text alt 2',
+      });
+
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Attachments' }).returns([
+
+        airtableBuilder.factory.buildAttachment({
+          id: 'attachmentId1',
+          type: 'illustration',
+          url: 'http://1',
+          challengeId: 'challengeId1',
+          localizedChallengeId: 'localizedChallengeId1'
+        }),
+        airtableBuilder.factory.buildAttachment({
+          id: 'attachmentId1Nl',
+          type: 'illustration',
+          url: 'http://1-nl',
+          challengeId: 'challengeId1',
+          localizedChallengeId: 'localizedChallengeId1Nl'
+        }),
+        airtableBuilder.factory.buildAttachment({
+          id: 'attachmentId2',
+          type: 'illustration',
+          url: 'http://2',
+          challengeId: 'challengeId2',
+          localizedChallengeId: 'localizedChallengeId2'
+        }),
+        airtableBuilder.factory.buildAttachment({
+          id: 'attachmentId3',
+          type: 'attachment',
+          url: 'http://3',
+          challengeId: 'challengeId2',
+          localizedChallengeId: 'localizedChallengeId2'
+        }),
+      ]).activate().nockScope;
+
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        attachmentId: 'attachmentId1',
+        localizedChallengeId: 'localizedChallengeId1'
+      });
+
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        attachmentId: 'attachmentId2',
+        localizedChallengeId: 'localizedChallengeId2'
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const attachments = await attachmentRepository.list();
+
+      // then
+      expect(attachments).toEqual([
+        domainBuilder.buildAttachment({
+          id: 'attachmentId1',
+          type: 'illustration',
+          alt: 'illustration text alt 1',
+          url: 'http://1',
+          challengeId: 'challengeId1',
+          localizedChallengeId: 'localizedChallengeId1',
+        }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentId1Nl',
+          type: 'illustration',
+          alt: 'illustration text alt 1 nl',
+          url: 'http://1-nl',
+          challengeId: 'challengeId1',
+          localizedChallengeId: 'localizedChallengeId1Nl',
+        }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentId2',
+          type: 'illustration',
+          alt: 'illustration text alt 2',
+          url: 'http://2',
+          challengeId: 'challengeId2',
+          localizedChallengeId: 'localizedChallengeId2',
+        }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentId3',
+          type: 'attachment',
+          alt: null,
+          url: 'http://3',
+          challengeId: 'challengeId2',
+          localizedChallengeId: 'localizedChallengeId2',
+        }),
+      ]);
+
+      airtableScope.done();
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -773,28 +773,24 @@ function _mockRichAirtableContent() {
   });
   const airtableAttachment1 = airtableBuilder.factory.buildAttachment({
     id: 'attachment1',
-    alt: 'attachment1 alt',
     type: 'attachment',
     url: 'attachment1 url',
     challengeId: 'challenge121211',
   });
   const airtableAttachment2 = airtableBuilder.factory.buildAttachment({
     id: 'attachment2',
-    alt: 'attachment2 alt',
     type: 'attachment',
     url: 'attachment2 url',
     challengeId: 'challenge121211',
   });
   const airtableAttachment3 = airtableBuilder.factory.buildAttachment({
     id: 'attachment3',
-    alt: 'attachment3 alt',
     type: 'attachment',
     url: 'attachment3 url',
     challengeId: 'challenge211111',
   });
   const airtableAttachment4 = airtableBuilder.factory.buildAttachmentForLocalizedChallenge({
     id: 'attachment4',
-    alt: 'attachment4 alt',
     type: 'attachment',
     url: 'attachment4 url',
     challengeId: '',

--- a/api/tests/tooling/airtable-builder/factory/build-attachment.js
+++ b/api/tests/tooling/airtable-builder/factory/build-attachment.js
@@ -1,6 +1,5 @@
 export function buildAttachment({
   id = 'attid1',
-  alt = 'alt',
   type = 'illustration',
   url = 'url/to/attachment',
   challengeId = 'challid1',
@@ -13,7 +12,6 @@ export function buildAttachment({
     'fields': {
       'Record ID': id,
       'challengeId persistant': [challengeId],
-      alt,
       createdAt,
       localizedChallengeId,
       type,

--- a/api/tests/tooling/domain-builder/factory/build-attachment.js
+++ b/api/tests/tooling/domain-builder/factory/build-attachment.js
@@ -1,3 +1,5 @@
+import { Attachment } from '../../../../lib/domain/models/Attachment';
+
 export function buildAttachment({
   id = 'attachmentId',
   url = 'http://',
@@ -7,12 +9,12 @@ export function buildAttachment({
   localizedChallengeId = challengeId,
 } = {}) {
 
-  return {
+  return new Attachment({
     id,
     url,
     alt,
     type,
     challengeId,
     localizedChallengeId,
-  };
+  });
 }

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -49,6 +49,7 @@ export function buildChallenge({
   skillId = 'recSkillId',
   alpha = 0.5,
   delta = 0.2,
+  illustrationAlt = null,
   translations = {
     [Challenge.getPrimaryLocale(locales)]: {
       instruction,
@@ -57,6 +58,7 @@ export function buildChallenge({
       solution,
       solutionToDisplay,
       embedTitle,
+      illustrationAlt,
     },
   },
   localizedChallenges = [{

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -87,7 +87,6 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             id: 'attId1',
             type: 'illustration',
             url: 'https://dl.example.com/illustration1.jpg',
-            alt: 'A dog making bubbles with his nose',
             challengeId: 'challenge-id',
             localizedChallengeId: 'challenge-id',
           },
@@ -95,7 +94,6 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             id: 'attId2',
             type: 'illustration',
             url: 'https://dl.example.com/illustration2.jpg',
-            alt: 'A cat doing nothing cause he is useless',
             challengeId: 'other-challenge-id',
             localizedChallengeId: 'other-challenge-id',
           },
@@ -103,7 +101,6 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             id: 'attId3',
             type: 'illustration',
             url: 'https://dl.example.com/illustration1-nl.jpg',
-            alt: 'A dog making bubbles with his nose nl',
             challengeId: 'challenge-id',
             localizedChallengeId: 'challenge-id-nl',
           },
@@ -115,6 +112,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
               instruction: 'Consigne',
               alternativeInstruction: 'Consigne alternative',
               proposals: 'Propositions',
+              illustrationAlt: 'Un chien qui fait des bulles avec son museau'
             },
           },
           locales: ['fr', 'fr-fr'],
@@ -129,7 +127,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         expect(result).to.deep.equal(
           _buildReleaseChallenge({
             ...challenge,
-            illustrationAlt: 'A dog making bubbles with his nose',
+            illustrationAlt: 'Un chien qui fait des bulles avec son museau',
             illustrationUrl: 'https://dl.example.com/illustration1.jpg',
           }),
         );

--- a/api/tests/unit/repositories/release-repository_test.js
+++ b/api/tests/unit/repositories/release-repository_test.js
@@ -56,7 +56,6 @@ describe('Unit | Repository | release-repository', () => {
     it('serializes attachment', async () => {
       const entity = airtableBuilder.factory.buildAttachment({
         id: 'recAttachment',
-        alt: 'texte alternatif à l\'image',
         url: 'http://example.com/test',
         type: 'illustration',
         challengeId: 'recChallenge'
@@ -92,6 +91,7 @@ describe('Unit | Repository | release-repository', () => {
         embedHeight: 500,
         format: 'mots',
         autoReply: false,
+        illustrationAlt: 'texte alternatif à l\'image',
         files: [{
           fileId: 'recAttachment',
           localizedChallengeId: 'recChallenge'


### PR DESCRIPTION
## :unicorn: Problème
On écrit le texte alternatif des illustrations dans PG mais on le lit depuis Airtable.

## :robot: Proposition
Lire depuis Airtable.

## :rainbow: Remarques
N/A

## :100: Pour tester
Créer un décalage entre Airtable et les translations dans PG, et vérifier que c'est PG qui fait fois :
 - dans le front ✅ 
 - dans la release ✅ 
 - dans la répli ✅ 
