### PR TITLE
[FEATURE] Améliorer le champ d'URLs externes (PIX-12014)

### DIFF
--- a/pix-editor/app/components/field/textarea.hbs
+++ b/pix-editor/app/components/field/textarea.hbs
@@ -1,5 +1,8 @@
 <div class={{concat "field textArea" (if @edition "" " disabled") (if this.maximized " maximized" "")}} ...attributes>
-  <label for={{@id}}>
+  <div>
+    <label class="bold" for={{@id}}>
+      {{@title}}
+    </label>
     {{#if @edition}}
       <button
         {{on "click" this.toggleMaximized}}
@@ -18,7 +21,6 @@
         </div>
       {{/if}}
     {{/if}}
-    {{@title}}
-  </label>
-  <Textarea id={{@id}} @value={{@value}} rows="4" readonly={{not @edition}} class="attached" />
+  </div>
+  <Textarea id={{@id}} @value={{@value}} rows="4" readonly={{not @edition}} class="attached" {{on "change" this.change}}/>
 </div>

--- a/pix-editor/app/components/field/textarea.js
+++ b/pix-editor/app/components/field/textarea.js
@@ -15,4 +15,9 @@ export default class Textarea extends Component {
   toggleMaximized() {
     this.maximized = !this.maximized;
   }
+
+  @action
+  change(evt) {
+    this.args.change?.(evt.target.value);
+  }
 }

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -122,25 +122,34 @@
       @id="challenge-solution-to-display"
     />
   </Field::ToggleField>
-  {{#if this.displayUrlsToConsult}}
-    <div class="field">
-      <Field::Input
-        @label="URLs externes à consulter"
-        @value={{@urlsToConsult}}
-        @change={{@setUrlsToConsult}}
-        @edition={{@edition}}
-        @helpContent={{this.helpUrlsToConsult}}
-        @id="challenge-urls-to-consult"
-        data-test-challenge-urls-to-consult
-      />
-    </div>
-    {{#if @invalidUrlsToConsult}}
-        <p class="ui red message" data-test-invalid-urls-to-consult>
-          URLs invalides :
-          {{@invalidUrlsToConsult}}
-        </p>
-    {{/if}}
+
+  <Field::ToggleField
+    @edition={{@edition}}
+    @model={{@challenge}}
+    @modelField="urlsToConsult"
+    @hideTextButton="Supprimer les URLs à consulter"
+    @displayTextButton="Ajouter des URLs à consulter"
+    @confirmText="URLs à consulter"
+    @displayField={{@displayUrlsToConsultField}}
+    @setDisplayField={{@setDisplayUrlsToConsultField}}
+  >
+    <Field::Textarea
+      @title="URLs externes à consulter"
+      @value={{@urlsToConsult}}
+      @edition={{@edition}}
+      @change={{@setUrlsToConsult}}
+      @helpContent={{this.helpUrlsToConsult}}
+      data-test-urls-to-consult-field
+      @id="urls-to-consult-to-display"
+    />
+  </Field::ToggleField>
+  {{#if @invalidUrlsToConsult}}
+    <p class="ui red message" data-test-invalid-urls-to-consult>
+      URLs invalides :
+      {{@invalidUrlsToConsult}}
+    </p>
   {{/if}}
+
   <Field::Illustration
     @title="Illustration"
     @value={{@challenge.illustration}}

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -9,20 +9,6 @@ export default class ChallengeForm extends Component {
   @service store;
 
   @tracked languageOptions = [];
-
-  constructor() {
-    super(...arguments);
-    const localeToLanguageMap = this.config.localeToLanguageMap;
-
-    for (const localeToLanguageMapKey in localeToLanguageMap) {
-      const option =  {
-        label: localeToLanguageMap[localeToLanguageMapKey],
-        value: localeToLanguageMapKey,
-      };
-      this.languageOptions.push(option);
-    }
-  }
-
   options = {
     'types': [
       { value:'QCU', label:'QCU' },
@@ -53,10 +39,21 @@ export default class ChallengeForm extends Component {
       { value: 'solution', label: 'Réponse' },
     ],
   };
-
   helpInstructions = '<u>Style d’écriture :</u><br>*Écriture en italique*<br>**Écriture en gras**<br>***Écriture en italique et gras***<br><br><u>Aller à la ligne :</u><br>Phrase 1<br><br>Phrase 2<br><br><u>Liste :</u><br>- texte item 1<br>- texte item 2<br><br><u>Paragraphe avec retrait précédé d’un trait vertical gris :</u><br>> texte 1ere ligne<br>><br>> texte 3e ligne<br><br><u>Lien vers une page web :</u><br>[mot cliquable](url avec protocole)';
+  helpUrlsToConsult = '<p>Séparer les liens par un retour à la ligne</p>';
 
-  helpUrlsToConsult = '<p>Séparer les liens par une virgule</p>';
+  constructor() {
+    super(...arguments);
+    const localeToLanguageMap = this.config.localeToLanguageMap;
+
+    for (const localeToLanguageMapKey in localeToLanguageMap) {
+      const option =  {
+        label: localeToLanguageMap[localeToLanguageMapKey],
+        value: localeToLanguageMapKey,
+      };
+      this.languageOptions.push(option);
+    }
+  }
 
   get helpSuggestions() {
     const type = this.args.challenge.type;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
@@ -13,7 +13,12 @@ export default class LocalizedPrototypeRoute extends Route {
   setupController(controller, model) {
     super.setupController(...arguments);
     const localizedChallenge = model.localizedChallenge;
-    controller.urlsToConsult = localizedChallenge.urlsToConsult?.join(', ') ?? '';
+    controller.urlsToConsult = localizedChallenge.urlsToConsult?.join('\n') ?? '';
     controller.invalidUrlsToConsult = '';
+  }
+
+  resetController(controller, _isExiting, _transition) {
+    super.resetController(controller, _isExiting, _transition);
+    controller.send('cancelEdit');
   }
 }

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single.js
@@ -21,7 +21,7 @@ export default class SingleRoute extends Route {
   setupController(controller, model) {
     super.setupController(...arguments);
     controller.edition = false;
-    controller.urlsToConsult = model.urlsToConsult?.join(', ') ?? '';
+    controller.urlsToConsult = model.urlsToConsult?.join('\n') ?? '';
     controller.invalidUrlsToConsult = '';
     const competenceController = this.controllerFor('authenticated.competence');
     competenceController.setSection('challenges');

--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  label .ui.icon.right {
+   .ui.icon.right {
     border: none;
     box-shadow: none;
   }

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -61,23 +61,34 @@
         @options={{this.options.geography}}
         @setValue={{fn (mut this.localizedChallenge.geography)}}
       />
-      {{#if this.displayUrlsToConsult}}
-        <Field::Input
-          @label="URLs externes à consulter"
+
+      <Field::ToggleField
+        @edition={{this.edition}}
+        @model={{this.localizedChallenge}}
+        @modelField="urlsToConsult"
+        @hideTextButton="Supprimer les URLs à consulter"
+        @displayTextButton="Ajouter des URLs à consulter"
+        @confirmText="URLs à consulter"
+        @displayField={{this.displayUrlsToConsultField}}
+        @setDisplayField={{this.setDisplayUrlsToConsultField}}
+      >
+        <Field::Textarea
+          @title="URLs externes à consulter"
           @value={{this.urlsToConsult}}
-          @change={{this.setUrlsToConsult}}
           @edition={{this.edition}}
+          @change={{this.setUrlsToConsult}}
           @helpContent={{this.helpUrlsToConsult}}
-          @id="localized-challenge-urls-to-consult"
           data-test-localized-challenge-urls-to-consult
+          @id="localized-challenge-urls-to-consult"
         />
-        {{#if this.invalidUrlsToConsult}}
-          <p class="ui red message" data-test-invalid-urls-to-consult>
-            URLs invalides :
-            {{this.invalidUrlsToConsult}}
-          </p>
-        {{/if}}
+      </Field::ToggleField>
+      {{#if this.invalidUrlsToConsult}}
+        <p class="ui red message" data-test-invalid-urls-to-consult>
+          URLs invalides :
+          {{this.invalidUrlsToConsult}}
+        </p>
       {{/if}}
+
       {{#unless this.edition}}
         <Field::Input
           @id="localized-challenge-id"

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -64,9 +64,11 @@
                      @setDisplaySolutionToDisplayField={{this.setDisplaySolutionToDisplayField}}
                      @removeIllustration={{this.removeIllustration}}
                      @removeAttachment={{this.removeAttachment}}
-                    @invalidUrlsToConsult={{this.invalidUrlsToConsult}}
-                    @urlsToConsult={{this.urlsToConsult}}
-                    @setUrlsToConsult={{this.setUrlsToConsult}}
+                     @invalidUrlsToConsult={{this.invalidUrlsToConsult}}
+                     @displayUrlsToConsultField={{this.displayUrlsToConsultField}}
+                     @setDisplayUrlsToConsultField={{this.setDisplayUrlsToConsultField}}
+                     @urlsToConsult={{this.urlsToConsult}}
+                     @setUrlsToConsult={{this.setUrlsToConsult}}
     />
   </div>
 <div class="ui vertical compact labeled icon menu challenge-menu">

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { findAll, click, find, fillIn } from '@ember/test-helpers';
+import { click, find, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { runTask } from 'ember-lifeline';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
@@ -38,12 +37,9 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     await click(findAll('[data-test-area-item]')[0]);
     await click(findAll('[data-test-competence-item]')[0]);
     await click(findAll('[data-test-skill-cell-link]')[0]);
-    await click(find('[data-test-modify-challenge-button]'));
-    // Ugly hack to wait for ToastUI to be ready
-    // otherwise test is flacky and fails with error message
-    // Attempted to access the computed <pixeditor@component:tui-editor::ember393>.options on a destroyed object, which is not allowed
-    await runTask(this, async () => {}, 200);
-    await fillIn('#challenge-urls-to-consult', 'https://mon-url.com, mon-autre-url.com');
+    await clickByText('Modifier');
+    await clickByText('Ajouter des URLs à consulter');
+    await fillByLabel('URLs externes à consulter', ' https://mon-url.com \n mon-autre-url.com');
     await click(find('[data-test-save-challenge-button]'));
     await click(find('[data-test-confirm-log-approve]'));
 
@@ -66,8 +62,9 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     assert.dom('[data-test-challenge-urls-to-consult]').doesNotExist();
 
     await clickByText('Modifier');
+    await clickByText('Ajouter des URLs à consulter');
 
-    await fillByLabel('URLs externes à consulter :', 'https://mon-url.com, mon-autre-url.com');
+    await fillByLabel('URLs externes à consulter', 'https://mon-url.com\n mon-autre-url.com');
 
     // then
     const challenge = await store.peekRecord('challenge', 'recChallenge1');

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, clickByText, fillByLabel } from '@1024pix/ember-testing-library';
-import { findAll, click } from '@ember/test-helpers';
+import { clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -38,9 +38,8 @@ module('Acceptance | Modify-Localized-Challenge', function(hooks) {
     assert.dom('[data-test-localized-challenge-urls-to-consult]').doesNotExist();
 
     await clickByText('Modifier');
-
-    await fillByLabel('URLs externes à consulter :', 'https://mon-url.com, mon-autre-url.com');
-
+    await clickByText('Ajouter des URLs à consulter');
+    await fillByLabel('URLs externes à consulter', 'https://mon-url.com\n mon-autre-url.com');
 
     // then
     const challenge = await store.peekRecord('localized-challenge', 'recChallenge1NL');


### PR DESCRIPTION
## :unicorn: Problème
On souhaite avoir un champ qui soit plus grand et avec lequel on puisse interagir comme avec les alternatives textuelles (par ex)

## :robot: Proposition
Pour la page de modification d'épreuve ET d'épreuve traduite :
- Mise en place d'un bouton pour faire apparaître un text area
- on sépare les urls par des retours à la ligne

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Jouer avec le champ sur la page d'épreuve ET d'épreuve traduite
