### PR TITLE
[FEATURE] Ajouter le néerlandais dans la liste des langues disponibles sur les vues Epreuves et Acquis (PIX-12645)

### DIFF
--- a/pix-editor/app/components/competence/competence-header.js
+++ b/pix-editor/app/components/competence/competence-header.js
@@ -39,6 +39,9 @@ export default class CompetenceHeader extends Component {
   }, {
     language: 'Portugais',
     local: 'pt',
+  }, {
+    language: 'Néerlandais',
+    local: 'nl',
   }];
 
   get liteClass() {


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pas avoir la vue Acquis et Epreuves en néerlandais.

## :robot: Proposition
Ajouter la langue dans la liste, même si pour le moment ça renvoie pas des résultats cools.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
aller sur la grille compétence et choisir néerlandais dans la liste !
