### PR TITLE
[FEATURE] Exclu les missions inactive de la `release` (PIX-13588)

### DIFF
--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -38,8 +38,8 @@ export async function findAllMissions({ filter, page }) {
 const SCHOOL_PLAYABLE_CHALLENGE_STATUSES = [Challenge.STATUSES.VALIDE, Challenge.STATUSES.PROPOSE];
 const SCHOOL_PLAYABLE_SKILL_STATUSES = [SkillForRelease.STATUSES.ACTIF, SkillForRelease.STATUSES.EN_CONSTRUCTION];
 
-export async function list() {
-  const missions = await knex('missions').select('*');
+export async function listActive() {
+  const missions = await knex('missions').select('*').whereNot({ status: 'INACTIVE' });
 
   const translations = await translationRepository.listByPrefix(missionTranslations.prefix);
   const tubes = await tubeRepository.list();

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -152,7 +152,7 @@ async function _getCurrentContentFromPG() {
   const staticCoursesDTO = await knex('static_courses')
     .select(['id', 'name', 'description', 'isActive', 'challengeIds'])
     .orderBy('id');
-  const missions = await missionRepository.list();
+  const missions = await missionRepository.listActive();
 
   return {
     courses: staticCoursesDTO.map(({ id, name, description, isActive, challengeIds }) => {

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -169,7 +169,7 @@ async function mockCurrentContent() {
       thematicIds: 'thematicId,thematicId',
       learningObjectives_i18n: { fr: 'Alt objectives' },
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-      status: Mission.status.INACTIVE,
+      status: Mission.status.EXPERIMENTAL,
       createdAt: new Date('2010-01-05'),
     })]
   };
@@ -229,6 +229,16 @@ async function mockCurrentContent() {
   });
   databaseBuilder.factory.buildMission({
     id: 2,
+    name: 'Alt name',
+    competenceId: 'competenceId',
+    thematicIds: 'thematicId,thematicId',
+    learningObjectives: 'Alt objectives',
+    validatedObjectives: 'Alt validated objectives',
+    status: Mission.status.EXPERIMENTAL,
+    createdAt: new Date('2010-01-05'),
+  });
+  databaseBuilder.factory.buildMission({
+    id: 3,
     name: 'Alt name',
     competenceId: 'competenceId',
     thematicIds: 'thematicId,thematicId',
@@ -479,7 +489,7 @@ async function mockContentForRelease() {
       competenceId: 'competenceId',
       learningObjectives_i18n: { fr: 'Alt objectives' },
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-      status: Mission.status.INACTIVE,
+      status: Mission.status.EXPERIMENTAL,
       content: {
         dareChallenges: [],
         steps: []
@@ -752,6 +762,15 @@ describe('Acceptance | Controller | release-controller', () => {
         });
         databaseBuilder.factory.buildMission({
           id: 2,
+          name: 'Alt name',
+          competenceId: 'competenceId',
+          thematicIds: 'thematicId,thematicId',
+          learningObjectives: 'Alt objectives',
+          validatedObjectives: 'Alt validated objectives',
+          status: Mission.status.EXPERIMENTAL,
+        });
+        databaseBuilder.factory.buildMission({
+          id: 3,
           name: 'Alt name',
           competenceId: 'competenceId',
           thematicIds: 'thematicId,thematicId',

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -1,7 +1,7 @@
 import { omit } from 'lodash';
 import { beforeEach, describe as context, describe, expect, expectTypeOf, it } from 'vitest';
 import { airtableBuilder, databaseBuilder, knex } from '../../../test-helper.js';
-import { findAllMissions, getById, list, save, } from '../../../../lib/infrastructure/repositories/mission-repository.js';
+import { findAllMissions, getById, listActive, save, } from '../../../../lib/infrastructure/repositories/mission-repository.js';
 import { Challenge, Mission } from '../../../../lib/domain/models/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { SkillForRelease } from '../../../../lib/domain/models/release/index.js';
@@ -98,7 +98,7 @@ describe('Integration | Repository | mission-repository', function() {
     });
     context('With statuses filter', function() {
       context('with results', function() {
-        it('should return all missions of given status', async function() {
+        it('should return all active missions', async function() {
           const activeMission = databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.VALIDATED });
           databaseBuilder.factory.buildMission({ id: 2, status: Mission.status.INACTIVE });
           databaseBuilder.factory.buildMission({ id: 3, status: Mission.status.EXPERIMENTAL });
@@ -136,7 +136,7 @@ describe('Integration | Repository | mission-repository', function() {
     });
   });
 
-  describe('#list', function() {
+  describe('#listActive', function() {
     let mockedLearningContent;
 
     beforeEach(async function() {
@@ -190,7 +190,7 @@ describe('Integration | Repository | mission-repository', function() {
 
     });
 
-    it('should return all missions', async function() {
+    it('should return all active missions', async function() {
       airtableBuilder.mockLists(mockedLearningContent);
 
       buildLocalizedChallenges(mockedLearningContent);
@@ -204,9 +204,18 @@ describe('Integration | Repository | mission-repository', function() {
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
       });
 
+      databaseBuilder.factory.buildMission({
+        id: 3,
+        name: 'inactive name',
+        status: Mission.status.INACTIVE,
+        learningObjectives: 'Alt objectives',
+        validatedObjectives: 'Alt validated objectives',
+        thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
+      });
+
       await databaseBuilder.commit();
 
-      const result = await list();
+      const result = await listActive();
 
       expect(result).to.deep.equal([new Mission({
         id: 2,
@@ -270,7 +279,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -331,7 +340,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -386,7 +395,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -440,7 +449,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -481,7 +490,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -521,7 +530,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -560,7 +569,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -593,7 +602,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -626,7 +635,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,
@@ -658,7 +667,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         await databaseBuilder.commit();
 
-        const result = await list();
+        const result = await listActive();
 
         expect(result).to.deep.equal([new Mission({
           id: 2,

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -197,7 +197,17 @@ describe('Integration | Repository | release-repository', function() {
 
       databaseBuilder.factory.buildMission({
         id: 123456789,
-        name: 'mission PG name',
+        name: 'validated mission PG name',
+        competenceId: 'competenceId',
+        learningObjectives: 'Que tu sois le meilleur',
+        thematicIds: 'thematicIds',
+        validatedObjectives: 'Rien',
+        status: Mission.status.VALIDATED,
+      });
+
+      databaseBuilder.factory.buildMission({
+        id: 987654321,
+        name: 'inactive mission PG name',
         competenceId: 'competenceId',
         learningObjectives: 'Que tu sois le meilleur',
         thematicIds: 'thematicIds',
@@ -852,7 +862,7 @@ function _mockRichAirtableContent() {
     areas: [area1, area2],
     competences: [competence11, competence12, competence21],
     thematics: [thematic111, thematic112, thematic121, thematic211],
-    tubeIds:  [airtableTube1111.id, airtableTube1121.id, airtableTube1211.id, airtableTube1212.id, airtableTube2111.id],
+    tubeIds: [airtableTube1111.id, airtableTube1121.id, airtableTube1211.id, airtableTube1212.id, airtableTube2111.id],
     skills: [skill11111, skill11112, skill12121, skill21111],
     challenges: [challenge121211, challenge121212, challenge211111, challenge211112, challenge211113],
   };
@@ -1407,12 +1417,12 @@ function _getRichCurrentContentDTO() {
   const expectedMissionsDTOs = [
     new Mission({
       id: 123456789,
-      name_i18n : { fr: 'mission PG name' },
+      name_i18n: { fr: 'validated mission PG name' },
       competenceId: 'competenceId',
       thematicIds: 'thematicIds',
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
-      status: Mission.status.INACTIVE,
+      status: Mission.status.VALIDATED,
       createdAt: new Date('2010-01-04'),
     }),
   ];


### PR DESCRIPTION
## :unicorn: Problème

Certaines missions sont désactivées, et pourtant, elles apparaissent dans la liste des missions. Nous ne faisons pas de filtre côté front.

## :robot: Proposition

Exclure les missions inactive dans la construction de release.

## :rainbow: Remarques


## :100: Pour tester

S'assurer que nous avons des missions actives et d'autres inactives.
Générer une release et s'assurer qu'il n'y a que les missions active dedans.

Pour tester le contenu d'une release :
```bash
curl -X POST https://pix-lcms-review-pr711.osc-fr1.scalingo.io/api/releases -H "Authorization: Bearer 1111111111-API-KEY-AAAAA" > release.json
jq .content.missions release.json
```