### PR TITLE
[BUGFIX] Corriger le clonage physique en masse des attachments (PIX-13199)

### DIFF
--- a/api/lib/domain/usecases/clone-skill.js
+++ b/api/lib/domain/usecases/clone-skill.js
@@ -50,7 +50,7 @@ export async function cloneSkill({
   await challengeRepository.createBatch(clonedChallenges);
   // for now only persist primary attachments
   const attachmentsToPersist = clonedAttachments.filter((attachment) => attachment.challengeId === attachment.localizedChallengeId);
-  await attachmentRepository.createBatch(attachmentsToPersist);
+  await attachmentRepository.createBatch(attachmentsToPersist, { shouldClonePhysicalFile: true });
   return 'ok';
 }
 

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -29,8 +29,9 @@ export async function createBatch(attachments, { shouldClonePhysicalFile = false
   const airtableChallengeIdsByIds = await challengeDatasource.getAirtableIdsByIds(necessaryChallengeIds);
   const attachmentToSaveDTOs = [];
 
+  let newUrlByAttachmentMap;
   if (shouldClonePhysicalFile) {
-    await cloneAttachmentsFileInBucket({
+    newUrlByAttachmentMap = await cloneAttachmentsFileInBucket({
       attachments,
       millisecondsTimestamp: Date.now(),
     });
@@ -38,7 +39,7 @@ export async function createBatch(attachments, { shouldClonePhysicalFile = false
 
   for (const attachment of attachments) {
     attachmentToSaveDTOs.push({
-      url: attachment.url,
+      url: shouldClonePhysicalFile ? newUrlByAttachmentMap.get(attachment) : attachment.url,
       size: attachment.size,
       type: attachment.type,
       mimeType: attachment.mimeType,

--- a/api/lib/infrastructure/utils/storage.js
+++ b/api/lib/infrastructure/utils/storage.js
@@ -13,16 +13,19 @@ export async function cloneAttachmentsFileInBucket({ attachments, millisecondsTi
           'X-Copy-From': `${config.pixEditor.storageBucket}/${path}`,
         },
       });
-      attachment.url = cloneUrl;
+      return cloneUrl;
     };
     const identicFilenamesCount = {};
+    const newUrlByAttachmentMap = new Map();
     for (const attachment of attachments) {
       const filename = attachment.url.split('/').pop();
       if (!identicFilenamesCount[filename]) identicFilenamesCount[filename] = 0;
       ++identicFilenamesCount[filename];
       const variableCloneUrlPortion = `${millisecondsTimestamp}_${identicFilenamesCount[filename].toString().padStart(3, '0')}/${filename}`;
-      await fnc(attachment, variableCloneUrlPortion);
+      const cloneUrl = await fnc(attachment, variableCloneUrlPortion);
+      newUrlByAttachmentMap.set(attachment, cloneUrl);
     }
+    return newUrlByAttachmentMap;
   });
 }
 

--- a/api/scripts/fix-cloned-attachments/index.js
+++ b/api/scripts/fix-cloned-attachments/index.js
@@ -165,7 +165,7 @@ async function _fixFor({ originSkill, cloneSkill, skillChallenges, dryRun, scrip
       throw err;
     }
     try {
-      await attachmentRepository.createBatch(clonedAttachments);
+      await attachmentRepository.createBatch(clonedAttachments, { shouldClonePhysicalFile: false });
     } catch (err) {
       await _logInHistoricAndPrint({
         persistantId: originSkill.id,

--- a/api/scripts/move-skills-to-focus/index.js
+++ b/api/scripts/move-skills-to-focus/index.js
@@ -187,7 +187,7 @@ async function _cloneSkillAndChallengesAndAttachments({ skill, skillChallenges, 
       throw err;
     }
     try {
-      await attachmentRepository.createBatch(clonedAttachments);
+      await attachmentRepository.createBatch(clonedAttachments, { shouldClonePhysicalFile: true });
     } catch (err) {
       await _logInHistoricAndPrint({
         persistantId: skill.id,

--- a/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
@@ -558,8 +558,10 @@ describe('Integration | Repository | attachment-repository', () => {
             expect.unreachable('Wrong attachments sent for cloning');
           if (millisecondsTimestamp !== Date.now())
             expect.unreachable('Wrong timestamp sent for cloning');
-          attachments[0].url = 'cloned/url/attachmentA';
-          attachments[1].url = 'cloned/url/attachmentB';
+          const newUrlByAttachmentMap = new Map();
+          newUrlByAttachmentMap.set(attachmentA, 'cloned/url/attachmentA');
+          newUrlByAttachmentMap.set(attachmentB, 'cloned/url/attachmentB');
+          return newUrlByAttachmentMap;
         });
       vi.spyOn(airtableClient, 'createRecords').mockImplementation((tableName, airtableRequestBodies) => {
         if (tableName !== 'Attachments') expect.unreachable('Airtable tableName should be Attachments');

--- a/api/tests/scripts/fix-cloned-attachments_test.js
+++ b/api/tests/scripts/fix-cloned-attachments_test.js
@@ -520,7 +520,7 @@ describe('Script | Fix cloned attachments', function() {
         challengeId: 'valideProtoForActifSkillNewId',
         localizedChallengeId: 'valideProtoForActifSkillNLNewId',
       }),
-    ]);
+    ], { shouldClonePhysicalFile: false });
     const focus_phrase_records = await knex('focus_phrase').select('*').where({ scriptExectId: myCurrentScriptId }).orderBy(['type', 'persistantId']);
     expect(focus_phrase_records).toStrictEqual([
       {

--- a/api/tests/scripts/move-skills-to-focus_test.js
+++ b/api/tests/scripts/move-skills-to-focus_test.js
@@ -639,7 +639,7 @@ describe('Script | Move skills to focus', function() {
           challengeId: 'valideDecliValideProtoForActifSkillNewId',
           localizedChallengeId: 'valideDecliValideProtoForActifSkillNewId',
         }),
-      ]);
+      ], { shouldClonePhysicalFile: true });
       const focus_phrase_records = await knex('focus_phrase').select('*').orderBy(['type', 'persistantId']);
       expect(focus_phrase_records).toStrictEqual([
         {

--- a/api/tests/unit/domain/usecases/clone-skill_test.js
+++ b/api/tests/unit/domain/usecases/clone-skill_test.js
@@ -202,7 +202,7 @@ describe('Unit | Domain | Usecases | clone-skill', () => {
       // then
       expect(skillRepository.create).toHaveBeenCalledWith(clonedSkill);
       expect(challengeRepository.createBatch).toHaveBeenCalledWith(clonedChallenges);
-      expect(attachmentRepository.createBatch).toHaveBeenCalledWith([{ challengeId: 'primaryChallengeId', localizedChallengeId: 'primaryChallengeId' }]);
+      expect(attachmentRepository.createBatch).toHaveBeenCalledWith([{ challengeId: 'primaryChallengeId', localizedChallengeId: 'primaryChallengeId' }], { shouldClonePhysicalFile: true });
     });
   });
 });

--- a/api/tests/unit/infrastructure/utils/storage_test.js
+++ b/api/tests/unit/infrastructure/utils/storage_test.js
@@ -56,15 +56,15 @@ describe('Unit | Infrastructure | Storage', () => {
         .reply(200);
 
       // when
-      await cloneAttachmentsFileInBucket({ attachments: [attachmentA, attachmentB, attachmentC], millisecondsTimestamp: Date.now() });
+      const newUrlByAttachmentMap = await cloneAttachmentsFileInBucket({ attachments: [attachmentA, attachmentB, attachmentC], millisecondsTimestamp: Date.now() });
 
       // then
       expect(requestInterceptorA.isDone()).to.be.true;
       expect(requestInterceptorB.isDone()).to.be.true;
       expect(requestInterceptorC.isDone()).to.be.true;
-      expect(attachmentA.url).toStrictEqual(expectedDestUrlA);
-      expect(attachmentB.url).toStrictEqual(expectedDestUrlB);
-      expect(attachmentC.url).toStrictEqual(expectedDestUrlC);
+      expect(newUrlByAttachmentMap.get(attachmentA)).toStrictEqual(expectedDestUrlA);
+      expect(newUrlByAttachmentMap.get(attachmentB)).toStrictEqual(expectedDestUrlB);
+      expect(newUrlByAttachmentMap.get(attachmentC)).toStrictEqual(expectedDestUrlC);
     });
   });
 });

--- a/api/tests/unit/infrastructure/utils/storage_test.js
+++ b/api/tests/unit/infrastructure/utils/storage_test.js
@@ -30,8 +30,12 @@ describe('Unit | Infrastructure | Storage', () => {
       const attachmentB = domainBuilder.buildAttachment({
         url: `${config.pixEditor.storagePost}un_dossier/mon_imageB.jpg`,
       });
-      const expectedDestUrlA = `${config.pixEditor.storagePost}${Date.now()}/mon_imageA.jpg`;
-      const expectedDestUrlB = `${config.pixEditor.storagePost}${Date.now()}/mon_imageB.jpg`;
+      const attachmentC = domainBuilder.buildAttachment({
+        url: `${config.pixEditor.storagePost}un_autre_dossier/mon_imageA.jpg`,
+      });
+      const expectedDestUrlA = `${config.pixEditor.storagePost}${Date.now()}_001/mon_imageA.jpg`;
+      const expectedDestUrlB = `${config.pixEditor.storagePost}${Date.now()}_001/mon_imageB.jpg`;
+      const expectedDestUrlC = `${config.pixEditor.storagePost}${Date.now()}_002/mon_imageA.jpg`;
       const [, baseUrlA, routeA] = [...expectedDestUrlA.matchAll(/^(http.*com)(.*)/g)][0];
       const requestInterceptorA = nock(baseUrlA)
         .put(routeA)
@@ -44,15 +48,23 @@ describe('Unit | Infrastructure | Storage', () => {
         .matchHeader('X-Auth-Token', token)
         .matchHeader('X-Copy-From', `${config.pixEditor.storageBucket}/un_dossier/mon_imageB.jpg`)
         .reply(200);
+      const [, baseUrlC, routeC] = [...expectedDestUrlC.matchAll(/^(http.*com)(.*)/g)][0];
+      const requestInterceptorC = nock(baseUrlC)
+        .put(routeC)
+        .matchHeader('X-Auth-Token', token)
+        .matchHeader('X-Copy-From', `${config.pixEditor.storageBucket}/un_autre_dossier/mon_imageA.jpg`)
+        .reply(200);
 
       // when
-      await cloneAttachmentsFileInBucket({ attachments: [attachmentA, attachmentB], millisecondsTimestamp: Date.now() });
+      await cloneAttachmentsFileInBucket({ attachments: [attachmentA, attachmentB, attachmentC], millisecondsTimestamp: Date.now() });
 
       // then
       expect(requestInterceptorA.isDone()).to.be.true;
       expect(requestInterceptorB.isDone()).to.be.true;
+      expect(requestInterceptorC.isDone()).to.be.true;
       expect(attachmentA.url).toStrictEqual(expectedDestUrlA);
       expect(attachmentB.url).toStrictEqual(expectedDestUrlB);
+      expect(attachmentC.url).toStrictEqual(expectedDestUrlC);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Identifié pendant la session de passage en focus en masse.
Lorsque des déclinaisons d'un même proto ont des pièces jointes dont le nom est identique alors lors du clonage de l'acquis correspondant les déclinaisons clonées se retrouvent avec un clone physique d'une pièce jointe identique
Exemple :
- mon/dossier/imageA.jpg  --- clone --> mon/clone/imageA.jpg
- mon/autre_dossier/imageA.jpg  --- clone --> mon/clone/imageA.jpg

## :robot: Proposition
Dans l'url de clonage, on mettait un timestamp en milliseconds pour "uniquiser" les urls. Le problème c'est que ce timestamp en milliseconds était déterminé avant l'appel de la méthode du storage pour cloner en masse les attachments, donc tout le monde avait le même timestamp.
Et de toute façon, déplacer la génération du timestamp au moment vraiment de l'appel API au bucket pour le clonage ne suffit pas non plus à éliminer toute possibilité de doublon, donc il faut s'assurer que pour un paquet de fichiers avec le même nom on a un bien un nom final différent et unique.
Ma proposition c'est : (123456789 représente le timestamp)
avant : 
- bucket/des_dossiers/imageA.jpg  --- clone --> bucket/123456789/imageA.jpg
- bucket/autres_dossiers/imageA.jpg  --- clone --> bucket/123456789/imageA.jpg

après :
- bucket/des_dossiers/imageA.jpg  --- clone --> bucket/123456789_001/imageA.jpg
- bucket/autres_dossiers/imageA.jpg  --- clone --> bucket/123456789_002/imageA.jpg

## :rainbow: Remarques


## :100: Pour tester
Essayer le script de clonage d'acquis par exemple (move-skills-to-focus)
