### PR TITLE
[BUGFIX] Impossible de créer un test statique avec une longue description (PIX-11592)

### DIFF
--- a/api/db/migrations/20240308213328_alter-description-column-in-static-courses-table.js
+++ b/api/db/migrations/20240308213328_alter-description-column-in-static-courses-table.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'static_courses';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function up(knex) {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('description', 1000).alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function down(knex) {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('description', 255).alter();
+  });
+}


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on essaye de créer un test statique avec une longue description (+ 255 caractères) ça plante.
Ca ne devrait pas car l'éditeur suggère que la limite c'est 1000...

## :robot: Proposition
La taille de la colonne dans la table n'est pas bonne. Il faut la changer

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Essayer de créer un test statique avec + de 255 caractères (mais moins de 1000 😄 )
