### PR TITLE
[BUGFIX] Les thématiques créées dans l'atelier de l'atelier n'avaient pas d'id persistant (PIX-12711)

### DIFF
--- a/api/scripts/fix-missing-id-persistant-for-some-thematics/index.js
+++ b/api/scripts/fix-missing-id-persistant-for-some-thematics/index.js
@@ -1,0 +1,64 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import _ from 'lodash';
+import { disconnect } from '../../db/knex-database-connection.js';
+import { generateNewId } from '../../lib/infrastructure/utils/id-generator.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function fixMissingIdPersistantForThematics({ airtableClient }) {
+  const thematicsWithoutIdPersistant = await fetchThematicsWithoutIdPersistant({ airtableClient });
+  console.log(`About to fix ${thematicsWithoutIdPersistant.length} thematics without id persistant.`);
+  const thematicsToUpdate = [];
+  for (const thematic of thematicsWithoutIdPersistant) {
+    thematicsToUpdate.push({
+      id: thematic.recordId,
+      fields: {
+        'id persistant': generateNewId('thematic'),
+      }
+    });
+  }
+
+  for (const thematicChunk of _.chunk(thematicsToUpdate, 10)) {
+    await airtableClient.table('Thematiques').update(thematicChunk);
+  }
+}
+
+async function fetchThematicsWithoutIdPersistant({ airtableClient }) {
+  const rawThematics = await airtableClient
+    .table('Thematiques')
+    .select({
+      fields: [
+        'Record Id',
+      ],
+      filterByFormula: '{id persistant} = BLANK()'
+    })
+    .all();
+
+  return rawThematics.map((rawThematic) => {
+    return {
+      recordId: rawThematic.get('Record Id'),
+    };
+  });
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    await fixMissingIdPersistantForThematics({ airtableClient });
+    console.log('All thematics have now an "id persistant" !');
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -63,7 +63,8 @@ export default class CompetenceManagementNewController extends Controller {
     const workbenchTheme = this.store.createRecord('theme', {
       name: themeWorkbenchName,
       competence,
-      index: 0
+      index: 0,
+      pixId: this.idGenerator.newId('thematic'),
     });
     return await workbenchTheme.save();
   }

--- a/pix-editor/tests/unit/controllers/competence-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/new-test.js
@@ -124,7 +124,8 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     const expectedTheme = {
       name: 'workbench_Pix+_1_1',
       competence,
-      index: 0
+      index: 0,
+      pixId: 'recId',
     };
     const expectedTube = {
       name: '@workbench',


### PR DESCRIPTION
## :unicorn: Problème
Les thématiques créées dans l'atelier de l'atelier n'avaient pas d'id persistant

## :robot: Proposition
- faire en sorte qu'ils en aient un
- faire un script pour la reprise de données 

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
