### PR TITLE
[FEATURE] Ecrire dans la base PG les données traduites des sujets (PIX-9409).

### DIFF
--- a/api/lib/infrastructure/translations/index.js
+++ b/api/lib/infrastructure/translations/index.js
@@ -1,3 +1,4 @@
 export * as Acquis from './skill.js';
 export * as Competences from './competence.js';
 export * as Domaines from './area.js';
+export * as Tubes from './tube.js';

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -1,0 +1,22 @@
+import { buildTranslationsUtils } from './utils.js';
+
+export const prefix = 'tube.';
+
+const locales = [
+  { airtableLocale: 'fr-fr', locale: 'fr' },
+  { airtableLocale: 'en-us', locale: 'en' },
+];
+
+const fields = [
+  { airtableField: 'Titre pratique', field: 'practicalTitle' },
+  { airtableField: 'Description pratique', field: 'practicalDescription' },
+];
+
+const idField = 'id persistant';
+
+const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, idField });
+
+export const {
+  extractFromProxyObject,
+  prefixFor,
+} = tubeTranslationUtils;

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-tube_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-tube_test.js
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import nock from 'nock';
+import {
+  airtableBuilder,
+  databaseBuilder,
+  domainBuilder,
+  generateAuthorizationHeader,
+  inputOutputDataBuilder,
+  knex,
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | Controller | airtable-proxy-controller | create tube translations', () => {
+  beforeEach(() => {
+    nock('https://api.test.pix.fr').post(/.*/).reply(200);
+
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+  });
+
+  afterEach(async () => {
+    try {
+      expect(nock.isDone()).to.be.true;
+    } finally {
+      await knex('translations').truncate();
+    }
+  });
+
+  describe('POST /api/airtable/content/Tubes', () => {
+    let airtableRawTube;
+    let tubeToSave;
+    let user;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+      await databaseBuilder.commit();
+      const tube = domainBuilder.buildTubeDatasourceObject({ id: 'mon_id_persistant' });
+      airtableRawTube = airtableBuilder.factory.buildTube(tube);
+      tubeToSave = inputOutputDataBuilder.factory.buildTube({
+        ...tube,
+        practicalTitle_i18n: {
+          fr: 'Outils d\'accès au web',
+          en: 'Tools for web',
+        },
+        practicalDescription_i18n: {
+          fr: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
+          en: 'Identify a web browser and a search engine, know how the search engine works',
+        },
+      });
+    });
+
+    describe('nominal cases', () => {
+      it('should proxy request to airtable and add translations to the PG table', async () => {
+        // Given
+        nock('https://api.airtable.com')
+          .post('/v0/airtableBaseValue/Tubes', airtableRawTube)
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableRawTube);
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/airtable/content/Tubes',
+          headers: generateAuthorizationHeader(user),
+          payload: tubeToSave,
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+        const translations = await knex('translations').select().orderBy([{
+          column: 'key',
+          order: 'asc'
+        }, { column: 'locale', order: 'asc' }]);
+
+        expect(translations).to.deep.equal([{
+          key: 'tube.mon_id_persistant.practicalDescription',
+          locale: 'en',
+          value: 'Identify a web browser and a search engine, know how the search engine works'
+        }, {
+          key: 'tube.mon_id_persistant.practicalDescription',
+          locale: 'fr',
+          value: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche'
+        }, {
+          key: 'tube.mon_id_persistant.practicalTitle',
+          locale: 'en',
+          value: 'Tools for web'
+        }, {
+          key: 'tube.mon_id_persistant.practicalTitle',
+          locale: 'fr',
+          value: 'Outils d\'accès au web'
+        }]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/input-output-data-builder/factory/build-tube.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-tube.js
@@ -1,0 +1,30 @@
+export function buildTube({
+  id = 'areaid1',
+  name,
+  title,
+  description,
+  practicalTitle_i18n: {
+    fr: practicalTitleFrFr,
+    en: practicalTitleEnUs,
+  } = {},
+  practicalDescription_i18n: {
+    fr: practicalDescriptionFrFr,
+    en: practicalDescriptionEnUs,
+  } = {},
+  competenceId,
+} = {}) {
+  return {
+    id,
+    'fields': {
+      'id persistant': id,
+      'Nom': name,
+      'Titre': title,
+      'Description': description,
+      'Titre pratique fr-fr': practicalTitleFrFr,
+      'Titre pratique en-us': practicalTitleEnUs,
+      'Description pratique fr-fr': practicalDescriptionFrFr,
+      'Description pratique en-us': practicalDescriptionEnUs,
+      'Competences (id persistant)': [competenceId],
+    },
+  };
+}

--- a/api/tests/tooling/input-output-data-builder/factory/index.js
+++ b/api/tests/tooling/input-output-data-builder/factory/index.js
@@ -1,4 +1,5 @@
-export * from './build-competence.js';
-export * from './build-skill.js';
 export * from './build-area.js';
 export * from './build-attachment.js';
+export * from './build-competence.js';
+export * from './build-skill.js';
+export * from './build-tube.js';


### PR DESCRIPTION
## :unicorn: Problème
Nous voulons rendre facilement traduisible les champ practicalTitle et PracticalDescription des sujets.

## :robot: Proposition
Enregistrer les champ traduisible des sujets dans la table translation comme première étape.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un sujet et vérifier que les champs practicalTitle et PracticalDescription sont écrit dans la base postgres et airtable.
