### PR TITLE
[BUGFIX] La détection de la locale dans `defaultEmbedURL` est cassée (PIX-13850)

### DIFF
--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -112,14 +112,11 @@ export class LocalizedChallenge {
 
 function hasLocaleInFirstPathSegment(url) {
   if (url.searchParams.has('lang')) return false;
-  return isLocale(url.pathname.split('/')[1]);
+  return isSupportedLocale(url.pathname.split('/')[1]);
 }
 
-function isLocale(s) {
-  try {
-    new Intl.Locale(s);
-    return true;
-  } catch {
-    return false;
-  }
+function isSupportedLocale(s) {
+  return SUPPORTED_LOCALES.includes(s);
 }
+
+const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -51,6 +51,21 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         expect(localizedChallenge).toHaveProperty('defaultEmbedUrl', 'http://test.com/ar/path/to/page.html');
       });
     });
+
+    describe('when URL doesn\'t have explicit locale', () => {
+      it('should compute default embed URL from primary embed URL', () => {
+        // given
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'alternativeId',
+          challengeId: 'challengeId',
+          locale: 'ar',
+          primaryEmbedUrl: 'http://test.com/pix-embed/to/page.html',
+        });
+
+        // then
+        expect(localizedChallenge).toHaveProperty('defaultEmbedUrl', 'http://test.com/pix-embed/to/page.html?lang=ar');
+      });
+    });
   });
 
   describe('static buildPrimary', function() {


### PR DESCRIPTION
## :unicorn: Problème
La méthode `isLocale()` introduite dans [cette PR](https://github.com/1024pix/pix-editor/pull/686) ne fonctionne pas, en effet, `Intl.Locale` ne throw pas d'erreur dans tous les cas et ne vérifie pas si la string passée est vraiment une locale. En effet, cette méthode vérifie seulement que la string passée est formatée comme une locale, mais ne la compare pas à une whitelist de locales connues.

## :robot: Proposition
Définir une liste de locales connues/supportées.

## :rainbow: Remarques
Un nouveau test de régression a été ajouté pour éviter que ce problème se reproduise.

## :100: Pour tester
Aller sur une épreuve avec une version nl (rechercher l'id `recwWzTquPlvIl4So`), faire évoluer l'URL de l'embed, puis sur sa version nl vérifier l'URL générée automatiquement.

Pour https://epreuves.pix.fr/carousel/carousel.html?lang=fr&mode=animaux on doit obtenir https://epreuves.pix.fr/carousel/carousel.html?lang=nl&mode=animaux
Pour https://epreuves.pix.fr/fr/carousel/animaux.html on doit obtenir https://epreuves.pix.fr/nl/carousel/animaux.html
Pour https://epreuves.pix.fr/pixmail-alcapone/pixmail-alcapone.html?lang=fr&mode=animaux on doit obtenir https://epreuves.pix.fr/pixmail-alcapone/pixmail-alcapone.html?lang=nl&mode=animaux
Pour https://epreuves.pix.fr/pixmail-alcapone/pixmail-alcapone.html?mode=animaux on doit obtenir https://epreuves.pix.fr/pixmail-alcapone/pixmail-alcapone.html?lang=nl&mode=animaux
