### PR TITLE
[FEATURE] Remonter les "URLs externes à consulter" dans métabase (PIX-12409)

### DIFF
--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -53,7 +53,15 @@ async function mockCurrentContent() {
     localizedChallengeId: 'localized-challenge-id',
   };
 
-  const expectedChallenge = { ...challenge, geography: 'Brésil', area: 'Brésil' };
+  const expectedChallenge = {
+    ...challenge,
+    geography: 'Brésil',
+    area: 'Brésil',
+    urlsToConsult: [
+      'https://example.com/',
+      'https://pix.org/nl-be',
+    ],
+  };
   delete expectedChallenge.localizedChallenges;
 
   const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', geography: 'Neutre', area: 'Neutre' };
@@ -159,6 +167,10 @@ async function mockCurrentContent() {
     embedUrl: challenge.embedUrl,
     status: 'validé',
     geography: 'BR',
+    urlsToConsult: [
+      'https://example.com/',
+      'https://pix.org/nl-be',
+    ],
   });
   databaseBuilder.factory.buildLocalizedChallenge({
     id: 'localized-challenge-id',


### PR DESCRIPTION
## :unicorn: Problème
On veut les URLs à consulter dans la répli.

## :robot: Proposition
Elles sont déjà dans les données de réplis.

- [x] On ajouter un test pour le valider.
- [x] On fait [une PR sur pix-d-repli](https://github.com/1024pix/pix-db-replication/pull/245) pour les réceptionner.

## :rainbow: Remarques
N/A

## :100: Pour tester
Vérifier qu'elles sortent bien sur le endpoint de répli.