### PR TITLE
[FEATURE] Renommer et supprimer les colonnes traduites des thématiques de Airtable (PIX-9477)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -12,8 +12,6 @@ export const thematicDatasource = datasource.extend({
     'Index',
   ],
 
-  sortField: 'Index',
-
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.id,

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -7,22 +7,16 @@ export const thematicDatasource = datasource.extend({
   tableName: 'Thematiques',
 
   usedFields: [
-    'Nom',
-    'Titre en-us',
     'Competence (id persistant)',
     'Tubes (id persistant)',
     'Index',
   ],
 
-  sortField: 'Nom',
+  sortField: 'Index',
 
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.id,
-      name_i18n: {
-        fr: airtableRecord.get('Nom'),
-        en: airtableRecord.get('Titre en-us'),
-      },
       competenceId: airtableRecord.get('Competence (id persistant)')[0],
       tubeIds: airtableRecord.get('Tubes (id persistant)'),
       index: airtableRecord.get('Index'),

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -12,9 +12,9 @@ export async function list() {
 
 function toDomainList(datasourceThematics, translations) {
   const translationsByThematicId = _.groupBy(translations, 'entityId');
-  return datasourceThematics.map(
+  return _.orderBy(datasourceThematics.map(
     (datasourceThematic) => toDomain(datasourceThematic, translationsByThematicId[datasourceThematic.id]),
-  );
+  ), ['index', 'name_i18n.fr']);
 }
 
 function toDomain(datasourceThematic, translations = []) {

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -32,6 +32,7 @@ export const {
   extractFromProxyObject,
   airtableObjectToProxyObject,
   extractFromReleaseObject,
+  proxyObjectToAirtableObject,
   toDomain,
   prefixFor,
 } = thematicTranslationUtils;

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-thematic_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-thematic_test.js
@@ -39,7 +39,13 @@ describe('Acceptance | Controller | airtable-proxy-controller | write thematic',
       await databaseBuilder.commit();
       const thematic = domainBuilder.buildThematicDatasourceObject({ id: 'mon_id_persistant' });
       airtableRawThematic = airtableBuilder.factory.buildThematic(thematic);
-      thematicToSave = inputOutputDataBuilder.factory.buildThematic(thematic);
+      thematicToSave = inputOutputDataBuilder.factory.buildThematic({
+        ...thematic,
+        name_i18n: {
+          fr: 'téma tique',
+          en: 'look tic',
+        },
+      });
     });
 
     it('should proxy request to airtable and add translations to the PG table', async () => {
@@ -90,15 +96,15 @@ describe('Acceptance | Controller | airtable-proxy-controller | write thematic',
     beforeEach(async function() {
       user = databaseBuilder.factory.buildAdminUser();
 
-      const thematicDataObject = domainBuilder.buildThematicDatasourceObject({
-        id: 'mon_id_persistant',
+      const thematicDataObject = domainBuilder.buildThematicDatasourceObject({ id: 'mon_id_persistant' });
+      airtableThematic = airtableBuilder.factory.buildThematic(thematicDataObject);
+      thematicToUpdate = inputOutputDataBuilder.factory.buildThematic({
+        ...thematicDataObject,
         name_i18n: {
           fr: 'new french name',
           en: 'new english name',
         },
       });
-      airtableThematic = airtableBuilder.factory.buildThematic(thematicDataObject);
-      thematicToUpdate = inputOutputDataBuilder.factory.buildThematic(thematicDataObject);
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -13,20 +13,12 @@ describe('Integration | Repository | thematic-repository', () => {
           competenceId: 'competenceId1',
           index: '1',
           tubeIds: ['tubeId1', 'tubeId2'],
-          name_i18n: {
-            en: 'Thematic 1 name airtable',
-            fr: 'Nom thématique 1',
-          },
         }),
         airtableBuilder.factory.buildThematic({
           id: 'thematic2',
           competenceId: 'competenceId2',
           index: '2',
           tubeIds: ['tubeId3', 'tubeId4'],
-          name_i18n: {
-            en: 'Thematic 2 name airtable',
-            fr: 'Nom thématique 2',
-          },
         }),
       ]).activate().nockScope;
 

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -2,10 +2,6 @@ export function buildThematic(
   {
     id,
     airtableId = id,
-    name_i18n: {
-      fr: name,
-      en: nameEnUs,
-    } = {},
     competenceId,
     tubeIds,
     index,
@@ -14,8 +10,6 @@ export function buildThematic(
     id: airtableId,
     'fields': {
       'id persistant': id,
-      'Nom': name,
-      'Titre en-us': nameEnUs,
       'Competence (id persistant)': [competenceId],
       'Tubes (id persistant)': tubeIds,
       'Index': index

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-thematic-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-thematic-datasource-object.js
@@ -1,17 +1,12 @@
 export function buildThematicDatasourceObject(
   {
     id = 'recFvllz2Ckz',
-    name_i18n = {
-      fr: 'Nom de la thématique',
-      en: 'Thematic\'s name',
-    },
     competenceId = 'recCompetence0',
     tubeIds = ['recTube0'],
     index = 0
   } = {}) {
   return {
     id,
-    name_i18n,
     competenceId,
     tubeIds,
     index,

--- a/pix-editor/app/models/competence.js
+++ b/pix-editor/app/models/competence.js
@@ -30,7 +30,7 @@ export default class CompetenceModel extends Model {
   }
 
   get sortedThemes() {
-    return this.themes.sortBy('index');
+    return this.themes.sortBy('name').sortBy('index');
   }
 
   get productionTubes() {


### PR DESCRIPTION
## :unicorn: Problème
On écrit toujours les champs traduisibles des thématiques dans Airtable.

## :robot: Proposition
Arrêter d'écrire ces champs dans Airtable.

## :rainbow: Remarques
On trie maintenant les thématiques par index puis par nom, côté back et côté front.

## :100: Pour tester
Modifier le nom d'une thématique et vérifier que l'écriture dans Airtable n'est pas faite.