### PR TITLE
[FEATURE] Permettre de filtrer les tests statiques par nom (PIX-8886)

### DIFF
--- a/api/lib/application/static-courses/static-courses.js
+++ b/api/lib/application/static-courses/static-courses.js
@@ -99,20 +99,27 @@ function normalizePage(page) {
 }
 
 function normalizeFilter(filter) {
-  let isActive;
+  const normalizedFilter = {};
   if (filter.isActive === undefined)
-    isActive = null;
+    normalizedFilter.isActive = null;
   else if (_.isString(filter.isActive)) {
     const trimmedValueFromFilter = filter.isActive.trim().toLowerCase();
-    if (trimmedValueFromFilter === '') isActive = null;
-    else isActive = trimmedValueFromFilter === 'true';
+    if (trimmedValueFromFilter === '') normalizedFilter.isActive = null;
+    else normalizedFilter.isActive = trimmedValueFromFilter === 'true';
   } else {
-    isActive = false;
+    normalizedFilter.isActive = false;
   }
 
-  return {
-    isActive,
-  };
+  if (filter.name) {
+    const trimmedValueFromFilter = filter.name.toString().trim();
+    if (trimmedValueFromFilter.length > 0) normalizedFilter.name = trimmedValueFromFilter;
+    else normalizedFilter.name = null;
+  }
+  else {
+    normalizedFilter.name = null;
+  }
+
+  return normalizedFilter;
 }
 
 function normalizeCreationOrUpdateCommand(attrs) {

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -9,13 +9,17 @@ import { StaticCourse } from '../../domain/models/index.js';
 import { skillDatasource } from '../datasources/airtable/index.js';
 import * as challengeRepository from './challenge-repository.js';
 import { localizedChallengeRepository } from './index.js';
+import _ from 'lodash';
 
 export async function findReadSummaries({ filter, page }) {
   const query = knex('static_courses')
     .select('id', 'name', 'createdAt', 'challengeIds', 'isActive')
     .orderBy('createdAt', 'desc');
-  if (filter.isActive !== null) {
-    query.where('isActive', filter.isActive);
+  if (!_.isNil(filter.isActive)) {
+    query.andWhere('isActive', filter.isActive);
+  }
+  if (filter.name) {
+    query.andWhereILike('name', `%${filter.name}%`);
   }
   const { results: staticCourses, pagination } = await fetchPage(query, page);
 

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -26,7 +26,7 @@ export async function findReadSummaries({ filter, page }) {
   const staticCoursesSummaries = staticCourses.map((staticCourse) => {
     return new StaticCourseSummary_Read({
       id: staticCourse.id,
-      name: staticCourse.name || '',
+      name: staticCourse.name,
       createdAt: staticCourse.createdAt,
       challengeCount: staticCourse.challengeIds.split(',').length,
       isActive: staticCourse.isActive,

--- a/api/tests/acceptance/application/static-courses/get_static-course-summaries_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course-summaries_test.js
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  databaseBuilder,
-  generateAuthorizationHeader,
-} from '../../../test-helper.js';
+import { databaseBuilder, generateAuthorizationHeader, } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | API | static courses | GET /api/static-course-summaries', function() {
@@ -12,24 +9,31 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
     const user = databaseBuilder.factory.buildReadonlyUser();
     databaseBuilder.factory.buildStaticCourse({
       id: 'courseid1',
-      name: 'static course 1',
+      name: 'static course 01',
       challengeIds: 'challengeid1,challengeid2',
       createdAt: new Date('2021-01-01'),
       isActive: true,
     });
     databaseBuilder.factory.buildStaticCourse({
       id: 'courseid2',
-      name: 'static course 2',
+      name: 'static course 20',
       challengeIds: 'challengeid3,challengeid4,challengeid5',
       createdAt: new Date('2021-01-03'),
       isActive: false,
+    });
+    databaseBuilder.factory.buildStaticCourse({
+      id: 'courseid3',
+      name: 'static course 03',
+      challengeIds: 'challengeid2,challengeid3,challengeid5',
+      createdAt: new Date('2021-01-05'),
+      isActive: true,
     });
     await databaseBuilder.commit();
 
     // When
     const response = await server.inject({
       method: 'GET',
-      url: '/api/static-course-summaries',
+      url: '/api/static-course-summaries?filter[isActive]=true&filter[name]=Rse+0',
       headers: generateAuthorizationHeader(user),
     });
 
@@ -39,19 +43,19 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
     expect(response.result.data).to.deep.equal([
       {
         type: 'static-course-summaries',
-        id: 'courseid2',
+        id: 'courseid3',
         attributes: {
-          name: 'static course 2',
-          'created-at': new Date('2021-01-03'),
+          name: 'static course 03',
+          'created-at': new Date('2021-01-05'),
           'challenge-count': 3,
-          'is-active': false,
+          'is-active': true,
         },
       },
       {
         type: 'static-course-summaries',
         id: 'courseid1',
         attributes: {
-          name: 'static course 1',
+          name: 'static course 01',
           'created-at': new Date('2021-01-01'),
           'challenge-count': 2,
           'is-active': true,

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -124,6 +124,133 @@ describe('Integration | Repository | static-course-repository', function() {
           });
         });
       });
+      context('name', function() {
+        const page = { number: 1, size: 20 };
+
+        context('with results', function() {
+          beforeEach(function() {
+            // 4 Static courses
+            [{ createdAt: new Date('2010-01-01'), name: 'iRis' },
+              { createdAt:new Date('2011-01-01'), name: 'aras' },
+              { createdAt: new Date('2012-01-01'), name: 'iras' },
+              { createdAt: new Date('2013-01-01'), name: 'aris' }]
+              .map(({ createdAt, name }, index) => {
+                databaseBuilder.factory.buildStaticCourse({
+                  id: `courseId${index}`,
+                  name,
+                  createdAt,
+                });
+              });
+            return databaseBuilder.commit();
+          });
+
+          it('should return all the static courses of %name% when filter name is set', async function() {
+            // given
+            const filter = { name: 'ri' };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).toEqual(['courseId3', 'courseId0']);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 2,
+              pageCount: 1,
+            });
+          });
+
+          it('should return all the static courses of %name% when filter name is set in a case insensitive fashion', async function() {
+            // given
+            const filter = { name: 'rI' };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).toEqual(['courseId3', 'courseId0']);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 2,
+              pageCount: 1,
+            });
+          });
+
+          it('should return 0 static courses of %name% when filter name is set with a value that matches none of the records', async function() {
+            // given
+            const filter = { name: 'laura' };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).to.be.empty;
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 0,
+              pageCount: 0,
+            });
+          });
+        });
+      });
+      context('with many filters', function() {
+        const page = { number: 1, size: 20 };
+
+        context('with results', function() {
+          beforeEach(function() {
+            // 4 Static courses
+            [{ createdAt: new Date('2010-01-01'), name: 'iris' },
+              { createdAt:new Date('2011-01-01'), name: 'aras' },
+              { createdAt: new Date('2012-01-01'), name: 'iras' },
+              { createdAt: new Date('2013-01-01'), name: 'aris' }]
+              .map(({ createdAt, name }, index) => {
+                databaseBuilder.factory.buildStaticCourse({
+                  id: `courseId${index}`,
+                  isActive: index % 2 === 0, // pair actif, impair inactif
+                  name,
+                  createdAt,
+                });
+              });
+            return databaseBuilder.commit();
+          });
+
+          it('should return all the static courses according to given filters', async function() {
+            // given
+            const filter = { isActive: true, name: 'ri' };
+
+            // when
+            const {
+              results: actualStaticCourseSummaries,
+              meta
+            } = await findReadSummaries({ filter, page });
+
+            // then
+            const actualStaticCourseSummaryIds = actualStaticCourseSummaries.map(({ id }) => id);
+            expect(actualStaticCourseSummaryIds).toEqual(['courseId0']);
+            expect(meta).to.deep.equal({
+              page: 1,
+              pageSize: 20,
+              rowCount: 1,
+              pageCount: 1,
+            });
+          });
+        });
+      });
     });
   });
 

