### PR TITLE
[BUGFIX] Terminer de supprimer les données traduisibles liées aux sujets (PIX-11666).

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -10,10 +10,6 @@ export const tubeDatasource = datasource.extend({
   usedFields: [
     'id persistant',
     'Nom',
-    'Titre pratique fr-fr',
-    'Titre pratique en-us',
-    'Description pratique fr-fr',
-    'Description pratique en-us',
     'Competences (id persistant)',
   ],
 
@@ -21,14 +17,6 @@ export const tubeDatasource = datasource.extend({
     return {
       id: airtableRecord.get('id persistant'),
       name: airtableRecord.get('Nom'),
-      practicalTitle_i18n: {
-        fr: airtableRecord.get('Titre pratique fr-fr'),
-        en: airtableRecord.get('Titre pratique en-us'),
-      },
-      practicalDescription_i18n: {
-        fr: airtableRecord.get('Description pratique fr-fr'),
-        en: airtableRecord.get('Description pratique en-us'),
-      },
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };
   },

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -17,9 +17,10 @@ const idField = 'id persistant';
 const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, idField });
 
 export const {
-  toDomain,
   extractFromProxyObject,
   extractFromReleaseObject,
   airtableObjectToProxyObject,
+  proxyObjectToAirtableObject,
   prefixFor,
+  toDomain,
 } = tubeTranslationUtils;

--- a/api/tests/scripts/migrate-tubes-translations-from-airtable_test.js
+++ b/api/tests/scripts/migrate-tubes-translations-from-airtable_test.js
@@ -27,30 +27,29 @@ describe('Script | Migrate tubes translations from Airtable', function() {
 
   it('fills translations table', async function() {
     // given
-    const tubes = [
-      airtableBuilder.factory.buildTube({
-        id: 'tubeId1',
-        practicalTitle_i18n: {
-          fr: 'practicalTitleFrTubeId1',
-          en: 'practicalTitleEnUsTubeId1',
-        },
-        practicalDescription_i18n: {
-          fr: 'practicalDescriptionFrTubeId1',
-          en: 'practicalDescriptionEnUsTubeId1',
-        },
-      }),
-      airtableBuilder.factory.buildTube({
-        id: 'tubeId2',
-        practicalTitle_i18n: {
-          fr: 'practicalTitleFrTubeId2',
-          en: 'practicalTitleEnUsTubeId2',
-        },
-        practicalDescription_i18n: {
-          fr: 'practicalDescriptionFrTubeId2',
-          en: 'practicalDescriptionEnUsTubeId2',
-        },
-      }),
-    ];
+    const tube1FromAirtable = airtableBuilder.factory.buildTube({
+      id: 'tubeId1',
+    });
+    tube1FromAirtable.fields = {
+      ...tube1FromAirtable.fields,
+      'Titre pratique fr-fr': 'practicalTitleFrTubeId1',
+      'Titre pratique en-us': 'practicalTitleEnUsTubeId1',
+      'Description pratique fr-fr': 'practicalDescriptionFrTubeId1',
+      'Description pratique en-us': 'practicalDescriptionEnUsTubeId1',
+    };
+
+    const tube2FromAirtable = airtableBuilder.factory.buildTube({
+      id: 'tubeId2',
+    });
+    tube2FromAirtable.fields = {
+      ...tube2FromAirtable.fields,
+      'Titre pratique fr-fr': 'practicalTitleFrTubeId2',
+      'Titre pratique en-us': 'practicalTitleEnUsTubeId2',
+      'Description pratique fr-fr': 'practicalDescriptionFrTubeId2',
+      'Description pratique en-us': 'practicalDescriptionEnUsTubeId2',
+    };
+
+    const tubes = [tube1FromAirtable, tube2FromAirtable];
 
     nock('https://api.airtable.com')
       .get('/v0/airtableBaseValue/Tubes')

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -1,14 +1,6 @@
 export function buildTube({
   id,
   name,
-  practicalTitle_i18n: {
-    fr: practicalTitleFrFr,
-    en: practicalTitleEnUs,
-  } = {},
-  practicalDescription_i18n: {
-    fr: practicalDescriptionFrFr,
-    en: practicalDescriptionEnUs,
-  } = {},
   competenceId,
 } = {}) {
 
@@ -17,10 +9,6 @@ export function buildTube({
     'fields': {
       'id persistant': id,
       'Nom': name,
-      'Titre pratique fr-fr': practicalTitleFrFr,
-      'Titre pratique en-us': practicalTitleEnUs,
-      'Description pratique fr-fr': practicalDescriptionFrFr,
-      'Description pratique en-us': practicalDescriptionEnUs,
       'Competences (id persistant)': [competenceId],
     },
   };

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
@@ -2,21 +2,11 @@ export function buildTubeDatasourceObject(
   {
     id = 'recTIddrkopID23Fp',
     name = '@Moteur',
-    practicalTitle_i18n = {
-      fr: 'Outils d\'accès au web',
-      en: 'Tools for web',
-    },
-    practicalDescription_i18n = {
-      fr: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
-      en: 'Identify a web browser and a search engine, know how the search engine works',
-    },
     competenceId = 'recsvLz0W2ShyfD63',
   } = {}) {
   return {
     id,
     name,
-    practicalTitle_i18n,
-    practicalDescription_i18n,
     competenceId,
   };
 }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons laisser du code qui fait toujours la liaisons entre les champs traduit d'un sujet et `airtable` ce qui nous empêche de déprécier ces colonne.

## :robot: Proposition
Supprimer les champs traduits du `tube-datasource`.

## :rainbow: Remarques
Juste un petit oublis :)

## :100: Pour tester
Déprécier les colonnes de airtable RA (titre pratique en-us)
Lancer une release et vérifier que tout se passe bien.

