### PR TITLE
[FEATURE] Ne pas autoriser la validation d'une mission si celle-ci contient au moins une épreuve non validée (PIX-13613).

### DIFF
--- a/api/lib/domain/usecases/update-mission.js
+++ b/api/lib/domain/usecases/update-mission.js
@@ -1,6 +1,17 @@
-import { missionRepository } from '../../infrastructure/repositories/index.js';
+import { missionRepository, challengeRepository } from '../../infrastructure/repositories/index.js';
+import { Challenge, Mission } from '../models/index.js';
+import { BadRequestError } from '../../infrastructure/errors.js';
 
 export async function updateMission(mission, dependencies = { missionRepository }) {
   await missionRepository.getById(mission.id);
+
+  if (mission.status === Mission.status.VALIDATED && mission.thematicIds) {
+    const challenges = await challengeRepository.filterByThematicIds(mission.thematicIds.split(','));
+    const nonValidatedChallengeIds = challenges.filter((challenge) => challenge.status !== Challenge.STATUSES.VALIDE).map((challenge) => `"${challenge.id}"`);
+
+    if (nonValidatedChallengeIds.length > 0) {
+      throw new BadRequestError(`La mission ne peut pas être mise à jour car les challenges ${nonValidatedChallengeIds.join(', ')} ne sont pas au status VALIDE`);
+    }
+  }
   return await dependencies.missionRepository.save(mission);
 }

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -1,8 +1,9 @@
 import { describe, describe as context, expect, it, expectTypeOf } from 'vitest';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { updateMission } from '../../../../lib/domain/usecases/index.js';
