### PR TITLE
[FEATURE] Lecture des champs du sujet depuis PG (PIX-9411)

### DIFF
--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -1,0 +1,15 @@
+export class Tube {
+  constructor({
+    id,
+    name,
+    practicalTitle_i18n,
+    practicalDescription_i18n,
+    competenceId,
+  }) {
+    this.id = id;
+    this.name = name;
+    this.practicalTitle_i18n = practicalTitle_i18n;
+    this.practicalDescription_i18n = practicalDescription_i18n;
+    this.competenceId = competenceId;
+  }
+}

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -5,6 +5,7 @@ import { extractFromChallenge } from '../../infrastructure/translations/challeng
 import * as competenceTranslations from '../../infrastructure/translations/competence.js';
 import * as skillTranslations from '../../infrastructure/translations/skill.js';
 import * as areaTranslations from '../../infrastructure/translations/area.js';
+import * as tubeTranslations from '../../infrastructure/translations/tube.js';
 import { mergeStreams } from '../../infrastructure/utils/merge-stream.js';
 import { logger } from '../../infrastructure/logger.js';
 
@@ -32,6 +33,7 @@ export async function exportTranslations(stream, dependencies) {
   const translationsStreams = mergeStreams(
     createTranslationsStream(release.content.competences, extractMetadataFromCompetence, releaseContent, 'competence', competenceTranslations.extractFromReleaseObject),
     createTranslationsStream(release.content.areas, extractMetadataFromArea, releaseContent, 'domaine', areaTranslations.extractFromReleaseObject),
+    createTranslationsStream(release.content.tubes, extractMetadataFromTube, releaseContent, 'sujet', tubeTranslations.extractFromReleaseObject),
     createTranslationsStream(filteredActiveSkills, extractMetadataFromSkill, releaseContent, 'acquis', skillTranslations.extractFromReleaseObject),
     createTranslationsStream(filteredValidatedChallenges, _.curry(extractMetadataFromChallenge)(dependencies.baseUrl, localizedChallenges), releaseContent, 'epreuve', extractFromChallenge),
   );
@@ -121,6 +123,13 @@ function extractMetadataFromSkill(skill, releaseContent) {
   return {
     tags: extractTagsFromSkill(skill, releaseContent),
     description: '',
+  };
+}
+
+function extractMetadataFromTube(tube, releaseContent) {
+  return {
+    tags: extractTagsFromTube(tube, releaseContent),
+    description: ''
   };
 }
 

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,6 +1,5 @@
 import {
   thematicDatasource,
-  tubeDatasource,
   tutorialDatasource,
 } from '../../infrastructure/datasources/airtable/index.js';
 import {
@@ -9,6 +8,7 @@ import {
   challengeRepository,
   competenceRepository,
   skillRepository,
+  tubeRepository,
 } from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
@@ -26,7 +26,7 @@ export async function getLearningContentForReplication() {
   ] = await Promise.all([
     areaRepository.list(),
     competenceRepository.list(),
-    tubeDatasource.list(),
+    tubeRepository.list(),
     skillRepository.list(),
     challengeRepository.list(),
     tutorialDatasource.list(),

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -11,5 +11,6 @@ export * as skillRepository from './skill-repository.js';
 export * as staticCourseRepository from './static-course-repository.js';
 export * as staticCourseTagRepository from './static-course-tag-repository.js';
 export * as translationRepository from './translation-repository.js';
+export * as tubeRepository from './tube-repository.js';
 export * as urlErrorRepository from './url-error-repository.js';
 export * as userRepository from './user-repository.js';

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -4,7 +4,6 @@ import {
   challengeDatasource,
   frameworkDatasource,
   thematicDatasource,
-  tubeDatasource,
   tutorialDatasource,
 } from '../datasources/airtable/index.js';
 import {
@@ -13,6 +12,7 @@ import {
   competenceRepository,
   missionRepository,
   skillRepository,
+  tubeRepository,
 } from './index.js';
 import * as airtableSerializer from '../serializers/airtable-serializer.js';
 import {
@@ -122,7 +122,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     frameworkDatasource.list(),
     skillRepository.list(),
     thematicDatasource.list(),
-    tubeDatasource.list(),
+    tubeRepository.list(),
     tutorialDatasource.list(),
   ]);
   const translatedChallenges = challenges.flatMap((challenge) => [

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -1,0 +1,25 @@
+import { tubeDatasource } from '../datasources/airtable/index.js';
+import * as translationRepository from './translation-repository.js';
+import _ from 'lodash';
+import * as tubeTranslations from '../translations/tube.js';
+import { Tube } from '../../domain/models/Tube.js';
+
+export async function list() {
+  const datasourceTubes = await tubeDatasource.list();
+  const translations = await translationRepository.listByPrefix(tubeTranslations.prefix);
+  return toDomainList(datasourceTubes, translations);
+}
+
+function toDomainList(datasourceTubes, translations) {
+  const translationsByTubeId = _.groupBy(translations, 'entityId');
+  return datasourceTubes.map(
+    (datasourceTube) => toDomain(datasourceTube, translationsByTubeId[datasourceTube.id]),
+  );
+}
+
+function toDomain(datasourceTube, translations = []) {
+  return new Tube({
+    ...datasourceTube,
+    ...tubeTranslations.toDomain(translations),
+  });
+}

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -19,6 +19,7 @@ const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, i
 export const {
   toDomain,
   extractFromProxyObject,
+  extractFromReleaseObject,
   airtableObjectToProxyObject,
   prefixFor,
 } = tubeTranslationUtils;

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -18,5 +18,6 @@ const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, i
 
 export const {
   extractFromProxyObject,
+  airtableObjectToProxyObject,
   prefixFor,
 } = tubeTranslationUtils;

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -17,6 +17,7 @@ const idField = 'id persistant';
 const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, idField });
 
 export const {
+  toDomain,
   extractFromProxyObject,
   airtableObjectToProxyObject,
   prefixFor,

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -77,7 +77,7 @@ async function mockCurrentContent() {
         en: 'Description anglaise',
       }
     })],
-    tubes: [domainBuilder.buildTubeDatasourceObject()],
+    tubes: [domainBuilder.buildTube()],
     skills: [domainBuilder.buildSkill()],
     challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
@@ -183,6 +183,27 @@ async function mockCurrentContent() {
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
+    locale: 'fr',
+    value: expectedCurrentContent.tubes[0].practicalTitle_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
+    locale: 'en',
+    value: expectedCurrentContent.tubes[0].practicalTitle_i18n.en,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
+    locale: 'fr',
+    value: expectedCurrentContent.tubes[0].practicalDescription_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
+    locale: 'en',
+    value: expectedCurrentContent.tubes[0].practicalDescription_i18n.en,
   });
 
   databaseBuilder.factory.buildTranslation({

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -371,6 +371,16 @@ describe('Acceptance | Controller | phrase-controller', () => {
           'Indice - fr',
           'acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
           ''
+        ],[
+          'tube.recTube0.practicalDescription',
+          'Description pratique du Tube - fr',
+          'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],[
+          'tube.recTube0.practicalTitle',
+          'Titre pratique du Tube - fr',
+          'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
         ],
       ]);
     });

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -76,10 +76,12 @@ async function mockCurrentContent() {
       practicalTitle_i18n: {
         fr: 'Titre pratique du Tube - fr',
         en: 'Titre pratique du Tube - en',
+        nl: 'Titre pratique du Tube - nl',
       },
       practicalDescription_i18n: {
         fr: 'Description pratique du Tube - fr',
         en: 'Description pratique du Tube - en',
+        nl: 'Description pratique du Tube - nl',
       },
       competenceId: 'recCompetence0',
       thematicId: 'recThematic0',
@@ -259,6 +261,17 @@ async function mockCurrentContent() {
       locale,
       value: expectedCurrentContent.areas[0].title_i18n[locale],
     });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
