### PR TITLE
[BUGFIX] Le script pour corriger le script de passage en masse des focus ne prend pas la bonne date (PIX-13163)

### DIFF
--- a/api/scripts/fix-cloned-attachments/index.js
+++ b/api/scripts/fix-cloned-attachments/index.js
@@ -82,13 +82,13 @@ async function _obsoleteChallenges({ cloneSkills, scriptExectIdToFix, challengeR
   }
 }
 async function _getChallengesToClone({ skillChallenges, originSkillId, scriptExectIdToFix }) {
-  const [creattionSkillDate] = await knex('historic_focus').pluck('createdAt').where({
+  const { createdAt } = await knex('historic_focus').select('createdAt').where({
     persistantId: originSkillId,
     scriptExectId: scriptExectIdToFix
-  });
+  }).orderBy('createdAt', 'DESC').first();
 
-  const bottomDate = creattionSkillDate.getTime() - (10 * 60 * 1000);
-  const topDate = creattionSkillDate.getTime() + (10 * 60 * 1000);
+  const bottomDate = createdAt.getTime() - (10 * 60 * 1000);
+  const topDate = createdAt.getTime() + (10 * 60 * 1000);
 
   const protoToClone = skillChallenges.find((challenge) => {
     const archiveDate = new Date(challenge.archivedAt);

--- a/api/tests/scripts/fix-cloned-attachments_test.js
+++ b/api/tests/scripts/fix-cloned-attachments_test.js
@@ -185,6 +185,12 @@ describe('Script | Fix cloned attachments', function() {
         persistantId: 'skillABC',
         scriptExectId: scriptExectIdToFix,
         dryRun: false,
+        createdAt: new Date('2023-01-01T10:00:00Z')
+      },
+      {
+        persistantId: 'skillABC',
+        scriptExectId: scriptExectIdToFix,
+        dryRun: true,
         createdAt: new Date('2024-01-01T10:00:00Z')
       },
     ]);


### PR DESCRIPTION
## :unicorn: Problème
Si on a deux fois le meme acquis avec la meme execution, il faut prendre la date la plus récente (exemple exec en prod avec dryRun true/false)

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