-import { databaseBuilder } from '../../../test-helper.js';
-import { Mission } from '../../../../lib/domain/models/index.js';
+import { airtableBuilder, databaseBuilder } from '../../../test-helper.js';
+import { Challenge, Mission } from '../../../../lib/domain/models/index.js';
+import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 describe('Integration | Usecases | Update mission', function() {
   context('When the mission to update does not exist', function() {
     it('should return a not found error', async () => {
@@ -17,29 +18,119 @@ describe('Integration | Usecases | Update mission', function() {
     });
   });
   context('When the mission exists', function() {
-    it('should return the updated mission', async () => {
-      // given
-      const mission = databaseBuilder.factory.buildMission({ createdAt: new Date('2023-12-25') });
-      await databaseBuilder.commit();
 
-      const missionToUpdate = new Mission({
-        id: mission.id,
-        name_i18n: { fr: 'Updated mission'  },
-        competenceId: 'QWERTY',
-        thematicIds: 'Thematic',
-        learningObjectives_i18n:  { fr: null },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        status: Mission.status.INACTIVE,
-        createdAt: new Date('2023-12-25')
+    context('when requested status is not VALIDATED', function() {
+      it('should return the updated mission', async () => {
+        // given
+        const mission = databaseBuilder.factory.buildMission({ createdAt: new Date('2023-12-25') });
+        await databaseBuilder.commit();
+
+        const missionToUpdate = new Mission({
+          id: mission.id,
+          name_i18n: { fr: 'Updated mission'  },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n:  { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        // when
+        const updatedMission = await updateMission(missionToUpdate);
+
+        // then
+        expectTypeOf(updatedMission).toEqualTypeOf('Mission');
+        await expect(updatedMission).to.deep.equal(missionToUpdate);
+
       });
-
-      // when
-      const updatedMission = await updateMission(missionToUpdate);
-
-      // then
-      expectTypeOf(updatedMission).toEqualTypeOf('Mission');
-      await expect(updatedMission).to.deep.equal(missionToUpdate);
-
     });
+    context('when requested status is VALIDATED', function() {
+      context('when all challenges in the mission has VALIDATED status', function() {
+        it('should return the updated mission', async () => {
+          const mockedLearningContent =  {
+            challenges: [
+              airtableBuilder.factory.buildChallenge({ id: 'challengeTuto1', status: Challenge.STATUSES.VALIDE, skillId: 'skillTuto1' }),
+              airtableBuilder.factory.buildChallenge({ id: 'challengeTraining1', status: Challenge.STATUSES.VALIDE, skillId: 'skillTraining1' }),
+            ],
+          };
+
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          buildLocalizedChallenges(mockedLearningContent);
+
+          // given
+          const mission = databaseBuilder.factory.buildMission({ createdAt: new Date('2023-12-25') });
+          await databaseBuilder.commit();
+
+          const missionToUpdate = new Mission({
+            id: mission.id,
+            name_i18n: { fr: 'Updated mission'  },
+            competenceId: 'QWERTY',
+            thematicIds: 'Thematic',
+            learningObjectives_i18n:  { fr: null },
+            validatedObjectives_i18n: { fr: 'Très bien' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2023-12-25')
+          });
+
+          // when
+          const updatedMission = await updateMission(missionToUpdate);
+
+          // then
+          expectTypeOf(updatedMission).toEqualTypeOf('Mission');
+          await expect(updatedMission).to.deep.equal(missionToUpdate);
+
+        });
+      });
+      context('when some challenges in the mission has PROPOSE status', function() {
+        it('should return not update the mission', async () => {
+          const mockedLearningContent =  {
+            challenges: [
+              airtableBuilder.factory.buildChallenge({ id: 'challengeTuto1', status: Challenge.STATUSES.VALIDE, skillId: 'skillTuto1' }),
+              airtableBuilder.factory.buildChallenge({ id: 'challengeTraining1', status: Challenge.STATUSES.PROPOSE, skillId: 'skillTraining1' }),
+              airtableBuilder.factory.buildChallenge({ id: 'challengeTraining2', status: Challenge.STATUSES.PROPOSE, skillId: 'skillTraining2' }),
+            ],
+          };
+
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          buildLocalizedChallenges(mockedLearningContent);
+
+          // given
+          const mission = databaseBuilder.factory.buildMission({ createdAt: new Date('2023-12-25') });
+          await databaseBuilder.commit();
+
+          const missionToUpdate = new Mission({
+            id: mission.id,
+            name_i18n: { fr: 'Updated mission'  },
+            competenceId: 'QWERTY',
+            thematicIds: 'Thematic',
+            learningObjectives_i18n:  { fr: null },
+            validatedObjectives_i18n: { fr: 'Très bien' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2023-12-25')
+          });
+
+          // when
+          const promise = updateMission(missionToUpdate);
+
+          // then
+          await expect(promise).rejects.to.deep.equal(new BadRequestError('La mission ne peut pas être mise à jour car les challenges "challengeTraining1", "challengeTraining2" ne sont pas au status VALIDE'));
+
+        });
+
+      });
+    });
+
   });
 });
+
+function buildLocalizedChallenges(mockedLearningContent) {
+  mockedLearningContent.challenges.forEach((airtableChallenge) => {
+    databaseBuilder.factory.buildLocalizedChallenge({
+      id: airtableChallenge.fields['id persistant'],
+      challengeId: airtableChallenge.fields['id persistant']
+    });
+  });
+}

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { filter, get, list, update } from '../../../../lib/infrastructure/repositories/challenge-repository.js';
+import * as challengeRepository from '../../../../lib/infrastructure/repositories/challenge-repository.js';
 import { challengeDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import {
   localizedChallengeRepository,
@@ -7,6 +7,8 @@ import {
 } from '../../../../lib/infrastructure/repositories/index.js';
 import { domainBuilder } from '../../../test-helper.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+const { filter, get, list, update } = challengeRepository;
 
 describe('Unit | Repository | challenge-repository', () => {
   describe('#list', () => {
@@ -135,7 +137,7 @@ describe('Unit | Repository | challenge-repository', () => {
         expect(challenges[0].instruction).to.equal('instruction');
         expect(challenges[0].proposals).to.equal('proposals');
         expect(challenges[0].alternativeLocales).to.deep.equal(['en']);
-        expect(challenges[0].localizedChallenges).to.deep.equal([ localizedChallenge1, localizedChallenge1_en]);
+        expect(challenges[0].localizedChallenges).to.deep.equal([localizedChallenge1, localizedChallenge1_en]);
         expect(challenges[0].geography).to.equal('Brésil');
         expect(challenges[1].instruction).to.equal('instruction 2');
         expect(challenges[1].proposals).to.equal('proposals 2');
@@ -288,6 +290,18 @@ describe('Unit | Repository | challenge-repository', () => {
         expect(translationRepository.listByPrefix).not.toHaveBeenCalled();
         expect(localizedChallengeRepository.listByChallengeIds).not.toHaveBeenCalled();
       });
+    });
+  });
+  describe('#filterByThematicIds', () => {
+    it('calls filter with filterByFormula defined to filter by thematic ids', async function() {
+      const thematicsIds = ['id1', 'id2'];
+      vi.spyOn(challengeDatasource, 'filter').mockResolvedValue([]);
+      vi.spyOn(translationRepository, 'listByPrefix');
+      vi.spyOn(localizedChallengeRepository, 'listByChallengeIds');
+
+      await challengeRepository.filterByThematicIds(thematicsIds);
+
+      expect(challengeDatasource.filter).toHaveBeenCalledWith({ filter : { formula: 'OR(FIND("id1", {Thematique (Record ID)}), FIND("id2", {Thematique (Record ID)}))' } });
     });
   });
   describe('#get', () => {

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -20,6 +20,11 @@ export default class MissionEditController extends Controller {
       this.router.transitionTo('authenticated.missions.mission');
     } catch (err) {
       this.model.mission.rollbackAttributes();
+
+      if (err.errors?.[0]) {
+        await this.notifications.error(err.errors[0].detail);
+        return;
+      }
       await this.notifications.error('Une erreur est survenue lors de la mise à jour de la mission.');
     }
   }

--- a/pix-editor/config/environment.js
+++ b/pix-editor/config/environment.js
@@ -88,6 +88,10 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+
+    ENV['ember-cli-notifications'] = {
+      autoClear: false,
+    };
   }
 
   return ENV;

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -106,7 +106,7 @@ function routes() {
   this.post('/airtable/content/Thematiques', (schema, request) => {
     const themePayload = JSON.parse(request.requestBody);
     const theme = _deserializePayload(themePayload, 'theme');
-    const createdTheme =  schema.themes.create(theme);
+    const createdTheme = schema.themes.create(theme);
     return _serializeModel(createdTheme, 'theme');
   });
 
@@ -144,7 +144,7 @@ function routes() {
   this.post('/airtable/content/Acquis', (schema, request) => {
     const skillPayload = JSON.parse(request.requestBody);
     const skill = _deserializePayload(skillPayload, 'skill');
-    const createdSkill =  schema.skills.create(skill);
+    const createdSkill = schema.skills.create(skill);
     return _serializeModel(createdSkill, 'skill');
   });
 
@@ -192,7 +192,7 @@ function routes() {
     const search = request.queryParams['filter[search]'];
     let records = null;
     if (ids) {
-      records = schema.challenges.where((challenge)=> ids.includes(challenge.id));
+      records = schema.challenges.where((challenge) => ids.includes(challenge.id));
     } else if (search) {
       records = schema.challenges.where((challenge) => challenge.instruction.includes(search));
     } else {
@@ -212,7 +212,7 @@ function routes() {
   this.get('/localized-challenges', (schema, request) => {
     const ids = request.queryParams['filter[ids]'];
     if (ids) {
-      return schema.localizedChallenges.where((localizedChallenge)=> ids.includes(localizedChallenge.id));
+      return schema.localizedChallenges.where((localizedChallenge) => ids.includes(localizedChallenge.id));
     }
     return schema.localizedChallenges.all();
   });
@@ -287,14 +287,14 @@ function routes() {
     return json;
   });
 
-  this.post('/missions', function(schema, request) {
+  this.post('/missions', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const mission = schema.create('mission', { ...attributes });
     schema.create('mission-summary', { id: mission.id, ...attributes });
     return mission;
   });
 
-  this.get('/missions/:id', function(schema, request) {
+  this.get('/missions/:id', function (schema, request) {
     const id = request.params.id;
     const mission = schema.missions.find(id);
     if (mission) return mission;
@@ -309,8 +309,17 @@ function routes() {
     });
   });
 
-  this.patch('/missions/:id', function(schema, request) {
+  this.patch('/missions/:id', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
+    if (attributes.name === 'will trigger error') {
+      return new Response(400, {}, {
+        errors: [{
+          status: '400',
+          title: 'Bad Request',
+          detail: 'La mission ne peut pas être mise à jour car les épreuves X, Y ne sont pas au statut VALIDE.'
+        }]
+      });
+    }
     const id = request.params.id;
     const mission = schema.missions.find(id);
     mission.update({ ...attributes });
@@ -318,11 +327,11 @@ function routes() {
     return mission;
   });
 
-  this.get('/static-course-summaries', function(schema, request) {
+  this.get('/static-course-summaries', function (schema, request) {
     const queryParams = request.queryParams;
     const {
       'filter[isActive]': isActiveFilter,
-      'filter[name]' : nameFilter,
+      'filter[name]': nameFilter,
     } = queryParams;
     let allStaticCourseSummaries;
     if (isActiveFilter === '') {
@@ -356,7 +365,7 @@ function routes() {
 
   this.get('/static-course-tags');
 
-  this.post('/static-courses', function(schema, request) {
+  this.post('/static-courses', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const tagIds = attributes['tag-ids'];
     const tags = schema.staticCourseTags.all().models.filter(({ id }) => tagIds.includes(id));
@@ -369,7 +378,7 @@ function routes() {
     });
   });
 
-  this.put('/static-courses/:id', function(schema, request) {
+  this.put('/static-courses/:id', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const tagIds = attributes['tag-ids'];
     const tags = schema.staticCourseTags.all().models.filter(({ id }) => tagIds.includes(id));
@@ -383,7 +392,7 @@ function routes() {
     return staticCourse;
   });
 
-  this.put('/static-courses/:id/deactivate', function(schema, request) {
+  this.put('/static-courses/:id/deactivate', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const staticCourse = schema.staticCourses.find(request.params.id);
     staticCourse.update({
@@ -393,7 +402,7 @@ function routes() {
     return staticCourse;
   });
 
-  this.put('/static-courses/:id/reactivate', function(schema, request) {
+  this.put('/static-courses/:id/reactivate', function (schema, request) {
     const staticCourse = schema.staticCourses.find(request.params.id);
     staticCourse.update({
       isActive: true,
@@ -405,7 +414,7 @@ function routes() {
 
 function _serializeModel(instance, modelName) {
   const serializer = new (getDsSerializers()[modelName]);
-  const payload = { id: instance.id, fields: { [serializer.primaryKey] : instance.id } };
+  const payload = { id: instance.id, fields: { [serializer.primaryKey]: instance.id } };
   const model = new getDsModels();
   const relationships = model[modelName].relationships;
 

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -5,16 +5,14 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import { click, currentURL, find, triggerEvent } from '@ember/test-helpers';
 import { clickByName, clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
 
-module('Acceptance | Missions | Edit', function(hooks) {
+module('Acceptance | Missions | Edit', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const notifications = this.owner.lookup('service:notifications');
-    notifications.setDefaultClearDuration(50);
     this.server.create('config', 'default');
     this.server.create('theme', { id: 'recTheme1' });
-    this.server.create('competence', { id:  'recCompetence1.1', pixId: 'recCompetence1.1', rawThemeIds: ['recTheme1'], title: 'Notre compétence' });
+    this.server.create('competence', { id: 'recCompetence1.1', pixId: 'recCompetence1.1', rawThemeIds: ['recTheme1'], title: 'Notre compétence' });
     this.server.create('area', {
       id: 'recArea1',
       name: '1. Information et données',
@@ -27,7 +25,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       name: 'Mission 1',
       competenceId: 'recCompetence1.1',
       createdAt: '2023/12/11',
-      status: 'ACTIVE'
+      status: 'VALIDATED'
     });
   });
 
@@ -57,7 +55,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
         competenceId: 'recCompetence1.1',
         thematicIds: '',
         createdAt: '2023/12/11',
-        status: 'ACTIVE'
+        status: 'VALIDATED'
       });
       const screen = await visit('/missions/3/edit');
 
@@ -73,6 +71,31 @@ module('Acceptance | Missions | Edit', function(hooks) {
       // then
       assert.strictEqual(currentURL(), '/missions/3');
       assert.dom(screen.getByText('Nouvelle mission de test')).exists();
+    });
+
+    test('should display errors if any', async function (assert) {
+      // given
+      this.server.create('mission', {
+        id: 3,
+        name: 'Mission',
+        competenceId: 'recCompetence1.1',
+        thematicIds: '',
+        createdAt: '2023/12/11',
+        status: 'VALIDATED'
+      });
+      const screen = await visit('/missions/3/edit');
+
+      // when
+      await fillByLabel('* Nom de la mission', 'will trigger error');
+      await triggerEvent(find('#mission-name'), 'keyup', '');
+
+      await clickByText('Compétence');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Notre compétence' }));
+      await click(screen.getByRole('button', { name: 'Modifier la mission' }));
+
+      // then
+      assert.dom(screen.getByText('La mission ne peut pas être mise à jour car les épreuves X, Y ne sont pas au statut VALIDE.')).exists();
     });
   });
 });

--- a/pix-editor/tests/test-helper.js
+++ b/pix-editor/tests/test-helper.js
@@ -5,6 +5,19 @@ import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
 
+import NotificationMessageService from 'ember-cli-notifications/services/notifications';
+
+NotificationMessageService.reopen({
+  removeNotification(notification) {
+    if (!notification) {
+      return;
+    }
+
+    notification.set('dismiss', true);
+    this.content.removeObject(notification);
+  }
+});
+
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);


### PR DESCRIPTION
## :unicorn: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Lorsqu'un producteur de contenu valide une mission (en changeant son statut), il n'a aucune garantie que toutes les épreuves constituant la mission soient effectivement validées.

## :robot: Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

Lors de l'édition d'une mission, si le nouveau statut est "VALIDÉE", alors on vérifie que toutes les épreuves soient au statut "valide".
Si ce n'est pas le cas, une erreur est affichée à l'utilisateur, lui indiquant les identifiants des épreuves bloquant le changement de statut.

Pour simplifier le nombre de requêtes faites à Airtable afin de connaitre les épreuves d'une mission, nous avons ajouté des colonnes de type Lookup permettant depuis la table Epreuves de connaitre l'identifiant de la thématique associée.
Les missions contenant des identifiants de thématiques, on peut alors, en une requête vers Airtable, récupérer l'ensemble des épreuves d'une mission.

## :rainbow: Remarques

On a découvert au cours de cette PR qu'il existe deux services pour notifier l'utilisateur dans l'application : `notify` qui est un service "maison" et `notifications` qui est fourni par `ember-cli-notification`.
Afin de pouvoir tester le contenu de la notification lors d'une erreur de modification de mission, nous avons désactivé la fermeture automatique (`autoclear`) de la notification en test uniquement.
Nous avons également appliqué la configuration en test permettant de s'affranchir des temps d'attente liées aux animations de la notification (voir https://github.com/mansona/ember-cli-notifications/issues/111#issuecomment-481760365)

## :100: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Se connecter à Pix Editor.
Choisir le référentiel Pix 1D.
Cliquer sur `Missions` dans le menu de gauche.
Choisir une mission et modifier son statut vers "VALIDÉE".
Vérifier qu'un message d'erreur apparait.
Modifier les épreuves de la mission pour qu'elles soient toutes valides.
Modifier de nouveau le statut de la mission vers "VALIDÉE".
Vérifier que la modification est effective.
Choisir une autre mission et modifier son statut vers "INACTIVE" ou "EXPERIMENTAL".
Vérifier que la modification est effective.
