### PR TITLE
[FEATURE] Ajouter une documentation à une misson (Pix-13774)

### DIFF
--- a/api/db/migrations/20240819145954_add_documentation_url_to_mission_table.js
+++ b/api/db/migrations/20240819145954_add_documentation_url_to_mission_table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'missions';
+const DOCUMENTATION_URL = 'documentationUrl';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.text(DOCUMENTATION_URL);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn(DOCUMENTATION_URL);
+  });
+}

--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -12,6 +12,7 @@ export class Mission {
     introductionMediaAlt,
     status,
     content,
+    documentationUrl,
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -25,6 +26,7 @@ export class Mission {
     this.introductionMediaAlt = introductionMediaAlt;
     this.status = status;
     this.content = new Content(content);
+    this.documentationUrl = documentationUrl;
   }
 }
 

--- a/api/lib/domain/models/release/MissionForRelease.js
+++ b/api/lib/domain/models/release/MissionForRelease.js
@@ -9,7 +9,8 @@ export class MissionForRelease {
     content,
     introductionMediaUrl,
     introductionMediaType,
-    introductionMediaAlt
+    introductionMediaAlt,
+    documentationUrl
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
@@ -21,5 +22,6 @@ export class MissionForRelease {
     this.introductionMediaUrl = introductionMediaUrl;
     this.introductionMediaType = introductionMediaType;
     this.introductionMediaAlt = introductionMediaAlt;
+    this.documentationUrl = documentationUrl;
   }
 }

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -127,6 +127,7 @@ export async function save(mission) {
     introductionMediaUrl: mission.introductionMediaUrl,
     introductionMediaType: mission.introductionMediaType,
     introductionMediaAlt: mission.introductionMediaAlt,
+    documentationUrl: mission.documentationUrl,
   }).onConflict('id')
     .merge()
     .returning('*');
@@ -149,6 +150,7 @@ function _toDomain(mission, translations) {
     introductionMediaUrl: mission.introductionMediaUrl,
     introductionMediaType: mission.introductionMediaType,
     introductionMediaAlt: mission.introductionMediaAlt,
+    documentationUrl: mission.documentationUrl,
     ...missionTranslations.toDomain(translationsByMissionId[mission.id])
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -36,6 +36,7 @@ export function serializeMission(mission) {
       'introductionMediaUrl',
       'introductionMediaType',
       'introductionMediaAlt',
+      'documentationUrl',
       'createdAt',
       'status'
     ],
@@ -58,6 +59,7 @@ export function deserializeMission(attributes) {
     introductionMediaUrl: attributes['introduction-media-url'] || null,
     introductionMediaType: attributes['introduction-media-type'] || null,
     introductionMediaAlt: attributes['introduction-media-alt'] || null,
+    documentationUrl: attributes['documentation-url'] || null,
     status: attributes.status,
   });
 }

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -44,6 +44,7 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
           'introduction-media-url': null,
           'introduction-media-type': null,
           'introduction-media-alt': null,
+          'documentation-url': null,
           'created-at': new Date('2024-01-01')
         },
       },

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -165,6 +165,7 @@ async function mockCurrentContent() {
       introductionMediaUrl: null,
       introductionMediaType: null,
       introductionMediaAlt: null,
+      documentationUrl: null,
     }), new Mission({
       id: 2,
       name_i18n: { fr: 'Alt name' },
@@ -177,6 +178,7 @@ async function mockCurrentContent() {
       introductionMediaUrl: 'http://example.com',
       introductionMediaType: 'image',
       introductionMediaAlt: null,
+      documentationUrl: null,
     })]
   };
 
