### PR TITLE
[FEATURE] Vérifier les colonnes du CSV avant l'import de la calibration certif V3 (PIX-11415)

### DIFF
--- a/scripts/populate-alpha-and-delta-column-with-csv/index.js
+++ b/scripts/populate-alpha-and-delta-column-with-csv/index.js
@@ -19,11 +19,19 @@ const HEADERS_MAPPING = {
   discriminants: 'alpha',
 };
 
+const getMissingHeaders = (headers) => Object.keys(HEADERS_MAPPING).filter((h) => !headers.includes(h));
+
 export function parseData(csvData) {
   return new Promise((resolve, reject) => {
     const result = [];
 
-    parseString(csvData, { headers: (headers) => headers.map((h) => HEADERS_MAPPING[h]) })
+    parseString(csvData, { headers: (headers) => {
+      const missingHeaders = getMissingHeaders(headers);
+      if (missingHeaders.length > 0) {
+        reject(new Error(`Missing header: ${missingHeaders.join(',')}`));
+      }
+      return headers.map((h) => HEADERS_MAPPING[h]);
+    } })
       .on('error', (error) => {
         console.error(error);
         reject(error);

--- a/scripts/populate-alpha-and-delta-column/index-tests.js
+++ b/scripts/populate-alpha-and-delta-column/index-tests.js
@@ -6,9 +6,22 @@ const expect = chai.expect;
 import _ from 'lodash';
 import { matchData, findAirtableIds, updateRecords } from './index.js';
 import airtable from 'airtable';
+import { parseData } from '../populate-alpha-and-delta-column-with-csv/index.js';
 const { Record: AirtableRecord } = airtable;
 
 describe('Populate alpha and delta column', function() {
+  describe('#parseData', function() {
+    describe('when an expected header is missing', function() {
+      it('should throw an error', async function() {
+        const data = 'missing,difficulties\nrec1,0.8423189520825876\nrec2,-0.9423189520825878';
+        const dataPromise = parseData(data);
+        const parseDataError = await dataPromise.catch((error) => error);
+
+        expect(parseDataError).to.deep.equal(new Error('Missing header: items,discriminants'));
+      });
+    });
+  });
+
   describe('#matchData', function() {
     it('should return a object table with challenge persistent id, alpha and delta',  async function() {
       const csvData = 'ChallengeIdHash,challengeId\nhash1,recPix1\nhash2,recPix2';


### PR DESCRIPTION
## :unicorn: Problème
Une erreur dans les noms de colonnes attendus par le script d’import risque de causer une suppression de l’intégralité de la calibration.

## :robot: Proposition
Il faut retourner une erreur pour que le script ne s’exécute pas lorsque les noms de colonnes ne sont pas les bons.