--- a/api/tests/unit/application/static-courses/static-courses_test.js
+++ b/api/tests/unit/application/static-courses/static-courses_test.js
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
-import { hFake, domainBuilder, catchErr } from '../../../test-helper.js';
+import { catchErr, domainBuilder, hFake } from '../../../test-helper.js';
 import * as staticCourseController from '../../../../lib/application/static-courses/static-courses.js';
-import { localizedChallengeRepository, staticCourseRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import {
+  localizedChallengeRepository,
+  staticCourseRepository
+} from '../../../../lib/infrastructure/repositories/index.js';
 import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
 import { InvalidStaticCourseCreationOrUpdateError } from '../../../../lib/domain/errors.js';
 
@@ -9,7 +12,7 @@ describe('Unit | Controller | static courses controller', function() {
   describe('findSummaries', function() {
     describe('pagination normalization', function() {
       let stub;
-      const filter = { isActive: null };
+      const filter = { isActive: null, name: null };
 
       beforeEach(function() {
         stub = vi.spyOn(staticCourseRepository, 'findReadSummaries');
@@ -110,13 +113,13 @@ describe('Unit | Controller | static courses controller', function() {
 
       it('should pass along filter from query params when all is valid', async function() {
         // given
-        const request = { query: { 'filter[isActive]': 'true' } };
+        const request = { query: { 'filter[isActive]': 'true', 'filter[name]': 'Laura' } };
 
         // when
         await staticCourseController.findSummaries(request, hFake);
 
         // then
-        expect(stub).toHaveBeenCalledWith({ filter: { isActive: true }, page });
+        expect(stub).toHaveBeenCalledWith({ filter: { isActive: true, name: 'Laura' }, page });
       });
 
       it('ignore unknown filter parameters', async function() {
@@ -127,7 +130,7 @@ describe('Unit | Controller | static courses controller', function() {
         await staticCourseController.findSummaries(request, hFake);
 
         // then
-        expect(stub).toHaveBeenCalledWith({ filter: { isActive: true }, page });
+        expect(stub).toHaveBeenCalledWith({ filter: { isActive: true, name: null }, page });
       });
 
       context('filter isActive', function() {
@@ -149,12 +152,33 @@ describe('Unit | Controller | static courses controller', function() {
           await staticCourseController.findSummaries(request5, hFake);
 
           // then
-          expect(stub).toHaveBeenNthCalledWith(1, { filter: { isActive: false }, page });
-          expect(stub).toHaveBeenNthCalledWith(2, { filter: { isActive: false }, page });
-          expect(stub).toHaveBeenNthCalledWith(3, { filter: { isActive: null }, page });
-          expect(stub).toHaveBeenNthCalledWith(4, { filter: { isActive: true }, page });
-          expect(stub).toHaveBeenNthCalledWith(5, { filter: { isActive: false }, page });
-          expect(stub).toHaveBeenNthCalledWith(6, { filter: { isActive: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(1, { filter: { isActive: false, name: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(2, { filter: { isActive: false, name: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(3, { filter: { isActive: null, name: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(4, { filter: { isActive: true, name: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(5, { filter: { isActive: false, name: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(6, { filter: { isActive: null, name: null }, page });
+        });
+      });
+      context('filter name', function() {
+        it('extract name parameter correctly', async function() {
+          // given
+          const request0 = { query: { 'filter[name]': 3 } };
+          const request1 = { query: { 'filter[name]': 'ok' } };
+          const request2 = { query: { 'filter[somethingElse]': 'coucou' } };
+          const request3 = { query: { 'filter[name]': '' } };
+
+          // when
+          await staticCourseController.findSummaries(request0, hFake);
+          await staticCourseController.findSummaries(request1, hFake);
+          await staticCourseController.findSummaries(request2, hFake);
+          await staticCourseController.findSummaries(request3, hFake);
+
+          // then
+          expect(stub).toHaveBeenNthCalledWith(1, { filter: { isActive: null, name: '3' }, page });
+          expect(stub).toHaveBeenNthCalledWith(2, { filter: { isActive: null, name: 'ok' }, page });
+          expect(stub).toHaveBeenNthCalledWith(3, { filter: { isActive: null, name: null }, page });
+          expect(stub).toHaveBeenNthCalledWith(4, { filter: { isActive: null, name: null }, page });
         });
       });
     });

--- a/pix-editor/app/controllers/authenticated/static-courses/list.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/list.js
@@ -5,11 +5,14 @@ import { tracked } from '@glimmer/tracking';
 
 export default class StaticCoursesController extends Controller {
   @service router;
-  queryParams = ['pageNumber', 'pageSize', 'isActive'];
+  queryParams = ['pageNumber', 'pageSize', 'isActive', 'name'];
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
   @tracked showActiveOnly = true;
   @tracked isActive = true;
+  @tracked tempIsActive = true;
+  @tracked name = '';
+  @tracked tempName = '';
 
   @action
   async copyStaticCoursePreviewUrl(staticCourseSummary) {
@@ -25,12 +28,25 @@ export default class StaticCoursesController extends Controller {
   @action
   async toggleShowActiveOnly() {
     this.showActiveOnly = !this.showActiveOnly;
-    this.isActive = this.showActiveOnly || null;
+    this.tempIsActive = this.showActiveOnly || null;
+  }
+
+  @action
+  async updateName(event) {
+    this.tempName = event.target.value;
   }
 
   @action
   clearFilters() {
     this.showActiveOnly = true;
     this.isActive = true;
+    this.name = '';
+  }
+
+  @action
+  async submitFilters(event) {
+    event.preventDefault();
+    this.name = this.tempName;
+    this.isActive = this.tempIsActive;
   }
 }

--- a/pix-editor/app/routes/authenticated/static-courses/list.js
+++ b/pix-editor/app/routes/authenticated/static-courses/list.js
@@ -12,6 +12,9 @@ export default class StaticCoursesRoute extends Route {
     isActive: {
       refreshModel: true,
     },
+    name: {
+      refreshModel: true,
+    }
   };
 
   @service store;
@@ -27,6 +30,7 @@ export default class StaticCoursesRoute extends Route {
         },
         filter: {
           isActive: params.isActive,
+          name: params.name,
         },
       },
       { reload: true }

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -29,23 +29,38 @@
 </header>
 <main class="page-body">
   <section class="page-section">
-    <PixFilterBanner
-    @title="Filtres"
-    class="table-filter-banner"
-    @clearFiltersLabel="Réinitialiser les filtres"
-    @onClearFilters={{this.clearFilters}}
-    @isClearFilterButtonDisabled={{false}}
-    >
-      <PixToggle
-        @label="Statut"
-        @inline={{true}}
-        @onLabel="Actifs"
-        @offLabel="Tous"
-        @toggled={{this.showActiveOnly}}
-        @onChange={{this.toggleShowActiveOnly}}
-        @screenReaderOnly={{true}}
-      />
-    </PixFilterBanner>
+    <form {{on "submit" this.submitFilters}} class="new-mission-form">
+      <PixFilterBanner
+      @title="Filtres"
+      class="table-filter-banner"
+      @clearFiltersLabel="Réinitialiser les filtres"
+      @onClearFilters={{this.clearFilters}}
+      @isClearFilterButtonDisabled={{false}}
+      >
+        <PixInput
+          @id="static-course-filter-name"
+          @label="Nom"
+          placeholder="Nom"
+          @screenReaderOnly={{true}}
+          @value={{this.name}}
+          {{on "keyup" this.updateName}}
+        />
+        <PixToggle
+          @label="Statut"
+          @inline={{true}}
+          @onLabel="Actifs"
+          @offLabel="Tous"
+          @toggled={{this.showActiveOnly}}
+          @onChange={{this.toggleShowActiveOnly}}
+          @screenReaderOnly={{true}}
+        />
+        <PixButton
+          @type="submit"
+        >
+          Filtrer
+        </PixButton>
+      </PixFilterBanner>
+    </form>
     <div class="panel-table-v2">
       <table class="content-text content-text--small">
         <colgroup class="table__column">

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -1,5 +1,5 @@
 import { applyEmberDataSerializers, discoverEmberDataModels } from 'ember-cli-mirage';
-import { Response, createServer } from 'miragejs';
+import { createServer, Response } from 'miragejs';
 import { getDsModels, getDsSerializers } from 'ember-cli-mirage/ember-data';
 import slice from 'lodash/slice';
 
@@ -322,6 +322,7 @@ function routes() {
     const queryParams = request.queryParams;
     const {
       'filter[isActive]': isActiveFilter,
+      'filter[name]' : nameFilter,
     } = queryParams;
     let allStaticCourseSummaries;
     if (isActiveFilter === '') {
@@ -329,6 +330,12 @@ function routes() {
     } else {
       const isActive = isActiveFilter === 'true';
       allStaticCourseSummaries = schema.staticCourseSummaries.where({ isActive }).models;
+    }
+    if (nameFilter.length > 0) {
+      allStaticCourseSummaries = allStaticCourseSummaries.filter((staticCourse) => {
+        const staticCourseName = staticCourse.name.toLowerCase();
+        return staticCourseName.includes(nameFilter.toLowerCase());
+      });
     }
     const rowCount = allStaticCourseSummaries.length;
 

--- a/pix-editor/tests/acceptance/static-courses/activation-test.js
+++ b/pix-editor/tests/acceptance/static-courses/activation-test.js
@@ -87,6 +87,7 @@ module('Acceptance | Static Courses | Activation', function(hooks) {
         const screen = await visit('/');
         await clickByName('Tests statiques');
         await click(await screen.findByRole('button', { name: 'Statut' }));
+        await click(await screen.findByRole('button', { name: 'Filtrer' }));
         await click(screen.getAllByRole('cell')[0]);
         await clickByName('Réactiver');
         await screen.findByRole('dialog');

--- a/pix-editor/tests/acceptance/static-courses/edition-test.js
+++ b/pix-editor/tests/acceptance/static-courses/edition-test.js
@@ -96,6 +96,7 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
         const screen = await visit('/');
         await clickByName('Tests statiques');
         await click(await screen.findByRole('button', { name: 'Statut' }));
+        await click(await screen.findByRole('button', { name: 'Filtrer' }));
         await click(screen.getAllByRole('cell')[0]);
         await click(screen.getAllByText('Éditer le test statique')[0]);
 

--- a/pix-editor/tests/acceptance/static-courses/list-test.js
+++ b/pix-editor/tests/acceptance/static-courses/list-test.js
@@ -2,8 +2,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { click, currentURL } from '@ember/test-helpers';
-import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, triggerEvent } from '@ember/test-helpers';
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Static Courses | List', function(hooks) {
   setupApplicationTest(hooks);
@@ -34,10 +34,13 @@ module('Acceptance | Static Courses | List', function(hooks) {
     const screen = await visit('/');
     await clickByName('Tests statiques');
     await click(await screen.findByRole('button', { name: 'Statut' }));
+    await fillByLabel('Nom', 'prem');
+    await triggerEvent(await screen.getByLabelText('Nom'), 'keyup', '');
+    await click(await screen.findByRole('button', { name: 'Filtrer' }));
 
     // then
-    assert.strictEqual(currentURL(), '/static-courses');
+    assert.strictEqual(currentURL(), '/static-courses?name=prem');
     assert.dom(screen.getByText('Premier test statique')).exists();
-    assert.dom(screen.getByText('Deuxième test statique')).exists();
+    assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aucune fonction de recherche n'est mise en place sur la liste des tests statiques, il est donc difficile de rechercher un test spécifique.

## :robot: Proposition
Ajouter un champ de recherche par nom sur la page de liste de tests statiques.
Modifications :
- Pour appliquer les filtres (nom et statut), il faut appuyer sur le bouton "Filtrer" ou bien appuyer sur le bouton Entrée (quand on est sur le champ "Nom")

## :rainbow: Remarques
L'application des filtres DOIT être déclenchée volontairement ! Parfaitement ! Et toc !

## :100: Pour tester
Se rendre sur pixeditor, se connecter, aller sur la page des tests statiques, et jouer avec les filtres ! (quel amusement)
