### PR TITLE
[BUGFIX] Ajout d'une clé primaire sur localized_challenges-attachments (PIX-13359)

### DIFF
--- a/api/db/migrations/20240710091831_localized-challenges-attachements-pkey.js
+++ b/api/db/migrations/20240710091831_localized-challenges-attachements-pkey.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'localized_challenges-attachments';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropNullable('localizedChallengeId');
+    table.primary(['localizedChallengeId', 'attachmentId']);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropPrimary();
+    table.setNullable('localizedChallengeId');
+  });
+}


### PR DESCRIPTION
## :unicorn: Problème
La table `localized_challenges-attachments` n'a pas de clé primaire, et sa colonne `localizedChallengeId` est nullable.

## :robot: Proposition
Rendre la colonne non nullable et ajouter la clé primaire.

## :rainbow: Remarques
On a vérifié au préalable que la migration ne poserait pas de pb en PROD:
```
scalingo --region osc-secnum-fr1  -a pix-lcms-production pgsql-console
-----> Starting container one-off-8462  Done in 0.070 seconds
-----> Connecting to container [one-off-8462]...
-----> Process 'pgsql-console pix_lcms_ap_2308' is starting...

---> Download and extract the database CLI
---> Database CLI installed:
psql (PostgreSQL) 14.11
psql (14.11, server 14.10 (Debian 14.10-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
Type "help" for help.

pix_lcms_ap_2308=> select * from "localized_challenges-attachments" where "localizedChallengeId" is null;
 attachmentId | localizedChallengeId
--------------+----------------------
(0 rows)

pix_lcms_ap_2308=> select * from "localized_challenges-attachments" group by "localizedChallengeId", "attachmentId" having count(*) > 1;
 attachmentId | localizedChallengeId
--------------+----------------------
(0 rows)
```

## :100: Pour tester
Se connecter sur le PG de la RA et vérifier que le schéma de la table est conforme.