### PR TITLE
[BUGFIX] Script migration en focus: correction requête Airtable attachments (PIX-13700)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/attachment-datasource.js
@@ -60,7 +60,7 @@ export const attachmentDatasource = datasource.extend({
   async filterByLocalizedChallengeIds(localizedChallengeIds) {
     if (localizedChallengeIds.length === 0) return undefined;
     const airtableRawObjects = await findRecords(this.tableName, {
-      filterByFormula: `OR(${localizedChallengeIds.map((id) => `FIND("${id}", ARRAYJOIN({localizedChallengeId}))`).join(',')})`,
+      filterByFormula: `OR(${localizedChallengeIds.map((id) => `({localizedChallengeId} = "${id}")`).join(',')})`,
     });
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -53,14 +53,14 @@ export async function createBatch(attachments) {
 
 function toDomainList(datasourceAttachments, translations, localizedChallenges) {
   const translationsByChallengeId = _.groupBy(translations, 'entityId');
-  const localizedChallengesById = _.groupBy(localizedChallenges, 'id');
+  const localizedChallengesById = _.keyBy(localizedChallenges, 'id');
 
   return datasourceAttachments.map((attachment) => {
     if (attachment.type !== Attachment.TYPES.ILLUSTRATION) {
       return toDomain(attachment);
     }
     const challengeTranslations = translationsByChallengeId[attachment.challengeId];
-    const locale = localizedChallengesById[attachment.localizedChallengeId][0].locale;
+    const locale = localizedChallengesById[attachment.localizedChallengeId].locale;
     const translation = challengeTranslations?.find((translation) => locale === translation.locale);
 
     return toDomain(attachment, translation);

--- a/api/scripts/move-skills-to-focus/index.js
+++ b/api/scripts/move-skills-to-focus/index.js
@@ -111,8 +111,7 @@ async function _cloneSkillAndChallengesAndAttachments({ skill, skillChallenges, 
   let clonedAttachments, clonedChallenges, clonedSkill;
   try {
     const tubeSkills = await skillRepository.listByTubeId(skill.tubeId);
-    const localizedChallengeIds = skillChallenges.flatMap((ch) => ch.localizedChallenges.map((loc) => loc.id));
-    const attachments = await attachmentRepository.listByLocalizedChallengeIds(localizedChallengeIds);
+
     // Exploitation du duck typing pour tricher
     // tubeDestination : besoin de name, competenceId et id
     const tubeDestination = {
@@ -126,6 +125,9 @@ async function _cloneSkillAndChallengesAndAttachments({ skill, skillChallenges, 
       (challenge.genealogy === Challenge.GENEALOGIES.PROTOTYPE && challenge.isValide)
       || (challenge.genealogy === Challenge.GENEALOGIES.DECLINAISON && (challenge.isValide || challenge.isPropose))
     );
+
+    const localizedChallengeIds = preFilteredSkillChallenges.flatMap((ch) => ch.localizedChallenges.map((loc) => loc.id));
+    const attachments = await attachmentRepository.listByLocalizedChallengeIds(localizedChallengeIds);
 
     const res = skill.cloneSkillAndChallenges({
       tubeDestination,

--- a/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
@@ -241,7 +241,7 @@ describe('Integration | Repository | attachment-repository', () => {
       await databaseBuilder.commit();
       vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Attachments') expect.unreachable('Airtable tableName should be Attachments');
-        if (options?.filterByFormula !== 'OR(FIND("challengeA", ARRAYJOIN({localizedChallengeId})),FIND("localizedChallengeNLForChallengeA", ARRAYJOIN({localizedChallengeId})),FIND("challengeB", ARRAYJOIN({localizedChallengeId})))') expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !== 'OR(({localizedChallengeId} = "challengeA"),({localizedChallengeId} = "localizedChallengeNLForChallengeA"),({localizedChallengeId} = "challengeB"))') expect.unreachable('Wrong filterByFormula');
         return [
           {
             id: attachment_NL_forChallengeA_data.id,
@@ -362,7 +362,7 @@ describe('Integration | Repository | attachment-repository', () => {
       // given
       vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Attachments') expect.unreachable('Airtable tableName should be Attachments');
-        if (options?.filterByFormula !== 'OR(FIND("someLocalizedChallengeId", ARRAYJOIN({localizedChallengeId})))') expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !== 'OR(({localizedChallengeId} = "someLocalizedChallengeId"))') expect.unreachable('Wrong filterByFormula');
         return [];
       });
 


### PR DESCRIPTION
## :unicorn: Problème
La requête de listing des attachments ramène trop de lignes.

## :robot: Proposition
Corriger la requête.

## :rainbow: Remarques
On évite également de lister les attachments des challenges qui ne seront pas migrés.

## :100: Pour tester
Exécuter le script.