### PR TITLE
[BUGFIX] URL pour vérifier la version d'API

### DIFF
--- a/pix-editor/app/adapters/api.js
+++ b/pix-editor/app/adapters/api.js
@@ -2,6 +2,6 @@ import RESTAdapter from '@ember-data/adapter/rest';
 
 export default class ApiAdapter extends RESTAdapter {
   urlForQueryRecord() {
-    return 'api';
+    return '/api';
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

L'URL utilisée pour vérifier la version d'API est relative à la page courante...

## :robot: Proposition

Utiliser une URL absolue.

## :rainbow: Remarques

N/A

## :100: Pour tester

Se placer sur une page autre que la page d'accueil et vérifier que le poll de version se fait correctement.