### PR TITLE
[BUGFIX] Migration focus: Ne migrer que les acquis de Pix coeur (PIX-13709)

### DIFF
--- a/api/scripts/move-skills-to-focus/index.js
+++ b/api/scripts/move-skills-to-focus/index.js
@@ -61,7 +61,7 @@ async function _getSkillsToFocus({ airtableClient }) {
       fields: [
         'id persistant',
       ],
-      filterByFormula: '{Spoil_focus} = "focusable"',
+      filterByFormula: 'AND(({Spoil_focus} = "focusable"), ({Origine} = "Pix"))',
     })
     .all();
   const skillIdsToFocus = airtableSkills.map((at) => at.get('id persistant'));


### PR DESCRIPTION
## :unicorn: Problème

Le script de migration en focus traite les acquis de tous les référentiels, alors qu’il ne devrait traiter que les acquis du référentiel Pix coeur.

## :robot: Proposition
Filtrer les acquis pour ne traiter que les acquis du référentiel coeur.

## :rainbow: Remarques
N/A

## :100: Pour tester
N/A