### PR TITLE
[FEATURE] Afficher les tags d'un test statique sur la liste (PIX-11378)

### DIFF
--- a/api/db/migrations/20240226092502_create-static-course-tag-tables.js
+++ b/api/db/migrations/20240226092502_create-static-course-tag-tables.js
@@ -1,0 +1,28 @@
+const TAG_TABLE_NAME = 'static_course_tags';
+const ASSOCIATIVE_TABLE_NAME = 'static_courses_tags_link';
+const STATIC_COURSE_TABLE_NAME = 'static_courses';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TAG_TABLE_NAME, function(table) {
+    table.increments('id').notNullable();
+    table.string('label', 30).notNullable();
+  });
+  await knex.schema.createTable(ASSOCIATIVE_TABLE_NAME, function(table) {
+    table.increments('id').notNullable();
+    table.bigInteger('staticCourseTagId').references(`${TAG_TABLE_NAME}.id`).index();
+    table.string('staticCourseId').references(`${STATIC_COURSE_TABLE_NAME}.id`).index();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(ASSOCIATIVE_TABLE_NAME);
+  await knex.schema.dropTable(TAG_TABLE_NAME);
+}

--- a/api/db/seeds/data/static-courses.js
+++ b/api/db/seeds/data/static-courses.js
@@ -1,15 +1,13 @@
 export function staticCoursesBuilder(databaseBuilder) {
-  databaseBuilder.factory.buildStaticCourse({
-    id: 'courseFr0mS33d5',
+  const staticCourseId1 = databaseBuilder.factory.buildStaticCourse({
     name: 'Static Course 1',
     description: 'Static Course 1 description',
     challengeIds: 'challenge1NQqfx9mYKUQEO,challengeTYFrFy5EGYEet,challenge1rSPsnisQ8ft4W',
     createdAt: new Date(),
     isActive: true,
-  });
+  }).id;
 
   databaseBuilder.factory.buildStaticCourse({
-    id: 'courseABC123CoCo',
     name: 'Static Course 2',
     description: 'Static Course 2 description',
     challengeIds: 'challenge1NQqfx9mYKUQEO',
@@ -17,4 +15,23 @@ export function staticCoursesBuilder(databaseBuilder) {
     isActive: false,
     deactivationReason: 'Les épreuves sont trop faciles',
   });
+
+  const staticCourseId3 = databaseBuilder.factory.buildStaticCourse({
+    name: 'Static Course 3 PLEIN DE TAGS',
+    description: 'Static Course 3 description',
+    challengeIds: 'challenge1NQqfx9mYKUQEO,challengeTYFrFy5EGYEet',
+    createdAt: new Date('2022-01-01'),
+    isActive: true,
+    deactivationReason: 'Les épreuves sont trop cools',
+  }).id;
+  const tagA = databaseBuilder.factory.buildStaticCourseTag({ label: 'Panel Externe' });
+  databaseBuilder.factory.linkTagTo({ staticCourseId: staticCourseId3, staticCourseTagId: tagA.id });
+  const tagB = databaseBuilder.factory.buildStaticCourseTag({ label: 'International' });
+  databaseBuilder.factory.linkTagTo({ staticCourseId: staticCourseId3, staticCourseTagId: tagB.id });
+  const tagC = databaseBuilder.factory.buildStaticCourseTag({ label: 'Pix+ BTP' });
+  databaseBuilder.factory.linkTagTo({ staticCourseId: staticCourseId3, staticCourseTagId: tagC.id });
+  const tagD = databaseBuilder.factory.buildStaticCourseTag({ label: 'Brouillon' });
+  databaseBuilder.factory.linkTagTo({ staticCourseId: staticCourseId3, staticCourseTagId: tagD.id });
+  const tagE = databaseBuilder.factory.buildStaticCourseTag({ label: 'Panel Interne' });
+  databaseBuilder.factory.linkTagTo({ staticCourseId: staticCourseId1, staticCourseTagId: tagE.id });
 }

--- a/api/lib/domain/readmodels/StaticCourseSummary.js
+++ b/api/lib/domain/readmodels/StaticCourseSummary.js
@@ -5,11 +5,13 @@ export class StaticCourseSummary {
     challengeCount,
     isActive,
     createdAt,
+    tags,
   }) {
     this.id = id;
     this.name = name;
     this.challengeCount = challengeCount;
     this.isActive = isActive;
     this.createdAt = createdAt;
+    this.tags = tags;
   }
 }

