### PR TITLE
[FEATURE] Renommer "Synchroniser les traductions" en "Récupérer les traductions" (PIX-11673)

### DIFF
--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -7,7 +7,7 @@
   <div class="secondary-links">
     {{#if this.maySynchronizeTranslations}}
       <LinkTo @route="authenticated.synchronize-translations" {{on "click" @close}}>
-        <i class="sync icon"></i> Synchroniser les traductions
+        <i class="sync icon"></i> Récupérer les traductions
       </LinkTo>
     {{/if}}
     {{#if this.shouldShowMissionsLink}}

--- a/pix-editor/app/templates/authenticated/synchronize-translations.hbs
+++ b/pix-editor/app/templates/authenticated/synchronize-translations.hbs
@@ -1,6 +1,6 @@
 <div class="page">
   <header class="page-header">
-    <h1 class="page-title">Synchronisation des traductions</h1>
+    <h1 class="page-title">Récupération des traductions</h1>
   </header>
   <main class="page-body synchronize-translations">
     <section class="page-section">

--- a/pix-editor/tests/acceptance/synchronize_translations_test.js
+++ b/pix-editor/tests/acceptance/synchronize_translations_test.js
@@ -18,7 +18,7 @@ module('Acceptance | Synchronize Translations', function(hooks) {
   test('should display page to synchronize translations', async function(assert) {
     // when
     const screen = await visit('/');
-    await clickByName('Synchroniser les traductions');
+    await clickByName('Récupérer les traductions');
 
     // then
     assert.strictEqual(currentURL(), '/synchronize-translations');


### PR DESCRIPTION
## :unicorn: Problème
Dans la section "Synchroniser les traductions" nous ne faisons que récupérer les traduction et pas l'envoie ce donc pas une synchronisation.

## :robot: Proposition
Renommer la section "Synchroniser les traductions" en "Récupérer les traductions"

## :rainbow: Remarques
RAS

## :100: Pour tester
Dans le menu vérifier que le bouton menant à la section "Récupérer les traductions" ne se nomme pas "Synchroniser les traductions"
