### PR TITLE
[BUGFIX] Ajout d'un filtre sur le status des skills lors de la release des missions

### DIFF
--- a/api/tests/tooling/airtable-builder/factory/build-skill.js
+++ b/api/tests/tooling/airtable-builder/factory/build-skill.js
@@ -6,7 +6,7 @@ export function buildSkill({
   learningMoreTutorialIds,
   pixValue,
   competenceId,
-  status,
+  status = 'actif',
   tubeId,
   description,
   level,


### PR DESCRIPTION
## :unicorn: Problème
Lors de la release, des acquis n'avaient pas d'épreuve associée, alors que ces acquis étaient périmés, un message d'alert était envoyé 0_o

## :robot: Proposition
Ajouter un filtre des "acquis" suivant leur états pour assurer le bon fonctionnement des filtres et de ses alertes.

## :rainbow:  Remarque
Le contenu de la release était pour autant valide

## :100: Pour tester
Lancer une release, et ne pas voir d'alerte sur des acquis non présent. 