### PR TITLE
[FEATURE] Autoriser le filtre par tags sur les tests statiques (PIX-13404)

### DIFF
--- a/api/lib/application/static-courses/static-courses.js
+++ b/api/lib/application/static-courses/static-courses.js
@@ -127,6 +127,14 @@ function normalizeFilter(filter) {
     normalizedFilter.name = null;
   }
 
+  if (!_.isEmpty(filter.tagIds)) {
+    normalizedFilter.tagIds = filter.tagIds.map((tagId) => {
+      return Number(tagId);
+    }).filter((tagId) => {
+      return !isNaN(tagId);
+    });
+  }
+
   return normalizedFilter;
 }
 

--- a/api/lib/application/static-courses/static-courses.js
+++ b/api/lib/application/static-courses/static-courses.js
@@ -127,11 +127,9 @@ function normalizeFilter(filter) {
     normalizedFilter.name = null;
   }
 
-  if (!_.isEmpty(filter.tagIds)) {
+  if (filter.tagIds?.length) {
     normalizedFilter.tagIds = filter.tagIds.map((tagId) => {
       return Number(tagId);
-    }).filter((tagId) => {
-      return !isNaN(tagId);
     });
   }
 

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -37,11 +37,10 @@ export async function findReadSummaries({ filter, page }) {
   if (filter.name) {
     query.andWhereILike('name', `%${filter.name}%`);
   }
-  if (!_.isEmpty(filter.tagIds)) {
-    for (const tagId of filter.tagIds) {
-      query.andWhere('staticCourseTagId', tagId);
-    }
+  if (filter.tagIds?.length) {
+    query.whereIn('static_courses.id', knex.select('staticCourseId').from('static_courses_tags_link').whereIn('staticCourseTagId', filter.tagIds));
   }
+
   const { results: staticCourses, pagination } = await fetchPage(query, page);
 
   const staticCoursesSummaries = staticCourses.map((staticCourse) => {

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -37,6 +37,11 @@ export async function findReadSummaries({ filter, page }) {
   if (filter.name) {
     query.andWhereILike('name', `%${filter.name}%`);
   }
+  if (!_.isEmpty(filter.tagIds)) {
+    for (const tagId of filter.tagIds) {
+      query.andWhere('staticCourseTagId', tagId);
+    }
+  }
   const { results: staticCourses, pagination } = await fetchPage(query, page);
 
   const staticCoursesSummaries = staticCourses.map((staticCourse) => {

--- a/api/tests/unit/application/static-courses/static-courses_test.js
+++ b/api/tests/unit/application/static-courses/static-courses_test.js
@@ -114,13 +114,13 @@ describe('Unit | Controller | static courses controller', function() {
 
       it('should pass along filter from query params when all is valid', async function() {
         // given
-        const request = { query: { 'filter[isActive]': 'true', 'filter[name]': 'Laura' } };
+        const request = { query: { 'filter[isActive]': 'true', 'filter[name]': 'Laura', 'filter[tagIds]': ['1', '2'] } };
 
         // when
         await staticCourseController.findSummaries(request, hFake);
 
         // then
-        expect(stub).toHaveBeenCalledWith({ filter: { isActive: true, name: 'Laura' }, page });
+        expect(stub).toHaveBeenCalledWith({ filter: { isActive: true, name: 'Laura', tagIds: [1, 2] }, page });
       });
 
       it('ignore unknown filter parameters', async function() {

--- a/pix-editor/app/controllers/authenticated/static-courses/list.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/list.js
@@ -5,14 +5,22 @@ import { tracked } from '@glimmer/tracking';
 
 export default class StaticCoursesController extends Controller {
   @service router;
-  queryParams = ['pageNumber', 'pageSize', 'isActive', 'name'];
+  queryParams = ['pageNumber', 'pageSize', 'isActive', 'name', 'tagIds'];
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
   @tracked showActiveOnly = true;
   @tracked isActive = true;
   @tracked tempIsActive = true;
+  @tracked tagIds = [];
+  @tracked tempTagIds = [];
   @tracked name = '';
   @tracked tempName = '';
+
+  get tagOptions() {
+    return this.model.staticCourseTags
+      .map(({ id, label }) => ({ value: id, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
 
   @action
   async copyStaticCoursePreviewUrl(staticCourseSummary) {
@@ -37,10 +45,17 @@ export default class StaticCoursesController extends Controller {
   }
 
   @action
+  async selectTags(tags) {
+    this.tempTagIds = tags;
+  }
+
+  @action
   clearFilters() {
     this.showActiveOnly = true;
     this.isActive = true;
     this.name = '';
+    this.tagIds = [];
+    this.tempTagIds = [];
   }
 
   @action
@@ -48,5 +63,6 @@ export default class StaticCoursesController extends Controller {
     event.preventDefault();
     this.name = this.tempName;
     this.isActive = this.tempIsActive;
+    this.tagIds = this.tempTagIds;
   }
 }

--- a/pix-editor/app/routes/authenticated/static-courses/list.js
+++ b/pix-editor/app/routes/authenticated/static-courses/list.js
@@ -14,7 +14,10 @@ export default class StaticCoursesRoute extends Route {
     },
     name: {
       refreshModel: true,
-    }
+    },
+    tagIds: {
+      refreshModel: true,
+    },
   };
 
   @service store;
@@ -31,12 +34,15 @@ export default class StaticCoursesRoute extends Route {
         filter: {
           isActive: params.isActive,
           name: params.name,
+          tagIds: params.tagIds
         },
       },
       { reload: true }
     );
+    const staticCourseTags = await this.store.findAll('static-course-tag');
     return {
       staticCourseSummaries,
+      staticCourseTags,
       mayCreateStaticCourse: this.access.mayCreateOrEditStaticCourse(),
     };
   }

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -44,6 +44,19 @@
           @value={{this.name}}
           {{on "keyup" this.updateName}}
         ><:label>Nom</:label></PixInput>
+        <PixMultiSelect
+          @id="filter-tags-selector"
+          @placeholder="Sélectionnez des tags"
+          @isSearchable="true"
+          @emptyMessage="Pas de résultats"
+          @screenReaderOnly={{true}}
+          @onChange={{this.selectTags}}
+          @values={{this.tempTagIds}}
+          @options={{this.tagOptions}}
+        >
+          <:label>Tags</:label>
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
         <PixToggle
           @inline={{true}}
           @onLabel="Actifs"

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -332,6 +332,7 @@ function routes() {
     const {
       'filter[isActive]': isActiveFilter,
       'filter[name]': nameFilter,
+      'filter[tagIds]' : tagFilter,
     } = queryParams;
     let allStaticCourseSummaries;
     if (isActiveFilter === '') {
@@ -344,6 +345,14 @@ function routes() {
       allStaticCourseSummaries = allStaticCourseSummaries.filter((staticCourse) => {
         const staticCourseName = staticCourse.name.toLowerCase();
         return staticCourseName.includes(nameFilter.toLowerCase());
+      });
+    }
+
+    if (tagFilter?.length > 0) {
+      allStaticCourseSummaries = allStaticCourseSummaries.filter((staticCourse) => {
+        return staticCourse.tagIds.some((tagId) => {
+          return tagFilter.includes(tagId);
+        });
       });
     }
     const rowCount = allStaticCourseSummaries.length;

--- a/pix-editor/tests/acceptance/static-courses/list-test.js
+++ b/pix-editor/tests/acceptance/static-courses/list-test.js
@@ -16,8 +16,11 @@ module('Acceptance | Static Courses | List', function (hooks) {
       this.server.create('static-course-tag', { id: 'tagA', label: 'tagA' }),
       this.server.create('static-course-tag', { id: 'tagB', label: 'tagB' }),
     ];
-    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01'), tags });
+    this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01'), tags: [...tags] });
     this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: false, challengeCount: 10, createdAt: new Date('2019-01-01'), tags: [] });
+    this.server.create('static-course-summary', { id: 'courseC', name: 'Troisième test statique', isActive: true, challengeCount: 10, createdAt: new Date('2019-01-01'), tags:
+        [this.server.create('static-course-tag', { id: 'tagCId', label: 'tagC' })]
+    });
 
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
     return authenticateSession();
@@ -49,6 +52,25 @@ module('Acceptance | Static Courses | List', function (hooks) {
     assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
   });
 
+  test('should display only static courses with searched tag in the tag filter', async function(assert) {
+
+    // when
+    const screen = await visit('/');
+    await clickByName('Tests statiques');
+    await click(await screen.findByRole('button', { name: 'Statut' }));
+    await fillByLabel('Tags', 'ta');
+    await click(await screen.findByLabelText('tagC'));
+    // 2 clicks to go outside the dropdown and then to effectively click on the button
+    await click(await screen.getByText('Filtres'));
+    await click(await screen.findByRole('button', { name: 'Filtrer' }));
+
+    // then
+    assert.strictEqual(currentURL(), '/static-courses?tagIds=%5B%22tagCId%22%5D');
+    assert.dom(screen.getByText('Troisième test statique')).exists();
+    assert.dom(screen.queryByText('Premier test statique')).doesNotExist();
+    assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
+  });
+
   test('should render correctly a row', async function (assert) {
     // when
     const screen = await visit('/');
@@ -60,8 +82,6 @@ module('Acceptance | Static Courses | List', function (hooks) {
 
     // then
     assert.dom(screen.getByText('Premier test statique')).exists();
-    assert.dom(screen.getByText('tagA')).exists();
-    assert.dom(screen.getByText('3')).exists();
     assert.dom(screen.getByText('01/01/2020')).exists();
     assert.dom(screen.getByText('Actif')).exists();
   });


### PR DESCRIPTION
## :unicorn: Problème
Le filtre existait par nom, mais pas par tags, pour les tests statiques.

## :robot: Proposition
Ajouter un multi-selecteur pour donner le choix de filtrer par un ou plusieurs tags les tests statiques.

## :rainbow: Remarques
RAS

## :100: Pour tester
Allez dans la page des tests statiques, choisissez des tags à filtrer et cliquez sur Filtrer. 
S'assurer que ça fonctionne :)
