### PR TITLE
[BUGFIX] Vérifie la validité des thématiques de la mission via l'id persistant.

### DIFF
--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -127,7 +127,7 @@ export default class MissionForm extends Component {
   @action
   updateAvailableThematicIds(competenceId) {
     const filteredCompetence = this.args.competences.filter((competence) => competence.pixId === competenceId);
-    const availableThematicIds = filteredCompetence[0].themes.map((thematic) => thematic.id);
+    const availableThematicIds = filteredCompetence[0].themes.map((thematic) => thematic.pixId);
     this.thematicIds.setAvailableThematicIds(availableThematicIds);
   }
 


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Lors de la saisie d'une mission, la validité des thématiques est vérifiée en se basant sur l'identifiant Airtable.
Depuis la v3.147.0, c'est l'identifiant `id persistant` qui est l'identifiant unique utilisée par LCMS pour générer la release.
Cela entraine une release avec des missions dont le contenu est manquant.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On vérifie la validité des thématiques saisies via la propriété `pixId` qui correspond au champ `id persistant`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
Heureusement, nous l'avons trouvé avant les panels.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Modifier une mission en saisissant des identifiants de thématiques.
Générer une release.
Vérifier que les missions contiennent toutes les étapes et le défi.
