### PR TITLE
[FEATURE] Supprime les clés non mentionnées après l'envoi des traductions sur Phrase (PIX-11547).

### DIFF
--- a/api/lib/domain/usecases/delete-unmentioned-keys-after-upload.js
+++ b/api/lib/domain/usecases/delete-unmentioned-keys-after-upload.js
@@ -1,0 +1,27 @@
+import { Configuration, UploadsApi, KeysApi } from 'phrase-js';
+import * as config from '../../config.js';
+
+export const RETRY = Symbol('retry');
+export const COMPLETED = Symbol('completed');
+
+export async function deleteUnmentionedKeysAfterUpload(uploadId) {
+  const { apiKey, projectId } = config.phrase;
+  const configuration = new Configuration({
+    fetchApi: fetch,
+    apiKey: `token ${apiKey}`,
+  });
+
+  const upload = await new UploadsApi(configuration).uploadShow({ projectId, id: uploadId });
+
+  if (upload.state === 'processing') {
+    return RETRY;
+  }
+  if (upload.state !== 'success' ||
+      upload.summary.translationKeysUnmentioned === 0) {
+    return COMPLETED;
+  }
+
+  await new KeysApi(configuration).keysDeleteCollection({ projectId, q: `unmentioned_in_upload:${uploadId}` });
+
+  return COMPLETED;
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,4 +1,5 @@
 export * from './create-mission.js';
+export * from './delete-unmentioned-keys-after-upload.js';
 export * from './download-translation-from-phrase.js';
 export * from './export-translations.js';
 export * from './find-all-missions.js';

--- a/api/lib/infrastructure/scheduled-jobs/create-queue.js
+++ b/api/lib/infrastructure/scheduled-jobs/create-queue.js
@@ -3,6 +3,8 @@ import Sentry from '@sentry/node';
 import Queue from 'bull';
 import * as config from '../../config.js';
 
+export const queues = [];
+
 const queueError = (queueName, err, ...messages) => {
   logger.error(err, queueName, ...messages);
   Sentry.captureException(err);
@@ -24,6 +26,6 @@ export function createQueue(queueName) {
   queue.on('cleaned', () => queueMessage(queueName, 'The queue has been cleaned'));
   queue.on('drained', () => queueMessage(queueName, 'The queue has been drained'));
   queue.on('removed', () => queueMessage(queueName, 'A job has been removed'));
-
+  queues.push(queue);
   return queue;
 }

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.cjs
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.cjs
@@ -1,0 +1,4 @@
+module.exports = async function deleteUnmentionedKeysAfterUploadJobProcessor(job) {
+  const { default: processor } = await import('./delete-unmentioned-keys-after-upload-job-processor.js');
+  return processor(job);
+};

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
@@ -1,0 +1,10 @@
+import { RETRY, deleteUnmentionedKeysAfterUpload } from '../../domain/usecases/index.js';
+import { schedule } from './delete-unmentioned-keys-after-upload-job.js';
+
+export default async function deleteUnmentionedKeysAfterUploadJobProcessor(job) {
+  const status = await deleteUnmentionedKeysAfterUpload(job.data.uploadId);
+
+  if (status === RETRY) {
+    schedule(job.data);
+  }
+}

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js
@@ -1,0 +1,28 @@
+import { createQueue } from './create-queue.js';
+import * as config from '../../config.js';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export const queue = createQueue('delete-unmentioned-keys-after-upload-queue');
+
+const esmFile = __dirname + '/delete-unmentioned-keys-after-upload-job-processor.js';
+const cjsFile = __dirname + '/delete-unmentioned-keys-after-upload-job-processor.cjs';
+if (process.env.NODE_ENV === 'test') {
+  const module = await import(esmFile);
+  queue.process(module.default);
+} else {
+  queue.process(cjsFile);
+}
+
+const deleteUnmentionedKeysAfterUploadJobOptions = {
+  attempts: config.scheduledJobs.attempts,
+  backoff: { type: 'exponential', delay: 100 },
+  removeOnComplete: true,
+  removeOnFail: true,
+  delay: 3 * 60 * 1000
+};
+
+export function schedule({ uploadId }) {
+  queue.add({ uploadId }, deleteUnmentionedKeysAfterUploadJobOptions);
+}

--- a/api/lib/infrastructure/scheduled-jobs/index.js
+++ b/api/lib/infrastructure/scheduled-jobs/index.js
@@ -1,0 +1,1 @@
+export { queues } from './create-queue.js';

--- a/api/tests/integration/domain/usecases/delete-unmentioned-keys-after-upload_test.js
+++ b/api/tests/integration/domain/usecases/delete-unmentioned-keys-after-upload_test.js
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import nock from 'nock';
+import { RETRY, COMPLETED, deleteUnmentionedKeysAfterUpload } from '../../../../lib/domain/usecases/index.js';
+
+describe('Integration | Usecases | Delete unmentioned keys after upload', function() {
+  it('should delete unmentioned keys when upload is in success', async function() {
+    // given
+    const phraseAPIUpload = nock('https://api.phrase.com')
+      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .reply(200,  {
+        id: 'upload-id',
+        state: 'success',
+        summary: {
+          translation_keys_unmentioned: 2,
+        },
+      });
+
+    const phraseAPIDelete = nock('https://api.phrase.com')
+      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .query({
+        q: 'unmentioned_in_upload:upload-id'
+      })
+      .reply(200, {
+        records_affected: 2
+      });
+
+    // when
+    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+
+    // then
+    expect(result).to.equal(COMPLETED);
+    expect(phraseAPIUpload.isDone()).to.be.true;
+    expect(phraseAPIDelete.isDone()).to.be.true;
+  });
+
+  it('should not delete unmentioned keys when there is no unmentioned keys', async function() {
+    // given
+    const phraseAPIUpload = nock('https://api.phrase.com')
+      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .reply(200,  {
+        id: 'upload-id',
+        state: 'success',
+        summary: {
+          translation_keys_unmentioned: 0,
+        },
+      });
+
+    const phraseAPIDelete = nock('https://api.phrase.com')
+      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .query({
+        q: 'unmentioned_in_upload:upload-id'
+      })
+      .reply(200, {
+        records_affected: 0
+      });
+
+    // when
+    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+
+    // then
+    expect(result).to.equal(COMPLETED);
+    expect(phraseAPIUpload.isDone()).to.be.true;
+    expect(phraseAPIDelete.isDone()).to.be.false;
+  });
+
+  it('should returns status retry when the upload is processing', async function() {
+    // given
+    const phraseAPIUpload = nock('https://api.phrase.com')
+      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .reply(200, {
+        id: 'upload-id',
+        state: 'processing'
+      });
+
+    const phraseAPIDelete = nock('https://api.phrase.com')
+      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .query({
+        q: 'unmentioned_in_upload:upload-id'
+      })
+      .reply(200,  {
+        records_affected: 0
+      });
+
+    // when
+    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+
+    // then
+    expect(result).to.equal(RETRY);
+    expect(phraseAPIUpload.isDone()).to.be.true;
+    expect(phraseAPIDelete.isDone()).to.be.false;
+  });
+
+  it('should returns status completed when the upload is in error', async function() {
+    // given
+    const phraseAPIUpload = nock('https://api.phrase.com')
+      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .reply(200, {
+        id: 'upload-id',
+        state: 'error'
+      });
+
+    const phraseAPIDelete = nock('https://api.phrase.com')
+      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .query({
+        q: 'unmentioned_in_upload:upload-id'
+      })
+      .reply(200,  {
+        records_affected: 0
+      });
+
+    // when
+    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+
+    // then
+    expect(result).to.equal(COMPLETED);
+    expect(phraseAPIUpload.isDone()).to.be.true;
+    expect(phraseAPIDelete.isDone()).to.be.false;
+  });
+});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -7,6 +7,7 @@ import { AirtableBuilder } from './tooling/airtable-builder/airtable-builder.js'
 import { InputOutputDataBuilder }  from './tooling/input-output-data-builder/input-output-data-builder.js';
 import { knex } from '../db/knex-database-connection.js';
 import './tooling/vitest-custom-matchers/index.js';
+import { queues } from '../lib/infrastructure/scheduled-jobs/index.js';
 
 beforeEach(() => {
   nock.disableNetConnect();
@@ -17,6 +18,9 @@ afterEach(async () => {
   await databaseBuilder.clean();
   cache.flushAll();
   nock.cleanAll();
+  for (const queue of queues) {
+    await queue.obliterate({ force: true });
+  }
 });
 
 export { streamToPromise, streamToPromiseArray } from '../lib/infrastructure/utils/stream-to-promise.js';

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { uploadTranslationToPhrase } from '../../../../lib/domain/usecases/index.js';
+import * as exportTranslationsUseCase from '../../../../lib/domain/usecases/export-translations.js';
+import * as deleteUnmentionedKeysAfterUploadJob from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
+
+describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
+  it('should upload to Phrase', async () => {
+    // given
+    const ConfigurationStub = class {};
+    const uploadCreateStub = vi.fn().mockResolvedValue({ id: 'upload-id' });
+    const UploadsApiStub = class {
+      uploadCreate() { return uploadCreateStub(); }
+    };
+    vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+
+    // when
+    await uploadTranslationToPhrase({ url: 'https://example.net' }, { Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
+
+    // then
+    expect(uploadCreateStub).toHaveBeenCalled();
+  });
+
+  it('should schedule deletion of unmentioned keys', async () => {
+    // given
+    const ConfigurationStub = class {};
+    const uploadCreateStub = vi.fn().mockResolvedValue({ id: 'upload-id' });
+    const UploadsApiStub = class {
+      uploadCreate() { return uploadCreateStub(); }
+    };
+    vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+    const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule').mockResolvedValue();
+
+    // when
+    await uploadTranslationToPhrase({ url: 'https://example.net' }, { Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
+
+    // then
+    expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });
+  });
+});
+

--- a/api/tests/unit/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job_test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as deleteUnmentionedKeysAfterUploadJob from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
+import deleteUnmentionedKeysAfterUploadJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js';
+import * as deleteUnmentionedKeysAfterUploadUsecase from '../../../../lib/domain/usecases/delete-unmentioned-keys-after-upload.js';
+
+describe('Unit | Infrastructure | scheduled-jobs | delete-unmentioned-keys-after-upload-job', function() {
+  it('should schedule a new job when delete-unmentioned-keys-after-upload return status is `retry`', async function() {
+    // given
+    const deleteUnmentionedKeysAfterUploadStub = vi.spyOn(deleteUnmentionedKeysAfterUploadUsecase, 'deleteUnmentionedKeysAfterUpload').mockResolvedValue(deleteUnmentionedKeysAfterUploadUsecase.RETRY);
+    const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
+
+    // when
+    await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id' } });
+
+    // then
+    expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });
+    expect(deleteUnmentionedKeysAfterUploadStub).toHaveBeenCalledWith('upload-id');
+  });
+
+  it('should not schedule a new job when delete-unmentioned-keys-after-upload return status is `completed`', async function() {
+    // given
+    const deleteUnmentionedKeysAfterUploadStub = vi.spyOn(deleteUnmentionedKeysAfterUploadUsecase, 'deleteUnmentionedKeysAfterUpload').mockResolvedValue(deleteUnmentionedKeysAfterUploadUsecase.COMPLETED);
+    const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
+
+    // when
+    await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id' } });
+
+    // then
+    expect(scheduleStub).not.toHaveBeenCalled();
+    expect(deleteUnmentionedKeysAfterUploadStub).toHaveBeenCalledWith('upload-id');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lors de l'export des traductions vers Phrase, les clés absentes de l'import sont conservées.
Il n'est donc pas possible pour les traducteurs d'être sûr que les traductions présentes sont bien celles à traiter.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Après l'appel à l'API Phrase faisant l'envoi des traductions, on planifie un appel pour vérifier l'état de l'envoi et supprimer les clés non mentionnées dans celui-ci lorsqu'il est terminé.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Créer une épreuve.
Envoyer les traductions via le bouton d'export de l'interface d'administration.
Vérifier que les traductions liées à l'épreuve crées ont été ajoutées dans Phrase.

Périmer l'épreuve.
Envoyer les traductions via le bouton d'export de l'interface d'administration.
Vérifier que les traductions liées à l'épreuve périmée ont été supprimées dans Phrase.
