### PR TITLE
[TECH] Déplacer la logique de duplication d'acquis côté back (PIX-12733)

### DIFF
--- a/api/lib/application/localized-challenges.js
+++ b/api/lib/application/localized-challenges.js
@@ -37,7 +37,7 @@ export async function register(server) {
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
           const { locale: _, ...localizedChallenge } = await localizedChallengeSerializer.deserialize(request.payload);
-          const isAdmin = hasAuthenticatedUserAccess(request, 'admin');
+          const isAdmin = hasAuthenticatedUserAccess(request, ['admin']);
           try {
             const updatedLocalizedChallenge = await modifyLocalizedChallenge({
               isAdmin,

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -27,5 +27,5 @@ export async function checkUserIsAuthenticatedViaBasicAndAdmin(username) {
 }
 
 export function checkUserHasWriteAccess(request, h) {
-  return hasAuthenticatedUserAccess(request, 'readonly') ? replyForbiddenError(h) : h.response(true);
+  return hasAuthenticatedUserAccess(request, ['replicator', 'editor', 'admin']) ? h.response(true) : replyForbiddenError(h);
 }

--- a/api/lib/application/security-utils.js
+++ b/api/lib/application/security-utils.js
@@ -2,9 +2,9 @@ import JsonapiSerializer from 'jsonapi-serializer';
 
 const { Error: JSONAPIError } = JsonapiSerializer;
 
-export function hasAuthenticatedUserAccess(request, access) {
+export function hasAuthenticatedUserAccess(request, accesses) {
   const authenticatedUser = request.auth.credentials.user;
-  return authenticatedUser.access === access;
+  return accesses.includes(authenticatedUser.access);
 }
 
 export function replyWithAuthenticationError(h) {

--- a/api/lib/application/skills/index.js
+++ b/api/lib/application/skills/index.js
@@ -1,0 +1,17 @@
+import * as securityPreHandlers from '../security-pre-handlers.js';
+import * as skillsController from './skills.js';
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'PUT',
+      path: '/api/skills/clone',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
+        handler: skillsController.clone,
+      },
+    },
+  ]);
+}
+
+export const name = 'skills-api';

--- a/api/lib/application/skills/skills.js
+++ b/api/lib/application/skills/skills.js
@@ -1,0 +1,58 @@
+import _ from 'lodash';
+import { extractUserIdFromRequest } from '../../infrastructure/monitoring-tools.js';
+import {
+  attachmentRepository,
+  challengeRepository,
+  skillRepository,
+  tubeRepository,
+  userRepository,
+} from '../../infrastructure/repositories/index.js';
+import { generateNewId } from '../../infrastructure/utils/id-generator.js';
+import { cloneSkill } from '../../domain/usecases/index.js';
+
+export async function clone(request, h) {
+  const userId = extractUserIdFromRequest(request);
+  try {
+    const cloneCommand = normalizeCloneCommand(request.payload.data.attributes, userId);
+    return await cloneSkill({
+      cloneCommand,
+      dependencies: {
+        userRepository,
+        skillRepository,
+        challengeRepository,
+        tubeRepository,
+        attachmentRepository,
+        generateNewIdFnc: generateNewId,
+      },
+    });
+  } catch (err) {
+    console.log(err);
+    return h.response(err).code(400);
+  }
+}
+
+function normalizeCloneCommand(attrs, userId) {
+  const cloneCommand = {};
+  if (!_.isString(attrs.tubeDestinationId)) {
+    throw new Error('tubeDestinationId PAS BON');
+  } else {
+    cloneCommand.tubeDestinationId = attrs.tubeDestinationId;
+  }
+  if (!_.isString(attrs.skillIdToClone)) {
+    throw new Error('skillIdToClone PAS BON');
+  } else {
+    cloneCommand.skillIdToClone = attrs.skillIdToClone;
+  }
+  if (!_.isNumber(parseInt(attrs.level))) {
+    throw new Error('level PAS BON');
+  } else {
+    cloneCommand.level = parseInt(attrs.level);
+  }
+  if (!_.isString(attrs.changelogText)) {
+    cloneCommand.changelogText = '';
+  } else {
+    cloneCommand.changelogText = attrs.changelogText;
+  }
+  cloneCommand.userId = userId;
+  return cloneCommand;
+}

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -136,6 +136,9 @@ if (process.env.NODE_ENV === 'test') {
     password: '123',
   };
 
+  pixEditor.storagePost = 'https://url-de-mon-storage.com/v1/AUTH_blabla/local-app/';
+  pixEditor.storageBucket = 'mon-bucket-local';
+
   pixApp = {
     baseUrlFr: 'https://app.test.pix.fr',
     baseUrlOrg: 'https://app.test.pix.org',

--- a/api/lib/domain/models/Attachment.js
+++ b/api/lib/domain/models/Attachment.js
@@ -3,12 +3,14 @@ export class Attachment {
     id,
     url,
     type,
+    alt,
     challengeId,
     localizedChallengeId,
   }) {
     this.id = id;
     this.url = url;
     this.type = type;
+    this.alt = alt;
     this.challengeId = challengeId;
     this.localizedChallengeId = localizedChallengeId;
   }

--- a/api/lib/domain/models/Attachment.js
+++ b/api/lib/domain/models/Attachment.js
@@ -12,4 +12,15 @@ export class Attachment {
     this.challengeId = challengeId;
     this.localizedChallengeId = localizedChallengeId;
   }
+
+  clone({ challengeId, localizedChallengeId }) {
+    return new Attachment({
+      id: null,
+      url: this.url,
+      type: this.type,
+      alt: this.alt,
+      challengeId,
+      localizedChallengeId,
+    });
+  }
 }

--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -30,4 +30,17 @@ export class Skill {
     this.level = level;
     this.internationalisation = internationalisation;
   }
+
+  static get STATUSES() {
+    return {
+      ACTIF: 'actif',
+      EN_CONSTRUCTION: 'en construction',
+      ARCHIVE: 'archivé',
+      PERIME: 'périmé',
+    };
+  }
+
+  get isLive() {
+    return [Skill.STATUSES.EN_CONSTRUCTION, Skill.STATUSES.ACTIF].includes(this.status);
+  }
 }

