### PR TITLE
[BUGFIX] Corriger l'ordre des challenge quand la déclinaison est undefined (Pix-12881)

### DIFF
--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -85,7 +85,7 @@ export async function list() {
 }
 
 const _byLevel = (skillA, skillB) => skillA.level - skillB.level;
-const _byAlternativeVersion = (challengeA, challengeB) => challengeA.alternativeVersion - challengeB.alternativeVersion;
+const _byAlternativeVersion = (challengeA, challengeB) => (challengeA.alternativeVersion ?? 0) - (challengeB.alternativeVersion ?? 0);
 
 function _getChallengeIdsForActivity(missionTubes, skills, challenges, activityPostfix) {
   const activityTube = missionTubes.find(({ name }) => name.endsWith(activityPostfix));

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -421,10 +421,10 @@ describe('Integration | Repository | mission-repository', function() {
     context('with alternative challenges in activities', async function() {
       it('should return ordered alternative challenges', async function() {
         mockedLearningContent.challenges = [
-          airtableBuilder.factory.buildChallenge({ id: 'secondAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 2 }),
-          airtableBuilder.factory.buildChallenge({ id: 'firstAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 1 }),
-          airtableBuilder.factory.buildChallenge({ id: 'fourthAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 4 }),
-          airtableBuilder.factory.buildChallenge({ id: 'thirdAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 3 }),
+          airtableBuilder.factory.buildChallenge({ id: 'secondAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 1 }),
+          airtableBuilder.factory.buildChallenge({ id: 'firstAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: undefined }),
+          airtableBuilder.factory.buildChallenge({ id: 'fourthAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 3 }),
+          airtableBuilder.factory.buildChallenge({ id: 'thirdAltChallengeValidation', status: 'validé', skillId: 'skillValidation1', alternativeVersion: 2 }),
         ];
         mockedLearningContent.skills = [
           airtableBuilder.factory.buildSkill({ id: 'skillValidation1', level: 1, tubeId: 'tubeValidation1' }),


### PR DESCRIPTION
## :unicorn: Problème
On a des challenge qui n'ont pas d'alternative version (ce sont les proto/première version d'une épreuve). Or dans notre tri, on ne les a pas pris en compte, donc ça les ordonnes de manière aléatoire.

## :robot: Proposition
Corriger pour prendre les épreuves dans le bon ordre.

## :rainbow: Remarques

## :100: Pour tester
- générer une release et vérifier que les challenges sont ordonnés dans le bon ordre dans les missions