### PR TITLE
[BUGFIX] Impossible d'enregistrer une illustration sur une épreuve NL (PIX-11416)

### DIFF
--- a/pix-editor/app/models/attachment.js
+++ b/pix-editor/app/models/attachment.js
@@ -7,7 +7,6 @@ export default class Attachment extends Model {
   @attr size;
   @attr mimeType;
   @attr type;
-  @attr alt;
 
   @tracked cloneBeforeSave;
 

--- a/pix-editor/tests/unit/serializers/attachment-test.js
+++ b/pix-editor/tests/unit/serializers/attachment-test.js
@@ -13,8 +13,7 @@ module('Unit | Serializer | attachment', function (hooks) {
       mimeType: 'mimeType',
       size: 'size',
       type: 'type',
-      alt: 'alt',
-      challenge
+      challenge,
     });
 
     const expectedSerializedAttachment = {
@@ -23,7 +22,6 @@ module('Unit | Serializer | attachment', function (hooks) {
       mimeType: 'mimeType',
       size: 'size',
       type: 'type',
-      alt: 'alt',
       challengeId: ['myAirtableId'],
       localizedChallengeId: 'challengeId'
     };


### PR DESCRIPTION
## :unicorn: Problème

Erreur `unknown field "alt"` revenant de Airtable.

## :robot: Proposition

Supprimer le champ alt du model front Attachment.

## :rainbow: Remarques

N/A

## :100: Pour tester

Enregistrer une illustration sur une épreuve NL.