### PR TITLE
[FEATURE] Ajouter les champs spoil à l'acquis pour la réplication (PIX-11762)

### DIFF
--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,7 +1,4 @@
-import {
-  thematicDatasource,
-  tutorialDatasource,
-} from '../../infrastructure/datasources/airtable/index.js';
+import { thematicDatasource, tutorialDatasource, } from '../../infrastructure/datasources/airtable/index.js';
 import {
   areaRepository,
   attachmentRepository,
@@ -47,6 +44,8 @@ export async function getLearningContentForReplication() {
     challengeId: attachment.localizedChallengeId,
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
+
+  await skillRepository.addSpoilData(skills);
 
   return {
     areas,

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -4,11 +4,29 @@ import { skillDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
+import * as airtable from '../airtable.js';
 
 export async function list() {
   const datasourceSkills = await skillDatasource.list();
   const translations = await translationRepository.listByPrefix(skillTranslations.prefix);
   return toDomainList(datasourceSkills, translations);
+}
+
+export async function addSpoilData(skills) {
+  const SPOIL_COLUMNS = ['Spoil_focus', 'Spoil_variabilisation', 'Spoil_mauvaisereponse', 'Spoil_nouvelacquis'];
+  const options = { fields: ['id persistant', ...SPOIL_COLUMNS] };
+  const airtableRawObjects = await airtable.findRecords('Acquis', options);
+
+  skills.forEach((skill) => addSpoilDataToSkill(skill, airtableRawObjects));
+}
+
+function addSpoilDataToSkill(skill, airtableSkills) {
+  const airtableSkill = airtableSkills.find((item) => item.get('id persistant') === skill.id);
+
+  skill.spoil_focus = airtableSkill.get('Spoil_focus') || null;
+  skill.spoil_variabilisation = airtableSkill.get('Spoil_variabilisation')?.filter((val) => val.length > 0) ?? [];
+  skill.spoil_mauvaisereponse = airtableSkill.get('Spoil_mauvaisereponse')?.filter((val) => val.length > 0) ?? [];
+  skill.spoil_nouvelacquis = airtableSkill.get('Spoil_nouvelacquis') ?? null;
 }
 
 function toDomainList(datasourceSkills, translations) {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -78,7 +78,13 @@ async function mockCurrentContent() {
       }
     })],
     tubes: [domainBuilder.buildTube()],
-    skills: [domainBuilder.buildSkill()],
+    skills: [{
+      ...domainBuilder.buildSkill({ id: 'recSkill1' }),
+      spoil_focus: 'en_devenir',
+      spoil_variabilisation: [],
+      spoil_mauvaisereponse: ['courgette', '67'],
+      spoil_nouvelacquis: null,
+    }],
     challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
     thematics: [domainBuilder.buildThematicDatasourceObject()],
@@ -91,12 +97,21 @@ async function mockCurrentContent() {
       name: 'nameCourse2',
     }],
   };
-
+  const airtableSkill = buildSkill(expectedCurrentContent.skills[0]);
   airtableBuilder.mockLists({
     areas: [buildArea(expectedCurrentContent.areas[0])],
     competences: [buildCompetence(expectedCurrentContent.competences[0])],
     tubes: [buildTube(expectedCurrentContent.tubes[0])],
-    skills: [buildSkill(expectedCurrentContent.skills[0])],
+    skills: [{
+      ...airtableSkill,
+      fields: {
+        ...airtableSkill.fields,
+        Spoil_focus: 'en_devenir',
+        Spoil_variabilisation: [''],
+        Spoil_mauvaisereponse: ['courgette', '67'],
+        Spoil_nouvelacquis: null,
+      },
+    }],
     challenges: [buildChallenge({
       ...expectedChallenge,
       files: [


### PR DESCRIPTION
## :unicorn: Problème
Des champs liés au spoil ont été rajoutés sur airtable dans l'objectif d'être utilisés sur metabase.

## :robot: Proposition
Ajouter les champs spoil à l'objet Acquis envoyé pour la répli

## :rainbow: Remarques
Ceci devra disparaître une fois le travail effectué par Zoé

## :100: Pour tester
?
