### PR TITLE
[BUGFIX] Fermeture de la modal d'illustration sur une épreuve NL (PIX-11355)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -17,7 +17,7 @@ export default class LocalizedController extends Controller {
   @tracked edition = false;
   @tracked displayConfirm = false;
   @tracked popInImageSrc = null;
-  @tracked displayImage = false;
+  @tracked displayIllustration = false;
 
   @controller('authenticated.competence') competenceController;
   @controller('authenticated.competence.prototypes.single.alternatives') alternativesController;
@@ -88,9 +88,11 @@ export default class LocalizedController extends Controller {
 
   @action
   showIllustration() {
-    const illustration = this.model.illustration;
-    this.popInImageSrc = illustration.url;
-    this.displayImage = true;
+    this.displayIllustration = true;
+  }
+
+  @action closeIllustration() {
+    this.displayIllustration = false;
   }
 
   @action async confirmApprove() {

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -100,9 +100,9 @@
     data-testid='change-status-confirm-popin'
   />
   <PopIn::Image
-    @imageSrc={{this.popInImageSrc}}
+    @imageSrc={{this.model.illustration.url}}
     @close={{this.closeIllustration}}
-    @showModal={{this.displayImage}}
+    @showModal={{this.displayIllustration}}
     data-testid='display-illustration-pop-in'
   />
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Impossible de fermer cette satanée modal.

## :robot: Proposition
Ajouter le code permettant de fermer la modal.

## :rainbow: Remarques
N/A

## :100: Pour tester
Aller sur un challenge NL avec une illustration, ouvrir et fermer la modal.

https://pix-lcms-review-pr541.osc-fr1.scalingo.io/competence/recUta0fyZ5wKelsh/prototypes/challenge1hw7yRYWvBiApF/localized/challenge1hw7yRYWvBiApF-nl?view=workbench-list