### PR TITLE
[FEATURE] Ajouter des informations à l'extract de la moulinette des URLs cassées (PIX-6304)

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -103,7 +103,7 @@ export function findUrlsFromChallenges(challenges, release, localizedChallengesB
       findUrlsProposalsFromChallenge,
       findUrlsSolutionFromChallenge,
       findUrlsSolutionToDisplayFromChallenge,
-      (challenge) => localizedChallengesById[challenge.id][0].urlsToConsult,
+      (challenge) => localizedChallengesById[challenge.id].urlsToConsult ?? [],
     ];
     const urls = functions
       .flatMap((fun) => fun(challenge))

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -52,10 +52,10 @@ export function findUrlsInMarkdown(value) {
   return _.uniq(urls.map(cleanUrl).map(prependProtocol));
 }
 
-function findCompetenceNameFromChallenge(challenge, release) {
+function findCompetenceOriginAndNameFromChallenge(challenge, release) {
   const skill = release.skills.find(({ id }) => challenge.skillId === id);
-  if (!skill) return '';
-  return findCompetenceNameFromSkill(skill, release);
+  if (!skill) return ['', ''];
+  return findCompetenceOriginAndNameFromSkill(skill, release);
 }
 
 function findCompetencesNameFromTutorial(tutorial, release) {
@@ -67,11 +67,20 @@ function findCompetencesNameFromTutorial(tutorial, release) {
   return competenceNames.join(' ');
 }
 
-function findCompetenceNameFromSkill(skill, release) {
+function findCompetenceFromSkill(skill, release) {
   const tube = release.tubes.find(({ id }) => skill.tubeId === id);
   if (!tube) return '';
-  const competence = release.competences.find(({ id }) => tube.competenceId === id);
-  return competence?.name_i18n.fr || '';
+  return release.competences.find(({ id }) => tube.competenceId === id);
+}
+
+function findCompetenceNameFromSkill(skill, release) {
+  const competence = findCompetenceFromSkill(skill, release);
+  return competence?.name_i18n.fr ?? '';
+}
+
+function findCompetenceOriginAndNameFromSkill(skill, release) {
+  const competence = findCompetenceFromSkill(skill, release);
+  return [competence?.origin ?? '', competence?.name_i18n.fr ?? ''];
 }
 
 function findSkillsNameFromChallenge(challenge, release) {
@@ -99,7 +108,7 @@ export function findUrlsFromChallenges(challenges, release, localizedChallengesB
     const urls = functions
       .flatMap((fun) => fun(challenge))
       .map((url) => {
-        return { id: [findCompetenceNameFromChallenge(challenge, release), findSkillsNameFromChallenge(challenge, release), challenge.id, challenge.status].join(';'), url };
+        return { id: [findCompetenceOriginAndNameFromChallenge(challenge, release).join(';'), findSkillsNameFromChallenge(challenge, release), challenge.id, challenge.status, challenge.locales[0]].join(';'), url };
       });
     return _.uniqBy(urls, 'url');
   });

--- a/api/scripts/_template.js
+++ b/api/scripts/_template.js
@@ -1,9 +1,9 @@
 import 'dotenv/config';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
-import { knex, disconnect } from '../db/knex-database-connection.js';
+import { disconnect, knex } from '../db/knex-database-connection.js';
 import { logger } from '../lib/infrastructure/logger.js';
-import yargs from 'yargs/yargs'
+import yargs from 'yargs/yargs';
 
 const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
@@ -17,7 +17,7 @@ export async function doSomething({ throwError }) {
   logger.info(`Args : ${argv}`);
   const data = await knex.select('id').from('releases').first();
   return data;
-};
+}
 
 async function main() {
   const startTime = performance.now();

--- a/api/scripts/dev/moulinette-urls-cassees.js
+++ b/api/scripts/dev/moulinette-urls-cassees.js
@@ -1,0 +1,35 @@
+import 'dotenv/config';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { disconnect } from '../../db/knex-database-connection.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+import checkUrlsJobProcessor from '../../lib/infrastructure/scheduled-jobs/check-urls-job-processor.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+function onLanceLaMoulinette() {
+  return checkUrlsJobProcessor() ;
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  await onLanceLaMoulinette();
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -133,10 +133,11 @@ describe('Check urls from release', function() {
   describe('#findUrlsFromChallenges', function() {
     it('should find urls from challenges', async function() {
       const localizedChallengesById = {
-        'challenge1': [domainBuilder.buildLocalizedChallenge({ id: 'challenge1', urlsToConsult: ['http://google.com', 'https://zouzou.fr'] })],
-        'challenge2': [domainBuilder.buildLocalizedChallenge({ id: 'challenge2', urlsToConsult: ['https://editor.pix.fr'] })],
-        'challenge3': [domainBuilder.buildLocalizedChallenge({ id: 'challenge3', urlsToConsult: [] })],
-        'challenge4': [domainBuilder.buildLocalizedChallenge({ id: 'challenge4', urlsToConsult: ['http://alice.hole'] })],
+        'challenge1': domainBuilder.buildLocalizedChallenge({ id: 'challenge1', urlsToConsult: ['http://google.com', 'https://zouzou.fr'] }),
+        'challenge2': domainBuilder.buildLocalizedChallenge({ id: 'challenge2', urlsToConsult: ['https://editor.pix.fr'] }),
+        'challenge3': domainBuilder.buildLocalizedChallenge({ id: 'challenge3', urlsToConsult: [] }),
+        'challenge4': domainBuilder.buildLocalizedChallenge({ id: 'challenge4', urlsToConsult: null }),
+        'challenge5': domainBuilder.buildLocalizedChallenge({ id: 'challenge5', urlsToConsult: ['http://alice.hole'] }),
       };
       const release = {
         competences: [
@@ -212,6 +213,14 @@ describe('Check urls from release', function() {
         {
           id: 'challenge4',
           instruction: 'instructions',
+          solutionToDisplay: 'solution to display https://solution_challenge4.org/',
+          skillId: 'skill2',
+          status: 'validé',
+          locales: ['fr']
+        },
+        {
+          id: 'challenge5',
+          instruction: 'instructions',
           solutionToDisplay: '',
           skillId: 'skill23',
           status: 'validé',
@@ -228,7 +237,8 @@ describe('Check urls from release', function() {
         { id: ';;;challenge2;validé;fr', url: 'https://example.fr/' },
         { id: ';;;challenge2;validé;fr', url: 'https://editor.pix.fr' },
         { id: 'Pix;competence 1.1;@mySkill2;challenge3;validé;en', url: 'https://solutionToDisplay_example.org/' },
-        { id: 'wonderland;competence 4.5;@mySkill23;challenge4;validé;nl', url: 'http://alice.hole' },
+        { id: 'Pix;competence 1.1;@mySkill2;challenge4;validé;fr', url: 'https://solution_challenge4.org/' },
+        { id: 'wonderland;competence 4.5;@mySkill23;challenge5;validé;nl', url: 'http://alice.hole' },
       ];
 
       const urls = findUrlsFromChallenges(challenges, release, localizedChallengesById);

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -136,13 +136,22 @@ describe('Check urls from release', function() {
         'challenge1': [domainBuilder.buildLocalizedChallenge({ id: 'challenge1', urlsToConsult: ['http://google.com', 'https://zouzou.fr'] })],
         'challenge2': [domainBuilder.buildLocalizedChallenge({ id: 'challenge2', urlsToConsult: ['https://editor.pix.fr'] })],
         'challenge3': [domainBuilder.buildLocalizedChallenge({ id: 'challenge3', urlsToConsult: [] })],
+        'challenge4': [domainBuilder.buildLocalizedChallenge({ id: 'challenge4', urlsToConsult: ['http://alice.hole'] })],
       };
       const release = {
         competences: [
           {
             id: 'competence1',
+            origin: 'Pix',
             name_i18n: {
               fr: 'competence 1.1'
+            }
+          },
+          {
+            id: 'competence2',
+            origin: 'wonderland',
+            name_i18n: {
+              fr: 'competence 4.5'
             }
           }
         ],
@@ -150,6 +159,10 @@ describe('Check urls from release', function() {
           {
             id: 'tube1',
             competenceId: 'competence1'
+          },
+          {
+            id: 'tube2',
+            competenceId: 'competence2'
           }
         ],
         skills: [
@@ -162,6 +175,11 @@ describe('Check urls from release', function() {
             id: 'skill2',
             tubeId: 'tube1',
             name: '@mySkill2'
+          },
+          {
+            id: 'skill23',
+            tubeId: 'tube2',
+            name: '@mySkill23'
           }
         ]
       };
@@ -173,6 +191,7 @@ describe('Check urls from release', function() {
           solution: 'solution [link](https://solution_example.net/)',
           skillId: 'skill1',
           status: 'validé',
+          locales: ['fr']
         },
         {
           id: 'challenge2',
@@ -180,6 +199,7 @@ describe('Check urls from release', function() {
           proposals: 'proposals [link](https://example.fr/)',
           skillId: undefined,
           status: 'validé',
+          locales: ['fr', 'FR-fr']
         },
         {
           id: 'challenge3',
@@ -187,18 +207,28 @@ describe('Check urls from release', function() {
           solutionToDisplay: 'solution to display https://solutionToDisplay_example.org/',
           skillId: 'skill2',
           status: 'validé',
+          locales: ['en']
+        },
+        {
+          id: 'challenge4',
+          instruction: 'instructions',
+          solutionToDisplay: '',
+          skillId: 'skill23',
+          status: 'validé',
+          locales: ['nl']
         }
       ];
 
       const expectedOutput = [
-        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://example.net/' },
-        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://other_example.net/' },
-        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://solution_example.net/' },
-        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'http://google.com' },
-        { id: 'competence 1.1;@mySkill1;challenge1;validé', url: 'https://zouzou.fr' },
-        { id: ';;challenge2;validé', url: 'https://example.fr/' },
-        { id: ';;challenge2;validé', url: 'https://editor.pix.fr' },
-        { id: 'competence 1.1;@mySkill2;challenge3;validé', url: 'https://solutionToDisplay_example.org/' },
+        { id: 'Pix;competence 1.1;@mySkill1;challenge1;validé;fr', url: 'https://example.net/' },
+        { id: 'Pix;competence 1.1;@mySkill1;challenge1;validé;fr', url: 'https://other_example.net/' },
+        { id: 'Pix;competence 1.1;@mySkill1;challenge1;validé;fr', url: 'https://solution_example.net/' },
+        { id: 'Pix;competence 1.1;@mySkill1;challenge1;validé;fr', url: 'http://google.com' },
+        { id: 'Pix;competence 1.1;@mySkill1;challenge1;validé;fr', url: 'https://zouzou.fr' },
+        { id: ';;;challenge2;validé;fr', url: 'https://example.fr/' },
+        { id: ';;;challenge2;validé;fr', url: 'https://editor.pix.fr' },
+        { id: 'Pix;competence 1.1;@mySkill2;challenge3;validé;en', url: 'https://solutionToDisplay_example.org/' },
+        { id: 'wonderland;competence 4.5;@mySkill23;challenge4;validé;nl', url: 'http://alice.hole' },
       ];
 
       const urls = findUrlsFromChallenges(challenges, release, localizedChallengesById);


### PR DESCRIPTION
## :unicorn: Problème
On souhaite avoir plus d'informations sur les épreuves dans l'extract de la moulinette.

## :robot: Proposition
Ajout de deux colonnes :
- Référentiel : référentiel auquel appartient l'épreuve (vide si workbench)
- Locale de l'épreuve

## :rainbow: Remarques
Un fois merge, penser à éditer le google sheet de production en ajoutant les deux colonnes uniquement dans la feuille "Epreuves" :
- La colonne "Référentiel" au tout début
- La colonne "Locale" juste avant la colonne "URL"

## :100: Pour tester
On va essayer de lancer le job depuis la PR et voir si c'est bon
