### PR TITLE
[FEATURE]  Exporter les traductions vers phrase après que le job de la release soit finit (PIX-11220)

### DIFF
--- a/api/lib/application/phrase.js
+++ b/api/lib/application/phrase.js
@@ -9,7 +9,7 @@ export async function register(server) {
       config: {
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
-          await uploadTranslationToPhrase(request);
+          await uploadTranslationToPhrase();
           return h.response();
         }
       },

--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -16,8 +16,7 @@ export async function register(server) {
       config: {
         handler: function(request, h) {
           const stream = new PassThrough();
-          const url = new URL(request.url);
-          const baseUrl = `${url.protocol}//${url.host}`;
+          const baseUrl = config.lcms.baseUrl;
           exportTranslations(stream, { releaseRepository, localizedChallengeRepository, baseUrl });
           return h.response(stream).header('Content-type', 'text/csv');
         }

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -140,7 +140,7 @@ if (process.env.NODE_ENV === 'test') {
 
   pixApp.baseUrl = 'https://app.test.pix.fr';
 
-  lcms.PIX_EDITOR_BASE_URL = 'http://test.site';
+  lcms.baseUrl = 'http://test.site';
 
   storage = {
     authUrl: 'https://storage.auth.example.net/api/auth',

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -53,6 +53,10 @@ export const pixApp = {
   baseUrl: process.env.PIX_APP_BASEURL
 };
 
+export const lcms = {
+  baseUrl: process.env.PIX_EDITOR_BASE_URL
+};
+
 export const pixEditor = {
   airtableUrl: process.env.AIRTABLE_URL,
   airtableBase: process.env.AIRTABLE_BASE,
@@ -135,6 +139,8 @@ if (process.env.NODE_ENV === 'test') {
   };
 
   pixApp.baseUrl = 'https://app.test.pix.fr';
+
+  lcms.PIX_EDITOR_BASE_URL = 'http://test.site';
 
   storage = {
     authUrl: 'https://storage.auth.example.net/api/auth',

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -8,6 +8,14 @@ import { streamToPromise } from '../../infrastructure/utils/stream-to-promise.js
 import { schedule as scheduleDeleteUnmentionedKeysAfterUploadJob } from '../../infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 
 export async function uploadTranslationToPhrase(phraseApi = { Configuration, UploadsApi }) {
+
+  const { apiKey, projectId } = config.phrase;
+
+  if (!apiKey || !projectId) {
+    logger.info('Phrase API Key or Project Id is not defined. Skipping upload translations.');
+    return;
+  }
+
   const baseUrl = config.lcms.baseUrl;
   const stream = new PassThrough();
   exportTranslations(stream, { releaseRepository, localizedChallengeRepository, baseUrl });

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -7,10 +7,9 @@ import { releaseRepository, localizedChallengeRepository } from '../../infrastru
 import { streamToPromise } from '../../infrastructure/utils/stream-to-promise.js';
 import { schedule as scheduleDeleteUnmentionedKeysAfterUploadJob } from '../../infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 
-export async function uploadTranslationToPhrase(request, phraseApi = { Configuration, UploadsApi }) {
+export async function uploadTranslationToPhrase(phraseApi = { Configuration, UploadsApi }) {
+  const baseUrl = config.lcms.baseUrl;
   const stream = new PassThrough();
-  const url = new URL(request.url);
-  const baseUrl = `${url.protocol}//${url.host}`;
   exportTranslations(stream, { releaseRepository, localizedChallengeRepository, baseUrl });
   const csvFile = new File([await streamToPromise(stream)], 'translations.csv');
 

--- a/api/lib/infrastructure/scheduled-jobs/check-urls-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/check-urls-job-processor.js
@@ -1,22 +1,7 @@
+import './job-process.js';
 import { validateUrlsFromRelease } from '../../domain/usecases/validate-urls-from-release.js';
-import { logger } from '../logger.js';
-import { disconnect } from '../../../db/knex-database-connection.js';
 import { releaseRepository, urlErrorRepository } from '../repositories/index.js';
 
 export default function checkUrlsJobProcessor() {
   return validateUrlsFromRelease({ releaseRepository, urlErrorRepository });
 }
-
-async function exitOnSignal(signal) {
-  logger.info(`Processor received signal ${signal}. Closing DB connections before exiting.`);
-  try {
-    await disconnect();
-    process.exit(0);
-  } catch (err) {
-    logger.error(err);
-    process.exit(1);
-  }
-}
-
-process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
-process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
@@ -1,3 +1,4 @@
+import './job-process.js';
 import { RETRY, deleteUnmentionedKeysAfterUpload } from '../../domain/usecases/index.js';
 import { schedule } from './delete-unmentioned-keys-after-upload-job.js';
 

--- a/api/lib/infrastructure/scheduled-jobs/job-process.js
+++ b/api/lib/infrastructure/scheduled-jobs/job-process.js
@@ -12,5 +12,7 @@ async function exitOnSignal(signal) {
   }
 }
 
-process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
-process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
+if (process.env.NODE_ENV !== 'test') {
+  process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+  process.on('SIGINT', () => { exitOnSignal('SIGINT'); });
+}

--- a/api/lib/infrastructure/scheduled-jobs/job-process.js
+++ b/api/lib/infrastructure/scheduled-jobs/job-process.js
@@ -1,0 +1,16 @@
+import { logger } from '../logger.js';
+import { disconnect } from '../../../db/knex-database-connection.js';
+
+async function exitOnSignal(signal) {
+  logger.info(`Processor received signal ${signal}. Closing DB connections before exiting.`);
+  try {
+    await disconnect();
+    process.exit(0);
+  } catch (err) {
+    logger.error(err);
+    process.exit(1);
+  }
+}
+
+process.on('SIGTERM', () => { exitOnSignal('SIGTERM'); });
+process.on('SIGINT', () => { exitOnSignal('SIGINT'); });

--- a/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
@@ -5,6 +5,7 @@ import { downloadTranslationFromPhrase } from '../../domain/usecases/download-tr
 import * as learningContentNotification from '../../domain/services/learning-content-notification.js';
 import { logger } from '../logger.js';
 import { releaseRepository } from '../repositories/index.js';
+import { uploadTranslationToPhrase } from '../../domain/usecases/index.js';
 import { disconnect } from '../../../db/knex-database-connection.js';
 
 export default async function releaseJobProcessor(job) {
@@ -18,6 +19,7 @@ export default async function releaseJobProcessor(job) {
     if (config.scheduledJobs.startCheckUrlJob) {
       checkUrlsJob.start();
     }
+    uploadTranslationToPhrase();
     return releaseId;
   } catch (error) {
     if (_isSlackNotificationGloballyEnabled()) {

--- a/api/lib/infrastructure/scheduled-jobs/upload-translation-job-processor.cjs
+++ b/api/lib/infrastructure/scheduled-jobs/upload-translation-job-processor.cjs
@@ -1,0 +1,4 @@
+module.exports = async function uploadTranslationJobProcessor() {
+  const { default: processor } = await import('./upload-translation-job-processor.js');
+  return processor();
+};

--- a/api/lib/infrastructure/scheduled-jobs/upload-translation-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/upload-translation-job-processor.js
@@ -1,0 +1,6 @@
+import './job-process.js';
+import { uploadTranslationToPhrase } from '../../domain/usecases/index.js';
+
+export default async function uploadTranslationJobProcessor() {
+  await uploadTranslationToPhrase();
+}

--- a/api/lib/infrastructure/scheduled-jobs/upload-translation-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/upload-translation-job.js
@@ -1,0 +1,28 @@
+import { createQueue } from './create-queue.js';
+import * as config from '../../config.js';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export const queue = createQueue('upload-translation-queue');
+
+const esmFile = __dirname + '/upload-translation-job-processor.js';
+const cjsFile = __dirname + '/upload-translation-job-processor.cjs';
+if (process.env.NODE_ENV === 'test') {
+  const module = await import(esmFile);
+  queue.process(module.default);
+} else {
+  queue.process(cjsFile);
+}
+
+const uploadTranslationJobOptions = {
+  attempts: config.scheduledJobs.attempts,
+  backoff: { type: 'exponential', delay: 100 },
+  removeOnComplete: true,
+  removeOnFail: 1,
+  delay: 1000
+};
+
+export function start() {
+  return queue.add({}, uploadTranslationJobOptions);
+}

--- a/api/sample.env
+++ b/api/sample.env
@@ -487,7 +487,6 @@ CHECK_URLS_TUTORIALS_SHEET_NAME=
 # default: `undefined` (`false`)
 # SENTRY_DEBUG=true
 
-
 # ===================================
 # PHRASE (TRANSLATION PLATFORM)
 # ===================================
@@ -516,3 +515,14 @@ CHECK_URLS_TUTORIALS_SHEET_NAME=
 # type: String
 # default: none
 # PHRASE_FR_LOCALE_ID=xxxxxn
+
+# =================
+# UPLOAD TRANSLATION TO PHRASE JOB
+# =================
+
+# Base URL for generating translation preview link
+#
+# presence: optional
+# type: String
+# default: none
+# PIX_EDITOR_BASE_URL=

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -207,10 +207,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
       const postPhraseUploadOptions = {
         method: 'POST',
         url: '/api/phrase/upload',
-        headers: {
-          ...generateAuthorizationHeader(user),
-          host: 'test.site',
-        },
+        headers: generateAuthorizationHeader(user),
       };
 
       // When

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -243,10 +243,7 @@ describe('Acceptance | Controller | translations-controller', () => {
       const getTranslationsOptions = {
         method: 'GET',
         url: '/api/translations.csv',
-        headers: {
-          ...generateAuthorizationHeader(user),
-          host: 'test.site',
-        },
+        headers: generateAuthorizationHeader(user),
       };
 
       // When

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
 
     // when
-    await uploadTranslationToPhrase({ url: 'https://example.net' }, { Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
 
     // then
     expect(uploadCreateStub).toHaveBeenCalled();
@@ -31,7 +31,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule').mockResolvedValue();
 
     // when
-    await uploadTranslationToPhrase({ url: 'https://example.net' }, { Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
 
     // then
     expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { uploadTranslationToPhrase } from '../../../../lib/domain/usecases/index.js';
 import * as exportTranslationsUseCase from '../../../../lib/domain/usecases/export-translations.js';
 import * as deleteUnmentionedKeysAfterUploadJob from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
+import * as config from '../../../../lib/config.js';
 
 describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
   it('should upload to Phrase', async () => {
@@ -36,5 +37,30 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     // then
     expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });
   });
-});
 
+  it('should not upload to Phrase when apiKey is not set', async () => {
+    // given
+    vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
+
+    const ConfigurationStub = vi.fn();
+
+    // when
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub });
+
+    // then
+    expect(ConfigurationStub).not.toHaveBeenCalled();
+  });
+
+  it('should not upload to Phrase when projectId is not set', async () => {
+    // given
+    vi.spyOn(config.phrase, 'projectId', 'get').mockReturnValue(undefined);
+
+    const ConfigurationStub = vi.fn();
+
+    // when
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub });
+
+    // then
+    expect(ConfigurationStub).not.toHaveBeenCalled();
+  });
+});

--- a/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { releaseRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { Release } from '../../../../lib/domain/models/release/Release.js';
 import releaseJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/release-job-processor.js';
+import * as uploadTranslationToPhraseJob from '../../../../lib/infrastructure/scheduled-jobs/upload-translation-job.js';
 import * as learningContentNotification from '../../../../lib/domain/services/learning-content-notification.js';
 import * as downloadTranslationFromPhraseUseCase from '../../../../lib/domain/usecases/download-translation-from-phrase.js';
-import * as uploadTranslationToPhraseUsecase from '../../../../lib/domain/usecases/upload-translation-to-phrase.js';
 import { logger } from '../../../../lib/infrastructure/logger.js';
 import { SlackNotifier } from '../../../../lib/infrastructure/notifications/SlackNotifier.js';
 import * as config from '../../../../lib/config.js';
@@ -19,6 +19,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
       vi.spyOn(downloadTranslationFromPhraseUseCase, 'downloadTranslationFromPhrase').mockResolvedValue();
       vi.spyOn(releaseRepository, 'create').mockResolvedValue(resolvedCreatedRelease);
       vi.spyOn(learningContentNotification, 'notifyReleaseCreationSuccess').mockResolvedValue();
+      vi.spyOn(uploadTranslationToPhraseJob, 'start').mockResolvedValue();
 
       // when
       await releaseJobProcessor({ data: {} });
@@ -35,6 +36,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         vi.spyOn(downloadTranslationFromPhraseUseCase, 'downloadTranslationFromPhrase').mockResolvedValue();
         vi.spyOn(releaseRepository, 'create').mockResolvedValue(resolvedCreatedReleaseId);
         vi.spyOn(learningContentNotification, 'notifyReleaseCreationSuccess').mockResolvedValue();
+        vi.spyOn(uploadTranslationToPhraseJob, 'start').mockResolvedValue();
       });
 
       it('should return the persisted release ID', async () => {
@@ -90,15 +92,15 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         expect(learningContentNotification.notifyReleaseCreationSuccess).not.toHaveBeenCalled();
       });
 
-      it('should call upload translation to phrase when is finished', async () => {
+      it('should start the upload translation job to  phrase when is finished', async () => {
         // given
-        const uploadTranslationToPhraseStub = vi.spyOn(uploadTranslationToPhraseUsecase, 'uploadTranslationToPhrase');
+        const uploadTranslationToPhraseStub = vi.spyOn(uploadTranslationToPhraseJob, 'start').mockResolvedValue();
 
         // when
         await releaseJobProcessor({ data: {} });
 
         // then
-        expect(uploadTranslationToPhraseStub).toHaveBeenCalled();
+        expect(uploadTranslationToPhraseStub).toHaveBeenCalledOnce();
       });
     });
 
@@ -108,6 +110,7 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         vi.spyOn(downloadTranslationFromPhraseUseCase, 'downloadTranslationFromPhrase').mockResolvedValue();
         vi.spyOn(releaseRepository, 'create').mockRejectedValue(new Error('Network error'));
         vi.spyOn(learningContentNotification, 'notifyReleaseCreationFailure').mockResolvedValue();
+        vi.spyOn(uploadTranslationToPhraseJob, 'start');
       });
 
       it('should log the error', async () => {

--- a/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
@@ -4,6 +4,7 @@ import { Release } from '../../../../lib/domain/models/release/Release.js';
 import releaseJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/release-job-processor.js';
 import * as learningContentNotification from '../../../../lib/domain/services/learning-content-notification.js';
 import * as downloadTranslationFromPhraseUseCase from '../../../../lib/domain/usecases/download-translation-from-phrase.js';
+import * as uploadTranslationToPhraseUsecase from '../../../../lib/domain/usecases/upload-translation-to-phrase.js';
 import { logger } from '../../../../lib/infrastructure/logger.js';
 import { SlackNotifier } from '../../../../lib/infrastructure/notifications/SlackNotifier.js';
 import * as config from '../../../../lib/config.js';
@@ -87,6 +88,17 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
         // Then
         expect(learningContentNotification.notifyReleaseCreationSuccess).not.toHaveBeenCalled();
+      });
+
+      it('should call upload translation to phrase when is finished', async () => {
+        // given
+        const uploadTranslationToPhraseStub = vi.spyOn(uploadTranslationToPhraseUsecase, 'uploadTranslationToPhrase');
+
+        // when
+        await releaseJobProcessor({ data: {} });
+
+        // then
+        expect(uploadTranslationToPhraseStub).toHaveBeenCalled();
       });
     });
 

--- a/api/tests/unit/infrastructure/scheduled-jobs/upload-translation-job-processor_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/upload-translation-job-processor_test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest';
+import uploadTranslationJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/upload-translation-job-processor.js';
+import * as uploadTranslationToPhraseUseCase from '../../../../lib/domain/usecases/upload-translation-to-phrase.js';
+
+describe('Unit | Infrastructure | scheduled-jobs | upload-translation-job-job', function() {
+  it('should call the usecase', async function() {
+    // given
+    const uploadTranslationToPhraseStub = vi.spyOn(uploadTranslationToPhraseUseCase, 'uploadTranslationToPhrase').mockResolvedValue();
+
+    // when
+    await uploadTranslationJobProcessor();
+
+    // then
+    expect(uploadTranslationToPhraseStub).toHaveBeenCalledOnce();
+  });
+});

--- a/scalingo.json
+++ b/scalingo.json
@@ -4,6 +4,9 @@
     "REVIEW_APP": {
       "description": "Indicates that the application is a review app",
       "value": "true"
+    },
+    "PIX_EDITOR_BASE_URL": {
+      "generator": "url"
     }
   },
   "scripts": {


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons automatiser l'export des traduction vers phrases.

## :robot: Proposition
L'export des traductions étant basé sur la release nous utilisons le job de la release qui se joue chaque nuit pour exécuter l'export des traductions.

## :rainbow: Remarques
RAS

## :100: Pour tester
modifier le contenu d'une traduction.
Activer la création de la release via le cron et constater la mise à jour de la traduction sur phrase, avec le bon lien de prévisualisation.