--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -1,3 +1,5 @@
+import { Challenge } from './Challenge.js';
+
 export class Skill {
   constructor({
     id,
@@ -40,7 +42,76 @@ export class Skill {
     };
   }
 
+  static get ID_PREFIX() {
+    return 'skill';
+  }
+
   get isLive() {
     return [Skill.STATUSES.EN_CONSTRUCTION, Skill.STATUSES.ACTIF].includes(this.status);
+  }
+
+  cloneSkillAndChallenges({ tubeDestination, level, skillChallenges, tubeSkills, attachments, generateNewIdFnc }) {
+    const version = tubeSkills.filter((sk) => sk.level === level).length + 1;
+    const name = `${tubeDestination.name}${level}`;
+    const id = generateNewIdFnc(Skill.ID_PREFIX);
+    const liveChallenges = skillChallenges.filter((ch) => [Challenge.STATUSES.PROPOSE, Challenge.STATUSES.VALIDE].includes(ch.status));
+    const prototypesWithActiveFirst = liveChallenges
+      .filter((ch) => ch.genealogy === 'Prototype 1')
+      .sort((chA, chB) => {
+        if (chA.status === Challenge.STATUSES.VALIDE) return -1;
+        if (chB.status === Challenge.STATUSES.VALIDE) return 1;
+        return 0;
+      });
+    const clonedChallenges = [];
+    const clonedAttachments = [];
+    let prototypeVersion = 1;
+    for (const prototype of prototypesWithActiveFirst) {
+      const { clonedChallenge: cloneProto, clonedAttachments: cloneAttachmentsProto } = prototype.cloneChallengeAndAttachments({
+        skillId: id,
+        competenceId: tubeDestination.competenceId,
+        generateNewIdFnc,
+        prototypeVersion,
+        alternativeVersion: null,
+        attachments,
+      });
+      clonedChallenges.push(cloneProto);
+      clonedAttachments.push(...cloneAttachmentsProto);
+      const declinaisons = liveChallenges.filter((ch) => ch.genealogy === 'Décliné 1' && ch.version === prototype.version);
+      let alternativeVersion = 1;
+      for (const declinaison of declinaisons) {
+        const { clonedChallenge: cloneDecli, clonedAttachments: cloneAttachmentsDecli } = declinaison.cloneChallengeAndAttachments({
+          skillId: id,
+          competenceId: tubeDestination.competenceId,
+          generateNewIdFnc,
+          prototypeVersion,
+          alternativeVersion: alternativeVersion,
+          attachments,
+        });
+        clonedChallenges.push(cloneDecli);
+        clonedAttachments.push(...cloneAttachmentsDecli);
+        ++alternativeVersion;
+      }
+      ++prototypeVersion;
+    }
+    const clonedSkill = new Skill({
+      id,
+      version,
+      name,
+      level,
+      tubeId: tubeDestination.id,
+      competenceId: tubeDestination.competenceId,
+      status: Skill.STATUSES.EN_CONSTRUCTION,
+      description: this.description,
+      hint_i18n: this.hint_i18n,
+      hintStatus: this.hintStatus,
+      tutorialIds: this.tutorialIds,
+      learningMoreTutorialIds: this.learningMoreTutorialIds,
+      internationalisation: this.internationalisation,
+    });
+    return {
+      clonedSkill,
+      clonedChallenges,
+      clonedAttachments,
+    };
   }
 }

--- a/api/lib/domain/models/release/SkillForRelease.js
+++ b/api/lib/domain/models/release/SkillForRelease.js
@@ -1,3 +1,5 @@
+import { Skill } from '../Skill.js';
+
 export class SkillForRelease {
   constructor({
     id,
@@ -28,16 +30,11 @@ export class SkillForRelease {
     this.hint_i18n = hint_i18n;
   }
 
-  canExportForTranslation() {
-    return this.status === SkillForRelease.STATUSES.ACTIF;
+  static get STATUSES() {
+    return Skill.STATUSES;
   }
 
-  static get STATUSES() {
-    return {
-      ACTIF: 'actif',
-      EN_CONSTRUCTION: 'en construction',
-      ARCHIVE: 'archivé',
-      PERIME: 'périmé',
-    };
+  canExportForTranslation() {
+    return this.status === SkillForRelease.STATUSES.ACTIF;
   }
 }

--- a/api/lib/domain/usecases/clone-skill.js
+++ b/api/lib/domain/usecases/clone-skill.js
@@ -1,3 +1,9 @@
+// TODO LIST
+// industrialiser les utils translations pour gérer les objets du domaine
+// factoriser du code entre pix-api-client et storage et faire un peu mieux (separation of concerns etc...)
+// les objets du domaine devraient maintenant avoir un id (id persistant) et un airtableId (record id de airtable)
+// tester les répos mieux (parce que là on a déconné)
+
 export async function cloneSkill({
   cloneCommand,
   dependencies: {

--- a/api/lib/domain/usecases/clone-skill.js
+++ b/api/lib/domain/usecases/clone-skill.js
@@ -1,0 +1,83 @@
+export async function cloneSkill({
+  cloneCommand,
+  dependencies: {
+    skillRepository,
+    challengeRepository,
+    tubeRepository,
+    attachmentRepository,
+    generateNewIdFnc,
+  },
+}) {
+  const { tube, skillToClone } = await _checkIfCloningIsPossible({
+    level: cloneCommand.level,
+    tubeId: cloneCommand.tubeDestinationId,
+    skillIdToClone: cloneCommand.skillIdToClone,
+    tubeRepository,
+    skillRepository,
+  });
+
+  const {
+    skillChallenges,
+    tubeSkills,
+    attachments,
+  } = await _fetchData({
+    skillToCloneId: skillToClone.id,
+    tubeId: tube.id,
+    challengeRepository,
+    skillRepository,
+    attachmentRepository,
+  });
+
+  const {
+    clonedSkill,
+    clonedChallenges,
+    clonedAttachments,
+  } = skillToClone.cloneSkillAndChallenges({
+    tubeDestination: tube,
+    level: cloneCommand.level,
+    skillChallenges,
+    tubeSkills,
+    attachments,
+    generateNewIdFnc,
+  });
+  await skillRepository.create(clonedSkill);
+  await challengeRepository.createBatch(clonedChallenges);
+  // for now only persist primary attachments
+  const attachmentsToPersist = clonedAttachments.filter((attachment) => attachment.challengeId === attachment.localizedChallengeId);
+  await attachmentRepository.createBatch(attachmentsToPersist);
+  return 'ok';
+}
+
+async function _checkIfCloningIsPossible({ level, tubeId, skillIdToClone, tubeRepository, skillRepository }) {
+  if (level < 1 || level > 7) {
+    throw new Error('Le niveau doit être compris entre 1 et 7');
+  }
+  const tube = await tubeRepository.get(tubeId);
+  if (!tube) {
+    throw new Error(`Le sujet d'id "${tubeId}" n'existe pas`);
+  }
+  const skillToClone = await skillRepository.get(skillIdToClone);
+  if (!skillToClone) {
+    throw new Error(`L'acquis d'id "${skillIdToClone}" n'existe pas`);
+  }
+  if (!skillToClone.isLive) {
+    throw new Error('Impossible de cloner un acquis qui ne soit ni en construction ni actif');
+  }
+  return {
+    tube,
+    skillToClone,
+  };
+}
+
+async function _fetchData({ skillToCloneId, tubeId, challengeRepository, skillRepository, attachmentRepository }) {
+  const skillChallenges = await challengeRepository.listBySkillId(skillToCloneId);
+  const tubeSkills = await skillRepository.listByTubeId(tubeId);
+  const challengeIds = skillChallenges.map((ch) => ch.id);
+  const attachments = await attachmentRepository.listByChallengeIds(challengeIds);
+
+  return {
+    skillChallenges,
+    tubeSkills,
+    attachments,
+  };
+}

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -32,7 +32,7 @@ export function importTranslations(csvStream, dependencies = { translationReposi
       })
       .on('end', async () => {
         const challengesLocales = extractChallengesLocales(translations);
-        await dependencies.localizedChallengeRepository.create(challengesLocales);
+        await dependencies.localizedChallengeRepository.create({ localizedChallenges:challengesLocales });
 
         await dependencies.translationRepository.save({ translations, shouldDuplicateToAirtable: false });
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,3 +1,4 @@
+export * from './clone-skill.js';
 export * from './create-mission.js';
 export * from './delete-unmentioned-keys-after-upload.js';
 export * from './download-translation-from-phrase.js';

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -1,6 +1,7 @@
 import Airtable from 'airtable';
 import * as config from '../config.js';
 import { logger } from './logger.js';
+import _ from 'lodash';
 
 function _airtableClient() {
   return new Airtable({ apiKey: config.airtable.apiKey }).base(config.airtable.base);
@@ -19,6 +20,17 @@ export async function createRecord(tableName, body) {
     .table(tableName)
     .create([body]);
   return records[0];
+}
+
+export async function createRecords(tableName, bodies) {
+  const records = [];
+  for (const chunkBodies  of _.chunk(bodies, 10)) {
+    const chunkRecords = await _airtableClient()
+      .table(tableName)
+      .create(chunkBodies);
+    records.push(...chunkRecords) ;
+  }
+  return records;
 }
 
 export async function updateRecord(tableName, body) {

--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -36,6 +36,15 @@ export const attachmentDatasource = datasource.extend({
       filterByFormula : `{localizedChallengeId} = '${localizedChallengeId}'`,
     });
     return airtableRawObjects.map(this.fromAirTableObject);
-  }
+  },
+
+  async filterByChallengeIds(challengeIds) {
+    if (challengeIds.length === 0) return undefined;
+    const airtableRawObjects = await findRecords(this.tableName, {
+      filterByFormula: `OR(${challengeIds.map((id) => `FIND("${id}", ARRAYJOIN({challengeId persistant}))`).join(',')})`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
+  },
 });
 

--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -31,6 +31,22 @@ export const attachmentDatasource = datasource.extend({
     };
   },
 
+  /* Attributes to not write while in Airtable because they are formulas or lookups
+    challengeId persistant                      (write "challengeId" instead)
+   */
+  toAirTableObject(model) {
+    return {
+      fields: {
+        'url': model.url,
+        'size': model.size,
+        'type': model.type,
+        'mimeType': model.mimeType,
+        'challengeId': [model.challengeId],
+        'localizedChallengeId': model.localizedChallengeId,
+      }
+    };
+  },
+
   async filterByLocalizedChallengeId(localizedChallengeId) {
     const airtableRawObjects = await findRecords(this.tableName, {
       filterByFormula : `{localizedChallengeId} = '${localizedChallengeId}'`,

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -179,14 +179,13 @@ export const challengeDatasource = datasource.extend({
     return this.fromAirTableObject(airtableRawObjects[0]);
   },
 
-  async getAllIdsIn(challengeIds) {
-    const options = {
-      fields: ['id persistant'],
-      filterByFormula: 'OR(' + challengeIds.map((id) => `'${id}' = {id persistant}`).join(',') + ')'
-    };
-    const airtableRawObjects = await findRecords(this.tableName, options);
-    return airtableRawObjects.map((airtableRawObject) => airtableRawObject.get('id persistant'));
-  }
+  async filterBySkillId(skillId) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      filterByFormula: `FIND("${skillId}", ARRAYJOIN({Acquix (id persistant)}))`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
+  },
 });
 
 function _escapeQuery(value) {

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -186,6 +186,18 @@ export const challengeDatasource = datasource.extend({
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);
   },
+
+  async getAirtableIdsByIds(challengeIds) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: ['Record ID', 'id persistant'],
+      filterByFormula: `OR(${challengeIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
+    });
+    const airtableIdsByIds = {};
+    for (const challengeId of challengeIds) {
+      airtableIdsByIds[challengeId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === challengeId)?.get('Record ID');
+    }
+    return airtableIdsByIds;
+  },
 });
 
 function _escapeQuery(value) {

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -186,18 +186,6 @@ export const challengeDatasource = datasource.extend({
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);
   },
-
-  async getAirtableIdsByIds(challengeIds) {
-    const airtableRawObjects = await findRecords(this.tableName, {
-      fields: ['Record ID', 'id persistant'],
-      filterByFormula: `OR(${challengeIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
-    });
-    const airtableIdsByIds = {};
-    for (const challengeId of challengeIds) {
-      airtableIdsByIds[challengeId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === challengeId)?.get('Record ID');
-    }
-    return airtableIdsByIds;
-  },
 });
 
 function _escapeQuery(value) {

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -1,4 +1,5 @@
 import { datasource } from './datasource.js';
+import { findRecords } from '../../airtable.js';
 
 export const competenceDatasource = datasource.extend({
 
@@ -24,5 +25,17 @@ export const competenceDatasource = datasource.extend({
       thematicIds: airtableRecord.get('Thematiques (id persistant)') || [],
       origin: airtableRecord.get('Origine2')[0],
     };
+  },
+
+  async getAirtableIdsByIds(competenceIds) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: ['Record ID', 'id persistant'],
+      filterByFormula: `OR(${competenceIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
+    });
+    const airtableIdsByIds = {};
+    for (const competenceId of competenceIds) {
+      airtableIdsByIds[competenceId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === competenceId)?.get('Record ID');
+    }
+    return airtableIdsByIds;
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -1,5 +1,4 @@
 import { datasource } from './datasource.js';
-import { findRecords } from '../../airtable.js';
 
 export const competenceDatasource = datasource.extend({
 
@@ -25,17 +24,5 @@ export const competenceDatasource = datasource.extend({
       thematicIds: airtableRecord.get('Thematiques (id persistant)') || [],
       origin: airtableRecord.get('Origine2')[0],
     };
-  },
-
-  async getAirtableIdsByIds(competenceIds) {
-    const airtableRawObjects = await findRecords(this.tableName, {
-      fields: ['Record ID', 'id persistant'],
-      filterByFormula: `OR(${competenceIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
-    });
-    const airtableIdsByIds = {};
-    for (const competenceId of competenceIds) {
-      airtableIdsByIds[competenceId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === competenceId)?.get('Record ID');
-    }
-    return airtableIdsByIds;
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -68,7 +68,7 @@ const _DatasourcePrototype = {
     });
     return Object
       .fromEntries(airtableRawObjects
-        .map((airtableObject) => [airtableObject.get(this.airtableIdField), airtableObject.get('id persistant')]));
+        .map((airtableObject) => [airtableObject.get('id persistant'), airtableObject.get(this.airtableIdField)]));
   },
 };
 

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -60,6 +60,16 @@ const _DatasourcePrototype = {
   async delete(ids) {
     return airtable.deleteRecords(this.tableName, ids);
   },
+
+  async getAirtableIdsByIds(entityIds) {
+    const airtableRawObjects = await airtable.findRecords(this.tableName, {
+      fields: [this.airtableIdField, 'id persistant'],
+      filterByFormula: `OR(${entityIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
+    });
+    return Object
+      .fromEntries(airtableRawObjects
+        .map((airtableObject) => [airtableObject.get(this.airtableIdField), airtableObject.get('id persistant')]));
+  },
 };
 
 function* chunks(array, chunkSize) {
@@ -72,6 +82,7 @@ export const datasource = {
 
   extend(props) {
     props.sortField = props.sortField || 'id persistant';
+    props.airtableIdField = props.airtableIdField || 'Record ID';
     const result = Object.assign({}, _DatasourcePrototype, props);
     _.bindAll(result, _.functions(result));
     return result;

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -35,6 +35,12 @@ const _DatasourcePrototype = {
     return this.fromAirTableObject(airtableRawObject);
   },
 
+  async createBatch(models) {
+    const airtableRequestBodies = models.map(this.toAirTableObject);
+    const airtableRawObjects = await airtable.createRecords(this.tableName, airtableRequestBodies);
+    return airtableRawObjects.map(this.fromAirTableObject);
+  },
+
   async update(model) {
     const airtableRequestBody = this.toAirTableObject(model);
     const airtableRawObject = await airtable.updateRecord(this.tableName, airtableRequestBody);

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -50,4 +50,16 @@ export const skillDatasource = datasource.extend({
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);
   },
+
+  async getAirtableIdsByIds(skillIds) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: ['Record Id', 'id persistant'],
+      filterByFormula: `OR(${skillIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
+    });
+    const airtableIdsByIds = {};
+    for (const skillId of skillIds) {
+      airtableIdsByIds[skillId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === skillId)?.get('Record Id');
+    }
+    return airtableIdsByIds;
+  },
 });

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -8,6 +8,8 @@ export const skillDatasource = datasource.extend({
 
   tableName: 'Acquis',
 
+  airtableIdField: 'Record Id',
+
   usedFields: [
     'id persistant',
     'Nom',
@@ -73,17 +75,5 @@ export const skillDatasource = datasource.extend({
     });
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);
-  },
-
-  async getAirtableIdsByIds(skillIds) {
-    const airtableRawObjects = await findRecords(this.tableName, {
-      fields: ['Record Id', 'id persistant'],
-      filterByFormula: `OR(${skillIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
-    });
-    const airtableIdsByIds = {};
-    for (const skillId of skillIds) {
-      airtableIdsByIds[skillId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === skillId)?.get('Record Id');
-    }
-    return airtableIdsByIds;
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { datasource } from './datasource.js';
+import { findRecords } from '../../airtable.js';
 
 export const skillDatasource = datasource.extend({
 
@@ -40,5 +41,13 @@ export const skillDatasource = datasource.extend({
       internationalisation: airtableRecord.get('Internationalisation'),
       version: airtableRecord.get('Version')
     };
+  },
+
+  async filterByTubeId(tubeId) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      filterByFormula: `FIND("${tubeId}", ARRAYJOIN({Tube (id persistant)}))`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -43,6 +43,30 @@ export const skillDatasource = datasource.extend({
     };
   },
 
+  /* Attributes to not write while in Airtable because they are formulas or lookups
+    Nom
+    Tube (id persistant)                        (write "Tube" instead)
+    Comprendre (id persistant)                  (write "Comprendre" instead)
+    En savoir plus (id persistant)              (write "En savoir plus" instead)
+    PixValue
+   */
+  toAirTableObject(model) {
+    return {
+      fields: {
+        'id persistant': model.id,
+        'Statut de l\'indice': model.hintStatus,
+        'Comprendre': model.tutorialIds,
+        'En savoir plus': model.learningMoreTutorialIds,
+        'Status': model.status,
+        'Tube': [model.tubeId],
+        'Description': model.description,
+        'Level': model.level,
+        'Internationalisation': model.internationalisation,
+        'Version': model.version,
+      }
+    };
+  },
+
   async filterByTubeId(tubeId) {
     const airtableRawObjects = await findRecords(this.tableName, {
       filterByFormula: `FIND("${tubeId}", ARRAYJOIN({Tube (id persistant)}))`,

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -6,6 +6,8 @@ export const thematicDatasource = datasource.extend({
 
   tableName: 'Thematiques',
 
+  airtableIdField: 'Record Id',
+
   usedFields: [
     'id persistant',
     'Competence (id persistant)',

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { datasource } from './datasource.js';
+import { findRecords } from '../../airtable.js';
 
 export const tubeDatasource = datasource.extend({
 
@@ -19,5 +20,17 @@ export const tubeDatasource = datasource.extend({
       name: airtableRecord.get('Nom'),
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };
+  },
+
+  async getAirtableIdsByIds(tubeIds) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: ['Record Id', 'id persistant'],
+      filterByFormula: `OR(${tubeIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
+    });
+    const airtableIdsByIds = {};
+    for (const tubeId of tubeIds) {
+      airtableIdsByIds[tubeId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === tubeId)?.get('Record Id');
+    }
+    return airtableIdsByIds;
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import { datasource } from './datasource.js';
-import { findRecords } from '../../airtable.js';
 
 export const tubeDatasource = datasource.extend({
 
   modelName: 'Tube',
 
   tableName: 'Tubes',
+
+  airtableIdField: 'Record Id',
 
   usedFields: [
     'id persistant',
@@ -20,17 +21,5 @@ export const tubeDatasource = datasource.extend({
       name: airtableRecord.get('Nom'),
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };
-  },
-
-  async getAirtableIdsByIds(tubeIds) {
-    const airtableRawObjects = await findRecords(this.tableName, {
-      fields: ['Record Id', 'id persistant'],
-      filterByFormula: `OR(${tubeIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
-    });
-    const airtableIdsByIds = {};
-    for (const tubeId of tubeIds) {
-      airtableIdsByIds[tubeId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === tubeId)?.get('Record Id');
-    }
-    return airtableIdsByIds;
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -1,4 +1,5 @@
 import { datasource } from './datasource.js';
+import { findRecords } from '../../airtable.js';
 
 export const tutorialDatasource = datasource.extend({
 
@@ -30,6 +31,18 @@ export const tutorialDatasource = datasource.extend({
       tutorialForSkills: airtableRecord.get('Solution à'),
       furtherInformation: airtableRecord.get('En savoir plus'),
     };
+  },
+
+  async getAirtableIdsByIds(tutorialIds) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: ['Record ID', 'id persistant'],
+      filterByFormula: `OR(${tutorialIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
+    });
+    const airtableIdsByIds = {};
+    for (const tutorialId of tutorialIds) {
+      airtableIdsByIds[tutorialId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === tutorialId)?.get('Record ID');
+    }
+    return airtableIdsByIds;
   },
 });
 

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -1,5 +1,4 @@
 import { datasource } from './datasource.js';
-import { findRecords } from '../../airtable.js';
 
 export const tutorialDatasource = datasource.extend({
 
@@ -31,18 +30,6 @@ export const tutorialDatasource = datasource.extend({
       tutorialForSkills: airtableRecord.get('Solution à'),
       furtherInformation: airtableRecord.get('En savoir plus'),
     };
-  },
-
-  async getAirtableIdsByIds(tutorialIds) {
-    const airtableRawObjects = await findRecords(this.tableName, {
-      fields: ['Record ID', 'id persistant'],
-      filterByFormula: `OR(${tutorialIds.map((id) => `'${id}' = {id persistant}`).join(',')})`,
-    });
-    const airtableIdsByIds = {};
-    for (const tutorialId of tutorialIds) {
-      airtableIdsByIds[tutorialId] = airtableRawObjects.find((airtableRecord) => airtableRecord.get('id persistant') === tutorialId)?.get('Record ID');
-    }
-    return airtableIdsByIds;
   },
 });
 

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -12,6 +12,15 @@ export async function list() {
   return toDomainList(datasourceAttachments, translations, localizedChallenges);
 }
 
+export async function listByChallengeIds(challengeIds) {
+  const datasourceAttachments = await attachmentDatasource.filterByChallengeIds(challengeIds);
+  if (!datasourceAttachments) return [];
+  const translations = await translationRepository.listByPattern('challenge.%.illustrationAlt');
+  const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds });
+
+  return toDomainList(datasourceAttachments, translations, localizedChallenges);
+}
+
 function toDomainList(datasourceAttachments, translations, localizedChallenges) {
   const translationsByChallengeId = _.groupBy(translations, 'entityId');
   const localizedChallengesById = _.groupBy(localizedChallenges, 'id');

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -1,8 +1,9 @@
-import { attachmentDatasource } from '../datasources/airtable/index.js';
+import { attachmentDatasource, challengeDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as localizedChallengeRepository from './localized-challenge-repository.js';
 import _ from 'lodash';
 import { Attachment } from '../../domain/models/index.js';
+import { cloneFile } from '../utils/storage.js';
 
 export async function list() {
   const datasourceAttachments = await attachmentDatasource.list();
@@ -19,6 +20,33 @@ export async function listByChallengeIds(challengeIds) {
   const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds });
 
   return toDomainList(datasourceAttachments, translations, localizedChallenges);
+}
+
+export async function createBatch(attachments) {
+  if (!attachments || attachments.length === 0) return [];
+  const necessaryChallengeIds = _.uniq(attachments.map((attachment) => attachment.challengeId));
+  const airtableChallengeIdsByIds = await challengeDatasource.getAirtableIdsByIds(necessaryChallengeIds);
+  const attachmentToSaveDTOs = [];
+  for (const attachment of attachments) {
+    const isPrimaryLocaleAttachment = attachment.challengeId === attachment.localizedChallengeId;
+    if (!isPrimaryLocaleAttachment) continue;
+    const newUrl = await cloneFile({
+      url: attachment.url,
+      millisecondsTimestamp: Date.now(),
+    });
+    attachmentToSaveDTOs.push({
+      url: newUrl,
+      size: attachment.size,
+      type: attachment.type,
+      mimeType: attachment.mimeType,
+      challengeId: airtableChallengeIdsByIds[attachment.challengeId],
+      localizedChallengeId: attachment.localizedChallengeId,
+    });
+  }
+  const createdAttachmentsDtos = await attachmentDatasource.createBatch(attachmentToSaveDTOs);
+  const translations = await translationRepository.listByPattern('challenge.%.illustrationAlt');
+  const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds: attachments.map((attachment) => attachment.challengeId) });
+  return toDomainList(createdAttachmentsDtos, translations, localizedChallenges);
 }
 
 function toDomainList(datasourceAttachments, translations, localizedChallenges) {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -96,9 +96,13 @@ export async function update(challenge) {
     return toDomain(updatedChallengeDto, translations, localizedChallenges);
   });
 }
-
-export async function getAllIdsIn(challengeIds) {
-  return challengeDatasource.getAllIdsIn(challengeIds);
+export async function listBySkillId(skillId) {
+  const challengeDTOs = await challengeDatasource.filterBySkillId(skillId);
+  const [translations, localizedChallenges] = await Promise.all([
+    translationRepository.listByPrefix(prefix),
+    localizedChallengeRepository.listByChallengeIds({ challengeIds: challengeDTOs.map((ch) => ch.id) }),
+  ]);
+  return toDomainList(challengeDTOs, translations, localizedChallenges);
 }
 
 async function loadTranslationsAndLocalizedChallengesForChallenges(challengeDtos) {

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -13,7 +13,7 @@ function _generateId() {
   return generateNewId('challenge');
 }
 
-export async function create(localizedChallenges = [], generateId = _generateId) {
+export async function create({ localizedChallenges = [], generateId = _generateId, transaction: knexConnection = knex }) {
   if (localizedChallenges.length === 0) {
     return;
   }
@@ -28,7 +28,7 @@ export async function create(localizedChallenges = [], generateId = _generateId)
       urlsToConsult: localizedChallenge.urlsToConsult,
     };
   });
-  await knex('localized_challenges').insert(localizedChallengesWithId).onConflict().ignore();
+  await knexConnection('localized_challenges').insert(localizedChallengesWithId).onConflict().ignore();
 }
 
 export async function getByChallengeIdAndLocale({ challengeId, locale }) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -8,7 +8,6 @@ import {
 } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
-import { prefixFor } from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
 import * as airtable from '../airtable.js';
 
@@ -32,6 +31,13 @@ export async function get(id) {
   const prefix = `${skillTranslations.prefix}${skillDTO.id}`;
   const translations = await translationRepository.listByPrefix(prefix);
   return toDomain(skillDTO, translations);
+}
+
+export async function listByTubeId(tubeId) {
+  const datasourceSkills = await skillDatasource.filterByTubeId(tubeId);
+  if (!datasourceSkills) return [];
+  const translations = await translationRepository.listByPrefix(skillTranslations.prefix);
+  return toDomainList(datasourceSkills, translations);
 }
 
 export async function create(skill) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -1,6 +1,11 @@
 import _ from 'lodash';
 
-import { skillDatasource } from '../datasources/airtable/index.js';
+import {
+  competenceDatasource,
+  skillDatasource,
+  tubeDatasource,
+  tutorialDatasource
+} from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { prefixFor } from '../translations/skill.js';
@@ -27,6 +32,14 @@ export async function get(id) {
   const prefix = `${skillTranslations.prefix}${skillDTO.id}`;
   const translations = await translationRepository.listByPrefix(prefix);
   return toDomain(skillDTO, translations);
+}
+
+export async function create(skill) {
+  // liens airtable à rétablir :
+  // Compétence, Comprendre, En savoir plus, Tube
+  const airtableCompetenceId = (await competenceDatasource.getAirtableIdsByIds([skill.competenceId]))[skill.competenceId];
+  const airtableTubeId = (await tubeDatasource.getAirtableIdsByIds([skill.tubeId]))[skill.tubeId];
+  const airtableTutorialAirtableIdsByIds = await tutorialDatasource.getAirtableIdsByIds([...skill.tutorialIds, ...skill.learningMoreTutorialIds]);
 }
 
 function addSpoilDataToSkill(skill, airtableSkills) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { skillDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
+import { prefixFor } from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
 import * as airtable from '../airtable.js';
 
@@ -18,6 +19,14 @@ export async function addSpoilData(skills) {
   const airtableRawObjects = await airtable.findRecords('Acquis', options);
 
   skills.forEach((skill) => addSpoilDataToSkill(skill, airtableRawObjects));
+}
+
+export async function get(id) {
+  const [skillDTO] = await skillDatasource.filter({ filter: { ids: [id] } });
+  if (!skillDTO) return null;
+  const prefix = `${skillTranslations.prefix}${skillDTO.id}`;
+  const translations = await translationRepository.listByPrefix(prefix);
+  return toDomain(skillDTO, translations);
 }
 
 function addSpoilDataToSkill(skill, airtableSkills) {

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -10,6 +10,14 @@ export async function list() {
   return toDomainList(datasourceTubes, translations);
 }
 
+export async function get(id) {
+  const [tubeDTO] = await tubeDatasource.filter({ filter: { ids: [id] } });
+  if (!tubeDTO) return null;
+  const prefix = `${tubeTranslations.prefix}${tubeDTO.id}`;
+  const translations = await translationRepository.listByPrefix(prefix);
+  return toDomain(tubeDTO, translations);
+}
+
 function toDomainList(datasourceTubes, translations) {
   const translationsByTubeId = _.groupBy(translations, 'entityId');
   return datasourceTubes.map(

--- a/api/lib/infrastructure/utils/storage.js
+++ b/api/lib/infrastructure/utils/storage.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import * as config from '../../config.js';
+import { fileStorageTokenRepository } from '../repositories/index.js';
+
+export async function cloneFiles({ urls, millisecondsTimestamp }) {
+  return _callAPIWithRetry(async (token) => {
+    const fnc = async (url) => {
+      const path = url.replace(config.pixEditor.storagePost, '');
+      const filename = url.split('/').pop();
+      const cloneUrl = `${config.pixEditor.storagePost}${millisecondsTimestamp}/${filename}`;
+      await axios.put(cloneUrl, null, {
+        headers: {
+          'X-Auth-Token': token,
+          'X-Copy-From': `${config.pixEditor.storageBucket}/${path}`,
+        },
+      });
+      return cloneUrl;
+    };
+    return Promise.all(urls.map((url) => fnc(url)));
+  });
+}
+
+async function _callAPIWithRetry(fn) {
+  const { value: token } = await fileStorageTokenRepository.create();
+  try {
+    return await fn(token);
+  } catch (error) {
+    if (error.response && error.response.status === 401) {
+      return _callAPIWithRetry(fn);
+    } else {
+      throw error;
+    }
+  }
+}

--- a/api/lib/infrastructure/utils/storage.js
+++ b/api/lib/infrastructure/utils/storage.js
@@ -2,11 +2,11 @@ import axios from 'axios';
 import * as config from '../../config.js';
 import { fileStorageTokenRepository } from '../repositories/index.js';
 
-export async function cloneFiles({ urls, millisecondsTimestamp }) {
+export async function cloneAttachmentsFileInBucket({ attachments, millisecondsTimestamp }) {
   return _callAPIWithRetry(async (token) => {
-    const fnc = async (url) => {
-      const path = url.replace(config.pixEditor.storagePost, '');
-      const filename = url.split('/').pop();
+    const fnc = async (attachment) => {
+      const path = attachment.url.replace(config.pixEditor.storagePost, '');
+      const filename = attachment.url.split('/').pop();
       const cloneUrl = `${config.pixEditor.storagePost}${millisecondsTimestamp}/${filename}`;
       await axios.put(cloneUrl, null, {
         headers: {
@@ -14,9 +14,9 @@ export async function cloneFiles({ urls, millisecondsTimestamp }) {
           'X-Copy-From': `${config.pixEditor.storageBucket}/${path}`,
         },
       });
-      return cloneUrl;
+      attachment.url = cloneUrl;
     };
-    return Promise.all(urls.map((url) => fnc(url)));
+    return Promise.all(attachments.map((attachment) => fnc(attachment)));
   });
 }
 

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -8,6 +8,7 @@ import * as missionsRoute from './application/missions/index.js';
 import * as phraseRoute from './application/phrase.js';
 import * as releasesRoute from './application/releases.js';
 import * as replicationDataRoute from './application/replication-data.js';
+import * as skillsRoute from './application/skills/index.js';
 import * as staticCoursesRoute from './application/static-courses/index.js';
 import * as staticCourseTagsRoute from './application/static-course-tags/index.js';
 import * as staticRoute from './application/static/index.js';
@@ -25,6 +26,7 @@ export const routes = [
   phraseRoute,
   releasesRoute,
   replicationDataRoute,
+  skillsRoute,
   staticCoursesRoute,
   staticCourseTagsRoute,
   staticRoute,

--- a/api/scripts/fill-localized-challenges/index.js
+++ b/api/scripts/fill-localized-challenges/index.js
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
 export async function fillLocalizedChallenges({ airtableClient }) {
   const localizedChallenges = await fetchLocalizedChallenges({ airtableClient });
-  await localizedChallengeRepository.create(localizedChallenges);
+  await localizedChallengeRepository.create({ localizedChallenges });
 }
 
 export async function fetchLocalizedChallenges({ airtableClient }) {

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -94,7 +94,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
 
     it('should create a localized challenge', async function() {
       // when
-      await localizedChallengeRepository.create([
+      await localizedChallengeRepository.create({ localizedChallenges: [
         domainBuilder.buildLocalizedChallenge({
           id: 'localizedChallengeId',
           challengeId: 'challengeId',
@@ -103,7 +103,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
           geography: 'AZ',
           urlsToConsult: ['lien1', 'lien2'],
         })
-      ]);
+      ] });
 
       // then
       const localizedChallenge = await knex('localized_challenges').select();
@@ -122,7 +122,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
     context('when there is no arg', function() {
       it('should do nothing', async function() {
         // when
-        await localizedChallengeRepository.create();
+        await localizedChallengeRepository.create({});
 
         // then
         const localizedChallenge = await knex('localized_challenges').select();
@@ -134,13 +134,13 @@ describe('Integration | Repository | localized-challenge-repository', function()
     context('when there is no id', function() {
       it('should generate an id and create a localized challenge', async function() {
         // when
-        await localizedChallengeRepository.create([{
+        await localizedChallengeRepository.create({ localizedChallenges:[{
           challengeId: 'challengeId',
           locale: 'locale',
           embedUrl: 'https://example.com/embed.html',
           geography: 'BE',
           urlsToConsult: ['lien1', 'lien2'],
-        }], () => 'generated-id');
+        }], generateId: () => 'generated-id' });
 
         // then
         const localizedChallenge = await knex('localized_challenges').select();
@@ -159,7 +159,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
       it('should generate multiple unique ids and create localized challenges', async function() {
 
         // when
-        await localizedChallengeRepository.create([
+        await localizedChallengeRepository.create({ localizedChallenges: [
           {
             challengeId: 'challengeId',
             locale: 'en',
@@ -168,7 +168,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
             challengeId: 'challengeId',
             locale: 'fr',
           }
-        ]);
+        ] });
 
         // then
         const localizedChallenges = await knex('localized_challenges').select();
@@ -189,7 +189,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
         await databaseBuilder.commit();
 
         // when
-        await localizedChallengeRepository.create([
+        await localizedChallengeRepository.create({ localizedChallenges: [
           {
             challengeId: 'challengeId',
             locale: 'en',
@@ -204,7 +204,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
             geography: 'FR',
             urlsToConsult: ['lien1', 'lien2'],
           }
-        ]);
+        ] });
 
         // then
         const localizedChallenges = await knex('localized_challenges').select().orderBy('locale');

--- a/api/tests/tooling/domain-builder/factory/build-attachment.js
+++ b/api/tests/tooling/domain-builder/factory/build-attachment.js
@@ -4,6 +4,7 @@ export function buildAttachment({
   id = 'attachmentId',
   url = 'http://',
   type = 'image',
+  alt = 'alt text',
   challengeId = 'recChallengeId',
   localizedChallengeId = challengeId,
 } = {}) {
@@ -12,6 +13,7 @@ export function buildAttachment({
     id,
     url,
     type,
+    alt,
     challengeId,
     localizedChallengeId,
   });

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -1,6 +1,10 @@
 import { describe, describe as context, expect, it, vi } from 'vitest';
 import { hFake } from '../../test-helper.js';
-import { checkUserHasWriteAccess, checkUserIsAuthenticatedViaBasicAndAdmin, checkUserIsAuthenticatedViaBearer } from '../../../lib/application/security-pre-handlers.js';
+import {
+  checkUserHasWriteAccess,
+  checkUserIsAuthenticatedViaBasicAndAdmin,
+  checkUserIsAuthenticatedViaBearer
+} from '../../../lib/application/security-pre-handlers.js';
 import { userRepository } from '../../../lib/infrastructure/repositories/index.js';
 import { User } from '../../../lib/domain/models/User.js';
 import { UserNotFoundError } from '../../../lib/domain/errors.js';
@@ -171,6 +175,23 @@ describe('Unit | Application | SecurityPreHandlers', () => {
       expect(response.source).to.equal(true);
     });
 
+    it('returns nothing when the user is replicator', async () => {
+      // given
+      const user = new User({
+        id: '1',
+        name: 'AuthenticatedUser',
+        trigram: 'ABC',
+        access: 'replicator',
+      });
+      const request = { auth: { credentials: { user } } };
+
+      // when
+      const response = await checkUserHasWriteAccess(request, hFake);
+
+      // then
+      expect(response.source).to.equal(true);
+    });
+
     it('returns an error when the user is readonly', async () => {
       // given
       const user = new User({
@@ -178,6 +199,24 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         name: 'AuthenticatedUser',
         trigram: 'ABC',
         access: 'readonly',
+      });
+      const request = { auth: { credentials: { user } } };
+
+      // when
+      const response = await checkUserHasWriteAccess(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+      expect(response.isTakeOver).to.be.true;
+    });
+
+    it('returns an error when the user is pix-readonly', async () => {
+      // given
+      const user = new User({
+        id: '1',
+        name: 'AuthenticatedUser',
+        trigram: 'ABC',
+        access: 'readpixonly',
       });
       const request = { auth: { credentials: { user } } };
 

--- a/api/tests/unit/domain/models/Attachment_test.js
+++ b/api/tests/unit/domain/models/Attachment_test.js
@@ -1,0 +1,36 @@
+import { describe, describe as context, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Domain | Attachment', () => {
+  context('#clone', () => {
+    it('should clone the Attachment with a null ID', () => {
+      // given
+      const attachment = domainBuilder.buildAttachment({
+        id: 'oldId',
+        url:'http://cc.c',
+        type: 'illustration',
+        alt: 'je suis où là ?',
+        challengeId: 'challengeId',
+        localizedChallengeId: 'localizedChallengeId'
+      });
+
+      // when
+      const clonedAttachment = attachment.clone({
+        challengeId: 'newChallengeId',
+        localizedChallengeId: 'newLocalizedChallengeId',
+      });
+
+      // then
+      const expectedAttachment = domainBuilder.buildAttachment({
+        id: null,
+        url:'http://cc.c',
+        type: 'illustration',
+        alt: 'je suis où là ?',
+        challengeId: 'newChallengeId',
+        localizedChallengeId: 'newLocalizedChallengeId'
+      });
+
+      expect(clonedAttachment).toStrictEqual(expectedAttachment);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Challenge, LocalizedChallenge } from '../../../../lib/domain/models/index.js';
 import { domainBuilder } from '../../../test-helper.js';
 
@@ -403,6 +403,259 @@ describe('Unit | Domain | Challenge', () => {
 
       // then
       expect(codes).toEqual([null, null, null]);
+    });
+  });
+
+  describe('#cloneChallengeAndAttachments', ()=> {
+    it('should clone challenge (no translations yet)', () => {
+      // given
+      const clonedChallengeId = 'clonedChallengeId';
+      const competenceId = 'competenceId';
+      const skillId = 'skillId';
+      const alternativeVersion = 3;
+      const prototypeVersion = 1;
+      const generateNewIdFnc = vi.fn().mockImplementation(() => clonedChallengeId);
+      const challenge = new Challenge({
+        id: 'challengeId',
+        translations: {
+          fr: {
+            instruction: 'instruction',
+            alternativeInstruction: 'alternativeInstruction',
+            proposals: 'proposals',
+            solution: 'solution',
+            solutionToDisplay: 'solutionToDisplay',
+          },
+        },
+        locales: ['fr'],
+        localizedChallenges: [
+          new LocalizedChallenge({
+            id: 'challengeId',
+            challengeId: 'challengeId',
+            locale: 'fr',
+            status: null,
+            fileIds: [],
+            embedUrl: 'pix-mailccoule.fr',
+            geography: 'France',
+            urlsToConsult: ['https://monurl.fr'],
+          }),
+        ],
+        files: [{
+          fileId: 'attID',
+          localizedChallengeId: 'challengeId'
+        }],
+        accessibility1: 'someValue',
+        accessibility2: 'someOtherValue',
+        alternativeVersion: 5,
+        alpha: 'olé',
+        archivedAt: new Date('2020-01-01'),
+        author: 'CHU',
+        autoReply: 'oui c auto reply',
+        competenceId: 'someCompetenceId',
+        contextualizedFields : ['mes super contextualizedFields'],
+        createdAt: new Date('2019-01-01'),
+        declinable: 'NON',
+        delta: 'super delta',
+        embedHeight: 800,
+        focusable: 'oui avec plaisir',
+        format: 'a4',
+        genealogy: 'Décliné 1',
+        geography: 'Monde',
+        madeObsoleteAt: new Date('2021-01-01'),
+        pedagogy: 'très fort',
+        responsive: 'non pas pour mobile',
+        shuffled: true,
+        skillId: 'oldSkillId',
+        skills: ['videz moi'],
+        spoil: 'poil de nez',
+        status: Challenge.STATUSES.VALIDE,
+        t1Status: 'super t1',
+        t2Status: 'super t2',
+        t3Status: 'super t3',
+        timer: '01:30',
+        type: 'QROCM',
+        updatedAt: new Date('2020-01-01'),
+        validatedAt: new Date('2022-01-01'),
+        version: 8,
+      });
+
+      // when
+      const { clonedChallenge, clonedAttachments } = challenge.cloneChallengeAndAttachments({
+        skillId,
+        competenceId,
+        generateNewIdFnc,
+        prototypeVersion,
+        alternativeVersion,
+        attachments: []
+      });
+
+      // then
+      expect(clonedAttachments).toStrictEqual([]);
+
+      expect(clonedChallenge.id).toEqual(clonedChallengeId);
+      expect(clonedChallenge.accessibility1).toEqual(challenge.accessibility1);
+      expect(clonedChallenge.accessibility2).toEqual(challenge.accessibility2);
+      expect(clonedChallenge.alternativeVersion).toEqual(alternativeVersion);
+      expect(clonedChallenge.alpha).toBeNull;
+      expect(clonedChallenge.archivedAt).toBeNull;
+      expect(clonedChallenge.author).toEqual(challenge.author);
+      expect(clonedChallenge.autoReply).toEqual(challenge.autoReply);
+      expect(clonedChallenge.competenceId).toEqual(competenceId);
+      expect(clonedChallenge.contextualizedFields).toEqual(challenge.contextualizedFields);
+      expect(clonedChallenge.createdAt).toBeNull;
+      expect(clonedChallenge.declinable).toEqual(challenge.declinable);
+      expect(clonedChallenge.delta).toBeNull;
+      expect(clonedChallenge.embedHeight).toEqual(challenge.embedHeight);
+      expect(clonedChallenge.focusable).toEqual(challenge.focusable);
+      expect(clonedChallenge.format).toEqual(challenge.format);
+      expect(clonedChallenge.genealogy).toEqual(challenge.genealogy);
+      expect(clonedChallenge.geography).toEqual(challenge.geography);
+      expect(clonedChallenge.madeObsoleteAt).toBeNull;
+      expect(clonedChallenge.pedagogy).toEqual(challenge.pedagogy);
+      expect(clonedChallenge.responsive).toEqual(challenge.responsive);
+      expect(clonedChallenge.shuffled).toEqual(challenge.shuffled);
+      expect(clonedChallenge.skillId).toEqual(skillId);
+      expect(clonedChallenge.status).toEqual(Challenge.STATUSES.PROPOSE);
+      expect(clonedChallenge.t1Status).toEqual(challenge.t1Status);
+      expect(clonedChallenge.t2Status).toEqual(challenge.t2Status);
+      expect(clonedChallenge.t3Status).toEqual(challenge.t3Status);
+      expect(clonedChallenge.timer).toEqual(challenge.timer);
+      expect(clonedChallenge.type).toEqual(challenge.type);
+      expect(clonedChallenge.updatedAt).toBeNull;
+      expect(clonedChallenge.validatedAt).toBeNull;
+      expect(clonedChallenge.version).toEqual(prototypeVersion);
+      expect(clonedChallenge.locales).toEqual(challenge.locales);
+      expect(clonedChallenge.localizedChallenges[0]).toStrictEqual(domainBuilder.buildLocalizedChallenge({
+        id: clonedChallengeId,
+        challengeId: clonedChallengeId,
+        status: null,
+        embedUrl: challenge.localizedChallenges[0].embedUrl,
+        geography: challenge.localizedChallenges[0].geography,
+        urlsToConsult: challenge.localizedChallenges[0].urlsToConsult,
+        fileIds: [],
+        locale: challenge.localizedChallenges[0].locale,
+      }));
+    });
+
+    it('should clone challenge translations and attachments', () => {
+      // given
+      const clonedChallengeId = 'clonedChallengeId';
+      const competenceId = 'competenceId';
+      const skillId = 'skillId';
+      const alternativeVersion = 3;
+      const prototypeVersion = 1;
+      const generateNewIdFnc = vi.fn().mockImplementation(() => clonedChallengeId);
+      const locales = ['fr', 'nl'];
+
+      const challenge = new Challenge({
+        id: 'challengeId',
+        translations: {
+          fr: {
+            instruction: 'instruction FR',
+            alternativeInstruction: 'alternativeInstruction FR',
+            proposals: 'proposals FR',
+            solution: 'solution FR',
+            solutionToDisplay: 'solutionToDisplay FR',
+          },
+          nl: {
+            instruction: 'instruction NL',
+            alternativeInstruction: 'alternativeInstruction NL',
+            proposals: 'proposals NL',
+            solution: 'solution NL',
+            solutionToDisplay: 'solutionToDisplay NL',
+          },
+        },
+        locales,
+        localizedChallenges: [
+          new LocalizedChallenge({
+            id: 'challengeId',
+            challengeId: 'challengeId',
+            locale: 'fr',
+            status: null,
+            fileIds: ['attachmentIdA'],
+            embedUrl: 'pix-mailccoule.fr',
+            geography: 'France',
+            urlsToConsult: ['https://monurl.fr'],
+          }),
+          new LocalizedChallenge({
+            id: 'locNLChallengeId',
+            challengeId: 'challengeId',
+            locale: 'nl',
+            status: Challenge.STATUSES.VALIDE,
+            fileIds: ['attachmentIdB'],
+            embedUrl: 'pix-mailccoule.nl',
+            geography: 'Netherlands',
+            urlsToConsult: ['https://monurl.nl'],
+          }),
+        ],
+        files: [{
+          fileId: 'attachmentIdA',
+          localizedChallengeId: 'challengeId'
+        },{
+          fileId: 'attachmentIdB',
+          localizedChallengeId: 'locNLChallengeId'
+        }],
+      });
+
+      const attachmentIdA = domainBuilder.buildAttachment({
+        id: 'attachmentIdA',
+        url: 'cc',
+        type: 'illustration',
+        alt: 'mdr',
+        challengeId: 'challengeId',
+        localizedChallengeId: 'challengeId'
+      });
+      const attachmentIdB = domainBuilder.buildAttachment({
+        id: 'attachmentIdB',
+        url: 'cc',
+        type: 'illustration',
+        alt: 'mdr',
+        challengeId: 'challengeId',
+        localizedChallengeId: 'locNLChallengeId'
+      });
+
+      // when
+      const { clonedChallenge, clonedAttachments } = challenge.cloneChallengeAndAttachments({
+        skillId,
+        competenceId,
+        generateNewIdFnc,
+        prototypeVersion,
+        alternativeVersion,
+        attachments: [attachmentIdA, attachmentIdB]
+      });
+
+      // then
+      // airtable ids are unknown yet
+      expect(clonedChallenge.files).toStrictEqual([]);
+
+      expect(clonedChallenge.translations).toStrictEqual({
+        fr: {
+          instruction: 'instruction FR',
+          alternativeInstruction: 'alternativeInstruction FR',
+          proposals: 'proposals FR',
+          solution: 'solution FR',
+          solutionToDisplay: 'solutionToDisplay FR',
+        },
+      });
+
+      expect(clonedChallenge.localizedChallenges).toStrictEqual([domainBuilder.buildLocalizedChallenge({
+        id: clonedChallengeId,
+        challengeId: clonedChallengeId,
+        status: null,
+        embedUrl: challenge.localizedChallenges[0].embedUrl,
+        geography: challenge.localizedChallenges[0].geography,
+        urlsToConsult: challenge.localizedChallenges[0].urlsToConsult,
+        fileIds: [],
+        locale: challenge.localizedChallenges[0].locale,
+      })]);
+
+      expect(clonedAttachments).toStrictEqual([domainBuilder.buildAttachment({
+        id: null,
+        type: attachmentIdA.type,
+        alt: attachmentIdA.alt,
+        url: attachmentIdA.url,
+        localizedChallengeId: clonedChallengeId,
+        challengeId: clonedChallengeId
+      })]);
     });
   });
 });

--- a/api/tests/unit/domain/models/Skill_test.js
+++ b/api/tests/unit/domain/models/Skill_test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { Skill } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Skill', () => {
+  describe('#get isLive', () => {
+    it('should return true when skill is active', () => {
+      // given
+      const skill  = domainBuilder.buildSkill({
+        status: Skill.STATUSES.ACTIF,
+      });
+
+      // when
+      const isLive = skill.isLive;
+
+      // then
+      expect(isLive).to.be.true;
+    });
+
+    it('should return true when skill is en construction', () => {
+      // given
+      const skill  = domainBuilder.buildSkill({
+        status: Skill.STATUSES.EN_CONSTRUCTION,
+      });
+
+      // when
+      const isLive = skill.isLive;
+
+      // then
+      expect(isLive).to.be.true;
+    });
+
+    it.each(Object.keys(Skill.STATUSES).filter((status) => [Skill.STATUSES.ACTIF, Skill.STATUSES.EN_CONSTRUCTION].includes(Skill.STATUSES[status]))
+    )('should return false when status key is %s', (status) => {
+      // given
+      const skill  = domainBuilder.buildSkill({
+        status,
+      });
+
+      // when
+      const isLive = skill.isLive;
+
+      // then
+      expect(isLive).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/Skill_test.js
+++ b/api/tests/unit/domain/models/Skill_test.js
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { Skill } from '../../../../lib/domain/models/index.js';
+import { Challenge, Skill } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Skill', () => {
   describe('#get isLive', () => {
@@ -42,6 +42,251 @@ describe('Unit | Domain | Skill', () => {
 
       // then
       expect(isLive).to.be.false;
+    });
+  });
+
+  describe('#cloneSkillAndChallenges', () => {
+    const clonedSkillId = 'clonedSkillId';
+    const level = 4;
+    let generateNewIdFnc, tubeDestination, skillChallenges;
+
+    beforeEach(() => {
+      generateNewIdFnc = vi.fn().mockImplementation(() => clonedSkillId);
+      tubeDestination = domainBuilder.buildTube({
+        id: 'tubeACB',
+        competenceId: 'competenceA',
+        name: '@monSuperTube',
+      });
+      const lonelyChallenge = domainBuilder.buildChallenge();
+      vi.spyOn(lonelyChallenge, 'cloneChallengeAndAttachments').mockReturnValue({
+        clonedChallenge: 'clonedChallenge',
+        clonedAttachments: ['clonedAttachment'],
+      });
+      skillChallenges = [lonelyChallenge];
+    });
+
+    it('should duplicate skill when destination has no skills', () => {
+      // given
+      const tubeSkills = [
+        domainBuilder.buildSkill({
+          id: 'skillTubeABC1Id',
+          tubeId: tubeDestination.id,
+          level: 1,
+        }),
+        domainBuilder.buildSkill({
+          id: 'skillTubeABC2Id',
+          tubeId: tubeDestination.id,
+          level: 2,
+        }),
+      ];
+      const skillToClone = domainBuilder.buildSkill({
+        id: 'skillToCloneId',
+        version: 3,
+        name: '@unTube5',
+        status: Skill.STATUSES.ACTIF,
+        level: 5,
+        tubeId: 'tubeUnAutreTubeId',
+        competenceId: 'unAutreCompetenceId',
+        description: 'description de mon acquis',
+        hint_i18n: { fr: 'mon super hint en francais' },
+        tutorialIds: ['tutoABC'],
+        learningMoreTutorialIds: ['tutoDEF'],
+        internationalisation: 'Monde',
+      });
+
+      // when
+      const {
+        clonedSkill,
+        clonedChallenges,
+        clonedAttachments,
+      } = skillToClone.cloneSkillAndChallenges({
+        tubeDestination,
+        level,
+        skillChallenges,
+        tubeSkills,
+        generateNewIdFnc,
+      });
+
+      // then
+      const expectedClonedSkill = domainBuilder.buildSkill({
+        id: clonedSkillId,
+        version: 1,
+        level: 4,
+        name: '@monSuperTube4',
+        status: 'en construction',
+        tubeId: tubeDestination.id,
+        competenceId: tubeDestination.competenceId,
+      });
+
+      expect(clonedSkill.id).toEqual(clonedSkillId);
+      expect(clonedSkill.version).toEqual(expectedClonedSkill.version);
+      expect(clonedSkill.name).toEqual(expectedClonedSkill.name);
+      expect(clonedSkill.status).toEqual(expectedClonedSkill.status);
+      expect(clonedSkill.level).toEqual(expectedClonedSkill.level);
+      expect(clonedSkill.tubeId).toEqual(expectedClonedSkill.tubeId);
+      expect(clonedSkill.competenceId).toEqual(expectedClonedSkill.competenceId);
+      expect(clonedChallenges).toEqual(['clonedChallenge']);
+      expect(clonedAttachments).toEqual(['clonedAttachment']);
+
+      expect(clonedSkill.description).toEqual(skillToClone.description);
+      expect(clonedSkill.hint_i18n).toEqual(skillToClone.hint_i18n);
+      expect(clonedSkill.hintStatus).toEqual(skillToClone.hintStatus);
+      expect(clonedSkill.tutorialIds).toEqual(skillToClone.tutorialIds);
+      expect(clonedSkill.learningMoreTutorialIds).toEqual(skillToClone.learningMoreTutorialIds);
+      expect(clonedSkill.internationalisation).toEqual(skillToClone.internationalisation);
+    });
+    it('should set the good version when destination has several skills', () => {
+      // given
+      const tubeSkills = [
+        domainBuilder.buildSkill({
+          id: 'skillTubeABC1Id',
+          tubeId: tubeDestination.id,
+          level: 1,
+        }),
+        domainBuilder.buildSkill({
+          id: 'skillTubeABC2Id',
+          tubeId: tubeDestination.id,
+          level,
+        }),
+      ];
+      const skillToClone = domainBuilder.buildSkill({
+        id: 'skillToCloneId',
+        version: 3,
+        name: '@unTube5',
+        status: Skill.STATUSES.ACTIF,
+        level: 5,
+        tubeId: 'tubeUnAutreTubeId',
+        competenceId: 'unAutreCompetenceId',
+        description: 'description de mon acquis',
+        hint_i18n: { fr: 'mon super hint en francais' },
+        tutorialIds: ['tutoABC'],
+        learningMoreTutorialIds: ['tutoDEF'],
+        internationalisation: 'Monde',
+      });
+
+      // when
+      const {
+        clonedSkill,
+        clonedChallenges,
+        clonedAttachments,
+      } = skillToClone.cloneSkillAndChallenges({
+        tubeDestination,
+        level,
+        skillChallenges,
+        tubeSkills,
+        generateNewIdFnc,
+      });
+
+      // then
+      const expectedClonedSkill = domainBuilder.buildSkill({
+        id: clonedSkillId,
+        version: 2,
+        level: 4,
+        name: '@monSuperTube4',
+        status: 'en construction',
+        tubeId: tubeDestination.id,
+        competenceId: tubeDestination.competenceId,
+      });
+
+      expect(clonedSkill.id).toEqual(clonedSkillId);
+      expect(clonedSkill.version).toEqual(expectedClonedSkill.version);
+      expect(clonedSkill.name).toEqual(expectedClonedSkill.name);
+      expect(clonedSkill.status).toEqual(expectedClonedSkill.status);
+      expect(clonedSkill.level).toEqual(expectedClonedSkill.level);
+      expect(clonedSkill.tubeId).toEqual(expectedClonedSkill.tubeId);
+      expect(clonedSkill.competenceId).toEqual(expectedClonedSkill.competenceId);
+      expect(clonedChallenges).toEqual(['clonedChallenge']);
+      expect(clonedAttachments).toEqual(['clonedAttachment']);
+
+      expect(clonedSkill.description).toEqual(skillToClone.description);
+      expect(clonedSkill.hint_i18n).toEqual(skillToClone.hint_i18n);
+      expect(clonedSkill.hintStatus).toEqual(skillToClone.hintStatus);
+      expect(clonedSkill.tutorialIds).toEqual(skillToClone.tutorialIds);
+      expect(clonedSkill.learningMoreTutorialIds).toEqual(skillToClone.learningMoreTutorialIds);
+      expect(clonedSkill.internationalisation).toEqual(skillToClone.internationalisation);
+    });
+
+    it('should handle reversioning of all challenges', () => {
+      // given
+      const tubeSkills = [
+        domainBuilder.buildSkill({
+          id: 'skillTubeABC2Id',
+          tubeId: tubeDestination.id,
+          level,
+        }),
+      ];
+      const skillToClone = domainBuilder.buildSkill({
+        id: 'skillToCloneId',
+        version: 3,
+        name: '@unTube5',
+        status: Skill.STATUSES.ACTIF,
+        level: 5,
+        tubeId: 'tubeUnAutreTubeId',
+        competenceId: 'unAutreCompetenceId',
+        description: 'description de mon acquis',
+        hint_i18n: { fr: 'mon super hint en francais' },
+        tutorialIds: ['tutoABC'],
+        learningMoreTutorialIds: ['tutoDEF'],
+        internationalisation: 'Monde',
+      });
+
+      const perimeProto = domainBuilder.buildChallenge({ id: 'perimeProtoId', version: 3, genealogy: 'Prototype 1', status: Challenge.STATUSES.PERIME });
+      const archiveProto = domainBuilder.buildChallenge({ id: 'archiveProtoId', version: 4, genealogy: 'Prototype 1', status: Challenge.STATUSES.ARCHIVE });
+      const activeProto = domainBuilder.buildChallenge({ id: 'activeProtoId', version: 5, genealogy: 'Prototype 1', status: Challenge.STATUSES.VALIDE });
+      const decliPerimeProtoActive = domainBuilder.buildChallenge({ id: 'decliPerimeProtoActiveId', version: 5, alternativeVersion: 1, genealogy: 'Décliné 1', status: Challenge.STATUSES.PERIME });
+      const decliArchiveProtoActive = domainBuilder.buildChallenge({ id: 'decliArchiveProtoActiveId', version: 5, alternativeVersion: 2, genealogy: 'Décliné 1', status: Challenge.STATUSES.ARCHIVE });
+      const decliValideProtoActive = domainBuilder.buildChallenge({ id: 'decliValideProtoActiveId', version: 5, alternativeVersion: 3, genealogy: 'Décliné 1', status: Challenge.STATUSES.VALIDE });
+      const decliProposeProtoActive = domainBuilder.buildChallenge({ id: 'decliProposeProtoActiveId', version: 5, alternativeVersion: 4, genealogy: 'Décliné 1', status: Challenge.STATUSES.PROPOSE });
+      const proposeProto = domainBuilder.buildChallenge({ id: 'proposeProtoId', version: 7, genealogy: 'Prototype 1', status: Challenge.STATUSES.PROPOSE });
+      const decliPerimeProtoPropose = domainBuilder.buildChallenge({ id: 'decliPerimeProtoProposeId', version: 7, genealogy: 'Décliné 1', status: Challenge.STATUSES.PERIME });
+      const decliProposeProtoPropose = domainBuilder.buildChallenge({ id: 'decliProposeProtoProposeId', version: 7, genealogy: 'Décliné 1', status: Challenge.STATUSES.PROPOSE });
+      skillChallenges = [
+        perimeProto,
+        archiveProto,
+        activeProto,
+        decliPerimeProtoActive,
+        decliArchiveProtoActive,
+        decliValideProtoActive,
+        decliProposeProtoActive,
+        proposeProto,
+        decliPerimeProtoPropose,
+        decliProposeProtoPropose,
+      ];
+      const spies = {};
+      for (const challenge of skillChallenges) {
+        spies[challenge.id] = vi.spyOn(challenge, 'cloneChallengeAndAttachments').mockImplementation(() => ({
+          clonedChallenge: challenge.id,
+          clonedAttachments: [`${challenge.id}_attachment`],
+        }));
+      }
+
+      // when
+      const { clonedChallenges, clonedAttachments } = skillToClone.cloneSkillAndChallenges({
+        tubeDestination,
+        level,
+        skillChallenges,
+        tubeSkills,
+        generateNewIdFnc,
+      });
+
+      // then
+      expect(clonedAttachments).toEqual(['activeProtoId_attachment', 'decliValideProtoActiveId_attachment', 'decliProposeProtoActiveId_attachment', 'proposeProtoId_attachment', 'decliProposeProtoProposeId_attachment']);
+      expect(clonedChallenges).toEqual(['activeProtoId', 'decliValideProtoActiveId', 'decliProposeProtoActiveId', 'proposeProtoId', 'decliProposeProtoProposeId']);
+      expect(spies[perimeProto.id]).toHaveBeenCalledTimes(0);
+      expect(spies[archiveProto.id]).toHaveBeenCalledTimes(0);
+      expect(spies[decliPerimeProtoActive.id]).toHaveBeenCalledTimes(0);
+      expect(spies[decliArchiveProtoActive.id]).toHaveBeenCalledTimes(0);
+      expect(spies[decliPerimeProtoPropose.id]).toHaveBeenCalledTimes(0);
+      expect(spies[activeProto.id]).toHaveBeenCalledTimes(1);
+      expect(spies[activeProto.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: null, prototypeVersion: 1 });
+      expect(spies[decliValideProtoActive.id]).toHaveBeenCalledTimes(1);
+      expect(spies[decliValideProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 1, prototypeVersion: 1 });
+      expect(spies[decliProposeProtoActive.id]).toHaveBeenCalledTimes(1);
+      expect(spies[decliProposeProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 2, prototypeVersion: 1 });
+      expect(spies[proposeProto.id]).toHaveBeenCalledTimes(1);
+      expect(spies[proposeProto.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: null, prototypeVersion: 2 });
+      expect(spies[decliProposeProtoPropose.id]).toHaveBeenCalledTimes(1);
+      expect(spies[decliProposeProtoPropose.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 1, prototypeVersion: 2 });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/clone-skill_test.js
+++ b/api/tests/unit/domain/usecases/clone-skill_test.js
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cloneSkill } from '../../../../lib/domain/usecases/index.js';
+import { domainBuilder } from '../../../test-helper.js';
+import { Skill } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Usecases | clone-skill', () => {
+  let attachmentRepository, skillRepository, challengeRepository, tubeRepository, generateNewIdFnc;
+  let dependencies;
+  const userId = 123;
+
+  beforeEach(() => {
+    skillRepository = {
+      get: vi.fn(),
+      listByTubeId: vi.fn(),
+      create: vi.fn(),
+    };
+    tubeRepository = {
+      get: vi.fn(),
+    };
+    challengeRepository = {
+      listBySkillId: vi.fn(),
+      createBatch: vi.fn(),
+    };
+    attachmentRepository = {
+      listByChallengeIds: vi.fn(),
+      createBatch: vi.fn(),
+    };
+    generateNewIdFnc = vi.fn();
+    dependencies = {
+      attachmentRepository,
+      skillRepository,
+      challengeRepository,
+      tubeRepository,
+      generateNewIdFnc,
+    };
+  });
+
+  describe('pre-checks KO', () => {
+    it('should throw an error when level is not valid', async () => {
+      // given
+      const cloneCommand = {
+        tubeDestinationId: 'tubeABCId',
+        level: -1,
+        changelogText: '',
+        skillIdToClone: 'skillABC1Id',
+        userId,
+      };
+      skillRepository.get.mockResolvedValue(domainBuilder.buildSkill({ id: cloneCommand.skillIdToClone }));
+      tubeRepository.get.mockResolvedValue(domainBuilder.buildTube({ id: cloneCommand.tubeDestinationId }));
+
+      // when
+      const promise = cloneSkill({ cloneCommand, dependencies });
+
+      // then
+      await expect(promise).rejects.toThrow('Le niveau doit être compris entre 1 et 7');
+    });
+
+    it('should throw an error when tube does not exist', async () => {
+      // given
+      const cloneCommand = {
+        tubeDestinationId: 'tubeABCId',
+        level: 7,
+        changelogText: '',
+        skillIdToClone: 'skillABC1Id',
+        userId,
+      };
+      skillRepository.get.mockResolvedValue('un super acquis');
+      tubeRepository.get.mockResolvedValue(null);
+
+      // when
+      const promise = cloneSkill({ cloneCommand, dependencies });
+
+      // then
+      await expect(promise).rejects.toThrow('Le sujet d\'id "tubeABCId" n\'existe pas');
+    });
+
+    it('should throw an error when skill does not exist', async () => {
+      // given
+      const cloneCommand = {
+        tubeDestinationId: 'tubeABCId',
+        level: 7,
+        changelogText: '',
+        skillIdToClone: 'skillABC1Id',
+        userId,
+      };
+      skillRepository.get.mockResolvedValue(null);
+      tubeRepository.get.mockResolvedValue(domainBuilder.buildTube({ id: cloneCommand.tubeDestinationId }));
+
+      // when
+      const promise = cloneSkill({ cloneCommand, dependencies });
+
+      // then
+      await expect(promise).rejects.toThrow('L\'acquis d\'id "skillABC1Id" n\'existe pas');
+    });
+
+    it('should throw an error when skill is not live', async () => {
+      // given
+      const cloneCommand = {
+        tubeDestinationId: 'tubeABCId',
+        level: 7,
+        changelogText: '',
+        skillIdToClone: 'skillABC1Id',
+        userId,
+      };
+      skillRepository.get.mockResolvedValue(domainBuilder.buildSkill({
+        id: cloneCommand.skillIdToClone,
+        status: Skill.STATUSES.ARCHIVE,
+      }));
+      tubeRepository.get.mockResolvedValue(domainBuilder.buildTube({ id: cloneCommand.tubeDestinationId }));
+
+      // when
+      const promise = cloneSkill({ cloneCommand, dependencies });
+
+      // then
+      await expect(promise).rejects.toThrow('Impossible de cloner un acquis qui ne soit ni en construction ni actif');
+    });
+  });
+
+  describe('pre-check OK', () => {
+    let cloneCommand, spyCloneFnc, skillToClone, tube, challengeToClone1, challengeToClone2, tubeSkill1, tubeSkill2, attachmentToClone1;
+    beforeEach(() => {
+      cloneCommand = {
+        tubeDestinationId: 'tubeABCId',
+        level: 4,
+        changelogText: '',
+        skillIdToClone: 'skillABC1Id',
+        userId,
+      };
+      skillToClone = domainBuilder.buildSkill({ id: cloneCommand.skillIdToClone });
+      skillRepository.get.mockResolvedValue(skillToClone);
+      tube = domainBuilder.buildTube({ id: cloneCommand.tubeDestinationId });
+      tubeRepository.get.mockResolvedValue(tube);
+      challengeToClone1 = domainBuilder.buildChallenge({ id: 'challenge1' });
+      challengeToClone2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+      challengeRepository.listBySkillId.mockResolvedValue([challengeToClone1, challengeToClone2]);
+      tubeSkill1 = domainBuilder.buildSkill({ id: 'tubeSkill1', tubeId: cloneCommand.tubeDestinationId });
+      tubeSkill2 = domainBuilder.buildSkill({ id: 'tubeSkill2', tubeId: cloneCommand.tubeDestinationId });
+      skillRepository.listByTubeId.mockResolvedValue([tubeSkill1, tubeSkill2]);
+      attachmentToClone1 = domainBuilder.buildAttachment({ id: 'challenge1_attachment', challengeId: 'challenge1' });
+      attachmentRepository.listByChallengeIds.mockResolvedValue([attachmentToClone1]);
+      skillRepository.create.mockResolvedValue();
+      challengeRepository.createBatch.mockResolvedValue();
+      attachmentRepository.createBatch.mockResolvedValue();
+    });
+
+    it('should call the cloning method with expected arguments', async () => {
+      // given
+      spyCloneFnc = vi.spyOn(skillToClone, 'cloneSkillAndChallenges').mockReturnValue({
+        clonedSkill: 'clonedSkill',
+        clonedChallenges: 'clonedChallenges',
+        clonedAttachments: [{ challengeId: 'attachmentChallengeId', localizedChallengeId: 'attachmentLocalizedChallengeId' }],
+      });
+
+      // when
+      await cloneSkill({ cloneCommand, dependencies });
+
+      // then
+      expect(skillRepository.get).toHaveBeenCalledWith(cloneCommand.skillIdToClone);
+      expect(tubeRepository.get).toHaveBeenCalledWith(cloneCommand.tubeDestinationId);
+      expect(challengeRepository.listBySkillId).toHaveBeenCalledWith(cloneCommand.skillIdToClone);
+      expect(skillRepository.listByTubeId).toHaveBeenCalledWith(cloneCommand.tubeDestinationId);
+      expect(attachmentRepository.listByChallengeIds).toHaveBeenCalledWith([challengeToClone1.id, challengeToClone2.id]);
+      expect(spyCloneFnc).toHaveBeenCalledWith({
+        tubeDestination: tube,
+        level: cloneCommand.level,
+        skillChallenges: [challengeToClone1, challengeToClone2],
+        tubeSkills: [tubeSkill1, tubeSkill2],
+        attachments: [attachmentToClone1],
+        generateNewIdFnc,
+      });
+    });
+
+    it('should send to persistance to cloned entities', async () => {
+      // given
+      const clonedSkill = Symbol('clonedSkill');
+      const clonedChallenges = Symbol('clonedChallenges');
+      const clonedAttachments = [
+        { challengeId: 'notPrimaryChal', localizedChallengeId: 'notPrimaryLoc' },
+        { challengeId: 'primaryChallengeId', localizedChallengeId: 'primaryChallengeId' },
+      ];
+      spyCloneFnc = vi.spyOn(skillToClone, 'cloneSkillAndChallenges').mockReturnValue({
+        clonedSkill,
+        clonedChallenges,
+        clonedAttachments,
+      });
+
+      // when
+      await cloneSkill({ cloneCommand, dependencies });
+
+      // then
+      expect(skillRepository.create).toHaveBeenCalledWith(clonedSkill);
+      expect(challengeRepository.createBatch).toHaveBeenCalledWith(clonedChallenges);
+      expect(attachmentRepository.createBatch).toHaveBeenCalledWith([{ challengeId: 'primaryChallengeId', localizedChallengeId: 'primaryChallengeId' }]);
+    });
+
+    it.todo('should send to persistance the changelog');
+  });
+});

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -91,7 +91,7 @@ describe('Unit | Domain | Usecases | import-translations', function() {
       shouldDuplicateToAirtable: false,
     });
     expect(localizedChallengeRepository.create).toHaveBeenCalledOnce();
-    expect(localizedChallengeRepository.create).toHaveBeenCalledWith([
+    expect(localizedChallengeRepository.create).toHaveBeenCalledWith({ localizedChallenges: [
       new LocalizedChallenge({
         id: null,
         challengeId: 'id',
@@ -112,6 +112,6 @@ describe('Unit | Domain | Usecases | import-translations', function() {
         geography: null,
         urlsToConsult: null,
       }),
-    ]);
+    ] });
   });
 });

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { domainBuilder, airtableBuilder } from '../../../../test-helper.js';
-import { challengeDatasource } from '../../../../../lib/infrastructure/datasources/airtable/challenge-datasource.js';
+import { airtableBuilder, domainBuilder } from '../../../../test-helper.js';
+import { challengeDatasource } from '../../../../../lib/infrastructure/datasources/airtable/index.js';
 import * as airtable from '../../../../../lib/infrastructure/airtable.js';
 import airtableLib from 'airtable';
 

--- a/api/tests/unit/infrastructure/utils/storage_test.js
+++ b/api/tests/unit/infrastructure/utils/storage_test.js
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fileStorageTokenRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import * as config from '../../../../lib/config.js';
+import nock from 'nock';
+import { cloneFiles } from '../../../../lib/infrastructure/utils/storage.js';
+
+describe('Unit | Infrastructure | Storage', () => {
+
+  describe('#cloneFiles', () => {
+    const token = 'mon_super_token';
+    beforeEach(() => {
+      vi.spyOn(fileStorageTokenRepository, 'create').mockImplementation(() => ({ value: token }));
+      vi.useFakeTimers({
+        now: new Date('2021-07-14T03:04:00Z'),
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    });
+
+    it('should clone files', async () => {
+      // given
+      const originUrlA = `${config.pixEditor.storagePost}un_dossier/mon_imageA.jpg`;
+      const originUrlB = `${config.pixEditor.storagePost}un_dossier/mon_imageB.jpg`;
+      const expectedDestUrlA = `${config.pixEditor.storagePost}${Date.now()}/mon_imageA.jpg`;
+      const expectedDestUrlB = `${config.pixEditor.storagePost}${Date.now()}/mon_imageB.jpg`;
+      const [, baseUrlA, routeA] = [...expectedDestUrlA.matchAll(/^(http.*com)(.*)/g)][0];
+      const requestInterceptorA = nock(baseUrlA)
+        .put(routeA)
+        .matchHeader('X-Auth-Token', token)
+        .matchHeader('X-Copy-From', `${config.pixEditor.storageBucket}/un_dossier/mon_imageA.jpg`)
+        .reply(200);
+      const [, baseUrlB, routeB] = [...expectedDestUrlB.matchAll(/^(http.*com)(.*)/g)][0];
+      const requestInterceptorB = nock(baseUrlB)
+        .put(routeB)
+        .matchHeader('X-Auth-Token', token)
+        .matchHeader('X-Copy-From', `${config.pixEditor.storageBucket}/un_dossier/mon_imageB.jpg`)
+        .reply(200);
+
+      // when
+      const clonedUrls = await cloneFiles({ urls: [originUrlA, originUrlB], millisecondsTimestamp: Date.now() });
+
+      // then
+      expect(requestInterceptorA.isDone()).to.be.true;
+      expect(requestInterceptorB.isDone()).to.be.true;
+      expect(clonedUrls).toStrictEqual([expectedDestUrlA, expectedDestUrlB]);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/utils/storage_test.js
+++ b/api/tests/unit/infrastructure/utils/storage_test.js
@@ -2,11 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fileStorageTokenRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import * as config from '../../../../lib/config.js';
 import nock from 'nock';
-import { cloneFiles } from '../../../../lib/infrastructure/utils/storage.js';
+import { domainBuilder } from '../../../test-helper.js';
+import { cloneAttachmentsFileInBucket } from '../../../../lib/infrastructure/utils/storage.js';
 
 describe('Unit | Infrastructure | Storage', () => {
 
-  describe('#cloneFiles', () => {
+  describe('#cloneAttachmentsFileInBucket', () => {
     const token = 'mon_super_token';
     beforeEach(() => {
       vi.spyOn(fileStorageTokenRepository, 'create').mockImplementation(() => ({ value: token }));
@@ -23,8 +24,12 @@ describe('Unit | Infrastructure | Storage', () => {
 
     it('should clone files', async () => {
       // given
-      const originUrlA = `${config.pixEditor.storagePost}un_dossier/mon_imageA.jpg`;
-      const originUrlB = `${config.pixEditor.storagePost}un_dossier/mon_imageB.jpg`;
+      const attachmentA = domainBuilder.buildAttachment({
+        url: `${config.pixEditor.storagePost}un_dossier/mon_imageA.jpg`,
+      });
+      const attachmentB = domainBuilder.buildAttachment({
+        url: `${config.pixEditor.storagePost}un_dossier/mon_imageB.jpg`,
+      });
       const expectedDestUrlA = `${config.pixEditor.storagePost}${Date.now()}/mon_imageA.jpg`;
       const expectedDestUrlB = `${config.pixEditor.storagePost}${Date.now()}/mon_imageB.jpg`;
       const [, baseUrlA, routeA] = [...expectedDestUrlA.matchAll(/^(http.*com)(.*)/g)][0];
@@ -41,12 +46,13 @@ describe('Unit | Infrastructure | Storage', () => {
         .reply(200);
 
       // when
-      const clonedUrls = await cloneFiles({ urls: [originUrlA, originUrlB], millisecondsTimestamp: Date.now() });
+      await cloneAttachmentsFileInBucket({ attachments: [attachmentA, attachmentB], millisecondsTimestamp: Date.now() });
 
       // then
       expect(requestInterceptorA.isDone()).to.be.true;
       expect(requestInterceptorB.isDone()).to.be.true;
-      expect(clonedUrls).toStrictEqual([expectedDestUrlA, expectedDestUrlB]);
+      expect(attachmentA.url).toStrictEqual(expectedDestUrlA);
+      expect(attachmentB.url).toStrictEqual(expectedDestUrlB);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Besoin de dupliquer en masse des acquis pour les passer en focus.
On voulait faire un script pour faire ça bien (car y'a pas mal de règles métier liées à la duplication) mais tout est fait côté front aujourd'hui.

## :robot: Proposition
Etape 1 (cette PR):
Créer un usecase côté back qui duplique un acquis et ses épreuves avec les mêmes règles métier que dans le front.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
On a créé un acquis prêt à dupliquer dans le réf des dev > compétence 1.3
