### PR TITLE
[FEATURE] Ajouter les fonctions de synchronisation de et vers Phrase dans Pix-Editor (PIX-11621).

### DIFF
--- a/pix-editor/app/adapters/phrase.js
+++ b/pix-editor/app/adapters/phrase.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application.js';
+
+export default class PhraseAdapter extends ApplicationAdapter {
+  pathForType() {
+    return 'phrase';
+  }
+}

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -5,6 +5,11 @@
   <Sidebar::Search @displaySearch={{this.maySearch}} @close={{@close}} />
   <Sidebar::Navigation @displayFrameworkList={{this.maySwitchFramework}} @close={{@close}}/>
   <div class="secondary-links">
+    {{#if this.maySynchronizeTranslations}}
+      <LinkTo @route="authenticated.synchronize-translations" {{on "click" @close}}>
+        <i class="sync icon"></i> Synchroniser les traductions
+      </LinkTo>
+    {{/if}}
     {{#if this.shouldShowMissionsLink}}
       <LinkTo @route="authenticated.missions" {{on "click" @close}}>
         <i class="graduation cap icon"></i> Missions Pix 1D

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -33,6 +33,10 @@ export default class SidebarMain extends Component {
     return this.access.isReadOnly();
   }
 
+  get maySynchronizeTranslations() {
+    return this.access.isEditor();
+  }
+
   get shouldShowMissionsLink() {
     return this.currentData?.getFramework()?.name.toLowerCase() === FrameworkModel.pix1DFrameworkName.toLowerCase();
   }

--- a/pix-editor/app/controllers/authenticated/synchronize-translations.js
+++ b/pix-editor/app/controllers/authenticated/synchronize-translations.js
@@ -6,16 +6,6 @@ export default class SynchronizeTranslationsController extends Controller {
   @service notifications;
 
   @action
-  async uploadToPhrase() {
-    try {
-      await this.model.upload();
-      this.notifications.success('Envoi des traductions effectué.');
-    } catch {
-      this.notifications.error('Erreur lors de l\'envoi des traductions.');
-    }
-  }
-
-  @action
   async importFromPhrase() {
     try {
       await this.model.download();

--- a/pix-editor/app/controllers/authenticated/synchronize-translations.js
+++ b/pix-editor/app/controllers/authenticated/synchronize-translations.js
@@ -1,0 +1,27 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class SynchronizeTranslationsController extends Controller {
+  @service notifications;
+
+  @action
+  async uploadToPhrase() {
+    try {
+      await this.model.upload();
+      this.notifications.success('Envoi des traductions effectué.');
+    } catch {
+      this.notifications.error('Erreur lors de l\'envoi des traductions.');
+    }
+  }
+
+  @action
+  async importFromPhrase() {
+    try {
+      await this.model.download();
+      this.notifications.success('Téléchargement des traductions depuis Phrase effectué.');
+    } catch {
+      this.notifications.error('Erreur lors du téléchargement des traductions.');
+    }
+  }
+}

--- a/pix-editor/app/models/phrase.js
+++ b/pix-editor/app/models/phrase.js
@@ -1,0 +1,16 @@
+import Model from '@ember-data/model';
+import { collectionAction } from 'ember-api-actions';
+
+export default class PhraseModel extends Model {
+  upload = collectionAction({
+    path: 'upload',
+    type: 'post',
+    urlType: 'findRecord'
+  });
+
+  download = collectionAction({
+    path: 'download',
+    type: 'post',
+    urlType: 'findRecord'
+  });
+}

--- a/pix-editor/app/models/phrase.js
+++ b/pix-editor/app/models/phrase.js
@@ -2,12 +2,6 @@ import Model from '@ember-data/model';
 import { collectionAction } from 'ember-api-actions';
 
 export default class PhraseModel extends Model {
-  upload = collectionAction({
-    path: 'upload',
-    type: 'post',
-    urlType: 'findRecord'
-  });
-
   download = collectionAction({
     path: 'download',
     type: 'post',

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -75,5 +75,6 @@ Router.map(function () {
         this.route('edit');
       });
     });
+    this.route('synchronize-translations');
   });
 });

--- a/pix-editor/app/routes/authenticated/synchronize-translations.js
+++ b/pix-editor/app/routes/authenticated/synchronize-translations.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class SynchronizeTranslationsRoute extends Route {
+  @service store;
+
+  model() {
+    return this.store.createRecord('phrase');
+  }
+}

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -28,6 +28,7 @@
 @import 'authenticated/missions/details';
 @import 'authenticated/static-courses/list';
 @import 'authenticated/static-courses/static-course';
+@import 'authenticated/synchronize-translations';
 @import 'components/card';
 @import 'components/login-form';
 @import 'components/field';

--- a/pix-editor/app/styles/authenticated/synchronize-translations.scss
+++ b/pix-editor/app/styles/authenticated/synchronize-translations.scss
@@ -1,0 +1,10 @@
+.synchronize-translations {
+  &--block {
+    padding: var(--pix-spacing-4x);
+    margin-bottom: var(--pix-spacing-4x);
+  }
+
+  &--action {
+    margin-top: var(--pix-spacing-4x);
+  }
+}

--- a/pix-editor/app/templates/authenticated/synchronize-translations.hbs
+++ b/pix-editor/app/templates/authenticated/synchronize-translations.hbs
@@ -1,0 +1,36 @@
+<div class="page">
+  <header class="page-header">
+    <h1 class="page-title">Synchronisation des traductions</h1>
+  </header>
+  <main class="page-body synchronize-translations">
+    <section class="page-section">
+      <PixBlock @shadow="light" class="synchronize-translations--block">
+        <p>Envoi l'ensemble des traductions du référentiel Pix en français sur Phrase. Seules les épreuves validées sont envoyées.
+        <br><em>Le traitement de l'envoi par Phrase peut prendre plusieurs minutes. Une fois lancé, vous pouvez suivre le traitement sur la page Uploads du projet Phrase.</em></p>
+
+        <PixButton
+          @triggerAction={{this.uploadToPhrase}}
+          @loadingColor="white"
+          @size="small"
+          @isBorderVisible="{{true}}"
+          class="synchronize-translations--action"
+        >
+          Envoyer les traductions vers Phrase
+        </PixButton>
+      </PixBlock>
+
+      <PixBlock @shadow="light" class="synchronize-translations--block">
+        <p>Récupére toutes les traductions de Phrase, sauf celles de la langue principale (le fr).</p>
+        <PixButton
+          @triggerAction={{this.importFromPhrase}}
+          @loadingColor="white"
+          @size="small"
+          @isBorderVisible="{{true}}"
+          class="synchronize-translations--action"
+        >
+          Récupérer les traductions depuis Phrase
+        </PixButton>
+      </PixBlock>
+    </section>
+  </main>
+</div>

--- a/pix-editor/app/templates/authenticated/synchronize-translations.hbs
+++ b/pix-editor/app/templates/authenticated/synchronize-translations.hbs
@@ -5,22 +5,14 @@
   <main class="page-body synchronize-translations">
     <section class="page-section">
       <PixBlock @shadow="light" class="synchronize-translations--block">
-        <p>Envoi l'ensemble des traductions du référentiel Pix en français sur Phrase. Seules les épreuves validées sont envoyées.
-        <br><em>Le traitement de l'envoi par Phrase peut prendre plusieurs minutes. Une fois lancé, vous pouvez suivre le traitement sur la page Uploads du projet Phrase.</em></p>
-
-        <PixButton
-          @triggerAction={{this.uploadToPhrase}}
-          @loadingColor="white"
-          @size="small"
-          @isBorderVisible="{{true}}"
-          class="synchronize-translations--action"
-        >
-          Envoyer les traductions vers Phrase
-        </PixButton>
+      <p>L'envoi des traductions du référentiel se base sur la dernière release du référentiel et se fait automatiquement à ce moment la.
+        <br>Est envoyé sur Phrase l'ensemble des traductions du référentiel Pix en français et les épreuves validées.
+        <br><em>Le traitement de l'envoi par Phrase peut prendre plusieurs minutes. Une fois une release lancé, vous pouvez suivre le traitement sur la page Uploads du projet Phrase.</em></p>
       </PixBlock>
 
       <PixBlock @shadow="light" class="synchronize-translations--block">
-        <p>Récupére toutes les traductions de Phrase, sauf celles de la langue principale (le fr).</p>
+      <p>La récupération des traductions depuis Phrase se fait automatiquement à la création de la release du référentiel. Vous pouvez récupérez manuellement les traductions pour la prévisualisation par exemple.
+        <br>Récupére toutes les traductions de Phrase, sauf celles de la langue principale (le fr).</p>
         <PixButton
           @triggerAction={{this.importFromPhrase}}
           @loadingColor="white"

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -31,6 +31,7 @@
         "base-x": "^4.0.0",
         "canvg": "^4.0.1",
         "ember-a11y-accordion": "^3.0.0",
+        "ember-api-actions": "^0.2.9",
         "ember-aria-tabs": "^7.0.0",
         "ember-auto-import": "^2.6.3",
         "ember-cli": "^5.0.0",
@@ -26925,6 +26926,639 @@
       }
     },
     "node_modules/ember-a11y-accordion/node_modules/workerpool": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
+      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.3.4",
+        "object-assign": "4.1.1",
+        "rsvp": "^4.8.4"
+      }
+    },
+    "node_modules/ember-api-actions": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/ember-api-actions/-/ember-api-actions-0.2.9.tgz",
+      "integrity": "sha512-RDyGOL+CkpzpovOB3W2acawCfoDB/P3cevR+QDA+VqOeFDz9sd9bOkDvx0Vn1qeapGC/1yGx6cTpQkQhmuNLmg==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.1.3",
+        "ember-cli-typescript": "^3.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/async-disk-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
+      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.5.3",
+        "rsvp": "^3.0.18",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/async-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/async-disk-cache/node_modules/rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true,
+      "engines": {
+        "node": "0.12.* || 4.* || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-babel-transpiler": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
+      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/polyfill": "^7.11.5",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-persistent-filter": "^2.2.1",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-merge-trees": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-persistent-filter": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
+      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^1.2.1",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^1.0.0",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "mkdirp": "^0.5.1",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^2.6.1",
+        "rsvp": "^4.7.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^1.3.3",
+        "walk-sync": "^1.0.0"
+      },
+      "engines": {
+        "node": "6.* || >= 8.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^1.1.1"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-plugin/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/broccoli-source": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
+      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/ember-cli-babel": {
+      "version": "7.26.11",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
+      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.0",
+        "@babel/helper-compilation-targets": "^7.12.0",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
+        "@babel/plugin-transform-modules-amd": "^7.13.0",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.13.0",
+        "@babel/polyfill": "^7.11.5",
+        "@babel/preset-env": "^7.16.5",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^3.2.0",
+        "broccoli-babel-transpiler": "^7.8.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-source": "^2.1.2",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^4.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "fixturify-project": "^1.10.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^3.0.1",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/ember-cli-babel/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/ember-cli-version-checker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^2.0.0",
+        "semver": "^6.3.0",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/fixturify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
+      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^5.0.5",
+        "@types/minimatch": "^3.0.3",
+        "@types/rimraf": "^2.0.2",
+        "fs-extra": "^7.0.1",
+        "matcher-collection": "^2.0.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/fixturify-project": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
+      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
+      "dev": true,
+      "dependencies": {
+        "fixturify": "^1.2.0",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/istextorbinary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "1 || 2",
+        "editions": "^1.1.1",
+        "textextensions": "1 || 2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/ember-api-actions/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
+    "node_modules/ember-api-actions/node_modules/reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
+      "dev": true
+    },
+    "node_modules/ember-api-actions/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/sync-disk-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
+      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.1.3",
+        "heimdalljs": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^2.2.8",
+        "username-sync": "^1.0.2"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/sync-disk-cache/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/walk-sync": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+      "dev": true,
+      "dependencies": {
+        "ensure-posix-path": "^1.0.0",
+        "matcher-collection": "^1.0.0"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/walk-sync/node_modules/matcher-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.2"
+      }
+    },
+    "node_modules/ember-api-actions/node_modules/workerpool": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
       "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -49,6 +49,7 @@
     "base-x": "^4.0.0",
     "canvg": "^4.0.1",
     "ember-a11y-accordion": "^3.0.0",
