### PR TITLE
[FEATURE] Preview d'épreuve avec Pix App dans la langue de l'épreuve (PIX-11717)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -49,8 +49,9 @@ export let pixApi = {
   password: process.env.PIX_API_USER_PASSWORD,
 };
 
-export const pixApp = {
-  baseUrl: process.env.PIX_APP_BASEURL
+export let pixApp = {
+  baseUrlFr: process.env.PIX_APP_BASEURL_FR ?? process.env.PIX_APP_BASEURL,
+  baseUrlOrg: process.env.PIX_APP_BASEURL_ORG ?? process.env.PIX_APP_BASEURL,
 };
 
 export const lcms = {
@@ -137,7 +138,10 @@ if (process.env.NODE_ENV === 'test') {
     password: '123',
   };
 
-  pixApp.baseUrl = 'https://app.test.pix.fr';
+  pixApp = {
+    baseUrlFr: 'https://app.test.pix.fr',
+    baseUrlOrg: 'https://app.test.pix.org',
+  };
 
   lcms.baseUrl = 'http://test.site';
 

--- a/api/lib/domain/usecases/preview-challenge.js
+++ b/api/lib/domain/usecases/preview-challenge.js
@@ -12,5 +12,7 @@ export async function previewChallenge(
   const challenge = await challengeRepository.get(challengeId);
   const translatedChallenge = challenge.translate(locale);
   await refreshCache({ challenge: translatedChallenge });
-  return new URL(`challenges/${translatedChallenge.id}/preview`, config.pixApp.baseUrlFr).href;
+  const url = new URL(`challenges/${translatedChallenge.id}/preview`, config.pixApp.baseUrlOrg);
+  url.searchParams.set('lang', locale);
+  return url.href;
 }

--- a/api/lib/domain/usecases/preview-challenge.js
+++ b/api/lib/domain/usecases/preview-challenge.js
@@ -8,9 +8,9 @@ export async function previewChallenge(
     refreshCache,
   },
 ) {
-  if (!locale) return new URL(`challenges/${challengeId}/preview`, config.pixApp.baseUrl).href;
+  if (!locale) return new URL(`challenges/${challengeId}/preview`, config.pixApp.baseUrlFr).href;
   const challenge = await challengeRepository.get(challengeId);
   const translatedChallenge = challenge.translate(locale);
   await refreshCache({ challenge: translatedChallenge });
-  return new URL(`challenges/${translatedChallenge.id}/preview`, config.pixApp.baseUrl).href;
+  return new URL(`challenges/${translatedChallenge.id}/preview`, config.pixApp.baseUrlFr).href;
 }

--- a/api/sample.env
+++ b/api/sample.env
@@ -323,14 +323,23 @@ PIX_API_USER_PASSWORD=
 # ========
 # PIX APP
 # ========
-# Pix APP base url used to preview translated challenges.
+# Pix APP base url used to preview challenges for France.
+#
+# If not present the application cannot preview challenges.
+#
+# presence: required
+# type: Url
+# default: none
+PIX_APP_BASEURL_FR=
+
+# Pix APP base url used to preview translated challenges for other languages/countries.
 #
 # If not present the application cannot preview translated challenges.
 #
 # presence: required
 # type: Url
 # default: none
-PIX_APP_BASEURL=
+PIX_APP_BASEURL_ORG=
 
 
 # ==============

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -845,7 +845,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       await databaseBuilder.commit();
     });
 
-    it('should redirect to a staging Pix App preview URL', async () => {
+    it.fails('should redirect to a staging Pix App preview URL', async () => {
       // given
       const apiToken = 'secret';
       const apiTokenScope = nock('https://api.test.pix.fr')
@@ -890,7 +890,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
       // then
       expect(response.statusCode).to.equal(302);
-      expect(response.headers.location).to.equal(`https://app.test.pix.fr/challenges/${localizedChallengeId}/preview`);
+      expect(response.headers.location).to.equal(`https://app.test.pix.org/challenges/${localizedChallengeId}/preview?lang=${locale}`);
 
       apiTokenScope.done();
       apiCacheScope.done();

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -845,7 +845,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       await databaseBuilder.commit();
     });
 
-    it.fails('should redirect to a staging Pix App preview URL', async () => {
+    it('should redirect to a staging Pix App preview URL', async () => {
       // given
       const apiToken = 'secret';
       const apiTokenScope = nock('https://api.test.pix.fr')

--- a/api/tests/unit/domain/usecases/preview-challenge_test.js
+++ b/api/tests/unit/domain/usecases/preview-challenge_test.js
@@ -7,7 +7,7 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
 
   it('should return a preview url for challengeId and locale', async () => {
     // given
-    vi.spyOn(config.pixApp, 'baseUrl', 'get').mockReturnValue('https://preview.url.fr');
+    vi.spyOn(config.pixApp, 'baseUrlFr', 'get').mockReturnValue('https://preview.url.fr');
     const locale = 'fr';
     const challengeId = 'challenge-id';
     const localizedChallengeId = 'localizedChallengeId';
@@ -41,7 +41,7 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
   describe('when no locale is specified', () => {
     it('should redirect to a preview on given challengeId without updating cache', async () => {
       // given
-      vi.spyOn(config.pixApp, 'baseUrl', 'get').mockReturnValue('https://preview.url.fr');
+      vi.spyOn(config.pixApp, 'baseUrlFr', 'get').mockReturnValue('https://preview.url.fr');
       const challengeId = 'challenge-id';
 
       // when

--- a/api/tests/unit/domain/usecases/preview-challenge_test.js
+++ b/api/tests/unit/domain/usecases/preview-challenge_test.js
@@ -7,7 +7,7 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
 
   it('should return a preview url for challengeId and locale', async () => {
     // given
-    vi.spyOn(config.pixApp, 'baseUrlFr', 'get').mockReturnValue('https://preview.url.fr');
+    vi.spyOn(config.pixApp, 'baseUrlOrg', 'get').mockReturnValue('https://preview.url.org');
     const locale = 'fr';
     const challengeId = 'challenge-id';
     const localizedChallengeId = 'localizedChallengeId';
@@ -33,7 +33,7 @@ describe('Unit | Domain | Usecases | preview-challenge', function() {
     const url = await previewChallenge({ challengeId, locale }, { localizedChallengeRepository, challengeRepository, refreshCache });
 
     // then
-    expect(url).to.equal(`https://preview.url.fr/challenges/${localizedChallengeId}/preview`);
+    expect(url).to.equal(`https://preview.url.org/challenges/${localizedChallengeId}/preview?lang=fr`);
     expect(challengeRepository.get).toHaveBeenCalledWith(challengeId);
     expect(refreshCache).toHaveBeenCalledWith({ challenge });
   });


### PR DESCRIPTION
## :unicorn: Problème

La preview d'épreuve NL se fait dans un Pix App en français.

## :robot: Proposition

Faire la preview d'épreuve dans Pix App en NL.

## :rainbow: Remarques

Il faut créer les variables d'environnement `PIX_APP_BASEURL_FR` et `PIX_APP_BASEURL_ORG` sur les environnements pour remplacer l'ancienne variable `PIX_APP_BASEURL`.

Fait sur :
 - [x] [pix-lcms-review](https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-review/environment)
 - [x] [pix-lcms-integration](https://dashboard.scalingo.com/apps/osc-fr1/pix-lcms-integration/environment)
 - [x] [pix-lcms-production](https://dashboard.scalingo.com/apps/osc-secnum-fr1/pix-lcms-production/environment)

## :100: Pour tester

Faire une preview d'épreuve française et une preview d'épreuve NL.