### PR TITLE
[FEATURE] Introduire le concept d'étape d'une mission (PIX-11699).

### DIFF
--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -8,12 +8,7 @@ export class Mission {
     learningObjectives_i18n,
     validatedObjectives_i18n,
     status,
-    content = {
-      tutorialChallenges: [],
-      trainingChallenges: [],
-      validationChallenges: [],
-      dareChallenges: [],
-    },
+    content,
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -23,7 +18,7 @@ export class Mission {
     this.learningObjectives_i18n = learningObjectives_i18n;
     this.validatedObjectives_i18n = validatedObjectives_i18n;
     this.status = status;
-    this.content = content;
+    this.content = new Content(content);
   }
 }
 
@@ -33,3 +28,30 @@ const status = {
 };
 
 Mission.status = status;
+
+class Content {
+  constructor({
+    steps = [new Step()],
+    dareChallenges = [],
+  } = {}) {
+    this.steps = steps.map((step) => new Step(step));
+    this.dareChallenges = dareChallenges;
+    // for retro compatibility we keep former format (ie. without any step)
+    this.tutorialChallenges = steps[0].tutorialChallenges;
+    this.trainingChallenges = steps[0].trainingChallenges;
+    this.validationChallenges = steps[0].validationChallenges;
+  }
+}
+
+class Step {
+  constructor({
+    tutorialChallenges = [],
+    trainingChallenges = [],
+    validationChallenges = [],
+  } = {}) {
+    this.tutorialChallenges = tutorialChallenges;
+    this.trainingChallenges = trainingChallenges;
+    this.validationChallenges = validationChallenges;
+  }
+}
+

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -60,9 +60,11 @@ export async function list() {
     }
 
     const content = {
-      tutorialChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_di'),
-      trainingChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_en'),
-      validationChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_va'),
+      steps: [{
+        tutorialChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_di'),
+        trainingChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_en'),
+        validationChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_va'),
+      }],
       dareChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_de'),
     };
     return new Mission({ ...mission, content });

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -10,15 +10,6 @@ import {
 import { Mission } from '../../../../lib/domain/models/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
-function buildLocalizedChallenges(mockedLearningContent) {
-  mockedLearningContent.challenges.forEach((airtableChallenge) => {
-    databaseBuilder.factory.buildLocalizedChallenge({
-      id: airtableChallenge.fields['id persistant'],
-      challengeId: airtableChallenge.fields['id persistant']
-    });
-  });
-}
-
 describe('Integration | Repository | mission-repository', function() {
 
   beforeEach(async function() {
@@ -207,6 +198,17 @@ describe('Integration | Repository | mission-repository', function() {
         status: Mission.status.ACTIVE,
         createdAt: new Date('2010-01-04'),
         content: {
+          steps: [{
+            tutorialChallenges: [
+              ['challengeTuto1'],
+            ],
+            trainingChallenges: [
+              ['challengeTraining1'],
+            ],
+            validationChallenges: [
+              ['challengeValidation1'],
+            ],
+          }],
           tutorialChallenges: [
             ['challengeTuto1'],
           ],
@@ -259,6 +261,13 @@ describe('Integration | Repository | mission-repository', function() {
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
           content: {
+            steps: [{
+              tutorialChallenges: [],
+              trainingChallenges: [],
+              validationChallenges: [
+                ['challengeValidationValidé', 'challengeValidationProposé'],
+              ],
+            }],
             tutorialChallenges: [],
             trainingChallenges: [],
             validationChallenges: [
@@ -311,6 +320,16 @@ describe('Integration | Repository | mission-repository', function() {
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
           content: {
+            steps: [{
+              tutorialChallenges: [],
+              trainingChallenges: [],
+              validationChallenges: [
+                ['firstChallengeValidation'],
+                ['secondChallengeValidation'],
+                ['thirdChallengeValidation'],
+                ['fourthChallengeValidation'],
+              ],
+            }],
             tutorialChallenges: [],
             trainingChallenges: [],
             validationChallenges: [
@@ -352,12 +371,6 @@ describe('Integration | Repository | mission-repository', function() {
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
-          content: {
-            tutorialChallenges: [],
-            trainingChallenges: [],
-            validationChallenges: [],
-            dareChallenges: [],
-          },
         })]);
 
       });
@@ -391,14 +404,7 @@ describe('Integration | Repository | mission-repository', function() {
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
-          content: {
-            tutorialChallenges: [],
-            trainingChallenges: [],
-            validationChallenges: [],
-            dareChallenges: [],
-          },
         })]);
-
       });
     });
     context('Without tubes', async function() {
@@ -430,12 +436,6 @@ describe('Integration | Repository | mission-repository', function() {
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
-          content: {
-            tutorialChallenges: [],
-            trainingChallenges: [],
-            validationChallenges: [],
-            dareChallenges: [],
-          },
         })]);
 
       });
@@ -469,12 +469,6 @@ describe('Integration | Repository | mission-repository', function() {
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
-          content: {
-            tutorialChallenges: [],
-            trainingChallenges: [],
-            validationChallenges: [],
-            dareChallenges: [],
-          },
         })]);
 
       });
