### PR TITLE
[FEATURE] Lire les traductions des thématiques dans PG (PIX-9474)

### DIFF
--- a/api/lib/domain/models/Thematic.js
+++ b/api/lib/domain/models/Thematic.js
@@ -1,0 +1,15 @@
+export class Thematic {
+  constructor({
+    id,
+    name_i18n,
+    index,
+    competenceId,
+    tubeIds,
+  }) {
+    this.id = id;
+    this.name_i18n = name_i18n;
+    this.index = index;
+    this.competenceId = competenceId;
+    this.tubeIds = tubeIds;
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -6,5 +6,6 @@ export * from './LocalizedChallenge.js';
 export * from './Mission.js';
 export * from './Skill.js';
 export * from './StaticCourse.js';
+export * from './Thematic.js';
 export * from './Translation.js';
 export * from './User.js';

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -3,6 +3,7 @@ import csv from 'fast-csv';
 import _ from 'lodash';
 import { extractFromChallenge } from '../../infrastructure/translations/challenge.js';
 import * as competenceTranslations from '../../infrastructure/translations/competence.js';
+import * as thematicTranslations from '../../infrastructure/translations/thematic.js';
 import * as skillTranslations from '../../infrastructure/translations/skill.js';
 import * as areaTranslations from '../../infrastructure/translations/area.js';
 import * as tubeTranslations from '../../infrastructure/translations/tube.js';
@@ -36,6 +37,7 @@ export async function exportTranslations(stream, dependencies) {
 
   const translationsStreams = mergeStreams(
     createTranslationsStream(release.content.competences, extractMetadataFromCompetence, releaseContent, 'competence', competenceTranslations.extractFromReleaseObject),
+    createTranslationsStream(release.content.thematics, extractMetadataFromThematic, releaseContent, 'thematique', thematicTranslations.extractFromReleaseObject),
     createTranslationsStream(release.content.areas, extractMetadataFromArea, releaseContent, 'domaine', areaTranslations.extractFromReleaseObject),
     createTranslationsStream(filteredTubes, extractMetadataFromTube, releaseContent, 'sujet', tubeTranslations.extractFromReleaseObject),
     createTranslationsStream(filteredActiveSkills, extractMetadataFromSkill, releaseContent, 'acquis', skillTranslations.extractFromReleaseObject),
@@ -151,6 +153,13 @@ function extractMetadataFromCompetence(competence, releaseContent) {
   };
 }
 
+function extractMetadataFromThematic(thematic, releaseContent) {
+  return {
+    tags: extractTagsFromThematic(thematic, releaseContent),
+    description: '',
+  };
+}
+
 function extractTagsFromChallenge(challenge, releaseContent) {
   return [
     toTag(challenge.status),
@@ -171,6 +180,10 @@ function extractTagsFromTube(tube, releaseContent) {
     toTag(tube.name),
     ...extractTagsFromCompetence(releaseContent.competences[tube.competenceId], releaseContent),
   ];
+}
+
+function extractTagsFromThematic(thematic, releaseContent) {
+  return extractTagsFromCompetence(releaseContent.competences[thematic.competenceId], releaseContent);
 }
 
 function extractTagsFromCompetence(competence, releaseContent) {

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,10 +1,11 @@
-import { thematicDatasource, tutorialDatasource, } from '../../infrastructure/datasources/airtable/index.js';
+import { tutorialDatasource, } from '../../infrastructure/datasources/airtable/index.js';
 import {
   areaRepository,
   attachmentRepository,
   challengeRepository,
   competenceRepository,
   skillRepository,
+  thematicRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
@@ -28,7 +29,7 @@ export async function getLearningContentForReplication() {
     challengeRepository.list(),
     tutorialDatasource.list(),
     attachmentRepository.list(),
-    thematicDatasource.list(),
+    thematicRepository.list(),
     _getCoursesFromPGForReplication(),
   ]);
 

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -10,6 +10,7 @@ export * as releaseRepository from './release-repository.js';
 export * as skillRepository from './skill-repository.js';
 export * as staticCourseRepository from './static-course-repository.js';
 export * as staticCourseTagRepository from './static-course-tag-repository.js';
+export * as thematicRepository from './thematic-repository.js';
 export * as translationRepository from './translation-repository.js';
 export * as tubeRepository from './tube-repository.js';
 export * as urlErrorRepository from './url-error-repository.js';

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -3,7 +3,6 @@ import {
   attachmentDatasource,
   challengeDatasource,
   frameworkDatasource,
-  thematicDatasource,
   tutorialDatasource,
 } from '../datasources/airtable/index.js';
 import {
@@ -12,6 +11,7 @@ import {
   competenceRepository,
   missionRepository,
   skillRepository,
+  thematicRepository,
   tubeRepository,
 } from './index.js';
 import * as airtableSerializer from '../serializers/airtable-serializer.js';
@@ -121,7 +121,7 @@ async function _getCurrentContentFromAirtable(challenges) {
     competenceRepository.list(),
     frameworkDatasource.list(),
     skillRepository.list(),
-    thematicDatasource.list(),
+    thematicRepository.list(),
     tubeRepository.list(),
     tutorialDatasource.list(),
   ]);

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -1,0 +1,25 @@
+import { thematicDatasource } from '../datasources/airtable/index.js';
+import * as translationRepository from './translation-repository.js';
+import _ from 'lodash';
+import * as thematicTranslations from '../translations/thematic.js';
+import { Thematic } from '../../domain/models/index.js';
+
+export async function list() {
+  const datasourceThematics = await thematicDatasource.list();
+  const translations = await translationRepository.listByPrefix(thematicTranslations.prefix);
+  return toDomainList(datasourceThematics, translations);
+}
+
+function toDomainList(datasourceThematics, translations) {
+  const translationsByThematicId = _.groupBy(translations, 'entityId');
+  return datasourceThematics.map(
+    (datasourceThematic) => toDomain(datasourceThematic, translationsByThematicId[datasourceThematic.id]),
+  );
+}
+
+function toDomain(datasourceThematic, translations = []) {
+  return new Thematic({
+    ...datasourceThematic,
+    ...thematicTranslations.toDomain(translations),
+  });
+}

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -31,5 +31,6 @@ const thematicTranslationUtils = buildTranslationsUtils({ locales, fields, local
 export const {
   extractFromProxyObject,
   airtableObjectToProxyObject,
+  toDomain,
   prefixFor,
 } = thematicTranslationUtils;

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -31,6 +31,7 @@ const thematicTranslationUtils = buildTranslationsUtils({ locales, fields, local
 export const {
   extractFromProxyObject,
   airtableObjectToProxyObject,
+  extractFromReleaseObject,
   toDomain,
   prefixFor,
 } = thematicTranslationUtils;

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -30,5 +30,6 @@ const thematicTranslationUtils = buildTranslationsUtils({ locales, fields, local
 
 export const {
   extractFromProxyObject,
+  airtableObjectToProxyObject,
   prefixFor,
 } = thematicTranslationUtils;

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -87,7 +87,12 @@ async function mockCurrentContent() {
     }],
     challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
-    thematics: [domainBuilder.buildThematicDatasourceObject()],
+    thematics: [domainBuilder.buildThematic({
+      name_i18n: {
+        fr: 'Thématique en fr',
+        en: 'Thematic in en',
+      },
+    })],
     courses: [{
       id: 'recCourse1',
       name: 'nameCourse1',
@@ -198,6 +203,17 @@ async function mockCurrentContent() {
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
+  });
+
+  databaseBuilder.factory.buildTranslation({
+    key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
+    locale: 'fr',
+    value: expectedCurrentContent.thematics[0].name_i18n.fr,
+  });
+  databaseBuilder.factory.buildTranslation({
+    key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
+    locale: 'en',
+    value: expectedCurrentContent.thematics[0].name_i18n.en,
   });
 
   databaseBuilder.factory.buildTranslation({

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -371,12 +371,20 @@ describe('Acceptance | Controller | phrase-controller', () => {
           'Indice - fr',
           'acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
           ''
-        ],[
+        ],
+        [
+          'thematic.recThematic0.name',
+          'Nom',
+          'thematique,Pix-1-1.1,Pix-1,Pix',
+          '',
+        ],
+        [
           'tube.recTube0.practicalDescription',
           'Description pratique du Tube - fr',
           'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
           ''
-        ],[
+        ],
+        [
           'tube.recTube0.practicalTitle',
           'Titre pratique du Tube - fr',
           'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -65,6 +65,7 @@ async function mockCurrentContent() {
       name_i18n: {
         fr: 'Nom',
         en: 'name',
+        nl: 'name nl',
       },
       competenceId: 'recCompetence0',
       tubeIds: ['recTube0'],
@@ -251,6 +252,12 @@ async function mockCurrentContent() {
     });
 
     databaseBuilder.factory.buildTranslation({
+      key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
+      locale,
+      value: expectedCurrentContent.thematics[0].name_i18n[locale],
+    });
+
+    databaseBuilder.factory.buildTranslation({
       key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
       locale,
       value: expectedCurrentContent.skills[0].hint_i18n[locale],
@@ -368,6 +375,7 @@ async function mockContentForRelease() {
       name_i18n: {
         en: 'name',
         fr: 'Nom',
+        nl: 'name nl',
       },
     }],
     tubes: [{
@@ -526,6 +534,12 @@ async function mockContentForRelease() {
       key: `competence.${expectedCurrentContent.competences[0].id}.description`,
       locale,
       value: expectedCurrentContent.competences[0].description_i18n[locale],
+    });
+
+    databaseBuilder.factory.buildTranslation({
+      key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
+      locale,
+      value: expectedCurrentContent.thematics[0].name_i18n[locale],
     });
 
     databaseBuilder.factory.buildTranslation({

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -353,12 +353,20 @@ describe('Acceptance | Controller | translations-controller', () => {
           'Indice - fr',
           'acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
           ''
-        ],[
+        ],
+        [
+          'thematic.recThematic0.name',
+          'Nom',
+          'thematique,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+        [
           'tube.recTube0.practicalDescription',
           'Description pratique du Tube - fr',
           'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
           ''
-        ],[
+        ],
+        [
           'tube.recTube0.practicalTitle',
           'Titre pratique du Tube - fr',
           'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
@@ -513,6 +521,7 @@ describe('Acceptance | Controller | translations-controller', () => {
         'competence.recCompetence0.description,Description de la compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix",',
         'competence.recCompetence0.name,Nom de la Compétence - fr,"competence,Pix-1-1.1,Pix-1,Pix",',
         'skill.recSkill0.hint,Indice - fr,"acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
+        'thematic.recThematic0.name,Nom,"thematique,Pix-1-1.1,Pix-1,Pix",',
         'tube.recTube0.practicalDescription,Description pratique du Tube - fr,"sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
         'tube.recTube0.practicalTitle,Titre pratique du Tube - fr,"sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix",',
       ]);

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -170,10 +170,11 @@ describe('Integration | Repository | release-repository', function() {
   describe('#getCurrentContent', function() {
 
     beforeEach(function() {
-      const { areas, competences, tubeIds, skills, challenges } = _mockRichAirtableContent();
+      const { areas, competences, thematics, tubeIds, skills, challenges } = _mockRichAirtableContent();
 
       buildAreasTranslations(areas);
       buildCompetencesTranslations(competences);
+      buildThematicsTranslations(thematics);
       buildTubesTranslations(tubeIds);
       buildSkillsTranslations(skills);
       buildChallengesTranslationsAndLocalizedChallenges(challenges);
@@ -253,6 +254,21 @@ function buildCompetencesTranslations(competences) {
       key: `competence.${competence.id}.description`,
       locale: 'en',
       value: `${competence.id} descriptionEnUs`,
+    });
+  }
+}
+
+function buildThematicsTranslations(thematics) {
+  for (const thematic of thematics) {
+    databaseBuilder.factory.buildTranslation({
+      key: `thematic.${thematic.id}.name`,
+      locale: 'fr',
+      value: `${thematic.id} nameFrFr`,
+    });
+    databaseBuilder.factory.buildTranslation({
+      key: `thematic.${thematic.id}.name`,
+      locale: 'en',
+      value: `${thematic.id} nameEnUs`,
     });
   }
 }
@@ -398,7 +414,7 @@ function _mockRichAirtableContent() {
     origin: 'FrameworkA',
   };
   const airtableCompetence21 = airtableBuilder.factory.buildCompetence(competence21);
-  const airtableThematic111 = airtableBuilder.factory.buildThematic({
+  const thematic111 = {
     id: 'thematic111',
     name_i18n: {
       fr: 'thematic111 name',
@@ -407,8 +423,9 @@ function _mockRichAirtableContent() {
     competenceId: 'competence11',
     tubeIds: ['tube1111'],
     index: 'thematic111 index',
-  });
-  const airtableThematic112 = airtableBuilder.factory.buildThematic({
+  };
+  const airtableThematic111 = airtableBuilder.factory.buildThematic(thematic111);
+  const thematic112 = {
     id: 'thematic112',
     name_i18n: {
       fr: 'thematic112 name',
@@ -417,8 +434,9 @@ function _mockRichAirtableContent() {
     competenceId: 'competence11',
     tubeIds: ['tube1121'],
     index: 'thematic112 index',
-  });
-  const airtableThematic121 = airtableBuilder.factory.buildThematic({
+  };
+  const airtableThematic112 = airtableBuilder.factory.buildThematic(thematic112);
+  const thematic121 = {
     id: 'thematic121',
     name_i18n: {
       fr: 'thematic121 name',
@@ -427,8 +445,9 @@ function _mockRichAirtableContent() {
     competenceId: 'competence12',
     tubeIds: ['tube1211', 'tube1212'],
     index: 'thematic121 index',
-  });
-  const airtableThematic211 = airtableBuilder.factory.buildThematic({
+  };
+  const airtableThematic121 = airtableBuilder.factory.buildThematic(thematic121);
+  const thematic211 = {
     id: 'thematic211',
     name_i18n: {
       fr: 'thematic211 name',
@@ -437,7 +456,8 @@ function _mockRichAirtableContent() {
     competenceId: 'competence21',
     tubeIds: ['tube2111'],
     index: 'thematic211 index',
-  });
+  };
+  const airtableThematic211 = airtableBuilder.factory.buildThematic(thematic211);
   const airtableTube1111 = airtableBuilder.factory.buildTube({
     id: 'tube1111',
     name: 'tube1111 name',
@@ -830,6 +850,7 @@ function _mockRichAirtableContent() {
   return {
     areas: [area1, area2],
     competences: [competence11, competence12, competence21],
+    thematics: [thematic111, thematic112, thematic121, thematic211],
     tubeIds:  [airtableTube1111.id, airtableTube1121.id, airtableTube1211.id, airtableTube1212.id, airtableTube2111.id],
     skills: [skill11111, skill11112, skill12121, skill21111],
     challenges: [challenge121211, challenge121212, challenge211111, challenge211112, challenge211113],
@@ -946,7 +967,7 @@ function _getRichCurrentContentDTO() {
     {
       id: 'thematic111',
       name_i18n: {
-        fr: 'thematic111 name',
+        fr: 'thematic111 nameFrFr',
         en: 'thematic111 nameEnUs',
       },
       competenceId: 'competence11',
@@ -958,7 +979,7 @@ function _getRichCurrentContentDTO() {
     {
       id: 'thematic112',
       name_i18n: {
-        fr: 'thematic112 name',
+        fr: 'thematic112 nameFrFr',
         en: 'thematic112 nameEnUs',
       },
       competenceId: 'competence11',
@@ -970,7 +991,7 @@ function _getRichCurrentContentDTO() {
     {
       id: 'thematic121',
       name_i18n: {
-        fr: 'thematic121 name',
+        fr: 'thematic121 nameFrFr',
         en: 'thematic121 nameEnUs',
       },
       competenceId: 'competence12',
@@ -983,7 +1004,7 @@ function _getRichCurrentContentDTO() {
     {
       id: 'thematic211',
       name_i18n: {
-        fr: 'thematic211 name',
+        fr: 'thematic211 nameFrFr',
         en: 'thematic211 nameEnUs',
       },
       competenceId: 'competence21',

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
+
+describe('Integration | Repository | thematic-repository', () => {
+
+  describe('#list', () => {
+    it('should return the list of all thematics', async () => {
+      // given
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Thematiques' }).returns([
+        airtableBuilder.factory.buildThematic({
+          id: 'thematic1',
+          competenceId: 'competenceId1',
+          index: '1',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          name_i18n: {
+            en: 'Thematic 1 name airtable',
+            fr: 'Nom thématique 1',
+          },
+        }),
+        airtableBuilder.factory.buildThematic({
+          id: 'thematic2',
+          competenceId: 'competenceId2',
+          index: '2',
+          tubeIds: ['tubeId3', 'tubeId4'],
+          name_i18n: {
+            en: 'Thematic 2 name airtable',
+            fr: 'Nom thématique 2',
+          },
+        }),
+      ]).activate().nockScope;
+
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.thematic1.name',
+        locale: 'fr',
+        value: 'Nom thématique 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.thematic1.name',
+        locale: 'en',
+        value: 'Thematic 1 name',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.thematic2.name',
+        locale: 'fr',
+        value: 'Nom thématique 2',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.thematic2.name',
+        locale: 'en',
+        value: 'Thematic 2 name',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const thematics = await thematicRepository.list();
+
+      // then
+      expect(thematics).toEqual([
+        domainBuilder.buildThematic({
+          id: 'thematic1',
+          competenceId: 'competenceId1',
+          index: '1',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          name_i18n: {
+            en: 'Thematic 1 name',
+            fr: 'Nom thématique 1',
+          },
+        }),
+        domainBuilder.buildThematic({
+          id: 'thematic2',
+          competenceId: 'competenceId2',
+          index: '2',
+          tubeIds: ['tubeId3', 'tubeId4'],
+          name_i18n: {
+            en: 'Thematic 2 name',
+            fr: 'Nom thématique 2',
+          },
+        }),
+      ]);
+
+      airtableScope.done();
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-thematic.js
+++ b/api/tests/tooling/domain-builder/factory/build-thematic.js
@@ -1,0 +1,20 @@
+import { Thematic } from '../../../../lib/domain/models/index.js';
+
+export function buildThematic({
+  id = 'recFvllz2Ckz',
+  name_i18n = {
+    fr: 'Nom de la thématique',
+    en: 'Thematic\'s name',
+  },
+  competenceId = 'recCompetence0',
+  tubeIds = ['recTube0'],
+  index = 0,
+} = {}) {
+  return new Thematic({
+    id,
+    name_i18n,
+    competenceId,
+    tubeIds,
+    index,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -21,6 +21,7 @@ export * from './build-static-course.js';
 export * from './build-static-course-read.js';
 export * from './build-static-course-summary.js';
 export * from './build-tag.js';
+export * from './build-thematic.js';
 export * from './build-thematic-for-release.js';
 export * from './build-translation.js';
 export * from './build-tube.js';


### PR DESCRIPTION
## :unicorn: Problème
Les traductions des thématiques sont écrites dans PG mais pas lues.

## :robot: Proposition
Les lire dans PG.

## :rainbow: Remarques
Traite également PIX-9475, PIX-9476 et PIX-11815

## :100: Pour tester
Modifier une trad de thématique directement dans PG et vérifier que c'est visible dans :
 - le front
 - la release
 - la répli
 - l'export des trads pour Phrase