### PR TITLE
[BUGFIX] Echec lors du clone des attachments pour les épreuves localisées pour le script de passage en focus (PIX-13061)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -180,16 +180,10 @@ export class Challenge {
         newLocalizedChallengeId = generateNewIdFnc(Challenge.ID_PREFIX);
         status = LocalizedChallenge.STATUSES.PAUSE;
       }
-      const clonedLocalizedChallenge = localizedChallenge.clone({ id: newLocalizedChallengeId, challengeId: id, status });
+      const { clonedLocalizedChallenge, clonedAttachments: clonedAttachmentsForLoc } = localizedChallenge.clone({ id: newLocalizedChallengeId, challengeId: id, status, attachments });
       clonedLocalizedChallenges.push(clonedLocalizedChallenge);
       cloneSource.set(clonedLocalizedChallenge, localizedChallenge);
-      for (const attachmentId of localizedChallenge.fileIds) {
-        const attachmentToClone = attachments.find((attachment) => attachment.id === attachmentId);
-        clonedAttachments.push(attachmentToClone.clone({
-          challengeId: id,
-          localizedChallengeId: newLocalizedChallengeId,
-        }));
-      }
+      clonedAttachments.push(...clonedAttachmentsForLoc);
     }
 
     const clonedChallenge =  new Challenge({

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -66,8 +66,9 @@ export class LocalizedChallenge {
     });
   }
 