@@ -497,6 +499,7 @@ async function mockContentForRelease() {
       introductionMediaUrl: 'http://example.com',
       introductionMediaType: 'image',
       introductionMediaAlt: null,
+      documentationUrl: null,
       content: {
         dareChallenges: [],
         steps: []
@@ -511,6 +514,7 @@ async function mockContentForRelease() {
       introductionMediaUrl: null,
       introductionMediaType: null,
       introductionMediaAlt: null,
+      documentationUrl: 'http://url-example.net',
       content: {
         dareChallenges: [],
         steps: []
@@ -783,6 +787,7 @@ describe('Acceptance | Controller | release-controller', () => {
           introductionMediaUrl: 'http://example.com',
           introductionMediaType: 'image',
           introductionMediaAlt: null,
+          documentationUrl: null,
         });
         databaseBuilder.factory.buildMission({
           id: 2,
@@ -795,6 +800,7 @@ describe('Acceptance | Controller | release-controller', () => {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: 'http://url-example.net',
         });
         databaseBuilder.factory.buildMission({
           id: 3,

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -16,6 +16,7 @@ describe('Integration | Usecases | Create mission', function() {
         introductionMediaType: null,
         introductionMediaUrl: 'http://example.net',
         introductionMediaAlt: null,
+        documentationUrl: null,
         status: Mission.status.INACTIVE,
         createdAt: new Date('2023-12-25')
       });
@@ -40,6 +41,7 @@ describe('Integration | Usecases | Create mission', function() {
         introductionMediaType: 'image',
         introductionMediaUrl: null,
         introductionMediaAlt: null,
+        documentationUrl: null,
         status: Mission.status.INACTIVE,
         createdAt: new Date('2023-12-25')
       });

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -34,6 +34,7 @@ describe('Integration | Usecases | Update mission', function() {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: null,
           status: Mission.status.INACTIVE,
           createdAt: new Date('2023-12-25')
         });
@@ -75,6 +76,7 @@ describe('Integration | Usecases | Update mission', function() {
             introductionMediaUrl: null,
             introductionMediaType: null,
             introductionMediaAlt: null,
+            documentationUrl: null,
             status: Mission.status.VALIDATED,
             createdAt: new Date('2023-12-25')
           });

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -1,7 +1,12 @@
 import { omit } from 'lodash';
 import { beforeEach, describe as context, describe, expect, expectTypeOf, it } from 'vitest';
 import { airtableBuilder, databaseBuilder, knex } from '../../../test-helper.js';
-import { findAllMissions, getById, listActive, save, } from '../../../../lib/infrastructure/repositories/mission-repository.js';
+import {
+  findAllMissions,
+  getById,
+  listActive,
+  save,
+} from '../../../../lib/infrastructure/repositories/mission-repository.js';
 import { Challenge, Mission } from '../../../../lib/domain/models/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 import { SkillForRelease } from '../../../../lib/domain/models/release/index.js';
@@ -37,6 +42,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }));
@@ -68,6 +74,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         }), new Mission({
@@ -80,6 +87,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.INACTIVE,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -151,13 +159,41 @@ describe('Integration | Repository | mission-repository', function() {
     beforeEach(async function() {
       mockedLearningContent = {
         challenges: [
-          airtableBuilder.factory.buildChallenge({ id: 'challengeTuto1', status: Challenge.STATUSES.VALIDE, skillId: 'skillTuto1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeTraining1', status: Challenge.STATUSES.VALIDE, skillId: 'skillTraining1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeValidation1', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeTuto2', status: Challenge.STATUSES.VALIDE, skillId: 'skillTuto2' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeTraining2', status: Challenge.STATUSES.VALIDE, skillId: 'skillTraining2' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeValidation2', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation2' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeDare', status: Challenge.STATUSES.VALIDE, skillId: 'skillDare' }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeTuto1',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillTuto1'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeTraining1',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillTraining1'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeValidation1',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeTuto2',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillTuto2'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeTraining2',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillTraining2'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeValidation2',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation2'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeDare',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillDare'
+          }),
         ],
         skills: [
           airtableBuilder.factory.buildSkill({ id: 'skillTuto1', level: 1, tubeId: 'tubeTuto1' }),
@@ -236,6 +272,7 @@ describe('Integration | Repository | mission-repository', function() {
         introductionMediaUrl: null,
         introductionMediaAlt: null,
         introductionMediaType: null,
+        documentationUrl: null,
         status: Mission.status.VALIDATED,
         createdAt: new Date('2010-01-04'),
         content: {
@@ -272,10 +309,26 @@ describe('Integration | Repository | mission-repository', function() {
       context('when mission is EXPERIMENTAL', function() {
         it('should return proposal and active challenges only', async function() {
           mockedLearningContent.challenges = [
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationValidé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationProposé', status: Challenge.STATUSES.PROPOSE, skillId: 'skillValidation1' }),
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationPérimé', status: Challenge.STATUSES.PERIME, skillId: 'skillValidation1' }),
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationArchivé', status: Challenge.STATUSES.ARCHIVE, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationValidé',
+              status: Challenge.STATUSES.VALIDE,
+              skillId: 'skillValidation1'
+            }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationProposé',
+              status: Challenge.STATUSES.PROPOSE,
+              skillId: 'skillValidation1'
+            }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationPérimé',
+              status: Challenge.STATUSES.PERIME,
+              skillId: 'skillValidation1'
+            }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationArchivé',
+              status: Challenge.STATUSES.ARCHIVE,
+              skillId: 'skillValidation1'
+            }),
           ];
           airtableBuilder.mockLists(mockedLearningContent);
 
@@ -304,6 +357,7 @@ describe('Integration | Repository | mission-repository', function() {
             introductionMediaUrl: null,
             introductionMediaAlt: null,
             introductionMediaType: null,
+            documentationUrl: null,
             status: Mission.status.EXPERIMENTAL,
             createdAt: new Date('2010-01-04'),
             content: {
@@ -323,10 +377,26 @@ describe('Integration | Repository | mission-repository', function() {
       context('when mission is validated', function() {
         it('should return active challenges only', async function() {
           mockedLearningContent.challenges = [
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationValidé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationProposé', status: Challenge.STATUSES.PROPOSE, skillId: 'skillValidation1' }),
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationPérimé', status: Challenge.STATUSES.PERIME, skillId: 'skillValidation1' }),
-            airtableBuilder.factory.buildChallenge({ id: 'challengeValidationArchivé', status: Challenge.STATUSES.ARCHIVE, skillId: 'skillValidation1' }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationValidé',
+              status: Challenge.STATUSES.VALIDE,
+              skillId: 'skillValidation1'
+            }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationProposé',
+              status: Challenge.STATUSES.PROPOSE,
+              skillId: 'skillValidation1'
+            }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationPérimé',
+              status: Challenge.STATUSES.PERIME,
+              skillId: 'skillValidation1'
+            }),
+            airtableBuilder.factory.buildChallenge({
+              id: 'challengeValidationArchivé',
+              status: Challenge.STATUSES.ARCHIVE,
+              skillId: 'skillValidation1'
+            }),
           ];
           airtableBuilder.mockLists(mockedLearningContent);
 
@@ -355,6 +425,7 @@ describe('Integration | Repository | mission-repository', function() {
             introductionMediaUrl: null,
             introductionMediaAlt: null,
             introductionMediaType: null,
+            documentationUrl: null,
             status: Mission.status.VALIDATED,
             createdAt: new Date('2010-01-04'),
             content: {
@@ -376,18 +447,54 @@ describe('Integration | Repository | mission-repository', function() {
     context('with inactive, proposal, and active skills', async function() {
       it('should return in progress and active skill challenges only', async function() {
         mockedLearningContent.challenges = [
-          airtableBuilder.factory.buildChallenge({ id: 'challengeSkillActif', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1Active' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeSkillEnConstruction', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation2InProgress' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeSkillPérimé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation3Deprecated' }),
-          airtableBuilder.factory.buildChallenge({ id: 'challengeSkillArchivé', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation3Archived' }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeSkillActif',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1Active'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeSkillEnConstruction',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation2InProgress'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeSkillPérimé',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation3Deprecated'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'challengeSkillArchivé',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation3Archived'
+          }),
         ];
         mockedLearningContent.skills = [
           airtableBuilder.factory.buildSkill({ id: 'skillTuto1', level: 1, tubeId: 'tubeTuto1' }),
           airtableBuilder.factory.buildSkill({ id: 'skillTraining1', level: 1, tubeId: 'tubeTraining1' }),
-          airtableBuilder.factory.buildSkill({ id: 'skillValidation1Active', status: SkillForRelease.STATUSES.ACTIF, level: 1, tubeId: 'tubeValidation1' }),
-          airtableBuilder.factory.buildSkill({ id: 'skillValidation2InProgress', status: SkillForRelease.STATUSES.EN_CONSTRUCTION, level: 2, tubeId: 'tubeValidation1' }),
-          airtableBuilder.factory.buildSkill({ id: 'skillValidation3Deprecated', status: SkillForRelease.STATUSES.PERIME, level: 3, tubeId: 'tubeValidation1' }),
-          airtableBuilder.factory.buildSkill({ id: 'skillValidation3Archived', status: SkillForRelease.STATUSES.ARCHIVE, level: 4, tubeId: 'tubeValidation1' }),
+          airtableBuilder.factory.buildSkill({
+            id: 'skillValidation1Active',
+            status: SkillForRelease.STATUSES.ACTIF,
+            level: 1,
+            tubeId: 'tubeValidation1'
+          }),
+          airtableBuilder.factory.buildSkill({
+            id: 'skillValidation2InProgress',
+            status: SkillForRelease.STATUSES.EN_CONSTRUCTION,
+            level: 2,
+            tubeId: 'tubeValidation1'
+          }),
+          airtableBuilder.factory.buildSkill({
+            id: 'skillValidation3Deprecated',
+            status: SkillForRelease.STATUSES.PERIME,
+            level: 3,
+            tubeId: 'tubeValidation1'
+          }),
+          airtableBuilder.factory.buildSkill({
+            id: 'skillValidation3Archived',
+            status: SkillForRelease.STATUSES.ARCHIVE,
+            level: 4,
+            tubeId: 'tubeValidation1'
+          }),
           airtableBuilder.factory.buildSkill({ id: 'skillTuto2', level: 1, tubeId: 'tubeTuto2' }),
           airtableBuilder.factory.buildSkill({ id: 'skillTraining2', level: 1, tubeId: 'tubeTraining2' }),
           airtableBuilder.factory.buildSkill({ id: 'skillValidation2', level: 1, tubeId: 'tubeValidation2' }),
@@ -421,6 +528,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -441,10 +549,26 @@ describe('Integration | Repository | mission-repository', function() {
     context('with multiple challenges in activities', async function() {
       it('should return ordered challenges', async function() {
         mockedLearningContent.challenges = [
-          airtableBuilder.factory.buildChallenge({ id: 'secondChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation2' }),
-          airtableBuilder.factory.buildChallenge({ id: 'firstChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1' }),
-          airtableBuilder.factory.buildChallenge({ id: 'fourthChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation4' }),
-          airtableBuilder.factory.buildChallenge({ id: 'thirdChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation3' }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'secondChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation2'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'firstChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'fourthChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation4'
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'thirdChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation3'
+          }),
         ];
         mockedLearningContent.skills = [
           airtableBuilder.factory.buildSkill({ id: 'skillValidation2', level: 2, tubeId: 'tubeValidation1' }),
@@ -479,6 +603,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -501,10 +626,30 @@ describe('Integration | Repository | mission-repository', function() {
     context('with alternative challenges in activities', async function() {
       it('should return ordered alternative challenges', async function() {
         mockedLearningContent.challenges = [
-          airtableBuilder.factory.buildChallenge({ id: 'secondAltChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1', alternativeVersion: 1 }),
-          airtableBuilder.factory.buildChallenge({ id: 'firstAltChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1', alternativeVersion: undefined }),
-          airtableBuilder.factory.buildChallenge({ id: 'fourthAltChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1', alternativeVersion: 3 }),
-          airtableBuilder.factory.buildChallenge({ id: 'thirdAltChallengeValidation', status: Challenge.STATUSES.VALIDE, skillId: 'skillValidation1', alternativeVersion: 2 }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'secondAltChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1',
+            alternativeVersion: 1
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'firstAltChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1',
+            alternativeVersion: undefined
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'fourthAltChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1',
+            alternativeVersion: 3
+          }),
+          airtableBuilder.factory.buildChallenge({
+            id: 'thirdAltChallengeValidation',
+            status: Challenge.STATUSES.VALIDE,
+            skillId: 'skillValidation1',
+            alternativeVersion: 2
+          }),
         ];
         mockedLearningContent.skills = [
           airtableBuilder.factory.buildSkill({ id: 'skillValidation1', level: 1, tubeId: 'tubeValidation1' }),
@@ -537,6 +682,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: null,
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
@@ -580,6 +726,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -623,6 +770,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
           content: {
@@ -665,6 +813,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -673,7 +822,10 @@ describe('Integration | Repository | mission-repository', function() {
     });
     context('Without tubes in thematic', async function() {
       it('Should return missions', async function() {
-        mockedLearningContent.thematics = [airtableBuilder.factory.buildThematic({ id: 'thematicStep1', tubeIds: undefined }, { id: 'thematicDefiVide', tubeIds: undefined })];
+        mockedLearningContent.thematics = [airtableBuilder.factory.buildThematic({
+          id: 'thematicStep1',
+          tubeIds: undefined
+        }, { id: 'thematicDefiVide', tubeIds: undefined })];
         airtableBuilder.mockLists(mockedLearningContent);
 
         buildLocalizedChallenges(mockedLearningContent);
@@ -701,6 +853,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -737,6 +890,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaAlt: null,
           introductionMediaType: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -772,6 +926,7 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: null,
           introductionMediaType: null,
           introductionMediaAlt: null,
+          documentationUrl: null,
           status: Mission.status.VALIDATED,
           createdAt: new Date('2010-01-04'),
         })]);
@@ -791,12 +946,16 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: 'http://example.net',
           introductionMediaType: 'image',
           introductionMediaAlt: null,
+          documentationUrl: 'http://url-example.net',
           status: Mission.status.INACTIVE,
         });
 
         const savedMission = await save(mission);
         expectTypeOf(savedMission).toEqualTypeOf('Mission');
-        expect(omit(savedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...mission, id: savedMission.id }), ['createdAt']));
+        expect(omit(savedMission, ['createdAt'])).to.deep.equal(omit(new Mission({
+          ...mission,
+          id: savedMission.id
+        }), ['createdAt']));
 
         const expectedMission = {
           id: savedMission.id,
@@ -805,10 +964,11 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: 'http://example.net',
           introductionMediaType: 'image',
           introductionMediaAlt: null,
+          documentationUrl: 'http://url-example.net',
           status: Mission.status.INACTIVE,
         };
 
-        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMediaUrl', 'introductionMediaAlt', 'introductionMediaType');
+        const missionFromDb = await knex('missions').where({ id: savedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMediaUrl', 'introductionMediaAlt', 'introductionMediaType', 'documentationUrl');
         expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
@@ -849,7 +1009,12 @@ describe('Integration | Repository | mission-repository', function() {
 
     context('Update mission', function() {
       it('should update the mission', async function() {
-        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.VALIDATED });
+        const savedMission = databaseBuilder.factory.buildMission({
+          name: 'saved mission',
+          competenceId: 'AZERTY',
+          status: Mission.status.VALIDATED,
+          documentationUrl: null,
+        });
         await databaseBuilder.commit();
 
         const missionToUpdate = new Mission({
@@ -862,13 +1027,17 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: 'http://example.net',
           introductionMediaType: 'vidéo',
           introductionMediaAlt: null,
+          documentationUrl: 'http://fake-url.net',
           status: Mission.status.INACTIVE,
         });
 
         const updatedMission = await save(missionToUpdate);
 
         expectTypeOf(updatedMission).toEqualTypeOf('Mission');
-        expect(omit(updatedMission, ['createdAt'])).to.deep.equal(omit(new Mission({ ...missionToUpdate, id: updatedMission.id }), ['createdAt']));
+        expect(omit(updatedMission, ['createdAt'])).to.deep.equal(omit(new Mission({
+          ...missionToUpdate,
+          id: updatedMission.id
+        }), ['createdAt']));
 
         const expectedMission = {
           id: updatedMission.id,
@@ -878,14 +1047,19 @@ describe('Integration | Repository | mission-repository', function() {
           introductionMediaUrl: 'http://example.net',
           introductionMediaType: 'vidéo',
           introductionMediaAlt: null,
+          documentationUrl: 'http://fake-url.net',
         };
 
-        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMediaUrl','introductionMediaAlt', 'introductionMediaType');
+        const missionFromDb = await knex('missions').where({ id: updatedMission.id }).first().select('competenceId', 'thematicIds', 'status', 'id', 'introductionMediaUrl', 'introductionMediaAlt', 'introductionMediaType', 'documentationUrl');
         expect(missionFromDb).to.deep.equal(expectedMission);
       });
 
       it('should store I18n for mission', async function() {
-        const savedMission = databaseBuilder.factory.buildMission({ name: 'saved mission', competenceId: 'AZERTY', status: Mission.status.VALIDATED });
+        const savedMission = databaseBuilder.factory.buildMission({
+          name: 'saved mission',
+          competenceId: 'AZERTY',
+          status: Mission.status.VALIDATED
+        });
         await databaseBuilder.commit();
 
         const missionToUpdate = new Mission({

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -203,6 +203,7 @@ describe('Integration | Repository | release-repository', function() {
         thematicIds: 'thematicIds',
         validatedObjectives: 'Rien',
         status: Mission.status.VALIDATED,
+        documentationUrl: 'http://url-example.net'
       });
 
       databaseBuilder.factory.buildMission({
@@ -1427,6 +1428,7 @@ function _getRichCurrentContentDTO() {
       introductionMediaUrl: null,
       introductionMediaType: null,
       introductionMediaAlt: null,
+      documentationUrl: 'http://url-example.net'
     }),
   ];
 

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -13,11 +13,12 @@ export function buildMission({
   introductionMediaUrl = null,
   introductionMediaAlt = null,
   introductionMediaType = null,
+  documentationUrl = null,
 
   createdAt = new Date('2010-01-04'),
 } = {}) {
 
-  const values = { id, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, introductionMediaAlt };
+  const values = { id, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, introductionMediaAlt, documentationUrl };
 
   buildTranslation({
     key: `mission.${id}.name`,

--- a/api/tests/tooling/domain-builder/factory/build-mission.js
+++ b/api/tests/tooling/domain-builder/factory/build-mission.js
@@ -8,7 +8,10 @@ export function buildMission({
   createdAt = new Date('2023-10-14'),
   learningObjectives = '- Que tu deviennes forte\n Et...',
   validatedObjectives = '- Ca\n Et puis ça',
-  introductionMediaUrl = 'http://example.net',
+  introductionMediaUrl = null,
+  introductionMediaType = null,
+  introductionMediaAlt = null,
+  documentationUrl = null,
   status = Mission.status.VALIDATED,
 } = {}) {
   return new Mission ({
@@ -20,6 +23,9 @@ export function buildMission({
     learningObjectives_i18n: { fr: learningObjectives },
     validatedObjectives_i18n: { fr: validatedObjectives },
     introductionMediaUrl,
+    introductionMediaType,
+    introductionMediaAlt,
+    documentationUrl,
     status,
   });
 }

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -185,6 +185,7 @@ describe('Unit | Controller | missions controller', function() {
         introductionMediaUrl: null,
         introductionMediaType: null,
         introductionMediaAlt: null,
+        documentationUrl: null,
       });
       // then
       expect(createMissionMock).toHaveBeenCalledWith(deserializedMission);
@@ -212,7 +213,8 @@ describe('Unit | Controller | missions controller', function() {
       status: Mission.status.VALIDATED,
       'learning-objectives': 'apprendre à éviter les lasers',
       'validated-objectives': 'Très bien',
-      'thematic-id': null
+      'thematic-id': null,
+      'documentation-url': 'http://url-example.net'
     };
 
     const missionId = 1;
@@ -241,6 +243,7 @@ describe('Unit | Controller | missions controller', function() {
         introductionMediaUrl: null,
         introductionMediaType: null,
         introductionMediaAlt: null,
+        documentationUrl: 'http://url-example.net',
         status: Mission.status.VALIDATED,
       });
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/mission-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/mission-serializer_test.js
@@ -23,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
         introductionMediaUrl: 'introduction-media-url-value',
         introductionMediaType: 'introduction-media-type-value',
         introductionMediaAlt: 'introduction-media-alt-value',
+        documentationUrl: 'www.test.com',
         status: 'EXPERIMENTAL',
       });
 
@@ -36,6 +37,7 @@ describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
         'introduction-media-url': expectedMission.introductionMediaUrl,
         'introduction-media-type': expectedMission.introductionMediaType,
         'introduction-media-alt': expectedMission.introductionMediaAlt,
+        'documentation-url': expectedMission.documentationUrl,
         status: expectedMission.status
       };
       const deserializedMission = deserializeMission(attributes);
@@ -52,12 +54,14 @@ describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
         'introduction-media-url': '',
         'introduction-media-type': '',
         'introduction-media-alt': '',
+        'documentation-url': '',
       };
       const deserializedMission = deserializeMission(attributes);
 
       expect(deserializedMission.introductionMediaUrl).to.be.null;
       expect(deserializedMission.introductionMediaType).to.be.null;
       expect(deserializedMission.introductionMediaAlt).to.be.null;
+      expect(deserializedMission.documentationUrl).to.be.null;
     });
   });
 });

--- a/pix-editor/app/adapters/mission.js
+++ b/pix-editor/app/adapters/mission.js
@@ -19,5 +19,6 @@ function preparePayloadForCreateAndUpdate(payload, adapterOptions) {
   payload.data.attributes['introduction-media-url'] = adapterOptions.introductionMediaUrl;
   payload.data.attributes['introduction-media-type'] = adapterOptions.introductionMediaType;
   payload.data.attributes['introduction-media-alt'] = adapterOptions.introductionMediaAlt;
+  payload.data.attributes['documentation-url'] = adapterOptions.documentationUrl;
   return payload;
 }

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -55,8 +55,8 @@
 
     <label class="new-mission-form__label-text-area" for="mission-validated-objectives">Objectifs validés dans la
       mission</label>
-    <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de fin de mission.<br>Attention, cet
-      élément est pour le moment utilisé que pour de l’affichage dans Pix 1D</p>
+    <p class="new-mission-form__description">Ce texte s’affichera dans l’écran de fin de mission.<br>Attention, pour le moment, cet
+      élément n'est utilisé que pour de l’affichage dans Pix Junior</p>
     <PixTextarea
       @id="mission-validated-objectives"
       @value={{this.validatedObjectives}}
@@ -69,7 +69,7 @@
         épreuve. <br> Lorsqu'une URL est précisée, elle doit être obligatoirement accompagnée du type de média. <br>
         Si le média est de type image, un texte alternatif doit être renseigné.</p>
 
-      <label class="new-mission-form__label-text-area" for="mission-introduction-media-url">URL d'un média d'introduction
+      <label class="new-mission-form__label-text-area" for="mission-introduction-media-url">URL du média d'introduction
         de la mission</label>
       <PixInput
         @id="mission-introduction-media-url"
@@ -94,6 +94,14 @@
         {{on "change" this.updateIntroductionMediaAlt}}
       />
     </section>
+
+    <label class="new-mission-form__label-text-area" for="mission-documentation-url">URL de la documentation de la mission</label>
+      <PixInput
+        @id="mission-documentation-url"
+        @value={{this.documentationUrl}}
+        {{on "change" this.updateDocumentationUrl}}
+      />
+
   </Card>
 
   <div class="form-error">

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -18,6 +18,7 @@ export default class MissionForm extends Component {
   @tracked introductionMediaUrl = null;
   @tracked introductionMediaAlt = null;
   @tracked introductionMediaType = null;
+  @tracked documentationUrl = null;
   @tracked errorMessages = A([]);
   @tracked isSubmitting = false;
   @tracked isFormValid = false;
@@ -33,6 +34,7 @@ export default class MissionForm extends Component {
       this.introductionMediaUrl = this.args.mission.introductionMediaUrl;
       this.introductionMediaType = this.args.mission.introductionMediaType;
       this.introductionMediaAlt = this.args.mission.introductionMediaAlt;
+      this.documentationUrl = this.args.mission.documentationUrl;
       this.isFormValid = true;
       this.thematicIds.setValue(this.args.mission.thematicIds);
     }
@@ -83,7 +85,8 @@ export default class MissionForm extends Component {
       validatedObjectives: this.validatedObjectives,
       introductionMediaUrl: this.introductionMediaUrl,
       introductionMediaAlt: this.introductionMediaAlt,
-      introductionMediaType: this.introductionMediaType
+      introductionMediaType: this.introductionMediaType,
+      documentationUrl: this.documentationUrl,
     };
     try {
       await this.args.onFormSubmitted(formData);
@@ -138,6 +141,11 @@ export default class MissionForm extends Component {
   @action
   updateIntroductionMediaUrl(event) {
     this.introductionMediaUrl = event.target.value;
+  }
+
+  @action
+  updateDocumentationUrl(event) {
+    this.documentationUrl = event.target.value;
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -18,6 +18,7 @@ export default class MissionEditController extends Controller {
       this.model.mission.introductionMediaUrl = formData.introductionMediaUrl;
       this.model.mission.introductionMediaType = formData.introductionMediaType;
       this.model.mission.introductionMediaAlt = formData.introductionMediaAlt;
+      this.model.mission.documentationUrl = formData.documentationUrl;
       await this.model.mission.save();
       this.notifications.success('Mission mise à jour avec succès.');
       this.router.transitionTo('authenticated.missions.mission');

--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -9,4 +9,5 @@ export default class Mission extends MissionSummary {
   @attr introductionMediaUrl;
   @attr introductionMediaType;
   @attr introductionMediaAlt;
+  @attr documentationUrl;
 }

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -43,8 +43,8 @@
           </div>
         </li>
         <li>
-          <span class="bold">Média d'introduction de la mission : </span>
-          <a href={{ this.model.mission.introductionMediaUrl }}>{{this.model.mission.introductionMediaUrl}}</a>
+          <span class="bold">URL du média d'introduction de la mission : </span>
+          <a href={{ this.model.mission.introductionMediaUrl }} target="_blank">{{this.model.mission.introductionMediaUrl}}</a>
         </li>
         <li>
           <span class="bold">Type de média d'introduction : </span>
@@ -53,6 +53,10 @@
         <li>
           <span class="bold">Texte alternatif au média d'introduction de la mission : </span>
           {{ this.model.mission.introductionMediaAlt }}
+        </li>
+        <li>
+          <span class="bold">URL de la documentation de la mission : </span>
+          <a href={{ this.model.mission.documentationUrl }} target="_blank">{{this.model.mission.documentationUrl}} </a>
         </li>
         <li><span class="bold">Crée le : </span>{{dayjs-format this.model.mission.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
       </ul>

--- a/pix-editor/tests/acceptance/missions/detail_test.js
+++ b/pix-editor/tests/acceptance/missions/detail_test.js
@@ -19,7 +19,7 @@ module('Acceptance | Missions | Detail', function(hooks) {
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
     this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D', areaIds: ['recArea1'] });
     this.server.create('mission-summary', { id: 1, name: 'Mission 1', competence: 'Mirage', createdAt: '2023/12/11', status: 'ACTIVE' });
-    this.server.create('mission', { id: 1, name: 'Mission 1', competenceId: 'pixIdRecCompetence1.1', createdAt: '2023/12/11', status: 'ACTIVE', learningObjectives: 'Tout savoir', validatedObjectives: 'Jusque là, rien' });
+    this.server.create('mission', { id: 1, name: 'Mission 1', competenceId: 'pixIdRecCompetence1.1', createdAt: '2023/12/11', status: 'ACTIVE', learningObjectives: 'Tout savoir', validatedObjectives: 'Jusque là, rien', documentationUrl: 'http://url-example.net' });
     this.server.create('mission-summary', { id: 2, name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
 
     return authenticateSession();
@@ -42,6 +42,7 @@ module('Acceptance | Missions | Detail', function(hooks) {
     assert.dom(screen.getByText('Notre compétence')).exists();
     assert.dom(screen.getByText('Tout savoir')).exists();
     assert.dom(screen.getByText('Jusque là, rien')).exists();
+    assert.dom(screen.getByRole('link',  { name: 'http://url-example.net' })).exists();
   });
 
   test('it redirects to missions list', async function(assert) {

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -69,7 +69,8 @@ module('Acceptance | Missions | Edit', function (hooks) {
       await clickByText('Compétence');
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Notre compétence' }));
-      await fillByLabel('URL d\'un média d\'introduction de la mission', 'http://example.com');
+      await fillByLabel('URL du média d\'introduction de la mission', 'http://example.com');
+      await fillByLabel('URL de la documentation de la mission', 'http://doc.com');
 
       await click(screen.getByRole('button', { name: 'Modifier la mission' }));
 
@@ -77,6 +78,7 @@ module('Acceptance | Missions | Edit', function (hooks) {
       assert.strictEqual(currentURL(), '/missions/3');
       assert.dom(screen.getByText('Nouvelle mission de test')).exists();
       assert.dom(screen.getByText('http://example.com')).exists();
+      assert.dom(screen.getByText('http://doc.com')).exists();
     });
 
     test('should display errors if any', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

On souhaite pouvoir ajouter une documentation pour que les profs puissent comprendre l'intérêt de la mission.

## :robot: Proposition

Ajouter un champ de saisi dans l'éditeur pour ajouter l'information de l'URL de documentation dans la mission.

## :rainbow: Remarques


## :100: Pour tester
- créer une nouvelle mission en renseignant le champ `URL d'un média d'introduction de la mission` et valider la création.
- Voir dan sla page de détail de la mission qu'on voit l'url renseignée.
- Modifier la mission en enlevant ou en changeant l'url, valider le changement et voir dans la page de détails que la modification a été prise en compte.

