### PR TITLE
[TECH] Supprimer les translations dans Airtable qui ne référencent aucune entité pour alléger l'exécution des seeds en local et en RA (PIX-11556)

### DIFF
--- a/api/scripts/delete-unreferenced-translations/index.js
+++ b/api/scripts/delete-unreferenced-translations/index.js
@@ -1,0 +1,95 @@
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import { logger } from '../../lib/infrastructure/logger.js';
+import { performance } from 'node:perf_hooks';
+import _ from 'lodash';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+const MAX_RECORDS_ALLOWED = 10;
+
+export async function deleteUnreferencedTranslationsInAirtable({ dryRun = true, airtableClient }) {
+  const translations = await airtableClient
+    .table('translations')
+    .select()
+    .all();
+
+  const competences =  await airtableClient
+    .table('Competences')
+    .select()
+    .all();
+
+  const areas = await airtableClient
+    .table('Domaines')
+    .select()
+    .all();
+
+  const challenges = await airtableClient
+    .table('Epreuves')
+    .select()
+    .all();
+
+  const skills = await airtableClient
+    .table('Acquis')
+    .select()
+    .all();
+
+  const translationKeys = translations.map(({ fields }) => fields.key);
+  const baseKeys = [
+    ...competences.map(({ fields }) => `competence.${fields['id persistant']}`),
+    ...areas.map(({ fields }) => `area.${fields['id persistant']}`),
+    ...challenges.map(({ fields }) => `challenge.${fields['id persistant']}`),
+    ...skills.map(({ fields }) => `skill.${fields['id persistant']}`),
+  ];
+
+  const unreferenced = _.differenceWith(translationKeys, baseKeys, (translation, baseKey) => {
+    return translation.startsWith(baseKey);
+  });
+
+  const translationsToDelete = translations
+    .filter((translation) => {
+      return unreferenced.includes(translation.fields.key);
+    })
+    .map(({ id }) => id);
+
+  if (!dryRun) {
+    logger.info(`About to delete ${translationsToDelete.length} translations`);
+
+    for (const translationsToDeleteChunk of _.chunk(translationsToDelete, MAX_RECORDS_ALLOWED)) {
+      await airtableClient.table('translations').destroy(translationsToDeleteChunk);
+    }
+  } else {
+    logger.info(`${translationsToDelete.length} translations would have been deleted if dryRun disabled.`);
+  }
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  const dryRun = process.env.DRY_RUN !== 'false';
+
+  if (dryRun) logger.warn('Dry run: no actual modification will be performed, use DRY_RUN=false to disable');
+  const airtableClient = new Airtable({
+    apiKey: process.env.AIRTABLE_API_KEY,
+  }).base(process.env.AIRTABLE_BASE);
+
+  await deleteUnreferencedTranslationsInAirtable({ dryRun, airtableClient });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    }
+  }
+})();

