### PR TITLE
[BUGFIX] Le fichier de migration d'ajout de la colonne `géographie` est mal écrit pour le rollback.

### DIFF
--- a/api/db/migrations/20240228133540_add-column-localized-challenge-geography.js
+++ b/api/db/migrations/20240228133540_add-column-localized-challenge-geography.js
@@ -16,7 +16,7 @@ export async function up(knex) {
  * @returns { Promise<void> }
  */
 export async function down(knex) {
-  await knex.schema.table(COLUMN_NAME, function(table) {
-    table.dropColumn('geography');
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(COLUMN_NAME);
   });
 }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons mal écrit le fichier de migration d'ajout de la colonne `géography`.

## :robot: Proposition
Utiliser les bonne variable pour designer le nom de la table et le nom de la colonne.

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire un rollback de l'ajout de la colonne `géography` et vérifier que tout ce passe bien.
