### PR TITLE
[FEAUTURE] Ajouter un media d'introduction à une mission (Pix-13630)

### DIFF
--- a/api/db/migrations/20240807144411_add_introduction_media_into_mission_table.js
+++ b/api/db/migrations/20240807144411_add_introduction_media_into_mission_table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'missions';
+const INTRODUCTION_MEDIA_COLUMN = 'introductionMedia';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.text(INTRODUCTION_MEDIA_COLUMN);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(INTRODUCTION_MEDIA_COLUMN);
+  });
+}

--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -7,6 +7,7 @@ export class Mission {
     createdAt,
     learningObjectives_i18n,
     validatedObjectives_i18n,
+    introductionMedia,
     status,
     content,
   }) {
@@ -17,6 +18,7 @@ export class Mission {
     this.createdAt = createdAt;
     this.learningObjectives_i18n = learningObjectives_i18n;
     this.validatedObjectives_i18n = validatedObjectives_i18n;
+    this.introductionMedia = introductionMedia;
     this.status = status;
     this.content = new Content(content);
   }

--- a/api/lib/domain/models/release/MissionForRelease.js
+++ b/api/lib/domain/models/release/MissionForRelease.js
@@ -7,6 +7,7 @@ export class MissionForRelease {
     validatedObjectives_i18n,
     status,
     content,
+    introductionMedia
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -15,5 +16,6 @@ export class MissionForRelease {
     this.validatedObjectives_i18n = validatedObjectives_i18n;
     this.status = status;
     this.content = content;
+    this.introductionMedia = introductionMedia;
   }
 }

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -123,7 +123,8 @@ export async function save(mission) {
     id: mission.id,
     competenceId: mission.competenceId,
     thematicIds: mission.thematicIds,
-    status: mission.status
+    status: mission.status,
+    introductionMedia: mission.introductionMedia,
   }).onConflict('id')
     .merge()
     .returning('*');
@@ -143,6 +144,7 @@ function _toDomain(mission, translations) {
     competenceId: mission.competenceId,
     thematicIds: mission.thematicIds,
     content: mission.content,
+    introductionMedia: mission.introductionMedia,
     ...missionTranslations.toDomain(translationsByMissionId[mission.id])
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -11,6 +11,7 @@ export function serializeMissionSummary(mission, meta) {
       'thematicIds',
       'learningObjectives',
       'validatedObjectives',
+      'introductionMedia',
       'createdAt',
       'status'
     ],
@@ -33,6 +34,7 @@ export function serializeMission(mission) {
       'thematicIds',
       'learningObjectives',
       'validatedObjectives',
+      'introductionMedia',
       'createdAt',
       'status'
     ],
@@ -52,6 +54,7 @@ export function deserializeMission(attributes) {
     thematicIds: attributes['thematic-ids'],
     learningObjectives_i18n:  { fr:  attributes['learning-objectives'] },
     validatedObjectives_i18n: { fr:  attributes['validated-objectives'] },
+    introductionMedia: attributes['introduction-media'],
     status: attributes.status,
   });
 }

--- a/api/package.json
+++ b/api/package.json
@@ -32,6 +32,7 @@
     "test:api": "NODE_ENV=test vitest run",
     "test:api:unit": "NODE_ENV=test vitest run tests/unit/",
     "test:api:integration": "NODE_ENV=test vitest run tests/integration/",
+    "test:api:acceptance": "NODE_ENV=test vitest run tests/acceptance/",
     "test:api:scripts": "NODE_ENV=test vitest run tests/scripts/",
     "test:api:debug": "NODE_ENV=test vitest run --inspect-brk=9229",
     "test:api:watch": "NODE_ENV=test vitest",

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -41,6 +41,7 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
           'thematic-ids': null,
           'validated-objectives': 'Être forte',
           'learning-objectives': 'Être imbattable',
+          'introduction-media': null,
           'created-at': new Date('2024-01-01')
         },
       },

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -162,6 +162,7 @@ async function mockCurrentContent() {
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.VALIDATED,
       createdAt: new Date('2010-01-04'),
+      introductionMedia: null,
     }), new Mission({
       id: 2,
       name_i18n: { fr: 'Alt name' },
@@ -171,6 +172,7 @@ async function mockCurrentContent() {
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
       status: Mission.status.EXPERIMENTAL,
       createdAt: new Date('2010-01-05'),
+      introductionMedia: 'http://example.com',
     })]
   };
 
