### PR TITLE
[TECH] Améliorer le script de passage en focus afin d'avoir la correspondance entre les ID des épreuves avant/après (PIX-13363)

### DIFF
--- a/api/scripts/move-skills-to-focus/index.js
+++ b/api/scripts/move-skills-to-focus/index.js
@@ -172,6 +172,12 @@ async function _cloneSkillAndChallengesAndAttachments({ skill, skillChallenges, 
       throw err;
     }
     try {
+      clonedChallenges.forEach((clonedChallenge) => {
+        logger.info({
+          clonedChallengeId: clonedChallenge.id,
+          sourceChallengeId: Challenge.getCloneSource(clonedChallenge).id,
+        }, 'Correspondance entre les challenges clonés et leur source');
+      });
       await challengeRepository.createBatch(clonedChallenges);
     } catch (err) {
       await _logInHistoricAndPrint({

--- a/api/scripts/move-skills-to-focus/index.js
+++ b/api/scripts/move-skills-to-focus/index.js
@@ -61,7 +61,7 @@ async function _getSkillsToFocus({ airtableClient }) {
       fields: [
         'id persistant',
       ],
-      filterByFormula: '"en_devenir" = {Spoil_focus}',
+      filterByFormula: '{Spoil_focus} = "focusable"',
     })
     .all();
   const skillIdsToFocus = airtableSkills.map((at) => at.get('id persistant'));


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'utilisation du script de passage en masse des acquis en mode focus nous voulons connaître la correspondance entre les épreuves clonées et leur source

## :robot: Proposition
Ajouter des log avant la persistance des épreuves clonées précisant leur correspondance avec leur source

## :rainbow: Remarques
RAS

## :100: Pour tester
Demain on le fait
