### PR TITLE
[BUGFIX] Export des URLs externes: crash sur certaines URLs (PIX-13253)

### DIFF
--- a/api/lib/domain/usecases/export-external-urls-from-release.js
+++ b/api/lib/domain/usecases/export-external-urls-from-release.js
@@ -11,10 +11,6 @@ export async function exportExternalUrlsFromRelease({ releaseRepository, urlRepo
 }
 
 function findUrlsFromChallenges(challenges, localizedChallengesById, release, UrlUtils) {
-  const baseUrl = function(url) {
-    const parsedUrl = new URL(url);
-    return parsedUrl.protocol + '//' + parsedUrl.host;
-  };
   const urlsFromChallenges = challenges.flatMap((challenge) => {
     const functions = [
       (challenge) => UrlUtils.findUrlsInMarkdown(challenge.instruction),
@@ -30,7 +26,7 @@ function findUrlsFromChallenges(challenges, localizedChallengesById, release, Ur
           origin: release.findOriginForChallenge(challenge) ?? '',
           tube: release.findTubeNameForChallenge(challenge) ?? '',
           locales: challenge.locales,
-          url: baseUrl(url),
+          url: UrlUtils.getOrigin(url),
           status: challenge.status,
         };
       });

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -14,7 +14,7 @@ export function findUrlsInMarkdown(value) {
   if (!urls) {
     return [];
   }
-  return _.uniq(urls.map(cleanUrl).map(prependProtocol));
+  return _.uniq(urls.map(cleanUrl).map(ensureProtocol));
 }
 
 /**
@@ -86,9 +86,11 @@ function cleanUrl(url) {
   return url;
 }
 
-function prependProtocol(url) {
-  if (!url.includes('http')) {
-    url = 'https://' + url;
-  }
-  return url;
+function ensureProtocol(url) {
+  if (/^https?:\/\//.test(url)) return url;
+  return  url = 'https://' + url;
+}
+
+export function getOrigin(url) {
+  return new URL(url).origin;
 }

--- a/api/tests/unit/domain/usecases/export-external-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/export-external-urls-from-release_test.js
@@ -6,7 +6,7 @@ import * as UrlUtils from '../../../../lib/infrastructure/utils/url-utils.js';
 
 describe('Unit | Domain | Usecases | Export external urls from release', function() {
   describe('#exportExternalUrlsFromRelease', function() {
-    let releaseRepository, mockedUrlUtils, urlRepository, localizedChallengeRepository;
+    let releaseRepository, urlRepository, localizedChallengeRepository;
 
     beforeEach(function() {
       const pixCompetence = domainBuilder.buildCompetenceForRelease({
@@ -105,9 +105,6 @@ describe('Unit | Domain | Usecases | Export external urls from release', functio
         domainBuilder.buildLocalizedChallenge({ id: 'challenge5', challengeId: 'challenge5', urlsToConsult: null }),
       ];
       localizedChallengeRepository = { list: vi.fn().mockResolvedValue(localizedChallenges) };
-      mockedUrlUtils = {
-        findUrlsInMarkdown: UrlUtils.findUrlsInMarkdown,
-      };
       urlRepository = {
         exportExternalUrls: vi.fn(),
       };
@@ -115,7 +112,7 @@ describe('Unit | Domain | Usecases | Export external urls from release', functio
 
     it('should export external URLs for operative challenges (and also get urls from primary localized challenge)', async function() {
       // when
-      await exportExternalUrlsFromRelease({ releaseRepository, urlRepository, UrlUtils: mockedUrlUtils, localizedChallengeRepository });
+      await exportExternalUrlsFromRelease({ releaseRepository, urlRepository, UrlUtils, localizedChallengeRepository });
 
       // then
       expect(urlRepository.exportExternalUrls).toHaveBeenCalledTimes(1);

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -42,13 +42,16 @@ describe('Unit | Utils | URL Utils', function() {
 
     it('should fix url by prepending protocol if missing', function() {
       // given
-      const markdownText = 'instructions [link](www.example.net/)';
+      const markdownText = 'instructions [link](www.example.net/) [second link](www.example.net/?url=https://example.com/path)';
 
       // when
       const urls = UrlUtils.findUrlsInMarkdown(markdownText);
 
       // then
-      expect(urls).toStrictEqual(['https://www.example.net/']);
+      expect(urls).toStrictEqual([
+        'https://www.example.net/',
+        'https://www.example.net/?url=https://example.com/path',
+      ]);
     });
 
     it('should return unique occurences', function() {
@@ -60,6 +63,20 @@ describe('Unit | Utils | URL Utils', function() {
 
       // then
       expect(urls).toStrictEqual(['https://www.example.net/']);
+    });
+  });
+
+  describe('#getOrigin', () => {
+    [
+      { url: 'http://pix.fr', expected: 'http://pix.fr' },
+      { url: 'https://pix.org', expected: 'https://pix.org' },
+      { url: 'https://app.pix.org/le/chemin/index.html?toto=123&titi=456#qwerty', expected: 'https://app.pix.org' },
+    ].forEach(({ url, expected }) => {
+      describe(`when url is "${url}"`, () => {
+        it(`should return "${expected}"`, () => {
+          expect(UrlUtils.getOrigin(url)).toBe(expected);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Certaines épreuves contiennent des URLs sans protocole, mais contenant "http" plus loin dans l'URL, cela fait crasher le script d'export.

## :robot: Proposition
Corriger le script pour la gestion de ces URLs.

## :rainbow: Remarques
Quel est la justification de la fonction `cleanUrl` ?

## :100: Pour tester
Lancer le script ?