### PR TITLE
[FEATURE] Préciser le type de média de l'URL d'introduction de mission (pix-13843)

### DIFF
--- a/api/db/migrations/20240812092902_add_columns_into_mission_table.js
+++ b/api/db/migrations/20240812092902_add_columns_into_mission_table.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'missions';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.renameColumn('introductionMedia', 'introductionMediaUrl');
+  });
+
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.string('introductionMediaType').nullable();
+    table.string('introductionMediaAlt').nullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.renameColumn('introductionMediaUrl', 'introductionMedia');
+  });
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn('introductionMediaType');
+    table.dropColumn('introductionMediaAlt');
+  });
+}

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -24,6 +24,12 @@ export class UserNotFoundError extends NotFoundError {
   }
 }
 
+export class MissionIntroductionMediaError extends DomainError {
+  constructor(message = 'Opération impossible car la mission n\'a pas de type pour le media d\'introduction') {
+    super(message);
+  }
+}
+
 export class StaticCourseIsInactiveError extends DomainError {
   constructor(message = 'Opération impossible sur un test statique inactif.') {
     super(message);

--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -7,7 +7,9 @@ export class Mission {
     createdAt,
     learningObjectives_i18n,
     validatedObjectives_i18n,
-    introductionMedia,
+    introductionMediaUrl,
+    introductionMediaType,
+    introductionMediaAlt,
     status,
     content,
   }) {
@@ -18,7 +20,9 @@ export class Mission {
     this.createdAt = createdAt;
     this.learningObjectives_i18n = learningObjectives_i18n;
     this.validatedObjectives_i18n = validatedObjectives_i18n;
-    this.introductionMedia = introductionMedia;
+    this.introductionMediaUrl = introductionMediaUrl;
+    this.introductionMediaType = introductionMediaType;
+    this.introductionMediaAlt = introductionMediaAlt;
     this.status = status;
     this.content = new Content(content);
   }

--- a/api/lib/domain/models/release/MissionForRelease.js
+++ b/api/lib/domain/models/release/MissionForRelease.js
@@ -7,7 +7,9 @@ export class MissionForRelease {
     validatedObjectives_i18n,
     status,
     content,
-    introductionMedia
+    introductionMediaUrl,
+    introductionMediaType,
+    introductionMediaAlt
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -16,6 +18,8 @@ export class MissionForRelease {
     this.validatedObjectives_i18n = validatedObjectives_i18n;
     this.status = status;
     this.content = content;
-    this.introductionMedia = introductionMedia;
+    this.introductionMediaUrl = introductionMediaUrl;
+    this.introductionMediaType = introductionMediaType;
+    this.introductionMediaAlt = introductionMediaAlt;
   }
 }

--- a/api/lib/domain/usecases/create-mission.js
+++ b/api/lib/domain/usecases/create-mission.js
@@ -1,5 +1,14 @@
 import { missionRepository } from '../../infrastructure/repositories/index.js';
+import { MissionIntroductionMediaError } from '../errors.js';
+import _ from 'lodash';
 
 export async function createMission(mission, dependencies = { missionRepository }) {
+  if (!_.isNull(mission.introductionMediaUrl) && _.isNull(mission.introductionMediaType)) {
+    throw new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.');
+  }
+  if (!_.isNull(mission.introductionMediaType) && _.isNull(mission.introductionMediaUrl)) {
+    throw new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.');
+  }
+
   return await dependencies.missionRepository.save(mission);
 }

--- a/api/lib/domain/usecases/update-mission.js
+++ b/api/lib/domain/usecases/update-mission.js
@@ -1,6 +1,8 @@
 import { missionRepository, challengeRepository } from '../../infrastructure/repositories/index.js';
 import { Challenge, Mission } from '../models/index.js';
 import { BadRequestError } from '../../infrastructure/errors.js';
+import _ from 'lodash';
+import { MissionIntroductionMediaError } from '../errors.js';
 
 export async function updateMission(mission, dependencies = { missionRepository }) {
   await missionRepository.getById(mission.id);
@@ -10,8 +12,15 @@ export async function updateMission(mission, dependencies = { missionRepository 
     const nonValidatedChallengeIds = challenges.filter((challenge) => challenge.status !== Challenge.STATUSES.VALIDE).map((challenge) => `"${challenge.id}"`);
 
     if (nonValidatedChallengeIds.length > 0) {
-      throw new BadRequestError(`La mission ne peut pas être mise à jour car les challenges ${nonValidatedChallengeIds.join(', ')} ne sont pas au status VALIDE`);
+      throw new BadRequestError(`La mission ne peut pas être mise à jour car les challenges ${nonValidatedChallengeIds.join(', ')} ne sont pas au statut VALIDE`);
     }
+  }
+
+  if (!_.isNull(mission.introductionMediaUrl) && _.isNull(mission.introductionMediaType)) {
+    throw new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.');
+  }
+  if (!_.isNull(mission.introductionMediaType) && _.isNull(mission.introductionMediaUrl)) {
+    throw new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.');
   }
   return await dependencies.missionRepository.save(mission);
 }

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -124,7 +124,9 @@ export async function save(mission) {
     competenceId: mission.competenceId,
     thematicIds: mission.thematicIds,
     status: mission.status,
-    introductionMedia: mission.introductionMedia,
+    introductionMediaUrl: mission.introductionMediaUrl,
+    introductionMediaType: mission.introductionMediaType,
+    introductionMediaAlt: mission.introductionMediaAlt,
   }).onConflict('id')
     .merge()
     .returning('*');
@@ -144,7 +146,9 @@ function _toDomain(mission, translations) {
     competenceId: mission.competenceId,
     thematicIds: mission.thematicIds,
     content: mission.content,
-    introductionMedia: mission.introductionMedia,
+    introductionMediaUrl: mission.introductionMediaUrl,
+    introductionMediaType: mission.introductionMediaType,
+    introductionMediaAlt: mission.introductionMediaAlt,
     ...missionTranslations.toDomain(translationsByMissionId[mission.id])
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -55,9 +55,9 @@ export function deserializeMission(attributes) {
     thematicIds: attributes['thematic-ids'],
     learningObjectives_i18n:  { fr:  attributes['learning-objectives'] },
     validatedObjectives_i18n: { fr:  attributes['validated-objectives'] },
-    introductionMediaUrl: attributes['introduction-media-url'],
-    introductionMediaType: attributes['introduction-media-type'],
-    introductionMediaAlt: attributes['introduction-media-alt'],
+    introductionMediaUrl: attributes['introduction-media-url'] || null,
+    introductionMediaType: attributes['introduction-media-type'] || null,
+    introductionMediaAlt: attributes['introduction-media-alt'] || null,
     status: attributes.status,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -11,7 +11,6 @@ export function serializeMissionSummary(mission, meta) {
       'thematicIds',
       'learningObjectives',
       'validatedObjectives',
-      'introductionMedia',
       'createdAt',
       'status'
     ],
@@ -34,7 +33,9 @@ export function serializeMission(mission) {
       'thematicIds',
       'learningObjectives',
       'validatedObjectives',
-      'introductionMedia',
+      'introductionMediaUrl',
+      'introductionMediaType',
+      'introductionMediaAlt',
       'createdAt',
       'status'
     ],
@@ -54,7 +55,9 @@ export function deserializeMission(attributes) {
     thematicIds: attributes['thematic-ids'],
     learningObjectives_i18n:  { fr:  attributes['learning-objectives'] },
     validatedObjectives_i18n: { fr:  attributes['validated-objectives'] },
-    introductionMedia: attributes['introduction-media'],
+    introductionMediaUrl: attributes['introduction-media-url'],
+    introductionMediaType: attributes['introduction-media-type'],
+    introductionMediaAlt: attributes['introduction-media-alt'],
     status: attributes.status,
   });
 }

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -41,7 +41,9 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
           'thematic-ids': null,
           'validated-objectives': 'Être forte',
           'learning-objectives': 'Être imbattable',
-          'introduction-media': null,
+          'introduction-media-url': null,
+          'introduction-media-type': null,
+          'introduction-media-alt': null,
           'created-at': new Date('2024-01-01')
         },
       },

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -162,7 +162,9 @@ async function mockCurrentContent() {
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.VALIDATED,
       createdAt: new Date('2010-01-04'),
-      introductionMedia: null,
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt: null,
     }), new Mission({
       id: 2,
       name_i18n: { fr: 'Alt name' },
@@ -172,7 +174,9 @@ async function mockCurrentContent() {
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
       status: Mission.status.EXPERIMENTAL,
       createdAt: new Date('2010-01-05'),
-      introductionMedia: 'http://example.com',
+      introductionMediaUrl: 'http://example.com',
+      introductionMediaType: 'image',
+      introductionMediaAlt: null,
     })]
   };
 
