### PR TITLE
[FEATURE] Télécharge les traductions depuis Phrase à chaque création de Release.

### DIFF
--- a/api/lib/domain/usecases/download-translation-from-phrase.js
+++ b/api/lib/domain/usecases/download-translation-from-phrase.js
@@ -4,16 +4,22 @@ import { logger } from '../../infrastructure/logger.js';
 import { importTranslations } from './import-translations.js';
 import { Readable } from 'node:stream';
 
-export async function downloadTranslationFromPhrase() {
+export async function downloadTranslationFromPhrase(phraseApi = { Configuration, LocalesApi }) {
+
   const { apiKey, projectId } = config.phrase;
 
-  const configuration = new Configuration({
+  if (!apiKey || !projectId) {
+    logger.info('Phrase API Key or Project Id is not defined. Skipping download translations.');
+    return;
+  }
+
+  const configuration = new phraseApi.Configuration({
     fetchApi: fetch,
     apiKey: `token ${apiKey}`,
   });
 
   try {
-    const localesApi = new LocalesApi(configuration);
+    const localesApi = new phraseApi.LocalesApi(configuration);
 
     const phraseLocales = await localesApi.localesList({ projectId });
 

--- a/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
@@ -1,6 +1,7 @@
 import { SlackNotifier } from '../notifications/SlackNotifier.js';
 import * as checkUrlsJob from './check-urls-job.js';
 import * as config from '../../config.js';
+import { downloadTranslationFromPhrase } from '../../domain/usecases/download-translation-from-phrase.js';
 import * as learningContentNotification from '../../domain/services/learning-content-notification.js';
 import { logger } from '../logger.js';
 import { releaseRepository } from '../repositories/index.js';
@@ -8,6 +9,7 @@ import { disconnect } from '../../../db/knex-database-connection.js';
 
 export default async function releaseJobProcessor(job) {
   try {
+    await downloadTranslationFromPhrase();
     const releaseId = await releaseRepository.create();
     if (_isSlackNotificationGloballyEnabled() && job.data.slackNotification === true) {
       await learningContentNotification.notifyReleaseCreationSuccess(new SlackNotifier(config.notifications.slack.webhookUrl));

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
+import nock from 'nock';
 import {
   airtableBuilder,
   databaseBuilder,
@@ -718,6 +719,18 @@ describe('Acceptance | Controller | release-controller', () => {
         const server = await createServer();
         await databaseBuilder.commit();
         const expectedCurrentContent = await mockContentForRelease();
+
+        nock('https://api.phrase.com')
+          .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales')
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, [
+            {
+              id: 'frLocaleId',
+              name: 'fr',
+              code: 'fr',
+              default: true,
+            },
+          ]);
 
         // When
         const response = await server.inject({

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,4 +1,4 @@
-import { afterEach } from 'vitest';
+import { beforeEach, afterEach } from 'vitest';
 import * as infraErrors from '../lib/infrastructure/errors.js';
 import { cache } from '../lib/infrastructure/cache.js';
 import nock from 'nock';
@@ -7,6 +7,10 @@ import { AirtableBuilder } from './tooling/airtable-builder/airtable-builder.js'
 import { InputOutputDataBuilder }  from './tooling/input-output-data-builder/input-output-data-builder.js';
 import { knex } from '../db/knex-database-connection.js';
 import './tooling/vitest-custom-matchers/index.js';
+
+beforeEach(() => {
+  nock.disableNetConnect();
+});
 
 afterEach(async () => {
   airtableBuilder.cleanAll();

--- a/api/tests/unit/domain/usecases/download-translation-from-phrase_test.js
+++ b/api/tests/unit/domain/usecases/download-translation-from-phrase_test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { downloadTranslationFromPhrase } from '../../../../lib/domain/usecases';
+import * as config from '../../../../lib/config.js';
+
+describe('Unit | Domain | Usecases | download-translation-from-phrase', () => {
+  it('should not download from Phrase when apiKey is not set', async () => {
+    // given
+    vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
+
+    const ConfigurationStub = vi.fn();
+
+    // when
+    await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+
+    // then
+    expect(ConfigurationStub).not.toHaveBeenCalled();
+  });
+
+  it('should not download from Phrase when projectId is not set', async () => {
+    // given
+    vi.spyOn(config.phrase, 'projectId', 'get').mockReturnValue(undefined);
+
+    const ConfigurationStub = vi.fn();
+
+    // when
+    await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+
+    // then
+    expect(ConfigurationStub).not.toHaveBeenCalled();
+  });
+
+  it('should download from Phrase when config is set', async () => {
+    // given
+    const ConfigurationStub = class {};
+    const localesListStub = vi.fn().mockResolvedValue([]);
+    const LocalesApiStub = class {
+      localesList() { return localesListStub(); }
+    };
+
+    // when
+    await downloadTranslationFromPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub });
+
+    // then
+    expect(localesListStub).toHaveBeenCalled();
+  });
+});

--- a/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
@@ -3,6 +3,7 @@ import { releaseRepository } from '../../../../lib/infrastructure/repositories/i
 import { Release } from '../../../../lib/domain/models/release/Release.js';
 import releaseJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/release-job-processor.js';
 import * as learningContentNotification from '../../../../lib/domain/services/learning-content-notification.js';
+import * as downloadTranslationFromPhraseUseCase from '../../../../lib/domain/usecases/download-translation-from-phrase.js';
 import { logger } from '../../../../lib/infrastructure/logger.js';
 import { SlackNotifier } from '../../../../lib/infrastructure/notifications/SlackNotifier.js';
 import * as config from '../../../../lib/config.js';
@@ -14,6 +15,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
     it('should create and persist a new Release in data repository', async () => {
       // given
+      vi.spyOn(downloadTranslationFromPhraseUseCase, 'downloadTranslationFromPhrase').mockResolvedValue();
       vi.spyOn(releaseRepository, 'create').mockResolvedValue(resolvedCreatedRelease);
       vi.spyOn(learningContentNotification, 'notifyReleaseCreationSuccess').mockResolvedValue();
 
@@ -29,6 +31,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
       const resolvedCreatedReleaseId = 1;
 
       beforeEach(() => {
+        vi.spyOn(downloadTranslationFromPhraseUseCase, 'downloadTranslationFromPhrase').mockResolvedValue();
         vi.spyOn(releaseRepository, 'create').mockResolvedValue(resolvedCreatedReleaseId);
         vi.spyOn(learningContentNotification, 'notifyReleaseCreationSuccess').mockResolvedValue();
       });
@@ -90,6 +93,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
     describe('when release creation failed', () => {
 
       beforeEach(() => {
+        vi.spyOn(downloadTranslationFromPhraseUseCase, 'downloadTranslationFromPhrase').mockResolvedValue();
         vi.spyOn(releaseRepository, 'create').mockRejectedValue(new Error('Network error'));
         vi.spyOn(learningContentNotification, 'notifyReleaseCreationFailure').mockResolvedValue();
       });


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Le téléchargement des traductions depuis Phrase est une opération uniquement manuelle via un bouton dans l'interface d'administration.
La cohérence entre les textes présents dans LCMS et ceux présents dans Phrase n'est pas garantie.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On automatise le téléchargement des traductions lors de chaque création de Release du référentiel.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

Afin de ne pas être bloquant, le téléchargement n'est pas tenté si un paramètre de configuration (PHRASE_PROJECT_ID ou PHRASE_API_KEY) n'est pas valorisé dans les variables d'environnement.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Ajouter une traduction dans Phrase dans le projet lié aux Review Apps (Référentiel - Intégration).
Créer une release sur la Review App via le endpoint dédié : `POST /api/releases`.
Vérifier que dans la release on a bien la traduction rajouté dans phrase.