-  clone({ id, challengeId, status }) {
-    return new LocalizedChallenge({
+  clone({ id, challengeId, status, attachments }) {
+    const clonedAttachments = [];
+    const clonedLocalizedChallenge = new LocalizedChallenge({
       id,
       challengeId,
       status,
@@ -77,5 +78,16 @@ export class LocalizedChallenge {
       geography: this.geography,
       urlsToConsult: this.urlsToConsult,
     });
+    for (const attachmentId of this.fileIds) {
+      const attachmentToClone = attachments.find((attachment) => attachment.id === attachmentId);
+      clonedAttachments.push(attachmentToClone.clone({
+        challengeId: this.isPrimary ? challengeId : null,
+        localizedChallengeId: id,
+      }));
+    }
+    return {
+      clonedLocalizedChallenge,
+      clonedAttachments,
+    };
   }
 }

--- a/api/lib/domain/usecases/clone-skill.js
+++ b/api/lib/domain/usecases/clone-skill.js
@@ -78,8 +78,8 @@ async function _checkIfCloningIsPossible({ level, tubeId, skillIdToClone, tubeRe
 async function _fetchData({ skillToCloneId, tubeId, challengeRepository, skillRepository, attachmentRepository }) {
   const skillChallenges = await challengeRepository.listBySkillId(skillToCloneId);
   const tubeSkills = await skillRepository.listByTubeId(tubeId);
-  const challengeIds = skillChallenges.map((ch) => ch.id);
-  const attachments = await attachmentRepository.listByChallengeIds(challengeIds);
+  const localizedChallengeIds = skillChallenges.flatMap((ch) => ch.localizedChallenges.map((loc) => loc.id));
+  const attachments = await attachmentRepository.listByLocalizedChallengeIds(localizedChallengeIds);
 
   return {
     skillChallenges,

--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -57,10 +57,10 @@ export const attachmentDatasource = datasource.extend({
     return airtableRawObjects.map(this.fromAirTableObject);
   },
 
-  async filterByChallengeIds(challengeIds) {
-    if (challengeIds.length === 0) return undefined;
+  async filterByLocalizedChallengeIds(localizedChallengeIds) {
+    if (localizedChallengeIds.length === 0) return undefined;
     const airtableRawObjects = await findRecords(this.tableName, {
-      filterByFormula: `OR(${challengeIds.map((id) => `FIND("${id}", ARRAYJOIN({challengeId persistant}))`).join(',')})`,
+      filterByFormula: `OR(${localizedChallengeIds.map((id) => `FIND("${id}", ARRAYJOIN({localizedChallengeId}))`).join(',')})`,
     });
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -14,11 +14,11 @@ export async function list() {
   return toDomainList(datasourceAttachments, translations, localizedChallenges);
 }
 
-export async function listByChallengeIds(challengeIds) {
-  const datasourceAttachments = await attachmentDatasource.filterByChallengeIds(challengeIds);
+export async function listByLocalizedChallengeIds(localizedChallengeIds) {
+  const datasourceAttachments = await attachmentDatasource.filterByLocalizedChallengeIds(localizedChallengeIds);
   if (!datasourceAttachments) return [];
   const translations = await translationRepository.listByPattern('challenge.%.illustrationAlt');
-  const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds });
+  const localizedChallenges = await localizedChallengeRepository.listByIds({ ids: localizedChallengeIds });
 
   return toDomainList(datasourceAttachments, translations, localizedChallenges);
 }

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -48,6 +48,13 @@ export async function listByChallengeIds({ challengeIds, transaction: knexConnec
   return dtos.map(_toDomain);
 }
 
+export async function listByIds({ ids, transaction: knexConnection = knex }) {
+  const dtos = await _queryLocalizedChallengeWithAttachment(knexConnection)
+    .whereIn('id', ids)
+    .orderBy(['challengeId', 'locale']);
+  return dtos.map(_toDomain);
+}
+
 export async function get({ id, transaction: knexConnection = knex }) {
   const dto = await _queryLocalizedChallengeWithAttachment(knexConnection)
     .where('id', id)

--- a/api/scripts/move-skills-to-focus/index.js
+++ b/api/scripts/move-skills-to-focus/index.js
@@ -108,8 +108,8 @@ async function _cloneSkillAndChallengesAndAttachments({ skill, skillChallenges, 
   let clonedAttachments, clonedChallenges, clonedSkill;
   try {
     const tubeSkills = await skillRepository.listByTubeId(skill.tubeId);
-    const challengeIds = skillChallenges.map((ch) => ch.id);
-    const attachments = await attachmentRepository.listByChallengeIds(challengeIds);
+    const localizedChallengeIds = skillChallenges.flatMap((ch) => ch.localizedChallenges.map((loc) => loc.id));
+    const attachments = await attachmentRepository.listByLocalizedChallengeIds(localizedChallengeIds);
     // Exploitation du duck typing pour tricher
     // tubeDestination : besoin de name, competenceId et id
     const tubeDestination = {

--- a/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
@@ -152,9 +152,9 @@ describe('Integration | Repository | attachment-repository', () => {
     });
   });
 
-  describe('#listByChallengeIds', () => {
+  describe('#listByLocalizedChallengeIds', () => {
 
-    it('should retrieve attachments by given challenge ids', async () => {
+    it('should retrieve attachments by given localized challenge ids', async () => {
       // given
       const attachment_NL_forChallengeA_data = {
         id: 'attachment_NL_forChallengeA_data_id',
@@ -229,7 +229,7 @@ describe('Integration | Repository | attachment-repository', () => {
       await databaseBuilder.commit();
       vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Attachments') expect.unreachable('Airtable tableName should be Attachments');
-        if (options?.filterByFormula !== 'OR(FIND("challengeA", ARRAYJOIN({challengeId persistant})),FIND("challengeB", ARRAYJOIN({challengeId persistant})))') expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !== 'OR(FIND("challengeA", ARRAYJOIN({localizedChallengeId})),FIND("localizedChallengeNLForChallengeA", ARRAYJOIN({localizedChallengeId})),FIND("challengeB", ARRAYJOIN({localizedChallengeId})))') expect.unreachable('Wrong filterByFormula');
         return [
           {
             id: attachment_NL_forChallengeA_data.id,
@@ -277,7 +277,7 @@ describe('Integration | Repository | attachment-repository', () => {
       });
 
       // when
-      const attachments = await attachmentRepository.listByChallengeIds(['challengeA', 'challengeB']);
+      const attachments = await attachmentRepository.listByLocalizedChallengeIds(['challengeA', 'localizedChallengeNLForChallengeA', 'challengeB']);
 
       // then
       expect(attachments).toStrictEqual([
@@ -317,7 +317,7 @@ describe('Integration | Repository | attachment-repository', () => {
       ]);
     });
 
-    it('should return an empty array when no challenge ids provided', async () => {
+    it('should return an empty array when no localized challenge ids provided', async () => {
       // given
       databaseBuilder.factory.buildTranslation({
         key: 'challenge.challengeA.illustrationAlt',
@@ -335,22 +335,22 @@ describe('Integration | Repository | attachment-repository', () => {
       });
 
       // when
-      const attachments = await attachmentRepository.listByChallengeIds([]);
+      const attachments = await attachmentRepository.listByLocalizedChallengeIds([]);
 
       // then
       expect(attachments).toStrictEqual([]);
     });
 
-    it('should return an empty array when no attachment found for provided challenge ids', async () => {
+    it('should return an empty array when no attachment found for provided localized challenge ids', async () => {
       // given
       vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Attachments') expect.unreachable('Airtable tableName should be Attachments');
-        if (options?.filterByFormula !== 'OR(FIND("someChallengeId", ARRAYJOIN({challengeId persistant})))') expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !== 'OR(FIND("someLocalizedChallengeId", ARRAYJOIN({localizedChallengeId})))') expect.unreachable('Wrong filterByFormula');
         return [];
       });
 
       // when
-      const attachments = await attachmentRepository.listByChallengeIds(['someChallengeId']);
+      const attachments = await attachmentRepository.listByLocalizedChallengeIds(['someLocalizedChallengeId']);
 
       // then
       expect(attachments).toStrictEqual([]);

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -502,6 +502,134 @@ describe('Integration | Repository | localized-challenge-repository', function()
     });
   });
 
+  context('#listByIds', () => {
+    it('should return the list of localized challenges for a list of challenge IDs', async () => {
+      const id1 = 'locChallengeId1';
+      const id2 = 'locChallengeId2';
+      const id3 = 'locChallengeId3';
+      const embedUrl = 'https://example.com';
+
+      // given
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: id1,
+        challengeId: 'challengeA',
+        locale: 'fr-fr',
+        embedUrl,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: id2,
+        challengeId: 'challengeA',
+        locale: 'en',
+        embedUrl,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: id3,
+        challengeId: 'challengeB',
+        locale: 'nl',
+        embedUrl,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'anotherOne',
+        challengeId: 'challengeB',
+        locale: 'fr-fr',
+        embedUrl,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const localizedChallenges = await localizedChallengeRepository.listByIds({ ids: [id1, id2, id3] });
+
+      // then
+      expect(localizedChallenges).to.deep.equal([
+        domainBuilder.buildLocalizedChallenge({
+          id: id2,
+          challengeId: 'challengeA',
+          locale: 'en',
+          embedUrl,
+          urlsToConsult: null,
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: id1,
+          challengeId: 'challengeA',
+          locale: 'fr-fr',
+          embedUrl,
+          urlsToConsult: null,
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: id3,
+          challengeId: 'challengeB',
+          locale: 'nl',
+          embedUrl,
+          urlsToConsult: null,
+        }),
+      ]);
+    });
+    context('when there are attachments', () => {
+      it('should return the list of localized challenges with attachment for a list of challenge IDs', async () => {
+        const id1 = 'locChallengeId1';
+        const id2 = 'locChallengeId2';
+        const id3 = 'locChallengeId3';
+        const embedUrl = 'url.com';
+
+        // given
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: id1,
+          challengeId: 'challengeA',
+          locale: 'fr-fr',
+          embedUrl,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: id2,
+          challengeId: 'challengeA',
+          locale: 'en',
+          embedUrl,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: id3,
+          challengeId: 'challengeB',
+          locale: 'nl',
+          embedUrl,
+        });
+
+        databaseBuilder.factory.buildLocalizedChallengeAttachment({
+          localizedChallengeId: id2,
+          attachmentId: 'attachment-en',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const localizedChallenges = await localizedChallengeRepository.listByIds({ ids: [id1, id2, id3] });
+
+        // then
+        expect(localizedChallenges).to.deep.equal([
+          domainBuilder.buildLocalizedChallenge({
+            id: id2,
+            challengeId: 'challengeA',
+            locale: 'en',
+            embedUrl,
+            urlsToConsult: null,
+            fileIds: ['attachment-en'],
+          }),
+          domainBuilder.buildLocalizedChallenge({
+            id: id1,
+            challengeId: 'challengeA',
+            locale: 'fr-fr',
+            embedUrl,
+            urlsToConsult: null,
+          }),
+          domainBuilder.buildLocalizedChallenge({
+            id: id3,
+            challengeId: 'challengeB',
+            locale: 'nl',
+            embedUrl,
+            urlsToConsult: null,
+          })
+        ]);
+      });
+    });
+  });
+
   context('#get', () => {
     it('should return localized challenge by id', async () => {
       // given

--- a/api/tests/scripts/move-skills-to-focus_test.js
+++ b/api/tests/scripts/move-skills-to-focus_test.js
@@ -34,7 +34,7 @@ describe('Script | Move skills to focus', function() {
     vi.spyOn(skillRepository, 'create');
     vi.spyOn(skillRepository, 'update');
     vi.spyOn(idGenerator, 'generateNewId');
-    vi.spyOn(attachmentRepository, 'listByChallengeIds');
+    vi.spyOn(attachmentRepository, 'listByLocalizedChallengeIds');
     vi.spyOn(attachmentRepository, 'createBatch');
   });
 
@@ -310,7 +310,7 @@ describe('Script | Move skills to focus', function() {
         challengeId: 'valideDecliValideProtoForActifSkillId',
         localizedChallengeId: 'valideDecliValideProtoForActifSkillId',
       });
-      attachmentRepository.listByChallengeIds.mockImplementation(() => [
+      attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => [
         valideProtoAttachment,
         proposeDecliAttachment,
         valideDecliAttachment,
@@ -701,7 +701,7 @@ describe('Script | Move skills to focus', function() {
         .reply(200, { records: [actifSkill] });
 
       skillRepository.listByTubeId.mockImplementation(() => []);
-      attachmentRepository.listByChallengeIds.mockImplementation(() => []);
+      attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => []);
 
       const valideForActifSkillData = {
         id: 'valideForActifSkillId',
@@ -896,7 +896,7 @@ describe('Script | Move skills to focus', function() {
           challengeId: 'valideDecliValideProtoForActifSkillId',
           localizedChallengeId: 'valideDecliValideProtoForActifSkillId',
         });
-        attachmentRepository.listByChallengeIds.mockImplementation(() => [
+        attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => [
           valideProtoAttachment,
           proposeDecliAttachment,
           valideDecliAttachment,

--- a/api/tests/scripts/move-skills-to-focus_test.js
+++ b/api/tests/scripts/move-skills-to-focus_test.js
@@ -614,7 +614,7 @@ describe('Script | Move skills to focus', function() {
           size: valideProtoAttachmentNL.size,
           mimeType: valideProtoAttachmentNL.mimeType,
           filename: valideProtoAttachmentNL.filename,
-          challengeId: 'valideProtoForActifSkillNewId',
+          challengeId: null,
           localizedChallengeId: 'valideProtoForActifSkillNLNewId',
         }),
         domainBuilder.buildAttachment({

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -744,7 +744,7 @@ describe('Unit | Domain | Challenge', () => {
           alt: attachmentIdB.alt,
           url: attachmentIdB.url,
           localizedChallengeId: clonedNLLocalizedChallengeId,
-          challengeId: clonedChallengeId,
+          challengeId: null,
         }),
       ]);
     });

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -79,24 +79,47 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('clone', function() {
-    it('should return a cloned localized challenge', function() {
+    it('should return a cloned localized challenge and its cloned attachments (primary)', function() {
       // given
-      const newId = 'newLocId';
+      const newId = 'newChallengeId';
       const newChallengeId = 'newChallengeId';
       const newStatus = LocalizedChallenge.STATUSES.PLAY;
       const localizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: 'oldLocId',
-        challengeId: 'oldChallengeId',
+        challengeId: 'oldLocId',
         embedUrl: 'https://example.com/embed.html',
-        fileIds: ['ignore me'],
+        fileIds: ['attachmentA', 'attachmentB'],
         locale: 'fr',
         status: LocalizedChallenge.STATUSES.PAUSE,
         geography: 'France',
         urlsToConsult: ['http://url.com'],
       });
+      const attachments = [
+        domainBuilder.buildAttachment({ id: 'someIrrelevantAttachment' }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentA',
+          url: 'https://www.attA.com',
+          type: 'illustration',
+          alt: 'osef',
+          size: 123,
+          mimeType: 'image/png',
+          filename: 'fraise_des_bois',
+          localizedChallengeId: 'oldLocId',
+        }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentB',
+          url: 'https://www.attB.com',
+          type: 'attachment',
+          alt: 'osef le retour',
+          size: 456,
+          mimeType: 'text/csv',
+          filename: 'liste_de_courses',
+          localizedChallengeId: 'oldLocId',
+        }),
+      ];
 
       // when
-      const clonedLocalizedChallenge = localizedChallenge.clone({ id: newId, challengeId: newChallengeId, status: newStatus });
+      const { clonedLocalizedChallenge, clonedAttachments } = localizedChallenge.clone({ id: newId, challengeId: newChallengeId, status: newStatus, attachments });
 
       // then
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
@@ -110,6 +133,109 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         urlsToConsult: localizedChallenge.urlsToConsult,
       });
       expect(clonedLocalizedChallenge).toStrictEqual(expectedLocalizedChallenge);
+      expect(clonedAttachments).toStrictEqual([
+        domainBuilder.buildAttachment({
+          id: null,
+          url: 'https://www.attA.com',
+          type: 'illustration',
+          alt: 'osef',
+          size: 123,
+          mimeType: 'image/png',
+          filename: 'fraise_des_bois',
+          challengeId: newChallengeId,
+          localizedChallengeId: newId,
+        }),
+        domainBuilder.buildAttachment({
+          id: null,
+          url: 'https://www.attB.com',
+          type: 'attachment',
+          alt: 'osef le retour',
+          size: 456,
+          mimeType: 'text/csv',
+          filename: 'liste_de_courses',
+          challengeId: newChallengeId,
+          localizedChallengeId: newId,
+        }),
+      ]);
+    });
+    it('should return a cloned localized challenge and its cloned attachments (not primary)', function() {
+      // given
+      const newId = 'newLocId';
+      const newChallengeId = 'newChallengeId';
+      const newStatus = LocalizedChallenge.STATUSES.PLAY;
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+        id: 'oldLocId',
+        challengeId: 'oldChallengeId',
+        embedUrl: 'https://example.com/embed.html',
+        fileIds: ['attachmentA', 'attachmentB'],
+        locale: 'fr',
+        status: LocalizedChallenge.STATUSES.PAUSE,
+        geography: 'France',
+        urlsToConsult: ['http://url.com'],
+      });
+      const attachments = [
+        domainBuilder.buildAttachment({ id: 'someIrrelevantAttachment' }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentA',
+          url: 'https://www.attA.com',
+          type: 'illustration',
+          alt: 'osef',
+          size: 123,
+          mimeType: 'image/png',
+          filename: 'fraise_des_bois',
+          localizedChallengeId: 'oldLocId',
+        }),
+        domainBuilder.buildAttachment({
+          id: 'attachmentB',
+          url: 'https://www.attB.com',
+          type: 'attachment',
+          alt: 'osef le retour',
+          size: 456,
+          mimeType: 'text/csv',
+          filename: 'liste_de_courses',
+          localizedChallengeId: 'oldLocId',
+        }),
+      ];
+
+      // when
+      const { clonedLocalizedChallenge, clonedAttachments } = localizedChallenge.clone({ id: newId, challengeId: newChallengeId, status: newStatus, attachments });
+
+      // then
+      const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
+        id: newId,
+        challengeId: newChallengeId,
+        embedUrl: localizedChallenge.embedUrl,
+        fileIds: [],
+        locale: localizedChallenge.locale,
+        status: newStatus,
+        geography: localizedChallenge.geography,
+        urlsToConsult: localizedChallenge.urlsToConsult,
+      });
+      expect(clonedLocalizedChallenge).toStrictEqual(expectedLocalizedChallenge);
+      expect(clonedAttachments).toStrictEqual([
+        domainBuilder.buildAttachment({
+          id: null,
+          url: 'https://www.attA.com',
+          type: 'illustration',
+          alt: 'osef',
+          size: 123,
+          mimeType: 'image/png',
+          filename: 'fraise_des_bois',
+          challengeId: null,
+          localizedChallengeId: newId,
+        }),
+        domainBuilder.buildAttachment({
+          id: null,
+          url: 'https://www.attB.com',
+          type: 'attachment',
+          alt: 'osef le retour',
+          size: 456,
+          mimeType: 'text/csv',
+          filename: 'liste_de_courses',
+          challengeId: null,
+          localizedChallengeId: newId,
+        }),
+      ]);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/clone-skill_test.js
+++ b/api/tests/unit/domain/usecases/clone-skill_test.js
@@ -22,7 +22,7 @@ describe('Unit | Domain | Usecases | clone-skill', () => {
       createBatch: vi.fn(),
     };
     attachmentRepository = {
-      listByChallengeIds: vi.fn(),
+      listByLocalizedChallengeIds: vi.fn(),
       createBatch: vi.fn(),
     };
     generateNewIdFnc = vi.fn();
@@ -130,14 +130,26 @@ describe('Unit | Domain | Usecases | clone-skill', () => {
       skillRepository.get.mockResolvedValue(skillToClone);
       tube = domainBuilder.buildTube({ id: cloneCommand.tubeDestinationId });
       tubeRepository.get.mockResolvedValue(tube);
-      challengeToClone1 = domainBuilder.buildChallenge({ id: 'challenge1' });
-      challengeToClone2 = domainBuilder.buildChallenge({ id: 'challenge2' });
+      challengeToClone1 = domainBuilder.buildChallenge({
+        id: 'challenge1',
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({ id: 'challenge1' }),
+          domainBuilder.buildLocalizedChallenge({ id: 'localizedChallengeA' }),
+        ],
+      });
+      challengeToClone2 = domainBuilder.buildChallenge({
+        id: 'challenge2',
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({ id: 'challenge2' }),
+          domainBuilder.buildLocalizedChallenge({ id: 'localizedChallengeB' }),
+        ],
+      });
       challengeRepository.listBySkillId.mockResolvedValue([challengeToClone1, challengeToClone2]);
       tubeSkill1 = domainBuilder.buildSkill({ id: 'tubeSkill1', tubeId: cloneCommand.tubeDestinationId });
       tubeSkill2 = domainBuilder.buildSkill({ id: 'tubeSkill2', tubeId: cloneCommand.tubeDestinationId });
       skillRepository.listByTubeId.mockResolvedValue([tubeSkill1, tubeSkill2]);
-      attachmentToClone1 = domainBuilder.buildAttachment({ id: 'challenge1_attachment', challengeId: 'challenge1' });
-      attachmentRepository.listByChallengeIds.mockResolvedValue([attachmentToClone1]);
+      attachmentToClone1 = domainBuilder.buildAttachment({ id: 'challenge1_attachment' });
+      attachmentRepository.listByLocalizedChallengeIds.mockResolvedValue([attachmentToClone1]);
       skillRepository.create.mockResolvedValue();
       challengeRepository.createBatch.mockResolvedValue();
       attachmentRepository.createBatch.mockResolvedValue();
@@ -159,7 +171,7 @@ describe('Unit | Domain | Usecases | clone-skill', () => {
       expect(tubeRepository.get).toHaveBeenCalledWith(cloneCommand.tubeDestinationId);
       expect(challengeRepository.listBySkillId).toHaveBeenCalledWith(cloneCommand.skillIdToClone);
       expect(skillRepository.listByTubeId).toHaveBeenCalledWith(cloneCommand.tubeDestinationId);
-      expect(attachmentRepository.listByChallengeIds).toHaveBeenCalledWith([challengeToClone1.id, challengeToClone2.id]);
+      expect(attachmentRepository.listByLocalizedChallengeIds).toHaveBeenCalledWith(['challenge1', 'localizedChallengeA', 'challenge2', 'localizedChallengeB']);
       expect(spyCloneFnc).toHaveBeenCalledWith({
         tubeDestination: tube,
         level: cloneCommand.level,

--- a/api/tests/unit/infrastructure/datasources/airtable/attachment-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/attachment-datasource_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { airtableBuilder } from '../../../../test-helper.js';
-import { attachmentDatasource } from '../../../../../lib/infrastructure/datasources/airtable/attachment-datasource.js';
+import { attachmentDatasource } from '../../../../../lib/infrastructure/datasources/airtable/index.js';
 import * as airtable from '../../../../../lib/infrastructure/airtable.js';
 import airtableClient from 'airtable';
 


### PR DESCRIPTION
## :unicorn: Problème
Pb lors du clone des attachments pour les épreuves localisées

## :robot: Proposition
Il faut récupérer les attachments depuis airtable à l'aide du localizedChallengeId.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