--- a/api/lib/domain/readmodels/StaticCourseTag.js
+++ b/api/lib/domain/readmodels/StaticCourseTag.js
@@ -1,0 +1,9 @@
+export class StaticCourseTag {
+  constructor({
+    id,
+    label,
+  }) {
+    this.id = id;
+    this.label = label;
+  }
+}

--- a/api/lib/domain/readmodels/index.js
+++ b/api/lib/domain/readmodels/index.js
@@ -2,3 +2,4 @@ export * from './ChallengeSummary.js';
 export * from './MissionSummary.js';
 export * from './StaticCourse.js';
 export * from './StaticCourseSummary.js';
+export * from './StaticCourseTag.js';

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -13,7 +13,13 @@ import _ from 'lodash';
 
 export async function findReadSummaries({ filter, page }) {
   const query = knex('static_courses')
-    .select('id', 'name', 'createdAt', 'challengeIds', 'isActive')
+    .select({
+      id: 'static_courses.id',
+      name: 'static_courses.name',
+      createdAt: 'static_courses.createdAt',
+      challengeIds: 'static_courses.challengeIds',
+      isActive: 'static_courses.isActive',
+    })
     .orderBy('createdAt', 'desc');
   if (!_.isNil(filter.isActive)) {
     query.andWhere('isActive', filter.isActive);

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -4,6 +4,7 @@ import {
   ChallengeSummary as ChallengeSummary_Read,
   StaticCourse as StaticCourse_Read,
   StaticCourseSummary as StaticCourseSummary_Read,
+  StaticCourseTag as StaticCourseTag_Read,
 } from '../../domain/readmodels/index.js';
 import { StaticCourse } from '../../domain/models/index.js';
 import { skillDatasource } from '../datasources/airtable/index.js';
@@ -19,8 +20,17 @@ export async function findReadSummaries({ filter, page }) {
       createdAt: 'static_courses.createdAt',
       challengeIds: 'static_courses.challengeIds',
       isActive: 'static_courses.isActive',
+      tags: knex.raw(`
+        json_agg(
+          json_build_object('id', "static_course_tags"."id", 'label', "static_course_tags"."label")
+          ORDER BY "static_course_tags"."label" ASC
+        )`),
     })
+    .leftJoin('static_courses_tags_link', 'static_courses.id', 'static_courses_tags_link.staticCourseId')
+    .leftJoin('static_course_tags', 'static_course_tags.id', 'static_courses_tags_link.staticCourseTagId')
+    .groupBy('static_courses.id')
     .orderBy('createdAt', 'desc');
+
   if (!_.isNil(filter.isActive)) {
     query.andWhere('isActive', filter.isActive);
   }
@@ -30,12 +40,14 @@ export async function findReadSummaries({ filter, page }) {
   const { results: staticCourses, pagination } = await fetchPage(query, page);
 
   const staticCoursesSummaries = staticCourses.map((staticCourse) => {
+    const tags = staticCourse.tags.map(({ id, label }) => new StaticCourseTag_Read({ id, label })).filter(({ id }) => id !== null);
     return new StaticCourseSummary_Read({
       id: staticCourse.id,
       name: staticCourse.name,
       createdAt: staticCourse.createdAt,
       challengeCount: staticCourse.challengeIds.split(',').length,
       isActive: staticCourse.isActive,
+      tags,
     });
   });
 

--- a/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/static-course-serializer.js
@@ -9,8 +9,18 @@ export function serializeSummary(staticCourseSummary, meta) {
       'createdAt',
       'challengeCount',
       'isActive',
+      'tags',
     ],
+    tags: {
+      ref: 'id',
+      included: true,
+      attributes: ['label'],
+    },
     meta,
+    typeForAttribute(attribute) {
+      if (attribute === 'tags') return 'static-course-tags';
+      return undefined;
+    },
   }).serialize(staticCourseSummary);
 }
 

