### PR TITLE
[FEATURE] Agrandir le nombre de lignes visibles dans le champ texte de la description d'un test statique (PIX-11377)

### DIFF
--- a/pix-editor/app/components/form/static-course.hbs
+++ b/pix-editor/app/components/form/static-course.hbs
@@ -14,6 +14,7 @@
       @id="static-course-description"
       @label="Description à usage interne"
       @maxlength="1000"
+      rows="5"
       @value={{@initialDescription}}
       {{on "keyup" this.updateDescription}}
     />


### PR DESCRIPTION
## :unicorn: Problème
Le champ libre "description" est un peu étriqué

## :robot: Proposition
Afficher les 5 premières lignes dans les textArea en modification et en création de test statique

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur pixeditor, créer et éditer un test statique et constater que le textarea de la description est plus grand (5 lignes)
