### PR TITLE
[BUGFIX] Corriger le problème d'attachment lors du passage en focus en masse (PIX-13098)

### DIFF
--- a/api/db/migrations/20240621123457_add-script-execution-id-column-for-focus-phrase.js
+++ b/api/db/migrations/20240621123457_add-script-execution-id-column-for-focus-phrase.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'focus_phrase';
+
+const COLUMN_NAME = 'scriptExectId';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    // refers to 21/06/2024 at midnight
+    table.string(COLUMN_NAME).notNullable().defaultTo('1718928000000');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/api/db/migrations/20240621123508_add-script-execution-id-column-for-historic-focus.js
+++ b/api/db/migrations/20240621123508_add-script-execution-id-column-for-historic-focus.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'historic_focus';
+
+const COLUMN_NAME = 'scriptExectId';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    // refers to 21/06/2024 at midnight
+    table.string(COLUMN_NAME).notNullable().defaultTo('1718928000000');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/api/db/migrations/20240624090645_add-previous-entity-id-in-focus-phrase-table.js
+++ b/api/db/migrations/20240624090645_add-previous-entity-id-in-focus-phrase-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'focus_phrase';
+
+const COLUMN_NAME = 'originPersistantId';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.string(COLUMN_NAME).notNullable().defaultTo('null');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -253,6 +253,13 @@ export class Challenge {
     }
   }
 
