### PR TITLE
[TECH] Supprimer les usages des titre et description des sujets qui sont des champs dépréciés (PIX-11629).

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -10,8 +10,6 @@ export const tubeDatasource = datasource.extend({
   usedFields: [
     'id persistant',
     'Nom',
-    'Titre',
-    'Description',
     'Titre pratique fr-fr',
     'Titre pratique en-us',
     'Description pratique fr-fr',
@@ -23,8 +21,6 @@ export const tubeDatasource = datasource.extend({
     return {
       id: airtableRecord.get('id persistant'),
       name: airtableRecord.get('Nom'),
-      title: airtableRecord.get('Titre'),
-      description: airtableRecord.get('Description'),
       practicalTitle_i18n: {
         fr: airtableRecord.get('Titre pratique fr-fr'),
         en: airtableRecord.get('Titre pratique en-us'),

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -91,8 +91,6 @@ describe('Acceptance | Controller | phrase-controller', () => {
         tubes: [{
           id: 'recTube0',
           name: '@acquis',
-          title: 'Titre du Tube',
-          description: 'Description du Tube',
           practicalTitle_i18n: {
             fr: 'Titre pratique du Tube - fr',
             en: 'Titre pratique du Tube - en',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -73,8 +73,6 @@ async function mockCurrentContent() {
     tubes: [{
       id: 'recTube0',
       name: 'Nom du Tube',
-      title: 'Titre du Tube',
-      description: 'Description du Tube',
       practicalTitle_i18n: {
         fr: 'Titre pratique du Tube - fr',
         en: 'Titre pratique du Tube - en',
@@ -362,8 +360,6 @@ async function mockContentForRelease() {
     tubes: [{
       id: 'recTube0',
       name: 'Nom du Tube',
-      title: 'Titre du Tube',
-      description: 'Description du Tube',
       competenceId: 'recCompetence0',
       thematicId: 'recThematic0',
       skillIds: ['recSkill0'],

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -978,8 +978,6 @@ function _getRichCurrentContentDTO() {
     {
       id: 'tube1111',
       name: 'tube1111 name',
-      title: 'tube1111 title',
-      description: 'tube1111 description',
       practicalTitle_i18n: {
         fr: 'tube1111 practicalTitleFrFr',
         en: 'tube1111 practicalTitleEnUs',
@@ -997,8 +995,6 @@ function _getRichCurrentContentDTO() {
     {
       id: 'tube1121',
       name: 'tube1121 name',
-      title: 'tube1121 title',
-      description: 'tube1121 description',
       practicalTitle_i18n: {
         fr: 'tube1121 practicalTitleFrFr',
         en: 'tube1121 practicalTitleEnUs',
@@ -1016,8 +1012,6 @@ function _getRichCurrentContentDTO() {
     {
       id: 'tube1211',
       name: 'tube1211 name',
-      title: 'tube1211 title',
-      description: 'tube1211 description',
       practicalTitle_i18n: {
         fr: 'tube1211 practicalTitleFrFr',
         en: 'tube1211 practicalTitleEnUs',
@@ -1035,8 +1029,6 @@ function _getRichCurrentContentDTO() {
     {
       id: 'tube1212',
       name: 'tube1212 name',
-      title: 'tube1212 title',
-      description: 'tube1212 description',
       practicalTitle_i18n: {
         fr: 'tube1212 practicalTitleFrFr',
         en: 'tube1212 practicalTitleEnUs',
@@ -1054,8 +1046,6 @@ function _getRichCurrentContentDTO() {
     {
       id: 'tube2111',
       name: 'tube2111 name',
-      title: 'tube2111 title',
-      description: 'tube2111 description',
       practicalTitle_i18n: {
         fr: 'tube2111 practicalTitleFrFr',
         en: 'tube2111 practicalTitleEnUs',

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -1,8 +1,6 @@
 export function buildTube({
   id,
   name,
-  title,
-  description,
   practicalTitle_i18n: {
     fr: practicalTitleFrFr,
     en: practicalTitleEnUs,
@@ -19,8 +17,6 @@ export function buildTube({
     'fields': {
       'id persistant': id,
       'Nom': name,
-      'Titre': title,
-      'Description': description,
       'Titre pratique fr-fr': practicalTitleFrFr,
       'Titre pratique en-us': practicalTitleEnUs,
       'Description pratique fr-fr': practicalDescriptionFrFr,

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
@@ -2,8 +2,6 @@ export function buildTubeDatasourceObject(
   {
     id = 'recTIddrkopID23Fp',
     name = '@Moteur',
-    title = 'Moteur de recherche',
-    description = 'Connaître le fonctionnement d\'un moteur de recherche',
     practicalTitle_i18n = {
       fr: 'Outils d\'accès au web',
       en: 'Tools for web',
@@ -17,8 +15,6 @@ export function buildTubeDatasourceObject(
   return {
     id,
     name,
-    title,
-    description,
     practicalTitle_i18n,
     practicalDescription_i18n,
     competenceId,

--- a/api/tests/tooling/input-output-data-builder/factory/build-tube.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-tube.js
@@ -1,8 +1,6 @@
 export function buildTube({
   id = 'areaid1',
   name,
-  title,
-  description,
   practicalTitle_i18n: {
     fr: practicalTitleFrFr,
     en: practicalTitleEnUs,
@@ -18,8 +16,6 @@ export function buildTube({
     'fields': {
       'id persistant': id,
       'Nom': name,
-      'Titre': title,
-      'Description': description,
       'Titre pratique fr-fr': practicalTitleFrFr,
       'Titre pratique en-us': practicalTitleEnUs,
       'Description pratique fr-fr': practicalDescriptionFrFr,

--- a/pix-editor/app/components/sidebar/export.js
+++ b/pix-editor/app/components/sidebar/export.js
@@ -49,8 +49,6 @@ export default class SidebarExportComponent extends Component {
               competence.name,
               theme.name,
               tube.name,
-              tube.title,
-              tube.description,
               tube.practicalTitleFr,
               tube.practicalDescriptionFr,
               tube.productionSkills.reduce((table, skill) => {
@@ -64,7 +62,7 @@ export default class SidebarExportComponent extends Component {
           }, content);
         }, content);
       }, content);
-    }, '"Domaine","Compétence","Thématique","Tube","Titre","Description","Titre pratique","Description pratique","Liste des acquis"');
+    }, '"Domaine","Compétence","Thématique","Tube","Titre pratique","Description pratique","Liste des acquis"');
   }
 
   _formatCSVString(str) {

--- a/pix-editor/app/models/tube.js
+++ b/pix-editor/app/models/tube.js
@@ -7,8 +7,6 @@ export default class TubeModel extends Model {
   selectedThematicResultSkills = [];
 
   @attr name;
-  @attr title;
-  @attr description;
   @attr practicalTitleFr;
   @attr practicalTitleEn;
   @attr practicalDescriptionFr;

--- a/pix-editor/mirage/factories/tube.js
+++ b/pix-editor/mirage/factories/tube.js
@@ -3,8 +3,6 @@ import { Factory } from 'miragejs';
 export default Factory.extend({
 
   name: 'name',
-  title: 'title',
-  description: 'description',
   practicalTitleFr: 'practicalTitleFr',
   practicalTitleEn: 'practicalTitleEn',
   practicalDescriptionFr: 'practicalDescriptionFr',

--- a/pix-editor/tests/unit/component/sidebar/export-test.js
+++ b/pix-editor/tests/unit/component/sidebar/export-test.js
@@ -42,8 +42,6 @@ module('unit | Component | sidebar/export', function(hooks) {
 
     const productionTubes_1_1 = {
       name: 'tube1',
-      title: 'title_tube1',
-      description: 'description_tube1',
       practicalTitleFr: 'practicalTitleFr_tube1',
       practicalDescriptionFr: 'practicalDescriptionFr_tube1',
       productionSkills: productionSkill_1_1,
@@ -52,8 +50,6 @@ module('unit | Component | sidebar/export', function(hooks) {
 
     const productionTubes_1_2 = {
       name: 'tube2',
-      title: 'title_tube2',
-      description: 'description_tube2',
       practicalTitleFr: 'practicalTitleFr_tube2',
       practicalDescriptionFr: 'practicalDescriptionFr_tube2',
       productionSkills: productionSkill_1_2,
@@ -62,8 +58,6 @@ module('unit | Component | sidebar/export', function(hooks) {
 
     const productionTubes_2_1 = {
       name: 'tube3',
-      title: 'title_tube3',
-      description: 'description_tube3',
       practicalTitleFr: 'practicalTitleFr_tube3',
       practicalDescriptionFr: 'practicalDescriptionFr_tube3',
       productionSkills: productionSkill_2_1,
@@ -103,10 +97,10 @@ module('unit | Component | sidebar/export', function(hooks) {
 
   test('it should return formatted cvs content', function(assert) {
     // given
-    const expectedCsvContent = `"Domaine","Compétence","Thématique","Tube","Titre","Description","Titre pratique","Description pratique","Liste des acquis"
-"area","competence1","theme1","tube1","title_tube1","description_tube1","practicalTitleFr_tube1","practicalDescriptionFr_tube1","skill1_1,░,skill1_3,░,░,skill1_6,░,░"
-"area","competence1","theme1","tube2","title_tube2","description_tube2","practicalTitleFr_tube2","practicalDescriptionFr_tube2","░,skill2_2,skill2_3,skill2_4,░,░,░,░"
-"area","competence2","theme2","tube3","title_tube3","description_tube3","practicalTitleFr_tube3","practicalDescriptionFr_tube3","skill3_1,░,░,░,skill3_5,skill3_6,░,░"`;
+    const expectedCsvContent = `"Domaine","Compétence","Thématique","Tube","Titre pratique","Description pratique","Liste des acquis"
+"area","competence1","theme1","tube1","practicalTitleFr_tube1","practicalDescriptionFr_tube1","skill1_1,░,skill1_3,░,░,skill1_6,░,░"
+"area","competence1","theme1","tube2","practicalTitleFr_tube2","practicalDescriptionFr_tube2","░,skill2_2,skill2_3,skill2_4,░,░,░,░"
+"area","competence2","theme2","tube3","practicalTitleFr_tube3","practicalDescriptionFr_tube3","skill3_1,░,░,░,skill3_5,skill3_6,░,░"`;
 
     // when
     const csvContent = component._buildCSVContent(areas);


### PR DESCRIPTION
## :unicorn: Problème
Les champs `titre` et `description` d'un sujet sont déprécier mais ils sont toujours présent dans le code. 

## :robot: Proposition
Supprimer les usage de ces champs dans le code.

## :rainbow: Remarques
RAS

## :100: Pour tester
Les tests sont vert
