### PR TITLE
[TECH] Supprimer le warning pour la géographie dans les seeds

### DIFF
--- a/api/db/seeds/data/localized-challenges.js
+++ b/api/db/seeds/data/localized-challenges.js
@@ -34,9 +34,6 @@ export async function localizedChallengesBuilder(databaseBuilder, translations) 
     const countryName = challenge.get('Géographie');
     const primaryLocale = convertLanguagesToLocales(challenge.get('Langues'))?.sort()?.[0] ?? 'fr';
     const countryCode = getCountryCode(countryName);
-    if (!countryCode) {
-      console.log({ challengeId }, `could not find country code for name "${countryName}"`);
-    }
     return [
       { id: challengeId, challengeId, locale: primaryLocale, embedUrl: challenge.get('Embed URL') },
       ...challengesLocales[challengeId]


### PR DESCRIPTION
## :unicorn: Problème
On a un warning qui s'affiche plein de fois à tort pour les valeurs "Neutre" et undefined.

## :robot: Proposition
Supprimer ce warning.

## :rainbow: Remarques
N/A

## :100: Pour tester
Seeder.