### PR TITLE
[FEATURE] Lien vers les trads de l'épreuve dans Phrase (PIX-11504)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -9,7 +9,7 @@ import { attachmentDatasource } from '../../infrastructure/datasources/airtable/
 import { createChallengeTransformer } from '../../infrastructure/transformers/index.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
-import { previewChallenge } from '../../domain/usecases/index.js';
+import { getPhraseTranslationsURL, previewChallenge } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 
 const challengeIdType = Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+$/).required();
@@ -81,6 +81,27 @@ export async function register(server) {
 
           const previewUrl = await previewChallenge({ challengeId, locale }, { refreshCache: _refreshCache });
           return h.redirect(previewUrl);
+        },
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/challenges/{id}/translations/{locale}',
+      config: {
+        auth: false,
+        validate: {
+          params: Joi.object({
+            id: challengeIdType,
+            locale: Joi.string().min(2).max(5),
+          }),
+        },
+        handler: async function(request, h) {
+          const challengeId = request.params.id;
+          const locale = request.params.locale;
+
+          const translationsUrl = await getPhraseTranslationsURL({ challengeId, locale });
+
+          return h.redirect(translationsUrl);
         },
       },
     },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -117,7 +117,6 @@ export const checkUrlsJobs = {
 export let phrase = {
   apiKey: process.env.PHRASE_API_KEY,
   projectId: process.env.PHRASE_PROJECT_ID,
-  frLocaleId: process.env.PHRASE_FR_LOCALE_ID,
 };
 
 export const importTranslationsFileMaxSize = process.env.IMPORT_TRANSLATIONS_FILE_MAX_SIZE || 2097152;
@@ -160,6 +159,5 @@ if (process.env.NODE_ENV === 'test') {
   phrase = {
     apiKey: 'MY_PHRASE_ACCESS_TOKEN',
     projectId: 'MY_PHRASE_PROJECT_ID',
-    frLocaleId: 'MY_PHRASE_LOCALE_ID',
   };
 }

--- a/api/lib/domain/usecases/get-phrase-translations-url.js
+++ b/api/lib/domain/usecases/get-phrase-translations-url.js
@@ -1,0 +1,27 @@
+import { Configuration, LocalesApi } from 'phrase-js';
+import * as config from '../../config.js';
+import { logger } from '../../infrastructure/logger.js';
+
+export async function getPhraseTranslationsURL({ challengeId, locale }, phrase = { Configuration, LocalesApi }) {
+  try {
+    const locales = await new phrase.LocalesApi(new phrase.Configuration({
+      apiKey: `token ${config.phrase.apiKey}`,
+      fetchApi: fetch,
+    })).localesList({
+      projectId: config.phrase.projectId,
+    });
+
+    const defaultLocaleId = locales.find(({ _default }) => _default)?.id;
+    const targetLocaleId = locales.find(({ code }) => code === locale)?.id;
+
+    const url = new URL(config.phrase.projectId, 'https://app.phrase.com/editor/v4/accounts/00000000000000000000000000000000/projects/');
+    url.searchParams.set('search', `keyNameQuery:challenge.${challengeId}`);
+    url.searchParams.set('locales', `'${defaultLocaleId}','${targetLocaleId}'`);
+
+    return url.href;
+  } catch (e) {
+    const text = await e.text?.() ?? e;
+    logger.error(`Phrase error while listing locales: ${text}`);
+    throw new Error('Phrase error', { cause: e });
+  }
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -3,6 +3,7 @@ export * from './delete-unmentioned-keys-after-upload.js';
 export * from './download-translation-from-phrase.js';
 export * from './export-translations.js';
 export * from './find-all-missions.js';
+export * from './get-phrase-translations-url.js';
 export * from './import-translations.js';
 export * from './modify-localized-challenge.js';
 export * from './preview-challenge.js';

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -11,6 +11,7 @@ const serializer = new Serializer('localized-challenges', {
     'embedUrl',
     'status',
     'fileIds',
+    'translations',
   ],
   typeForAttribute(attribute) {
     if (attribute === 'fileIds') return 'attachments';
@@ -32,6 +33,7 @@ const serializer = new Serializer('localized-challenges', {
     return {
       ...localizedChallenge,
       challenge: { id: challengeId },
+      translations: `/api/challenges/${challengeId}/translations/${localizedChallenge.locale}`,
     };
   }
 });

--- a/api/sample.env
+++ b/api/sample.env
@@ -508,14 +508,6 @@ CHECK_URLS_TUTORIALS_SHEET_NAME=
 # default: none
 # PHRASE_PROJECT_ID=xxxxx
 
-# The ID of the french language in the project
-# Get it on Project -> Languages -> Edit Language -> API
-#
-# presence: optional
-# type: String
-# default: none
-# PHRASE_FR_LOCALE_ID=xxxxxn
-
 # =================
 # UPLOAD TRANSLATION TO PHRASE JOB
 # =================

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -899,6 +899,66 @@ describe('Acceptance | Controller | challenges-controller', () => {
     });
   });
 
+  describe('GET /challenges/:id/translations/:locale', () => {
+
+    it('should redirect Phrase translations page', async () => {
+      // given
+      const challengeId = 'challenge123';
+      const locale = 'nl';
+
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeId,
+        challengeId,
+        locale: 'fr',
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challenge123_nl',
+        challengeId,
+        locale,
+      });
+
+      await databaseBuilder.commit();
+
+      const phraseLocalesApiScope = nock('https://api.phrase.com')
+        .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales')
+        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+        .reply(200, [
+          {
+            id: 'frLocaleId',
+            name: 'fr',
+            code: 'fr',
+            default: true,
+          },
+          {
+            id: 'enLocaleId',
+            name: 'en',
+            code: 'en',
+            default: false,
+          },
+          {
+            id: 'nlLocaleId',
+            name: 'nl',
+            code: 'nl',
+            default: false,
+          },
+        ]);
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/challenges/${challengeId}/translations/${locale}`,
+      });
+
+      // then
+      expect(response.statusCode).toBe(302);
+      expect(response.headers.location).toBe(`https://app.phrase.com/editor/v4/accounts/00000000000000000000000000000000/projects/MY_PHRASE_PROJECT_ID?search=keyNameQuery%3Achallenge.${challengeId}&locales=%27frLocaleId%27%2C%27nlLocaleId%27`);
+
+      expect(phraseLocalesApiScope.isDone()).toBe(true);
+    });
+  });
+
   describe('POST /challenges', () => {
     let user;
     beforeEach(async function() {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -919,6 +919,17 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
       await databaseBuilder.commit();
 
+      const phraseAccountsApiScope = nock('https://api.phrase.com')
+        .get('/v2/accounts')
+        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+        .query({ page:1 })
+        .reply(200, [
+          {
+            id: 'pixAccountId',
+            name: 'Pix',
+          },
+        ]);
+
       const phraseLocalesApiScope = nock('https://api.phrase.com')
         .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales')
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
@@ -953,8 +964,9 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
       // then
       expect(response.statusCode).toBe(302);
-      expect(response.headers.location).toBe(`https://app.phrase.com/editor/v4/accounts/00000000000000000000000000000000/projects/MY_PHRASE_PROJECT_ID?search=keyNameQuery%3Achallenge.${challengeId}&locales=%27frLocaleId%27%2C%27nlLocaleId%27`);
+      expect(response.headers.location).toBe(`https://app.phrase.com/editor/v4/accounts/pixAccountId/projects/MY_PHRASE_PROJECT_ID?search=keyNameQuery%3Achallenge.${challengeId}&locales=%27frLocaleId%27%2C%27nlLocaleId%27`);
 
+      expect(phraseAccountsApiScope.isDone()).toBe(true);
       expect(phraseLocalesApiScope.isDone()).toBe(true);
     });
   });

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -29,9 +29,10 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
           type: 'localized-challenges',
           id: localizedChallenge.id,
           attributes: {
-            'locale': localizedChallenge.locale,
+            locale: localizedChallenge.locale,
             'embed-url': localizedChallenge.embedUrl,
-            'status': localizedChallenge.status,
+            status: localizedChallenge.status,
+            translations: `/api/challenges/${localizedChallenge.challengeId}/translations/${localizedChallenge.locale}`,
           },
           relationships: {
             challenge: {
@@ -84,6 +85,7 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
             'locale': localizedChallenge.locale,
             'embed-url': localizedChallenge.embedUrl,
             status: null,
+            translations: `/api/challenges/${localizedChallenge.challengeId}/translations/${localizedChallenge.locale}`,
           },
           relationships: {
             challenge: {
@@ -143,6 +145,7 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
               'locale': localizedChallenges[0].locale,
               'embed-url': localizedChallenges[0].embedUrl,
               status: null,
+              translations: `/api/challenges/${localizedChallenges[0].challengeId}/translations/${localizedChallenges[0].locale}`,
             },
             relationships: {
               challenge: {
@@ -163,6 +166,7 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
               'locale': localizedChallenges[1].locale,
               'embed-url': localizedChallenges[1].embedUrl,
               status: null,
+              translations: `/api/challenges/${localizedChallenges[1].challengeId}/translations/${localizedChallenges[1].locale}`,
             },
             relationships: {
               challenge: {

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -8,6 +8,12 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
   it('should upload to Phrase', async () => {
     // given
     const ConfigurationStub = class {};
+    const localesListStub = vi.fn().mockResolvedValue([
+      { id: 'frLocaleId', code: 'fr', name: 'fr', _default: true },
+    ]);
+    const LocalesApiStub = class {
+      localesList() { return localesListStub(); }
+    };
     const uploadCreateStub = vi.fn().mockResolvedValue({ id: 'upload-id' });
     const UploadsApiStub = class {
       uploadCreate() { return uploadCreateStub(); }
@@ -15,7 +21,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
 
     // when
-    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
 
     // then
     expect(uploadCreateStub).toHaveBeenCalled();
@@ -24,6 +30,12 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
   it('should schedule deletion of unmentioned keys', async () => {
     // given
     const ConfigurationStub = class {};
+    const localesListStub = vi.fn().mockResolvedValue([
+      { id: 'frLocaleId', code: 'fr', name: 'fr', _default: true },
+    ]);
+    const LocalesApiStub = class {
+      localesList() { return localesListStub(); }
+    };
     const uploadCreateStub = vi.fn().mockResolvedValue({ id: 'upload-id' });
     const UploadsApiStub = class {
       uploadCreate() { return uploadCreateStub(); }
@@ -32,7 +44,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule').mockResolvedValue();
 
     // when
-    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, UploadsApi: UploadsApiStub });
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
 
     // then
     expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
@@ -121,6 +121,7 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
             locale: localizedChallenge.locale,
             'embed-url': null,
             status: localizedChallenge.status,
+            translations: `/api/challenges/${localizedChallenge.challengeId}/translations/${localizedChallenge.locale}`,
           },
           relationships: {
             files: {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -29,7 +29,7 @@ export default class LocalizedController extends Controller {
   }
 
   get translationsUrl() {
-    return new URL(`/api/challenges/${this.model.challenge.get('id')}/translations/${this.model.locale}`, window.location).href;
+    return new URL(`${this.model.translations}`, window.location).href;
   }
 
   get challengeRoute() {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -28,6 +28,10 @@ export default class LocalizedController extends Controller {
     return new URL(`${this.model.challenge.get('preview')}?locale=${this.model.locale}`, window.location).href;
   }
 
+  get translationsUrl() {
+    return new URL(`/api/challenges/${this.model.challenge.get('id')}/translations/${this.model.locale}`, window.location).href;
+  }
+
   get challengeRoute() {
     return this.isPrototype ? 'authenticated.competence.prototypes.single' : 'authenticated.competence.prototypes.single.alternatives.single';
   }

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -9,6 +9,7 @@ export default class LocalizedChallengeModel extends Model {
   @attr embedURL;
   @attr locale;
   @attr status;
+  @attr translations;
 
   @belongsTo('challenge', { inverse: 'localizedChallenges' }) challenge;
   @hasMany('attachment', { inverse: 'localizedChallenge' }) files;

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -77,6 +77,10 @@
         <i class="globe icon"></i>
         Version originale
       </LinkTo>
+      <a class="ui button item" href={{this.translationsUrl}} target="_blank" rel="noopener noreferrer">
+        <i class="language icon"></i>
+        Traductions
+      </a>
       {{#if this.mayEdit}}
         <button class="ui button item" {{on "click" this.edit}} type="button">
           <i class="edit icon"></i>

--- a/pix-editor/server/index.js
+++ b/pix-editor/server/index.js
@@ -20,5 +20,6 @@ module.exports = function(app, options) {
 
     app.use(morgan('dev'));
     app.get('/api/challenges/:id/preview', (req, res) => proxy.web(req, res));
+    app.get('/api/challenges/:id/translations/:locale', (req, res) => proxy.web(req, res));
   }
 };

--- a/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
@@ -36,11 +36,14 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     const embedUrlInput = await screen.getByRole('textbox', { name: 'Embed URL :' });
     assert.deepEqual(embedUrlInput.value, 'https://my-embed.com/en.html');
 
-    const link = await screen.findByText('Prévisualiser');
-    assert.ok(link.getAttribute('href').endsWith('/preview?locale=en'), 'href ends with /preview?locale=en');
+    const previewLink = await screen.findByText('Prévisualiser');
+    assert.ok(previewLink.getAttribute('href').endsWith('/preview?locale=en'), 'href ends with /preview?locale=en');
 
     const header = await screen.getByTestId('challenge-header');
     assert.dom(header).hasText(/Pas en prod/);
+
+    const translationsLink = await screen.findByText('Traductions');
+    assert.ok(translationsLink.getAttribute('href').endsWith('/translations/en'), 'href ends with /translations/en');
   });
 
   test('it should go back to the original challenge', async function(assert) {

--- a/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
@@ -15,7 +15,14 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     this.server.create('user', { trigram: 'ABC' });
 
     this.server.create('challenge', { id: 'recChallenge1', status: 'validé', alternativeLocales: ['en'] });
-    localizedChallenge = this.server.create('localized-challenge', { id: 'localized-challenge-id-1', challengeId: 'recChallenge1', locale: 'en', embedURL: 'https://my-embed.com/en.html', status: 'proposé' });
+    localizedChallenge = this.server.create('localized-challenge', {
+      id: 'localized-challenge-id-1',
+      challengeId: 'recChallenge1',
+      locale: 'en',
+      embedURL: 'https://my-embed.com/en.html',
+      status: 'proposé',
+      translations: '/api/challenges/recChallenge1/translations/en',
+    });
     this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'], level: 1 });
     this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
     this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });


### PR DESCRIPTION
## :unicorn: Problème

On veut pouvoir consulter rapidement les trads d'une épreuve depuis PixEditor, gottagofast :dash: 

## :robot: Proposition

Ajouter un lien vers Phrase sur l'épreuve.

## :rainbow: Remarques

N/A

## :100: Pour tester

Au préalable se logger sur Phrase.
Aller sur une épreuve NL.
Cliquer sur le lien "Traductions".