### PR TITLE
[FEATURE] Afficher l'url des embed calculée par défaut pour les épreuves traduites (PIX-11507).

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -103,6 +103,16 @@ export default class LocalizedController extends Controller {
       : 'Êtes-vous sûr de vouloir mettre en prod cette épreuve ?';
   }
 
+  get shouldDisplayPrimaryEmbedUrl() {
+    return !this.localizedChallenge.embedURL && this.challenge.embedURL;
+  }
+
+  get defaultEmbedUrl() {
+    const url = new URL(this.challenge.embedURL);
+    url.searchParams.set('lang', this.localizedChallenge.locale);
+    return url.href;
+  }
+
   @action
   showIllustration() {
     this.displayIllustration = true;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
@@ -4,7 +4,9 @@ import { service } from '@ember/service';
 export default class LocalizedPrototypeRoute extends Route {
   @service store;
 
-  model({ localized_challenge_id }) {
-    return this.store.findRecord('localized_challenge', localized_challenge_id);
+  async model({ localized_challenge_id }) {
+    const localizedChallenge = await this.store.findRecord('localized_challenge', localized_challenge_id);
+    const challenge =  await localizedChallenge.challenge;
+    return { localizedChallenge, challenge };
   }
 }

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -47,6 +47,11 @@
         @edition={{this.edition}}
         @placeholder="Url de l'embed"
       />
+      {{#if this.shouldDisplayPrimaryEmbedUrl }}
+        <div class="ui  blue message">
+         <p>Embed URL auto-générée : {{this.defaultEmbedUrl}}</p>
+        </div>
+      {{/if}}
       <Field::Select
         @title="Géographie"
         @value={{this.localizedChallenge.geography}}

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -6,9 +6,9 @@
   @close={{this.close}}
 >
   <:default>
-    <i class="{{convert-language-as-flag this.model.locale}} flag" title={{this.model.locale}}></i>
+    <i class="{{convert-language-as-flag this.localizedChallenge.locale}} flag" title={{this.localizedChallenge.locale}}></i>
     {{this.challengeTitle}}
-    <div class="ui circular label {{this.model.statusCSS}}">{{ this.model.statusText }}</div>
+    <div class="ui circular label {{this.localizedChallenge.statusCSS}}">{{ this.localizedChallenge.statusText }}</div>
   </:default>
 </Competence::Prototypes::ChallengeHeader>
 <div class="challenge">
@@ -16,16 +16,16 @@
     <form action="" class="ui form">
       <Field::Illustration
         @title="Illustration"
-        @value={{this.model.illustration}}
+        @value={{this.localizedChallenge.illustration}}
         @edition={{this.edition}}
         @addIllustration={{this.addIllustration}}
         @removeIllustration={{this.removeIllustration}}
         @display={{this.showIllustration}}
         data-test-file-input-illustration
       />
-      {{#if this.model.illustration}}
+      {{#if this.localizedChallenge.illustration}}
         <Field::Textarea
-          @value={{this.model.illustration.alt}}
+          @value={{this.localizedChallenge.illustration.alt}}
           @title="Texte alternatif"
           @edition={{false}}
           @id="challenge-illustration-alt"
@@ -33,8 +33,8 @@
       {{/if}}
       <Field::Files
         @title="Pièces jointes"
-        @value={{this.model.attachments}}
-        @baseName={{this.model.attachmentBaseName}}
+        @value={{this.localizedChallenge.attachments}}
+        @baseName={{this.localizedChallenge.attachmentBaseName}}
         @addAttachment={{this.addAttachment}}
         @edition={{this.edition}}
         @removeAttachment={{this.removeAttachment}}
@@ -43,23 +43,23 @@
       <Field::Input
         @id="localized-challenge-embed-url"
         @label="Embed URL"
-        @value={{this.model.embedURL}}
+        @value={{this.localizedChallenge.embedURL}}
         @edition={{this.edition}}
         @placeholder="Url de l'embed"
       />
       <Field::Select
         @title="Géographie"
-        @value={{this.model.geography}}
+        @value={{this.localizedChallenge.geography}}
         @edition={{this.edition}}
         @multiple={{false}}
         @defaultValue="Neutre"
         @options={{this.options.geography}}
-        @setValue={{fn (mut this.model.geography)}}
+        @setValue={{fn (mut this.localizedChallenge.geography)}}
       />
       {{#unless this.edition}}
         <Field::Input
           @id="localized-challenge-id"
-          @value={{this.model.id}}
+          @value={{this.localizedChallenge.id}}
           @label="Id"
           @edition={{false}}
         />
@@ -113,7 +113,7 @@
     data-testid='change-status-confirm-popin'
   />
   <PopIn::Image
-    @imageSrc={{this.model.illustration.url}}
+    @imageSrc={{this.localizedChallenge.illustration.url}}
     @close={{this.closeIllustration}}
     @showModal={{this.displayIllustration}}
     data-testid='display-illustration-pop-in'

--- a/pix-editor/mirage/factories/challenge.js
+++ b/pix-editor/mirage/factories/challenge.js
@@ -19,7 +19,7 @@ export default Factory.extend({
   preview: 'preview',
   airtableId: undefined,
   timer: 'timer',
-  embedURL: 'embedURL',
+  embedURL: 'https://mon-site.fr/my-link.html',
   embedTitle: 'embedTitle',
   embedHeight: 'embedHeight',
   alternativeVersion: 'alternativeVersion',

--- a/pix-editor/tests/acceptance/localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/localized-challenge-test.js
@@ -46,5 +46,40 @@ module('Acceptance | Localized-Challenge', function (hooks) {
     // then
     assert.dom(await screen.queryByText('https://mon-site.fr/my-link.html?lang=nl', { exact: false })).exists();
   });
+  test('should not display a default url if primary does not have any', async function(assert) {
+    // given
+    this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1', embedURL: null });
+    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl' });
+    this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 1, tubeId: 'recTube1' });
+
+    // when
+    const screen = await visit('/');
+    await click(findAll('[data-test-area-item]')[0]);
+    await click(findAll('[data-test-competence-item]')[0]);
+    await click(findAll('[data-test-skill-cell-link]')[0]);
+    await clickByText('Version nl');
+
+    // then
+    assert.dom(await screen.queryByText('Embed URL auto-générée', { exact: false })).doesNotExist();
+  });
+  test('should display an embed url if localized challenge has one', async function(assert) {
+    // given
+    this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1' });
+    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl', embedURL: 'https://mon-site.fr/my-nl-link.html' });
+    this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 1, tubeId: 'recTube1' });
+
+    // when
+    const screen = await visit('/');
+    await click(findAll('[data-test-area-item]')[0]);
+    await click(findAll('[data-test-competence-item]')[0]);
+    await click(findAll('[data-test-skill-cell-link]')[0]);
+    await clickByText('Version nl');
+
+    // then
+    const input = await screen.findByLabelText('Embed URL :');
+    assert.strictEqual(input.value, 'https://mon-site.fr/my-nl-link.html');
+  });
 });
 

--- a/pix-editor/tests/acceptance/localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/localized-challenge-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { visit, clickByText } from '@1024pix/ember-testing-library';
+import { findAll, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | Localized-Challenge', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1',  embedURL: 'https://mon-site.fr/my-link.html?lang=fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl' });
+    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'] });
+    this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+    this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+    this.server.create('competence', {
+      id: 'recCompetence1.1',
+      pixId: 'pixId recCompetence1.1',
+      rawThemeIds: ['recTheme1'],
+      rawTubeIds: ['recTube1']
+    });
+    this.server.create('area', {
+      id: 'recArea1',
+      name: '1. Information et données',
+      code: '1',
+      competenceIds: ['recCompetence1.1']
+    });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+    return authenticateSession();
+  });
+
+  test('should display a default embedUrl if is empty but not for primary', async function (assert) {
+    // when
+    const screen = await visit('/');
+    await click(findAll('[data-test-area-item]')[0]);
+    await click(findAll('[data-test-competence-item]')[0]);
+    await click(findAll('[data-test-skill-cell-link]')[0]);
+    await clickByText('Version nl');
+
+    // then
+    assert.dom(await screen.queryByText('https://mon-site.fr/my-link.html?lang=nl', { exact: false })).exists();
+  });
+});
+

--- a/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/localized-test.js
@@ -11,7 +11,7 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
   hooks.beforeEach(function () {
     //given
     controller = this.owner.lookup('controller:authenticated.competence/prototypes/localized');
-
+    controller.model = {};
     startStub = sinon.stub();
     stopStub = sinon.stub();
     class LoaderService extends Service {
@@ -39,7 +39,7 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
         save: sinon.stub().resolves(localizedChallenge),
         files: [],
       };
-      controller.model = localizedChallenge;
+      controller.model.localizedChallenge = localizedChallenge;
 
       handleIllustrationStub = sinon.stub().resolves(localizedChallenge);
       controller._handleIllustration = handleIllustrationStub;
@@ -92,7 +92,7 @@ module('Unit | Controller | competence/prototypes/localized', function (hooks) {
       rollbackAttributes: rollbackAttributesStub,
       files: [],
     });
-    controller.model = localizedChallenge;
+    controller.model.localizedChallenge = localizedChallenge;
 
     // when
     await controller.cancelEdit();


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un épreuve traduite ne possède pas d'embed URL mais que son épreuve mère en possède une alors nous calculons cette URL dynamiquement. Mais elle n'est pas affichée lorsqu'on consulte une épreuve traduite.

## :robot: Proposition
Afficher cette url

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur une épreuve traduite qui ne possède pas d'embed URL mais dont l'épreuve mère en possède une.
