### PR TITLE
[FEATURE] Ajout de contrôle sur la liste des Epreuves quand la Mission est VALIDATED (Pix-13589)

### DIFF
--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -70,12 +70,12 @@ export async function listActive() {
 
       if (index < thematicIds.length - 1) {
         content.steps.push({
-          tutorialChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_di'),
-          trainingChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_en'),
-          validationChallenges: _getChallengeIdsForActivity(missionTubes, skills, challenges, '_va'),
+          tutorialChallenges: _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_di'),
+          trainingChallenges: _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_en'),
+          validationChallenges: _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_va'),
         });
       } else {
-        content.dareChallenges = _getChallengeIdsForActivity(missionTubes, skills, challenges, '_de');
+        content.dareChallenges = _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_de');
       }
     });
     return new Mission({ ...mission, content });
@@ -87,7 +87,7 @@ export async function listActive() {
 const _byLevel = (skillA, skillB) => skillA.level - skillB.level;
 const _byAlternativeVersion = (challengeA, challengeB) => (challengeA.alternativeVersion ?? 0) - (challengeB.alternativeVersion ?? 0);
 
-function _getChallengeIdsForActivity(missionTubes, skills, challenges, activityPostfix) {
+function _getChallengeIdsForActivity(missionStatus, missionTubes, skills, challenges, activityPostfix) {
   const activityTube = missionTubes.find(({ name }) => name.endsWith(activityPostfix));
 
   if (!activityTube) {
@@ -108,7 +108,8 @@ function _getChallengeIdsForActivity(missionTubes, skills, challenges, activityP
   return activitySkills.map((activitySkill) => {
     const alternatives = challenges
       .filter((challenge) => activitySkill.id === challenge.skillId)
-      .filter((challenge) => SCHOOL_PLAYABLE_CHALLENGE_STATUSES.includes(challenge.status.toLowerCase()));
+      .filter((challenge) => SCHOOL_PLAYABLE_CHALLENGE_STATUSES.includes(challenge.status.toLowerCase()))
+      .filter((challenge) => (missionStatus === Mission.status.VALIDATED && challenge.status === Challenge.STATUSES.VALIDE) || missionStatus !== Mission.status.VALIDATED);
 
     if (alternatives.length === 0) {
       logger.warn({ activitySkill }, 'No challenges found for activitySkill');

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -257,50 +257,101 @@ describe('Integration | Repository | mission-repository', function() {
     });
 
     context('with inactive, proposal, and active challenges', async function() {
-      it('should return proposal and active challenges only', async function() {
-        mockedLearningContent.challenges = [
-          airtableBuilder.factory.buildChallenge({ id: 'challengeValidationValidé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeValidationProposé', status: Challenge.STATUSES.PROPOSE, skillId: 'skillValidation1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeValidationPérimé', status: Challenge.STATUSES.PERIME, skillId: 'skillValidation1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeValidationArchivé', status: Challenge.STATUSES.ARCHIVE, skillId: 'skillValidation1' }),
-        ];
-        airtableBuilder.mockLists(mockedLearningContent);
+      context('when mission is EXPERIMENTAL', function() {
+        it('should return proposal and active challenges only', async function() {
+          mockedLearningContent.challenges = [
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationValidé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationProposé', status: Challenge.STATUSES.PROPOSE, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationPérimé', status: Challenge.STATUSES.PERIME, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationArchivé', status: Challenge.STATUSES.ARCHIVE, skillId: 'skillValidation1' }),
+          ];
+          airtableBuilder.mockLists(mockedLearningContent);
 
-        buildLocalizedChallenges(mockedLearningContent);
+          buildLocalizedChallenges(mockedLearningContent);
 
-        databaseBuilder.factory.buildMission({
-          id: 2,
-          name: 'Alt name',
-          status: Mission.status.VALIDATED,
-          learningObjectives: 'Alt objectives',
-          validatedObjectives: 'Alt validated objectives',
-          thematicIds: 'thematicStep1,thematicDefiVide',
+          databaseBuilder.factory.buildMission({
+            id: 2,
+            name: 'Alt name',
+            status: Mission.status.EXPERIMENTAL,
+            learningObjectives: 'Alt objectives',
+            validatedObjectives: 'Alt validated objectives',
+            thematicIds: 'thematicStep1,thematicDefiVide',
+          });
+
+          await databaseBuilder.commit();
+
+          const result = await listActive();
+
+          expect(result).to.deep.equal([new Mission({
+            id: 2,
+            name_i18n: { fr: 'Alt name' },
+            competenceId: 'competenceId',
+            thematicIds: 'thematicStep1,thematicDefiVide',
+            learningObjectives_i18n: { fr: 'Alt objectives' },
+            validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+            status: Mission.status.EXPERIMENTAL,
+            createdAt: new Date('2010-01-04'),
+            content: {
+              steps: [{
+                tutorialChallenges: [],
+                trainingChallenges: [],
+                validationChallenges: [
+                  ['challengeValidationValidé', 'challengeValidationProposé'],
+                ],
+              }],
+              dareChallenges: [],
+            },
+          })]);
+        });
+      });
+
+      context('when mission is validated', function() {
+        it('should return active challenges only', async function() {
+          mockedLearningContent.challenges = [
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationValidé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationProposé', status: Challenge.STATUSES.PROPOSE, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationPérimé', status: Challenge.STATUSES.PERIME, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationArchivé', status: Challenge.STATUSES.ARCHIVE, skillId: 'skillValidation1' }),
+          ];
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          buildLocalizedChallenges(mockedLearningContent);
+
+          databaseBuilder.factory.buildMission({
+            id: 2,
+            name: 'Alt name',
+            status: Mission.status.VALIDATED,
+            learningObjectives: 'Alt objectives',
+            validatedObjectives: 'Alt validated objectives',
+            thematicIds: 'thematicStep1,thematicDefiVide',
+          });
+
+          await databaseBuilder.commit();
+
+          const result = await listActive();
+
+          expect(result).to.deep.equal([new Mission({
+            id: 2,
+            name_i18n: { fr: 'Alt name' },
+            competenceId: 'competenceId',
+            thematicIds: 'thematicStep1,thematicDefiVide',
+            learningObjectives_i18n: { fr: 'Alt objectives' },
+            validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2010-01-04'),
+            content: {
+              steps: [{
+                tutorialChallenges: [],
+                trainingChallenges: [],
+                validationChallenges: [
+                  ['challengeValidationValidé'],
+                ],
+              }],
+              dareChallenges: [],
+            },
+          })]);
         });
 
-        await databaseBuilder.commit();
-
-        const result = await listActive();
-
-        expect(result).to.deep.equal([new Mission({
-          id: 2,
-          name_i18n: { fr: 'Alt name' },
-          competenceId: 'competenceId',
-          thematicIds: 'thematicStep1,thematicDefiVide',
-          learningObjectives_i18n: { fr: 'Alt objectives' },
-          validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          status: Mission.status.VALIDATED,
-          createdAt: new Date('2010-01-04'),
-          content: {
-            steps: [{
-              tutorialChallenges: [],
-              trainingChallenges: [],
-              validationChallenges: [
-                ['challengeValidationValidé', 'challengeValidationProposé'],
-              ],
-            }],
-            dareChallenges: [],
-          },
-        })]);
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une mission est validée il est possible qu'un challenge ne soit plus validé si il y a un problème, issu de retour utilisateur par exemple.

## :robot: Proposition
Ajouter un filtre lorsque la mission est validée afin de retirer le challenge de la liste si il n'est pas validé.

## :rainbow: Remarques
RAS

## :100: Pour tester
Passer un challenge utilisé par une mission VALIDATED en status autre que validée.
Observer que ce challenge n'est pas présent dans la mission dans la release.
Si on le remet. On devrait observer son retour !