### PR TITLE
[FEATURE] Écrire et migrer les traductions des thématiques (PIX-9472)

### DIFF
--- a/api/lib/domain/usecases/proxy-read-request-to-airtable.js
+++ b/api/lib/domain/usecases/proxy-read-request-to-airtable.js
@@ -13,13 +13,10 @@ export async function proxyReadRequestToAirtable(request, airtableBase, {
 
   if (response.data.records) {
     const translations = await translationRepository.listByPrefix(tableTranslations.prefix);
-    response.data.records = response.data.records.map((entity) => ({
-      ...entity,
-      fields: tableTranslations.airtableObjectToProxyObject(entity.fields, translations),
-    }));
+    response.data.records = response.data.records.map((entity) => tableTranslations.airtableObjectToProxyObject(entity, translations));
   } else {
-    const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data.fields));
-    response.data.fields = tableTranslations.airtableObjectToProxyObject(response.data.fields, translations);
+    const translations = await translationRepository.listByPrefix(tableTranslations.prefixFor(response.data));
+    response.data = tableTranslations.airtableObjectToProxyObject(response.data, translations);
   }
 
   return response;

--- a/api/lib/infrastructure/translations/area.js
+++ b/api/lib/infrastructure/translations/area.js
@@ -11,7 +11,7 @@ const fields = [
   { airtableField: 'Titre', field: 'title' },
 ];
 
-const idField = 'id persistant';
+const idField = 'fields.id persistant';
 
 const areaTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, idField });
 
@@ -24,7 +24,7 @@ export const {
 
 export function airtableObjectToProxyObject(airtableObject, translations) {
   const areaProxyObject = areaTranslationUtils.airtableObjectToProxyObject(airtableObject, translations);
-  areaProxyObject.Nom = `${areaProxyObject.Code}. ${areaProxyObject['Titre fr-fr']}`;
+  areaProxyObject.fields.Nom = `${areaProxyObject.fields.Code}. ${areaProxyObject.fields['Titre fr-fr']}`;
   return areaProxyObject;
 }
 

--- a/api/lib/infrastructure/translations/competence.js
+++ b/api/lib/infrastructure/translations/competence.js
@@ -12,7 +12,7 @@ const fields = [
   { airtableField: 'Description', field: 'description' },
 ];
 
-const idField = 'id persistant';
+const idField = 'fields.id persistant';
 
 export const {
   extractFromProxyObject,

--- a/api/lib/infrastructure/translations/index.js
+++ b/api/lib/infrastructure/translations/index.js
@@ -1,4 +1,5 @@
 export * as Acquis from './skill.js';
 export * as Competences from './competence.js';
 export * as Domaines from './area.js';
+export * as Thematiques from './thematic.js';
 export * as Tubes from './tube.js';

--- a/api/lib/infrastructure/translations/skill.js
+++ b/api/lib/infrastructure/translations/skill.js
@@ -11,7 +11,7 @@ const fields = [
   { airtableField: 'Indice', field: 'hint' },
 ];
 
-const idField = 'id persistant';
+const idField = 'fields.id persistant';
 
 export const {
   extractFromProxyObject,

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -1,0 +1,34 @@
+import { buildTranslationsUtils } from './utils.js';
+
+export const prefix = 'thematic.';
+
+const locales = [
+  { locale: 'fr' },
+  { locale: 'en' },
+];
+
+const fields = [
+  { field: 'name' },
+];
+
+const localizedFields = [
+  {
+    airtableField: 'Nom',
+    field: 'name',
+    locale: 'fr',
+  },
+  {
+    airtableField: 'Titre en-us',
+    field: 'name',
+    locale: 'en',
+  },
+];
+
+const idField = 'id';
+
+const thematicTranslationUtils = buildTranslationsUtils({ locales, fields, localizedFields, prefix, idField });
+
+export const {
+  extractFromProxyObject,
+  prefixFor,
+} = thematicTranslationUtils;

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -24,7 +24,7 @@ const localizedFields = [
   },
 ];
 
-const idField = 'id';
+const idField = 'fields.id persistant';
 
 const thematicTranslationUtils = buildTranslationsUtils({ locales, fields, localizedFields, prefix, idField });
 

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -12,7 +12,7 @@ const fields = [
   { airtableField: 'Description pratique', field: 'practicalDescription' },
 ];
 
-const idField = 'id persistant';
+const idField = 'fields.id persistant';
 
 const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, idField });
 

