### PR TITLE
[TECH] Lire le champ "Géographie" depuis les localized_challenges de la base PG (PIX-11090)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -1,4 +1,4 @@
-import { getCountryCode } from './Geography.js';
+import { getCountryCode, getCountryName } from './Geography.js';
 
 export class Challenge {
 
@@ -93,58 +93,6 @@ export class Challenge {
     this.#translate(this.primaryLocale);
   }
 
-  translate(locale) {
-    const challenge = new Challenge({
-      ...this,
-      files: this.#allFiles,
-      locales: this.#primaryLocales,
-      status: this.#primaryStatus,
-      translations: this.#translations,
-    });
-    challenge.#translate(locale);
-    return challenge;
-  }
-
-  #translate(locale) {
-    this.locales = locale === this.primaryLocale
-      ? this.#primaryLocales
-      : [locale];
-
-    this.instruction = this.#translations[this.locale]?.instruction ?? '';
-    this.alternativeInstruction = this.#translations[this.locale]?.alternativeInstruction ?? '';
-    this.proposals = this.#translations[this.locale]?.proposals ?? '';
-    this.solution = this.#translations[this.locale]?.solution ?? '';
-    this.solutionToDisplay = this.#translations[this.locale]?.solutionToDisplay ?? '';
-    this.embedTitle = this.#translations[this.locale]?.embedTitle ?? '';
-    this.illustrationAlt = this.#translations[this.locale]?.illustrationAlt ?? null;
-
-    const localizedChallenge = this.localizedChallenges.find(({ locale }) => this.locale === locale);
-
-    this.id = localizedChallenge.id;
-    this.status = this.#translateStatus(localizedChallenge);
-    this.embedUrl = this.#translateEmbedUrl(localizedChallenge);
-
-    this.files = this.#allFiles
-      ?.filter(({ localizedChallengeId }) => localizedChallengeId === this.id)
-      .map(({ fileId }) => fileId);
-  }
-
-  #translateStatus(localizedChallenge) {
-    if (this.isPrimary) return this.#primaryStatus;
-    if (['proposé', 'périmé'].includes(this.status) || localizedChallenge.status === 'validé') {
-      return this.status;
-    }
-    return localizedChallenge.status;
-  }
-
-  #translateEmbedUrl(localizedChallenge) {
-    if (!this.#primaryEmbedUrl) return null;
-    if (localizedChallenge.embedUrl) return localizedChallenge.embedUrl;
-    const url = new URL(this.#primaryEmbedUrl);
-    url.searchParams.set('lang', localizedChallenge.locale);
-    return url.href;
-  }
-
   get primaryLocale() {
     return this.#primaryLocales[0];
   }
@@ -177,4 +125,61 @@ export class Challenge {
     if (locales == undefined || locales.length === 0) return ['fr'];
     return [...locales].sort();
   }
+
+  translate(locale) {
+    const challenge = new Challenge({
+      ...this,
+      files: this.#allFiles,
+      locales: this.#primaryLocales,
+      status: this.#primaryStatus,
+      translations: this.#translations,
+    });
+    challenge.#translate(locale);
+    return challenge;
+  }
+
+  #translate(locale) {
+    this.locales = locale === this.primaryLocale
+      ? this.#primaryLocales
+      : [locale];
+
+    this.instruction = this.#translations[this.locale]?.instruction ?? '';
+    this.alternativeInstruction = this.#translations[this.locale]?.alternativeInstruction ?? '';
+    this.proposals = this.#translations[this.locale]?.proposals ?? '';
+    this.solution = this.#translations[this.locale]?.solution ?? '';
+    this.solutionToDisplay = this.#translations[this.locale]?.solutionToDisplay ?? '';
+    this.embedTitle = this.#translations[this.locale]?.embedTitle ?? '';
+    this.illustrationAlt = this.#translations[this.locale]?.illustrationAlt ?? null;
+
+    const localizedChallenge = findCorrespondingLocalizedChallenge(this.localizedChallenges, this.locale);
+
+    this.id = localizedChallenge.id;
+    this.status = this.#translateStatus(localizedChallenge);
+    this.embedUrl = this.#translateEmbedUrl(localizedChallenge);
+    this.geography = getCountryName(localizedChallenge.geography);
+
+    this.files = this.#allFiles
+      ?.filter(({ localizedChallengeId }) => localizedChallengeId === this.id)
+      .map(({ fileId }) => fileId);
+  }
+
+  #translateStatus(localizedChallenge) {
+    if (this.isPrimary) return this.#primaryStatus;
+    if (['proposé', 'périmé'].includes(this.status) || localizedChallenge.status === 'validé') {
+      return this.status;
+    }
+    return localizedChallenge.status;
+  }
+
+  #translateEmbedUrl(localizedChallenge) {
+    if (!this.#primaryEmbedUrl) return null;
+    if (localizedChallenge.embedUrl) return localizedChallenge.embedUrl;
+    const url = new URL(this.#primaryEmbedUrl);
+    url.searchParams.set('lang', localizedChallenge.locale);
+    return url.href;
+  }
+}
+
+function findCorrespondingLocalizedChallenge(localizedChallenges, challengeLocale) {
+  return localizedChallenges.find(({ locale }) => challengeLocale === locale);
 }

--- a/api/lib/domain/models/Geography.js
+++ b/api/lib/domain/models/Geography.js
@@ -37,7 +37,7 @@ export function getCountryName(code) {
     ...nonStandardCountries
   ].find((standardCountry) => collator.compare(standardCountry.code, code) === 0);
 
