### PR TITLE
[FEATURE] Ajout des propriétés d'accessibilité des challenges dans la release (PIX-13351)

### DIFF
--- a/api/lib/domain/models/release/ChallengeForRelease.js
+++ b/api/lib/domain/models/release/ChallengeForRelease.js
@@ -32,6 +32,8 @@ export class ChallengeForRelease {
     illustrationUrl,
     shuffled,
     alternativeVersion,
+    accessibility1,
+    accessibility2,
   }) {
     this.id = id;
     this.instruction = instruction;
@@ -63,6 +65,8 @@ export class ChallengeForRelease {
     this.illustrationUrl = illustrationUrl;
     this.shuffled = shuffled;
     this.alternativeVersion = alternativeVersion;
+    this.accessibility1 = accessibility1;
+    this.accessibility2 = accessibility2;
   }
 
   static get STATUSES() {
@@ -83,6 +87,14 @@ export class ChallengeForRelease {
 
   static get FORMATS() {
     return Challenge.FORMATS;
+  }
+
+  static get ACCESSIBILITY1() {
+    return Challenge.ACCESSIBILITY1;
+  }
+
+  static get ACCESSIBILITY2() {
+    return Challenge.ACCESSIBILITY2;
   }
 
   get isOperative() {

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -40,6 +40,8 @@ function _filterChallengeFields(challenge) {
     'type',
     'shuffled',
     'alternativeVersion',
+    'accessibility1',
+    'accessibility2',
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -134,6 +134,8 @@ async function mockCurrentContent() {
       alpha: 0.9,
       responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
       genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.RAS,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.OK,
     }],
     tutorials: [{
       id: 'recTutorial0',
@@ -441,6 +443,8 @@ async function mockContentForRelease() {
       attachments: ['url de la pièce jointe'],
       illustrationUrl: 'url de l‘illustration',
       illustrationAlt: 'Texte alternatif illustration',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.RAS,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.OK,
     }],
     tutorials: [{
       id: 'recTutorial0',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1204,6 +1204,8 @@ function _getRichCurrentContentDTO() {
       illustrationAlt: null,
       shuffled: false,
       alternativeVersion: 'challenge121211 alternativeVersion',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.OK,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.RAS,
     },
     {
       id: 'challengeNl',
@@ -1236,6 +1238,8 @@ function _getRichCurrentContentDTO() {
       illustrationAlt: null,
       shuffled: false,
       alternativeVersion: 'challenge121211 alternativeVersion',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.OK,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.RAS,
     },
     {
       id: 'challenge121212',
@@ -1267,6 +1271,8 @@ function _getRichCurrentContentDTO() {
       illustrationAlt: null,
       shuffled: true,
       alternativeVersion: 'challenge121212 alternativeVersion',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.KO,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.OK,
     },
     {
       id: 'challenge211111',
@@ -1299,6 +1305,8 @@ function _getRichCurrentContentDTO() {
       illustrationAlt: null,
       shuffled: false,
       alternativeVersion: 'challenge211111 alternativeVersion',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.RAS,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.KO,
     },
     {
       id: 'challenge211112',
@@ -1330,6 +1338,8 @@ function _getRichCurrentContentDTO() {
       illustrationAlt: null,
       shuffled: false,
       alternativeVersion: 'challenge211112 alternativeVersion',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.RAS,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.RAS,
     },
     {
       id: 'challenge211113',
@@ -1361,6 +1371,8 @@ function _getRichCurrentContentDTO() {
       illustrationAlt: null,
       shuffled: false,
       alternativeVersion: 'challenge211113 alternativeVersion',
+      accessibility1: ChallengeForRelease.ACCESSIBILITY1.A_TESTER,
+      accessibility2: ChallengeForRelease.ACCESSIBILITY2.OK,
     },
   ];
   const expectedCourseDTOs = [

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -31,6 +31,8 @@ export function buildChallengeForRelease({
   illustrationUrl = 'url illu',
   shuffled = false,
   alternativeVersion = 2,
+  accessibility1 = ChallengeForRelease.ACCESSIBILITY1.OK,
+  accessibility2 = ChallengeForRelease.ACCESSIBILITY2.RAS,
 } = {}) {
 
   return new ChallengeForRelease({
@@ -64,5 +66,7 @@ export function buildChallengeForRelease({
     illustrationUrl,
     shuffled,
     alternativeVersion,
+    accessibility1,
+    accessibility2,
   });
 }

--- a/api/tests/unit/domain/models/ChallengeForRelease_test.js
+++ b/api/tests/unit/domain/models/ChallengeForRelease_test.js
@@ -66,4 +66,21 @@ describe('Unit | Domain | ChallengeForRelease', () => {
       expect(actual).to.equal(expectedIsOperative);
     });
   });
+
+  describe('#keep accessibility1 & 2 challenge properties for release', () => {
+    it('should return the same accessibility properties in the release', () => {
+      // given
+      const challengeProperties = {
+        accessibility1: 'KO',
+        accessibility2: 'OK',
+      };
+
+      // when
+      const challengeForRelease = domainBuilder.buildChallengeForRelease(challengeProperties);
+
+      // then
+      expect(challengeForRelease.accessibility1).to.equal('KO');
+      expect(challengeForRelease.accessibility2).to.equal('OK');
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -21,6 +21,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         },
         locales: ['fr', 'fr-fr'],
         files: [],
+        accessibility1: 'A tester',
+        accessibility2: 'KO',
       });
 
       // when
@@ -168,6 +170,8 @@ function _buildReleaseChallenge({
   illustrationAlt = null,
   shuffled,
   alternativeVersion,
+  accessibility1,
+  accessibility2,
 }) {
   const releaseChallenge = {
     id,
@@ -199,6 +203,8 @@ function _buildReleaseChallenge({
     illustrationAlt,
     shuffled,
     alternativeVersion,
+    accessibility1,
+    accessibility2,
   };
   if (attachments) {
     releaseChallenge.attachments = attachments;


### PR DESCRIPTION
## :unicorn: Problème
La release ne contenait pas les propriétés d'accessibilité des challenges. Un besoin de celles-ci nous a été signalé.

## :robot: Proposition
Ajout des propriétés `accessibility1` et `accessibility2` au `ChallengeForRelease` et autres builders.

## :rainbow: Remarques
Pas besoin de le faire pour la répli, les propriétés y sont déjà.

## :100: Pour tester
Créer une release en RA, la récupérer, et s'assurer que les propriétés `accessibility1` et `accessibility2` sont bien présentes sur les challenges.
