### PR TITLE
[TECH] Copie les champs traduisible des sujets depuis airtable vers la base postgres (PIX-9410)

### DIFF
--- a/api/scripts/migrate-tubes-translations-from-airtable/index.js
+++ b/api/scripts/migrate-tubes-translations-from-airtable/index.js
@@ -1,0 +1,48 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import * as tubesTranslations from '../../lib/infrastructure/translations/tube.js';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateTubesTranslationsFromAirtable({ airtableClient }) {
+  const tubes = await airtableClient
+    .table('Tubes')
+    .select({
+      fields: [
+        'id persistant',
+        'Titre pratique fr-fr',
+        'Titre pratique en-us',
+        'Description pratique fr-fr',
+        'Description pratique en-us',
+      ],
+    })
+    .all();
+
+  const translations = tubes.flatMap((tube) =>
+    tubesTranslations.extractFromProxyObject(tube.fields)
+  );
+
+  await translationRepository.save({ translations });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateTubesTranslationsFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/scripts/migrate-tubes-translations-from-airtable_test.js
+++ b/api/tests/scripts/migrate-tubes-translations-from-airtable_test.js
@@ -1,0 +1,113 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { airtableBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+
+import { migrateTubesTranslationsFromAirtable } from '../../scripts/migrate-tubes-translations-from-airtable/index.js';
+
+describe('Script | Migrate tubes translations from Airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const tubes = [
+      airtableBuilder.factory.buildTube({
+        id: 'tubeId1',
+        practicalTitle_i18n: {
+          fr: 'practicalTitleFrTubeId1',
+          en: 'practicalTitleEnUsTubeId1',
+        },
+        practicalDescription_i18n: {
+          fr: 'practicalDescriptionFrTubeId1',
+          en: 'practicalDescriptionEnUsTubeId1',
+        },
+      }),
+      airtableBuilder.factory.buildTube({
+        id: 'tubeId2',
+        practicalTitle_i18n: {
+          fr: 'practicalTitleFrTubeId2',
+          en: 'practicalTitleEnUsTubeId2',
+        },
+        practicalDescription_i18n: {
+          fr: 'practicalDescriptionFrTubeId2',
+          en: 'practicalDescriptionEnUsTubeId2',
+        },
+      }),
+    ];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Tubes')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: tubes });
+
+    // when
+    await migrateTubesTranslationsFromAirtable({ airtableClient });
+
+    // then
+    await expect(
+      knex('translations').select().orderBy([
+        { column: 'key', order: 'asc' },
+        { column: 'locale', order: 'asc' },
+      ]),
+    ).resolves.toEqual([
+      {
+        key: 'tube.tubeId1.practicalDescription',
+        locale: 'en',
+        value: tubes[0].fields['Description pratique en-us'],
+      },
+      {
+        key: 'tube.tubeId1.practicalDescription',
+        locale: 'fr',
+        value: tubes[0].fields['Description pratique fr-fr'],
+      },
+      {
+        key: 'tube.tubeId1.practicalTitle',
+        locale: 'en',
+        value: tubes[0].fields['Titre pratique en-us'],
+      },
+      {
+        key: 'tube.tubeId1.practicalTitle',
+        locale: 'fr',
+        value: tubes[0].fields['Titre pratique fr-fr'],
+      },
+      {
+        key: 'tube.tubeId2.practicalDescription',
+        locale: 'en',
+        value: tubes[1].fields['Description pratique en-us'],
+      },
+      {
+        key: 'tube.tubeId2.practicalDescription',
+        locale: 'fr',
+        value: tubes[1].fields['Description pratique fr-fr'],
+      },
+      {
+        key: 'tube.tubeId2.practicalTitle',
+        locale: 'en',
+        value: tubes[1].fields['Titre pratique en-us'],
+      },
+      {
+        key: 'tube.tubeId2.practicalTitle',
+        locale: 'fr',
+        value: tubes[1].fields['Titre pratique fr-fr'],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Afin de gérer la traduction des champs d'un sujet nous devons copier les données depuis Airtable vers PG.

## :robot: Proposition

Créer un script de migration afin de récupérer la valeur des champs à traduire pour les enregistrer sur la base pg.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Modifier un titre pratique ou description pratique d'un sujet depuis airtable.
- Lancer le script api/scripts/migrate-tubes-translations-from-airtable/index.js
- Vérifier la modification du titre ou de la description dans la base pg.

