### PR TITLE
[TECH] Envoyer le résultat des tests API et pix-editor a circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,11 @@ jobs:
           command: npm run lint
       - run:
           name: Test
-          command: |
-            npm test
+          command: npm test
+      - store_test_results:
+          path: ./test-results
+      - store_artifacts:
+          path: ./test-results
 
   checkout:
     executor: node-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,10 @@ jobs:
             npm test
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
+      - store_test_results:
+          path: ./test-results
+      - store_artifacts:
+          path: ./test-results
 
   scripts_test:
     executor: node-docker

--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*_test.js'],
-    reporters: 'dot',
+    reporters: process.env.CI ? 'junit' : 'dot',
+    outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     restoreMocks: true,
     poolOptions: {
       threads: {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -25,7 +25,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve --proxy http://localhost:3002",
     "test": "npm-run-all lint test:*",
-    "test:ember": "ember test --reporter=dot"
+    "test:ember": "ember test"
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^1.1.0",

--- a/pix-editor/testem.js
+++ b/pix-editor/testem.js
@@ -3,6 +3,7 @@
 const config = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
+  reporter: 'dot',
   launch_in_ci: [
     'Chrome'
   ],

--- a/pix-editor/testem.js
+++ b/pix-editor/testem.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = {
+const config = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
@@ -25,3 +25,10 @@ module.exports = {
     }
   }
 };
+
+module.exports = process.env.CI
+  ? {
+    ...config,
+    reporter: 'xunit',
+    report_file: './test-results/report.xml',
+  } : config;


### PR DESCRIPTION
## :unicorn: Problème
En cas d'erreur sur l'intégration continue, nous devons actuellement regarder la (longue) sortie des tests pour connaître le ou les tests qui ont échoués.

## :robot: Proposition
Lorsqu'on tourne sur l'intégration continue, envoyer un fichier xml au format *unit pour permettre a circleci d'afficher un jolie onglet "Tests".

## :rainbow: Remarques
C'était déjà fait sur le mono-repo, mais pas ici.

## :100: Pour tester
Sur circleci, voir l'onglet tests pour le job "api_build_and_test" et "pix-editor-test".
