### PR TITLE
[FEATURE] Ne pas checker les URLs des épreuves proposées (PIX-12411)

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -7,8 +7,12 @@ import { CookieJar } from 'tough-cookie';
 
 import { logger } from '../../infrastructure/logger.js';
 
-export function getLiveChallenges(release) {
-  return release.challenges.filter((challenge) => challenge.status !== 'périmé');
+export function getOperativeChallenges(release) {
+  return release.challenges.filter(isOperativeChallenge);
+}
+
+function isOperativeChallenge(challenge) {
+  return challenge.status !== 'proposé' && challenge.status !== 'périmé';
 }
 
 export function findUrlsInstructionFromChallenge(challenge) {
@@ -192,7 +196,7 @@ export async function validateUrlsFromRelease({ releaseRepository, urlErrorRepos
 }
 
 async function checkAndUploadKOUrlsFromChallenges(release, { urlErrorRepository, localizedChallengeRepository }) {
-  const challenges = getLiveChallenges(release.content);
+  const challenges = getOperativeChallenges(release.content);
   const localizedChallengesById = _.keyBy(await localizedChallengeRepository.list(), 'id');
   const urlList = findUrlsFromChallenges(challenges, release.content, localizedChallengesById);
 

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -8,7 +8,7 @@ import {
   findUrlsProposalsFromChallenge,
   findUrlsSolutionFromChallenge,
   findUrlsSolutionToDisplayFromChallenge,
-  getLiveChallenges
+  getOperativeChallenges
 } from '../../../../lib/domain/usecases/index.js';
 
 describe('Check urls from release', function() {
@@ -246,8 +246,8 @@ describe('Check urls from release', function() {
     });
   });
 
-  describe('#getLiveChallenges', function() {
-    it('should use challenge that are not outdated', function() {
+  describe('#getOperativeChallenges', function() {
+    it('should list challenges that are not outdated or proposed', function() {
       const release = {
         challenges : [
           {
@@ -261,7 +261,11 @@ describe('Check urls from release', function() {
           {
             id: 'challenge3',
             status: 'périmé'
-          }
+          },
+          {
+            id: 'challenge4',
+            status: 'archivé'
+          },
         ]
       };
 
@@ -271,12 +275,12 @@ describe('Check urls from release', function() {
           status: 'validé'
         },
         {
-          id: 'challenge2',
-          status: 'proposé'
+          id: 'challenge4',
+          status: 'archivé'
         }
       ];
 
-      const challenges = getLiveChallenges(release);
+      const challenges = getOperativeChallenges(release);
 
       expect(challenges).to.deep.equal(expectedOutput);
     });


### PR DESCRIPTION
## :unicorn: Problème
On voudrait ne vérifier les URLs que pour les épreuves validées et archivées.

## :robot: Proposition
Filtrer les épreuves proposées.

## :rainbow: Remarques
N/A

## :100: Pour tester
Lancer la release et tout le tralala.