### PR TITLE
[FEATURE] Ajout du statut "expérimental" des missions (PIX-13584).

### DIFF
--- a/api/db/migrations/20240729140413_change-active-missions-to-validated-missions.js
+++ b/api/db/migrations/20240729140413_change-active-missions-to-validated-missions.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'missions';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex(TABLE_NAME).update({ status: 'EXPERIMENTAL' }).where({ status: 'ACTIVE' });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex(TABLE_NAME).update({ status: 'ACTIVE' }).where({ status: 'EXPERIMENTAL' });
+}

--- a/api/db/seeds/data/missions.js
+++ b/api/db/seeds/data/missions.js
@@ -2,31 +2,40 @@ import { Mission } from '../../../lib/domain/models/Mission.js';
 
 export function buildMissions(databaseBuilder) {
   databaseBuilder.factory.buildMission({
-    name : 'Mission test active',
-    competenceId : 'competence1NC9NE3IIOa0ym',
-    learningObjectives : 'Que tu sois le meilleur',
-    thematicIds : 'recOO8OsMJpe5cZzi,recOO8OsMJpe5cZzi',
-    validatedObjectives : '- Ca\n Et puis ça',
-    status : Mission.status.ACTIVE,
-    createdAt : new Date('2023-12-17'),
+    name: 'Mission test active',
+    competenceId: 'competence1NC9NE3IIOa0ym',
+    learningObjectives: 'Que tu sois le meilleur',
+    thematicIds: 'recOO8OsMJpe5cZzi,recOO8OsMJpe5cZzi',
+    validatedObjectives: '- Ca\n Et puis ça',
+    status: Mission.status.VALIDATED,
+    createdAt: new Date('2023-12-17'),
   });
 
   databaseBuilder.factory.buildMission({
-    name : 'Mission test inactive',
-    competenceId : 'competence2k2eVZ2GRLwqFL',
-    learningObjectives : 'Y\'en a plus',
-    thematicIds : 'rec98EBX88mkQR3gx,rec98EBX88mkQR3gx',
-    validatedObjectives : '- Ca aussi\n Et puis ça aussi',
-    status : Mission.status.INACTIVE,
-    createdAt : new Date('2023-12-18'),
+    name: 'Mission test inactive',
+    competenceId: 'competence2k2eVZ2GRLwqFL',
+    learningObjectives: 'Y\'en a plus',
+    thematicIds: 'rec98EBX88mkQR3gx,rec98EBX88mkQR3gx',
+    validatedObjectives: '- Ca aussi\n Et puis ça aussi',
+    status: Mission.status.INACTIVE,
+    createdAt: new Date('2023-12-18'),
   });
   databaseBuilder.factory.buildMission({
-    name : 'Mission test inactive',
-    competenceId : 'competence1NC9NE3IIOa0ym',
-    learningObjectives : 'Y\'en a plus',
-    thematicIds : 'recOO8OsMJpe5cZzi,recj6ITlVfU0vByrR,recRSPkFIgrY6Ps61',
-    validatedObjectives : '- Ca aussi\n Et puis ça aussi',
-    status : Mission.status.INACTIVE,
-    createdAt : new Date('2023-12-18'),
+    name: 'Mission test inactive',
+    competenceId: 'competence1NC9NE3IIOa0ym',
+    learningObjectives: 'Y\'en a plus',
+    thematicIds: 'recOO8OsMJpe5cZzi,recj6ITlVfU0vByrR,recRSPkFIgrY6Ps61',
+    validatedObjectives: '- Ca aussi\n Et puis ça aussi',
+    status: Mission.status.INACTIVE,
+    createdAt: new Date('2023-12-18'),
+  });
+  databaseBuilder.factory.buildMission({
+    name: 'Mission test expérimentale',
+    competenceId: 'competence1NC9NE3IIOa0ym',
+    learningObjectives: 'Y\'en a plus',
+    thematicIds: 'recOO8OsMJpe5cZzi,recj6ITlVfU0vByrR,recRSPkFIgrY6Ps61',
+    validatedObjectives: '- Ca aussi\n Et puis ça aussi',
+    status: Mission.status.EXPERIMENTAL,
+    createdAt: new Date('2024-07-29'),
   });
 }

