### PR TITLE
[FEATURE] Ajoute les épreuves aux missions pour Pix1D (pix-11698)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -117,6 +117,15 @@ export class Challenge {
     return this.localizedChallenges.find(({ locale }) => locale === this.primaryLocale).embedUrl;
   }
 
+  static get STATUSES() {
+    return {
+      VALIDE: 'validé',
+      PROPOSE: 'proposé',
+      ARCHIVE: 'archivé',
+      PERIME: 'périmé',
+    };
+  }
+
   static getPrimaryLocale(locales) {
     return Challenge.defaultLocales(locales)[0];
   }

--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -8,6 +8,12 @@ export class Mission {
     learningObjectives_i18n,
     validatedObjectives_i18n,
     status,
+    content = {
+      tutorialChallenges: [],
+      trainingChallenges: [],
+      validationChallenges: [],
+      dareChallenges: [],
+    },
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -17,6 +23,7 @@ export class Mission {
     this.learningObjectives_i18n = learningObjectives_i18n;
     this.validatedObjectives_i18n = validatedObjectives_i18n;
     this.status = status;
+    this.content = content;
   }
 }
 

--- a/api/lib/domain/models/release/ChallengeForRelease.js
+++ b/api/lib/domain/models/release/ChallengeForRelease.js
@@ -1,3 +1,5 @@
+import { Challenge } from '../Challenge.js';
+
 export class ChallengeForRelease {
   constructor({
     id,
@@ -68,11 +70,6 @@ export class ChallengeForRelease {
   }
 
   static get STATUSES() {
-    return {
-      VALIDE: 'validé',
-      PROPOSE: 'proposé',
-      ARCHIVE: 'archivé',
-      PERIME: 'périmé',
-    };
+    return Challenge.STATUSES;
   }
 }

--- a/api/lib/domain/models/release/MissionForRelease.js
+++ b/api/lib/domain/models/release/MissionForRelease.js
@@ -7,6 +7,7 @@ export class MissionForRelease {
     learningObjectives_i18n,
     validatedObjectives_i18n,
     status,
+    content,
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -15,5 +16,6 @@ export class MissionForRelease {
     this.learningObjectives_i18n = learningObjectives_i18n;
     this.validatedObjectives_i18n = validatedObjectives_i18n;
     this.status = status;
+    this.content = content;
   }
 }

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -108,7 +108,7 @@ describe('Integration | Repository | release-repository', function() {
         competences: [],
         courses: [],
         frameworks: [],
-        mission: [],
+        missions: [],
         skills: [],
         thematics: [],
         tubes: [],
@@ -210,8 +210,8 @@ describe('Integration | Repository | release-repository', function() {
     it('should return current content as DTO', async function() {
       // When
       const currentContentDTO = await getCurrentContent();
-
       // Then
+
       const expectedReleaseContentDTO = _getRichCurrentContentDTO();
       expect(currentContentDTO).to.deep.equal(expectedReleaseContentDTO);
     });
@@ -1400,7 +1400,7 @@ function _getRichCurrentContentDTO() {
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.INACTIVE,
-      createdAt: new Date('2010-01-04')
+      createdAt: new Date('2010-01-04'),
     }),
   ];
 


### PR DESCRIPTION
## :unicorn: Problème

Pix1D utilise la structure du LCMS de manière un peu particulière. La transformation s'effectue dans l'API de Pix-App.

https://1024pix.atlassian.net/wiki/spaces/P1/pages/3778838530/Gestion+du+LCMS+pour+Pix+1D+-+Actuellement


## :robot: Proposition

Faire une release contenant directement la structure des missions pour Pix1D.


## :100: Pour tester

- les tests sont verts :heavy_check_mark: 
- générer une release et vérifier la présence de challenges dans l'objet mission.
- une clé content devrait contenir au minima des tableaux vide pour chaque challenge.

```
content : {
           tutorialChallenges: [],
           trainingChallenges: [],
           validationChallenges: [],
           dareChallenges: [],
}
```

sinon  les tableaux contiennent des tableau d'ID

exemple:
```
content : {
           tutorialChallenges: [['id1']],
           trainingChallenges: [['id1', 'id1_2']],
           validationChallenges: [['id1_1', 'id1_2', 'id1_3'], ['id2_1', 'id2_2']],
           dareChallenges: [],
}
```