### PR TITLE
[BUGFIX] Rectification des données de responsivité renvoyées false pour les Tubes for Release (PIX-13493)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -139,7 +139,7 @@ export class Challenge {
 
   static get GENEALOGIES() {
     return {
-      PROTOTYPE: 'Protoype 1',
+      PROTOTYPE: 'Prototype 1',
       DECLINAISON: 'Décliné 1',
       UNUSED_DECLINE: 'décliné',
       UNUSED_ENG: 'ENG',


### PR DESCRIPTION
## :unicorn: Problème
Du côté du mono-repo, les profils cibles n'avaient pas d'information de responsivité des épreuves (toujours `false` pour eux). C'est du côté de notre TubeForRelease chez Pix-Editor que le souci semble venir.

## :robot: Proposition
Réparer le souci. (une typo toute bête qu'on n'a pas vu passer 😅)

## :rainbow: Remarques
Normalement, on a vérifié les typos partout, il ne devrait plus y avoir de souci

## :100: Pour tester
Créer une release et voir que les tubes renvoient bien les données de responsivité comme prévu.