+      locale,
+      value: expectedCurrentContent.tubes[0].practicalTitle_i18n[locale],
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
+      locale,
+      value: expectedCurrentContent.tubes[0].practicalDescription_i18n[locale],
+    });
   }
 
   databaseBuilder.factory.buildTranslation({
@@ -368,10 +381,12 @@ async function mockContentForRelease() {
       practicalTitle_i18n: {
         en: 'Titre pratique du Tube - en',
         fr: 'Titre pratique du Tube - fr',
+        nl: 'Titre pratique du Tube - nl',
       },
       practicalDescription_i18n: {
         en: 'Description pratique du Tube - en',
         fr: 'Description pratique du Tube - fr',
+        nl: 'Description pratique du Tube - nl',
       },
     }],
     skills: [{
@@ -523,6 +538,17 @@ async function mockContentForRelease() {
       key: `area.${expectedCurrentContent.areas[0].id}.title`,
       locale,
       value: expectedCurrentContent.areas[0].title_i18n[locale],
+    });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
+      locale,
+      value: expectedCurrentContent.tubes[0].practicalTitle_i18n[locale],
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
+      locale,
+      value: expectedCurrentContent.tubes[0].practicalDescription_i18n[locale],
     });
   }
 

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -323,6 +323,16 @@ describe('Acceptance | Controller | translations-controller', () => {
           'Indice - fr',
           'acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
           ''
+        ],[
+          'tube.recTube0.practicalDescription',
+          'Description pratique du Tube - fr',
+          'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],[
+          'tube.recTube0.practicalTitle',
+          'Titre pratique du Tube - fr',
+          'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
         ],
       ]);
     });
