### PR TITLE
[TECH] Ajout d'un script pour lancer manuellement un job du dossier scheduled-jobs/ (PIX-13203)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -63,6 +63,7 @@
         "nodemon": "^3.0.0",
         "nyc": "15.1.0",
         "parse-multipart-data": "^1.5.0",
+        "prompt": "^1.3.0",
         "split2": "^4.1.0",
         "vitest": "^1.0.0",
         "yargs": "^17.7.2"
@@ -1930,6 +1931,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -4711,6 +4721,12 @@
         "node": "*"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5388,6 +5404,15 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5528,6 +5553,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -6348,6 +6382,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "dev": true,
+      "engines": {
+        "node": "> 0.1.90"
+      }
     },
     "node_modules/fast-copy": {
       "version": "3.0.2",
@@ -7524,6 +7567,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -8356,6 +8405,12 @@
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -9592,6 +9647,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prompt": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
+      "integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
+      "dev": true,
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "async": "3.2.3",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "winston": "2.x"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10147,6 +10218,18 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -10366,6 +10449,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/rfdc": {
@@ -10894,6 +10986,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -12128,6 +12229,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.7.tgz",
+      "integrity": "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/winston/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/wkx": {

--- a/api/package.json
+++ b/api/package.json
@@ -95,6 +95,7 @@
     "nodemon": "^3.0.0",
     "nyc": "15.1.0",
     "parse-multipart-data": "^1.5.0",
+    "prompt": "^1.3.0",
     "split2": "^4.1.0",
     "vitest": "^1.0.0",
     "yargs": "^17.7.2"

--- a/api/scripts/dev/run-job.js
+++ b/api/scripts/dev/run-job.js
@@ -1,0 +1,99 @@
+import 'dotenv/config';
+import prompt from 'prompt';
+import yargs from 'yargs/yargs';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { logger } from '../../lib/infrastructure/logger.js';
+import { disconnect } from '../../db/knex-database-connection.js';
+import fs from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+const JOBS_FOLDER = fileURLToPath(new URL('../../lib/infrastructure/scheduled-jobs', import.meta.url));
+const jobChoices = {};
+fs.readdirSync(JOBS_FOLDER).forEach((file) => {
+  if (file.endsWith('job-processor.js')) {
+    const regex = /(.*)-job-processor.js$/;
+    const [, jobName] = file.match(regex);
+    jobChoices[jobName] = new URL(`${JOBS_FOLDER}/${file}`, import.meta.url);
+  }
+});
+
+const argv = yargs(process.argv.slice(2))
+  .version(false)
+  .usage('Usage: $0 [options]')
+  .option('job', {
+    alias: 'j',
+    describe: 'Job name',
+    choices: Object.keys(jobChoices),
+    nargs: 1,
+    requiresArg: true,
+  })
+  .option('args', {
+    alias: 'a',
+    describe: 'JSON args for job (will be JSON.parsed and passed on to the job)',
+    nargs: 1,
+    requiresArg: false,
+  })
+  .demandOption(['job'], 'Please provide a job name to run')
+  .example('$0 -f check-urls', 'Run the "check-url" job')
+  .example('$0 -f release -a \'{"data": { "slackNotification": false } }\'', 'Run the "release" job with arguments')
+  .help('h')
+  .alias('h', 'help')
+  .argv;
+
+async function runJob({ jobName, jsonJobArgs }) {
+  const fileToRun = jobChoices[jobName];
+  logger.info(`About to run job "${jobName}" with args "${jsonJobArgs}", launching this file : ${fileToRun}...`);
+  await sleep(); // Need to wait here because logger doesn't pop on terminal right away and overlap with prompt
+  console.log('🌸🌸🌸 Do you wish to continue ? (Y/N) 🌸🌸🌸');
+  const { answer } = await prompt.get(['answer']);
+  if (answer !== 'Y') {
+    logger.info('Canceling job execution.');
+    return;
+  }
+  logger.info('Executing job...');
+  const jobModule = await importModule(fileToRun);
+  const args = JSON.parse(jsonJobArgs);
+  await jobModule.default(args);
+  logger.info('Done.');
+}
+
+function sleep() {
+  return new Promise((resolve) => setInterval(resolve, 500));
+}
+
+async function importModule(filePath) {
+  try {
+    const module = await import(filePath);
+    return module;
+  } catch (error) {
+    logger.error(`Dynamic import of ${filePath} failed`);
+    throw error;
+  }
+}
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  const jobName = argv.job;
+  const jsonJobArgs = argv.args;
+  await runJob({ jobName, jsonJobArgs });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();


### PR DESCRIPTION
## :unicorn: Problème
Parfois pour débugger ou même pour dépanner on aimerait bien pouvoir lancer un job manuelle et en one shot.

## :robot: Proposition
Ajout d'un script qui prend en param le nom d'un job et ses arguments si besoin jsonifié et exécute le job.

## :rainbow: Remarques
Je savais pas trop quoi écrire comme test unitaire, si vous avez des idées je suis preneuse.

## :100: Pour tester
Essayez-le en local !
`node api/scripts/dev/run-job.js --job release --args '{"data": { "slackNotification": false } }'`