@@ -508,12 +502,6 @@ describe('Integration | Repository | mission-repository', function() {
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
-          content: {
-            tutorialChallenges: [],
-            trainingChallenges: [],
-            validationChallenges: [],
-            dareChallenges: [],
-          },
         })]);
 
       });
@@ -546,12 +534,6 @@ describe('Integration | Repository | mission-repository', function() {
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.ACTIVE,
           createdAt: new Date('2010-01-04'),
-          content: {
-            tutorialChallenges: [],
-            trainingChallenges: [],
-            validationChallenges: [],
-            dareChallenges: [],
-          },
         })]);
       });
     });
@@ -571,7 +553,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         const savedMission = await save(mission);
         expectTypeOf(savedMission).toEqualTypeOf('Mission');
-        await expect(omit(savedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...mission, id: savedMission.id }), ['createdAt']));
+        expect(omit(savedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...mission, id: savedMission.id }), ['createdAt']));
 
         const expectedMission = {
           id: savedMission.id,
@@ -581,7 +563,7 @@ describe('Integration | Repository | mission-repository', function() {
         };
 
         const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicId', 'status', 'id');
-        await expect(missionFromDb).to.deep.equal(expectedMission);
+        expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
       it('should store I18n for mission', async function() {
@@ -637,7 +619,7 @@ describe('Integration | Repository | mission-repository', function() {
         const updatedMission = await save(missionToUpdate);
 
         expectTypeOf(updatedMission).toEqualTypeOf('Mission');
-        await expect(omit(updatedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...missionToUpdate, id: updatedMission.id }), ['createdAt']));
+        expect(omit(updatedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...missionToUpdate, id: updatedMission.id }), ['createdAt']));
 
         const expectedMission = {
           id: updatedMission.id,
@@ -647,7 +629,7 @@ describe('Integration | Repository | mission-repository', function() {
         };
 
         const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicId', 'status', 'id');
-        await expect(missionFromDb).to.deep.equal(expectedMission);
+        expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
       it('should store I18n for mission', async function() {
@@ -689,4 +671,13 @@ describe('Integration | Repository | mission-repository', function() {
     });
   });
 });
+
+function buildLocalizedChallenges(mockedLearningContent) {
+  mockedLearningContent.challenges.forEach((airtableChallenge) => {
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: airtableChallenge.fields['id persistant'],
+      challengeId: airtableChallenge.fields['id persistant']
+    });
+  });
+}
 


### PR DESCRIPTION
## :unicorn: Problème

Les missions, tel que fournies par le référentiel, ne permettent pas d'être jouées par étapes.
Toutes les épreuves sont classées par type (validation, entraînement, didacticiel, défi).
On souhaite séquencer le passage des épreuves au sein d'une mission en étape, comprenant chacun des épreuves de type validation, entraînement et didacticiel.
Les épreuves de défi restent à la fin de toutes les étapes d'une même mission, en conclusion de ladite mission.

## :robot: Proposition

On ajoute le concept de `Content` et de `Step` au modèle `Mission` actuel afin de modéliser les étapes d'une mission.
On conserve en parallèle le formatage actuel, afin de ne pas casser, même temporairement, l'application Pix 1D.

## :rainbow: Remarques

RAS

## :100: Pour tester

Créer une release depuis la review app et vérifier que les missions sont enrichies de la proporiété `steps`.

Pour vérifier la rétro compatibilité, brancher une application Pix 1d sur la review app et vérifier que les épreuves actuelles peuvent être jouées.
