### PR TITLE
[FEATURE] Popup de rechargement lors du déploiement d'une nouvelle version

### DIFF
--- a/pix-editor/app/adapters/api.js
+++ b/pix-editor/app/adapters/api.js
@@ -1,0 +1,7 @@
+import RESTAdapter from '@ember-data/adapter/rest';
+
+export default class ApiAdapter extends RESTAdapter {
+  urlForQueryRecord() {
+    return 'api';
+  }
+}

--- a/pix-editor/app/models/api.js
+++ b/pix-editor/app/models/api.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class ApiModel extends Model {
+  @attr version;
+}

--- a/pix-editor/app/serializers/api.js
+++ b/pix-editor/app/serializers/api.js
@@ -1,0 +1,13 @@
+import RESTSerializer from '@ember-data/serializer/rest';
+
+export default class ApiSerializer extends RESTSerializer {
+  normalizeResponse(store, primaryModelClass, payload, id, requestType) {
+    const apis = { id: 0 };
+    for (const key of Object.keys(payload)) {
+      apis[key] = payload[key];
+      delete payload[key];
+    }
+    payload.apis = apis;
+    return super.normalizeResponse(store, primaryModelClass, payload, id, requestType);
+  }
+}

--- a/pix-editor/tests/unit/controllers/authenticated-test.js
+++ b/pix-editor/tests/unit/controllers/authenticated-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated', function(hooks) {
+  setupTest(hooks);
+
+  let controller, confirmAskStub, storeQueryStub, reloadStub;
+
+  hooks.beforeEach(function () {
+    storeQueryStub = sinon.stub();
+    class Store extends Service {
+      queryRecord = storeQueryStub;
+    }
+    this.owner.register('service:store', Store);
+
+    confirmAskStub = sinon.stub();
+    class Confirm extends Service {
+      ask = confirmAskStub;
+      setTarget = sinon.stub();
+    }
+    this.owner.register('service:confirm', Confirm);
+
+    controller = this.owner.lookup('controller:authenticated');
+
+    reloadStub = sinon.stub();
+  });
+
+  test('it should reload when user confirms new version notification', async function(assert) {
+    // given
+    storeQueryStub.resolves({ version: 'nouvelle version' });
+    confirmAskStub.resolves();
+
+    // when
+    await controller.checkApiVersion(reloadStub);
+
+    // then
+    assert.true(reloadStub.calledOnce, 'window.location.reload() called');
+  });
+
+
+  test('it should not reload when user does not confirm new version notification', async function(assert) {
+    // given
+    storeQueryStub.resolves({ version: 'nouvelle version' });
+    confirmAskStub.rejects();
+
+    // when
+    await controller.checkApiVersion(reloadStub);
+
+    // then
+    assert.false(reloadStub.calledOnce, 'window.location.reload() called');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs continuent d'utiliser l'ancienne version du front après une mise en prod.

## :robot: Proposition
Ajouter une popup proposant aux utilisateurs de recharger le front quand une nouvelle version est mise en prod.

## :rainbow: Remarques
N/A

## :100: Pour tester
C'est compliqué.