+    "ember-api-actions": "^0.2.9",
     "ember-aria-tabs": "^7.0.0",
     "ember-auto-import": "^2.6.3",
     "ember-cli": "^5.0.0",

--- a/pix-editor/tests/acceptance/synchronize_translations_test.js
+++ b/pix-editor/tests/acceptance/synchronize_translations_test.js
@@ -22,7 +22,6 @@ module('Acceptance | Synchronize Translations', function(hooks) {
 
     // then
     assert.strictEqual(currentURL(), '/synchronize-translations');
-    assert.dom(screen.getByText('Envoyer les traductions vers Phrase')).exists();
     assert.dom(screen.getByText('Récupérer les traductions depuis Phrase')).exists();
   });
 });

--- a/pix-editor/tests/acceptance/synchronize_translations_test.js
+++ b/pix-editor/tests/acceptance/synchronize_translations_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { currentURL } from '@ember/test-helpers';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+
+module('Acceptance | Synchronize Translations', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+    return authenticateSession();
+  });
+
+  test('should display page to synchronize translations', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Synchroniser les traductions');
+
+    // then
+    assert.strictEqual(currentURL(), '/synchronize-translations');
+    assert.dom(screen.getByText('Envoyer les traductions vers Phrase')).exists();
+    assert.dom(screen.getByText('Récupérer les traductions depuis Phrase')).exists();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Seuls les administrateurs peuvent actuellement synchroniser les traductions de et vers Phrase.

## :robot: Proposition
Ajouter une page sur Pix Editor qui permet de synchroniser les traductions pour les éditeurs (et admin).

## :rainbow: Remarques
On pourra nettoyer le code qui fait la même chose coté admin ensuite.

## :100: Pour tester
1. Se connecter sur Pix editor en tant qu'éditeur
2. Cliquer sur le lien "Synchroniser les traductions" dans le menu de gauche
3. Constater les 2 boutons de synchronisation
4. Cliquer sur ceux ci et vérifier que l'upload et le download sont bien réalisés.