--- a/api/tests/acceptance/application/static-courses/get_static-course-summaries_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course-summaries_test.js
@@ -28,6 +28,15 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
       createdAt: new Date('2021-01-05'),
       isActive: true,
     });
+    const tagAId = databaseBuilder.factory.buildStaticCourseTag({ label: 'TagA' }).id;
+    const tagBId = databaseBuilder.factory.buildStaticCourseTag({ label: 'TagB' }).id;
+    const tagCId = databaseBuilder.factory.buildStaticCourseTag({ label: 'TagC' }).id;
+    databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagAId, staticCourseId: 'courseid1' });
+    databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagBId, staticCourseId: 'courseid1' });
+    databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagBId, staticCourseId: 'courseid2' });
+    databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagCId, staticCourseId: 'courseid2' });
+    databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagCId, staticCourseId: 'courseid3' });
+    databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagAId, staticCourseId: 'courseid3' });
     await databaseBuilder.commit();
 
     // When
@@ -50,6 +59,20 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
           'challenge-count': 3,
           'is-active': true,
         },
+        relationships: {
+          tags: {
+            data: [
+              {
+                type: 'static-course-tags',
+                id: `${tagAId}`,
+              },
+              {
+                type: 'static-course-tags',
+                id: `${tagCId}`,
+              },
+            ],
+          },
+        },
       },
       {
         type: 'static-course-summaries',
@@ -60,7 +83,45 @@ describe('Acceptance | API | static courses | GET /api/static-course-summaries',
           'challenge-count': 2,
           'is-active': true,
         },
+        relationships: {
+          tags: {
+            data: [
+              {
+                type: 'static-course-tags',
+                id: `${tagAId}`,
+              },
+              {
+                type: 'static-course-tags',
+                id: `${tagBId}`,
+              },
+            ],
+          },
+        },
       }
+    ]);
+    expect(response.result.included).to.deep.equal([
+      {
+        type: 'static-course-tags',
+        id: `${tagAId}`,
+        attributes: {
+          label: 'TagA',
+        },
+        relationships: {},
+      },
+      {
+        type: 'static-course-tags',
+        id: `${tagCId}`,
+        attributes: {
+          label: 'TagC',
+        },
+      },
+      {
+        type: 'static-course-tags',
+        id: `${tagBId}`,
+        attributes: {
+          label: 'TagB',
+        },
+      },
     ]);
   });
 });

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -10,6 +10,9 @@ describe('Integration | Repository | static-course-repository', function() {
       const page = { number: 1, size: 20 };
       it('should return complete StaticCourseSummary model', async function() {
         // given
+        const tagA_DB = databaseBuilder.factory.buildStaticCourseTag({ label: 'TagA' });
+        const tagB_DB = databaseBuilder.factory.buildStaticCourseTag({ label: 'TagB' });
+        const tagC_DB = databaseBuilder.factory.buildStaticCourseTag({ label: 'TagC' });
         const staticCourseDB1 = databaseBuilder.factory.buildStaticCourse({
           id: 'staticCourse1_id',
           name : 'Mon super test statique 1',
@@ -17,12 +20,23 @@ describe('Integration | Repository | static-course-repository', function() {
           isActive : true,
           createdAt : new Date('2010-01-04'),
         });
+        databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagB_DB.id, staticCourseId: staticCourseDB1.id });
+        databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagC_DB.id, staticCourseId: staticCourseDB1.id });
         const staticCourseDB2 = databaseBuilder.factory.buildStaticCourse({
           id: 'staticCourse2_id',
           name : 'Mon super test statique 2',
           challengeIds : 'challengeABC, challengeGHI, challengeJKL',
           isActive : false,
           createdAt : new Date('2013-01-04'),
+        });
+        databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagB_DB.id, staticCourseId: staticCourseDB2.id });
+        databaseBuilder.factory.linkTagTo({ staticCourseTagId: tagA_DB.id, staticCourseId: staticCourseDB2.id });
+        const staticCourseDB3 = databaseBuilder.factory.buildStaticCourse({
+          id: 'staticCourse3_id',
+          name : 'Mon super test statique 3',
+          challengeIds : 'challengeABC',
+          isActive : true,
+          createdAt : new Date('2012-01-04'),
         });
         await databaseBuilder.commit();
 