--- a/api/tests/scripts/delete-unreferenced-translations_test.js
+++ b/api/tests/scripts/delete-unreferenced-translations_test.js
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { airtableBuilder } from '../test-helper.js';
+import nock from 'nock';
+import Airtable from 'airtable';
+import { deleteUnreferencedTranslationsInAirtable } from '../../scripts/delete-unreferenced-translations/index.js';
+
+const {
+  buildArea,
+  buildChallenge,
+  buildCompetence,
+  buildFramework,
+  buildSkill,
+  buildThematic,
+  buildTranslation,
+  buildTube,
+} = airtableBuilder.factory;
+
+describe('Script | delete-unreferenced-translations', () => {
+  let airtableClient;
+
+  beforeEach(() => {
+    const currentContent = {
+      frameworks: [{
+        id: 'recFramework0',
+        name: 'Nom du referentiel'
+      }],
+      areas: [
+        {
+          id: 'recArea0',
+          competenceIds: ['recCompetence0'],
+          competenceAirtableIds: ['recCompetence123'],
+          frameworkId: 'recFramework0',
+        },
+        {
+          id: 'recArea1',
+          competenceIds: ['recCompetence1'],
+          competenceAirtableIds: ['recCompetence456'],
+          frameworkId: 'recFramework0',
+        }
+      ],
+      competences: [
+        {
+          id: 'recCompetence0',
+          areaId: '1',
+          skillIds: ['recSkill0'],
+          thematicIds: ['recThematic0'],
+        },
+        {
+          id: 'recCompetence1',
+          areaId: '1',
+          skillIds: ['recSkill1'],
+          thematicIds: ['recThematic1'],
+        }
+      ],
+      thematics: [
+        {
+          id: 'recThematic0',
+          competenceId: 'recCompetence0',
+          tubeIds: ['recTube0'],
+        },
+        {
+          id: 'recThematic1',
+          competenceId: 'recCompetence1',
+          tubeIds: ['recTube1'],
+        }
+      ],
+      tubes: [
+        {
+          id: 'recTube0',
+          competenceId: 'recCompetence0',
+          thematicId: 'recThematic0',
+          skillIds: ['recSkill0'],
+        },
+        {
+          id: 'recTube1',
+          competenceId: 'recCompetence1',
+          thematicId: 'recThematic1',
+          skillIds: ['recSkill1'],
+        }
+      ],
+      skills: [
+        {
+          id: 'recSkill0',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          competenceId: 'recCompetence0',
+          tubeId: 'recTube0',
+        },
+        {
+          id: 'recSkill1',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          competenceId: 'recCompetence1',
+          tubeId: 'recTube1',
+        }
+      ],
+      challenges: [
+        {
+          id: 'recChallenge0',
+          skillId: 'recSkill0',
+          competenceId: 'recCompetence0',
+        },
+        {
+          id: 'recChallenge1',
+          skillId: 'recSkill1',
+          competenceId: 'recCompetence1',
+        }
+      ],
+    };
+    const translations = [
+      {
+        id: 'translationArea0',
+        key: 'area.recArea0.field',
+      },
+      {
+        id: 'translationArea1',
+        key: 'area.recArea1.field',
+      },
+      {
+        id: 'translationArea2',
+        key: 'area.recArea2.field',
+      },
+      {
+        id: 'translationCompetence0',
+        key: 'competence.recCompetence0.field',
+      },
+      {
+        id: 'translationCompetence1',
+        key: 'competence.recCompetence1.field',
+      },
+      {
+        id: 'translationCompetence2',
+        key: 'competence.recCompetence2.field',
+      },
+      {
+        id: 'translationChallenge0',
+        key: 'challenge.recChallenge0.field',
+      },
+      {
+        id: 'translationChallenge1',
+        key: 'challenge.recChallenge1.field',
+      },
+      {
+        id: 'translationChallenge2',
+        key: 'challenge.recChallenge2.field',
+      },
+      {
+        id: 'translationSkill0',
+        key: 'skill.recSkill0.field',
+      },
+      {
+        id: 'translationSkill1',
+        key: 'skill.recSkill1.field',
+      },
+      {
+        id: 'translationSkill2',
+        key: 'skill.recSkill2.field',
+      },
+    ].map(buildTranslation);
+    airtableBuilder.mockLists({
+      areas: currentContent.areas.map(buildArea),
+      attachments: [],
+      challenges: currentContent.challenges.map(buildChallenge),
+      competences: currentContent.competences.map(buildCompetence),
+      frameworks: currentContent.frameworks.map(buildFramework),
+      skills: currentContent.skills.map(buildSkill),
+      thematics: currentContent.thematics.map(buildThematic),
+      tubes: currentContent.tubes.map(buildTube),
+      tutorials: [],
+      translations,
+    });
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  it('should delete translations that are not linked to any entities in Airtable when dryRun disabled', async() => {
+    // given
+    const deletedIds = ['translationArea2', 'translationCompetence2', 'translationChallenge2', 'translationSkill2'];
+    const deleteCommand = nock('https://api.airtable.com')
+      .delete('/v0/airtableBaseValue/translations')
+      .query({
+        records: {
+          '': deletedIds,
+        } })
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .matchHeader('content-type', 'application/json')
+      .reply(200, {
+        records: deletedIds.map((id) => ({
+          deleted: true,
+          id,
+        }))
+      });
+
+    // when
+    await deleteUnreferencedTranslationsInAirtable({ dryRun: false, airtableClient });
+
+    // then
+    expect(deleteCommand.isDone()).to.be.true;
+  });
+
+  it('should not delete anything if dryRun enabled', async() => {
+    // given
+    const deletedIds = ['translationArea2', 'translationCompetence2', 'translationChallenge2', 'translationSkill2'];
+    const deleteCommand = nock('https://api.airtable.com')
+      .delete('/v0/airtableBaseValue/translations')
+      .query({
+        records: {
+          '': deletedIds,
+        } })
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .matchHeader('content-type', 'application/json')
+      .reply(200, {
+        records: deletedIds.map((id) => ({
+          deleted: true,
+          id,
+        }))
+      });
+
+    // when
+    await deleteUnreferencedTranslationsInAirtable({ airtableClient });
+
+    // then
+    expect(deleteCommand.isDone()).to.be.false;
+  });
+});

--- a/api/tests/tooling/airtable-builder/airtable-builder.js
+++ b/api/tests/tooling/airtable-builder/airtable-builder.js
@@ -36,9 +36,15 @@ export class AirtableBuilder {
     frameworks,
     skills,
     thematics,
+    translations = [],
     tubes,
     tutorials,
   }) {
+    if (translations.length > 0) {
+      this.mockList({ tableName: 'translations' })
+        .returns(translations)
+        .activate();
+    }
     this.mockList({ tableName: 'Referentiel' })
       .returns(frameworks)
       .activate();

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -4,7 +4,7 @@ export function buildThematic(
     name_i18n: {
       fr: name,
       en: nameEnUs,
-    },
+    } = {},
     competenceId,
     tubeIds,
     index,

--- a/api/tests/tooling/airtable-builder/factory/build-translation.js
+++ b/api/tests/tooling/airtable-builder/factory/build-translation.js
@@ -1,0 +1,16 @@
+export function buildTranslation(
+  {
+    id,
+    key,
+    locale = 'de',
+    value = 'nachte flut',
+  } = {}) {
+  return {
+    id,
+    'fields': {
+      'key': key,
+      'locale': locale,
+      'value': value,
+    },
+  };
+}

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -6,11 +6,11 @@ export function buildTube({
   practicalTitle_i18n: {
     fr: practicalTitleFrFr,
     en: practicalTitleEnUs,
-  },
+  } = {},
   practicalDescription_i18n: {
     fr: practicalDescriptionFrFr,
     en: practicalDescriptionEnUs,
-  },
+  } = {},
   competenceId,
 } = {}) {
 

--- a/api/tests/tooling/airtable-builder/factory/index.js
+++ b/api/tests/tooling/airtable-builder/factory/index.js
@@ -5,5 +5,6 @@ export * from './build-competence.js';
 export * from './build-framework.js';
 export * from './build-skill.js';
 export * from './build-thematic.js';
+export * from './build-translation.js';
 export * from './build-tube.js';
 export * from './build-tutorial.js';


### PR DESCRIPTION
## :unicorn: Problème
Les seeds de Airtable des RA sont trop importantes. Des entités ont été supprimées, malheureusement il était difficile d'identifier les translations non référencées (de la table Airtable `translations` propre à la RA)

## :robot: Proposition
Script permettant d'identifier les records de la table `translations` qui ne référencent aucune entité (domaine/compétence/acquis/épreuve)

## :rainbow: Remarques
Cela ne concerne que les RAs, ce script n'est pas destiné à la prod (et n'a aucun sens en prod par ailleurs)

## :100: Pour tester
On va pas tester on est des oufs !
