### PR TITLE
[BUGFIX] Un mauvais usage de initSentry fait planté l'application. (PIX-13749)

### DIFF
--- a/pix-editor/app/app.js
+++ b/pix-editor/app/app.js
@@ -2,10 +2,10 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'pixeditor/config/environment';
-import { InitSentryForEmber } from '@sentry/ember';
+import { init as initSentry } from '@sentry/ember';
 
 if (config.sentry.enabled) {
-  InitSentryForEmber();
+  initSentry();
 }
 
 export default class App extends Application {


### PR DESCRIPTION
## :unicorn: Problème
 Un mauvais usage de initSentry fait planté l'application.

## :robot: Proposition
Modifier l'import de [InitSentryForEmber](https://docs.sentry.io/platforms/javascript/guides/ember/migration/v7-to-v8/#removal-of-initsentryforember-export)

## :rainbow: Remarques
RAS

## :100: Pour tester
RAS
