### PR TITLE
[BUGFIX] Trie les versions alternatives dans les missions de la release (PIX-12789).

### DIFF
--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -85,6 +85,7 @@ export async function list() {
 }
 
 const _byLevel = (skillA, skillB) => skillA.level - skillB.level;
+const _byAlternativeVersion = (challengeA, challengeB) => challengeA.alternativeVersion - challengeB.alternativeVersion;
 
 function _getChallengeIdsForActivity(missionTubes, skills, challenges, activityPostfix) {
   const activityTube = missionTubes.find(({ name }) => name.endsWith(activityPostfix));
@@ -112,7 +113,7 @@ function _getChallengeIdsForActivity(missionTubes, skills, challenges, activityP
     if (alternatives.length === 0) {
       logger.warn({ activitySkill }, 'No challenges found for activitySkill');
     }
-    return alternatives.map(({ id }) => id);
+    return alternatives.sort(_byAlternativeVersion).map(({ id }) => id);
   }).filter((activitySkills) => activitySkills.length > 0);
 }
 

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -418,6 +418,57 @@ describe('Integration | Repository | mission-repository', function() {
       });
     });
 
+    context('with alternative challenges in activities', async function() {
+      it('should return ordered alternative challenges', async function() {
+        mockedLearningContent.challenges = [
+          airtableBuilder.factory.buildChallenge({ id: 'secondAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 2 }),
+          airtableBuilder.factory.buildChallenge({ id: 'firstAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 1 }),
+          airtableBuilder.factory.buildChallenge({ id: 'fourthAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 4 }),
+          airtableBuilder.factory.buildChallenge({ id: 'thirdAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 3 }),
+        ];
+        mockedLearningContent.skills = [
+          airtableBuilder.factory.buildSkill({ id: 'skillValidation1', level: 1, tubeId: 'tubeValidation1' }),
+        ];
+        airtableBuilder.mockLists(mockedLearningContent);
+
+        buildLocalizedChallenges(mockedLearningContent);
+
+        databaseBuilder.factory.buildMission({
+          id: 2,
+          name: 'Alt name',
+          status: Mission.status.ACTIVE,
+          learningObjectives: 'Alt objectives',
+          validatedObjectives: 'Alt validated objectives',
+          thematicIds: 'thematicStep1,thematicDefiVide',
+        });
+
+        await databaseBuilder.commit();
+
+        const result = await list();
+
+        expect(result).to.deep.equal([new Mission({
+          id: 2,
+          name_i18n: { fr: 'Alt name' },
+          competenceId: 'competenceId',
+          thematicIds: 'thematicStep1,thematicDefiVide',
+          learningObjectives_i18n: { fr: 'Alt objectives' },
+          validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          status: Mission.status.ACTIVE,
+          createdAt: new Date('2010-01-04'),
+          content: {
+            steps: [{
+              tutorialChallenges: [],
+              trainingChallenges: [],
+              validationChallenges: [
+                ['firstAltChallengeValidation', 'secondAltChallengeValidation', 'thirdAltChallengeValidation', 'fourthAltChallengeValidation'],
+              ],
+            }],
+            dareChallenges: [],
+          },
+        })]);
+      });
+    });
+
     context('Without challenges for skills', async function() {
       it('Should return missions', async function() {
         mockedLearningContent.challenges = [];


### PR DESCRIPTION
## :unicorn: Problème

Les alternatives n'étaient pas bien trié dans les missions de la release

## :robot: Proposition

Trier les alternatives.

## :rainbow: Remarques

## :100: Pour tester

Générer une release dans laquelle il y a des versions alternatives, s'assurer qu'elles sont trié dans l'ordre.