-  return countryFound?.name ?? null;
+  return countryFound?.name ?? 'Neutre';
 }
 
 const collator = new Intl.Collator(NAME_LOCALE, {

--- a/api/lib/domain/models/Geography.js
+++ b/api/lib/domain/models/Geography.js
@@ -31,6 +31,15 @@ export function getCountryCode(name) {
   return nonStandardCountry?.code ?? null;
 }
 
+export function getCountryName(code) {
+  const countryFound = [
+    ...standardCountries,
+    ...nonStandardCountries
+  ].find((standardCountry) => collator.compare(standardCountry.code, code) === 0);
+
+  return countryFound?.name ?? null;
+}
+
 const collator = new Intl.Collator(NAME_LOCALE, {
   sensitivity: 'base',
   usage: 'search',

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -23,13 +23,18 @@ export class LocalizedChallenge {
     return this.id === this.challengeId;
   }
 
-  static buildPrimary(challenge) {
+  static buildPrimary({
+    challengeId,
+    locale,
+    embedUrl,
+    geography,
+  }) {
     return new LocalizedChallenge({
-      id: challenge.id,
-      challengeId: challenge.id,
-      locale: challenge.primaryLocale,
-      embedUrl: challenge.embedUrl,
-      geography: challenge.geographyCode,
+      id: challengeId,
+      challengeId,
+      locale,
+      embedUrl,
+      geography,
       status: null,
       fileIds: [],
     });

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -6,6 +6,9 @@ export class LocalizedChallenge {
     fileIds,
     locale,
     status,
+    // FIXME This is a geography code (not a country name !)
+    // remove me when all doubt is lifted (because in model challenge, geography references a country name !)
+    geography,
   } = {}) {
     this.id = id;
     this.challengeId = challengeId;
@@ -13,9 +16,34 @@ export class LocalizedChallenge {
     this.fileIds = fileIds ?? [];
     this.locale = locale;
     this.status = status;
+    this.geography = geography;
   }
 
   get isPrimary() {
     return this.id === this.challengeId;
+  }
+
+  static buildPrimary(challenge) {
+    return new LocalizedChallenge({
+      id: challenge.id,
+      challengeId: challenge.id,
+      locale: challenge.primaryLocale,
+      embedUrl: challenge.embedUrl,
+      geography: challenge.geographyCode,
+      status: null,
+      fileIds: [],
+    });
+  }
+
+  static buildAlternativeFromTranslation(translation) {
+    return new LocalizedChallenge({
+      id: null,
+      challengeId: translation.entityId,
+      locale: translation.locale,
+      status: 'proposé',
+      embedUrl: null,
+      fileIds: [],
+      geography: null,
+    });
   }
 }

--- a/api/lib/domain/models/Translation.js
+++ b/api/lib/domain/models/Translation.js
@@ -8,4 +8,8 @@ export class Translation {
     this.locale = locale;
     this.value = value;
   }
+
+  get entityId() {
+    return this.key.split('.')[1];
+  }
 }

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -1,4 +1,4 @@
-import { translationRepository, localizedChallengeRepository } from '../../infrastructure/repositories/index.js';
+import { localizedChallengeRepository, translationRepository } from '../../infrastructure/repositories/index.js';
 import { LocalizedChallenge, Translation } from '../models/index.js';
 import { parseStream } from 'fast-csv';
 import fp from 'lodash/fp.js';
@@ -45,12 +45,6 @@ const extractChallengesLocales = fp.flow(
   fp.filter((translation) => {
     return translation.key.startsWith('challenge.');
   }),
-  fp.map((challengeTranslation) => {
-    return new LocalizedChallenge({
-      challengeId: challengeTranslation.key.split('.')[1],
-      locale: challengeTranslation.locale,
-      status: 'proposé',
-    });
-  }),
+  fp.map(LocalizedChallenge.buildAlternativeFromTranslation),
   fp.uniqBy(({ challengeId, locale }) => `${challengeId}:${locale}`),
 );

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -11,7 +11,7 @@ export async function list() {
 }
 
 function toDomainList(datasourceAreas, translations) {
-  const translationsByAreaId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const translationsByAreaId = _.groupBy(translations, 'entityId');
   return datasourceAreas.map(
     (datasourceArea) => toDomain(datasourceArea, translationsByAreaId[datasourceArea.id]),
   );

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -13,7 +13,7 @@ export async function list() {
 }
 
 function toDomainList(datasourceAttachments, translations, localizedChallenges) {
-  const translationsByChallengeId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const translationsByChallengeId = _.groupBy(translations, 'entityId');
   const localizedChallengesById = _.groupBy(localizedChallenges, 'id');
 
   return datasourceAttachments.map((attachment) => {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { knex } from '../../../db/knex-database-connection.js';
-import { Challenge, LocalizedChallenge } from '../../domain/models/index.js';
+import { Challenge } from '../../domain/models/index.js';
 import { challengeDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as localizedChallengeRepository from './localized-challenge-repository.js';
@@ -56,8 +56,7 @@ export async function filter(params = {}) {
 
 export async function create(challenge) {
   const createdChallengeDto = await challengeDatasource.create(challenge);
-
-  const primaryLocalizedChallenge = LocalizedChallenge.buildPrimary(challenge);
+  const primaryLocalizedChallenge = challenge.localizedChallenges[0];
   await localizedChallengeRepository.create([primaryLocalizedChallenge]);
 
   const translations = extractTranslationsFromChallenge(challenge);

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { knex } from '../../../db/knex-database-connection.js';
-import { Challenge } from '../../domain/models/index.js';
+import { Challenge, LocalizedChallenge } from '../../domain/models/index.js';
 import { challengeDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as localizedChallengeRepository from './localized-challenge-repository.js';
@@ -57,13 +57,7 @@ export async function filter(params = {}) {
 export async function create(challenge) {
   const createdChallengeDto = await challengeDatasource.create(challenge);
 
-  const primaryLocalizedChallenge = {
-    id: challenge.id,
-    challengeId: challenge.id,
-    locale: challenge.primaryLocale,
-    embedUrl: challenge.embedUrl,
-    geography: challenge.geographyCode,
-  };
+  const primaryLocalizedChallenge = LocalizedChallenge.buildPrimary(challenge);
   await localizedChallengeRepository.create([primaryLocalizedChallenge]);
 
   const translations = extractTranslationsFromChallenge(challenge);

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -125,7 +125,7 @@ async function loadTranslationsAndLocalizedChallengesForChallenges(challengeDtos
 }
 
 function toDomainList(challengeDtos, translations, localizedChallenges) {
-  const translationsByChallengeId = _.groupBy(translations, ({ key }) => `${key.split('.')[1]}`);
+  const translationsByChallengeId = _.groupBy(translations, 'entityId');
   const localizedChallengesByChallengeId = _.groupBy(localizedChallenges, 'challengeId');
 
   return challengeDtos.map((challengeDto) => {

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -18,7 +18,7 @@ export async function getMany(ids) {
 }
 
 function toDomainList(datasourceCompetences, translations) {
-  const translationsByCompetenceId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const translationsByCompetenceId = _.groupBy(translations, 'entityId');
   return datasourceCompetences.map(
     (datasourceCompetence) => toDomain(datasourceCompetence, translationsByCompetenceId[datasourceCompetence.id]),
   );

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -57,7 +57,7 @@ export async function save(mission) {
 }
 
 function _toDomain(mission, translations) {
-  const translationsByMissionId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const translationsByMissionId = _.groupBy(translations, 'entityId');
   return new Mission({
     id: mission.id,
     createdAt: mission.createdAt,
@@ -69,6 +69,6 @@ function _toDomain(mission, translations) {
 }
 
 function _toDomainList(missions, translations) {
-  const translationsByMissionId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const translationsByMissionId = _.groupBy(translations, 'entityId');
   return missions.map((mission) => _toDomain(mission, translationsByMissionId[mission.id]));
 }

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -12,7 +12,7 @@ export async function list() {
 }
 
 function toDomainList(datasourceSkills, translations) {
-  const translationsBySkillId = _.groupBy(translations, ({ key }) => key.split('.')[1]);
+  const translationsBySkillId = _.groupBy(translations, 'entityId');
   return datasourceSkills.map(
     (datasourceSkill) => toDomain(datasourceSkill, translationsBySkillId[datasourceSkill.id]),
   );

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -1,5 +1,6 @@
 import JsonapiSerializer from 'jsonapi-serializer';
-import { Challenge } from '../../../domain/models/Challenge.js';
+import { Challenge, LocalizedChallenge } from '../../../domain/models/index.js';
+import { getCountryCode } from '../../../domain/models/Geography.js';
 
 const { Serializer, Deserializer } = JsonapiSerializer;
 
@@ -121,13 +122,12 @@ export function deserialize(challengeBody) {
   return new Promise((resolve, reject) => {
 
     deserializer.deserialize(challengeBody, (err, challengeObject) => {
-      challengeObject.localizedChallenges = [{
-        id: challengeObject.id,
+      challengeObject.localizedChallenges = [LocalizedChallenge.buildPrimary({
         challengeId: challengeObject.id,
         locale: Challenge.getPrimaryLocale(challengeObject.locales),
         embedUrl: challengeObject.embedUrl,
-        status: null,
-      }];
+        geography: getCountryCode(challengeObject.geography),
+      })];
       return err ? reject(err) : resolve(new Challenge(challengeObject));
     });
   });

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -63,5 +63,9 @@ const deserializer = new Deserializer({
 });
 
 export async function deserialize(localizedChallengeBody) {
-  return deserializer.deserialize(localizedChallengeBody);
+  const deserializedBody = await deserializer.deserialize(localizedChallengeBody);
+  return new LocalizedChallenge({
+    ...deserializedBody,
+    geography: null,
+  });
 }

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -2,10 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
 import _ from 'lodash';
 import {
+  airtableBuilder,
   databaseBuilder,
   domainBuilder,
   generateAuthorizationHeader,
-  airtableBuilder,
   knex
 } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
@@ -80,7 +80,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
     it('should return challenges', async () => {
       // Given
-      const challenge = domainBuilder.buildChallengeDatasourceObject({ id: 'my id' });
+      const challenge = domainBuilder.buildChallengeDatasourceObject({ id: 'my id', geography: 'DeprecatedLand' });
 
       const airtableChallenges = [
         airtableBuilder.factory.buildChallenge(challenge),
@@ -135,12 +135,14 @@ describe('Acceptance | Controller | challenges-controller', () => {
         id: 'my id',
         challengeId: 'my id',
         locale: 'fr',
-        embedUrl: 'http://example.com/my_embed.html'
+        embedUrl: 'http://example.com/my_embed.html',
+        geography: 'BR',
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'my id_nl',
         challengeId: 'my id',
-        locale: 'nl'
+        locale: 'nl',
+        geography: null,
       });
       await databaseBuilder.commit();
 
@@ -190,7 +192,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               responsive: 'non',
               locales: ['fr'],
               'alternative-locales': ['nl'],
-              geography: 'France',
+              geography: 'Brésil',
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
@@ -236,8 +238,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
     it('should filter challenges by id', async () => {
       // Given
-      const challenge1 = domainBuilder.buildChallengeDatasourceObject({ id: '1' });
-      const challenge2 = domainBuilder.buildChallengeDatasourceObject({ id: '2' });
+      const challenge1 = domainBuilder.buildChallengeDatasourceObject({ id: '1', geography: 'DeprecatedLand' });
+      const challenge2 = domainBuilder.buildChallengeDatasourceObject({ id: '2', geography: 'DeprecatedLand' });
       const airtableCall = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Epreuves')
         .query({
@@ -329,16 +331,19 @@ describe('Acceptance | Controller | challenges-controller', () => {
         challengeId: '1',
         locale: 'fr',
         embedUrl: 'http://example.com/my_embed.html',
+        geography: 'BR',
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: '2',
         challengeId: '2',
-        locale: 'fr'
+        locale: 'fr',
+        geography: 'PH',
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: '2_nl',
         challengeId: '2',
-        locale: 'nl'
+        locale: 'nl',
+        geography: null,
       });
 
       await databaseBuilder.commit();
@@ -391,7 +396,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               responsive: 'non',
               locales: ['fr'],
               'alternative-locales': [],
-              geography: 'France',
+              geography: 'Brésil',
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
@@ -460,7 +465,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
               responsive: 'non',
               locales: ['fr'],
               'alternative-locales': ['nl'],
-              geography: 'France',
+              geography: 'Philippines',
               'auto-reply': false,
               focusable: false,
               'updated-at': '2021-10-04',
@@ -577,6 +582,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           { fileId: 'fileId1', localizedChallengeId: 'recChallengeId1' },
           { fileId: 'fileId2', localizedChallengeId: 'recChallengeId2' },
         ],
+        geography: 'DeprecatedLand',
       });
       const airtableChallenge = airtableBuilder.factory.buildChallenge(challenge);
       const airtableCall = nock('https://api.airtable.com')
@@ -597,11 +603,13 @@ describe('Acceptance | Controller | challenges-controller', () => {
         challengeId: 'recChallengeId1',
         locale: 'fr',
         embedUrl: 'https://github.io/page/epreuve.html',
+        geography: 'BR',
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'localizedChallengeId2',
         challengeId: 'recChallengeId1',
         locale: 'nl',
+        geography: null,
       });
       databaseBuilder.factory.buildTranslation({
         key: 'challenge.recChallengeId1.instruction',
@@ -687,7 +695,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             responsive: 'non',
             locales: ['fr'],
             'alternative-locales': ['nl'],
-            geography: 'France',
+            geography: 'Brésil',
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
@@ -773,6 +781,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           id: challengeId,
           locales: ['fr', 'fr-fr'],
           status: 'validé',
+          geography: 'DeprecatedLand',
         })
       ]).activate().nockScope;
 
@@ -823,12 +832,14 @@ describe('Acceptance | Controller | challenges-controller', () => {
         id: challengeId,
         challengeId,
         locale: 'fr',
+        geography: 'BR',
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: localizedChallengeId,
         challengeId,
         locale,
         status: 'proposé',
+        geography: null,
       });
 
       await databaseBuilder.commit();
@@ -903,6 +914,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       // Given
       const challenge = {
         ...domainBuilder.buildChallengeDatasourceObject({ id: 'challengeId', locales: ['fr'] }),
+        geography: 'Mozambique',
         instruction: 'consigne',
         alternativeInstruction: 'consigne alternative',
         solution: 'solution',
@@ -1026,7 +1038,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             responsive: 'non',
             'alternative-locales': [],
             locales: ['fr'],
-            geography: 'France',
+            geography: 'Mozambique',
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
@@ -1069,7 +1081,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           locale: 'fr',
           embedUrl: challenge.embedUrl,
           status: null,
-          geography: 'FR',
+          geography: 'MZ',
         }
       ]);
       const translations = await knex('translations').select().orderBy('key');
@@ -1581,12 +1593,13 @@ describe('Acceptance | Controller | challenges-controller', () => {
         solutionToDisplay: 'solution à afficher',
         proposals: 'propositions',
         embedTitle: 'Titre d\'embed',
-        geography: 'Neutre',
+        geography: 'Jamaïque',
       };
       databaseBuilder.factory.buildLocalizedChallenge({
         id: challengeId,
         challengeId,
         locale: originalLocale,
+        geography: 'BR',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.instruction`,
@@ -1737,7 +1750,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             responsive: 'non',
             'alternative-locales': [],
             locales: ['fr', 'fr-fr'],
-            geography: 'Neutre',
+            geography: 'Jamaïque',
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
@@ -1781,7 +1794,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           embedUrl: challenge.embedUrl,
           locale: 'fr',
           status: null,
-          geography: null,
+          geography: 'JM',
         },
       ]);
       await expect(knex('translations').orderBy('key').select()).resolves.to.deep.equal([

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -56,7 +56,7 @@ async function mockCurrentContent() {
   const expectedChallenge = { ...challenge, geography: 'Brésil', area: 'Brésil' };
   delete expectedChallenge.localizedChallenges;
 
-  const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', geography: null, area: null };
+  const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', geography: 'Neutre', area: 'Neutre' };
   delete expectedChallengeNl.localizedChallenges;
   const expectedCurrentContent = {
     attachments: [

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -1,10 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import {
-  generateAuthorizationHeader,
-  databaseBuilder,
-  airtableBuilder,
-  domainBuilder
-} from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 const {
@@ -40,11 +35,6 @@ async function mockCurrentContent() {
       { fileId: 'attid2', localizedChallengeId: 'localized-challenge-id' },
     ],
   });
-  const expectedChallenge = { ...challenge, area: challenge.geography };
-  delete expectedChallenge.localizedChallenges;
-
-  const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', area: challenge.geography };
-  delete expectedChallengeNl.localizedChallenges;
 
   const expectedAttachment = {
     id: 'attid1',
@@ -63,6 +53,11 @@ async function mockCurrentContent() {
     localizedChallengeId: 'localized-challenge-id',
   };
 
+  const expectedChallenge = { ...challenge, geography: 'Brésil', area: 'Brésil' };
+  delete expectedChallenge.localizedChallenges;
+
+  const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', geography: null, area: null };
+  delete expectedChallengeNl.localizedChallenges;
   const expectedCurrentContent = {
     attachments: [
       { ...domainBuilder.buildAttachment(expectedAttachment),  alt: null, },
@@ -143,12 +138,14 @@ async function mockCurrentContent() {
     locale: 'fr',
     embedUrl: challenge.embedUrl,
     status: 'validé',
+    geography: 'BR',
   });
   databaseBuilder.factory.buildLocalizedChallenge({
     id: 'localized-challenge-id',
     challengeId: challenge.id,
     locale: 'nl',
     status: 'validé',
+    geography: null,
   });
   databaseBuilder.factory.buildTranslation({
     key: `challenge.${challenge.id}.instruction`,

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -1,4 +1,4 @@
-import { describe, describe as context, expect, it, afterEach } from 'vitest';
+import { afterEach, describe as context, describe, expect, it } from 'vitest';
 import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import { localizedChallengeRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
@@ -13,7 +13,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
         challengeId: 'challengeId',
         locale: 'fr-fr',
         embedUrl: 'https://example.com/embed.html',
-        status: 'proposé'
+        status: 'proposé',
+        geography: null,
       });
       await databaseBuilder.commit();
 
@@ -28,6 +29,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         embedUrl: 'https://example.com/embed.html',
         status: 'proposé',
         fileIds: [],
+        geography: null,
       }]);
     });
   });
@@ -671,6 +673,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
           embedUrl: 'my-new-url.html',
           locale: 'ar',
           status: null,
+          geography: 'AR',
         }));
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
@@ -9,15 +9,13 @@ export function buildLocalizedChallenge({
   status = null,
   geography = null,
 }) {
-  const localizedChallenge = new LocalizedChallenge({
+  return new LocalizedChallenge({
     id,
     challengeId,
     embedUrl,
     fileIds,
     locale,
-    status
+    status,
+    geography,
   });
-  // FIXME remove when constructor has geography
-  if (geography) localizedChallenge.geography = geography;
-  return localizedChallenge;
 }

--- a/api/tests/tooling/domain-builder/factory/build-translation.js
+++ b/api/tests/tooling/domain-builder/factory/build-translation.js
@@ -1,0 +1,13 @@
+import { Translation } from '../../../../lib/domain/models/index.js';
+
+export function buildTranslation({
+  key,
+  locale,
+  value,
+}) {
+  return new Translation({
+    key,
+    locale,
+    value,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -22,6 +22,7 @@ export * from './build-static-course-read.js';
 export * from './build-static-course-summary.js';
 export * from './build-tag.js';
 export * from './build-thematic-for-release.js';
+export * from './build-translation.js';
 export * from './build-tube-for-release.js';
 export * from './build-tutorial-for-release.js';
 export * from './datasource-objects/build-area-datasource-object.js';

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -199,6 +199,7 @@ describe('Unit | Domain | Challenge', () => {
         challengeId,
         locale: 'fr',
         embedUrl: 'https://example.com/index.html?lang=fr&mode=example',
+        geography: 'FR',
       });
       const dutchLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: dutchChallengeId,
@@ -206,6 +207,7 @@ describe('Unit | Domain | Challenge', () => {
         locale: 'nl',
         embedUrl: 'https://example.nl/index.html?mode=example',
         status: 'proposé',
+        geography: 'NL',
       });
       const englishLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: englishChallengeId,
@@ -213,6 +215,7 @@ describe('Unit | Domain | Challenge', () => {
         locale: 'en',
         embedUrl: null,
         status: 'validé',
+        geography: null,
       });
       const localizedChallenges = [
         frenchLocalizedChallenge,
@@ -256,6 +259,7 @@ describe('Unit | Domain | Challenge', () => {
           ...dutchFiles,
           ...englishFiles,
         ],
+        geography: 'France',
       });
 
       const expectedDutchChallenge = {
@@ -266,6 +270,7 @@ describe('Unit | Domain | Challenge', () => {
         ...translations.nl,
         embedUrl: dutchLocalizedChallenge.embedUrl,
         files: dutchFiles.map(({ fileId }) => fileId),
+        geography: 'Pays-Bas',
       };
 
       const expectedEnglishChallenge = {
@@ -276,6 +281,7 @@ describe('Unit | Domain | Challenge', () => {
         ...translations.en,
         embedUrl: 'https://example.com/index.html?lang=en&mode=example',
         files: englishFiles.map(({ fileId }) => fileId),
+        geography: null,
       };
 
       // when
@@ -362,9 +368,10 @@ describe('Unit | Domain | Challenge', () => {
           id: challengeId,
           challengeId,
           locale: 'fr',
+          geography: 'NZ',
         })],
         translations: { fr: {} },
-        geography: 'Nouvelle-Zélande',
+        geography: 'DeprecatedLand',
       });
 
       // then
@@ -382,8 +389,10 @@ describe('Unit | Domain | Challenge', () => {
           id: challengeId,
           challengeId,
           locale: 'fr',
+          geography: null,
         })],
         translations: { fr: {} },
+        geography: 'DeprecatedLand',
       });
 
       // when

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -281,7 +281,7 @@ describe('Unit | Domain | Challenge', () => {
         ...translations.en,
         embedUrl: 'https://example.com/index.html?lang=en&mode=example',
         files: englishFiles.map(({ fileId }) => fileId),
-        geography: null,
+        geography: 'Neutre',
       };
 
       // when

--- a/api/tests/unit/domain/models/Geography_test.js
+++ b/api/tests/unit/domain/models/Geography_test.js
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-
-import { getCountryCode } from '../../../../lib/domain/models/Geography';
+import { getCountryCode, getCountryName } from '../../../../lib/domain/models/Geography';
 
 describe('Unit | Model | Geography', () => {
   describe('#getCountryCode', () => {
@@ -246,6 +245,69 @@ describe('Unit | Model | Geography', () => {
       expect(codes).toEqual([
         null,
         null,
+        null,
+        null,
+        null,
+      ]);
+    });
+  });
+  describe('#getCountryName', () => {
+    it('should convert country code to country french name', () => {
+      // given
+      const codes = [
+        'af', 'ZA', 'AL', 'DZ', 'DE', 'AD',
+        'AO', 'AG', 'SA', 'AR', 'AM', 'AU',
+        'AT', 'AZ', 'BS', 'BH', 'BD', 'BB',
+        'BE', 'BZ', 'BJ', 'BT', 'BY', 'MM',
+        'BO', 'BA', 'BW', 'BR', 'BN', 'BG',
+        'BF', 'BI', 'KH', 'CM', 'CA', 'CV',
+        'CL', 'CN', 'CY', 'CO', 'KM', 'CG',
+        'CK', 'KP', 'KR', 'CR', 'CI', 'HR',
+        'CU', 'DK',
+        'DJ', 'DO', 'DM', 'EG', 'AE', 'EC',
+        'ER', 'ES', 'EE', 'SZ', 'ET', 'FJ',
+        'FI', 'FR', 'GA', 'GM', 'GE', 'GH',
+        'GR', 'GD', 'GN', 'GT', 'GQ', 'GW',
+        'GY', 'HT', 'HN', 'HU', 'IN', 'ID',
+        'IQ', 'IR', 'IE', 'IS', 'IL', 'IT',
+        'JM', 'JP', 'JO', 'KZ', 'KE', 'KG',
+        'KI', 'XK', 'KW', 'LA', 'LS', 'LV',
+        'LB', 'LR',
+        'LY', 'LI', 'LT', 'LU', 'MK', 'MG',
+        'MY', 'MW', 'MV', 'ML', 'MT', 'MA',
+        'MH', 'MU', 'MR', 'MX', 'FM', 'MD',
+        'MC', 'MN', 'ME', 'MZ', 'NA', 'NR',
+        'NP', 'NI', 'NE', 'NG', 'NU', 'NO',
+        'NZ', 'OM', 'UG', 'UZ', 'PK', 'PW',
+        'PS', 'PA', 'PG', 'PY', 'NL', 'PE',
+        'PH', 'PL', 'PT', 'QA', 'CF', 'RO',
+        'RU', 'RW',
+        'KN', 'LC', 'SM', 'VC', 'SB', 'SV',
+        'WS', 'ST', 'SN', 'RS', 'SL', 'SG',
+        'SK', 'SI', 'SO', 'SD', 'SS', 'LK',
+        'SE', 'CH', 'SR', 'SY', 'TJ', 'TZ',
+        'TD', 'CZ', 'TH', 'TL', 'TG', 'TO',
+        'TT', 'TN', 'TM', 'TR', 'TV', 'GB',
+        'UA', 'UY', 'US', 'VU', 'VA', 'VE',
+        'VN', 'YE', 'ZM', 'ZW',
+      ];
+
+      // when
+      const names = codes.map(getCountryName);
+
+      // then
+      expect(names, `no country name for ${codes[names.indexOf(undefined)]}`).not.toContain(undefined);
+    });
+
+    it('should return null for unknown country code', () => {
+      // given
+      const codes = [ null, 'UKNOWN', undefined ];
+
+      // when
+      const names = codes.map(getCountryName);
+
+      // then
+      expect(names).toEqual([
         null,
         null,
         null,

--- a/api/tests/unit/domain/models/Geography_test.js
+++ b/api/tests/unit/domain/models/Geography_test.js
@@ -299,7 +299,7 @@ describe('Unit | Model | Geography', () => {
       expect(names, `no country name for ${codes[names.indexOf(undefined)]}`).not.toContain(undefined);
     });
 
-    it('should return null for unknown country code', () => {
+    it('should return \'Neutre\' for unknown country code', () => {
       // given
       const codes = [ null, 'UKNOWN', undefined ];
 
@@ -308,9 +308,9 @@ describe('Unit | Model | Geography', () => {
 
       // then
       expect(names).toEqual([
-        null,
-        null,
-        null,
+        'Neutre',
+        'Neutre',
+        'Neutre',
       ]);
     });
   });

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -24,15 +24,18 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   describe('static buildPrimary', function() {
     it('should build a primary localized challenge', function() {
       // given
-      const challenge = domainBuilder.buildChallenge({
-        id: 'idDuChallenge',
-        locales: ['jp', 'fr', 'en'],
-        geography: 'Japon',
-        embedUrl: 'mon/embed.url',
-      });
+      const challengeId = 'idDuChallenge';
+      const locale = 'en';
+      const embedUrl = 'mon/embed.url';
+      const geography = 'JP';
 
       // when
-      const primaryLocalizedChallenge = LocalizedChallenge.buildPrimary(challenge);
+      const primaryLocalizedChallenge = LocalizedChallenge.buildPrimary({
+        challengeId,
+        locale,
+        embedUrl,
+        geography,
+      });
 
       // then
       expect(primaryLocalizedChallenge).to.deep.equal({

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { domainBuilder } from '../../../tooling/domain-builder/domain-builder.js';
+import { LocalizedChallenge } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | LocalizedChallenge', () => {
   describe('#isPrimary', () => {
@@ -17,6 +18,56 @@ describe('Unit | Domain | LocalizedChallenge', () => {
       // then
       expect(primaryLocalizedChallenge.isPrimary).toBe(true);
       expect(alternativeLocalizedChallenge.isPrimary).toBe(false);
+    });
+  });
+
+  describe('static buildPrimary', function() {
+    it('should build a primary localized challenge', function() {
+      // given
+      const challenge = domainBuilder.buildChallenge({
+        id: 'idDuChallenge',
+        locales: ['jp', 'fr', 'en'],
+        geography: 'Japon',
+        embedUrl: 'mon/embed.url',
+      });
+
+      // when
+      const primaryLocalizedChallenge = LocalizedChallenge.buildPrimary(challenge);
+
+      // then
+      expect(primaryLocalizedChallenge).to.deep.equal({
+        id: 'idDuChallenge',
+        challengeId: 'idDuChallenge',
+        embedUrl: 'mon/embed.url',
+        fileIds: [],
+        locale: 'en',
+        status: null,
+        geography: 'JP',
+      });
+    });
+  });
+
+  describe('static buildAlternativeFromTranslation', function() {
+    it('should build an alternative localized challenge', function() {
+      // given
+      const translation = domainBuilder.buildTranslation({
+        key: 'challenge.idDuChallenge.field',
+        locale: 'fr',
+      });
+
+      // when
+      const primaryLocalizedChallenge = LocalizedChallenge.buildAlternativeFromTranslation(translation);
+
+      // then
+      expect(primaryLocalizedChallenge).to.deep.equal({
+        id: null,
+        challengeId: 'idDuChallenge',
+        locale: 'fr',
+        status: 'proposé',
+        embedUrl: null,
+        fileIds: [],
+        geography: null,
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/Translation_test.js
+++ b/api/tests/unit/domain/models/Translation_test.js
@@ -1,0 +1,19 @@
+import { describe, describe as context, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Domain | Translation', function() {
+  context('get entityId', function() {
+    it('should generate the expected entityId', function() {
+      // given
+      const translation = domainBuilder.buildTranslation({
+        key: 'challenge.idDuChallenge.champ',
+      });
+
+      // when
+      const entityId = translation.entityId;
+
+      // then
+      expect(entityId).to.equal('idDuChallenge');
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Translation, LocalizedChallenge } from '../../../../lib/domain/models/index.js';
-import {
-  InvalidFileError,
-  importTranslations
-} from '../../../../lib/domain/usecases/import-translations';
+import { LocalizedChallenge, Translation } from '../../../../lib/domain/models/index.js';
+import { importTranslations, InvalidFileError } from '../../../../lib/domain/usecases/index.js';
 import { PassThrough } from 'node:stream';
 
 describe('Unit | Domain | Usecases | import-translations', function() {
@@ -35,7 +32,7 @@ describe('Unit | Domain | Usecases | import-translations', function() {
       translations: [new Translation({
         key: 'some.key',
         locale: 'nl',
-        value: 'Hallo'
+        value: 'Hallo',
       })],
     });
   });
@@ -94,14 +91,22 @@ describe('Unit | Domain | Usecases | import-translations', function() {
     expect(localizedChallengeRepository.create).toHaveBeenCalledOnce();
     expect(localizedChallengeRepository.create).toHaveBeenCalledWith([
       new LocalizedChallenge({
+        id: null,
         challengeId: 'id',
         locale: 'nl',
         status: 'proposé',
+        embedUrl: null,
+        fileIds: [],
+        geography: null,
       }),
       new LocalizedChallenge({
+        id: null,
         challengeId: 'id2',
         locale: 'nl',
         status: 'proposé',
+        embedUrl: null,
+        fileIds: [],
+        geography: null,
       }),
     ]);
   });

--- a/api/tests/unit/domain/usecases/preview-challenge_test.js
+++ b/api/tests/unit/domain/usecases/preview-challenge_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { previewChallenge } from '../../../../lib/domain/usecases/preview-challenge.js';
+import { previewChallenge } from '../../../../lib/domain/usecases/index.js';
 import * as config from '../../../../lib/config.js';
 
 describe('Unit | Domain | Usecases | preview-challenge', function() {
@@ -11,16 +11,18 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
     const locale = 'fr';
     const challengeId = 'challenge-id';
     const localizedChallengeId = 'localizedChallengeId';
-    const localizedChallenge = {
+    const localizedChallenge = domainBuilder.buildLocalizedChallenge({
       id: localizedChallengeId,
       challengeId,
       locale,
-    };
+      geography: 'TJ',
+    });
     const localizedChallengeRepository = {
       getByChallengeIdAndLocale: vi.fn().mockResolvedValueOnce(localizedChallenge),
     };
     const challenge = domainBuilder.buildChallenge({
       localizedChallenges: [localizedChallenge],
+      geography: 'Tadjikistan',
     });
     const challengeRepository = {
       get: vi.fn().mockResolvedValueOnce(challenge),

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -56,7 +56,7 @@ describe('Unit | Repository | challenge-repository', () => {
       const challenges = await list();
 
       // then
-      expect(challenges.length).equal(2);
+      expect(challenges.length).to.equal(2);
       expect(challengeDatasource.list).toHaveBeenCalled();
       expect(translationRepository.listByPrefix).toHaveBeenCalledWith('challenge.');
       expect(localizedChallengeRepository.list).toHaveBeenCalled();
@@ -131,7 +131,7 @@ describe('Unit | Repository | challenge-repository', () => {
         const challenges = await filter({ filter: { ids: ['1', '2'] } });
 
         // then
-        expect(challenges.length).equal(2);
+        expect(challenges.length).to.equal(2);
         expect(challenges[0].instruction).to.equal('instruction');
         expect(challenges[0].proposals).to.equal('proposals');
         expect(challenges[0].alternativeLocales).to.deep.equal(['en']);
@@ -170,7 +170,7 @@ describe('Unit | Repository | challenge-repository', () => {
         const challenges = await filter({ filter: { ids: ['1'] } });
 
         // then
-        expect(challenges.length).equal(1);
+        expect(challenges.length).to.equal(1);
         expect(challenges[0].instruction).to.equal('');
         expect(challenges[0].proposals).to.equal('proposals');
         expect(challenges[0].geography).to.equal('Brésil');
@@ -198,7 +198,7 @@ describe('Unit | Repository | challenge-repository', () => {
         const challenges = await filter({ filter: { ids: ['1'] } });
 
         // then
-        expect(challenges.length).equal(1);
+        expect(challenges.length).to.equal(1);
         expect(challenges[0].proposals).to.equal('');
         expect(challenges[0].geography).to.equal('Brésil');
       });
@@ -231,7 +231,7 @@ describe('Unit | Repository | challenge-repository', () => {
         const challenges = await filter({ page: { size: 20 } });
 
         // then
-        expect(challenges.length).equal(2);
+        expect(challenges.length).to.equal(2);
         expect(challengeDatasource.filter).not.toHaveBeenCalled();
         expect(challengeDatasource.list).toHaveBeenCalledWith({ page: { size: 20 } });
       });
@@ -257,8 +257,8 @@ describe('Unit | Repository | challenge-repository', () => {
         const challenges = await filter({ filter: { search: 'toto' }, page: { size: 'limit' } });
 
         // then
-        expect(challenges.length).equal(1);
-        expect(challenges[0].geography).equal('Brésil');
+        expect(challenges.length).to.equal(1);
+        expect(challenges[0].geography).to.equal('Brésil');
         expect(translationRepository.search).toHaveBeenCalledWith({
           entity: 'challenge',
           fields: ['instruction', 'proposals'],

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { filter, list, get, update } from '../../../../lib/infrastructure/repositories/challenge-repository.js';
-import { challengeDatasource } from '../../../../lib/infrastructure/datasources/airtable/challenge-datasource.js';
+import { filter, get, list, update } from '../../../../lib/infrastructure/repositories/challenge-repository.js';
+import { challengeDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import {
   localizedChallengeRepository,
   translationRepository
@@ -30,7 +30,7 @@ describe('Unit | Repository | challenge-repository', () => {
           key: 'challenge.2.proposals',
           value: 'proposals 2',
           locale: 'fr'
-        }]);
+        }].map(domainBuilder.buildTranslation));
       vi.spyOn(localizedChallengeRepository, 'list').mockResolvedValueOnce([
         domainBuilder.buildLocalizedChallenge({
           id: '1',
@@ -88,7 +88,7 @@ describe('Unit | Repository | challenge-repository', () => {
             key: 'challenge.1.proposals',
             value: 'proposals',
             locale: 'fr'
-          }])
+          }].map(domainBuilder.buildTranslation))
           .mockResolvedValueOnce([{
             key: 'challenge.2.instruction',
             value: 'instruction 2',
@@ -97,7 +97,7 @@ describe('Unit | Repository | challenge-repository', () => {
             key: 'challenge.2.proposals',
             value: 'proposals 2',
             locale: 'fr'
-          }]);
+          }].map(domainBuilder.buildTranslation));
 
         const localizedChallenge1 = domainBuilder.buildLocalizedChallenge({
           id: '1',
@@ -148,7 +148,7 @@ describe('Unit | Repository | challenge-repository', () => {
             key: 'challenge.1.proposals',
             value: 'proposals',
             locale: 'fr'
-          }]);
+          }].map(domainBuilder.buildTranslation));
         vi.spyOn(localizedChallengeRepository, 'listByChallengeIds').mockResolvedValueOnce([
           domainBuilder.buildLocalizedChallenge({
             id: '1',

--- a/api/tests/unit/infrastructure/repository/competence-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/competence-repository_test.js
@@ -60,7 +60,7 @@ describe('Unit | Repository | competence-repository', () => {
           key: 'competence.competence2.description',
           locale: 'en',
           value: 'Competence 2 description',
-        }]);
+        }].map(domainBuilder.buildTranslation));
 
       // when
       const competences = await competenceRepository.getMany(['competence1', 'competence2']);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -1,15 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { domainBuilder } from '../../../../test-helper.js';
-import { serialize, deserialize } from '../../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
+import { deserialize, serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer.js';
 
 describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
   describe('#serialize', () => {
     it('should serialize a Challenge', () => {
       // Given
-      const localizedChallenge = domainBuilder.buildLocalizedChallenge({ id: 'recwWzTquPlvIl4So' });
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({ id: 'recwWzTquPlvIl4So', geography: 'MZ' });
       const challenge = domainBuilder.buildChallenge({
         id: 'recwWzTquPlvIl4So',
         localizedChallenges: [localizedChallenge],
+        geography: 'DEPRECATED',
       });
       const alternativeLocales = ['en', 'nl'];
       const expectedSerializedChallenge = {
@@ -47,7 +48,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             responsive: 'non',
             locales: ['fr'],
             'alternative-locales': ['en', 'nl'],
-            geography: 'France',
+            geography: 'Mozambique',
             'auto-reply': false,
             focusable: false,
             'updated-at': '2021-10-04',
@@ -90,7 +91,11 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
   describe('#deserialize', () => {
     it('should deserialize a Challenge', async () => {
       // Given
-      const expectedDeserializedChallenge = domainBuilder.buildChallenge(undefined, ['alpha', 'delta', 'skillId']);
+      const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
+        geography: 'MD',
+        embedUrl: 'https://github.io/page/epreuve.html',
+      });
+      const expectedDeserializedChallenge = domainBuilder.buildChallenge({ localizedChallenges: [expectedLocalizedChallenge] }, ['alpha', 'delta', 'skillId']);
       const json = {
         data: {
           type: 'challenges',
@@ -124,7 +129,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             spoil: 'Non Sp',
             responsive: 'non',
             locales: [],
-            geography: 'France',
+            geography: 'Moldavie',
             'auto-reply': false,
             focusable: false,
             competenceId: 'recsvLz0W2ShyfD63',


### PR DESCRIPTION
## :unicorn: Problème
L'information "Géographie" des épreuves est déplacée dans la table `localized_challenges` de PG.
A ce jour, cette information est écrite au bon endroit mais pas lue depuis la table `localized_challenges`.

## :robot: Proposition
Lire l'info depuis la table `localized_challenges`.
Vérifier :
- Les seeds : lors de la création à la volée des `localized challenges` dans les seeds, informer le champ `geography` ✅ 
- PixEditor : écrire l'information correctement dans modèles envoyés au front ✅ 
- Réplication : copier l'information correctement dans `challenge.area` ✅ 
- Release : pas de modification, l'information n'est pas embarquée dans la release ✅ 

## :rainbow: Remarques


## :100: Pour tester
Tester PixEditor.

Pour tester la répli, avec l'aide de httpie et de jq, essayer de trouver les challenges modifiés en cherchant un id qui a eu sa géographie modifiée et en tapant la commande suivante : 
`http GET https://pix-lcms-review-pr590.osc-fr1.scalingo.io/api/replication-data -A "bearer" -a "la-valeur-de-mon-bearer" | jq '.challenges[] | select(.area!="Neutre")'` 
(Ici, on va chercher tous les "area" qui n'ont pas la valeur neutre, mais on peut chercher d'autres choses.)