@@ -32,12 +46,16 @@ describe('Integration | Repository | static-course-repository', function() {
         } = await findReadSummaries({ filter: {}, page });
 
         // then
+        const expectedTagA = domainBuilder.buildStaticCourseTag({ id: tagA_DB.id, label: tagA_DB.label });
+        const expectedTagB = domainBuilder.buildStaticCourseTag({ id: tagB_DB.id, label: tagB_DB.label });
+        const expectedTagC = domainBuilder.buildStaticCourseTag({ id: tagC_DB.id, label: tagC_DB.label });
         const expectedStaticCourseSummary1 = domainBuilder.buildStaticCourseSummary({
           id: staticCourseDB1.id,
           name: staticCourseDB1.name,
           challengeCount: 2,
           isActive: staticCourseDB1.isActive,
           createdAt: staticCourseDB1.createdAt,
+          tags: [expectedTagB, expectedTagC],
         });
         const expectedStaticCourseSummary2 = domainBuilder.buildStaticCourseSummary({
           id: staticCourseDB2.id,
@@ -45,9 +63,19 @@ describe('Integration | Repository | static-course-repository', function() {
           challengeCount: 3,
           isActive: staticCourseDB2.isActive,
           createdAt: staticCourseDB2.createdAt,
+          tags: [expectedTagA, expectedTagB],
+        });
+        const expectedStaticCourseSummary3 = domainBuilder.buildStaticCourseSummary({
+          id: staticCourseDB3.id,
+          name: staticCourseDB3.name,
+          challengeCount: 1,
+          isActive: staticCourseDB3.isActive,
+          createdAt: staticCourseDB3.createdAt,
+          tags: [],
         });
         expect(actualStaticCourseSummaries[0]).to.deep.equal(expectedStaticCourseSummary2);
-        expect(actualStaticCourseSummaries[1]).to.deep.equal(expectedStaticCourseSummary1);
+        expect(actualStaticCourseSummaries[1]).to.deep.equal(expectedStaticCourseSummary3);
+        expect(actualStaticCourseSummaries[2]).to.deep.equal(expectedStaticCourseSummary1);
       });
     });
     context('filter', function() {

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -6,6 +6,50 @@ import { challengeRepository, localizedChallengeRepository } from '../../../../l
 
 describe('Integration | Repository | static-course-repository', function() {
   context('#findReadSummaries', function() {
+    context('content', function() {
+      const page = { number: 1, size: 20 };
+      it('should return complete StaticCourseSummary model', async function() {
+        // given
+        const staticCourseDB1 = databaseBuilder.factory.buildStaticCourse({
+          id: 'staticCourse1_id',
+          name : 'Mon super test statique 1',
+          challengeIds : 'challengeABC, challengeDEF',
+          isActive : true,
+          createdAt : new Date('2010-01-04'),
+        });
+        const staticCourseDB2 = databaseBuilder.factory.buildStaticCourse({
+          id: 'staticCourse2_id',
+          name : 'Mon super test statique 2',
+          challengeIds : 'challengeABC, challengeGHI, challengeJKL',
+          isActive : false,
+          createdAt : new Date('2013-01-04'),
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const {
+          results: actualStaticCourseSummaries,
+        } = await findReadSummaries({ filter: {}, page });
+
+        // then
+        const expectedStaticCourseSummary1 = domainBuilder.buildStaticCourseSummary({
+          id: staticCourseDB1.id,
+          name: staticCourseDB1.name,
+          challengeCount: 2,
+          isActive: staticCourseDB1.isActive,
+          createdAt: staticCourseDB1.createdAt,
+        });
+        const expectedStaticCourseSummary2 = domainBuilder.buildStaticCourseSummary({
+          id: staticCourseDB2.id,
+          name: staticCourseDB2.name,
+          challengeCount: 3,
+          isActive: staticCourseDB2.isActive,
+          createdAt: staticCourseDB2.createdAt,
+        });
+        expect(actualStaticCourseSummaries[0]).to.deep.equal(expectedStaticCourseSummary2);
+        expect(actualStaticCourseSummaries[1]).to.deep.equal(expectedStaticCourseSummary1);
+      });
+    });
     context('filter', function() {
       context('isActive', function() {
         const page = { number: 1, size: 20 };

--- a/api/tests/tooling/database-builder/factory/build-release.js
+++ b/api/tests/tooling/database-builder/factory/build-release.js
@@ -1,7 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildRelease({
-  id,
+  id = databaseBuffer.nextId++,
   content,
   createdAt = new Date(),
 } = {}) {

--- a/api/tests/tooling/database-builder/factory/build-static-course-tag.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course-tag.js
@@ -1,0 +1,24 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildStaticCourseTag({
+  id = databaseBuffer.nextId++,
+  label,
+} = {}) {
+
+  const values = { id, label };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'static_course_tags',
+    values,
+  });
+}
+
+export function linkTagTo({
+  staticCourseTagId,
+  staticCourseId,
+} = {}) {
+  databaseBuffer.pushInsertable({
+    tableName: 'static_courses_tags_link',
+    values: { id: databaseBuffer.nextId++, staticCourseTagId, staticCourseId },
+  });
+}

--- a/api/tests/tooling/database-builder/factory/build-static-course.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course.js
@@ -1,7 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildStaticCourse({
-  id = 'staticCourseABC123',
+  id = `staticCourse${databaseBuffer.nextId++}`,
   name = 'Mon super test statique',
   description = 'Ma super description de test statique',
   challengeIds = 'challengeABC, challengeDEF',

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -1,7 +1,7 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildUser({
-  id,
+  id = databaseBuffer.nextId++,
   name,
   trigram,
   access,

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -3,5 +3,6 @@ export * from './build-localized-challenge-attachment.js';
 export * from './build-mission.js';
 export * from './build-release.js';
 export * from './build-static-course.js';
+export * from './build-static-course-tag.js';
 export * from './build-translation.js';
 export * from './build-user.js';

--- a/api/tests/tooling/domain-builder/factory/build-area-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-area-for-release.js
@@ -1,4 +1,4 @@
-import { AreaForRelease } from '../../../../lib/domain/models/release/AreaForRelease.js';
+import { AreaForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildAreaForRelease({
   id = 'recArea1',

--- a/api/tests/tooling/domain-builder/factory/build-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-area.js
@@ -1,4 +1,4 @@
-import { Area } from '../../../../lib/domain/models/Area';
+import { Area } from '../../../../lib/domain/models/index.js';
 
 export function buildArea({
   id = 'recArea1',

--- a/api/tests/tooling/domain-builder/factory/build-attachment.js
+++ b/api/tests/tooling/domain-builder/factory/build-attachment.js
@@ -1,4 +1,4 @@
-import { Attachment } from '../../../../lib/domain/models/Attachment';
+import { Attachment } from '../../../../lib/domain/models/index.js';
 
 export function buildAttachment({
   id = 'attachmentId',

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -1,4 +1,4 @@
-import { ChallengeForRelease } from '../../../../lib/domain/models/release/ChallengeForRelease.js';
+import { ChallengeForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildChallengeForRelease({
   id = 'recwWzTquPlvIl4So',

--- a/api/tests/tooling/domain-builder/factory/build-competence-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence-for-release.js
@@ -1,4 +1,4 @@
-import { CompetenceForRelease } from '../../../../lib/domain/models/release/CompetenceForRelease.js';
+import { CompetenceForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildCompetenceForRelease({
   id = 'recCompetence1',

--- a/api/tests/tooling/domain-builder/factory/build-content-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-content-for-release.js
@@ -1,4 +1,4 @@
-import { Content } from '../../../../lib/domain/models/release/Content.js';
+import { Content } from '../../../../lib/domain/models/release/index.js';
 
 export function buildContentForRelease({
   areas = [],

--- a/api/tests/tooling/domain-builder/factory/build-course-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-course-for-release.js
@@ -1,4 +1,4 @@
-import { CourseForRelease } from '../../../../lib/domain/models/release/CourseForRelease.js';
+import { CourseForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildCourseForRelease({
   id = 'recPBOj7JzBcgXEtO',

--- a/api/tests/tooling/domain-builder/factory/build-domain-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-domain-release.js
@@ -1,4 +1,4 @@
-import { Release } from '../../../../lib/domain/models/release/Release.js';
+import { Release } from '../../../../lib/domain/models/release/index.js';
 import { buildContentForRelease } from './build-content-for-release.js';
 
 export function buildDomainRelease({

--- a/api/tests/tooling/domain-builder/factory/build-framework-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-framework-for-release.js
@@ -1,4 +1,4 @@
-import { FrameworkForRelease } from '../../../../lib/domain/models/release/FrameworkForRelease.js';
+import { FrameworkForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildFrameworkForRelease(
   {

--- a/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
@@ -1,4 +1,4 @@
-import { LocalizedChallenge } from '../../../../lib/domain/models';
+import { LocalizedChallenge } from '../../../../lib/domain/models/index.js';
 
 export function buildLocalizedChallenge({
   id = 'persistant id',

--- a/api/tests/tooling/domain-builder/factory/build-skill-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-skill-for-release.js
@@ -1,4 +1,4 @@
-import { SkillForRelease } from '../../../../lib/domain/models/release/SkillForRelease.js';
+import { SkillForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildSkillForRelease({
   id = 'recTIddrkopID28Ep',

--- a/api/tests/tooling/domain-builder/factory/build-skill.js
+++ b/api/tests/tooling/domain-builder/factory/build-skill.js
@@ -1,4 +1,4 @@
-import { Skill } from '../../../../lib/domain/models/Skill.js';
+import { Skill } from '../../../../lib/domain/models/index.js';
 
 export function buildSkill({
   id = 'recTIddrkopID28Ep',

--- a/api/tests/tooling/domain-builder/factory/build-static-course-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-static-course-summary.js
@@ -1,0 +1,19 @@
+import { StaticCourseSummary } from '../../../../lib/domain/readmodels/index.js';
+
+export function buildStaticCourseSummary({
+  id = 'courseABC123',
+  name = 'static course name',
+  challengeCount = 4,
+  isActive = true,
+  createdAt = new Date(),
+  tags = [],
+} = {}) {
+  return new StaticCourseSummary({
+    id,
+    name,
+    challengeCount,
+    isActive,
+    createdAt,
+    tags,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/build-static-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-static-course.js
@@ -1,4 +1,4 @@
-import { StaticCourse } from '../../../../lib/domain/models/StaticCourse.js';
+import { StaticCourse } from '../../../../lib/domain/models/index.js';
 
 export function buildStaticCourse({
   id = 'courseABC123',

--- a/api/tests/tooling/domain-builder/factory/build-tag.js
+++ b/api/tests/tooling/domain-builder/factory/build-tag.js
@@ -1,0 +1,11 @@
+import { StaticCourseTag } from '../../../../lib/domain/readmodels/index.js';
+
+export function buildStaticCourseTag({
+  id = 123,
+  label = 'Label de tag',
+} = {}) {
+  return new StaticCourseTag({
+    id,
+    label,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/build-thematic-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-thematic-for-release.js
@@ -1,4 +1,4 @@
-import { ThematicForRelease } from '../../../../lib/domain/models/release/ThematicForRelease.js';
+import { ThematicForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildThematicForRelease({
   id = 'recFvllz2Ckz',

--- a/api/tests/tooling/domain-builder/factory/build-tube-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube-for-release.js
@@ -1,4 +1,4 @@
-import { TubeForRelease } from '../../../../lib/domain/models/release/TubeForRelease.js';
+import { TubeForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildTubeForRelease({
   id = 'recTIddrkopID23Fp',

--- a/api/tests/tooling/domain-builder/factory/build-tutorial-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-tutorial-for-release.js
@@ -1,4 +1,4 @@
-import { TutorialForRelease } from '../../../../lib/domain/models/release/TutorialForRelease.js';
+import { TutorialForRelease } from '../../../../lib/domain/models/release/index.js';
 
 export function buildTutorialForRelease(
   {

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -18,6 +18,7 @@ export * from './build-skill.js';
 export * from './build-skill-for-release.js';
 export * from './build-static-course.js';
 export * from './build-static-course-summary.js';
+export * from './build-tag.js';
 export * from './build-thematic-for-release.js';
 export * from './build-tube-for-release.js';
 export * from './build-tutorial-for-release.js';

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -17,6 +17,7 @@ export * from './build-release.js';
 export * from './build-skill.js';
 export * from './build-skill-for-release.js';
 export * from './build-static-course.js';
+export * from './build-static-course-summary.js';
 export * from './build-thematic-for-release.js';
 export * from './build-tube-for-release.js';
 export * from './build-tutorial-for-release.js';

--- a/pix-editor/app/controllers/authenticated/static-courses/list.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/list.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import ENV from 'pixeditor/config/environment';
 
 export default class StaticCoursesController extends Controller {
   @service router;
@@ -13,6 +14,7 @@ export default class StaticCoursesController extends Controller {
   @tracked tempIsActive = true;
   @tracked name = '';
   @tracked tempName = '';
+  @tracked shouldDisplayTags = ENV.APP.ENABLE_STATIC_COURSE_TAGS;
 
   @action
   async copyStaticCoursePreviewUrl(staticCourseSummary) {

--- a/pix-editor/app/models/static-course-summary.js
+++ b/pix-editor/app/models/static-course-summary.js
@@ -1,10 +1,11 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class StaticCourseSummaryModel extends Model {
   @attr name;
   @attr challengeCount;
   @attr isActive;
   @attr createdAt;
+  @hasMany('static-course-tag') tags;
 
   get previewURL() {
     return `https://app.pix.fr/courses/${this.id}`;

--- a/pix-editor/app/models/static-course-tag.js
+++ b/pix-editor/app/models/static-course-tag.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class StaticCourseTag extends Model {
+  @attr label;
+}

--- a/pix-editor/app/styles/authenticated/static-courses/list.scss
+++ b/pix-editor/app/styles/authenticated/static-courses/list.scss
@@ -5,3 +5,7 @@
 .page-section {
   padding: 0 !important;
 }
+
+.static-course-tag {
+  margin-bottom: 8px;
+}

--- a/pix-editor/app/styles/globals/table.scss
+++ b/pix-editor/app/styles/globals/table.scss
@@ -131,7 +131,7 @@
   th {
     word-wrap: break-word;
     text-align: left;
-    padding-left: 24px;
+    padding: 12px;
   }
 
   th::first-letter {

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -74,7 +74,7 @@
         <thead>
           <tr>
             <th>Nom</th>
-            <th>Tags</th>
+            {{#if this.shouldDisplayTags}}<th>Tags</th>{{/if}}
             <th>Epreuves</th>
             <th>Créé le</th>
             <th>Statut</th>
@@ -87,13 +87,15 @@
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
               {{staticCourseSummary.name}}
             </td>
-            <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
-              {{#each staticCourseSummary.tags as |tag|}}
-                <PixTag class="static-course-tag" @color="yellow-light">
-                  {{tag.label}}
-                </PixTag>
-              {{/each}}
-            </td>
+            {{#if this.shouldDisplayTags}}
+              <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
+                {{#each staticCourseSummary.tags as |tag|}}
+                  <PixTag class="static-course-tag" @color="yellow-light">
+                    {{tag.label}}
+                  </PixTag>
+                {{/each}}
+              </td>
+            {{/if}}
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{staticCourseSummary.challengeCount}}</td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{dayjs-format staticCourseSummary.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -65,6 +65,7 @@
       <table class="content-text content-text--small">
         <colgroup class="table__column">
           <col class="table__column--wide" />
+          <col class="table__column--wide" />
           <col class="table__column--small" />
           <col class="table__column--small" />
           <col class="table__column--small" />
@@ -73,6 +74,7 @@
         <thead>
           <tr>
             <th>Nom</th>
+            <th>Tags</th>
             <th>Epreuves</th>
             <th>Créé le</th>
             <th>Statut</th>
@@ -84,6 +86,13 @@
           <tr class="tr--clickable">
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
               {{staticCourseSummary.name}}
+            </td>
+            <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
+              {{#each staticCourseSummary.tags as |tag|}}
+                <PixTag class="static-course-tag" @color="yellow-light">
+                  {{tag.label}}
+                </PixTag>
+              {{/each}}
             </td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{staticCourseSummary.challengeCount}}</td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{dayjs-format staticCourseSummary.createdAt "DD/MM/YYYY" allow-empty=true}}</td>

--- a/pix-editor/config/environment.js
+++ b/pix-editor/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function (environment) {
         defaultValue: 4,
         minValue: 1
       }),
+      ENABLE_STATIC_COURSE_TAGS: _isFeatureEnabled(process.env.ENABLE_STATIC_COURSE_TAGS || 'true'),
     },
 
     fontawesome: {

--- a/pix-editor/mirage/serializers/static-course-summary.js
+++ b/pix-editor/mirage/serializers/static-course-summary.js
@@ -1,3 +1,7 @@
 import ApplicationSerializer from './application';
 
-export default ApplicationSerializer.extend({});
+const include = ['tags'];
+
+export default ApplicationSerializer.extend({
+  include,
+});

--- a/pix-editor/tests/acceptance/static-courses/list-test.js
+++ b/pix-editor/tests/acceptance/static-courses/list-test.js
@@ -12,8 +12,13 @@ module('Acceptance | Static Courses | List', function(hooks) {
   hooks.beforeEach(function() {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
-    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01') });
-    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: false, challengeCount: 10, createdAt: new Date('2019-01-01') });
+    const tags = [
+      this.server.create('static-course-tag', { id: 'tagA', label: 'tagA' }),
+      this.server.create('static-course-tag', { id: 'tagB', label: 'tagB' }),
+    ];
+    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01'), tags });
+    this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: false, challengeCount: 10, createdAt: new Date('2019-01-01'), tags: [] });
+
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
     return authenticateSession();
   });
@@ -42,5 +47,22 @@ module('Acceptance | Static Courses | List', function(hooks) {
     assert.strictEqual(currentURL(), '/static-courses?name=prem');
     assert.dom(screen.getByText('Premier test statique')).exists();
     assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
+  });
+
+  test('should render correctly a row', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Tests statiques');
+    await click(await screen.findByRole('button', { name: 'Statut' }));
+    await fillByLabel('Nom', 'prem');
+    await triggerEvent(await screen.getByLabelText('Nom'), 'keyup', '');
+    await click(await screen.findByRole('button', { name: 'Filtrer' }));
+
+    // then
+    assert.dom(screen.getByText('Premier test statique')).exists();
+    assert.dom(screen.getByText('tagA')).exists();
+    assert.dom(screen.getByText('3')).exists();
+    assert.dom(screen.getByText('01/01/2020')).exists();
+    assert.dom(screen.getByText('Actif')).exists();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On introduit le concept de tag autour des tests statiques.

## :robot: Proposition
Pouvoir voir la liste des tags sur chaque ligne de la liste des tests statiques.
On limite la largeur de la colonne à 30 caractères.
On met les tags dans des bidules arrondis là.

## :rainbow: Remarques

## :100: Pour tester
PixEditor > Tests statiques et regarder les tags. Pour bidouiller avec les data il va falloir dans un premier temps le faire direct en bdd
