### PR TITLE
[BUGFIX] Utiliser l'id persistant des thématiques dans le code + écrire la traduction des noms des thématiques "workbench" (PIX-12726)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -11,7 +11,7 @@ export const competenceDatasource = datasource.extend({
     'Sous-domaine',
     'Domaine (id persistant)',
     'Acquis (via Tubes) (id persistant)',
-    'Thematiques',
+    'Thematiques (id persistant)',
     'Origine2',
   ],
 
@@ -21,7 +21,7 @@ export const competenceDatasource = datasource.extend({
       index: airtableRecord.get('Sous-domaine'),
       areaId: airtableRecord.get('Domaine (id persistant)') ? airtableRecord.get('Domaine (id persistant)')[0] : '',
       skillIds: airtableRecord.get('Acquis (via Tubes) (id persistant)') || [],
-      thematicIds: airtableRecord.get('Thematiques') || [],
+      thematicIds: airtableRecord.get('Thematiques (id persistant)') || [],
       origin: airtableRecord.get('Origine2')[0],
     };
   },

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -7,6 +7,7 @@ export const thematicDatasource = datasource.extend({
   tableName: 'Thematiques',
 
   usedFields: [
+    'id persistant',
     'Competence (id persistant)',
     'Tubes (id persistant)',
     'Index',
@@ -14,7 +15,7 @@ export const thematicDatasource = datasource.extend({
 
   fromAirTableObject(airtableRecord) {
     return {
-      id: airtableRecord.id,
+      id: airtableRecord.get('id persistant'),
       competenceId: airtableRecord.get('Competence (id persistant)')[0],
       tubeIds: airtableRecord.get('Tubes (id persistant)'),
       index: airtableRecord.get('Index'),

--- a/api/scripts/fill-missing-thematics-name-in-translations-table/index.js
+++ b/api/scripts/fill-missing-thematics-name-in-translations-table/index.js
@@ -1,0 +1,124 @@
+import { fileURLToPath } from 'node:url';
+import Airtable from 'airtable';
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function fillMissingNameForThematicsInTranslationsTable({ airtableClient, dryRun }) {
+  const {
+    thematics,
+    tubes,
+    competences,
+  } = await _fetchDataFromAirtable({ airtableClient });
+  for (const competence of competences) {
+    const thematicIdsWorkbench = [];
+    const thematicIdsNotWorkbench = [];
+    const thematicsForCompetence = thematics.filter((th) => competence.thematicIds.includes(th.id));
+    for (const thematic of thematicsForCompetence) {
+      const thematicKey = `thematic.${thematic.id}.name`;
+      const res = await knex('translations').select('value').where({ key: thematicKey }).first();
+      if (!res?.value) {
+        const tubesForThematic = tubes.filter((tu) => thematic.tubeIds.includes(tu.id));
+        if (tubesForThematic.length === 1 && tubesForThematic[0].name === '@workbench') {
+          thematicIdsWorkbench.push(thematic.id);
+          if (!dryRun) {
+            const thematicName = `workbench_${competence.origin}_${competence.code.split('.').join('_')}`;
+            await knex.insert({ value: thematicName, key: thematicKey, locale: 'fr' });
+          }
+        } else {
+          thematicIdsNotWorkbench.push(thematic.id);
+        }
+      }
+    }
+    if (thematicIdsWorkbench.length + thematicIdsNotWorkbench.length > 0) {
+      console.log(`Nombre de thématiques workbench corrigées pour la compétence ${competence.id}: ${thematicIdsWorkbench.length}`);
+      console.log(`Nombre de thématiques NON workbench NON corrigées pour la compétence ${competence.id}: ${thematicIdsNotWorkbench.length} (${thematicIdsNotWorkbench.join(', ')})`);
+    }
+  }
+}
+
+async function _fetchDataFromAirtable({ airtableClient }) {
+  const rawCompetences = await airtableClient
+    .table('Competences')
+    .select({
+      fields: [
+        'Record ID',
+        'id persistant',
+        'Origine2',
+        'Sous-domaine',
+        'Thematiques (id persistant)',
+      ],
+    })
+    .all();
+  const competences = rawCompetences.map((rawCompetence) => {
+    return {
+      recordId: rawCompetence.get('Record ID'),
+      id: rawCompetence.get('id persistant'),
+      origin: rawCompetence.get('Origine2'),
+      code: rawCompetence.get('Sous-domaine'),
+      thematicIds: rawCompetence.get('Thematiques (id persistant)') ?? [],
+    };
+  });
+
+  const rawThematics = await airtableClient
+    .table('Thematiques')
+    .select({
+      fields: [
+        'Record Id',
+        'id persistant',
+        'Tubes (id persistant)',
+      ],
+    })
+    .all();
+  const thematics = rawThematics.map((rawThematic) => ({
+    recordId: rawThematic.get('Record Id'),
+    id: rawThematic.get('id persistant'),
+    tubeIds: rawThematic.get('Tubes (id persistant)') ?? [],
+  }));
+
+  const rawTubes = await airtableClient
+    .table('Tubes')
+    .select({
+      fields: [
+        'id persistant',
+        'Nom',
+      ],
+    })
+    .all();
+  const tubes = rawTubes.map((rawTube) => ({
+    id: rawTube.get('id persistant'),
+    name: rawTube.get('Nom'),
+  }));
+
+  return {
+    thematics,
+    tubes,
+    competences,
+  };
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const airtableClient = new Airtable({
+      apiKey: process.env.AIRTABLE_API_KEY,
+    }).base(process.env.AIRTABLE_BASE);
+
+    const dryRun = process.env.DRY_RUN !== 'false';
+
+    if (dryRun) logger.warn('Dry run: no actual modification will be performed, use DRY_RUN=false to disable');
+
+    await fillMissingNameForThematicsInTranslationsTable({ airtableClient, dryRun });
+    console.log('All thematics have now name in translations table !');
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();

--- a/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-thematic_test.js
+++ b/api/tests/acceptance/application/airtable-proxy/airtable-proxy-controller-thematic_test.js
@@ -169,14 +169,10 @@ describe('Acceptance | Controller | airtable-proxy-controller | read thematics',
     thematicDataObject = domainBuilder.buildThematicDatasourceObject({
       id: 'mon_id_persistant',
     });
-    airtableThematic = airtableBuilder.factory.buildThematic({
-      ...thematicDataObject,
-      airtableId: 'mon_id_airtable',
-    });
+    airtableThematic = airtableBuilder.factory.buildThematic(thematicDataObject);
 
     outputThematic = inputOutputDataBuilder.factory.buildThematic({
       ...thematicDataObject,
-      airtableId: 'mon_id_airtable',
       name_i18n: {
         fr: 'french name',
         en: 'english name',

--- a/api/tests/scripts/migrate-thematics-translations-from-airtable_test.js
+++ b/api/tests/scripts/migrate-thematics-translations-from-airtable_test.js
@@ -1,9 +1,11 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { airtableBuilder, knex } from '../test-helper.js';
 import Airtable from 'airtable';
 import nock from 'nock';
 
-import { migrateThematicsTranslationsFromAirtable } from '../../scripts/migrate-thematics-translations-from-airtable/index.js';
+import {
+  migrateThematicsTranslationsFromAirtable
+} from '../../scripts/migrate-thematics-translations-from-airtable/index.js';
 
 describe('Script | Migrate thematics translations from Airtable', function() {
 
@@ -29,7 +31,6 @@ describe('Script | Migrate thematics translations from Airtable', function() {
     // given
     const thematic1FromAirtable = airtableBuilder.factory.buildThematic({
       id: 'thematicId1',
-      airtableId: 'airtableThematicId1',
     });
     thematic1FromAirtable.fields = {
       ...thematic1FromAirtable.fields,
@@ -38,7 +39,6 @@ describe('Script | Migrate thematics translations from Airtable', function() {
     };
 
     const thematic2FromAirtable = airtableBuilder.factory.buildThematic({
-      airtableId: 'airtableThematicId2',
       id: 'thematicId2',
     });
     thematic2FromAirtable.fields = {

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -13,7 +13,7 @@ export function buildCompetence({
       'Sous-domaine': index,
       'Domaine (id persistant)': [areaId],
       'Acquis (via Tubes) (id persistant)': skillIds,
-      'Thematiques': thematicIds,
+      'Thematiques (id persistant)': thematicIds,
       'Origine2': [origin],
     },
   };

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -1,13 +1,12 @@
 export function buildThematic(
   {
     id,
-    airtableId = id,
     competenceId,
     tubeIds,
     index,
   } = {}) {
   return {
-    id: airtableId,
+    id,
     'fields': {
       'id persistant': id,
       'Competence (id persistant)': [competenceId],

--- a/api/tests/tooling/input-output-data-builder/factory/build-competence.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-competence.js
@@ -17,7 +17,7 @@ export function buildCompetence({
       'Titre fr-fr': nameFrFr,
       'Titre en-us': nameEnUs,
       'Acquis (via Tubes) (id persistant)': skillIds,
-      'Thematiques': thematicIds,
+      'Thematiques (id persistant)': thematicIds,
       'Origine2': [origin],
       'Description fr-fr': descriptionFrFr,
       'Description en-us': descriptionEnUs,

--- a/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
@@ -1,7 +1,6 @@
 export function buildThematic(
   {
     id,
-    airtableId = id,
     name_i18n: {
       fr: name,
       en: nameEnUs,
@@ -11,7 +10,7 @@ export function buildThematic(
     index,
   } = {}) {
   return {
-    id: airtableId,
+    id,
     'fields': {
       'id persistant': id,
       'Nom': name,


### PR DESCRIPTION
## :unicorn: Problème
Côté consommateur de l'API, certaines thématiques n'ont pas le nom qui est remonté.
C'est parce qu'on utilisait l'id Airtable ETQ id normal pour les thématiques alors qu'il faudrait toujours passer par l'id persistant.

## :robot: Proposition
- Utiliser l'id persistant des thématiques partout
- Faire une récupération des noms des thématiques pour les thématiques workbench

## :rainbow: Remarques
En fait les thématiques qui ont été concernées par le bug vu en prod côté pix c'était les thématiques pour lesquelles le record id !== id persistant

## :100: Pour tester
Se balader dans PE et voir que c'est ok