@@ -226,6 +228,7 @@ async function mockCurrentContent() {
     validatedObjectives: 'Rien',
     status: Mission.status.VALIDATED,
     createdAt: new Date('2010-01-04'),
+    introductionMedia: null,
   });
   databaseBuilder.factory.buildMission({
     id: 2,
@@ -236,6 +239,7 @@ async function mockCurrentContent() {
     validatedObjectives: 'Alt validated objectives',
     status: Mission.status.EXPERIMENTAL,
     createdAt: new Date('2010-01-05'),
+    introductionMedia: 'http://example.com',
   });
   databaseBuilder.factory.buildMission({
     id: 3,
@@ -246,6 +250,7 @@ async function mockCurrentContent() {
     validatedObjectives: 'Alt validated objectives',
     status: Mission.status.INACTIVE,
     createdAt: new Date('2010-01-05'),
+    introductionMedia: null,
   });
 
   for (const locale of ['fr', 'en', 'nl']) {
@@ -479,6 +484,7 @@ async function mockContentForRelease() {
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.VALIDATED,
+      introductionMedia: 'http://example.com',
       content: {
         dareChallenges: [],
         steps: []
@@ -490,6 +496,7 @@ async function mockContentForRelease() {
       learningObjectives_i18n: { fr: 'Alt objectives' },
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
       status: Mission.status.EXPERIMENTAL,
+      introductionMedia: null,
       content: {
         dareChallenges: [],
         steps: []
@@ -759,6 +766,7 @@ describe('Acceptance | Controller | release-controller', () => {
           learningObjectives: 'Que tu sois le meilleur',
           validatedObjectives: 'Rien',
           status: Mission.status.VALIDATED,
+          introductionMedia: 'http://example.com',
         });
         databaseBuilder.factory.buildMission({
           id: 2,
@@ -768,6 +776,7 @@ describe('Acceptance | Controller | release-controller', () => {
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           status: Mission.status.EXPERIMENTAL,
+          introductionMedia: null,
         });
         databaseBuilder.factory.buildMission({
           id: 3,

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -32,6 +32,7 @@ describe('Integration | Usecases | Update mission', function() {
           thematicIds: 'Thematic',
           learningObjectives_i18n:  { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMedia: null,
           status: Mission.status.INACTIVE,
           createdAt: new Date('2023-12-25')
         });
@@ -70,6 +71,7 @@ describe('Integration | Usecases | Update mission', function() {
             thematicIds: 'Thematic',
             learningObjectives_i18n:  { fr: null },
             validatedObjectives_i18n: { fr: 'Très bien' },
+            introductionMedia: null,
             status: Mission.status.VALIDATED,
             createdAt: new Date('2023-12-25')
           });

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -34,6 +34,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
           validatedObjectives_i18n: { fr: 'Rien' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }));
@@ -62,6 +63,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
           validatedObjectives_i18n: { fr: 'Rien' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }), new Mission({
@@ -71,6 +73,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.INACTIVE,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -224,6 +227,7 @@ describe('Integration | Repository | mission-repository', function() {
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
         learningObjectives_i18n: { fr: 'Alt objectives' },
         validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+        introductionMedia: null,
         status: Mission.status.VALIDATED,
         createdAt: new Date('2010-01-04'),
         content: {
@@ -289,6 +293,7 @@ describe('Integration | Repository | mission-repository', function() {
             thematicIds: 'thematicStep1,thematicDefiVide',
             learningObjectives_i18n: { fr: 'Alt objectives' },
             validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+            introductionMedia: null,
             status: Mission.status.EXPERIMENTAL,
             createdAt: new Date('2010-01-04'),
             content: {
@@ -337,6 +342,7 @@ describe('Integration | Repository | mission-repository', function() {
             thematicIds: 'thematicStep1,thematicDefiVide',
             learningObjectives_i18n: { fr: 'Alt objectives' },
             validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+            introductionMedia: null,
             status: Mission.status.VALIDATED,
             createdAt: new Date('2010-01-04'),
             content: {
@@ -400,6 +406,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -455,6 +462,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -510,6 +518,7 @@ describe('Integration | Repository | mission-repository', function() {
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.VALIDATED,
+          introductionMedia: null,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -550,6 +559,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -590,6 +600,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -629,6 +640,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -662,6 +674,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -695,6 +708,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -727,6 +741,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: null,
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+          introductionMedia: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -743,6 +758,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'QWERTY',
           learningObjectives_i18n: { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMedia: 'http://example.net',
           status: Mission.status.INACTIVE,
         });
 
@@ -754,10 +770,11 @@ describe('Integration | Repository | mission-repository', function() {
           id: savedMission.id,
           competenceId: 'AZERTY',
           thematicIds: 'QWERTY',
+          introductionMedia: 'http://example.net',
           status: Mission.status.INACTIVE,
         };
 
-        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id');
+        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMedia');
         expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
@@ -808,6 +825,7 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'Thematic',
           learningObjectives_i18n: { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMedia: 'http://example.net',
           status: Mission.status.INACTIVE,
         });
 
@@ -821,9 +839,10 @@ describe('Integration | Repository | mission-repository', function() {
           competenceId: 'QWERTY',
           thematicIds: 'Thematic',
           status: Mission.status.INACTIVE,
+          introductionMedia: 'http://example.net',
         };
 
-        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id');
+        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMedia');
         expect(missionFromDb).to.deep.equal(expectedMission);
       });
 

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1424,6 +1424,7 @@ function _getRichCurrentContentDTO() {
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.VALIDATED,
       createdAt: new Date('2010-01-04'),
+      introductionMedia: null,
     }),
   ];
 

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -10,10 +10,11 @@ export function buildMission({
   thematicIds = 'thematicIds',
   validatedObjectives = 'Rien',
   status = Mission.status.INACTIVE,
+  introductionMedia = null,
   createdAt = new Date('2010-01-04'),
 } = {}) {
 
-  const values = { id, competenceId, thematicIds, createdAt, status };
+  const values = { id, competenceId, thematicIds, createdAt, status, introductionMedia };
 
   buildTranslation({
     key: `mission.${id}.name`,

--- a/api/tests/tooling/domain-builder/factory/build-mission.js
+++ b/api/tests/tooling/domain-builder/factory/build-mission.js
@@ -8,6 +8,7 @@ export function buildMission({
   createdAt = new Date('2023-10-14'),
   learningObjectives = '- Que tu deviennes forte\n Et...',
   validatedObjectives = '- Ca\n Et puis ça',
+  introductionMedia = 'http://example.net',
   status = Mission.status.VALIDATED,
 } = {}) {
   return new Mission ({
@@ -18,6 +19,7 @@ export function buildMission({
     createdAt,
     learningObjectives_i18n: { fr: learningObjectives },
     validatedObjectives_i18n: { fr: validatedObjectives },
+    introductionMedia,
     status,
   });
 }

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -200,6 +200,7 @@ describe('Unit | Controller | missions controller', function() {
       );
     });
   });
+
   describe('updateMission', function() {
     let updateMissionMock;
     const attributes = {

--- a/pix-editor/app/adapters/mission.js
+++ b/pix-editor/app/adapters/mission.js
@@ -16,5 +16,6 @@ function preparePayloadForCreateAndUpdate(payload, adapterOptions) {
   payload.data.attributes['thematic-ids'] = adapterOptions.thematicIds;
   payload.data.attributes['learning-objectives'] = adapterOptions.learningObjectives;
   payload.data.attributes['validated-objectives'] = adapterOptions.validatedObjectives;
+  payload.data.attributes['introduction-media'] = adapterOptions.introductionMedia;
   return payload;
 }

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -52,7 +52,16 @@
       @value={{this.validatedObjectives}}
       {{on "change" this.updateValidatedObjectives}}
     />
+
+    <label class="new-mission-form__label-text-area" for="mission-introduction-media">Média d'introduction de la mission</label>
+    <p class="new-mission-form__description">Ce média s’affichera avant de démarrer la mission, avant la première épreuve.</p>
+    <PixInput
+      @id="mission-introduction-media"
+      @value={{this.introductionMedia}}
+      {{on "change" this.updateIntroductionMedia}}
+    />
    </Card>
+ 
   <div class="form-error">
     {{#each this.errorMessages as |errorMessage|}}
       {{errorMessage}}<br/>

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -15,6 +15,7 @@ export default class MissionForm extends Component {
   @tracked selectedStatus = 'ACTIVE';
   @tracked validatedObjectives = null;
   @tracked learningObjectives = null;
+  @tracked introductionMedia = null;
   @tracked errorMessages = A([]);
   @tracked isSubmitting = false;
   @tracked isFormValid = false;
@@ -27,6 +28,7 @@ export default class MissionForm extends Component {
       this.selectedStatus = this.args.mission.status;
       this.validatedObjectives = this.args.mission.validatedObjectives;
       this.learningObjectives = this.args.mission.learningObjectives;
+      this.introductionMedia = this.args.mission.introductionMedia;
       this.isFormValid = true;
       this.thematicIds.setValue(this.args.mission.thematicIds);
     }
@@ -70,7 +72,8 @@ export default class MissionForm extends Component {
       thematicIds: this.thematicIds.getValueForSubmit(),
       status: this.selectedStatus,
       learningObjectives: this.learningObjectives,
-      validatedObjectives: this.validatedObjectives
+      validatedObjectives: this.validatedObjectives,
+      introductionMedia: this.introductionMedia
 
     };
     try {
@@ -111,6 +114,11 @@ export default class MissionForm extends Component {
   validateCompetence() {
     this.selectedCompetenceId.validate();
     this.checkFormValidity();
+  }
+
+  @action
+  updateIntroductionMedia(event) {
+    this.introductionMedia = event.target.value;
   }
 
   @action

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -74,7 +74,6 @@ export default class MissionForm extends Component {
       learningObjectives: this.learningObjectives,
       validatedObjectives: this.validatedObjectives,
       introductionMedia: this.introductionMedia
-
     };
     try {
       await this.args.onFormSubmitted(formData);

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -15,6 +15,7 @@ export default class MissionEditController extends Controller {
       this.model.mission.thematicIds = formData.thematicIds;
       this.model.mission.validatedObjectives = formData.validatedObjectives;
       this.model.mission.learningObjectives = formData.learningObjectives;
+      this.model.mission.introductionMedia = formData.introductionMedia;
       await this.model.mission.save();
       this.notifications.success('Mission mise à jour avec succès.');
       this.router.transitionTo('authenticated.missions.mission');

--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -6,4 +6,5 @@ export default class Mission extends MissionSummary {
   @attr thematicIds;
   @attr learningObjectives;
   @attr validatedObjectives;
+  @attr introductionMedia;
 }

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -42,6 +42,10 @@
             <MarkdownToHtml @markdown={{this.model.mission.validatedObjectives}} />
           </div>
         </li>
+        <li>
+          <span class="bold">Média d'introduction de la mission : </span>
+          <a href={{ this.model.mission.introductionMedia }}>{{this.model.mission.introductionMedia}}</a>
+        </li>
         <li><span class="bold">Crée le : </span>{{dayjs-format this.model.mission.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
       </ul>
     </Card>

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -55,6 +55,7 @@ module('Acceptance | Missions | Edit', function (hooks) {
         competenceId: 'recCompetence1.1',
         thematicIds: '',
         createdAt: '2023/12/11',
+        introductionMedia: null,
         status: 'VALIDATED'
       });
       const screen = await visit('/missions/3/edit');
@@ -66,11 +67,14 @@ module('Acceptance | Missions | Edit', function (hooks) {
       await clickByText('Compétence');
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Notre compétence' }));
+      await fillByLabel('Média d\'introduction de la mission', 'http://example.com');
+
       await click(screen.getByRole('button', { name: 'Modifier la mission' }));
 
       // then
       assert.strictEqual(currentURL(), '/missions/3');
       assert.dom(screen.getByText('Nouvelle mission de test')).exists();
+      assert.dom(screen.getByText('http://example.com')).exists();
     });
 
     test('should display errors if any', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Au commencement d'une mission, on aimerait avec un lien de média (image, vidéo, ~embed~ :trollface: ) qui donne du contexte.

## :robot: Proposition
Pouvoir ajouter un `introductionMedia` à la mission et l'envoyer dans la release

## :rainbow: Remarques
- ajouter une commande pour ne jouer que les tests d'acceptance

## :100: Pour tester
- lancer pix editor
- Créer une nouvelle mission avec un `introductionMedia` et enregistrer. Remarquer qu'on peut voir le lien dans la page de détails de la mission
- Modifier une mission existante pour mettre un lien de média et enregistrer. Remarquer qu'on peut voir le lien dans la page de détails de la mission