### PR TITLE
[TECH] Nettoyage des données de l'enquête anti-spoil (PIX-13812)

### DIFF
--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -46,8 +46,6 @@ export async function getLearningContentForReplication() {
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
 
-  await skillRepository.addSpoilData(skills);
-
   return {
     areas,
     competences,

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -4,7 +4,6 @@ import { skillDatasource, tubeDatasource, tutorialDatasource } from '../datasour
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
-import * as airtable from '../airtable.js';
 import { Translation } from '../../domain/models/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
@@ -12,14 +11,6 @@ export async function list() {
   const datasourceSkills = await skillDatasource.list();
   const translations = await translationRepository.listByPrefix(skillTranslations.prefix);
   return toDomainList(datasourceSkills, translations);
-}
-
-export async function addSpoilData(skills) {
-  const SPOIL_COLUMNS = ['Spoil_focus', 'Spoil_variabilisation', 'Spoil_mauvaisereponse', 'Spoil_nouvelacquis'];
-  const options = { fields: ['id persistant', ...SPOIL_COLUMNS] };
-  const airtableRawObjects = await airtable.findRecords('Acquis', options);
-
-  skills.forEach((skill) => addSpoilDataToSkill(skill, airtableRawObjects));
 }
 
 export async function get(id) {
@@ -105,15 +96,6 @@ export async function update(skill) {
     }
     return toDomain(updatedSkillDto, translations);
   });
-}
-
-function addSpoilDataToSkill(skill, airtableSkills) {
-  const airtableSkill = airtableSkills.find((item) => item.get('id persistant') === skill.id);
-
-  skill.spoil_focus = airtableSkill.get('Spoil_focus') || null;
-  skill.spoil_variabilisation = airtableSkill.get('Spoil_variabilisation')?.filter((val) => val.length > 0) ?? [];
-  skill.spoil_mauvaisereponse = airtableSkill.get('Spoil_mauvaisereponse')?.filter((val) => val.length > 0) ?? [];
-  skill.spoil_nouvelacquis = airtableSkill.get('Spoil_nouvelacquis') ?? null;
 }
 
 function toDomainList(datasourceSkills, translations) {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -91,13 +91,7 @@ async function mockCurrentContent() {
       }
     })],
     tubes: [domainBuilder.buildTube()],
-    skills: [{
-      ...domainBuilder.buildSkill({ id: 'recSkill1' }),
-      spoil_focus: 'en_devenir',
-      spoil_variabilisation: [],
-      spoil_mauvaisereponse: ['courgette', '67'],
-      spoil_nouvelacquis: null,
-    }],
+    skills: [domainBuilder.buildSkill({ id: 'recSkill1' })],
     challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
     thematics: [domainBuilder.buildThematic({
@@ -122,13 +116,6 @@ async function mockCurrentContent() {
     tubes: [buildTube(expectedCurrentContent.tubes[0])],
     skills: [{
       ...airtableSkill,
-      fields: {
-        ...airtableSkill.fields,
-        Spoil_focus: 'en_devenir',
-        Spoil_variabilisation: [''],
-        Spoil_mauvaisereponse: ['courgette', '67'],
-        Spoil_nouvelacquis: null,
-      },
     }],
     challenges: [buildChallenge({
       ...expectedChallenge,


### PR DESCRIPTION
## :unicorn: Problème
L'enquête anti-spoil étant terminée, nous pouvons arrêter d'envoyer les données de celle-ci à répliquer.

## :robot: Proposition
Suppression de la réplication des champs `spoil_*`.

## :rainbow: Remarques
RAS

## :100: Pour tester
RAS
