### PR TITLE
[FEATURE] Ajoute les Localized Challenge au panneau d'administration.

### DIFF
--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -1,6 +1,6 @@
 import { AdminJS, ComponentLoader } from 'adminjs';
 import AdminJSSequelize from '@adminjs/sequelize';
-import { User, Release, Translations } from './models.js';
+import { User, Release, Translations, LocalizedChallenge } from './models.js';
 import { checkUserIsAuthenticatedViaBasicAndAdmin } from '../../../application/security-pre-handlers.js';
 
 AdminJS.registerAdapter(AdminJSSequelize);
@@ -10,6 +10,21 @@ export { default as plugin } from '@adminjs/hapi';
 const componentLoader = new ComponentLoader();
 const Components = {
   ImportExportComponent: componentLoader.add('ImportExportComponent', './components/ImportExportComponent.jsx'),
+};
+
+const readOnlyOptions =  {
+  edit: {
+    isVisible: false,
+  },
+  new: {
+    isVisible: false,
+  },
+  delete: {
+    isVisible: false,
+  },
+  bulkDelete: {
+    isVisible: false,
+  },
 };
 
 export const options = {
@@ -51,17 +66,27 @@ export const options = {
     },
     {
       resource: Release,
+      options: {
+        actions: readOnlyOptions,
+      }
     },
     {
       resource: Translations,
       options: {
         actions: {
+          ...readOnlyOptions,
           importExport: {
             actionType: 'resource',
             component: Components.ImportExportComponent,
           },
         },
       },
+    },
+    {
+      resource: LocalizedChallenge,
+      options: {
+        actions: readOnlyOptions,
+      }
     },
   ],
   auth: {

--- a/api/lib/infrastructure/plugins/adminjs/models.js
+++ b/api/lib/infrastructure/plugins/adminjs/models.js
@@ -24,6 +24,34 @@ export const User = sequelize.define(
   {}
 );
 
+export const LocalizedChallenge = sequelize.define(
+  'localized_challenges',
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    challengeId: {
+      type: DataTypes.STRING,
+    },
+    locale: {
+      type: DataTypes.STRING,
+    },
+    status: {
+      type: DataTypes.STRING,
+    },
+    embedUrl: {
+      type: DataTypes.STRING,
+    },
+    geography: {
+      type: DataTypes.STRING,
+    },
+  },
+  {
+    timestamps: false,
+  },
+);
+
 export const Release = sequelize.define(
   'release',
   {


### PR DESCRIPTION
## :unicorn: Problème

Les épreuves traduites (LocalizedChallenge) ne sont pas visibles dans le panneau d'administration.

## :robot: Proposition

Ajouter les LocalizedChallenge dans la configuration adminjs.

## :rainbow: Remarques

On en profite pour limiter les resources Release, Translation et LocalizedChallenge en lecture seule dans le panneau d'administration.

## :100: Pour tester

Se connecter à l'interface d'admin (/admin).
Se rendre sur `LocalizedChallenge`.
Constater que les épreuves traduites sont affichées.