--- a/api/lib/application/missions/mission-controller.js
+++ b/api/lib/application/missions/mission-controller.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import { findAllMissions, createMission, updateMission } from '../../domain/usecases/index.js';
 import { missionSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
-import * as missionRepository  from '../../infrastructure/repositories/mission-repository.js';
+import * as missionRepository from '../../infrastructure/repositories/mission-repository.js';
 //TODO Faire éventuellement un refacto pour mutualiser la gestion de la pagination
 const DEFAULT_PAGE = {
   number: 1,
@@ -44,6 +44,7 @@ function normalizePage(page) {
 
 function normalizeFilter(filter) {
   return {
-    isActive: filter.isActive === 'true',
+    statuses: filter.statuses,
   };
 }
+

--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -23,7 +23,8 @@ export class Mission {
 }
 
 const status = {
-  ACTIVE: 'ACTIVE',
+  VALIDATED: 'VALIDATED',
+  EXPERIMENTAL: 'EXPERIMENTAL',
   INACTIVE: 'INACTIVE',
 };
 

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -23,8 +23,8 @@ export async function findAllMissions({ filter, page }) {
   const query = knex('missions')
     .select('*')
     .orderBy('createdAt', 'desc');
-  if (filter?.isActive) {
-    query.where('status', Mission.status.ACTIVE);
+  if (filter?.statuses) {
+    query.whereIn('status', filter.statuses.map((status) => status.toUpperCase()));
   }
   const { results, pagination } = await fetchPage(query, page);
   const translations = await translationRepository.listByPrefix(missionTranslations.prefix);

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -18,7 +18,7 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
 
     //given
     const user = databaseBuilder.factory.buildAdminUser();
-    const mission = databaseBuilder.factory.buildMission({ name: 'Condor', status: Mission.status.ACTIVE, competenceId: 'recCompetence0', thematicIds: null, validatedObjectives: 'Être forte', learningObjectives: 'Être imbattable', createdAt: new Date('2024-01-01') });
+    const mission = databaseBuilder.factory.buildMission({ name: 'Condor', status: Mission.status.VALIDATED, competenceId: 'recCompetence0', thematicIds: null, validatedObjectives: 'Être forte', learningObjectives: 'Être imbattable', createdAt: new Date('2024-01-01') });
     await databaseBuilder.commit();
 
     //when
@@ -36,7 +36,7 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
         id: mission.id.toString(),
         attributes: {
           name: 'Condor',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           'competence-id': 'recCompetence0',
           'thematic-ids': null,
           'validated-objectives': 'Être forte',

--- a/api/tests/acceptance/application/mission/put_mission_test.js
+++ b/api/tests/acceptance/application/mission/put_mission_test.js
@@ -27,7 +27,7 @@ describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
             name: 'Mission à mettre à jour',
             'competence-id': 'TYUI',
             'thematic-id': null,
-            status: Mission.status.ACTIVE,
+            status: Mission.status.VALIDATED,
             'learning-objectives': 'Une chose',
             'validated-objectives': null
           },

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -160,7 +160,7 @@ async function mockCurrentContent() {
       thematicIds: 'thematicId,thematicId',
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
-      status: Mission.status.ACTIVE,
+      status: Mission.status.VALIDATED,
       createdAt: new Date('2010-01-04'),
     }), new Mission({
       id: 2,
@@ -224,7 +224,7 @@ async function mockCurrentContent() {
     thematicIds: 'thematicId,thematicId',
     learningObjectives: 'Que tu sois le meilleur',
     validatedObjectives: 'Rien',
-    status: Mission.status.ACTIVE,
+    status: Mission.status.VALIDATED,
     createdAt: new Date('2010-01-04'),
   });
   databaseBuilder.factory.buildMission({
@@ -468,7 +468,7 @@ async function mockContentForRelease() {
       competenceId: 'competenceId',
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
-      status: Mission.status.ACTIVE,
+      status: Mission.status.VALIDATED,
       content: {
         dareChallenges: [],
         steps: []
@@ -748,7 +748,7 @@ describe('Acceptance | Controller | release-controller', () => {
           thematicIds: 'thematicId,thematicId',
           learningObjectives: 'Que tu sois le meilleur',
           validatedObjectives: 'Rien',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
         });
         databaseBuilder.factory.buildMission({
           id: 2,

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -22,7 +22,7 @@ describe('Integration | Repository | mission-repository', function() {
     });
     context('When mission exists', function() {
       it('should return the mission', async function() {
-        databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.ACTIVE });
+        databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.VALIDATED });
         await databaseBuilder.commit();
 
         const result = await getById(1);
@@ -34,7 +34,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
           validatedObjectives_i18n: { fr: 'Rien' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }));
       });
@@ -43,7 +43,7 @@ describe('Integration | Repository | mission-repository', function() {
   describe('#findAllMissions', function() {
     context('When there are missions', function() {
       it('should return all missions', async function() {
-        databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.ACTIVE });
+        databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.VALIDATED });
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
@@ -62,7 +62,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
           validatedObjectives_i18n: { fr: 'Rien' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }), new Mission({
           id: 2,
@@ -96,14 +96,15 @@ describe('Integration | Repository | mission-repository', function() {
         });
       });
     });
-    context('With isActive filter', function() {
+    context('With statuses filter', function() {
       context('with results', function() {
-        it('should return all active missions', async function() {
-          const activeMission = databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.ACTIVE });
+        it('should return all missions of given status', async function() {
+          const activeMission = databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.VALIDATED });
           databaseBuilder.factory.buildMission({ id: 2, status: Mission.status.INACTIVE });
+          databaseBuilder.factory.buildMission({ id: 3, status: Mission.status.EXPERIMENTAL });
           await databaseBuilder.commit();
 
-          const results = await findAllMissions({ filter: { isActive: true }, page: { number: 1, size: 20 } });
+          const results = await findAllMissions({ filter: { statuses: ['validated'] }, page: { number: 1, size: 20 } });
 
           expect(results.missions.length).to.equal(1);
           expect(results.missions[0].id).to.equal(activeMission.id);
@@ -121,7 +122,7 @@ describe('Integration | Repository | mission-repository', function() {
           databaseBuilder.factory.buildMission({ id: 2, status: Mission.status.INACTIVE });
           await databaseBuilder.commit();
 
-          const results = await findAllMissions({ filter: { isActive: true }, page: { number: 1, size: 20 } });
+          const results = await findAllMissions({ filter: { statuses: [] }, page: { number: 1, size: 20 } });
 
           expect(results.missions.length).to.equal(0);
           expect(results.meta).to.deep.equal({
@@ -135,7 +136,7 @@ describe('Integration | Repository | mission-repository', function() {
     });
   });
 
-  describe('#list', function()  {
+  describe('#list', function() {
     let mockedLearningContent;
 
     beforeEach(async function() {
@@ -197,7 +198,7 @@ describe('Integration | Repository | mission-repository', function() {
       databaseBuilder.factory.buildMission({
         id: 2,
         name: 'Alt name',
-        status: Mission.status.ACTIVE,
+        status: Mission.status.VALIDATED,
         learningObjectives: 'Alt objectives',
         validatedObjectives: 'Alt validated objectives',
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
@@ -214,7 +215,7 @@ describe('Integration | Repository | mission-repository', function() {
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
         learningObjectives_i18n: { fr: 'Alt objectives' },
         validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-        status: Mission.status.ACTIVE,
+        status: Mission.status.VALIDATED,
         createdAt: new Date('2010-01-04'),
         content: {
           steps: [{
@@ -227,7 +228,7 @@ describe('Integration | Repository | mission-repository', function() {
             validationChallenges: [
               ['challengeValidation1'],
             ],
-          },{
+          }, {
             tutorialChallenges: [
               ['challengeTuto2'],
             ],
@@ -261,7 +262,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -278,7 +279,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -322,7 +323,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -339,7 +340,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -377,7 +378,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -394,7 +395,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -431,7 +432,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -448,7 +449,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -472,7 +473,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -489,7 +490,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -512,7 +513,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -529,7 +530,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -551,7 +552,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -568,7 +569,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
 
@@ -576,7 +577,7 @@ describe('Integration | Repository | mission-repository', function() {
     });
     context('Without tubes in thematic', async function() {
       it('Should return missions', async function() {
-        mockedLearningContent.thematics = [ airtableBuilder.factory.buildThematic({ id: 'thematicStep1', tubeIds: undefined }, { id: 'thematicDefiVide', tubeIds: undefined }) ];
+        mockedLearningContent.thematics = [airtableBuilder.factory.buildThematic({ id: 'thematicStep1', tubeIds: undefined }, { id: 'thematicDefiVide', tubeIds: undefined })];
         airtableBuilder.mockLists(mockedLearningContent);
 
         buildLocalizedChallenges(mockedLearningContent);
@@ -584,7 +585,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -601,7 +602,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
 
@@ -617,7 +618,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -634,7 +635,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
 
@@ -649,7 +650,7 @@ describe('Integration | Repository | mission-repository', function() {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           thematicIds: null,
@@ -666,7 +667,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: null,
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.ACTIVE,
+          status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
       });
@@ -677,10 +678,10 @@ describe('Integration | Repository | mission-repository', function() {
     context('Mission creation', function() {
       it('should store mission', async function() {
         const mission = new Mission({
-          name_i18n: { fr: 'Mission impossible'  },
+          name_i18n: { fr: 'Mission impossible' },
           competenceId: 'AZERTY',
           thematicIds: 'QWERTY',
-          learningObjectives_i18n:  { fr: null },
+          learningObjectives_i18n: { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
           status: Mission.status.INACTIVE,
         });
@@ -703,10 +704,10 @@ describe('Integration | Repository | mission-repository', function() {
       it('should store I18n for mission', async function() {
 
         const mission = new Mission({
-          name_i18n: { fr: 'Mission impossible'  },
+          name_i18n: { fr: 'Mission impossible' },
           competenceId: 'AZERTY',
           thematicIds: 'QWERTY',
-          learningObjectives_i18n:  { fr: 'au boulot' },
+          learningObjectives_i18n: { fr: 'au boulot' },
           validatedObjectives_i18n: { fr: 'Très bien' },
           status: Mission.status.INACTIVE,
         });
@@ -737,15 +738,15 @@ describe('Integration | Repository | mission-repository', function() {
 
     context('Update mission', function() {
       it('should update the mission', async function() {
-        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.ACTIVE });
+        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.VALIDATED });
         await databaseBuilder.commit();
 
         const missionToUpdate = new Mission({
           id: savedMission.id,
-          name_i18n: { fr: 'Updated mission'  },
+          name_i18n: { fr: 'Updated mission' },
           competenceId: 'QWERTY',
           thematicIds: 'Thematic',
-          learningObjectives_i18n:  { fr: null },
+          learningObjectives_i18n: { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
           status: Mission.status.INACTIVE,
         });
@@ -767,15 +768,15 @@ describe('Integration | Repository | mission-repository', function() {
       });
 
       it('should store I18n for mission', async function() {
-        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.ACTIVE });
+        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.VALIDATED });
         await databaseBuilder.commit();
 
         const missionToUpdate = new Mission({
           id: savedMission.id,
-          name_i18n: { fr: 'Updated mission'  },
+          name_i18n: { fr: 'Updated mission' },
           competenceId: 'QWERTY',
           thematicIds: 'Thematic',
-          learningObjectives_i18n:  { fr: 'Etre la boss' },
+          learningObjectives_i18n: { fr: 'Etre la boss' },
           validatedObjectives_i18n: { fr: 'intermédiaire' },
           status: Mission.status.INACTIVE,
         });

--- a/api/tests/tooling/domain-builder/factory/build-mission-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-mission-summary.js
@@ -6,7 +6,7 @@ export function buildMissionSummary({
   name = 'Ma mission',
   competence = '1.1 Traitement',
   createdAt = new Date('2023-10-14'),
-  status = Mission.status.ACTIVE,
+  status = Mission.status.VALIDATED,
 } = {}) {
   return new MissionSummary ({
     id,

--- a/api/tests/tooling/domain-builder/factory/build-mission.js
+++ b/api/tests/tooling/domain-builder/factory/build-mission.js
@@ -8,7 +8,7 @@ export function buildMission({
   createdAt = new Date('2023-10-14'),
   learningObjectives = '- Que tu deviennes forte\n Et...',
   validatedObjectives = '- Ca\n Et puis ça',
-  status = Mission.status.ACTIVE,
+  status = Mission.status.VALIDATED,
 } = {}) {
   return new Mission ({
     id,

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -18,7 +18,7 @@ describe('Unit | Controller | missions controller', function() {
               id: 1,
               name: 'Ma première mission',
               competence: '1.1 Ma compétence',
-              status: Mission.status.ACTIVE,
+              status: Mission.status.VALIDATED,
               createdAt: new Date('2010-01-04'),
             })],
           meta: {}
@@ -27,17 +27,17 @@ describe('Unit | Controller | missions controller', function() {
 
     it('should call the repository with all query params when they are valid', async function() {
       // given
-      const request = { query: { 'page[size]': 5, 'page[number]': 3, 'filter[isActive]': 'true' } };
+      const request = { query: { 'page[size]': 5, 'page[number]': 3, 'filter[statuses][]': ['VALIDATED'] } };
 
       // when
       await missionsController.findMissions(request, hFake);
 
       // then
-      expect(findAllMissions).toHaveBeenCalledWith({ filter: { isActive: true }, page: { number: 3, size: 5 } });
+      expect(findAllMissions).toHaveBeenCalledWith({ filter: { statuses: ['VALIDATED'] }, page: { number: 3, size: 5 } });
     });
     it('should return the serialized mission with french translations', async function() {
       // given
-      const request = { query: { 'page[size]': 5, 'page[number]': 3, 'filter[isActive]': 'true' } };
+      const request = { query: { 'page[size]': 5, 'page[number]': 3, 'filter[statuses][]': ['VALIDATED'] } };
 
       // when
       const result = await missionsController.findMissions(request, hFake);
@@ -51,14 +51,14 @@ describe('Unit | Controller | missions controller', function() {
             name: 'Ma première mission',
             competence: '1.1 Ma compétence',
             'created-at': new Date('2010-01-04'),
-            status: 'ACTIVE'
+            status: Mission.status.VALIDATED
           }
         }
       ]);
     });
 
     describe('pagination', function() {
-      const filter = { isActive: false };
+      const filter = {};
 
       it('ignore unknown pagination parameters', async function() {
         // given
@@ -138,41 +138,13 @@ describe('Unit | Controller | missions controller', function() {
 
       it('ignore unknown filter parameters', async function() {
         // given
-        const request = { query: { 'filter[isActive]': 'true', 'filter[damn]': 'ok' } };
+        const request = { query: { 'filter[statuses][]': 'VALIDATED', 'filter[damn]': 'ok' } };
 
         // when
         await missionsController.findMissions(request, hFake);
 
         // then
-        expect(findAllMissions).toHaveBeenCalledWith({ filter: { isActive: true }, page });
-      });
-
-      context('filter isActive', function() {
-        it('extract isActive parameter correctly', async function() {
-          // given
-          const request0 = { query: { 'filter[isActive]': 3 } };
-          const request1 = { query: { 'filter[isActive]': 'ok' } };
-          const request2 = { query: { 'filter[somethingElse]': 'coucou' } };
-          const request3 = { query: { 'filter[isActive]': 'true' } };
-          const request4 = { query: { 'filter[isActive]': 'false' } };
-          const request5 = { query: { 'filter[isActive]': '' } };
-
-          // when
-          await missionsController.findMissions(request0, hFake);
-          await missionsController.findMissions(request1, hFake);
-          await missionsController.findMissions(request2, hFake);
-          await missionsController.findMissions(request3, hFake);
-          await missionsController.findMissions(request4, hFake);
-          await missionsController.findMissions(request5, hFake);
-
-          // then
-          expect(findAllMissions).toHaveBeenNthCalledWith(1, { filter: { isActive: false }, page });
-          expect(findAllMissions).toHaveBeenNthCalledWith(2, { filter: { isActive: false }, page });
-          expect(findAllMissions).toHaveBeenNthCalledWith(3, { filter: { isActive: false }, page });
-          expect(findAllMissions).toHaveBeenNthCalledWith(4, { filter: { isActive: true }, page });
-          expect(findAllMissions).toHaveBeenNthCalledWith(5, { filter: { isActive: false }, page });
-          expect(findAllMissions).toHaveBeenNthCalledWith(6, { filter: { isActive: false }, page });
-        });
+        expect(findAllMissions).toHaveBeenCalledWith({ filter: { statuses: ['VALIDATED'] }, page });
       });
     });
   });
@@ -233,7 +205,7 @@ describe('Unit | Controller | missions controller', function() {
     const attributes = {
       name: 'Mission possible',
       'competence-id': 'QWERTY',
-      status: Mission.status.ACTIVE,
+      status: Mission.status.VALIDATED,
       'learning-objectives': 'apprendre à éviter les lasers',
       'validated-objectives': 'Très bien',
       'thematic-id': null
@@ -262,7 +234,7 @@ describe('Unit | Controller | missions controller', function() {
         thematicId: null,
         learningObjectives_i18n: { fr: 'apprendre à éviter les lasers' },
         validatedObjectives_i18n: { fr: 'Très bien' },
-        status: Mission.status.ACTIVE,
+        status: Mission.status.VALIDATED,
       });
       // then
       expect(updateMissionMock).toHaveBeenCalledWith(deserializedMission);

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -3,6 +3,7 @@ import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import MissionSummary from '../../models/mission-summary';
 
 export default class MissionForm extends Component {
   @service currentData;
@@ -43,8 +44,13 @@ export default class MissionForm extends Component {
     return this.args.mission.name?.length > 0;
   }
 
-  get statusOptions() {
-    return [{ value: 'ACTIVE', label: 'ACTIVE' }, { value: 'INACTIVE', label: 'INACTIVE' }];
+  get statusOptions () {
+    return Object.keys(MissionSummary.statuses).map((status) => {
+      return {
+        value: MissionSummary.statuses[status],
+        label:  MissionSummary.displayableStatuses[status],
+      };
+    });
   }
 
   get competencesOptions() {

--- a/pix-editor/app/controllers/authenticated/missions/list.js
+++ b/pix-editor/app/controllers/authenticated/missions/list.js
@@ -13,8 +13,8 @@ export default class MissionsListController extends Controller {
 
 
   @action
-  onChangesStatus(arg1) {
-    this.statuses = arg1;
+  onChangesStatus(selectedStatuses) {
+    this.statuses = selectedStatuses;
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/missions/list.js
+++ b/pix-editor/app/controllers/authenticated/missions/list.js
@@ -2,27 +2,41 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import MissionSummary from '../../../models/mission-summary';
 
 export default class MissionsListController extends Controller {
   @service router;
-  queryParams = ['pageNumber', 'pageSize', 'showActiveMissions'];
+  queryParams = ['pageNumber', 'pageSize', 'statuses'];
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
-  @tracked showActiveMissions = false;
+  @tracked statuses = [];
 
 
   @action
-  toggleShowActiveMissions() {
-    this.showActiveMissions = !this.showActiveMissions;
+  onChangesStatus(arg1) {
+    this.statuses = arg1;
   }
 
   @action
   clearFilters() {
-    this.showActiveMissions = false;
+    this.statuses = [];
   }
 
   @action
   goToMissionDetails(id) {
     this.router.transitionTo('authenticated.missions.mission.details', id);
+  }
+
+  get statusesOption() {
+    return Object.keys(MissionSummary.statuses).map((status) => {
+      return {
+        value: MissionSummary.statuses[status],
+        label: MissionSummary.displayableStatuses[status],
+      };
+    });
+  }
+
+  get getStatusSelected() {
+    return this.statuses;
   }
 }

--- a/pix-editor/app/models/mission-summary.js
+++ b/pix-editor/app/models/mission-summary.js
@@ -6,7 +6,42 @@ export default class MissionSummary extends Model {
   @attr createdAt;
   @attr status;
 
-  get isActive() {
-    return this.status === 'ACTIVE';
+  static get statuses () {
+    return {
+      VALIDATED: 'VALIDATED',
+      EXPERIMENTAL: 'EXPERIMENTAL',
+      INACTIVE: 'INACTIVE',
+    };
+  }
+
+  static get displayableStatuses () {
+    return {
+      VALIDATED: 'Validée',
+      EXPERIMENTAL: 'Expérimentale',
+      INACTIVE: 'Inactive',
+    };
+  }
+
+  get displayableStatus () {
+    return MissionSummary.displayableStatuses[this.status];
+  }
+
+  get statusColor () {
+    if (this.isExperimental) return 'secondary';
+    if (this.isValidated) return 'green-light';
+    return 'grey-light';
+  }
+
+  get isExperimental () {
+    return this.status === MissionSummary.statuses.EXPERIMENTAL;
+
+  }
+
+  get isValidated () {
+    return this.status === MissionSummary.statuses.VALIDATED;
+  }
+
+  get isInactive () {
+    return !this.isExperimental && !this.isValidated;
   }
 }

--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -1,15 +1,9 @@
-import Model, { attr } from '@ember-data/model';
+import { attr } from '@ember-data/model';
+import MissionSummary from './mission-summary';
 
-export default class Mission extends Model {
-  @attr name;
+export default class Mission extends MissionSummary {
   @attr competenceId;
   @attr thematicIds;
-  @attr createdAt;
-  @attr status;
   @attr learningObjectives;
   @attr validatedObjectives;
-
-  get isActive () {
-    return this.status === 'ACTIVE';
-  }
 }

--- a/pix-editor/app/routes/authenticated/missions/list.js
+++ b/pix-editor/app/routes/authenticated/missions/list.js
@@ -17,7 +17,6 @@ export default class MissionsRoute extends Route {
   @service store;
   @service access;
   async model(params) {
-    console.log(params);
     const missions = await this.store.query('mission-summary', {
       page: {
         number: params.pageNumber,

--- a/pix-editor/app/routes/authenticated/missions/list.js
+++ b/pix-editor/app/routes/authenticated/missions/list.js
@@ -9,7 +9,7 @@ export default class MissionsRoute extends Route {
     pageSize: {
       refreshModel: true,
     },
-    showActiveMissions: {
+    statuses: {
       refreshModel: true,
     },
   };
@@ -17,6 +17,7 @@ export default class MissionsRoute extends Route {
   @service store;
   @service access;
   async model(params) {
+    console.log(params);
     const missions = await this.store.query('mission-summary', {
       page: {
         number: params.pageNumber,
@@ -24,7 +25,7 @@ export default class MissionsRoute extends Route {
       },
 
       filter: {
-        isActive: params.showActiveMissions,
+        statuses: params.statuses,
       },
     }, { reload: true });
     return {

--- a/pix-editor/app/templates/authenticated/missions/list.hbs
+++ b/pix-editor/app/templates/authenticated/missions/list.hbs
@@ -24,14 +24,19 @@
       @onClearFilters={{this.clearFilters}}
       @isClearFilterButtonDisabled={{false}}
     >
-      <PixToggle
-        @inline={{true}}
-        @onLabel="Actives"
-        @offLabel="Toutes"
-        @toggled={{this.showActiveMissions}}
-        @onChange={{this.toggleShowActiveMissions}}
+      <PixMultiSelect
+        id="mission-status-multi-select"
         @screenReaderOnly={{true}}
-      ><:label>Statut</:label></PixToggle>
+        @placeholder="Aucun"
+        @onChange={{this.onChangesStatus}}
+        @values={{this.getStatusSelected}}
+        @emptyMessage="Il n'y a pas de statut"
+        @options={{this.statusesOption}}
+      >
+        <:label>Statut</:label>
+        <:default as |option|>{{option.label}}</:default>
+      </PixMultiSelect>
+
     </PixFilterBanner>
     <div class="panel-table-v2">
       <table class="content-text content-text--small">
@@ -58,8 +63,8 @@
             <td>{{mission.competence}}</td>
             <td>{{dayjs-format mission.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
             <td>
-              <PixTag @color="{{if mission.isActive "green-light" "grey-light"}}">
-                {{if mission.isActive "Active" "Inactive"}}
+              <PixTag @color="{{mission.statusColor}}">
+                {{mission.displayableStatus}}
               </PixTag>
             </td>
           </tr>

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -26,8 +26,8 @@
           {{this.model.thematics}}
         </li>
         <li><span class="bold">Statut : </span>
-          <PixTag @color="{{if this.model.mission.isActive "green-light" "grey-light"}}">
-            {{ if this.model.mission.isActive "Active" "Inactive" }}
+          <PixTag @color="{{this.model.mission.statusColor}}">
+            {{this.model.mission.displayableStatus }}
           </PixTag>
         </li>
         <li>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -125,7 +125,7 @@ function routes() {
   this.post('/airtable/content/Tubes', (schema, request) => {
     const tubePayload = JSON.parse(request.requestBody);
     const tube = _deserializePayload(tubePayload, 'tube');
-    const createdTube =  schema.tubes.create(tube);
+    const createdTube = schema.tubes.create(tube);
     return _serializeModel(createdTube, 'tube');
   });
 
@@ -265,11 +265,11 @@ function routes() {
   this.get('/missions', function (schema, request) {
     const queryParams = request.queryParams;
     const {
-      'filter[isActive]': isActiveFilter,
+      'filter[statuses]': statuses,
     } = queryParams;
     let allmissionSummaries;
-    if (isActiveFilter === 'true') {
-      allmissionSummaries = schema.missionSummaries.where({ status: 'ACTIVE' }).models;
+    if (statuses) {
+      allmissionSummaries = schema.missionSummaries.where((mission) => statuses.includes(mission.status)).models;
     } else {
       allmissionSummaries = schema.missionSummaries.all().models;
     }

--- a/pix-editor/tests/acceptance/missions/list_test.js
+++ b/pix-editor/tests/acceptance/missions/list_test.js
@@ -5,22 +5,23 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import { click, currentURL } from '@ember/test-helpers';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 
-module('Acceptance | Missions | List', function(hooks) {
+module('Acceptance | Missions | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
     this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D' });
-    this.server.create('mission-summary', { name: 'Mission 1', competence: 'Mirage', createdAt: '2023/12/11', status: 'ACTIVE' });
+    this.server.create('mission-summary', { name: 'Mission 1', competence: 'Mirage', createdAt: '2023/12/11', status: 'VALIDATED' });
     this.server.create('mission-summary', { name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
+    this.server.create('mission-summary', { name: 'Mission 3', competence: 'Autres', createdAt: '2023/11/11', status: 'EXPERIMENTAL' });
 
     return authenticateSession();
   });
 
-  test('it displays all Pix 1D missions', async function(assert) {
+  test('it displays all Pix 1D missions', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
@@ -34,16 +35,36 @@ module('Acceptance | Missions | List', function(hooks) {
     assert.dom(screen.queryByText('Mission 2')).exists();
   });
 
-  test('should display only active missions', async function(assert) {
+  test('should display only validated missions', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'Pix 1D' }));
     await clickByName('Missions Pix 1D');
-    await click(await screen.findByRole('button', { name: 'Statut' }));
+    await click(screen.getByLabelText('Statut'));
+    await click(await screen.findByRole('checkbox', { name: 'Validée' }));
+
     // then
     assert.dom(screen.queryByText('Mission 1')).exists();
     assert.dom(screen.queryByText('Mission 2')).doesNotExist();
   });
+
+  test('should display only mission validée et expérimental', async function (assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Sélectionner un référentiel');
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'Pix 1D' }));
+    await clickByName('Missions Pix 1D');
+    await click(screen.getByLabelText('Statut'));
+    await click(await screen.findByRole('checkbox', { name: 'Validée' }));
+    await click(await screen.findByRole('checkbox', { name: 'Expérimentale' }));
+
+    // then
+    assert.dom(screen.queryByText('Mission 1')).exists();
+    assert.dom(screen.queryByText('Mission 3')).exists();
+    assert.dom(screen.queryByText('Mission 2')).doesNotExist();
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
Le métier contenu a besoin de pouvoir jouer des missions non validées pour la production.
Il faut donc pouvoir distinguer les missions au statut "expérimental" des autres missions actives.

## :robot: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On change le statut "active" en "validée".
On ajoute le statut "expérimental".
On adapte la page de liste des missions, de détail d'une mission et les formulaires d'ajout/modification de mission.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS
## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Dans Pix Editor, sélectionner le référentiel Pix 1D.
Dans l'onglet missions, vérifier que les filtres de status fonctionnent.
Vérifier qu'il est possible de créer une mission au statut expérimental.
Vérifier qu'il est possible de modifier une mission au statut expérimental.