--- a/api/lib/infrastructure/translations/utils.js
+++ b/api/lib/infrastructure/translations/utils.js
@@ -101,7 +101,6 @@ export function buildTranslationsUtils({
   const prefixFor = makePrefixFor({ prefix, idField });
 
   return {
-    localizedFields,
     prefixFor,
     extractFromProxyObject: extractFromProxyObject({ localizedFields, prefixFor }),
     airtableObjectToProxyObject: airtableObjectToProxyObject({ localizedFields, prefixFor }),

--- a/api/scripts/migrate-areas-translations-from-airtable/index.js
+++ b/api/scripts/migrate-areas-translations-from-airtable/index.js
@@ -20,7 +20,7 @@ export async function migrateAreasTranslationsFromAirtable({ airtableClient }) {
     .all();
 
   const translations = areas.flatMap((area) =>
-    areaTranslations.extractFromProxyObject(area.fields)
+    areaTranslations.extractFromProxyObject(area)
   );
 
   await translationRepository.save({ translations });

--- a/api/scripts/migrate-competences-translation-from-airtable/index.js
+++ b/api/scripts/migrate-competences-translation-from-airtable/index.js
@@ -22,7 +22,7 @@ export async function migrateCompetencesTranslationFromAirtable({ airtableClient
     .all();
 
   const translations = allCompetences.flatMap((competence) =>
-    competenceTranslations.extractFromProxyObject(competence.fields)
+    competenceTranslations.extractFromProxyObject(competence)
   );
 
   await translationRepository.save({ translations });

--- a/api/scripts/migrate-skills-translation-from-airtable/index.js
+++ b/api/scripts/migrate-skills-translation-from-airtable/index.js
@@ -20,7 +20,7 @@ export async function migrateSkillsTranslationFromAirtable({ airtableClient }) {
     .all();
 
   const translations = allSkills.flatMap((skill) =>
-    skillTranslations.extractFromProxyObject(skill.fields)
+    skillTranslations.extractFromProxyObject(skill)
   );
 
   await translationRepository.save({ translations });

--- a/api/scripts/migrate-thematics-translations-from-airtable/index.js
+++ b/api/scripts/migrate-thematics-translations-from-airtable/index.js
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import * as thematicsTranslations from '../../lib/infrastructure/translations/thematic.js';
+import { translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function migrateThematicsTranslationsFromAirtable({ airtableClient }) {
+  const thematics = await airtableClient
+    .table('Thematiques')
+    .select({
+      fields: [
+        'id persistant',
+        'Nom',
+        'Titre en-us',
+      ],
+    })
+    .all();
+
+  const translations = thematics.flatMap((thematic) =>
+    thematicsTranslations.extractFromProxyObject(thematic)
+  );
+
+  await translationRepository.save({ translations });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await migrateThematicsTranslationsFromAirtable({ airtableClient });
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/scripts/migrate-tubes-translations-from-airtable/index.js
+++ b/api/scripts/migrate-tubes-translations-from-airtable/index.js
@@ -22,7 +22,7 @@ export async function migrateTubesTranslationsFromAirtable({ airtableClient }) {
     .all();
 
   const translations = tubes.flatMap((tube) =>
-    tubesTranslations.extractFromProxyObject(tube.fields)
+    tubesTranslations.extractFromProxyObject(tube)
   );
 
   await translationRepository.save({ translations });

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-thematic_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-thematic_test.js
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import nock from 'nock';
+import {
+  airtableBuilder,
+  databaseBuilder,
+  domainBuilder,
+  generateAuthorizationHeader,
+  inputOutputDataBuilder,
+  knex,
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | Controller | airtable-proxy-controller | create thematic', () => {
+  beforeEach(() => {
+    nock('https://api.test.pix.fr').post(/.*/).reply(200);
+
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+  });
+
+  afterEach(async () => {
+    try {
+      expect(nock.isDone()).to.be.true;
+    } finally {
+      await knex('translations').truncate();
+    }
+  });
+
+  describe('POST /api/airtable/content/Thematiques', () => {
+    let airtableRawThematic;
+    let thematicToSave;
+    let user;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+      await databaseBuilder.commit();
+      const thematic = domainBuilder.buildThematicDatasourceObject({ id: 'mon_id_persistant' });
+      airtableRawThematic = airtableBuilder.factory.buildThematic(thematic);
+      thematicToSave = inputOutputDataBuilder.factory.buildThematic(thematic);
+    });
+
+    describe('nominal cases', () => {
+      it('should proxy request to airtable and add translations to the PG table', async () => {
+        // Given
+        nock('https://api.airtable.com')
+          .post('/v0/airtableBaseValue/Thematiques', airtableRawThematic)
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableRawThematic);
+        const server = await createServer();
+
+        // When
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/airtable/content/Thematiques',
+          headers: generateAuthorizationHeader(user),
+          payload: thematicToSave,
+        });
+
+        // Then
+        expect(response.statusCode).to.equal(200);
+
+        await expect(
+          knex('translations')
+            .select()
+            .orderBy([
+              { column: 'key', order: 'asc' },
+              { column: 'locale', order: 'asc' },
+            ])
+        ).resolves.toEqual([
+          {
+            key: 'thematic.mon_id_persistant.name',
+            locale: 'en',
+            value: thematicToSave.fields['Titre en-us'],
+          }, {
+            key: 'thematic.mon_id_persistant.name',
+            locale: 'fr',
+            value: thematicToSave.fields['Nom'],
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/scripts/migrate-thematics-translations-from-airtable_test.js
+++ b/api/tests/scripts/migrate-thematics-translations-from-airtable_test.js
@@ -1,0 +1,90 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { airtableBuilder, knex } from '../test-helper.js';
+import Airtable from 'airtable';
+import nock from 'nock';
+
+import { migrateThematicsTranslationsFromAirtable } from '../../scripts/migrate-thematics-translations-from-airtable/index.js';
+
+describe('Script | Migrate thematics translations from Airtable', function() {
+
+  let airtableClient;
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    airtableClient = new Airtable({
+      apiKey: 'airtableApiKeyValue',
+    }).base('airtableBaseValue');
+  });
+
+  afterEach(async () => {
+    await knex('translations').truncate();
+  });
+
+  it('fills translations table', async function() {
+    // given
+    const thematic1FromAirtable = airtableBuilder.factory.buildThematic({
+      id: 'thematicId1',
+      airtableId: 'airtableThematicId1',
+    });
+    thematic1FromAirtable.fields = {
+      ...thematic1FromAirtable.fields,
+      'Nom': 'name 1 fr',
+      'Titre en-us': 'name 1 en',
+    };
+
+    const thematic2FromAirtable = airtableBuilder.factory.buildThematic({
+      airtableId: 'airtableThematicId2',
+      id: 'thematicId2',
+    });
+    thematic2FromAirtable.fields = {
+      ...thematic2FromAirtable.fields,
+      'Nom': 'name 2 fr',
+      'Titre en-us': 'name 2 en',
+    };
+
+    const thematics = [thematic1FromAirtable, thematic2FromAirtable];
+
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Thematiques')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .reply(200, { records: thematics });
+
+    // when
+    await migrateThematicsTranslationsFromAirtable({ airtableClient });
+
+    // then
+    await expect(
+      knex('translations').select().orderBy([
+        { column: 'key', order: 'asc' },
+        { column: 'locale', order: 'asc' },
+      ]),
+    ).resolves.toEqual([
+      {
+        key: 'thematic.thematicId1.name',
+        locale: 'en',
+        value: thematics[0].fields['Titre en-us'],
+      },
+      {
+        key: 'thematic.thematicId1.name',
+        locale: 'fr',
+        value: thematics[0].fields['Nom'],
+      },
+      {
+        key: 'thematic.thematicId2.name',
+        locale: 'en',
+        value: thematics[1].fields['Titre en-us'],
+      },
+      {
+        key: 'thematic.thematicId2.name',
+        locale: 'fr',
+        value: thematics[1].fields['Nom'],
+      },
+    ]);
+  });
+});

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -1,6 +1,7 @@
 export function buildThematic(
   {
     id,
+    airtableId = id,
     name_i18n: {
       fr: name,
       en: nameEnUs,
@@ -10,8 +11,9 @@ export function buildThematic(
     index,
   } = {}) {
   return {
-    id,
+    id: airtableId,
     'fields': {
+      'id persistant': id,
       'Nom': name,
       'Titre en-us': nameEnUs,
       'Competence (id persistant)': [competenceId],

--- a/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
@@ -1,6 +1,7 @@
 export function buildThematic(
   {
     id,
+    airtableId = id,
     name_i18n: {
       fr: name,
       en: nameEnUs,
@@ -10,8 +11,9 @@ export function buildThematic(
     index,
   } = {}) {
   return {
-    id,
+    id: airtableId,
     'fields': {
+      'id persistant': id,
       'Nom': name,
       'Titre en-us': nameEnUs,
       'Competence (id persistant)': [competenceId],

--- a/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
@@ -1,0 +1,22 @@
+export function buildThematic(
+  {
+    id,
+    name_i18n: {
+      fr: name,
+      en: nameEnUs,
+    } = {},
+    competenceId,
+    tubeIds,
+    index,
+  } = {}) {
+  return {
+    id,
+    'fields': {
+      'Nom': name,
+      'Titre en-us': nameEnUs,
+      'Competence (id persistant)': [competenceId],
+      'Tubes (id persistant)': tubeIds,
+      'Index': index
+    },
+  };
+}

--- a/api/tests/tooling/input-output-data-builder/factory/index.js
+++ b/api/tests/tooling/input-output-data-builder/factory/index.js
@@ -2,4 +2,5 @@ export * from './build-area.js';
 export * from './build-attachment.js';
 export * from './build-competence.js';
 export * from './build-skill.js';
+export * from './build-thematic.js';
 export * from './build-tube.js';

--- a/api/tests/unit/domain/usecases/proxy-read-request-to-airtable_test.js
+++ b/api/tests/unit/domain/usecases/proxy-read-request-to-airtable_test.js
@@ -25,10 +25,10 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
   });
 
   describe('when reading a single entity', () => {
-    const airtableFields = Symbol('airtableFields');
+    const airtableData = Symbol('airtableData');
 
     beforeEach(() => {
-      response = { status: 200, data: { fields: airtableFields } };
+      response = { status: 200, data: airtableData };
       proxyRequestToAirtable.mockResolvedValue(response);
     });
 
@@ -47,13 +47,13 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
     });
 
     describe('when reading translations from PG is enabled', () => {
-      const proxyResponseFields = Symbol('proxyResponseFields');
+      const proxyResponseData = Symbol('proxyResponseData');
 
       beforeEach(() => {
         tableTranslations.readFromPgEnabled = true;
         tableTranslations.prefixFor.mockReturnValue('entity.id.');
         translationRepository.listByPrefix.mockResolvedValue(translations);
-        tableTranslations.airtableObjectToProxyObject.mockReturnValue(proxyResponseFields);
+        tableTranslations.airtableObjectToProxyObject.mockReturnValue(proxyResponseData);
       });
 
       it('should hydrate response with translations from PG', async () => {
@@ -66,26 +66,26 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
 
         // then
         expect(actualResponse).toBe(response);
-        expect(response.data.fields).toBe(proxyResponseFields);
+        expect(response.data).toBe(proxyResponseData);
 
         expect(tableTranslations.prefixFor).toHaveBeenCalledOnce();
-        expect(tableTranslations.prefixFor).toHaveBeenCalledWith(airtableFields);
+        expect(tableTranslations.prefixFor).toHaveBeenCalledWith(airtableData);
 
         expect(translationRepository.listByPrefix).toHaveBeenCalledOnce();
         expect(translationRepository.listByPrefix).toHaveBeenCalledWith('entity.id.');
 
         expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenCalledOnce();
-        expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenCalledWith(airtableFields, translations);
+        expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenCalledWith(airtableData, translations);
       });
     });
   });
 
   describe('when reading several entities', () => {
-    const airtableFields1 = Symbol('airtableFields1');
-    const airtableFields2 = Symbol('airtableFields2');
+    const airtableData1 = Symbol('airtableData1');
+    const airtableData2 = Symbol('airtableData2');
 
     beforeEach(() => {
-      response = { status: 200, data: { records: [{ fields: airtableFields1 }, { fields: airtableFields2 }] } };
+      response = { status: 200, data: { records: [airtableData1, airtableData2] } };
       proxyRequestToAirtable.mockResolvedValue(response);
     });
 
@@ -104,14 +104,14 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
     });
 
     describe('when reading translations from PG is enabled', () => {
-      const proxyResponseFields1 = Symbol('proxyResponseFields1');
-      const proxyResponseFields2 = Symbol('proxyResponseFields2');
+      const proxyResponseData1 = Symbol('proxyResponseData1');
+      const proxyResponseData2 = Symbol('proxyResponseData2');
 
       beforeEach(() => {
         tableTranslations.readFromPgEnabled = true;
         translationRepository.listByPrefix.mockResolvedValue(translations);
-        tableTranslations.airtableObjectToProxyObject.mockReturnValueOnce(proxyResponseFields1);
-        tableTranslations.airtableObjectToProxyObject.mockReturnValueOnce(proxyResponseFields2);
+        tableTranslations.airtableObjectToProxyObject.mockReturnValueOnce(proxyResponseData1);
+        tableTranslations.airtableObjectToProxyObject.mockReturnValueOnce(proxyResponseData2);
       });
 
       it('should hydrate response with translations from PG', async () => {
@@ -124,15 +124,15 @@ describe('Unit | Domain | Usecases | proxy-read-request-to-airtable', () => {
 
         // then
         expect(actualResponse).toBe(response);
-        expect(actualResponse.data.records[0].fields).toBe(proxyResponseFields1);
-        expect(actualResponse.data.records[1].fields).toBe(proxyResponseFields2);
+        expect(actualResponse.data.records[0]).toBe(proxyResponseData1);
+        expect(actualResponse.data.records[1]).toBe(proxyResponseData2);
 
         expect(translationRepository.listByPrefix).toHaveBeenCalledOnce();
         expect(translationRepository.listByPrefix).toHaveBeenCalledWith(tableTranslations.prefix);
 
         expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenCalledTimes(2);
-        expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenNthCalledWith(1, airtableFields1, translations);
-        expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenNthCalledWith(2, airtableFields2, translations);
+        expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenNthCalledWith(1, airtableData1, translations);
+        expect(tableTranslations.airtableObjectToProxyObject).toHaveBeenNthCalledWith(2, airtableData2, translations);
       });
     });
   });

--- a/api/tests/unit/infrastructure/translations/utils_test.js
+++ b/api/tests/unit/infrastructure/translations/utils_test.js
@@ -14,7 +14,7 @@ describe('Unit | Infrastructure | Entity translations', () => {
   ];
 
   const prefix = 'entity.';
-  const idField = 'mon id';
+  const idField = 'fields.mon id';
 
   let translationsUtils;
 
@@ -26,11 +26,13 @@ describe('Unit | Infrastructure | Entity translations', () => {
     it('should return the list of translations', () => {
       // given
       const entity = {
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr',
-        'Attribut en-us': 'value en-us',
-        'Attribut2 fr-fr': 'value2 fr-fr',
-        'Attribut2 en-us': 'value2 en-us',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr',
+          'Attribut en-us': 'value en-us',
+          'Attribut2 fr-fr': 'value2 fr-fr',
+          'Attribut2 en-us': 'value2 en-us',
+        },
       };
 
       // when
@@ -48,9 +50,11 @@ describe('Unit | Infrastructure | Entity translations', () => {
     it('should return translations only for field w/ values', () => {
       // given
       const entity = {
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr',
-        'Attribut en-us': 'value en-us',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr',
+          'Attribut en-us': 'value en-us',
+        },
       };
 
       // when
@@ -68,9 +72,11 @@ describe('Unit | Infrastructure | Entity translations', () => {
     it('should set translated fields into the object', () => {
       // given
       const airtableObject = {
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr initial',
-        otherField: 'foo',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr initial',
+          otherField: 'foo',
+        },
       };
       const translations = [
         { key: 'entity.test.attribute', locale: 'fr', value: 'value fr-fr' },
@@ -92,26 +98,32 @@ describe('Unit | Infrastructure | Entity translations', () => {
 
       // then
       expect(proxyObject).to.deep.equal({
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr',
-        'Attribut en-us': 'value en-us',
-        'Attribut2 fr-fr': 'value2 fr-fr',
-        'Attribut2 en-us': 'value2 en-us',
-        otherField: 'foo',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr',
+          'Attribut en-us': 'value en-us',
+          'Attribut2 fr-fr': 'value2 fr-fr',
+          'Attribut2 en-us': 'value2 en-us',
+          otherField: 'foo',
+        },
       });
 
       expect(airtableObject).to.deep.equal({
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr initial',
-        otherField: 'foo',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr initial',
+          otherField: 'foo',
+        },
       });
     });
 
     it('should set null value for missing translations', () => {
       // given
       const airtableObject = {
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr initial',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr initial',
+        },
       };
       const translations = [
         { key: 'entity.test.attribute', locale: 'en', value: 'value en-us' },
@@ -127,16 +139,20 @@ describe('Unit | Infrastructure | Entity translations', () => {
 
       // then
       expect(proxyObject).to.deep.equal({
-        'mon id': 'test',
-        'Attribut fr-fr': null,
-        'Attribut en-us': 'value en-us',
-        'Attribut2 fr-fr': null,
-        'Attribut2 en-us': 'value2 en-us',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': null,
+          'Attribut en-us': 'value en-us',
+          'Attribut2 fr-fr': null,
+          'Attribut2 en-us': 'value2 en-us',
+        },
       });
 
       expect(airtableObject).to.deep.equal({
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr initial',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr initial',
+        },
       });
     });
   });
@@ -145,10 +161,12 @@ describe('Unit | Infrastructure | Entity translations', () => {
     it('should return an airtable object', () => {
       // given
       const proxyObject = {
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr initial',
-        'Attribut2 fr-fr': 'value2 fr-fr initial',
-        otherField: 'foo',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr initial',
+          'Attribut2 fr-fr': 'value2 fr-fr initial',
+          otherField: 'foo',
+        },
       };
 
       // when
@@ -156,15 +174,19 @@ describe('Unit | Infrastructure | Entity translations', () => {
 
       // then
       expect(airtableObject).to.deep.equal({
-        'mon id': 'test',
-        otherField: 'foo',
+        fields: {
+          'mon id': 'test',
+          otherField: 'foo',
+        },
       });
 
       expect(proxyObject).to.deep.equal({
-        'mon id': 'test',
-        'Attribut fr-fr': 'value fr-fr initial',
-        'Attribut2 fr-fr': 'value2 fr-fr initial',
-        otherField: 'foo',
+        fields: {
+          'mon id': 'test',
+          'Attribut fr-fr': 'value fr-fr initial',
+          'Attribut2 fr-fr': 'value2 fr-fr initial',
+          otherField: 'foo',
+        },
       });
     });
   });
@@ -239,7 +261,9 @@ describe('Unit | Infrastructure | Entity translations', () => {
     it('should return the prefix for entity fields keys', () => {
       // given
       const entity = {
-        'mon id': 'rec123',
+        fields: {
+          'mon id': 'rec123',
+        },
       };
 
       // when

--- a/pix-editor/app/models/theme.js
+++ b/pix-editor/app/models/theme.js
@@ -2,6 +2,7 @@ import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 
 export default class ThemeModel extends Model {
 
+  @attr pixId;
   @attr name;
   @attr nameEnUs;
   @attr index;

--- a/pix-editor/app/routes/authenticated/competence/themes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/themes/new.js
@@ -4,9 +4,12 @@ import { inject as service } from '@ember/service';
 export default class CompetenceThemesNewRoute extends CompetenceThemesSingleRoute {
   templateName = 'authenticated/competence/themes/single';
   @service store;
+  @service idGenerator;
 
   model() {
-    return this.store.createRecord('theme');
+    return this.store.createRecord('theme', {
+      pixId: this.idGenerator.newId('thematic'),
+    });
   }
 
   setupController(controller) {

--- a/pix-editor/app/serializers/theme.js
+++ b/pix-editor/app/serializers/theme.js
@@ -4,6 +4,7 @@ export default class ThemeSerializer extends AirtableSerializer {
   primaryKey = 'Record Id';
 
   attrs = {
+    pixId: 'id persistant',
     name: 'Nom',
     nameEnUs:'Titre en-us',
     rawTubes: 'Tubes',


### PR DESCRIPTION
## :unicorn: Problème
Les traductions des thématiques ne sont pas dans PG.

## :robot: Proposition
Les écrire et les migrer dans PG.

## :rainbow: Remarques
Traite également PIX-9473

## :100: Pour tester
Le script de migration a été passé sur la RA.
Créer/modifier de la thématique.
Vérifier que ça s'écrit bien dans PG.