@@ -473,6 +483,8 @@ describe('Acceptance | Controller | translations-controller', () => {
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix",',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix",',
         'skill.recSkill0.hint,Indice - fr,"acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
+        'tube.recTube0.practicalDescription,Description pratique du Tube - fr,"sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
+        'tube.recTube0.practicalTitle,Titre pratique du Tube - fr,"sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
       ]);
     });
 

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -5,7 +5,7 @@ import * as areaRepository from '../../../../lib/infrastructure/repositories/are
 describe('Integration | Repository | area-repository', () => {
 
   describe('#list', () => {
-    it('should return the list of all competences', async () => {
+    it('should return the list of all areas', async () => {
       // given
       const airtableScope = airtableBuilder.mockList({ tableName: 'Domaines' }).returns([
         airtableBuilder.factory.buildArea({

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -170,10 +170,11 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getCurrentContent', function() {
 
     beforeEach(function() {
-      const { areas, competences, skills, challenges } = _mockRichAirtableContent();
+      const { areas, competences, tubeIds, skills, challenges } = _mockRichAirtableContent();
 
       buildAreasTranslations(areas);
       buildCompetencesTranslations(competences);
+      buildTubesTranslations(tubeIds);
       buildSkillsTranslations(skills);
       buildChallengesTranslationsAndLocalizedChallenges(challenges);
 
@@ -271,6 +272,31 @@ function buildSkillsTranslations(skills) {
   }
 }
 
+function buildTubesTranslations(tubeIds) {
+  for (const id of tubeIds) {
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${id}.practicalDescription`,
+      locale: 'fr',
+      value: `${id} practicalDescriptionFrFr from PG`,
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${id}.practicalDescription`,
+      locale: 'en',
+      value: `${id} practicalDescriptionEnUs from PG`,
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${id}.practicalTitle`,
+      locale: 'fr',
+      value: `${id} practicalTitleFrFr from PG`,
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `tube.${id}.practicalTitle`,
+      locale: 'en',
+      value: `${id} practicalTitleEnUs from PG`,
+    });
+  }
+}
+
 function buildChallengesTranslationsAndLocalizedChallenges(challenges) {
   for (const challenge of challenges) {
     buildChallengeTranslationsAndLocalizedChallenge(challenge, challenge.locales[0]);
@@ -329,10 +355,6 @@ function _mockRichAirtableContent() {
     id: 'area1',
     competenceIds: ['competence11', 'competence12'],
     competenceAirtableIds: ['competence11', 'competence12'],
-    title_i18n: {
-      fr: 'area1 titleFrFr',
-      en: 'area1 titleEnUs',
-    },
     code: '1',
     name: 'area1 name',
     color: 'area1 color',
@@ -343,10 +365,6 @@ function _mockRichAirtableContent() {
     id: 'area2',
     competenceIds: ['competence21'],
     competenceAirtableIds: ['competence21'],
-    title_i18n: {
-      fr: 'area2 titleFrFr',
-      en: 'area2 titleEnUs',
-    },
     code: '2',
     name: 'area2 name',
     color: 'area2 color',
@@ -812,6 +830,7 @@ function _mockRichAirtableContent() {
   return {
     areas: [area1, area2],
     competences: [competence11, competence12, competence21],
+    tubeIds:  [airtableTube1111.id, airtableTube1121.id, airtableTube1211.id, airtableTube1212.id, airtableTube2111.id],
     skills: [skill11111, skill11112, skill12121, skill21111],
     challenges: [challenge121211, challenge121212, challenge211111, challenge211112, challenge211113],
   };
@@ -979,12 +998,12 @@ function _getRichCurrentContentDTO() {
       id: 'tube1111',
       name: 'tube1111 name',
       practicalTitle_i18n: {
-        fr: 'tube1111 practicalTitleFrFr',
-        en: 'tube1111 practicalTitleEnUs',
+        fr: 'tube1111 practicalTitleFrFr from PG',
+        en: 'tube1111 practicalTitleEnUs from PG',
       },
       practicalDescription_i18n: {
-        fr: 'tube1111 practicalDescriptionFrFr',
-        en: 'tube1111 practicalDescriptionEnUs',
+        fr: 'tube1111 practicalDescriptionFrFr from PG',
+        en: 'tube1111 practicalDescriptionEnUs from PG',
       },
       competenceId: 'competence11',
       isMobileCompliant: false,
@@ -996,12 +1015,12 @@ function _getRichCurrentContentDTO() {
       id: 'tube1121',
       name: 'tube1121 name',
       practicalTitle_i18n: {
-        fr: 'tube1121 practicalTitleFrFr',
-        en: 'tube1121 practicalTitleEnUs',
+        fr: 'tube1121 practicalTitleFrFr from PG',
+        en: 'tube1121 practicalTitleEnUs from PG',
       },
       practicalDescription_i18n: {
-        fr: 'tube1121 practicalDescriptionFrFr',
-        en: 'tube1121 practicalDescriptionEnUs',
+        fr: 'tube1121 practicalDescriptionFrFr from PG',
+        en: 'tube1121 practicalDescriptionEnUs from PG',
       },
       competenceId: 'competence11',
       isMobileCompliant: false,
@@ -1013,12 +1032,12 @@ function _getRichCurrentContentDTO() {
       id: 'tube1211',
       name: 'tube1211 name',
       practicalTitle_i18n: {
-        fr: 'tube1211 practicalTitleFrFr',
-        en: 'tube1211 practicalTitleEnUs',
+        fr: 'tube1211 practicalTitleFrFr from PG',
+        en: 'tube1211 practicalTitleEnUs from PG',
       },
       practicalDescription_i18n: {
-        fr: 'tube1211 practicalDescriptionFrFr',
-        en: 'tube1211 practicalDescriptionEnUs',
+        fr: 'tube1211 practicalDescriptionFrFr from PG',
+        en: 'tube1211 practicalDescriptionEnUs from PG',
       },
       competenceId: 'competence12',
       isMobileCompliant: false,
@@ -1030,12 +1049,12 @@ function _getRichCurrentContentDTO() {
       id: 'tube1212',
       name: 'tube1212 name',
       practicalTitle_i18n: {
-        fr: 'tube1212 practicalTitleFrFr',
-        en: 'tube1212 practicalTitleEnUs',
+        fr: 'tube1212 practicalTitleFrFr from PG',
+        en: 'tube1212 practicalTitleEnUs from PG',
       },
       practicalDescription_i18n: {
-        fr: 'tube1212 practicalDescriptionFrFr',
-        en: 'tube1212 practicalDescriptionEnUs',
+        fr: 'tube1212 practicalDescriptionFrFr from PG',
+        en: 'tube1212 practicalDescriptionEnUs from PG',
       },
       competenceId: 'competence12',
       isMobileCompliant: true,
@@ -1047,12 +1066,12 @@ function _getRichCurrentContentDTO() {
       id: 'tube2111',
       name: 'tube2111 name',
       practicalTitle_i18n: {
-        fr: 'tube2111 practicalTitleFrFr',
-        en: 'tube2111 practicalTitleEnUs',
+        fr: 'tube2111 practicalTitleFrFr from PG',
+        en: 'tube2111 practicalTitleEnUs from PG',
       },
       practicalDescription_i18n: {
-        fr: 'tube2111 practicalDescriptionFrFr',
-        en: 'tube2111 practicalDescriptionEnUs',
+        fr: 'tube2111 practicalDescriptionFrFr from PG',
+        en: 'tube2111 practicalDescriptionEnUs from PG',
       },
       competenceId: 'competence21',
       isMobileCompliant: false,

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';
+
+describe('Integration | Repository | tube-repository', () => {
+
+  describe('#list', () => {
+    it('should return the list of all tubes', async () => {
+      // given
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Tubes' }).returns([
+        airtableBuilder.factory.buildTube({
+          id: 'tubeId1',
+          name: '@tube1',
+          practicalTitle_i18n: {
+            fr: 'practicalTitleFrFr tube1',
+            en: 'practicalTitleEnUs tube1',
+          },
+          practicalDescription_i18n: {
+            fr: 'practicalDescriptionFrFr tube1',
+            en: 'practicalDescriptionEnUs tube1',
+          },
+          competenceId: 'competenceId'
+        }),
+        airtableBuilder.factory.buildTube({
+          id: 'tubeId2',
+          name: '@tube2',
+          practicalTitle_i28n: {
+            fr: 'practicalTitleFrFr tube2',
+            en: 'practicalTitleEnUs tube2',
+          },
+          practicalDescription_i18n: {
+            fr: 'practicalDescriptionFrFr tube2',
+            en: 'practicalDescriptionEnUs tube2',
+          },
+          competenceId: 'competenceId'
+        }),
+      ]).activate().nockScope;
+      const tube1DescriptionEn = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId1.practicalDescription',
+        locale: 'en',
+        value: 'Identify a web browser and a search engine, know how the search engine works from PG 1'
+      });
+      const tube1DescriptionFr = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId1.practicalDescription',
+        locale: 'fr',
+        value: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche from PG 1'
+      });
+      const tube1TitleEn = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId1.practicalTitle',
+        locale: 'en',
+        value: 'Tools for web from PG 1'
+      });
+      const tube1TitleFr = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId1.practicalTitle',
+        locale: 'fr',
+        value: 'Outils d\'accès au web from PG 1'
+      });
+      const tube2DescriptionEn = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId2.practicalDescription',
+        locale: 'en',
+        value: 'Identify a web browser and a search engine, know how the search engine works from PG 2'
+      });
+      const tube2DescriptionFr = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId2.practicalDescription',
+        locale: 'fr',
+        value: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche from PG 2'
+      });
+      const tube2TitleEn = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId2.practicalTitle',
+        locale: 'en',
+        value: 'Tools for web from PG 2'
+      });
+      const tube2TitleFr = databaseBuilder.factory.buildTranslation({
+        key: 'tube.tubeId2.practicalTitle',
+        locale: 'fr',
+        value: 'Outils d\'accès au web from PG 2'
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const tubes = await tubeRepository.list();
+
+      // then
+      expect(tubes).toEqual([
+        domainBuilder.buildTube({
+          id: 'tubeId1',
+          name: '@tube1',
+          practicalTitle_i18n: {
+            fr: tube1TitleFr.value,
+            en: tube1TitleEn.value,
+          },
+          practicalDescription_i18n: {
+            fr: tube1DescriptionFr.value,
+            en: tube1DescriptionEn.value,
+          },
+          competenceId: 'competenceId',
+        }),
+        domainBuilder.buildTube({
+          id: 'tubeId2',
+          name: '@tube2',
+          practicalTitle_i18n: {
+            fr: tube2TitleFr.value,
+            en: tube2TitleEn.value,
+          },
+          practicalDescription_i18n: {
+            fr: tube2DescriptionFr.value,
+            en: tube2DescriptionEn.value,
+          },
+          competenceId: 'competenceId',
+        }),
+      ]);
+
+      airtableScope.done();
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube.js
@@ -1,0 +1,23 @@
+import { Tube } from '../../../../lib/domain/models/Tube.js';
+
+export function buildTube({
+  id = 'tubeTIddrkopID23Fp',
+  name = '@Moteur',
+  practicalTitle_i18n = {
+    fr: 'Outils d\'accès au web',
+    en: 'Tools for web',
+  },
+  practicalDescription_i18n = {
+    fr: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
+    en: 'Identify a web browser and a search engine, know how the search engine works',
+  },
+  competenceId = 'recsvLz0W2ShyfD63'
+} = {}) {
+  return new Tube({
+    id,
+    name,
+    practicalTitle_i18n,
+    practicalDescription_i18n,
+    competenceId,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -23,6 +23,7 @@ export * from './build-static-course-summary.js';
 export * from './build-tag.js';
 export * from './build-thematic-for-release.js';
 export * from './build-translation.js';
+export * from './build-tube.js';
 export * from './build-tube-for-release.js';
 export * from './build-tutorial-for-release.js';
 export * from './datasource-objects/build-area-datasource-object.js';


### PR DESCRIPTION
## :unicorn: Problème
On écrit les champs traduisible du sujet dans PG, mais on ne les lit pas.

## :robot: Proposition
Mettre en place la lecture hybride pour le sujet.

## :rainbow: Remarques
Couvre aussi PIX-9412 et PIX-9413

## :100: Pour tester
Modifier les champs traduisibles d'un sujet directement dans PG, vérifier que les valeurs s'affichent :
 - dans PixEditor
 - dans la Release
 - dans la Répli
 - dans l'export des trads