@@ -228,7 +232,9 @@ async function mockCurrentContent() {
     validatedObjectives: 'Rien',
     status: Mission.status.VALIDATED,
     createdAt: new Date('2010-01-04'),
-    introductionMedia: null,
+    introductionMediaUrl: null,
+    introductionMediaType: null,
+    introductionMediaAlt: null,
   });
   databaseBuilder.factory.buildMission({
     id: 2,
@@ -239,7 +245,9 @@ async function mockCurrentContent() {
     validatedObjectives: 'Alt validated objectives',
     status: Mission.status.EXPERIMENTAL,
     createdAt: new Date('2010-01-05'),
-    introductionMedia: 'http://example.com',
+    introductionMediaUrl: 'http://example.com',
+    introductionMediaType: 'image',
+    introductionMediaAlt: null,
   });
   databaseBuilder.factory.buildMission({
     id: 3,
@@ -250,7 +258,9 @@ async function mockCurrentContent() {
     validatedObjectives: 'Alt validated objectives',
     status: Mission.status.INACTIVE,
     createdAt: new Date('2010-01-05'),
-    introductionMedia: null,
+    introductionMediaUrl: null,
+    introductionMediaType: null,
+    introductionMediaAlt: null,
   });
 
   for (const locale of ['fr', 'en', 'nl']) {
@@ -484,7 +494,9 @@ async function mockContentForRelease() {
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.VALIDATED,
-      introductionMedia: 'http://example.com',
+      introductionMediaUrl: 'http://example.com',
+      introductionMediaType: 'image',
+      introductionMediaAlt: null,
       content: {
         dareChallenges: [],
         steps: []
@@ -496,7 +508,9 @@ async function mockContentForRelease() {
       learningObjectives_i18n: { fr: 'Alt objectives' },
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
       status: Mission.status.EXPERIMENTAL,
-      introductionMedia: null,
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt: null,
       content: {
         dareChallenges: [],
         steps: []
@@ -766,7 +780,9 @@ describe('Acceptance | Controller | release-controller', () => {
           learningObjectives: 'Que tu sois le meilleur',
           validatedObjectives: 'Rien',
           status: Mission.status.VALIDATED,
-          introductionMedia: 'http://example.com',
+          introductionMediaUrl: 'http://example.com',
+          introductionMediaType: 'image',
+          introductionMediaAlt: null,
         });
         databaseBuilder.factory.buildMission({
           id: 2,
@@ -776,7 +792,9 @@ describe('Acceptance | Controller | release-controller', () => {
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
           status: Mission.status.EXPERIMENTAL,
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
         });
         databaseBuilder.factory.buildMission({
           id: 3,

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -1,0 +1,56 @@
+import { describe, describe as context, expect, it } from 'vitest';
+import { MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
+import { createMission } from '../../../../lib/domain/usecases/index.js';
+import { Mission } from '../../../../lib/domain/models/index.js';
+
+describe('Integration | Usecases | Create mission', function() {
+  context('When the mission has a media url without a type', function() {
+    it('should return an error MissionIntroductionMediaError', async () => {
+      // given
+      const missionToSave = new Mission({
+        name_i18n: { fr: 'new mission'  },
+        competenceId: 'QWERTY',
+        thematicIds: 'Thematic',
+        learningObjectives_i18n:  { fr: null },
+        validatedObjectives_i18n: { fr: 'Très bien' },
+        introductionMediaType: null,
+        introductionMediaUrl: 'http://example.net',
+        introductionMediaAlt: null,
+        status: Mission.status.INACTIVE,
+        createdAt: new Date('2023-12-25')
+      });
+
+      // when
+      const promise = createMission(missionToSave);
+
+      // then
+      await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.'));
+
+    });
+  });
+  context('When the mission has a media type without an url', function() {
+    it('should return an error MissionIntroductionMediaError', async () => {
+      // given
+      const missionToSave = new Mission({
+        name_i18n: { fr: 'new mission'  },
+        competenceId: 'QWERTY',
+        thematicIds: 'Thematic',
+        learningObjectives_i18n:  { fr: null },
+        validatedObjectives_i18n: { fr: 'Très bien' },
+        introductionMediaType: 'image',
+        introductionMediaUrl: null,
+        introductionMediaAlt: null,
+        status: Mission.status.INACTIVE,
+        createdAt: new Date('2023-12-25')
+      });
+
+      // when
+      const promise = createMission(missionToSave);
+
+      // then
+      await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.'));
+
+    });
+  });
+});
+

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -18,7 +18,6 @@ describe('Integration | Usecases | Update mission', function() {
     });
   });
   context('When the mission exists', function() {
-
     context('when requested status is not VALIDATED', function() {
       it('should return the updated mission', async () => {
         // given
@@ -32,7 +31,9 @@ describe('Integration | Usecases | Update mission', function() {
           thematicIds: 'Thematic',
           learningObjectives_i18n:  { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
           status: Mission.status.INACTIVE,
           createdAt: new Date('2023-12-25')
         });
@@ -71,7 +72,9 @@ describe('Integration | Usecases | Update mission', function() {
             thematicIds: 'Thematic',
             learningObjectives_i18n:  { fr: null },
             validatedObjectives_i18n: { fr: 'Très bien' },
-            introductionMedia: null,
+            introductionMediaUrl: null,
+            introductionMediaType: null,
+            introductionMediaAlt: null,
             status: Mission.status.VALIDATED,
             createdAt: new Date('2023-12-25')
           });
@@ -118,7 +121,7 @@ describe('Integration | Usecases | Update mission', function() {
           const promise = updateMission(missionToUpdate);
 
           // then
-          await expect(promise).rejects.to.deep.equal(new BadRequestError('La mission ne peut pas être mise à jour car les challenges "challengeTraining1", "challengeTraining2" ne sont pas au status VALIDE'));
+          await expect(promise).rejects.to.deep.equal(new BadRequestError('La mission ne peut pas être mise à jour car les challenges "challengeTraining1", "challengeTraining2" ne sont pas au statut VALIDE'));
 
         });
 

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -34,7 +34,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
           validatedObjectives_i18n: { fr: 'Rien' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }));
@@ -63,7 +65,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
           validatedObjectives_i18n: { fr: 'Rien' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }), new Mission({
@@ -73,7 +77,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.INACTIVE,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -227,7 +233,9 @@ describe('Integration | Repository | mission-repository', function() {
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
         learningObjectives_i18n: { fr: 'Alt objectives' },
         validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-        introductionMedia: null,
+        introductionMediaUrl: null,
+        introductionMediaAlt: null,
+        introductionMediaType: null,
         status: Mission.status.VALIDATED,
         createdAt: new Date('2010-01-04'),
         content: {
@@ -293,7 +301,9 @@ describe('Integration | Repository | mission-repository', function() {
             thematicIds: 'thematicStep1,thematicDefiVide',
             learningObjectives_i18n: { fr: 'Alt objectives' },
             validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-            introductionMedia: null,
+            introductionMediaUrl: null,
+            introductionMediaAlt: null,
+            introductionMediaType: null,
             status: Mission.status.EXPERIMENTAL,
             createdAt: new Date('2010-01-04'),
             content: {
@@ -342,7 +352,9 @@ describe('Integration | Repository | mission-repository', function() {
             thematicIds: 'thematicStep1,thematicDefiVide',
             learningObjectives_i18n: { fr: 'Alt objectives' },
             validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-            introductionMedia: null,
+            introductionMediaUrl: null,
+            introductionMediaAlt: null,
+            introductionMediaType: null,
             status: Mission.status.VALIDATED,
             createdAt: new Date('2010-01-04'),
             content: {
@@ -406,7 +418,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -462,7 +476,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -518,7 +534,9 @@ describe('Integration | Repository | mission-repository', function() {
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
           status: Mission.status.VALIDATED,
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -559,7 +577,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -600,7 +620,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -640,7 +662,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -674,7 +698,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -708,7 +734,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'thematicStep1,thematicDefiVide',
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          introductionMediaType: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -741,7 +769,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: null,
           learningObjectives_i18n: { fr: 'Alt objectives' },
           validatedObjectives_i18n: { fr: 'Alt validated objectives' },
-          introductionMedia: null,
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -758,7 +788,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'QWERTY',
           learningObjectives_i18n: { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
-          introductionMedia: 'http://example.net',
+          introductionMediaUrl: 'http://example.net',
+          introductionMediaType: 'image',
+          introductionMediaAlt: null,
           status: Mission.status.INACTIVE,
         });
 
@@ -770,11 +802,13 @@ describe('Integration | Repository | mission-repository', function() {
           id: savedMission.id,
           competenceId: 'AZERTY',
           thematicIds: 'QWERTY',
-          introductionMedia: 'http://example.net',
+          introductionMediaUrl: 'http://example.net',
+          introductionMediaType: 'image',
+          introductionMediaAlt: null,
           status: Mission.status.INACTIVE,
         };
 
-        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMedia');
+        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMediaUrl', 'introductionMediaAlt', 'introductionMediaType');
         expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
@@ -825,7 +859,9 @@ describe('Integration | Repository | mission-repository', function() {
           thematicIds: 'Thematic',
           learningObjectives_i18n: { fr: null },
           validatedObjectives_i18n: { fr: 'Très bien' },
-          introductionMedia: 'http://example.net',
+          introductionMediaUrl: 'http://example.net',
+          introductionMediaType: 'vidéo',
+          introductionMediaAlt: null,
           status: Mission.status.INACTIVE,
         });
 
@@ -839,10 +875,12 @@ describe('Integration | Repository | mission-repository', function() {
           competenceId: 'QWERTY',
           thematicIds: 'Thematic',
           status: Mission.status.INACTIVE,
-          introductionMedia: 'http://example.net',
+          introductionMediaUrl: 'http://example.net',
+          introductionMediaType: 'vidéo',
+          introductionMediaAlt: null,
         };
 
-        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMedia');
+        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMediaUrl','introductionMediaAlt', 'introductionMediaType');
         expect(missionFromDb).to.deep.equal(expectedMission);
       });
 

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1424,7 +1424,9 @@ function _getRichCurrentContentDTO() {
       validatedObjectives_i18n: { fr: 'Rien' },
       status: Mission.status.VALIDATED,
       createdAt: new Date('2010-01-04'),
-      introductionMedia: null,
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt: null,
     }),
   ];
 

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -10,11 +10,14 @@ export function buildMission({
   thematicIds = 'thematicIds',
   validatedObjectives = 'Rien',
   status = Mission.status.INACTIVE,
-  introductionMedia = null,
+  introductionMediaUrl = null,
+  introductionMediaAlt = null,
+  introductionMediaType = null,
+
   createdAt = new Date('2010-01-04'),
 } = {}) {
 
-  const values = { id, competenceId, thematicIds, createdAt, status, introductionMedia };
+  const values = { id, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, introductionMediaAlt };
 
   buildTranslation({
     key: `mission.${id}.name`,

--- a/api/tests/tooling/domain-builder/factory/build-mission.js
+++ b/api/tests/tooling/domain-builder/factory/build-mission.js
@@ -8,7 +8,7 @@ export function buildMission({
   createdAt = new Date('2023-10-14'),
   learningObjectives = '- Que tu deviennes forte\n Et...',
   validatedObjectives = '- Ca\n Et puis ça',
-  introductionMedia = 'http://example.net',
+  introductionMediaUrl = 'http://example.net',
   status = Mission.status.VALIDATED,
 } = {}) {
   return new Mission ({
@@ -19,7 +19,7 @@ export function buildMission({
     createdAt,
     learningObjectives_i18n: { fr: learningObjectives },
     validatedObjectives_i18n: { fr: validatedObjectives },
-    introductionMedia,
+    introductionMediaUrl,
     status,
   });
 }

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -182,6 +182,9 @@ describe('Unit | Controller | missions controller', function() {
         learningObjectives_i18n: { fr: null },
         validatedObjectives_i18n: { fr: 'Très bien' },
         status: Mission.status.INACTIVE,
+        introductionMediaUrl: null,
+        introductionMediaType: null,
+        introductionMediaAlt: null,
       });
       // then
       expect(createMissionMock).toHaveBeenCalledWith(deserializedMission);
@@ -235,6 +238,9 @@ describe('Unit | Controller | missions controller', function() {
         thematicId: null,
         learningObjectives_i18n: { fr: 'apprendre à éviter les lasers' },
         validatedObjectives_i18n: { fr: 'Très bien' },
+        introductionMediaUrl: null,
+        introductionMediaType: null,
+        introductionMediaAlt: null,
         status: Mission.status.VALIDATED,
       });
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/mission-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/mission-serializer_test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { Mission } from '../../../../../lib/domain/models/Mission.js';
+import { deserializeMission } from '../../../../../lib/infrastructure/serializers/jsonapi/mission-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
+  describe('#deserialize', () => {
+    it('should deserialize a Mission', () => {
+
+      const expectedMission = new Mission({
+        id: 12,
+        learningObjectives_i18n: {
+          fr: 'learning objectives-value',
+        }, name_i18n: {
+          fr: 'Mission Name',
+        },
+        validatedObjectives_i18n: {
+          fr: 'validated-objectives-value',
+        },
+        competenceId: 'rec12E12EFZF',
+        thematicIds: 'someThematicIds',
+        learningObjectives: 'learning objectives-value',
+        validatedObjectives: 'validated-objectives-value',
+        introductionMediaUrl: 'introduction-media-url-value',
+        introductionMediaType: 'introduction-media-type-value',
+        introductionMediaAlt: 'introduction-media-alt-value',
+        status: 'EXPERIMENTAL',
+      });
+
+      const attributes = {
+        id: expectedMission.id,
+        name: expectedMission.name_i18n.fr,
+        'competence-id': expectedMission.competenceId,
+        'thematic-ids': expectedMission.thematicIds,
+        'learning-objectives': expectedMission.learningObjectives_i18n.fr,
+        'validated-objectives': expectedMission.validatedObjectives_i18n.fr,
+        'introduction-media-url': expectedMission.introductionMediaUrl,
+        'introduction-media-type': expectedMission.introductionMediaType,
+        'introduction-media-alt': expectedMission.introductionMediaAlt,
+        status: expectedMission.status
+      };
+      const deserializedMission = deserializeMission(attributes);
+
+      expect(deserializedMission).to.deep.equal(expectedMission);
+    });
+
+    it('should deserialize empty string into null value', () => {
+
+      const expectedMission = new Mission({ id: 12 });
+
+      const attributes = {
+        id: expectedMission.id,
+        'introduction-media-url': '',
+        'introduction-media-type': '',
+        'introduction-media-alt': '',
+      };
+      const deserializedMission = deserializeMission(attributes);
+
+      expect(deserializedMission.introductionMediaUrl).to.be.null;
+      expect(deserializedMission.introductionMediaType).to.be.null;
+      expect(deserializedMission.introductionMediaAlt).to.be.null;
+    });
+  });
+});
+

--- a/pix-editor/app/adapters/mission.js
+++ b/pix-editor/app/adapters/mission.js
@@ -16,6 +16,8 @@ function preparePayloadForCreateAndUpdate(payload, adapterOptions) {
   payload.data.attributes['thematic-ids'] = adapterOptions.thematicIds;
   payload.data.attributes['learning-objectives'] = adapterOptions.learningObjectives;
   payload.data.attributes['validated-objectives'] = adapterOptions.validatedObjectives;
-  payload.data.attributes['introduction-media'] = adapterOptions.introductionMedia;
+  payload.data.attributes['introduction-media-url'] = adapterOptions.introductionMediaUrl;
+  payload.data.attributes['introduction-media-type'] = adapterOptions.introductionMediaType;
+  payload.data.attributes['introduction-media-alt'] = adapterOptions.introductionMediaAlt;
   return payload;
 }

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -74,12 +74,12 @@
       <PixInput
         @id="mission-introduction-media-url"
         @value={{this.introductionMediaUrl}}
-        {{on "change" this.updateintroductionMediaUrl}}
+        {{on "change" this.updateIntroductionMediaUrl}}
       />
 
       <PixSelect
         @options={{this.typeOptions}}
-        @onChange={{this.updateintroductionMediaType}}
+        @onChange={{this.updateIntroductionMediaType}}
         @value={{this.introductionMediaType}}
         @placeholder="-- Sélectionner un type --"
       >
@@ -91,7 +91,7 @@
       <PixInput
         @id="mission-introduction-media-alt"
         @value={{this.introductionMediaAlt}}
-        {{on "change" this.updateintroductionMediaAlt}}
+        {{on "change" this.updateIntroductionMediaAlt}}
       />
     </section>
   </Card>

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -8,14 +8,18 @@
       @validationStatus={{this.name.state}}
       {{on "focusout" this.validateName}}
       {{on "keyup" this.updateName}}
-    ><:label>Nom de la mission</:label></PixInput>
-   <PixSelect
+    >
+      <:label>Nom de la mission</:label>
+    </PixInput>
+    <PixSelect
       @options={{this.statusOptions}}
       @value={{this.selectedStatus}}
       @hideDefaultOption={{true}}
       @onChange={{this.changeStatus}}
       @requiredLabel="{{this.name.errorMessage}}"
-    ><:label>Statut</:label></PixSelect>
+    >
+      <:label>Statut</:label>
+    </PixSelect>
 
     <PixSelect
       class="new-mission-form__select"
@@ -26,7 +30,9 @@
       @requiredLabel="champ requis"
       @errorMessage="{{this.selectedCompetenceId.errorMessage}}"
       {{on "focusout" this.validateCompetence}}
-    ><:label>Compétence</:label></PixSelect>
+    >
+      <:label>Compétence</:label>
+    </PixSelect>
 
     <PixInput
       @id="thematic-ids"
@@ -35,7 +41,9 @@
       @validationStatus={{this.thematicIds.state}}
       {{on "focusout" this.validateThematicIds}}
       {{on "keyup" this.updateThematicIds}}
-    ><:label>Liste des thématiques</:label></PixInput>
+    >
+      <:label>Liste des thématiques</:label>
+    </PixInput>
 
     <label class="new-mission-form__label-text-area" for="mission-learning-objectives">Objectifs d'apprentissage</label>
     <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de début de mission.</p>
@@ -45,37 +53,48 @@
       {{on "change" this.updateLearningObjectives}}
     />
 
-    <label class="new-mission-form__label-text-area" for="mission-validated-objectives">Objectifs validés dans la mission</label>
-    <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de fin de mission.<br>Attention, cet élément est pour le moment utilisé que pour de l’affichage dans Pix 1D</p>
+    <label class="new-mission-form__label-text-area" for="mission-validated-objectives">Objectifs validés dans la
+      mission</label>
+    <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de fin de mission.<br>Attention, cet
+      élément est pour le moment utilisé que pour de l’affichage dans Pix 1D</p>
     <PixTextarea
       @id="mission-validated-objectives"
       @value={{this.validatedObjectives}}
       {{on "change" this.updateValidatedObjectives}}
     />
 
-    <label class="new-mission-form__label-text-area" for="mission-introduction-media-url">URL d'un média d'introduction de la mission</label>
-    <p class="new-mission-form__description">Ce média s’affichera avant de démarrer la mission, avant la première épreuve.</p>
-    <PixInput
-      @id="mission-introduction-media-url"
-      @value={{this.introductionMediaUrl}}
-      {{on "change" this.updateintroductionMediaUrl}}
-    />
+    <section class="new-mission-form__mission-introduction">
+      <h2 class=" mission-introduction__title">Introduction à la mission</h2>
+      <p class="mission-introduction__description">Ce média s’affichera avant de démarrer la mission, avant la première
+        épreuve. <br> Lorsqu'une URL est précisée, elle doit être obligatoirement accompagnée du type de média. <br>
+        Si le média est de type image, un texte alternatif doit être renseigné.</p>
 
-    <label class="new-mission-form__label-text-area" for="mission-introduction-media-type">Type de média (image ou video)</label>
-    <PixInput
-      @id="mission-introduction-media-type"
-      @value={{this.introductionMediaType}}
-      {{on "change" this.updateintroductionMediaType}}
-    />
+      <label class="new-mission-form__label-text-area" for="mission-introduction-media-url">URL d'un média d'introduction
+        de la mission</label>
+      <PixInput
+        @id="mission-introduction-media-url"
+        @value={{this.introductionMediaUrl}}
+        {{on "change" this.updateintroductionMediaUrl}}
+      />
 
-    <label class="new-mission-form__label-text-area" for="mission-introduction-media-alt">Texte alternatif pour le média d'introduction</label>
-    <PixInput
-      @id="mission-introduction-media-alt"
-      @value={{this.introductionMediaAlt}}
-      {{on "change" this.updateintroductionMediaAlt}}
-    />
+      <PixSelect
+        @options={{this.typeOptions}}
+        @onChange={{this.updateintroductionMediaType}}
+        @value={{this.introductionMediaType}}
+        @placeholder="-- Sélectionner un type --"
+      >
+        <:label>Type de média</:label>
+      </PixSelect>
 
-   </Card>
+      <label class="new-mission-form__label-text-area" for="mission-introduction-media-alt">Texte alternatif pour le média
+        d'introduction</label>
+      <PixInput
+        @id="mission-introduction-media-alt"
+        @value={{this.introductionMediaAlt}}
+        {{on "change" this.updateintroductionMediaAlt}}
+      />
+    </section>
+  </Card>
 
   <div class="form-error">
     {{#each this.errorMessages as |errorMessage|}}

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -53,15 +53,30 @@
       {{on "change" this.updateValidatedObjectives}}
     />
 
-    <label class="new-mission-form__label-text-area" for="mission-introduction-media">Média d'introduction de la mission</label>
+    <label class="new-mission-form__label-text-area" for="mission-introduction-media-url">URL d'un média d'introduction de la mission</label>
     <p class="new-mission-form__description">Ce média s’affichera avant de démarrer la mission, avant la première épreuve.</p>
     <PixInput
-      @id="mission-introduction-media"
-      @value={{this.introductionMedia}}
-      {{on "change" this.updateIntroductionMedia}}
+      @id="mission-introduction-media-url"
+      @value={{this.introductionMediaUrl}}
+      {{on "change" this.updateintroductionMediaUrl}}
     />
+
+    <label class="new-mission-form__label-text-area" for="mission-introduction-media-type">Type de média (image ou video)</label>
+    <PixInput
+      @id="mission-introduction-media-type"
+      @value={{this.introductionMediaType}}
+      {{on "change" this.updateintroductionMediaType}}
+    />
+
+    <label class="new-mission-form__label-text-area" for="mission-introduction-media-alt">Texte alternatif pour le média d'introduction</label>
+    <PixInput
+      @id="mission-introduction-media-alt"
+      @value={{this.introductionMediaAlt}}
+      {{on "change" this.updateintroductionMediaAlt}}
+    />
+
    </Card>
- 
+
   <div class="form-error">
     {{#each this.errorMessages as |errorMessage|}}
       {{errorMessage}}<br/>

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -15,7 +15,9 @@ export default class MissionForm extends Component {
   @tracked selectedStatus = 'ACTIVE';
   @tracked validatedObjectives = null;
   @tracked learningObjectives = null;
-  @tracked introductionMedia = null;
+  @tracked introductionMediaUrl = null;
+  @tracked introductionMediaAlt = null;
+  @tracked introductionMediaType = null;
   @tracked errorMessages = A([]);
   @tracked isSubmitting = false;
   @tracked isFormValid = false;
@@ -28,7 +30,9 @@ export default class MissionForm extends Component {
       this.selectedStatus = this.args.mission.status;
       this.validatedObjectives = this.args.mission.validatedObjectives;
       this.learningObjectives = this.args.mission.learningObjectives;
-      this.introductionMedia = this.args.mission.introductionMedia;
+      this.introductionMediaUrl = this.args.mission.introductionMediaUrl;
+      this.introductionMediaType = this.args.mission.introductionMediaType;
+      this.introductionMediaAlt = this.args.mission.introductionMediaAlt;
       this.isFormValid = true;
       this.thematicIds.setValue(this.args.mission.thematicIds);
     }
@@ -73,7 +77,9 @@ export default class MissionForm extends Component {
       status: this.selectedStatus,
       learningObjectives: this.learningObjectives,
       validatedObjectives: this.validatedObjectives,
-      introductionMedia: this.introductionMedia
+      introductionMediaUrl: this.introductionMediaUrl,
+      introductionMediaAlt: this.introductionMediaAlt,
+      introductionMediaType: this.introductionMediaType
     };
     try {
       await this.args.onFormSubmitted(formData);
@@ -116,8 +122,18 @@ export default class MissionForm extends Component {
   }
 
   @action
-  updateIntroductionMedia(event) {
-    this.introductionMedia = event.target.value;
+  updateintroductionMediaType(event) {
+    this.introductionMediaType = event.target.value;
+  }
+
+  @action
+  updateintroductionMediaAlt(event) {
+    this.introductionMediaAlt = event.target.value;
+  }
+
+  @action
+  updateintroductionMediaUrl(event) {
+    this.introductionMediaUrl = event.target.value;
   }
 
   @action

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -126,17 +126,17 @@ export default class MissionForm extends Component {
   }
 
   @action
-  updateintroductionMediaType(value) {
+  updateIntroductionMediaType(value) {
     this.introductionMediaType = value;
   }
 
   @action
-  updateintroductionMediaAlt(event) {
+  updateIntroductionMediaAlt(event) {
     this.introductionMediaAlt = event.target.value;
   }
 
   @action
-  updateintroductionMediaUrl(event) {
+  updateIntroductionMediaUrl(event) {
     this.introductionMediaUrl = event.target.value;
   }
 

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -59,6 +59,10 @@ export default class MissionForm extends Component {
     });
   }
 
+  get typeOptions() {
+    return [{ value: 'image', label: 'Image' }, { value: 'video', label: 'Vidéo' }];
+  }
+
   get competencesOptions() {
     return this.args.competences.map((competence) => {
       return { value: competence.pixId, label: competence.title };
@@ -122,8 +126,8 @@ export default class MissionForm extends Component {
   }
 
   @action
-  updateintroductionMediaType(event) {
-    this.introductionMediaType = event.target.value;
+  updateintroductionMediaType(value) {
+    this.introductionMediaType = value;
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -15,7 +15,9 @@ export default class MissionEditController extends Controller {
       this.model.mission.thematicIds = formData.thematicIds;
       this.model.mission.validatedObjectives = formData.validatedObjectives;
       this.model.mission.learningObjectives = formData.learningObjectives;
-      this.model.mission.introductionMedia = formData.introductionMedia;
+      this.model.mission.introductionMediaUrl = formData.introductionMediaUrl;
+      this.model.mission.introductionMediaType = formData.introductionMediaType;
+      this.model.mission.introductionMediaAlt = formData.introductionMediaAlt;
       await this.model.mission.save();
       this.notifications.success('Mission mise à jour avec succès.');
       this.router.transitionTo('authenticated.missions.mission');

--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -6,5 +6,7 @@ export default class Mission extends MissionSummary {
   @attr thematicIds;
   @attr learningObjectives;
   @attr validatedObjectives;
-  @attr introductionMedia;
+  @attr introductionMediaUrl;
+  @attr introductionMediaType;
+  @attr introductionMediaAlt;
 }

--- a/pix-editor/app/styles/authenticated/missions/new.scss
+++ b/pix-editor/app/styles/authenticated/missions/new.scss
@@ -15,6 +15,7 @@
     .pix-textarea{
       width: 100%;
     }
+
   }
 
   &__select{
@@ -26,15 +27,34 @@
     margin-top: 10px;
   }
 
-  &__description {
-    font-size: 0.825rem;
-  }
-
   &__label {
     margin-bottom: 4px;
     color: rgb(23, 43, 77);
     font-weight: 500;
     font-size: 0.875rem;
     line-height: 1.375rem;
+  }
+
+  &__description {
+    font-size: 0.825rem;
+  }
+
+  &__mission-introduction {
+    margin-top: 20px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.mission-introduction {
+  &__title {
+    font-weight: bold;
+    margin-bottom: 8px;
+  }
+
+  &__description {
+    font-size: 1rem;
+    margin-bottom: 8px;
   }
 }

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -44,7 +44,15 @@
         </li>
         <li>
           <span class="bold">Média d'introduction de la mission : </span>
-          <a href={{ this.model.mission.introductionMedia }}>{{this.model.mission.introductionMedia}}</a>
+          <a href={{ this.model.mission.introductionMediaUrl }}>{{this.model.mission.introductionMediaUrl}}</a>
+        </li>
+        <li>
+          <span class="bold">Type de média d'introduction : </span>
+          {{ this.model.mission.introductionMediaType }}
+        </li>
+        <li>
+          <span class="bold">Texte alternatif au média d'introduction de la mission : </span>
+          {{ this.model.mission.introductionMediaAlt }}
         </li>
         <li><span class="bold">Crée le : </span>{{dayjs-format this.model.mission.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
       </ul>

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -55,7 +55,9 @@ module('Acceptance | Missions | Edit', function (hooks) {
         competenceId: 'recCompetence1.1',
         thematicIds: '',
         createdAt: '2023/12/11',
-        introductionMedia: null,
+        introductionMediaUrl: null,
+        introductionMediaAlt: null,
+        introductionMediaType: null,
         status: 'VALIDATED'
       });
       const screen = await visit('/missions/3/edit');
@@ -67,7 +69,7 @@ module('Acceptance | Missions | Edit', function (hooks) {
       await clickByText('Compétence');
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Notre compétence' }));
-      await fillByLabel('Média d\'introduction de la mission', 'http://example.com');
+      await fillByLabel('URL d\'un média d\'introduction de la mission', 'http://example.com');
 
       await click(screen.getByRole('button', { name: 'Modifier la mission' }));
 


### PR DESCRIPTION
## :unicorn: Problème

Nous avons ajouté une URL pour avoir un média d'introduction. Nous avons amorcé le développement avec une URL d'image pour commencer. Mais il faut aussi pouvoir afficher une vidéo ! 

## :robot: Proposition

Ajout d'un champ `introductionMediaType` pour pouvoir préciser image ou vidéo.

## :rainbow: Remarques

Nous avons également renommé `introductionMedia` en `introductionMediaUrl` pour plus de cohérence, et nous en avons profité pour ajouter un `introductionMediaAlt`

## :100: Pour tester

Aller sur une mission et ajouter une URL de vidéo ou d'image, spécifier le type et une valeur pour le ALT.

Générer une release et s'assurer que les valeurs sont présentes.
