### PR TITLE
[TECH] Utilise la façon moderne ES6 pour importer dotenv

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,11 +1,9 @@
-import * as dotenv from 'dotenv';
+import 'dotenv/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { LOCALE_TO_LANGUAGE_MAP, TUTORIAL_LOCALE_TO_LANGUAGE_MAP } from './domain/constants.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
-dotenv.config();
 
 function isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { knex, disconnect } from '../db/knex-database-connection.js';

--- a/api/scripts/create-tags-for-static-courses/index.js
+++ b/api/scripts/create-tags-for-static-courses/index.js
@@ -1,5 +1,5 @@
+import 'dotenv/config';
 import _ from 'lodash';
-import dotenv from 'dotenv';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { disconnect, knex } from '../../db/knex-database-connection.js';
@@ -7,7 +7,6 @@ import { logger } from '../../lib/infrastructure/logger.js';
 import { parseFile } from 'fast-csv';
 import { streamToPromiseArray } from '../../lib/infrastructure/utils/stream-to-promise.js';
 
-dotenv.config();
 const TAG_LABEL_MAX_LENGTH = 30;
 
 function removeCapitalizeAndDiacritics(str) {

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -1,5 +1,4 @@
-import * as dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import { PgClient } from '../PgClient.js';
 import { PGSQL_DUPLICATE_DATABASE_ERROR } from '../../db/pgsql-errors.js';
 

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -1,5 +1,4 @@
-import * as dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import { PgClient } from '../PgClient.js';
 import { PGSQL_NON_EXISTENT_DATABASE_ERROR } from '../../db/pgsql-errors.js';
 

--- a/api/scripts/delete-unreferenced-translations/index.js
+++ b/api/scripts/delete-unreferenced-translations/index.js
@@ -1,11 +1,9 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import { fileURLToPath } from 'node:url';
 import Airtable from 'airtable';
 import { logger } from '../../lib/infrastructure/logger.js';
 import { performance } from 'node:perf_hooks';
 import _ from 'lodash';
-
-dotenv.config();
 
 const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;

--- a/api/scripts/dev/get-latest-release.js
+++ b/api/scripts/dev/get-latest-release.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import fs from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';

--- a/api/scripts/fix-attachments/index.js
+++ b/api/scripts/fix-attachments/index.js
@@ -1,4 +1,4 @@
-import dotenv from 'dotenv/config';
+import 'dotenv/config';
 
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';

--- a/api/scripts/migrate-localized-challenges-geography/index.js
+++ b/api/scripts/migrate-localized-challenges-geography/index.js
@@ -1,5 +1,4 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import 'dotenv/config';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
## :unicorn: Problème

Depuis que nous sommes passé a ES6/ESM, la façon d'utiliser dotenv n'a pas changé comme indiqué dans la documentation de dotenv: https://github.com/motdotla/dotenv?tab=readme-ov-file#%EF%B8%8F-usage 

## :robot: Proposition
Changer `require('dotenv').config()` en `import 'dotenv/config'`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Démarrer l'API en local avec son .env et vérifier que la configuration est bien prise en compte.
