### PR TITLE
[FEATURE] Ajouter les URLs à consulter renseignées au niveau des épreuves dans la moulinette des URLs cassées (PIX-11736)

### DIFF
--- a/api/lib/infrastructure/scheduled-jobs/check-urls-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/check-urls-job-processor.js
@@ -1,7 +1,7 @@
 import './job-process.js';
-import { validateUrlsFromRelease } from '../../domain/usecases/validate-urls-from-release.js';
-import { releaseRepository, urlErrorRepository } from '../repositories/index.js';
+import { validateUrlsFromRelease } from '../../domain/usecases/index.js';
+import { localizedChallengeRepository, releaseRepository, urlErrorRepository } from '../repositories/index.js';
 
 export default function checkUrlsJobProcessor() {
-  return validateUrlsFromRelease({ releaseRepository, urlErrorRepository });
+  return validateUrlsFromRelease({ releaseRepository, urlErrorRepository, localizedChallengeRepository });
 }

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -1,14 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
 import {
+  findUrlsFromChallenges,
+  findUrlsFromTutorials,
   findUrlsInMarkdown,
   findUrlsInstructionFromChallenge,
   findUrlsProposalsFromChallenge,
   findUrlsSolutionFromChallenge,
   findUrlsSolutionToDisplayFromChallenge,
-  findUrlsFromChallenges,
-  getLiveChallenges,
-  findUrlsFromTutorials
-} from '../../../../lib/domain/usecases/validate-urls-from-release.js';
+  getLiveChallenges
+} from '../../../../lib/domain/usecases/index.js';
 
 describe('Check urls from release', function() {
   describe('#findUrlsInMarkdown', function() {
@@ -130,7 +131,12 @@ describe('Check urls from release', function() {
   });
 
   describe('#findUrlsFromChallenges', function() {
-    it('should find urls from challenges', function() {
+    it('should find urls from challenges', async function() {
+      const localizedChallengesById = {
+        'challenge1': [domainBuilder.buildLocalizedChallenge({ id: 'challenge1', urlsToConsult: ['http://google.com', 'https://zouzou.fr'] })],
+        'challenge2': [domainBuilder.buildLocalizedChallenge({ id: 'challenge2', urlsToConsult: ['https://editor.pix.fr'] })],
+        'challenge3': [domainBuilder.buildLocalizedChallenge({ id: 'challenge3', urlsToConsult: [] })],
+      };
       const release = {
         competences: [
           {
@@ -188,12 +194,14 @@ describe('Check urls from release', function() {
         { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://example.net/' },
         { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
         { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://solution_example.net/' },
+        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'http://google.com' },
+        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://zouzou.fr' },
         { id: ';;challenge2;validé', url: 'https://example.fr/' },
+        { id: ';;challenge2;validé', url: 'https://editor.pix.fr' },
         { id: 'competence 1.1;@mySkill2;challenge3;validé', url: 'https://solutionToDisplay_example.org/' },
       ];
 
-      const urls = findUrlsFromChallenges(challenges, release);
-
+      const urls = findUrlsFromChallenges(challenges, release, localizedChallengesById);
       expect(urls).to.deep.equal(expectedOutput);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
On a récemment ajouté la possibilité à l'équipe Contenus de renseigner les urls à consulter dans le cadre de l'épreuve.
Du coup il est intéressant de pouvoir vérifier régulièrement, avec la moulinette existante, si les URLs sont toujours au vert et les signaler à défaut.

## :robot: Proposition
Ajouter la liste des URLs à consulter (enregistrée au niveau des `localized_challenges`) dans la moulinette.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
On a "testouillé" en local en créant une release et en exécutant le job, ça marche bien 🚀 
