### PR TITLE
[BUGFIX] L'affichage des consignes en mode édition semblent être en gras.(PIX-11531)

### DIFF
--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -207,6 +207,10 @@ img.clickable {
       border-radius: 0.28571429rem;
     }
 
+    .ProseMirror {
+      font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    }
+
     .field.disabled {
       textarea,
       input[type="text"],


### PR DESCRIPTION
## :unicorn: Problème
L'affichage des consignes en mode édition semblent être en gras.

## :robot: Proposition
Utiliser la font `lato` qui est moins grasse

## :rainbow: Remarques
RAS

## :100: Pour tester
Modifier la consigne d'une épreuve et contemplé le texte qui ne semble pas être mis en gras.
Image du drame : 
![image](https://github.com/1024pix/pix-editor/assets/40383724/5e68f208-06f5-403e-85d1-c08e8fde0a42)

