### PR TITLE
[BUGFIX] Rétablir les statuts des épreuves malencontreusement périmées suite au script de passage en masse des acquis en focus (PIX-13173)

### DIFF
--- a/api/scripts/fix-obsolete-cloned-challenges/index.js
+++ b/api/scripts/fix-obsolete-cloned-challenges/index.js
@@ -1,0 +1,78 @@
+import 'dotenv/config';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { disconnect, knex } from '../../db/knex-database-connection.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+import { challengeRepository, releaseRepository } from '../../lib/infrastructure/repositories/index.js';
+import _ from 'lodash';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function revertObsoleteChallengesToOriginalStatus({ dryRun, scriptExectIdToFix, releaseId }) {
+  const challengeIds = await _getObsoleteChallengeIds({ scriptExectIdToFix });
+  logger.info(`${challengeIds.length} épreuves récupérées et à traiter.`);
+  const release = await releaseRepository.getRelease(releaseId);
+  const challengeForReleaseByIds = _.keyBy(release.content.challenges, 'id');
+  let updateCount = 0;
+
+  for (const [index, challengeId] of challengeIds.entries()) {
+    const challengeForRelease = challengeForReleaseByIds[challengeId];
+    if (!challengeForRelease) {
+      logger.warn(`(${index}/${challengeIds.length}) L'épreuve ${challengeId} n'a pas été trouvée dans la release.`);
+      continue;
+    }
+    if (_hasAttachment(challengeForRelease)) {
+      logger.warn(`(${index}/${challengeIds.length}) L'épreuve ${challengeId} a un attachment et ne doit donc pas être traité.`);
+      continue;
+    }
+    const currentChallenge = await challengeRepository.get(challengeId);
+    const previousStatus = currentChallenge.status;
+    currentChallenge.status = challengeForRelease.status;
+    currentChallenge.madeObsoleteAt = null;
+    logger.info(`(${index}/${challengeIds.length}) L'épreuve ${challengeId} va être passée du statut "${previousStatus}" au statut "${currentChallenge.status}"`);
+    ++updateCount;
+    if (!dryRun) {
+      await challengeRepository.update(currentChallenge);
+    }
+  }
+
+  logger.info(`${updateCount} épreuves ont été rétablies.`);
+}
+
+function _hasAttachment(challengeForRelease) {
+  return challengeForRelease.illustrationUrl || challengeForRelease.attachments?.length > 0;
+}
+
+async function _getObsoleteChallengeIds({ scriptExectIdToFix }) {
+  return knex('focus_phrase')
+    .pluck('persistantId')
+    .where({ scriptExectId: scriptExectIdToFix, type: 'challenge' });
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  const dryRun = process.env.DRY_RUN !== 'false';
+  const scriptExectIdToFix = process.env.SCRIPT_ID;
+  const releaseId = process.env.RELEASE_ID;
+
+  if (dryRun) logger.warn('Dry run: no actual modification will be performed, use DRY_RUN=false to disable');
+  await revertObsoleteChallengesToOriginalStatus({ dryRun, scriptExectIdToFix, releaseId });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();

--- a/api/tests/scripts/fix-obsolete-cloned-challenges_test.js
+++ b/api/tests/scripts/fix-obsolete-cloned-challenges_test.js
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { domainBuilder, knex } from '../test-helper.js';
+import { challengeRepository, releaseRepository } from '../../lib/infrastructure/repositories/index.js';
+import { ChallengeForRelease } from '../../lib/domain/models/release/index.js';
+import * as script from '../../scripts/fix-obsolete-cloned-challenges/index.js';
+import { Challenge } from '../../lib/domain/models/index.js';
+
+describe('Script | Fix obsolete cloned challenges', function() {
+  afterEach(async () => {
+    await knex('focus_phrase').truncate();
+  });
+
+  it('should revert obsolete challenges with no attachments within a specific script execution to their original statuses', async function() {
+    // given
+    const scriptToExect = '123456789';
+    await knex('focus_phrase').insert([
+      {
+        id: 1,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'challengeNotInScript',
+        type: 'challenge',
+        scriptExectId: '789456123',
+      },
+      {
+        id: 2,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'skillIgnored',
+        type: 'skill',
+        scriptExectId: scriptToExect,
+      },
+      {
+        id: 3,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'challengeWithAttachmentIllustration',
+        type: 'challenge',
+        scriptExectId: scriptToExect,
+      },
+      {
+        id: 4,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'challengeWithAttachmentAtt',
+        type: 'challenge',
+        scriptExectId: scriptToExect,
+      },
+      {
+        id: 5,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'challengeA',
+        type: 'challenge',
+        scriptExectId: scriptToExect,
+      },
+      {
+        id: 6,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'challengeB',
+        type: 'challenge',
+        scriptExectId: scriptToExect,
+      },
+      {
+        id: 7,
+        createdAt: new Date(),
+        originPersistantId: 'null',
+        persistantId: 'challengeC',
+        type: 'challenge',
+        scriptExectId: scriptToExect,
+      },
+    ]);
+    const challengeAFromRelease = domainBuilder.buildChallengeForRelease({
+      id: 'challengeA',
+      status: ChallengeForRelease.STATUSES.VALIDE,
+      illustrationUrl: null,
+    });
+    challengeAFromRelease.attachments = undefined;
+    const challengeBFromRelease = domainBuilder.buildChallengeForRelease({
+      id: 'challengeB',
+      status: ChallengeForRelease.STATUSES.PROPOSE,
+      illustrationUrl: null,
+      attachments: [],
+    });
+    const challengeWithIllustration = domainBuilder.buildChallengeForRelease({
+      id: 'challengeWithAttachmentIllustration',
+      status: ChallengeForRelease.STATUSES.VALIDE,
+      illustrationUrl: 'some attachment url',
+      attachments: [],
+    });
+    const challengeWithPieceJointe = domainBuilder.buildChallengeForRelease({
+      id: 'challengeWithAttachmentAtt',
+      status: ChallengeForRelease.STATUSES.PROPOSE,
+      illustrationUrl: null,
+      attachments: ['piece jointe'],
+    });
+    const release = domainBuilder.buildDomainRelease({
+      content: domainBuilder.buildContentForRelease({
+        challenges: [
+          challengeAFromRelease,
+          challengeBFromRelease,
+          challengeWithIllustration,
+          challengeWithPieceJointe,
+        ],
+      }),
+    });
+
+    const challengeAOnAirtable = domainBuilder.buildChallenge({
+      id: 'challengeA',
+      status: Challenge.STATUSES.PERIME,
+      madeObsoleteAt: '2023-04-04T10:47:05.555Z',
+      files: [],
+    });
+    const challengeBOnAirtable = domainBuilder.buildChallenge({
+      id: 'challengeB',
+      status: Challenge.STATUSES.PERIME,
+      madeObsoleteAt: '2023-04-04T10:57:05.555Z',
+      files: [],
+    });
+    const challengeCOnAirtable = domainBuilder.buildChallenge({
+      id: 'challengeC',
+      status: Challenge.STATUSES.PERIME,
+      madeObsoleteAt: '2023-04-04T10:37:05.555Z',
+      files: [],
+    });
+    const challengesFromAirtable = [challengeAOnAirtable, challengeBOnAirtable, challengeCOnAirtable];
+    vi.spyOn(releaseRepository, 'getRelease').mockResolvedValue(release);
+    vi.spyOn(challengeRepository, 'get')
+      .mockImplementation((id) => challengesFromAirtable.find((chal) => chal.id === id));
+    vi.spyOn(challengeRepository, 'update')
+      .mockResolvedValue(true);
+
+    // when
+    await script.revertObsoleteChallengesToOriginalStatus({
+      dryRun: false,
+      scriptExectIdToFix: scriptToExect,
+      releaseId: 'someReleaseId',
+    });
+
+    // then
+    expect(releaseRepository.getRelease).toHaveBeenCalledWith('someReleaseId');
+    expect(challengeRepository.update).toHaveBeenCalledTimes(2);
+    expect(challengeRepository.update).toHaveBeenCalledWith(domainBuilder.buildChallenge({
+      ...challengeAOnAirtable,
+      status: Challenge.STATUSES.VALIDE,
+      madeObsoleteAt: null,
+    }));
+    expect(challengeRepository.update).toHaveBeenCalledWith(domainBuilder.buildChallenge({
+      ...challengeBOnAirtable,
+      status: Challenge.STATUSES.PROPOSE,
+      madeObsoleteAt: null,
+    }));
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Erreurs sur erreurs, on se retrouve avec des épreuves qui étaient saines et qui se sont retrouvées périmées suite à l'exécution du script de fix qui corrigeait déjà une erreur suite au premier script de passage en focus en masse (bug sur les pièces jointes FYI).
Tout ceci sera reportée à l'occasion d'un post-mortem et documenté.

## :robot: Proposition
Rétablir le statut des épreuves clonées qui ont été périmées, qui n'ont pas d'attachment.
Pour retrouver le statut, on regarde dans la release (car on a interrompu les releases après péremption pour par tout casser).
Donc a priori dans la release pour chaque épreuve on a son statut d'avant.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
On a testé en prod en dry run ca a l'air OK
