### PR TITLE
[FEATURE] Création de script pour ajouter des tags de tests statiques (PIX-11538)

### DIFF
--- a/api/scripts/create-tags-for-static-courses/index.js
+++ b/api/scripts/create-tags-for-static-courses/index.js
@@ -1,0 +1,119 @@
+import _ from 'lodash';
+import dotenv from 'dotenv';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+import { parseFile } from 'fast-csv';
+import { streamToPromiseArray } from '../../lib/infrastructure/utils/stream-to-promise.js';
+
+dotenv.config();
+const TAG_LABEL_MAX_LENGTH = 30;
+
+function removeCapitalizeAndDiacritics(str) {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+async function readCsvFile(csvFilePath) {
+  const [data] = await streamToPromiseArray(parseFile(csvFilePath, { delimiter: ',', headers: false }));
+  return data;
+}
+
+async function checkDuplicatesInDB(tagLabelsToInsert) {
+  const uniqueTagLabelsToInsert = [];
+  const existingTags = await knex('static_course_tags').select('id', 'label');
+  for (const tagLabel of tagLabelsToInsert) {
+    const alreadyExistingTag = existingTags.find(({ label }) => removeCapitalizeAndDiacritics(label) === removeCapitalizeAndDiacritics(tagLabel));
+    if (!alreadyExistingTag) {
+      uniqueTagLabelsToInsert.push(tagLabel);
+    }
+    else {
+      logger.warn(`Tag "${tagLabel}" to insert is too similar to tag in DB (id|label) : ${alreadyExistingTag.id}|${alreadyExistingTag.label}`);
+    }
+  }
+  return uniqueTagLabelsToInsert;
+}
+
+async function checkDuplicatesInCSV(tagLabelsToInsert) {
+  const uniqueTagLabelsToInsert = [];
+  const similarGroupTags = [];
+  for (const currentTagLabel of tagLabelsToInsert) {
+    const similarTags = tagLabelsToInsert.filter((tagLabel) => removeCapitalizeAndDiacritics(currentTagLabel) === removeCapitalizeAndDiacritics(tagLabel));
+    if (similarTags.length > 1) { // myself and more
+      similarGroupTags.push(similarTags);
+    }
+    else {
+      uniqueTagLabelsToInsert.push(currentTagLabel);
+    }
+  }
+  if (similarGroupTags.length > 0) {
+    const uniqGroupTags = _.uniqBy(similarGroupTags, (content) => content.join(''));
+    for (const group of uniqGroupTags) {
+      logger.warn(`These tags are too similar to each other : ${group.join(', ')}`);
+    }
+  }
+  return uniqueTagLabelsToInsert;
+}
+
+async function checkIfTagTooLong(tagLabelsToInsert) {
+  const goodSizeTagLabelsToInsert = [];
+  for (const tagToCheck of tagLabelsToInsert) {
+    if (tagToCheck.length > TAG_LABEL_MAX_LENGTH) {
+      logger.warn(`This tag is too long, it wont be inserted in DB: ${tagToCheck}`);
+    } else {
+      goodSizeTagLabelsToInsert.push(tagToCheck);
+    }
+  }
+  return goodSizeTagLabelsToInsert;
+}
+
+export async function addTagsFromCSVFile({ dryRun, tagLabelsToInsert } = {}) {
+  logger.info(`${tagLabelsToInsert.length} found in file : ${tagLabelsToInsert.join(', ')}`);
+  let uniqTags = await checkDuplicatesInDB(tagLabelsToInsert);
+  uniqTags = await checkDuplicatesInCSV(uniqTags);
+  uniqTags = await checkIfTagTooLong(uniqTags);
+  logger.info(`About to insert ${uniqTags.length} tags`);
+
+  if (uniqTags.length === 0) {
+    logger.info('No tags to insert.');
+    return;
+  }
+  if (!dryRun) {
+    const insertion = await knex('static_course_tags').insert(uniqTags.map((tagLabel)=> ({ label: tagLabel })), ['label']);
+    logger.info(`${insertion.length} tags inserted : ${insertion.map(({ label }) => label).join(', ')}`);
+  } else {
+    logger.info(`${uniqTags.length} tags would have been inserted.`);
+  }
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+
+  const dryRun = process.env.DRY_RUN !== 'false';
+
+  if (dryRun) logger.warn('Dry run: no actual modification will be performed, use DRY_RUN=false to disable');
+
+  const csvPath = process.argv[2];
+  const csvContent = await readCsvFile(csvPath);
+  await addTagsFromCSVFile({ dryRun, tagLabelsToInsert: csvContent });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+if (isLaunchedFromCommandLine) {
+  main().catch((error) => {
+    logger.error(error);
+    process.exitCode = 1;
+  }).finally(async () => {
+    await disconnect();
+  });
+}

--- a/api/tests/scripts/create-tags-for-static-courses/create-tags-for-static-courses_test.js
+++ b/api/tests/scripts/create-tags-for-static-courses/create-tags-for-static-courses_test.js
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addTagsFromCSVFile } from '../../../scripts/create-tags-for-static-courses/index.js';
+import { knex } from '../../../db/knex-database-connection.js';
+import { databaseBuilder } from '../../test-helper.js';
+
+const CSV_CONTENT_OK = [
+  'mon tag avec ç',
+  'et puis @ tag',
+  'ÉLEVE ',
+  '&)=;)§61',
+  'Mon panel',
+  'bonjour et bienvenue dans ce t',
+  'avec, une virgule',
+];
+
+describe('Script | create-tags-for-static-courses', () => {
+
+  beforeEach(async () => {
+    ['Brouillon', 'pouet'].map((label) => databaseBuilder.factory.buildStaticCourseTag({ label }));
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await knex('static_courses_tags_link').del();
+    await knex('static_course_tags').del();
+  });
+
+  it('should not copy tags from csv to the db when dryRun is true', async () => {
+    // when
+    await addTagsFromCSVFile({ dryRun: true, tagLabelsToInsert: CSV_CONTENT_OK });
+
+    // then
+    const actualLabels = await knex('static_course_tags').pluck('label').orderBy('label', 'ASC');
+    expect(actualLabels).to.deep.equal(['Brouillon', 'pouet']);
+  });
+
+  it('should copy tags from csv to the db when dryRun is false', async () => {
+    // when
+    await addTagsFromCSVFile({ dryRun: false, tagLabelsToInsert: CSV_CONTENT_OK });
+
+    // then
+    const actualLabels = await knex('static_course_tags').pluck('label').orderBy('label', 'ASC');
+    expect(actualLabels).to.deep.equal([
+      '&)=;)§61',
+      'Brouillon',
+      'Mon panel',
+      'avec, une virgule',
+      'bonjour et bienvenue dans ce t',
+      'et puis @ tag',
+      'mon tag avec ç',
+      'pouet',
+      'ÉLEVE ',
+    ]);
+  });
+
+  it('should add all tags except the ones that are already in database (case and diacritics insensitive)', async function() {
+    // given
+    databaseBuilder.factory.buildStaticCourseTag({ label: 'bonjOur Ét bienvenuE dans çe t' });
+    await databaseBuilder.commit();
+
+    // when
+    await addTagsFromCSVFile({ dryRun: false, tagLabelsToInsert: CSV_CONTENT_OK });
+
+    // then
+    const actualLabels = await knex('static_course_tags').pluck('label').orderBy('label', 'ASC');
+    expect(actualLabels).to.deep.equal([
+      '&)=;)§61',
+      'Brouillon',
+      'Mon panel',
+      'avec, une virgule',
+      'bonjOur Ét bienvenuE dans çe t',
+      'et puis @ tag',
+      'mon tag avec ç',
+      'pouet',
+      'ÉLEVE ',
+    ]);
+  });
+
+  it('should add all tags except the duplicates within the csv file (case and diacritics insensitive)', async function() {
+    // given
+    const CSV_CONTENT_KO_DUPS_FILE = [
+      'Mon tag',
+      'mon tAg',
+      'mon tag ',
+      'mon autre tag',
+    ];
+
+    // when
+    await addTagsFromCSVFile({ dryRun: false, tagLabelsToInsert: CSV_CONTENT_KO_DUPS_FILE });
+
+    // then
+    const actualLabels = await knex('static_course_tags').pluck('label').orderBy('label', 'ASC');
+    expect(actualLabels).to.deep.equal([
+      'Brouillon',
+      'mon autre tag',
+      'pouet',
+    ]);
+  });
+
+  it('should add all tags except the ones that are over 30 characters', async() => {
+    const CSV_CONTENT_KO_LENGTH = [
+      'un tag',
+      'Signe diacritique ou diacritique (nom masculin), élément adjoint à une lettre d\'un alphabet pour en modifier la valeur ou pour distinguer des mots homographes. (Cet élément peut être suscrit [accents], souscrit [cédille] ou placé à côté de la lettre qu\'il modifie.)',
+    ];
+
+    // when
+    await addTagsFromCSVFile({ dryRun: false, tagLabelsToInsert: CSV_CONTENT_KO_LENGTH });
+
+    // then
+    const actualLabels = await knex('static_course_tags').pluck('label').orderBy('label', 'ASC');
+    expect(actualLabels).to.deep.equal([
+      'Brouillon',
+      'pouet',
+      'un tag',
+    ]);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La DB de tags est vide.

## :robot: Proposition
La remplir à l'aide d'un script et d'un fichier .csv incluant la liste des tags voulus.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un fichier .csv avec des tags à ajouter. (à mettre par exemple dans `api/tests/scripts/create-tags-for-static-courses`)
Se connecter à la DB de la RA
Lancer le script : `DRY_RUN=false node scripts/create-tags-for-static-courses/index.js tests/scripts/create-tags-for-static-courses/mon-fichier-csv.csv`
S'assurer que les tags sont existants (via db ou via pix-editor sur la RA)