+  obsolete() {
+    if (!this.isPerime) {
+      this.status = Challenge.STATUSES.PERIME;
+      this.madeObsoleteAt = new Date();
+    }
+  }
+
   translate(locale) {
     const challenge = new Challenge({
       ...this,

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -241,7 +241,7 @@ export class Challenge {
   }
 
   archive() {
-    const now = new Date();
+    const now = new Date().toISOString();
     if (this.isPropose) {
       this.status = Challenge.STATUSES.PERIME;
       this.madeObsoleteAt = now;
@@ -256,7 +256,7 @@ export class Challenge {
   obsolete() {
     if (!this.isPerime) {
       this.status = Challenge.STATUSES.PERIME;
-      this.madeObsoleteAt = new Date();
+      this.madeObsoleteAt = new Date().toISOString();
     }
   }
 

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -118,6 +118,14 @@ export class Challenge {
     return this.status === Challenge.STATUSES.VALIDE;
   }
 
+  get isArchive() {
+    return this.status === Challenge.STATUSES.ARCHIVE;
+  }
+
+  get isPerime() {
+    return this.status === Challenge.STATUSES.PERIME;
+  }
+
   get primaryLocale() {
     return this.#primaryLocales[0];
   }

--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -84,7 +84,13 @@ export class Skill {
       });
       clonedChallenges.push(cloneProto);
       clonedAttachments.push(...cloneAttachmentsProto);
-      const declinaisons = liveChallenges.filter((ch) => ch.genealogy === 'Décliné 1' && ch.version === prototype.version);
+      const declinaisons = liveChallenges
+        .filter((ch) => ch.genealogy === 'Décliné 1' && ch.version === prototype.version)
+        .sort((decliA, decliB) => {
+          if (!decliA.alternativeVersion) return 1;
+          if (!decliB.alternativeVersion) return -1;
+          return decliA.alternativeVersion - decliB.alternativeVersion;
+        });
       let alternativeVersion = 1;
       for (const declinaison of declinaisons) {
         const { clonedChallenge: cloneDecli, clonedAttachments: cloneAttachmentsDecli } = declinaison.cloneChallengeAndAttachments({
@@ -92,7 +98,7 @@ export class Skill {
           competenceId: tubeDestination.competenceId,
           generateNewIdFnc,
           prototypeVersion,
-          alternativeVersion: alternativeVersion,
+          alternativeVersion,
           attachments,
         });
         clonedChallenges.push(cloneDecli);

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -3,7 +3,6 @@ import * as translationRepository from './translation-repository.js';
 import * as localizedChallengeRepository from './localized-challenge-repository.js';
 import _ from 'lodash';
 import { Attachment } from '../../domain/models/index.js';
-import { cloneAttachmentsFileInBucket } from '../utils/storage.js';
 import * as localizedChallengesAttachmentsRepository from './localized-challenges-attachments-repository.js';
 
 export async function list() {
@@ -28,10 +27,7 @@ export async function createBatch(attachments) {
   const necessaryChallengeIds = _.uniq(attachments.map((attachment) => attachment.challengeId));
   const airtableChallengeIdsByIds = await challengeDatasource.getAirtableIdsByIds(necessaryChallengeIds);
   const attachmentToSaveDTOs = [];
-  await cloneAttachmentsFileInBucket({
-    attachments,
-    millisecondsTimestamp: Date.now(),
-  });
+
   for (const attachment of attachments) {
     attachmentToSaveDTOs.push({
       url: attachment.url,

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -48,6 +48,13 @@ export async function list() {
   return toDomainList(challengeDtos, translations, localizedChallenges);
 }
 
+export async function getMany(ids) {
+  const challengeDTOs = await challengeDatasource.filter({ filter: { ids } });
+  if (!challengeDTOs) return [];
+  const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(challengeDTOs);
+  return toDomainList(challengeDTOs, translations, localizedChallenges);
+}
+
 export async function filter(params = {}) {
   const challengeDtos = await _getChallengesFromParams(params);
   const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(challengeDtos);

--- a/api/lib/infrastructure/utils/storage.js
+++ b/api/lib/infrastructure/utils/storage.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import * as config from '../../config.js';
 import { fileStorageTokenRepository } from '../repositories/index.js';
 
+// todo fix timestamp bug on batch creation
 export async function cloneAttachmentsFileInBucket({ attachments, millisecondsTimestamp }) {
   return _callAPIWithRetry(async (token) => {
     const fnc = async (attachment) => {

--- a/api/scripts/fix-cloned-attachments/index.js
+++ b/api/scripts/fix-cloned-attachments/index.js
@@ -1,0 +1,218 @@
+import { fileURLToPath } from 'node:url';
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+import {
+  attachmentRepository,
+  challengeRepository,
+  skillRepository,
+} from '../../lib/infrastructure/repositories/index.js';
+import { generateNewId } from '../../lib/infrastructure/utils/id-generator.js';
+import { Challenge, Skill } from '../../lib/domain/models/index.js';
+import _ from 'lodash';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function fix({ dryRun, scriptExectIdToFix, scriptExectId }) {
+  const originSkillIds = await _getOriginSkillIds(scriptExectIdToFix);
+  const cloneSkillIds = await _getCloneSkillIds(scriptExectIdToFix);
+  const skills = await skillRepository.list();
+  const originSkills = skills.filter((skill) => originSkillIds.includes(skill.id) && skill.status === Skill.STATUSES.ARCHIVE);
+  const cloneSkills = skills.filter((skill) => cloneSkillIds.includes(skill.id));
+
+  logger.info(`${originSkills.length} skills to fix...`);
+  for (const originSkill of originSkills) {
+    const correspondingCloneSkill = cloneSkills.find((cloneSkill) => cloneSkill.name === originSkill.name);
+    if (!correspondingCloneSkill) {
+      await _logInHistoricAndPrint({ persistantId: originSkill.id, errorStr: 'clone non trouvé', details: `RAS Erreur lors du rematching acquis origine/cloné. Nom de l'acquis ${originSkill.name}.` }, dryRun, scriptExectId);
+      throw new Error('clone non trouvé');
+    }
+    const skillChallenges = await challengeRepository.listBySkillId(originSkill.id);
+
+    const challengesToClone = await _getChallengesToClone({ skillChallenges, originSkillId: originSkill.id, scriptExectIdToFix });
+    if (challengesToClone.length === 0) {
+      logger.info(`Acquis ${originSkill.id} n'a pas d'épreuve à cloner, rien à corriger...`);
+      continue;
+    }
+
+    const clonedChallenges = await _fixFor({ originSkill, cloneSkill: correspondingCloneSkill, skillChallenges: challengesToClone, dryRun, scriptExectId });
+    await _addToPhraseToFocus({ challenges: clonedChallenges, scriptExectId });
+  }
+
+  await _obsoleteChallenges({ cloneSkills, challengeRepository, dryRun, scriptExectIdToFix });
+  logger.info('Done');
+}
+
+async function _getOriginSkillIds(scriptExectIdToFix) {
+  return _.uniq(await knex('historic_focus')
+    .pluck('persistantId')
+    .where({ scriptExectId: scriptExectIdToFix }));
+}
+
+async function _getCloneSkillIds(scriptExectIdToFix) {
+  return _.uniq(await knex('focus_phrase')
+    .pluck('persistantId')
+    .where({ type: 'skill', scriptExectId: scriptExectIdToFix }));
+}
+
+async function _getCloneChallengeIds(scriptExectIdToFix) {
+  return _.uniq(await knex('focus_phrase')
+    .pluck('persistantId')
+    .where({ type: 'challenge', scriptExectId: scriptExectIdToFix }));
+}
+
+async function _obsoleteChallenges({ cloneSkills, scriptExectIdToFix, challengeRepository, dryRun }) {
+  const challengeIds = await _getCloneChallengeIds(scriptExectIdToFix);
+  const challenges = await challengeRepository.getMany(challengeIds);
+  challenges.forEach((challenge) => challenge.obsolete());
+  const allSkillIds = _.uniq(challenges.map((chal) => chal.skillId));
+  const filteredClonedSkills = cloneSkills.filter((skill) => allSkillIds.includes(skill.id));
+  if (!dryRun) {
+    try {
+      await challengeRepository.updateBatch(challenges);
+    } catch (err) {
+      await _logInHistoricAndPrint({
+        persistantId: challenges.map((chal) => chal.id).join(','),
+        errorStr: JSON.stringify(err),
+        details: `Erreur lors de la péremption des épreuves. A priori les clones sont sains. On peut envisager de périmer les épreuves nous-mêmes (mettre date + status ou via PixEditor).
+          Acquis concernés : ${filteredClonedSkills.map((skill) => skill.name).join(', ')}.`
+      }, dryRun);
+      throw err;
+    }
+  }
+}
+async function _getChallengesToClone({ skillChallenges, originSkillId, scriptExectIdToFix }) {
+  const [creattionSkillDate] = await knex('historic_focus').pluck('createdAt').where({
+    persistantId: originSkillId,
+    scriptExectId: scriptExectIdToFix
+  });
+
+  const bottomDate = creattionSkillDate.getTime() - (10 * 60 * 1000);
+  const topDate = creattionSkillDate.getTime() + (10 * 60 * 1000);
+
+  const protoToClone = skillChallenges.find((challenge) => {
+    return challenge.genealogy === 'Prototype 1' &&
+      (challenge.archivedAt.getTime() > bottomDate && challenge.archivedAt.getTime() < topDate);
+  });
+
+  if (!protoToClone?.files?.length > 0) {
+    return [];
+  }
+  const declinaisonsToClone = skillChallenges
+    .filter((challenge) => {
+      return challenge.version === protoToClone.version && challenge.genealogy === 'Décliné 1' && (challenge.isPerime || challenge.isArchive);
+    })
+    .filter((challenge) => {
+      if (challenge.isPerime) {
+        return challenge.madeObsoleteAt.getTime() > bottomDate && challenge.madeObsoleteAt.getTime() < topDate;
+      }
+      return challenge.archivedAt.getTime() > bottomDate && challenge.archivedAt.getTime() < topDate;
+    });
+  return [protoToClone, ...declinaisonsToClone];
+}
+
+async function _fixFor({ originSkill, cloneSkill, skillChallenges, dryRun, scriptExectId }) {
+  const clonedAttachments = [];
+  const clonedChallenges = [];
+  try {
+    const localizedChallengeIds = skillChallenges.flatMap((ch) => ch.localizedChallenges.map((loc) => loc.id));
+    const attachments = await attachmentRepository.listByLocalizedChallengeIds(localizedChallengeIds);
+    for (const challenge of skillChallenges) {
+      const res = challenge.cloneChallengeAndAttachments({
+        competenceId: originSkill.competenceId,
+        skillId: cloneSkill.id,
+        generateNewIdFnc: generateNewId,
+        alternativeVersion: challenge.alternativeVersion,
+        prototypeVersion: 2, // todo change me if you réexcute me again get the real prototype number im too tired
+        attachments,
+      });
+      clonedChallenges.push(res.clonedChallenge);
+      clonedAttachments.push(...res.clonedAttachments);
+    }
+
+    for (const clonedChallenge of clonedChallenges) {
+      clonedChallenge.focusable = true;
+
+      const sourceChallenge = Challenge.getCloneSource(clonedChallenge);
+      clonedChallenge.status = sourceChallenge.isArchive ? Challenge.STATUSES.VALIDE : Challenge.STATUSES.PROPOSE;
+
+      for (const clonedLocalizedChallenge of clonedChallenge.localizedChallenges) {
+        const sourceLocalizedChallenge = Challenge.getCloneSource(clonedLocalizedChallenge);
+        clonedLocalizedChallenge.status = sourceLocalizedChallenge.status;
+      }
+    }
+  } catch (err) {
+    await _logInHistoricAndPrint({ persistantId: originSkill.id, errorStr: JSON.stringify(err), details: `RAS Erreur lors d'une lecture sur Airtable. Rien à nettoyer. ID Clone : ${cloneSkill.id}` }, dryRun, scriptExectId);
+    throw err;
+  }
+
+  if (!dryRun) {
+    try {
+      await challengeRepository.createBatch(clonedChallenges);
+    } catch (err) {
+      await _logInHistoricAndPrint({
+        persistantId: originSkill.id,
+        errorStr: JSON.stringify(err),
+        details: `Erreur lors de la création en masse des épreuves clonées. Potentielles données à nettoyer (liste dans l'ordre de création):
+          challenges ${clonedChallenges.map((chal) => chal.id).join(', ')} sur Airtable,
+          translations avec les patterns ${clonedChallenges.map((chal) => `"challenge.${chal.id}%"`).join(', ')} sur PG,
+          localizedChallenges dont les challengeIds sont ${clonedChallenges.map((chal) => chal.id).join(', ')} sur PG`,
+      }, dryRun, scriptExectId);
+      throw err;
+    }
+    try {
+      await attachmentRepository.createBatch(clonedAttachments);
+    } catch (err) {
+      await _logInHistoricAndPrint({
+        persistantId: originSkill.id,
+        errorStr: JSON.stringify(err),
+        details: `Erreur lors de la création en masse des attachments clonés. Potentielles données à nettoyer (liste dans l'ordre de création):
+          challenges ${clonedChallenges.map((chal) => chal.id).join(', ')} sur Airtable,
+          translations avec les patterns ${clonedChallenges.map((chal) => `"challenge.${chal.id}%"`).join(', ')} sur PG,
+          localizedChallenges dont les challengeIds sont ${clonedChallenges.map((chal) => chal.id).join(', ')} sur PG,
+          attachments dont les challengeIds persistant sont ${clonedChallenges.map((chal) => chal.id).join(', ')} sur Airtable,
+          localized_challenges-attachments dont les localizedChallengeIds sont ${clonedChallenges.flatMap((chal) => chal.localizedChallenges.map((loc) => loc.id)).join(', ')} sur PG`,
+      }, dryRun, scriptExectId);
+      throw err;
+    }
+  }
+  logger.info(`Skill ${originSkill.id} moved to focus with fixed attachments along with ${clonedChallenges.length} challenges and ${clonedAttachments.length} attachments !`);
+  return clonedChallenges;
+}
+
+async function _logInHistoricAndPrint(historicLine, dryRun, scriptExectId) {
+  await knex('historic_focus').insert({ ...historicLine, dryRun, scriptExectId });
+  if (historicLine.details !== 'OK') logger.error(JSON.stringify(historicLine));
+}
+
+async function _addToPhraseToFocus({ challenges, scriptExectId }) {
+  await knex('focus_phrase').insert(challenges.map((challenge) => ({
+    type: 'challenge',
+    persistantId: challenge.id,
+    originPersistantId: Challenge.getCloneSource(challenge).id,
+    scriptExectId,
+  })));
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+
+  try {
+    const dryRun = process.env.DRY_RUN !== 'false';
+    const scriptExectIdToFix = process.env.SCRIPT_ID;
+
+    if (dryRun) logger.warn('Dry run: no actual modification will be performed, use DRY_RUN=false to disable');
+
+    const scriptExectId = `${Date.now()}`;
+    await fix({ dryRun, scriptExectIdToFix, scriptExectId });
+    logger.info('All done');
+  } catch (e) {
+    logger.error(e);
+    process.exitCode = 1;
+  } finally {
+    await disconnect();
+  }
+}
+
+main();
+

--- a/api/scripts/fix-cloned-attachments/index.js
+++ b/api/scripts/fix-cloned-attachments/index.js
@@ -91,8 +91,9 @@ async function _getChallengesToClone({ skillChallenges, originSkillId, scriptExe
   const topDate = creattionSkillDate.getTime() + (10 * 60 * 1000);
 
   const protoToClone = skillChallenges.find((challenge) => {
-    return challenge.genealogy === 'Prototype 1' &&
-      (challenge.archivedAt.getTime() > bottomDate && challenge.archivedAt.getTime() < topDate);
+    const archiveDate = new Date(challenge.archivedAt);
+    return challenge.genealogy === 'Prototype 1' && challenge.isArchive &&
+      (archiveDate.getTime() > bottomDate && archiveDate.getTime() < topDate);
   });
 
   if (!protoToClone?.files?.length > 0) {
@@ -104,9 +105,11 @@ async function _getChallengesToClone({ skillChallenges, originSkillId, scriptExe
     })
     .filter((challenge) => {
       if (challenge.isPerime) {
-        return challenge.madeObsoleteAt.getTime() > bottomDate && challenge.madeObsoleteAt.getTime() < topDate;
+        const obsoleteDate = new Date(challenge.madeObsoleteAt);
+        return obsoleteDate.getTime() > bottomDate && obsoleteDate.getTime() < topDate;
       }
-      return challenge.archivedAt.getTime() > bottomDate && challenge.archivedAt.getTime() < topDate;
+      const archiveDate = new Date(challenge.archivedAt);
+      return archiveDate.getTime() > bottomDate && archiveDate.getTime() < topDate;
     });
   return [protoToClone, ...declinaisonsToClone];
 }

--- a/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as attachmentRepository from '../../../../lib/infrastructure/repositories/attachment-repository.js';
 import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
-import * as storage from '../../../../lib/infrastructure/utils/storage.js';
 import { challengeDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import _ from 'lodash';
 
@@ -440,19 +439,12 @@ describe('Integration | Repository | attachment-repository', () => {
           expect.unreachable('Wrong challenge ids for fetching corresponding airtable ids');
         return airtableIdsByIds;
       });
-      vi.spyOn(storage, 'cloneAttachmentsFileInBucket')
-        .mockImplementation(({ attachments }) => {
-          if (attachments.length !== 2 || attachments[0] !== attachmentA || attachments[1] !== attachmentB)
-            expect.unreachable('Wrong attachments sent for cloning');
-          attachments[0].url = 'cloned/url/attachmentA';
-          attachments[1].url = 'cloned/url/attachmentB';
-        });
       vi.spyOn(airtableClient, 'createRecords').mockImplementation((tableName, airtableRequestBodies) => {
         if (tableName !== 'Attachments') expect.unreachable('Airtable tableName should be Attachments');
         if (
           airtableRequestBodies.length !== 2
           || !_.isEqual(airtableRequestBodies[0], { fields: {
-            url: 'cloned/url/attachmentA',
+            url: attachmentA.url,
             size: attachmentA.size,
             type: attachmentA.type,
             mimeType: attachmentA.mimeType,
@@ -461,7 +453,7 @@ describe('Integration | Repository | attachment-repository', () => {
             localizedChallengeId: attachmentA.localizedChallengeId,
           } })
           || !_.isEqual(airtableRequestBodies[1], { fields: {
-            url: 'cloned/url/attachmentB',
+            url: attachmentB.url,
             size: attachmentB.size,
             type: attachmentB.type,
             mimeType: attachmentB.mimeType,
@@ -475,7 +467,7 @@ describe('Integration | Repository | attachment-repository', () => {
             id: 'airtableIdAttachmentA',
             fields: {
               'Record ID': 'airtableIdAttachmentA',
-              url: 'cloned/url/attachmentA',
+              url: attachmentA.url,
               size: attachmentA.size,
               type: attachmentA.type,
               mimeType: attachmentA.mimeType,
@@ -489,7 +481,7 @@ describe('Integration | Repository | attachment-repository', () => {
             id: 'airtableIdAttachmentB',
             fields: {
               'Record ID': 'airtableIdAttachmentB',
-              url: 'cloned/url/attachmentB',
+              url: attachmentB.url,
               size: attachmentB.size,
               type: attachmentB.type,
               mimeType: attachmentB.mimeType,
@@ -509,7 +501,7 @@ describe('Integration | Repository | attachment-repository', () => {
       expect(attachments).toStrictEqual([
         domainBuilder.buildAttachment({
           id: 'airtableIdAttachmentA',
-          url: 'cloned/url/attachmentA',
+          url: attachmentA.url,
           type: attachmentA.type,
           alt: 'good illustrationAlt',
           size: attachmentA.size,
@@ -520,7 +512,7 @@ describe('Integration | Repository | attachment-repository', () => {
         }),
         domainBuilder.buildAttachment({
           id: 'airtableIdAttachmentB',
-          url: 'cloned/url/attachmentB',
+          url: attachmentB.url,
           type: attachmentB.type,
           alt: null,
           size: attachmentB.size,

--- a/api/tests/scripts/fix-cloned-attachments_test.js
+++ b/api/tests/scripts/fix-cloned-attachments_test.js
@@ -124,7 +124,7 @@ describe('Script | Fix cloned attachments', function() {
     const archiveProtoForActifSkill = domainBuilder.buildChallenge({
       id: 'archiveProtoForActifSkill',
       status: Challenge.STATUSES.ARCHIVE,
-      archivedAt: new Date('2020-01-01'),
+      archivedAt: new Date('2020-01-01').toISOString(),
       skillId: 'skillABC',
       genealogy: 'Prototype 1',
       version: 4,
@@ -258,7 +258,7 @@ describe('Script | Fix cloned attachments', function() {
       focusable: false,
       locales: ['fr', 'nl'],
       translations: { fr: { instruction: 'instruction valideProto fr' }, nl: { instruction: 'instruction valideProto nl' } },
-      archivedAt: new Date('2024-01-01T09:58:00Z'),
+      archivedAt: '2024-01-01T09:58:00Z',
       localizedChallenges: [
         domainBuilder.buildLocalizedChallenge({
           id: 'archiveProtoForSkillABC',
@@ -292,7 +292,7 @@ describe('Script | Fix cloned attachments', function() {
       focusable: false,
       locales: ['fr'],
       translations: { fr: { instruction: 'instruction valideDecli fr' } },
-      archivedAt: new Date('2024-01-01T10:02:00Z'),
+      archivedAt: '2024-01-01T10:02:00Z',
       localizedChallenges: [
         domainBuilder.buildLocalizedChallenge({
           id: 'archiveDecliForSkillABC',
@@ -316,7 +316,7 @@ describe('Script | Fix cloned attachments', function() {
       focusable: false,
       locales: ['fr'],
       translations: { fr: { instruction: 'instruction obsoleteDecli fr' } },
-      madeObsoleteAt: new Date('2024-01-01T10:02:00Z'),
+      madeObsoleteAt:'2024-01-01T10:02:00Z',
       localizedChallenges: [
         domainBuilder.buildLocalizedChallenge({
           id: 'obsoleteDecliForSkillABC',
@@ -343,7 +343,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 3,
         locales: [],
         translations: {},
-        archivedAt: new Date('2023-11-01T00:58:00Z'),
+        archivedAt: '2023-11-01T00:58:00Z',
       }),
       domainBuilder.buildChallenge({
         id: 'wrongArchiveProtoForSkillABC2',
@@ -353,7 +353,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 2,
         locales: [],
         translations: {},
-        archivedAt: new Date('2024-01-01T10:10:00Z'),
+        archivedAt: '2024-01-01T10:10:00Z',
       }),
       domainBuilder.buildChallenge({
         id: 'wrongArchiveProtoForSkillABC3',
@@ -363,7 +363,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 1,
         locales: [],
         translations: {},
-        archivedAt: new Date('2024-01-01T09:50:00Z'),
+        archivedAt: '2024-01-01T09:50:00Z',
       }),
       domainBuilder.buildChallenge({
         id: 'wrongArchiveDecliForSkillABC4',
@@ -373,7 +373,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 4,
         locales: [],
         translations: {},
-        archivedAt: new Date('2023-01-01T09:50:00Z'),
+        archivedAt: '2023-01-01T09:50:00Z',
       }),
       domainBuilder.buildChallenge({
         id: 'wrongObsoleteDecliForSkillABC5',
@@ -383,7 +383,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 4,
         locales: [],
         translations: {},
-        madeObsoleteAt: new Date('2024-01-01T09:50:00Z'),
+        madeObsoleteAt: '2024-01-01T09:50:00Z',
       }),
     ];
 
@@ -620,7 +620,7 @@ describe('Script | Fix cloned attachments', function() {
       version: 4,
       focusable: false,
       locales: ['fr'],
-      archivedAt: new Date('2020-01-01'),
+      archivedAt: new Date('2020-01-01').toISOString(),
       translations: { fr: { instruction: 'instruction archiveProto fr' } },
       localizedChallenges: [
         domainBuilder.buildLocalizedChallenge({
@@ -696,12 +696,12 @@ describe('Script | Fix cloned attachments', function() {
       domainBuilder.buildChallenge({
         ...challengeToPerime1_data,
         status: Challenge.STATUSES.PERIME,
-        madeObsoleteAt: obsoleteAt,
+        madeObsoleteAt: obsoleteAt.toISOString(),
       }),
       domainBuilder.buildChallenge({
         ...challengeToPerime2_data,
         status: Challenge.STATUSES.PERIME,
-        madeObsoleteAt: obsoleteAt,
+        madeObsoleteAt: obsoleteAt.toISOString(),
       }),
     ]);
   });
@@ -844,7 +844,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 4,
         focusable: false,
         locales: ['fr'],
-        archivedAt: new Date('2020-01-01'),
+        archivedAt: new Date('2020-01-01').toISOString(),
         translations: { fr: { instruction: 'instruction archiveProto fr' } },
         localizedChallenges: [
           domainBuilder.buildLocalizedChallenge({
@@ -948,7 +948,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 4,
         focusable: false,
         locales: ['fr'],
-        archivedAt: new Date('2020-01-01'),
+        archivedAt: new Date('2020-01-01').toISOString(),
         translations: { fr: { instruction: 'instruction archiveProto fr' } },
         localizedChallenges: [
           domainBuilder.buildLocalizedChallenge({
@@ -1058,7 +1058,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 4,
         focusable: false,
         locales: ['fr'],
-        archivedAt: new Date('2020-01-01'),
+        archivedAt: new Date('2020-01-01').toISOString(),
         translations: { fr: { instruction: 'instruction archiveProto fr' } },
         localizedChallenges: [
           domainBuilder.buildLocalizedChallenge({
@@ -1166,7 +1166,7 @@ describe('Script | Fix cloned attachments', function() {
         version: 4,
         focusable: false,
         locales: ['fr'],
-        archivedAt: new Date('2020-01-01'),
+        archivedAt: new Date('2020-01-01').toISOString(),
         translations: { fr: { instruction: 'instruction archiveProto fr' } },
         localizedChallenges: [
           domainBuilder.buildLocalizedChallenge({
@@ -1220,7 +1220,7 @@ describe('Script | Fix cloned attachments', function() {
         domainBuilder.buildChallenge({
           ...challengeToPerime1_data,
           status: Challenge.STATUSES.PERIME,
-          madeObsoleteAt: obsoleteAt,
+          madeObsoleteAt: obsoleteAt.toISOString(),
         }),
       ]);
     });

--- a/api/tests/scripts/fix-cloned-attachments_test.js
+++ b/api/tests/scripts/fix-cloned-attachments_test.js
@@ -1,0 +1,1228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { airtableBuilder, domainBuilder, knex } from '../test-helper.js';
+import nock from 'nock';
+import { Challenge, Skill } from '../../lib/domain/models/index.js';
+import * as script from '../../scripts/fix-cloned-attachments/index.js';
+import {
+  attachmentRepository,
+  challengeRepository,
+  skillRepository,
+} from '../../lib/infrastructure/repositories/index.js';
+import * as idGenerator from '../../lib/infrastructure/utils/id-generator.js';
+
+describe('Script | Fix cloned attachments', function() {
+  const obsoleteAt = new Date('2021-10-29T03:03:00Z');
+  const myCurrentScriptId = '1718928123456';
+
+  beforeEach(() => {
+    nock('https://api.airtable.com')
+      .get(/^\/v0\/airtableBaseValue\/translations\?.*/)
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .optionally()
+      .reply(404);
+
+    vi.spyOn(challengeRepository, 'listBySkillId');
+    vi.spyOn(challengeRepository, 'update');
+    vi.spyOn(challengeRepository, 'createBatch');
+    vi.spyOn(challengeRepository, 'updateBatch');
+    vi.spyOn(challengeRepository, 'getMany');
+    vi.spyOn(skillRepository, 'create');
+    vi.spyOn(skillRepository, 'update');
+    vi.spyOn(idGenerator, 'generateNewId');
+    vi.spyOn(attachmentRepository, 'listByLocalizedChallengeIds');
+    vi.spyOn(attachmentRepository, 'createBatch');
+    challengeRepository.update.mockImplementation(() => true);
+    challengeRepository.createBatch.mockImplementation(() => true);
+    challengeRepository.updateBatch.mockImplementation(() => true);
+    attachmentRepository.createBatch.mockImplementation(() => true);
+    vi.useFakeTimers();
+    vi.setSystemTime(obsoleteAt);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await knex('translations').truncate();
+    await knex('focus_phrase').truncate();
+    await knex('historic_focus').truncate();
+  });
+
+  it('should do nothing if there are no skills to fix with attachments or if skill is not included in specified script execution', async() => {
+    // given
+    const scriptExectIdToFix = '1711111111';
+    await knex('historic_focus').insert([
+      {
+        persistantId: 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+        dryRun: false,
+        createdAt: new Date('2021-01-01')
+      },
+      {
+        persistantId: 'skillDEF',
+        scriptExectId: scriptExectIdToFix,
+        dryRun: false,
+      },
+      {
+        persistantId: 'skillGHI',
+        scriptExectId: '17112222222',
+        dryRun: false,
+      },
+    ]);
+    await knex('focus_phrase').insert([
+      {
+        type: 'skill',
+        persistantId : 'skillABC_clone',
+        originPersistantId : 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+      },
+      {
+        type: 'skill',
+        persistantId : 'skillDEF_clone',
+        originPersistantId : 'skillDEF',
+        scriptExectId: scriptExectIdToFix,
+      },
+      {
+        type: 'skill',
+        persistantId : 'skillGHI_clone',
+        originPersistantId : 'skillGHI',
+        scriptExectId: '1766666666',
+      },
+    ]);
+    const skillABC_data = {
+      id: 'skillABC',
+      description: 'la description de mon acquis',
+      hintStatus: 'some hint status',
+      status: Skill.STATUSES.ARCHIVE,
+      tubeId: 'tubeId',
+      competenceId: 'competenceId',
+      version: 2,
+      level: 1,
+      name: '@baseTube1',
+      tutorialIds: ['monTuto1Id'],
+      learningMoreTutorialIds: ['monTuto2Id'],
+      internationalisation: 'France',
+    };
+    const skillABC_clone_data = {
+      ...skillABC_data,
+      id: 'skillABC_clone',
+    };
+    const skillDEF_data = {
+      id: 'skillDEF',
+      status: Skill.STATUSES.EN_CONSTRUCTION,
+    };
+    const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+    const skillDEF = airtableBuilder.factory.buildSkill(skillDEF_data);
+    const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Acquis')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .times(2)
+      .reply(200, { records: [skillABC, skillDEF, skillABC_clone] });
+    attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => []);
+
+    const archiveProtoForActifSkill = domainBuilder.buildChallenge({
+      id: 'archiveProtoForActifSkill',
+      status: Challenge.STATUSES.ARCHIVE,
+      archivedAt: new Date('2020-01-01'),
+      skillId: 'skillABC',
+      genealogy: 'Prototype 1',
+      version: 4,
+      focusable: false,
+      locales: ['fr', 'nl'],
+      translations: { fr: { instruction: 'instruction valideProto fr' }, nl: { instruction: 'instruction valideProto nl' } },
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'valideProtoForSkillABC',
+          challengeId: 'valideProtoForSkillABC',
+          embedUrl: 'valideProto embedUrl',
+          fileIds: [],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://valideProto.com'],
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: 'valideProtoForActifSkillLocNLId',
+          challengeId: 'valideProtoForSkillABC',
+          embedUrl: 'valideProto NL embedUrl',
+          fileIds: [],
+          locale: 'nl',
+          status: Challenge.STATUSES.VALIDE,
+          geography: 'Pays-Bas',
+          urlsToConsult: ['http://valideProtoNL.com'],
+        }),
+      ],
+      files: [],
+    });
+    const challenges = [archiveProtoForActifSkill];
+
+    vi.spyOn(challengeRepository, 'listBySkillId')
+      .mockImplementation((skillId) => challenges.filter((challenge) => challenge.skillId === skillId));
+    vi.spyOn(challengeRepository, 'getMany').mockResolvedValue([]);
+
+    // when
+    await script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId });
+
+    // then
+    expect(challengeRepository.createBatch).toHaveBeenCalledTimes(0);
+    expect(attachmentRepository.createBatch).toHaveBeenCalledTimes(0);
+    const focus_phrase_records = await knex('focus_phrase').select('*').where({ scriptExectId: myCurrentScriptId }).orderBy(['type', 'persistantId']);
+    expect(focus_phrase_records).toStrictEqual([]);
+  });
+
+  it('should clone challenges from origin skills and put them under cloned skill', async() => {
+    // given
+    const scriptExectIdToFix = '1718928111121';
+    idGenerator.generateNewId
+      .mockReturnValueOnce('valideProtoForActifSkillNewId')
+      .mockReturnValueOnce('valideProtoForActifSkillNLNewId')
+      .mockReturnValueOnce('valideDecliValideProtoForActifSkillNewId')
+      .mockReturnValueOnce('proposeDecliValideProtoForActifSkillNewId');
+
+    await knex('historic_focus').insert([
+      {
+        persistantId: 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+        dryRun: false,
+        createdAt: new Date('2024-01-01T10:00:00Z')
+      },
+    ]);
+    await knex('focus_phrase').insert([
+      {
+        type: 'skill',
+        persistantId : 'skillABC_clone',
+        originPersistantId : 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+      },
+    ]);
+    const skillABC_data = {
+      id: 'skillABC',
+      description: 'la description de mon acquis',
+      hintStatus: 'some hint status',
+      status: Skill.STATUSES.ARCHIVE,
+      tubeId: 'tubeId',
+      competenceId: 'competenceId',
+      version: 2,
+      level: 1,
+      name: '@baseTube1',
+      tutorialIds: ['monTuto1Id'],
+      learningMoreTutorialIds: ['monTuto2Id'],
+      internationalisation: 'France',
+    };
+    const skillABC_clone_data = {
+      ...skillABC_data,
+      id: 'skillABC_clone',
+    };
+    const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+    const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Acquis')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .times(2)
+      .reply(200, { records: [skillABC, skillABC_clone] });
+
+    const archiveProtoAttachment = domainBuilder.buildAttachment({
+      id: 'archiveProtoAttachmentId',
+      url: 'url attach valideProto',
+      type: 'type attach valideProto',
+      size: 1,
+      mimeType: 'mimeType1',
+      filename: 'filename_valideproto',
+      challengeId: 'archiveProtoForSkillABC',
+      localizedChallengeId: 'archiveProtoForSkillABC',
+    });
+    const archiveProtoAttachmentNL = domainBuilder.buildAttachment({
+      id: 'archiveProtoAttachmentNLId',
+      url: 'url attach valideProtoNL',
+      type: 'type attach valideProtoNL',
+      size: 2,
+      mimeType: 'mimeType2',
+      filename: 'filename_valideprotoNL',
+      challengeId: 'archiveProtoForSkillABC',
+      localizedChallengeId: 'archiveProtoForActifSkillLocNLId',
+    });
+
+    attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => [
+      archiveProtoAttachment,
+      archiveProtoAttachmentNL,
+    ]);
+
+    const ArchiveProtoForActifSkill = domainBuilder.buildChallenge({
+      id: 'archiveProtoForSkillABC',
+      status: Challenge.STATUSES.ARCHIVE,
+      skillId: 'skillABC',
+      genealogy: 'Prototype 1',
+      version: 4,
+      focusable: false,
+      locales: ['fr', 'nl'],
+      translations: { fr: { instruction: 'instruction valideProto fr' }, nl: { instruction: 'instruction valideProto nl' } },
+      archivedAt: new Date('2024-01-01T09:58:00Z'),
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'archiveProtoForSkillABC',
+          challengeId: 'archiveProtoForSkillABC',
+          embedUrl: 'archiveProto embedUrl',
+          fileIds: [archiveProtoAttachment.id],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://archiveProto.com'],
+        }),
+        domainBuilder.buildLocalizedChallenge({
+          id: 'archiveProtoForActifSkillLocNLId',
+          challengeId: 'archiveProtoForSkillABC',
+          embedUrl: 'archiveProto NL embedUrl',
+          fileIds: [archiveProtoAttachmentNL.id],
+          locale: 'nl',
+          status: Challenge.STATUSES.VALIDE,
+          geography: 'Pays-Bas',
+          urlsToConsult: ['http://archiveProtoNL.com'],
+        }),
+      ],
+    });
+
+    const archiveDecliForActifSkill = domainBuilder.buildChallenge({
+      id: 'archiveDecliForSkillABC',
+      status: Challenge.STATUSES.ARCHIVE,
+      skillId: 'skillABC',
+      genealogy: 'Décliné 1',
+      version: 4,
+      focusable: false,
+      locales: ['fr'],
+      translations: { fr: { instruction: 'instruction valideDecli fr' } },
+      archivedAt: new Date('2024-01-01T10:02:00Z'),
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'archiveDecliForSkillABC',
+          challengeId: 'archiveDecliForSkillABC',
+          embedUrl: 'archiveDecli embedUrl',
+          fileIds: [],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://archiveDecli.com'],
+        })
+      ],
+    });
+
+    const obsoleteDecliForActifSkill = domainBuilder.buildChallenge({
+      id: 'obsoleteDecliForSkillABC',
+      status: Challenge.STATUSES.PERIME,
+      skillId: 'skillABC',
+      genealogy: 'Décliné 1',
+      version: 4,
+      focusable: false,
+      locales: ['fr'],
+      translations: { fr: { instruction: 'instruction obsoleteDecli fr' } },
+      madeObsoleteAt: new Date('2024-01-01T10:02:00Z'),
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'obsoleteDecliForSkillABC',
+          challengeId: 'obsoleteDecliForSkillABC',
+          embedUrl: 'obsoleteDecli embedUrl',
+          fileIds: [],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://obsoleteDecli.com'],
+        })
+      ],
+    });
+
+    const challenges = [
+      ArchiveProtoForActifSkill,
+      archiveDecliForActifSkill,
+      obsoleteDecliForActifSkill,
+      domainBuilder.buildChallenge({
+        id: 'wrongArchiveProtoForSkillABC1',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 3,
+        locales: [],
+        translations: {},
+        archivedAt: new Date('2023-11-01T00:58:00Z'),
+      }),
+      domainBuilder.buildChallenge({
+        id: 'wrongArchiveProtoForSkillABC2',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 2,
+        locales: [],
+        translations: {},
+        archivedAt: new Date('2024-01-01T10:10:00Z'),
+      }),
+      domainBuilder.buildChallenge({
+        id: 'wrongArchiveProtoForSkillABC3',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 1,
+        locales: [],
+        translations: {},
+        archivedAt: new Date('2024-01-01T09:50:00Z'),
+      }),
+      domainBuilder.buildChallenge({
+        id: 'wrongArchiveDecliForSkillABC4',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Décliné 1',
+        version: 4,
+        locales: [],
+        translations: {},
+        archivedAt: new Date('2023-01-01T09:50:00Z'),
+      }),
+      domainBuilder.buildChallenge({
+        id: 'wrongObsoleteDecliForSkillABC5',
+        status: Challenge.STATUSES.PERIME,
+        skillId: 'skillABC',
+        genealogy: 'Décliné 1',
+        version: 4,
+        locales: [],
+        translations: {},
+        madeObsoleteAt: new Date('2024-01-01T09:50:00Z'),
+      }),
+    ];
+
+    vi.spyOn(challengeRepository, 'listBySkillId')
+      .mockResolvedValue(challenges);
+    vi.spyOn(challengeRepository, 'getMany').mockResolvedValue([]);
+
+    // when
+    await script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId });
+
+    // then
+    expect(challengeRepository.createBatch).toHaveBeenCalledTimes(1);
+    expect(challengeRepository.createBatch).toHaveBeenCalledWith([
+      domainBuilder.buildChallenge({
+        ...ArchiveProtoForActifSkill,
+        id: 'valideProtoForActifSkillNewId',
+        airtableId: null,
+        version: 2,
+        status: Challenge.STATUSES.VALIDE,
+        focusable: true,
+        competenceId: skillABC_data.competenceId,
+        skillId: skillABC_clone_data.id,
+        files: [],
+        skills: [],
+        alpha: null,
+        delta: null,
+        archivedAt: null,
+        createdAt: null,
+        madeObsoleteAt: null,
+        updatedAt: null,
+        validatedAt: null,
+        translations: { fr: { instruction: 'instruction valideProto fr' }, nl: { instruction: 'instruction valideProto nl' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            ...ArchiveProtoForActifSkill.localizedChallenges[0],
+            status: null,
+            id: 'valideProtoForActifSkillNewId',
+            challengeId: 'valideProtoForActifSkillNewId',
+            fileIds: [],
+          }),
+          domainBuilder.buildLocalizedChallenge({
+            ...ArchiveProtoForActifSkill.localizedChallenges[1],
+            status: Challenge.STATUSES.VALIDE,
+            id: 'valideProtoForActifSkillNLNewId',
+            challengeId: 'valideProtoForActifSkillNewId',
+            fileIds: [],
+          }),
+        ],
+      }),
+      domainBuilder.buildChallenge({
+        ...archiveDecliForActifSkill,
+        id: 'valideDecliValideProtoForActifSkillNewId',
+        airtableId: null,
+        version: 2,
+        status: Challenge.STATUSES.VALIDE,
+        focusable: true,
+        competenceId: skillABC_data.competenceId,
+        skillId: skillABC_clone_data.id,
+        files: [],
+        skills: [],
+        alpha: null,
+        delta: null,
+        archivedAt: null,
+        createdAt: null,
+        madeObsoleteAt: null,
+        updatedAt: null,
+        validatedAt: null,
+        translations: { fr: { instruction: 'instruction valideDecli fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            ...archiveDecliForActifSkill.localizedChallenges[0],
+            status: null,
+            id: 'valideDecliValideProtoForActifSkillNewId',
+            challengeId: 'valideDecliValideProtoForActifSkillNewId',
+            fileIds: [],
+          }),
+        ],
+      }),
+      domainBuilder.buildChallenge({
+        ...obsoleteDecliForActifSkill,
+        id: 'proposeDecliValideProtoForActifSkillNewId',
+        airtableId: null,
+        version: 2,
+        status: Challenge.STATUSES.PROPOSE,
+        focusable: true,
+        competenceId: skillABC_data.competenceId,
+        skillId: skillABC_clone_data.id,
+        files: [],
+        skills: [],
+        alpha: null,
+        delta: null,
+        archivedAt: null,
+        createdAt: null,
+        madeObsoleteAt: null,
+        updatedAt: null,
+        validatedAt: null,
+        translations: { fr: { instruction: 'instruction obsoleteDecli fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            ...obsoleteDecliForActifSkill.localizedChallenges[0],
+            status: null,
+            id: 'proposeDecliValideProtoForActifSkillNewId',
+            challengeId: 'proposeDecliValideProtoForActifSkillNewId',
+            fileIds: [],
+          }),
+        ],
+      }),
+    ]);
+    expect(attachmentRepository.createBatch).toHaveBeenCalledTimes(1);
+    expect(attachmentRepository.createBatch).toHaveBeenCalledWith([
+      domainBuilder.buildAttachment({
+        id: null,
+        url: archiveProtoAttachment.url,
+        type: archiveProtoAttachment.type,
+        size: archiveProtoAttachment.size,
+        mimeType: archiveProtoAttachment.mimeType,
+        filename: archiveProtoAttachment.filename,
+        challengeId: 'valideProtoForActifSkillNewId',
+        localizedChallengeId: 'valideProtoForActifSkillNewId',
+      }),
+      domainBuilder.buildAttachment({
+        id: null,
+        url: archiveProtoAttachmentNL.url,
+        type: archiveProtoAttachmentNL.type,
+        size: archiveProtoAttachmentNL.size,
+        mimeType: archiveProtoAttachmentNL.mimeType,
+        filename: archiveProtoAttachmentNL.filename,
+        challengeId: 'valideProtoForActifSkillNewId',
+        localizedChallengeId: 'valideProtoForActifSkillNLNewId',
+      }),
+    ]);
+    const focus_phrase_records = await knex('focus_phrase').select('*').where({ scriptExectId: myCurrentScriptId }).orderBy(['type', 'persistantId']);
+    expect(focus_phrase_records).toStrictEqual([
+      {
+        id: expect.any(Number),
+        persistantId: 'proposeDecliValideProtoForActifSkillNewId',
+        originPersistantId: 'obsoleteDecliForSkillABC',
+        type: 'challenge',
+        createdAt: expect.anything(),
+        scriptExectId: expect.anything(),
+      },
+      {
+        id: expect.any(Number),
+        persistantId: 'valideDecliValideProtoForActifSkillNewId',
+        originPersistantId: 'archiveDecliForSkillABC',
+        type: 'challenge',
+        createdAt: expect.anything(),
+        scriptExectId: expect.anything(),
+      },
+      {
+        id: expect.any(Number),
+        persistantId: 'valideProtoForActifSkillNewId',
+        originPersistantId: 'archiveProtoForSkillABC',
+        type: 'challenge',
+        createdAt: expect.anything(),
+        scriptExectId: expect.anything(),
+      },
+    ]);
+  });
+
+  it('should obsolete challenges of cloned skill', async() => {
+    // given
+    const scriptExectIdToFix = '1718928111121';
+    await knex('historic_focus').insert([
+      {
+        persistantId: 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+        dryRun: false,
+        createdAt: new Date('2020-01-01'),
+      },
+    ]);
+    await knex('focus_phrase').insert([
+      {
+        type: 'skill',
+        persistantId : 'skillABC_clone',
+        originPersistantId : 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+      },
+      {
+        type: 'challenge',
+        persistantId: 'challengeToPerime1',
+        originPersistantId : 'challengeOrigine1',
+        scriptExectId: scriptExectIdToFix,
+      },
+      {
+        type: 'challenge',
+        persistantId: 'challengeToPerime2',
+        originPersistantId : 'challengeOrigine2',
+        scriptExectId: scriptExectIdToFix,
+      },
+      {
+        type: 'challenge',
+        persistantId: 'ignoreMe',
+        originPersistantId : 'osef',
+        scriptExectId: '171892811487',
+      },
+    ]);
+    idGenerator.generateNewId
+      .mockReturnValueOnce('valideProtoForActifSkillNewId')
+      .mockReturnValueOnce('valideProtoForActifSkillNLNewId');
+    const skillABC_data = {
+      id: 'skillABC',
+      description: 'la description de mon acquis',
+      hintStatus: 'some hint status',
+      status: Skill.STATUSES.ARCHIVE,
+      tubeId: 'tubeId',
+      competenceId: 'competenceId',
+      version: 2,
+      level: 1,
+      name: '@baseTube1',
+      tutorialIds: ['monTuto1Id'],
+      learningMoreTutorialIds: ['monTuto2Id'],
+      internationalisation: 'France',
+    };
+    const skillABC_clone_data = {
+      ...skillABC_data,
+      id: 'skillABC_clone',
+    };
+    const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+    const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/Acquis')
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .query(true)
+      .times(2)
+      .reply(200, { records: [skillABC, skillABC_clone] });
+    attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => []);
+
+    const archiveProtoForActifSkill = domainBuilder.buildChallenge({
+      id: 'archiveProtoForSkillABC',
+      status: Challenge.STATUSES.ARCHIVE,
+      skillId: 'skillABC',
+      genealogy: 'Prototype 1',
+      version: 4,
+      focusable: false,
+      locales: ['fr'],
+      archivedAt: new Date('2020-01-01'),
+      translations: { fr: { instruction: 'instruction archiveProto fr' } },
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'archiveProtoForSkillABC',
+          challengeId: 'archiveProtoForSkillABC',
+          embedUrl: 'archiveProto embedUrl',
+          fileIds: [],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://archiveProto.com'],
+        }),
+      ],
+    });
+
+    const challengeToPerime1_data = {
+      id: 'challengeToPerime1',
+      status: Challenge.STATUSES.VALIDE,
+      skillId: 'osefId',
+      locales: ['fr'],
+      archivedAt: null,
+      madeObsoleteAt: null,
+      translations: { fr: { instruction: 'instruction valide fr' } },
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'challengeToPerime1Id',
+          challengeId: 'challengeToPerime1Id',
+          embedUrl: 'valide embedUrl',
+          fileIds: [],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://valide.com'],
+        }),
+      ],
+    };
+    const challengeToPerime2_data = {
+      id: 'challengeToPerime2',
+      status: Challenge.STATUSES.PROPOSE,
+      skillId: 'osefId',
+      locales: ['fr'],
+      archivedAt: null,
+      madeObsoleteAt: null,
+      translations: { fr: { instruction: 'instruction valide fr' } },
+      localizedChallenges: [
+        domainBuilder.buildLocalizedChallenge({
+          id: 'challengeToPerime2Id',
+          challengeId: 'challengeToPerime2Id',
+          embedUrl: 'propose embedUrl',
+          fileIds: [],
+          locale: 'fr',
+          status: null,
+          geography: 'France',
+          urlsToConsult: ['http://propose.com'],
+        }),
+      ],
+    };
+    const challengeToPerime1 = domainBuilder.buildChallenge(challengeToPerime1_data);
+    const challengeToPerime2 = domainBuilder.buildChallenge(challengeToPerime2_data);
+    const challenges = [archiveProtoForActifSkill, challengeToPerime1];
+
+    vi.spyOn(challengeRepository, 'listBySkillId')
+      .mockImplementation((skillId) => challenges.filter((challenge) => challenge.skillId === skillId));
+    vi.spyOn(challengeRepository, 'getMany')
+      .mockResolvedValue([challengeToPerime1, challengeToPerime2]);
+
+    // when
+    await script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId });
+
+    // then
+    expect(challengeRepository.updateBatch).toHaveBeenCalledTimes(1);
+    expect(challengeRepository.updateBatch).toHaveBeenCalledWith([
+      domainBuilder.buildChallenge({
+        ...challengeToPerime1_data,
+        status: Challenge.STATUSES.PERIME,
+        madeObsoleteAt: obsoleteAt,
+      }),
+      domainBuilder.buildChallenge({
+        ...challengeToPerime2_data,
+        status: Challenge.STATUSES.PERIME,
+        madeObsoleteAt: obsoleteAt,
+      }),
+    ]);
+  });
+
+  describe('historic line', () => {
+    it('clone not found', async() => {
+      // given
+      const scriptExectIdToFix = '1718928111121';
+      await knex('historic_focus').insert([
+        {
+          persistantId: 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+          dryRun: false,
+        },
+      ]);
+      await knex('focus_phrase').insert([
+        {
+          type: 'skill',
+          persistantId : 'skillDEF_clone',
+          originPersistantId : 'skillDEF',
+          scriptExectId: scriptExectIdToFix,
+        },
+      ]);
+      idGenerator.generateNewId
+        .mockReturnValueOnce('valideProtoForActifSkillNewId');
+      const skillABC_data = {
+        id: 'skillABC',
+        description: 'la description de mon acquis',
+        hintStatus: 'some hint status',
+        status: Skill.STATUSES.ARCHIVE,
+        tubeId: 'tubeId',
+        competenceId: 'competenceId',
+        version: 2,
+        level: 1,
+        name: '@baseTube1',
+        tutorialIds: ['monTuto1Id'],
+        learningMoreTutorialIds: ['monTuto2Id'],
+        internationalisation: 'France',
+      };
+      const skillDEF_clone_data = {
+        ...skillABC_data,
+        id: 'skillDEF_clone',
+        name: 'pas le meme',
+      };
+      const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+      const skillDEF_clone = airtableBuilder.factory.buildSkill(skillDEF_clone_data);
+      nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Acquis')
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .query(true)
+        .times(2)
+        .reply(200, { records: [skillABC, skillDEF_clone] });
+      attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => []);
+
+      vi.spyOn(challengeRepository, 'listBySkillId').mockResolvedValue([]);
+      vi.spyOn(challengeRepository, 'getMany').mockResolvedValue([]);
+
+      // when
+      await expect(() => script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId })).rejects.toThrowError('clone non trouvé');
+      const historic_focus = await knex('historic_focus').select('*').where({ scriptExectId: myCurrentScriptId });
+      expect(historic_focus).toStrictEqual([
+        {
+          id: expect.any(Number),
+          persistantId: skillABC_data.id,
+          errorStr: expect.any(String),
+          details: `RAS Erreur lors du rematching acquis origine/cloné. Nom de l'acquis ${skillABC_data.name}.`,
+          createdAt: expect.anything(),
+          dryRun: false,
+          scriptExectId: expect.anything(),
+        },
+      ]);
+    });
+
+    it('reading in airtable fails', async() => {
+      // given
+      const scriptExectIdToFix = '1718928111121';
+      await knex('historic_focus').insert([
+        {
+          persistantId: 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+          dryRun: false,
+          createdAt: new Date('2020-01-01'),
+        },
+      ]);
+      await knex('focus_phrase').insert([
+        {
+          type: 'skill',
+          persistantId : 'skillABC_clone',
+          originPersistantId : 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+        },
+      ]);
+      idGenerator.generateNewId
+        .mockReturnValueOnce('archiveProtoForActifSkillNewId');
+      const skillABC_data = {
+        id: 'skillABC',
+        description: 'la description de mon acquis',
+        hintStatus: 'some hint status',
+        status: Skill.STATUSES.ARCHIVE,
+        tubeId: 'tubeId',
+        competenceId: 'competenceId',
+        version: 2,
+        level: 1,
+        name: '@baseTube1',
+        tutorialIds: ['monTuto1Id'],
+        learningMoreTutorialIds: ['monTuto2Id'],
+        internationalisation: 'France',
+      };
+      const skillABC_clone_data = {
+        ...skillABC_data,
+        id: 'skillABC_clone',
+      };
+      const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+      const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+      nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Acquis')
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .query(true)
+        .times(2)
+        .reply(200, { records: [skillABC, skillABC_clone] });
+      const archiveProtoAttachment = domainBuilder.buildAttachment({
+        id: 'archiveProtoAttachmentId',
+        url: 'url attach archiveProto',
+        type: 'type attach archiveProto',
+        size: 1,
+        mimeType: 'mimeType1',
+        filename: 'filename_archiveproto',
+        challengeId: 'archiveProtoForSkillABC',
+        localizedChallengeId: 'archiveProtoForSkillABC',
+      });
+      attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => {
+        throw new Error('ERREUR attachmentRepository.listByLocalizedChallengeIds');
+      });
+
+      const archiveProtoForActifSkill = domainBuilder.buildChallenge({
+        id: 'archiveProtoForSkillABC',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 4,
+        focusable: false,
+        locales: ['fr'],
+        archivedAt: new Date('2020-01-01'),
+        translations: { fr: { instruction: 'instruction archiveProto fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: 'archiveProtoForSkillABC',
+            challengeId: 'archiveProtoForSkillABC',
+            embedUrl: 'archiveProto embedUrl',
+            fileIds: [archiveProtoAttachment.id],
+            locale: 'fr',
+            status: null,
+            geography: 'France',
+            urlsToConsult: ['http://archiveProto.com'],
+          }),
+        ],
+      });
+      const challenges = [archiveProtoForActifSkill];
+
+      vi.spyOn(challengeRepository, 'listBySkillId')
+        .mockImplementation((skillId) => challenges.filter((challenge) => challenge.skillId === skillId));
+      vi.spyOn(challengeRepository, 'getMany').mockResolvedValue([]);
+
+      // when
+      await expect(() => script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId })).rejects.toThrowError('ERREUR attachmentRepository.listByLocalizedChallengeIds');
+      const historic_focus = await knex('historic_focus').select('*').where({ scriptExectId: myCurrentScriptId });
+      expect(historic_focus).toStrictEqual([
+        {
+          id: expect.any(Number),
+          persistantId: skillABC_data.id,
+          errorStr: expect.any(String),
+          details: 'RAS Erreur lors d\'une lecture sur Airtable. Rien à nettoyer. ID Clone : skillABC_clone',
+          createdAt: expect.anything(),
+          dryRun: false,
+          scriptExectId: expect.anything(),
+        },
+      ]);
+    });
+
+    it('challenge creation fails', async() => {
+      // given
+      const scriptExectIdToFix = '1718928111121';
+      await knex('historic_focus').insert([
+        {
+          persistantId: 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+          dryRun: false,
+          createdAt: new Date('2020-01-01'),
+        },
+      ]);
+      await knex('focus_phrase').insert([
+        {
+          type: 'skill',
+          persistantId : 'skillABC_clone',
+          originPersistantId : 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+        },
+      ]);
+      idGenerator.generateNewId
+        .mockReturnValueOnce('valideProtoForActifSkillNewId');
+      const skillABC_data = {
+        id: 'skillABC',
+        description: 'la description de mon acquis',
+        hintStatus: 'some hint status',
+        status: Skill.STATUSES.ARCHIVE,
+        tubeId: 'tubeId',
+        competenceId: 'competenceId',
+        version: 2,
+        level: 1,
+        name: '@baseTube1',
+        tutorialIds: ['monTuto1Id'],
+        learningMoreTutorialIds: ['monTuto2Id'],
+        internationalisation: 'France',
+      };
+      const skillABC_clone_data = {
+        ...skillABC_data,
+        id: 'skillABC_clone',
+      };
+      const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+      const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+      nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Acquis')
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .query(true)
+        .times(2)
+        .reply(200, { records: [skillABC, skillABC_clone] });
+      const archiveProtoAttachment = domainBuilder.buildAttachment({
+        id: 'archiveProtoAttachmentId',
+        url: 'url attach archiveProto',
+        type: 'type attach archiveProto',
+        size: 1,
+        mimeType: 'mimeType1',
+        filename: 'filename_archiveproto',
+        challengeId: 'archiveProtoForSkillABC',
+        localizedChallengeId: 'archiveProtoForSkillABC',
+      });
+      attachmentRepository.listByLocalizedChallengeIds.mockResolvedValue([archiveProtoAttachment]);
+
+      const archiveProtoForActifSkill = domainBuilder.buildChallenge({
+        id: 'archiveProtoForSkillABC',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 4,
+        focusable: false,
+        locales: ['fr'],
+        archivedAt: new Date('2020-01-01'),
+        translations: { fr: { instruction: 'instruction archiveProto fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: 'archiveProtoForSkillABC',
+            challengeId: 'archiveProtoForSkillABC',
+            embedUrl: 'archiveProto embedUrl',
+            fileIds: [archiveProtoAttachment.id],
+            locale: 'fr',
+            status: null,
+            geography: 'France',
+            urlsToConsult: ['http://archiveProto.com'],
+          }),
+        ],
+      });
+      const challenges = [archiveProtoForActifSkill];
+
+      vi.spyOn(challengeRepository, 'listBySkillId')
+        .mockImplementation((skillId) => challenges.filter((challenge) => challenge.skillId === skillId));
+      vi.spyOn(challengeRepository, 'getMany').mockResolvedValue([]);
+      challengeRepository.createBatch.mockImplementationOnce(() => {
+        throw new Error('ERREUR challengeRepository.createBatch');
+      });
+
+      // when
+      await expect(() => script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId })).rejects.toThrowError('ERREUR challengeRepository.createBatch');
+      const historic_focus = await knex('historic_focus').select('*').where({ scriptExectId: myCurrentScriptId });
+      expect(historic_focus).toStrictEqual([
+        {
+          id: expect.any(Number),
+          persistantId: skillABC_data.id,
+          errorStr: expect.any(String),
+          details: `Erreur lors de la création en masse des épreuves clonées. Potentielles données à nettoyer (liste dans l'ordre de création):
+          challenges valideProtoForActifSkillNewId sur Airtable,
+          translations avec les patterns "challenge.valideProtoForActifSkillNewId%" sur PG,
+          localizedChallenges dont les challengeIds sont valideProtoForActifSkillNewId sur PG`,
+          createdAt: expect.anything(),
+          dryRun: false,
+          scriptExectId: expect.anything(),
+        },
+      ]);
+    });
+
+    it('attachment creation fails', async() => {
+      // given
+      const scriptExectIdToFix = '1718928111121';
+      await knex('historic_focus').insert([
+        {
+          persistantId: 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+          dryRun: false,
+          createdAt: new Date('2020-01-01'),
+        },
+      ]);
+      await knex('focus_phrase').insert([
+        {
+          type: 'skill',
+          persistantId : 'skillABC_clone',
+          originPersistantId : 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+        },
+      ]);
+      idGenerator.generateNewId
+        .mockReturnValueOnce('valideProtoForActifSkillNewId');
+      const skillABC_data = {
+        id: 'skillABC',
+        description: 'la description de mon acquis',
+        hintStatus: 'some hint status',
+        status: Skill.STATUSES.ARCHIVE,
+        tubeId: 'tubeId',
+        competenceId: 'competenceId',
+        version: 2,
+        level: 1,
+        name: '@baseTube1',
+        tutorialIds: ['monTuto1Id'],
+        learningMoreTutorialIds: ['monTuto2Id'],
+        internationalisation: 'France',
+      };
+      const skillABC_clone_data = {
+        ...skillABC_data,
+        id: 'skillABC_clone',
+      };
+      const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+      const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+      nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Acquis')
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .query(true)
+        .times(2)
+        .reply(200, { records: [skillABC, skillABC_clone] });
+      const archiveProtoAttachment = domainBuilder.buildAttachment({
+        id: 'archiveProtoAttachmentId',
+        url: 'url attach archiveProto',
+        type: 'type attach archiveProto',
+        size: 1,
+        mimeType: 'mimeType1',
+        filename: 'filename_archiveproto',
+        challengeId: 'archiveProtoForSkillABC',
+        localizedChallengeId: 'archiveProtoForSkillABC',
+      });
+      attachmentRepository.listByLocalizedChallengeIds.mockResolvedValue([archiveProtoAttachment]);
+
+      const archiveProtoForActifSkill = domainBuilder.buildChallenge({
+        id: 'archiveProtoForSkillABC',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 4,
+        focusable: false,
+        locales: ['fr'],
+        archivedAt: new Date('2020-01-01'),
+        translations: { fr: { instruction: 'instruction archiveProto fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: 'archiveProtoForSkillABC',
+            challengeId: 'archiveProtoForSkillABC',
+            embedUrl: 'archiveProto embedUrl',
+            fileIds: [archiveProtoAttachment.id],
+            locale: 'fr',
+            status: null,
+            geography: 'France',
+            urlsToConsult: ['http://archiveProto.com'],
+          }),
+        ],
+      });
+      const challenges = [archiveProtoForActifSkill];
+
+      vi.spyOn(challengeRepository, 'listBySkillId')
+        .mockImplementation((skillId) => challenges.filter((challenge) => challenge.skillId === skillId));
+      vi.spyOn(challengeRepository, 'getMany').mockResolvedValue([]);
+      attachmentRepository.createBatch.mockImplementationOnce(() => {
+        throw new Error('ERREUR attachmentRepository.createBatch');
+      });
+
+      // when
+      await expect(() => script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId })).rejects.toThrowError('ERREUR attachmentRepository.createBatch');
+      const historic_focus = await knex('historic_focus').select('*').where({ scriptExectId: myCurrentScriptId });
+      expect(historic_focus).toStrictEqual([
+        {
+          id: expect.any(Number),
+          persistantId: skillABC_data.id,
+          errorStr: expect.any(String),
+          details: `Erreur lors de la création en masse des attachments clonés. Potentielles données à nettoyer (liste dans l'ordre de création):
+          challenges valideProtoForActifSkillNewId sur Airtable,
+          translations avec les patterns "challenge.valideProtoForActifSkillNewId%" sur PG,
+          localizedChallenges dont les challengeIds sont valideProtoForActifSkillNewId sur PG,
+          attachments dont les challengeIds persistant sont valideProtoForActifSkillNewId sur Airtable,
+          localized_challenges-attachments dont les localizedChallengeIds sont valideProtoForActifSkillNewId sur PG`,
+          createdAt: expect.anything(),
+          dryRun: false,
+          scriptExectId: expect.anything(),
+        },
+      ]);
+    });
+
+    it('challenge obsolete fails', async() => {
+      // given
+      const scriptExectIdToFix = '1718928111121';
+      await knex('historic_focus').insert([
+        {
+          persistantId: 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+          dryRun: false,
+          createdAt: new Date('2020-01-01'),
+        },
+      ]);
+      await knex('focus_phrase').insert([
+        {
+          type: 'skill',
+          persistantId : 'skillABC_clone',
+          originPersistantId : 'skillABC',
+          scriptExectId: scriptExectIdToFix,
+        },
+        {
+          type: 'challenge',
+          persistantId: 'challengeToPerime1',
+          originPersistantId : 'challengeOrigine1',
+          scriptExectId: scriptExectIdToFix,
+        },
+      ]);
+      idGenerator.generateNewId
+        .mockReturnValueOnce('valideProtoForActifSkillNewId');
+      const skillABC_data = {
+        id: 'skillABC',
+        description: 'la description de mon acquis',
+        hintStatus: 'some hint status',
+        status: Skill.STATUSES.ARCHIVE,
+        tubeId: 'tubeId',
+        competenceId: 'competenceId',
+        version: 2,
+        level: 1,
+        name: '@baseTube1',
+        tutorialIds: ['monTuto1Id'],
+        learningMoreTutorialIds: ['monTuto2Id'],
+        internationalisation: 'France',
+      };
+      const skillABC_clone_data = {
+        ...skillABC_data,
+        id: 'skillABC_clone',
+      };
+      const skillABC = airtableBuilder.factory.buildSkill(skillABC_data);
+      const skillABC_clone = airtableBuilder.factory.buildSkill(skillABC_clone_data);
+      nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Acquis')
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .query(true)
+        .times(2)
+        .reply(200, { records: [skillABC, skillABC_clone] });
+      attachmentRepository.listByLocalizedChallengeIds.mockImplementation(() => []);
+
+      const archiveProtoForActifSkill = domainBuilder.buildChallenge({
+        id: 'archiveProtoForSkillABC',
+        status: Challenge.STATUSES.ARCHIVE,
+        skillId: 'skillABC',
+        genealogy: 'Prototype 1',
+        version: 4,
+        focusable: false,
+        locales: ['fr'],
+        archivedAt: new Date('2020-01-01'),
+        translations: { fr: { instruction: 'instruction archiveProto fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: 'archiveProtoForSkillABC',
+            challengeId: 'archiveProtoForSkillABC',
+            embedUrl: 'archiveProto embedUrl',
+            fileIds: [],
+            locale: 'fr',
+            status: null,
+            geography: 'France',
+            urlsToConsult: ['http://archiveProto.com'],
+          }),
+        ],
+      });
+
+      const challengeToPerime1_data = {
+        id: 'challengeToPerime1',
+        status: Challenge.STATUSES.VALIDE,
+        skillId: 'skillABC_clone',
+        locales: ['fr'],
+        archivedAt: null,
+        madeObsoleteAt: null,
+        translations: { fr: { instruction: 'instruction valide fr' } },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: 'challengeToPerime1Id',
+            challengeId: 'challengeToPerime1Id',
+            embedUrl: 'valide embedUrl',
+            fileIds: [],
+            locale: 'fr',
+            status: null,
+            geography: 'France',
+            urlsToConsult: ['http://valide.com'],
+          }),
+        ],
+      };
+      const challengeToPerime1 = domainBuilder.buildChallenge(challengeToPerime1_data);
+      const challenges = [archiveProtoForActifSkill, challengeToPerime1];
+
+      vi.spyOn(challengeRepository, 'listBySkillId')
+        .mockImplementation((skillId) => challenges.filter((challenge) => challenge.skillId === skillId));
+      vi.spyOn(challengeRepository, 'getMany')
+        .mockResolvedValue([challengeToPerime1]);
+
+      // when
+      await script.fix({ dryRun: false, scriptExectIdToFix, scriptExectId: myCurrentScriptId });
+
+      // then
+      expect(challengeRepository.updateBatch).toHaveBeenCalledTimes(1);
+      expect(challengeRepository.updateBatch).toHaveBeenCalledWith([
+        domainBuilder.buildChallenge({
+          ...challengeToPerime1_data,
+          status: Challenge.STATUSES.PERIME,
+          madeObsoleteAt: obsoleteAt,
+        }),
+      ]);
+    });
+  });
+});

--- a/api/tests/scripts/move-skills-to-focus_test.js
+++ b/api/tests/scripts/move-skills-to-focus_test.js
@@ -221,8 +221,10 @@ describe('Script | Move skills to focus', function() {
         {
           id: expect.any(Number),
           persistantId: 'skillNewId',
+          originPersistantId: 'actifSkillId',
           type: 'skill',
           createdAt: expect.anything(),
+          scriptExectId: expect.anything(),
         },
       ]);
     });
@@ -643,26 +645,34 @@ describe('Script | Move skills to focus', function() {
         {
           id: expect.any(Number),
           persistantId: 'proposeDecliValideProtoForActifSkillNewId',
+          originPersistantId: 'proposeDecliValideProtoForActifSkillId',
           type: 'challenge',
           createdAt: expect.anything(),
+          scriptExectId: expect.anything(),
         },
         {
           id: expect.any(Number),
           persistantId: 'valideDecliValideProtoForActifSkillNewId',
+          originPersistantId: 'valideDecliValideProtoForActifSkillId',
           type: 'challenge',
           createdAt: expect.anything(),
+          scriptExectId: expect.anything(),
         },
         {
           id: expect.any(Number),
           persistantId: 'valideProtoForActifSkillNewId',
+          originPersistantId: 'valideProtoForActifSkillId',
           type: 'challenge',
           createdAt: expect.anything(),
+          scriptExectId: expect.anything(),
         },
         {
           id: expect.any(Number),
           persistantId: 'skillNewId',
+          originPersistantId: 'actifSkillId',
           type: 'skill',
           createdAt: expect.anything(),
+          scriptExectId: expect.anything(),
         },
       ]);
     });
@@ -819,7 +829,7 @@ describe('Script | Move skills to focus', function() {
     describe('historic line', () => {
       let actifSkillData;
       const clonedSkillId = 'skillNewId';
-      const clonedChallengeIds = ['valideProtoForActifSkillNewId', 'valideDecliValideProtoForActifSkillNewId', 'proposeDecliValideProtoForActifSkillNewId'];
+      const clonedChallengeIds = ['valideProtoForActifSkillNewId', 'proposeDecliValideProtoForActifSkillNewId', 'valideDecliValideProtoForActifSkillNewId'];
       const clonedLocalizedChallengeId = 'valideProtoForActifSkillNLNewId';
 
       beforeEach(async () => {
@@ -1011,6 +1021,7 @@ describe('Script | Move skills to focus', function() {
             details: 'RAS Erreur lors d\'une lecture sur Airtable. Rien à nettoyer.',
             createdAt: expect.anything(),
             dryRun: false,
+            scriptExectId: expect.anything(),
           },
         ]);
         const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
@@ -1036,6 +1047,7 @@ describe('Script | Move skills to focus', function() {
             details: 'RAS Erreur lors d\'une lecture sur Airtable. Rien à nettoyer.',
             createdAt: expect.anything(),
             dryRun: false,
+            scriptExectId: expect.anything(),
           },
         ]);
         const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
@@ -1061,6 +1073,7 @@ describe('Script | Move skills to focus', function() {
           translations avec le pattern "skill.${clonedSkillId}%" sur PG`,
             createdAt: expect.anything(),
             dryRun: false,
+            scriptExectId: expect.anything(),
           },
         ]);
         const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
@@ -1089,6 +1102,7 @@ describe('Script | Move skills to focus', function() {
           localizedChallenges dont les challengeIds sont ${clonedChallengeIds[0]}, ${clonedChallengeIds[1]}, ${clonedChallengeIds[2]} sur PG`,
             createdAt: expect.anything(),
             dryRun: false,
+            scriptExectId: expect.anything(),
           },
         ]);
         const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
@@ -1123,6 +1137,7 @@ describe('Script | Move skills to focus', function() {
           `,
             createdAt: expect.anything(),
             dryRun: false,
+            scriptExectId: expect.anything(),
           },
         ]);
         const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
@@ -1146,6 +1161,7 @@ describe('Script | Move skills to focus', function() {
             details: 'Erreur lors de l\'archivage de l\'acquis. A priori les clones sont sains. On peut envisager d\'archiver l\'acquis à la main sur Airtable et ses épreuves (status + dates le cas échéant)',
             createdAt: expect.anything(),
             dryRun: false,
+            scriptExectId: expect.anything(),
           },
         ]);
         const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
@@ -1153,25 +1169,33 @@ describe('Script | Move skills to focus', function() {
           {
             id: expect.any(Number),
             persistantId: 'proposeDecliValideProtoForActifSkillNewId',
+            originPersistantId: 'proposeDecliValideProtoForActifSkillId',
             type: 'challenge',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
           {
             id: expect.any(Number),
             persistantId: 'valideDecliValideProtoForActifSkillNewId',
+            originPersistantId: 'valideDecliValideProtoForActifSkillId',
             type: 'challenge',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
           {
             id: expect.any(Number),
             persistantId: 'valideProtoForActifSkillNewId',
+            originPersistantId: 'valideProtoForActifSkillId',
             type: 'challenge',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
           {
             id: expect.any(Number),
             persistantId: 'skillNewId',
+            originPersistantId: 'actifSkillId',
             type: 'skill',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
         ]);
@@ -1192,6 +1216,7 @@ describe('Script | Move skills to focus', function() {
             persistantId: actifSkillData.id,
             errorStr: expect.any(String),
             details: 'Erreur lors de l\'archivage en masse des épreuves. A priori les clones sont sains. On peut envisager de finir l\'archivage des épreuves à la main sur Airtable',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
             dryRun: false,
           },
@@ -1201,25 +1226,33 @@ describe('Script | Move skills to focus', function() {
           {
             id: expect.any(Number),
             persistantId: 'proposeDecliValideProtoForActifSkillNewId',
+            originPersistantId: 'proposeDecliValideProtoForActifSkillId',
             type: 'challenge',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
           {
             id: expect.any(Number),
             persistantId: 'valideDecliValideProtoForActifSkillNewId',
+            originPersistantId: 'valideDecliValideProtoForActifSkillId',
             type: 'challenge',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
           {
             id: expect.any(Number),
             persistantId: 'valideProtoForActifSkillNewId',
+            originPersistantId: 'valideProtoForActifSkillId',
             type: 'challenge',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
           {
             id: expect.any(Number),
             persistantId: 'skillNewId',
+            originPersistantId: 'actifSkillId',
             type: 'skill',
+            scriptExectId: expect.anything(),
             createdAt: expect.anything(),
           },
         ]);

--- a/api/tests/scripts/move-skills-to-focus_test.js
+++ b/api/tests/scripts/move-skills-to-focus_test.js
@@ -770,7 +770,7 @@ describe('Script | Move skills to focus', function() {
       const archiveForActifSkillData = {
         id: 'archiveForActifSkillId',
         status: Challenge.STATUSES.ARCHIVE,
-        archivedAt: new Date('2020-01-01'),
+        archivedAt: new Date('2020-01-01').toISOString(),
         madeObsoleteAt: null,
         skillId: 'actifSkillId',
         locales: ['fr'],
@@ -808,14 +808,14 @@ describe('Script | Move skills to focus', function() {
         domainBuilder.buildChallenge({
           ...valideForActifSkillData,
           status: Challenge.STATUSES.ARCHIVE,
-          archivedAt: archivedAtDate,
+          archivedAt: archivedAtDate.toISOString(),
           madeObsoleteAt: null,
         }),
         domainBuilder.buildChallenge({
           ...proposeForActifSkillData,
           status: Challenge.STATUSES.PERIME,
           archivedAt: null,
-          madeObsoleteAt: archivedAtDate,
+          madeObsoleteAt: archivedAtDate.toISOString(),
         }),
         domainBuilder.buildChallenge({
           ...archiveForActifSkillData,

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -124,6 +124,35 @@ describe('Unit | Domain | Challenge', () => {
     });
   });
 
+  describe('#get isArchive', () => {
+    it('should return true when challenge is archive', () => {
+      // given
+      const challenge  = domainBuilder.buildChallenge({
+        status: Challenge.STATUSES.ARCHIVE,
+      });
+
+      // when
+      const isArchive = challenge.isArchive;
+
+      // then
+      expect(isArchive).to.be.true;
+    });
+
+    it.each(Object.keys(Challenge.STATUSES).filter((statusKey) => Challenge.STATUSES[statusKey] !== Challenge.STATUSES.ARCHIVE)
+    )('should return false when status key is %s', (statusKey) => {
+      // given
+      const challenge  = domainBuilder.buildChallenge({
+        status: Challenge.STATUSES[statusKey],
+      });
+
+      // when
+      const isArchive = challenge.isArchive;
+
+      // then
+      expect(isArchive).to.be.false;
+    });
+  });
+
   describe('#get isValide', () => {
     it('should return true when challenge is valide', () => {
       // given
@@ -150,6 +179,35 @@ describe('Unit | Domain | Challenge', () => {
 
       // then
       expect(isValide).to.be.false;
+    });
+  });
+
+  describe('#get isPerime', () => {
+    it('should return true when challenge is perime', () => {
+      // given
+      const challenge  = domainBuilder.buildChallenge({
+        status: Challenge.STATUSES.PERIME,
+      });
+
+      // when
+      const isPerime = challenge.isPerime;
+
+      // then
+      expect(isPerime).to.be.true;
+    });
+
+    it.each(Object.keys(Challenge.STATUSES).filter((statusKey) => Challenge.STATUSES[statusKey] !== Challenge.STATUSES.PERIME)
+    )('should return false when status key is %s', (statusKey) => {
+      // given
+      const challenge  = domainBuilder.buildChallenge({
+        status: Challenge.STATUSES[statusKey],
+      });
+
+      // when
+      const isPerime = challenge.isPerime;
+
+      // then
+      expect(isPerime).to.be.false;
     });
   });
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -884,4 +884,54 @@ describe('Unit | Domain | Challenge', () => {
       expect(challengeToArchive).toStrictEqual(expectedUnchangedChallenge);
     });
   });
+
+  describe('#obsolete', () => {
+    const now = new Date('2021-10-29T03:03:00Z');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should left the challenge unchanged when is already obsolete', () => {
+      // given
+      const obsoleteChallenge = domainBuilder.buildChallenge({
+        madeObsoleteAt: new Date('2024-01-01T00:00:00Z'),
+        status: Challenge.STATUSES.PERIME,
+      });
+
+      // when
+      obsoleteChallenge.obsolete();
+
+      // then
+      const expectedObsoleteChallenge = domainBuilder.buildChallenge({
+        madeObsoleteAt: new Date('2024-01-01T00:00:00Z'),
+        status: Challenge.STATUSES.PERIME,
+      });
+      expect(obsoleteChallenge).toStrictEqual(expectedObsoleteChallenge);
+    });
+
+    it.each(Object.keys(Challenge.STATUSES).filter((statusKey) => Challenge.STATUSES.PERIME !== Challenge.STATUSES[statusKey])
+    )('should do nothing when statusKey is %s', (statusKey) => {
+      // given
+      const challengeToPerime = domainBuilder.buildChallenge({
+        madeObsoleteAt: null,
+        status: Challenge.STATUSES[statusKey],
+      });
+
+      // when
+      challengeToPerime.obsolete();
+
+      // then
+      const expectedObsoleteChallenge = domainBuilder.buildChallenge({
+        madeObsoleteAt: now,
+        status: Challenge.STATUSES.PERIME,
+      });
+      expect(challengeToPerime).toStrictEqual(expectedObsoleteChallenge);
+    });
+  });
 });

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -837,7 +837,7 @@ describe('Unit | Domain | Challenge', () => {
       // then
       const expectedArchivedChallenge = domainBuilder.buildChallenge({
         archivedAt: null,
-        madeObsoleteAt: now,
+        madeObsoleteAt: now.toISOString(),
         status: Challenge.STATUSES.PERIME,
       });
       expect(challengeToArchive).toStrictEqual(expectedArchivedChallenge);
@@ -856,7 +856,7 @@ describe('Unit | Domain | Challenge', () => {
 
       // then
       const expectedArchivedChallenge = domainBuilder.buildChallenge({
-        archivedAt: now,
+        archivedAt: now.toISOString(),
         madeObsoleteAt: null,
         status: Challenge.STATUSES.ARCHIVE,
       });
@@ -867,8 +867,8 @@ describe('Unit | Domain | Challenge', () => {
     )('should do nothing when statusKey is %s', (statusKey) => {
       // given
       const challengeToArchive = domainBuilder.buildChallenge({
-        archivedAt: new Date('2019-10-01'),
-        madeObsoleteAt: new Date('2019-10-02'),
+        archivedAt: new Date('2019-10-01').toISOString(),
+        madeObsoleteAt: new Date('2019-10-02').toISOString(),
         status: Challenge.STATUSES[statusKey],
       });
 
@@ -877,8 +877,8 @@ describe('Unit | Domain | Challenge', () => {
 
       // then
       const expectedUnchangedChallenge = domainBuilder.buildChallenge({
-        archivedAt: new Date('2019-10-01'),
-        madeObsoleteAt: new Date('2019-10-02'),
+        archivedAt: new Date('2019-10-01').toISOString(),
+        madeObsoleteAt: new Date('2019-10-02').toISOString(),
         status: Challenge.STATUSES[statusKey],
       });
       expect(challengeToArchive).toStrictEqual(expectedUnchangedChallenge);
@@ -900,7 +900,7 @@ describe('Unit | Domain | Challenge', () => {
     it('should left the challenge unchanged when is already obsolete', () => {
       // given
       const obsoleteChallenge = domainBuilder.buildChallenge({
-        madeObsoleteAt: new Date('2024-01-01T00:00:00Z'),
+        madeObsoleteAt: new Date('2024-01-01T00:00:00Z').toISOString(),
         status: Challenge.STATUSES.PERIME,
       });
 
@@ -909,7 +909,7 @@ describe('Unit | Domain | Challenge', () => {
 
       // then
       const expectedObsoleteChallenge = domainBuilder.buildChallenge({
-        madeObsoleteAt: new Date('2024-01-01T00:00:00Z'),
+        madeObsoleteAt: new Date('2024-01-01T00:00:00Z').toISOString(),
         status: Challenge.STATUSES.PERIME,
       });
       expect(obsoleteChallenge).toStrictEqual(expectedObsoleteChallenge);
@@ -928,7 +928,7 @@ describe('Unit | Domain | Challenge', () => {
 
       // then
       const expectedObsoleteChallenge = domainBuilder.buildChallenge({
-        madeObsoleteAt: now,
+        madeObsoleteAt: now.toISOString(),
         status: Challenge.STATUSES.PERIME,
       });
       expect(challengeToPerime).toStrictEqual(expectedObsoleteChallenge);

--- a/api/tests/unit/domain/models/Skill_test.js
+++ b/api/tests/unit/domain/models/Skill_test.js
@@ -261,7 +261,6 @@ describe('Unit | Domain | Skill', () => {
       expect(clonedSkill.learningMoreTutorialIds).toEqual(skillToClone.learningMoreTutorialIds);
       expect(clonedSkill.internationalisation).toEqual(skillToClone.internationalisation);
     });
-
     it('should handle reversioning of all challenges', () => {
       // given
       const tubeSkills = [
@@ -291,8 +290,9 @@ describe('Unit | Domain | Skill', () => {
       const activeProto = domainBuilder.buildChallenge({ id: 'activeProtoId', version: 5, genealogy: 'Prototype 1', status: Challenge.STATUSES.VALIDE });
       const decliPerimeProtoActive = domainBuilder.buildChallenge({ id: 'decliPerimeProtoActiveId', version: 5, alternativeVersion: 1, genealogy: 'Décliné 1', status: Challenge.STATUSES.PERIME });
       const decliArchiveProtoActive = domainBuilder.buildChallenge({ id: 'decliArchiveProtoActiveId', version: 5, alternativeVersion: 2, genealogy: 'Décliné 1', status: Challenge.STATUSES.ARCHIVE });
-      const decliValideProtoActive = domainBuilder.buildChallenge({ id: 'decliValideProtoActiveId', version: 5, alternativeVersion: 3, genealogy: 'Décliné 1', status: Challenge.STATUSES.VALIDE });
+      const decliValide1ProtoActive = domainBuilder.buildChallenge({ id: 'decliValide1ProtoActiveId', version: 5, alternativeVersion: null, genealogy: 'Décliné 1', status: Challenge.STATUSES.VALIDE });
       const decliProposeProtoActive = domainBuilder.buildChallenge({ id: 'decliProposeProtoActiveId', version: 5, alternativeVersion: 4, genealogy: 'Décliné 1', status: Challenge.STATUSES.PROPOSE });
+      const decliValide2ProtoActive = domainBuilder.buildChallenge({ id: 'decliValide2ProtoActiveId', version: 5, alternativeVersion: 6, genealogy: 'Décliné 1', status: Challenge.STATUSES.VALIDE });
       const proposeProto = domainBuilder.buildChallenge({ id: 'proposeProtoId', version: 7, genealogy: 'Prototype 1', status: Challenge.STATUSES.PROPOSE });
       const decliPerimeProtoPropose = domainBuilder.buildChallenge({ id: 'decliPerimeProtoProposeId', version: 7, genealogy: 'Décliné 1', status: Challenge.STATUSES.PERIME });
       const decliProposeProtoPropose = domainBuilder.buildChallenge({ id: 'decliProposeProtoProposeId', version: 7, genealogy: 'Décliné 1', status: Challenge.STATUSES.PROPOSE });
@@ -300,10 +300,11 @@ describe('Unit | Domain | Skill', () => {
         perimeProto,
         archiveProto,
         activeProto,
+        decliValide2ProtoActive,
         decliPerimeProtoActive,
         decliArchiveProtoActive,
-        decliValideProtoActive,
         decliProposeProtoActive,
+        decliValide1ProtoActive,
         proposeProto,
         decliPerimeProtoPropose,
         decliProposeProtoPropose,
@@ -326,8 +327,8 @@ describe('Unit | Domain | Skill', () => {
       });
 
       // then
-      expect(clonedAttachments).toEqual(['activeProtoId_attachment', 'decliValideProtoActiveId_attachment', 'decliProposeProtoActiveId_attachment', 'proposeProtoId_attachment', 'decliProposeProtoProposeId_attachment']);
-      expect(clonedChallenges).toEqual(['activeProtoId', 'decliValideProtoActiveId', 'decliProposeProtoActiveId', 'proposeProtoId', 'decliProposeProtoProposeId']);
+      expect(clonedAttachments).toEqual(['activeProtoId_attachment', 'decliProposeProtoActiveId_attachment', 'decliValide2ProtoActiveId_attachment', 'decliValide1ProtoActiveId_attachment', 'proposeProtoId_attachment', 'decliProposeProtoProposeId_attachment']);
+      expect(clonedChallenges).toEqual(['activeProtoId', 'decliProposeProtoActiveId', 'decliValide2ProtoActiveId', 'decliValide1ProtoActiveId', 'proposeProtoId', 'decliProposeProtoProposeId']);
       expect(spies[perimeProto.id]).toHaveBeenCalledTimes(0);
       expect(spies[archiveProto.id]).toHaveBeenCalledTimes(0);
       expect(spies[decliPerimeProtoActive.id]).toHaveBeenCalledTimes(0);
@@ -335,16 +336,19 @@ describe('Unit | Domain | Skill', () => {
       expect(spies[decliPerimeProtoPropose.id]).toHaveBeenCalledTimes(0);
       expect(spies[activeProto.id]).toHaveBeenCalledTimes(1);
       expect(spies[activeProto.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: null, prototypeVersion: 1 });
-      expect(spies[decliValideProtoActive.id]).toHaveBeenCalledTimes(1);
-      expect(spies[decliValideProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 1, prototypeVersion: 1 });
+      expect(spies[decliValide1ProtoActive.id]).toHaveBeenCalledTimes(1);
+      expect(spies[decliValide1ProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 3, prototypeVersion: 1 });
+      expect(spies[decliValide2ProtoActive.id]).toHaveBeenCalledTimes(1);
+      expect(spies[decliValide2ProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 2, prototypeVersion: 1 });
       expect(spies[decliProposeProtoActive.id]).toHaveBeenCalledTimes(1);
-      expect(spies[decliProposeProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 2, prototypeVersion: 1 });
+      expect(spies[decliProposeProtoActive.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 1, prototypeVersion: 1 });
       expect(spies[proposeProto.id]).toHaveBeenCalledTimes(1);
       expect(spies[proposeProto.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: null, prototypeVersion: 2 });
       expect(spies[decliProposeProtoPropose.id]).toHaveBeenCalledTimes(1);
       expect(spies[decliProposeProtoPropose.id]).toHaveBeenCalledWith({ skillId: clonedSkillId, competenceId: tubeDestination.competenceId, generateNewIdFnc, alternativeVersion: 1, prototypeVersion: 2 });
     });
   });
+  
   describe('#archiveSkillAndChallenges', () => {
     it('should archive skill', () => {
       // given


### PR DESCRIPTION
## :unicorn: Problème
On s'est aperçus après l'exécution du premier script pour passer un lot d'acquis en focus qu'on avait fait une erreur lors du clonage des attachments.
Lorsque, dans une même grappe d'épreuves (plus particulièrement les déclinaisons d'un même proto), les déclis avait une pièce jointe ou illustration avec le même nom de fichier (exemples: url/decliA/image.png et url/decliB/image.png), il se trouve qu'au clonage on générait la même url clonée, et par conséquent on utilisait une seule et même pièce jointe pour tout le monde.

## :robot: Proposition
- Corriger l'ancien script pour ne plus cloner les pièces jointes (on y a réfléchi en fait on s'~~emmer~~ embête pour rien).
- Faire un nouveau script pour réparer le coup. Il s'agit de re-cloner les épreuves d'origines et de périmer les épreuves clonées la première fois
- On ajoute des infos en BDD pour se souvenir de l'épreuve d'origine et pour identifier les exécutions de script

## :rainbow: Remarques
Bonus pour faire plaisir à Jérôme on a re-versionné les déclinaisons selon leur ordre de base.

## :100: Pour tester
LOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOL
