### PR TITLE
[BUGFIX]  Affichage du bon statut sur les détails d'une mission (Pix-11164)

### DIFF
--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -8,4 +8,8 @@ export default class Mission extends Model {
   @attr status;
   @attr learningObjectives;
   @attr validatedObjectives;
+
+  get isActive () {
+    return this.status === 'ACTIVE';
+  }
 }

--- a/pix-editor/app/templates/authenticated/missions/list.hbs
+++ b/pix-editor/app/templates/authenticated/missions/list.hbs
@@ -60,7 +60,7 @@
             <td>{{dayjs-format mission.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
             <td>
               <PixTag @color="{{if mission.isActive "green-light" "grey-light"}}">
-                {{if mission.isActive "Actif" "Inactif"}}
+                {{if mission.isActive "Active" "Inactive"}}
               </PixTag>
             </td>
           </tr>

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -27,7 +27,7 @@
         </li>
         <li><span class="bold">Statut : </span>
           <PixTag @color="{{if this.model.mission.isActive "green-light" "grey-light"}}">
-            {{if this.model.mission.isActive "Actif" "Inactif"}}
+            {{ if this.model.mission.isActive "Active" "Inactive" }}
           </PixTag>
         </li>
         <li>


### PR DESCRIPTION
## :unicorn: Problème

Le status de la mission n'est pas le bon.

## :robot: Proposition

Afficher le status correspondant à la mission

## :100: Pour tester

Vérifier que le status d'une mission de la liste est bien le même que sur la page de détail.