### PR TITLE
[BUGFIX] Pouvoir passer une mission en validée même si elle contient des acquis périmés, archivés ou en construction (Pix-13942)

### DIFF
--- a/api/lib/application/missions/mission-controller.js
+++ b/api/lib/application/missions/mission-controller.js
@@ -24,8 +24,8 @@ export async function getMission(request, h) {
 export async function create(request, h) {
   const attributes = request?.payload?.data?.attributes;
   const mission = missionSerializer.deserializeMission(attributes);
-  const savedMission = await createMission(mission);
-  return h.response(missionSerializer.serializeMissionId(savedMission.id)).created();
+  const { mission: savedMission, warnings } = await createMission(mission);
+  return h.response(missionSerializer.serializeMission(savedMission, warnings)).created();
 }
 export async function update(request, h) {
   const attributes = request?.payload?.data?.attributes;

--- a/api/lib/application/missions/mission-controller.js
+++ b/api/lib/application/missions/mission-controller.js
@@ -31,8 +31,8 @@ export async function update(request, h) {
   const attributes = request?.payload?.data?.attributes;
   const missionId = request?.params?.id;
   const mission = missionSerializer.deserializeMission({ ...attributes, id: missionId });
-  const updatedMission = await updateMission(mission);
-  return h.response(missionSerializer.serializeMissionId(updatedMission.id)).created();
+  const { mission: updatedMission, warnings } = await updateMission(mission);
+  return h.response(missionSerializer.serializeMission(updatedMission, warnings)).created();
 }
 
 function normalizePage(page) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -30,6 +30,12 @@ export class MissionIntroductionMediaError extends DomainError {
   }
 }
 
+export class InvalidMissionContentError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 export class StaticCourseIsInactiveError extends DomainError {
   constructor(message = 'Opération impossible sur un test statique inactif.') {
     super(message);

--- a/api/lib/domain/services/mission-validator.js
+++ b/api/lib/domain/services/mission-validator.js
@@ -1,0 +1,50 @@
+import { Mission } from '../models/index.js';
+import _ from 'lodash';
+import { InvalidMissionContentError, MissionIntroductionMediaError } from '../errors.js';
+import * as challengeRepository from '../../infrastructure/repositories/challenge-repository.js';
+import * as thematicRepository from '../../infrastructure/repositories/thematic-repository.js';
+import * as skillRepository from '../../infrastructure/repositories/skill-repository.js';
+import * as tubeRepository from '../../infrastructure/repositories/tube-repository.js';
+
+export async function validate(mission, dependencies = { challengeRepository }) {
+  _validateMissionIntroductionMedia(mission);
+  return _validateMissionContent(mission, dependencies.challengeRepository);
+}
+
+function _validateMissionIntroductionMedia(mission) {
+  if (!_.isNull(mission.introductionMediaUrl) && _.isNull(mission.introductionMediaType)) {
+    throw new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.');
+  }
+
+  if (!_.isNull(mission.introductionMediaType) && _.isNull(mission.introductionMediaUrl)) {
+    throw new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.');
+  }
+}
+
+async function _validateMissionContent(mission) {
+  const warnings = [];
+  if (mission.status === Mission.status.VALIDATED) {
+    if (!mission.thematicIds) throw new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de thématique');
+
+    const thematics = await thematicRepository.getMany(mission.thematicIds.split(','));
+
+    const tubeIds = thematics.flatMap((thematic) => thematic.tubeIds);
+    if (tubeIds.length === 0)  throw new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de sujet');
+
+    for (const tubeId of tubeIds) {
+      const skills = await skillRepository.listByTubeId(tubeId);
+      const maxlevel = Math.max(...(skills.map((skill) => skill.level)));
+      for (let level = 1; level <= maxlevel; level++) {
+        const skillsByLevel = skills.filter((skill) => skill.level === level);
+        const activeSkillByLevel = skillsByLevel.filter((skill) => skill.isActif);
+
+        if (activeSkillByLevel.length === 0) {
+          const tube = await tubeRepository.get(tubeId);
+          if (skillsByLevel.filter((skill) => skill.isEnConstruction).length > 0) warnings.push(`L\'activité \'${tube.name}\' n\'a pas d\'acquis actif pour le niveau ${level}.`);
+        }
+      }
+    }
+  }
+  return warnings;
+}
+

--- a/api/lib/domain/usecases/create-mission.js
+++ b/api/lib/domain/usecases/create-mission.js
@@ -1,14 +1,8 @@
 import { missionRepository } from '../../infrastructure/repositories/index.js';
-import { MissionIntroductionMediaError } from '../errors.js';
-import _ from 'lodash';
+import * as missionValidator from '../services/mission-validator.js';
 
 export async function createMission(mission, dependencies = { missionRepository }) {
-  if (!_.isNull(mission.introductionMediaUrl) && _.isNull(mission.introductionMediaType)) {
-    throw new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.');
-  }
-  if (!_.isNull(mission.introductionMediaType) && _.isNull(mission.introductionMediaUrl)) {
-    throw new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.');
-  }
-
-  return await dependencies.missionRepository.save(mission);
+  const warnings = await missionValidator.validate(mission);
+  const createdMission = await dependencies.missionRepository.save(mission);
+  return { mission: createdMission, warnings };
 }

--- a/api/lib/domain/usecases/update-mission.js
+++ b/api/lib/domain/usecases/update-mission.js
@@ -1,26 +1,12 @@
-import { missionRepository, challengeRepository } from '../../infrastructure/repositories/index.js';
-import { Challenge, Mission } from '../models/index.js';
-import { BadRequestError } from '../../infrastructure/errors.js';
-import _ from 'lodash';
-import { MissionIntroductionMediaError } from '../errors.js';
+import { missionRepository } from '../../infrastructure/repositories/index.js';
+import  * as missionValidator from '../services/mission-validator.js';
 
 export async function updateMission(mission, dependencies = { missionRepository }) {
   await missionRepository.getById(mission.id);
 
-  if (mission.status === Mission.status.VALIDATED && mission.thematicIds) {
-    const challenges = await challengeRepository.filterByThematicIds(mission.thematicIds.split(','));
-    const nonValidatedChallengeIds = challenges.filter((challenge) => challenge.status !== Challenge.STATUSES.VALIDE).map((challenge) => `"${challenge.id}"`);
+  const warnings = await missionValidator.validate(mission);
 
-    if (nonValidatedChallengeIds.length > 0) {
-      throw new BadRequestError(`La mission ne peut pas être mise à jour car les challenges ${nonValidatedChallengeIds.join(', ')} ne sont pas au statut VALIDE`);
-    }
-  }
+  const updatedMission = await dependencies.missionRepository.save(mission);
 
-  if (!_.isNull(mission.introductionMediaUrl) && _.isNull(mission.introductionMediaType)) {
-    throw new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.');
-  }
-  if (!_.isNull(mission.introductionMediaType) && _.isNull(mission.introductionMediaUrl)) {
-    throw new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.');
-  }
-  return await dependencies.missionRepository.save(mission);
+  return { mission: updatedMission, warnings };
 }

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -10,6 +10,11 @@ export async function list() {
   return toDomainList(datasourceThematics, translations);
 }
 
+export async function getMany(thematicIds) {
+  const thematics = await list();
+  return thematics.filter((thematic) => thematicIds.includes(thematic.id));
+}
+
 function toDomainList(datasourceThematics, translations) {
   const translationsByThematicId = _.groupBy(translations, 'entityId');
   return _.orderBy(datasourceThematics.map(

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -17,14 +17,15 @@ export function serializeMissionSummary(mission, meta) {
     meta,
   }).serialize(mission);
 }
-export function serializeMission(mission) {
+export function serializeMission(mission, warnings) {
   return new Serializer('mission', {
     transform: (mission) => {
       return {
         ...mission,
         name: mission.name_i18n.fr,
         learningObjectives: mission.learningObjectives_i18n.fr,
-        validatedObjectives: mission.validatedObjectives_i18n.fr
+        validatedObjectives: mission.validatedObjectives_i18n.fr,
+        warnings,
       };
     },
     attributes: [
@@ -38,7 +39,8 @@ export function serializeMission(mission) {
       'introductionMediaAlt',
       'documentationUrl',
       'createdAt',
-      'status'
+      'status',
+      'warnings',
     ],
 
   }).serialize(mission);

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -46,10 +46,6 @@ export function serializeMission(mission, warnings) {
   }).serialize(mission);
 }
 
-export function serializeMissionId(id) {
-  return new Serializer('mission', {}).serialize({ id });
-}
-
 export function deserializeMission(attributes) {
   return new Mission({
     id: attributes.id,

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -45,7 +45,8 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
           'introduction-media-type': null,
           'introduction-media-alt': null,
           'documentation-url': null,
-          'created-at': new Date('2024-01-01')
+          'created-at': new Date('2024-01-01'),
+          'warnings': undefined,
         },
       },
     });

--- a/api/tests/acceptance/application/mission/post_mission_test.js
+++ b/api/tests/acceptance/application/mission/post_mission_test.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { afterEach, describe, describe as context, expect, it } from 'vitest';
 import {
   databaseBuilder,
@@ -19,7 +20,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
       // given
       const user = databaseBuilder.factory.buildAdminUser();
       await databaseBuilder.commit();
-  
+
       const payload = {
         data: {
           attributes: {
@@ -32,7 +33,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
           }
         },
       };
-  
+
       // when
       const server = await createServer();
       const response = await server.inject({
@@ -41,15 +42,28 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
         headers: generateAuthorizationHeader(user),
         payload,
       });
-  
+
       // then
       const { id: missionId } = await knex('missions').select('id').first();
-  
+
       expect(response.statusCode).to.equal(201);
-      expect(response.result).to.deep.equal({
+      expect(_.omit(response.result, 'data.attributes.created-at')).to.deep.equal({
         data: {
           type: 'missions',
           id: missionId.toString(),
+          'attributes': {
+            'competence-id': 'AZERTY',
+            'documentation-url': null,
+            'introduction-media-alt': null,
+            'introduction-media-type': null,
+            'introduction-media-url': null,
+            'learning-objectives': 'Autre chose',
+            'name': 'Mission impossible',
+            'status': 'INACTIVE',
+            'thematic-ids': null,
+            'validated-objectives': 'Très bien',
+            'warnings': [],
+          },
         },
       });
     });
@@ -60,7 +74,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
       // given
       const user = databaseBuilder.factory.buildReadonlyUser();
       await databaseBuilder.commit();
-  
+
       const payload = {
         data: {
           attributes: {
@@ -73,7 +87,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
           }
         },
       };
-  
+
       // when
       const server = await createServer();
       const response = await server.inject({
@@ -82,7 +96,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
         headers: generateAuthorizationHeader(user),
         payload,
       });
-  
+
       // then
       expect(response.statusCode).to.equal(403);
     });

--- a/api/tests/acceptance/application/mission/put_mission_test.js
+++ b/api/tests/acceptance/application/mission/put_mission_test.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { afterEach, describe, describe as context, expect, it } from 'vitest';
 import {
   databaseBuilder,
@@ -26,8 +27,8 @@ describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
           attributes: {
             name: 'Mission à mettre à jour',
             'competence-id': 'TYUI',
-            'thematic-id': null,
-            status: Mission.status.VALIDATED,
+            'thematic-ids': '',
+            status: Mission.status.EXPERIMENTAL,
             'learning-objectives': 'Une chose',
             'validated-objectives': null
           },
@@ -47,10 +48,23 @@ describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
       const { id: missionId } = await knex('missions').select('id').first();
 
       expect(response.statusCode).to.equal(201);
-      expect(response.result).to.deep.equal({
+      expect(_.omit(response.result, 'data.attributes.created-at')).to.deep.equal({
         data: {
           type: 'missions',
           id: missionId.toString(),
+          'attributes': {
+            'competence-id': 'TYUI',
+            'documentation-url': null,
+            'introduction-media-alt': null,
+            'introduction-media-type': null,
+            'introduction-media-url': null,
+            'learning-objectives': 'Une chose',
+            'name': 'Mission à mettre à jour',
+            'status': 'EXPERIMENTAL',
+            'thematic-ids': '',
+            'validated-objectives': null,
+            'warnings': [],
+          },
         },
       });
     });

--- a/api/tests/integration/domain/services/mission-validator_test.js
+++ b/api/tests/integration/domain/services/mission-validator_test.js
@@ -1,0 +1,394 @@
+import { describe, expect, it } from 'vitest';
+import { describe as context } from '@vitest/runner';
+import {  Mission, Skill } from '../../../../lib/domain/models/index.js';
+import * as missionValidator from '../../../../lib/domain/services/mission-validator.js';
+import { InvalidMissionContentError, MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
+import { airtableBuilder } from '../../../test-helper.js';
+
+describe('Integration | Validator | Mission', function() {
+  describe('status validation', function() {
+    describe('when requested mission status is not VALIDATED', function() {
+      it('should not reject mission with not validated challenges', async () => {
+        const mockedLearningContent = {
+          skills: [
+            airtableBuilder.factory.buildSkill({ id: 'skillTuto1', level: 1, tubeId: 'tubeTuto1' }),
+          ],
+          tubes: [
+            airtableBuilder.factory.buildTube({ id: 'tubeTuto1', name: '@Pix1D-recherche_di' }),
+          ],
+          thematics: [
+            airtableBuilder.factory.buildThematic({
+              id: 'Thematic',
+              tubeIds: ['tubeTuto1']
+            }),]
+        };
+        airtableBuilder.mockLists(mockedLearningContent);
+
+        // given
+        const mission = new Mission({
+          name_i18n: { fr: 'Updated mission' },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n: { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
+          documentationUrl: null,
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        const promise = missionValidator.validate(mission);
+
+        // then
+        await expect(promise).resolves.not.toThrow();
+      });
+    });
+
+    describe('when requested mission status is VALIDATED', function() {
+      context('When there is no thematic', function() {
+        it('throws InvalidMissionContentError', async () => {
+          const mockedLearningContent = {
+            tubes: [
+              airtableBuilder.factory.buildTube({ id: 'tubeFromOtherThematic' }),
+            ],
+            thematics: [
+              airtableBuilder.factory.buildThematic({
+                id: 'Thematic',
+                tubeIds: []
+              })]
+          };
+
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          // given
+          const mission = new Mission({
+            name_i18n: { fr: 'Updated mission' },
+            competenceId: 'QWERTY',
+            thematicIds: '',
+            learningObjectives_i18n: { fr: null },
+            validatedObjectives_i18n: { fr: 'Très bien' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2023-12-25')
+          });
+
+          // when
+          const promise = missionValidator.validate(mission);
+
+          // then
+          await expect(promise).rejects.to.deep.equal(new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de thématique'));
+        });
+      });
+
+      context('When there is no tubes', function() {
+        it('throws InvalidMissionContentError', async () => {
+          const mockedLearningContent = {
+            tubes: [
+              airtableBuilder.factory.buildTube({ id: 'tubeFromOtherThematic' }),
+            ],
+            thematics: [
+              airtableBuilder.factory.buildThematic({
+                id: 'Thematic',
+                tubeIds: []
+              })]
+          };
+
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          // given
+          const mission = new Mission({
+            name_i18n: { fr: 'Updated mission' },
+            competenceId: 'QWERTY',
+            thematicIds: 'Thematic',
+            learningObjectives_i18n: { fr: null },
+            validatedObjectives_i18n: { fr: 'Très bien' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2023-12-25')
+          });
+
+          // when
+          const promise = missionValidator.validate(mission);
+
+          // then
+          await expect(promise).rejects.to.deep.equal(new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de sujet'));
+        });
+      });
+
+      describe('Skill cases', () => {
+        context('when a skill has 2 versions including one with "ACTIF" status', function() {
+          it('should not return a warning', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ACTIF
+            });
+            const skill1Bis = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill1Bis],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal([]);
+          });
+        });
+        context('when a skill has versions with only "ARCHIVE" or "PERIME" statuses', function() {
+          it('should not return a warning', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ARCHIVE
+            });
+            const skill1Bis = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.PERIME
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill1Bis],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal([]);
+          });
+        });
+        context('when a skill has a "en construction" status version but no "actif" status version', function() {
+          it('should return a warning', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ACTIF
+            });
+            const skill1Bis = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+            const skill2 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto2',
+              level: 2,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill1Bis, skill2],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal(['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
+          });
+        });
+        context('when there is several skills with "en construction"', function() {
+          it('should return multiple warnings', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+            const skill2 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto2',
+              level: 2,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill2],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal(
+              [
+                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 1.',
+                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'
+              ]);
+          });
+        });
+      });
+    });
+  });
+
+  describe('introduction media validation', function() {
+    context('When the mission has a media url without a type', function() {
+      it('should return an error MissionIntroductionMediaError', async () => {
+        // given
+        const missionToSave = new Mission({
+          name_i18n: { fr: 'new mission' },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n: { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMediaType: null,
+          introductionMediaUrl: 'http://example.net',
+          introductionMediaAlt: null,
+          documentationUrl: null,
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        // when
+        const promise = missionValidator.validate(missionToSave);
+
+        // then
+        await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.'));
+
+      });
+    });
+    context('When the mission has a media type without an url', function() {
+      it('should return an error MissionIntroductionMediaError', async () => {
+        // given
+        const missionToSave = new Mission({
+          name_i18n: { fr: 'new mission' },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n: { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMediaType: 'image',
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          documentationUrl: null,
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        // when
+        const promise = missionValidator.validate(missionToSave);
+
+        // then
+        await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.'));
+
+      });
+    });
+  });
+});
+

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -1,58 +1,6 @@
-import { describe, describe as context, expect, it } from 'vitest';
-import { MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
-import { createMission } from '../../../../lib/domain/usecases/index.js';
-import { Mission } from '../../../../lib/domain/models/index.js';
+import { describe } from 'vitest';
 
 describe('Integration | Usecases | Create mission', function() {
-  context('When the mission has a media url without a type', function() {
-    it('should return an error MissionIntroductionMediaError', async () => {
-      // given
-      const missionToSave = new Mission({
-        name_i18n: { fr: 'new mission'  },
-        competenceId: 'QWERTY',
-        thematicIds: 'Thematic',
-        learningObjectives_i18n:  { fr: null },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        introductionMediaType: null,
-        introductionMediaUrl: 'http://example.net',
-        introductionMediaAlt: null,
-        documentationUrl: null,
-        status: Mission.status.INACTIVE,
-        createdAt: new Date('2023-12-25')
-      });
-
-      // when
-      const promise = createMission(missionToSave);
-
-      // then
-      await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.'));
-
-    });
-  });
-  context('When the mission has a media type without an url', function() {
-    it('should return an error MissionIntroductionMediaError', async () => {
-      // given
-      const missionToSave = new Mission({
-        name_i18n: { fr: 'new mission'  },
-        competenceId: 'QWERTY',
-        thematicIds: 'Thematic',
-        learningObjectives_i18n:  { fr: null },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        introductionMediaType: 'image',
-        introductionMediaUrl: null,
-        introductionMediaAlt: null,
-        documentationUrl: null,
-        status: Mission.status.INACTIVE,
-        createdAt: new Date('2023-12-25')
-      });
-
-      // when
-      const promise = createMission(missionToSave);
-
-      // then
-      await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.'));
-
-    });
-  });
+  //TODO transform into unit test
 });
 

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -1,6 +1,93 @@
-import { describe } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { InvalidMissionContentError } from '../../../../lib/domain/errors.js';
+import { createMission } from '../../../../lib/domain/usecases/index.js';
+import { airtableBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { Mission, Skill } from '../../../../lib/domain/models/index.js';
+import _ from 'lodash';
 
-describe('Integration | Usecases | Create mission', function() {
-  //TODO transform into unit test
+describe('Integration | Usecases | create mission', function() {
+  afterEach(async function() {
+    await knex('missions').delete();
+    await knex('translations').delete();
+  });
+
+  it('when mission is totally valid, should create mission without warnings', async () => {
+    // given
+    const mission = domainBuilder.buildMission({ status: Mission.status.EXPERIMENTAL });
+
+    // when
+    const result = await createMission(mission);
+
+    // then
+    expect(_.omit(result.mission, 'createdAt')).to.deep.equal(_.omit(mission, 'createdAt'));
+    expect(result.warnings).to.be.empty;
+  });
+
+  it('when mission is partially valid, should update mission with warnings', async () => {
+    const mockedLearningContent = {
+      skills: [
+        airtableBuilder.factory.buildSkill({
+          id: 'skillTuto2',
+          level: 2,
+          tubeId: 'tubeTuto',
+          status: Skill.STATUSES.EN_CONSTRUCTION
+        })],
+      tubes: [
+        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+      ],
+      thematics: [
+        airtableBuilder.factory.buildThematic({
+          id: 'Thematic',
+          tubeIds: ['tubeTuto']
+        }),
+      ],
+    };
+
+    airtableBuilder.mockLists(mockedLearningContent);
+
+    // given
+    const createdMission = domainBuilder.buildMission({ status: Mission.status.VALIDATED, thematicIds: 'Thematic' });
+
+    // when
+    const result = await createMission(createdMission);
+
+    // then
+    expect(result.warnings).to.deep.equal(['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
+  });
+
+  it('when mission is not valid, should throw an error', async () => {
+    const mockedLearningContent = {
+      skills: [
+        airtableBuilder.factory.buildSkill({
+          id: 'skillTuto2',
+          level: 2,
+          tubeId: 'tubeTuto',
+          status: Skill.STATUSES.EN_CONSTRUCTION
+        })],
+      tubes: [
+        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+      ],
+      thematics: [
+        airtableBuilder.factory.buildThematic({
+          id: 'Thematic',
+          tubeIds: ['tubeTuto']
+        }),
+      ],
+    };
+
+    airtableBuilder.mockLists(mockedLearningContent);
+
+    // given
+    const createdMission = domainBuilder.buildMission({
+      status: Mission.status.VALIDATED,
+      thematicIds: ''
+    });
+
+    // when
+    const promise = createMission(createdMission);
+
+    // then
+    await expect(promise).rejects.to.deep.equal(new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de thématique'));
+  });
 });
 

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -75,4 +75,57 @@ describe('Integration | Repository | thematic-repository', () => {
       airtableScope.done();
     });
   });
+
+  describe('#getMany', () => {
+    it('Should return correspond thematics', async () => {
+      const thematic1 = airtableBuilder.factory.buildThematic({
+        id: 'thematic1',
+        competenceId: 'competenceId1',
+        index: '1',
+        tubeIds: ['tubeId1', 'tubeId2'],
+      });
+
+      const thematic2 = airtableBuilder.factory.buildThematic({
+        id: 'thematic2',
+        competenceId: 'competenceId2',
+        index: '2',
+        tubeIds: ['tubeId3', 'tubeId4'],
+      });
+      const thematic3 = airtableBuilder.factory.buildThematic({
+        id: 'thematic3',
+        competenceId: 'competenceId3',
+        index: '3',
+        tubeIds: ['tubeId5', 'tubeId6'],
+      });
+
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Thematiques' }).returns([thematic1, thematic2, thematic3]).activate().nockScope;
+
+      const result = await thematicRepository.getMany([thematic2.id, thematic3.id]);
+
+      expect(result.map((thematic) => thematic.id)).toEqual([thematic2.id, thematic3.id]);
+      airtableScope.done();
+    });
+    it('Should return empty array when there is no correspond thematics', async () => {
+      const thematic1 = airtableBuilder.factory.buildThematic({
+        id: 'thematic1',
+        competenceId: 'competenceId1',
+        index: '1',
+        tubeIds: ['tubeId1', 'tubeId2'],
+      });
+
+      const thematic2 = airtableBuilder.factory.buildThematic({
+        id: 'thematic2',
+        competenceId: 'competenceId2',
+        index: '2',
+        tubeIds: ['tubeId3', 'tubeId4'],
+      });
+
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Thematiques' }).returns([thematic1, thematic2]).activate().nockScope;
+
+      const result = await thematicRepository.getMany(['thematic5']);
+
+      expect(result).toEqual([]);
+      airtableScope.done();
+    });
+  });
 });

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -213,18 +213,38 @@ describe('Unit | Controller | missions controller', function() {
       status: Mission.status.VALIDATED,
       'learning-objectives': 'apprendre à éviter les lasers',
       'validated-objectives': 'Très bien',
-      'thematic-id': null,
-      'documentation-url': 'http://url-example.net'
+      'thematic-ids': undefined,
+      'created-at': undefined,
+      'documentation-url': 'http://url-example.net',
+      'introduction-media-alt': null,
+      'introduction-media-type': null,
+      'introduction-media-url': null,
+
     };
 
     const missionId = 1;
     const request = { payload: { data: { attributes } }, params: { id: missionId } };
+    const deserializedMission = new Mission({
+      id: missionId,
+      name_i18n: { fr: 'Mission possible' },
+      competenceId: 'QWERTY',
+      thematicId: null,
+      learningObjectives_i18n: { fr: 'apprendre à éviter les lasers' },
+      validatedObjectives_i18n: { fr: 'Très bien' },
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt: null,
+      documentationUrl: 'http://url-example.net',
+      status: Mission.status.VALIDATED,
+    });
 
     beforeEach(function() {
       updateMissionMock = vi.spyOn(usecases, 'updateMission');
-      updateMissionMock.mockResolvedValue(new Mission({
-        id: missionId
-      }));
+
+      updateMissionMock.mockResolvedValue({
+        mission: deserializedMission,
+        warnings: ['Ca va pas du tout là !'],
+      });
     });
 
     it('should call the usecase with a domain object', async function() {
@@ -233,24 +253,11 @@ describe('Unit | Controller | missions controller', function() {
       // when
       await missionsController.update(request, hFake);
 
-      const deserializedMission = new Mission({
-        id: missionId,
-        name_i18n: { fr: 'Mission possible' },
-        competenceId: 'QWERTY',
-        thematicId: null,
-        learningObjectives_i18n: { fr: 'apprendre à éviter les lasers' },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        introductionMediaUrl: null,
-        introductionMediaType: null,
-        introductionMediaAlt: null,
-        documentationUrl: 'http://url-example.net',
-        status: Mission.status.VALIDATED,
-      });
       // then
       expect(updateMissionMock).toHaveBeenCalledWith(deserializedMission);
     });
 
-    it('should return the serialized mission id', async function() {
+    it('should return the serialized mission id and warnings', async function() {
       // when
       const result = await missionsController.update(request, hFake);
 
@@ -259,6 +266,10 @@ describe('Unit | Controller | missions controller', function() {
         {
           type: 'missions',
           id: '1',
+          attributes: {
+            ...attributes,
+            warnings: ['Ca va pas du tout là !'],
+          }
         }
       );
     });

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -152,21 +152,39 @@ describe('Unit | Controller | missions controller', function() {
   describe('createMission', function() {
     let createMissionMock;
     const attributes = {
-      name: 'Mission impossible',
+      name: 'Mission possible',
       'competence-id': 'AZERTY',
-      status: Mission.status.INACTIVE,
+      status: Mission.status.VALIDATED,
       'learning-objectives': null,
       'validated-objectives': 'Très bien',
-      'thematic-id': null
+      'thematic-ids': null,
+      'introduction-media-url': null,
+      'introduction-media-type': null,
+      'introduction-media-alt': null,
+      'documentation-url': 'http://url-example.net',
     };
 
     const request = { payload: { data: { attributes } } };
+    const deserializedMission = new Mission({
+      name_i18n: { fr: 'Mission possible' },
+      competenceId: 'AZERTY',
+      thematicIds: null,
+      learningObjectives_i18n: { fr: null },
+      validatedObjectives_i18n: { fr: 'Très bien' },
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt: null,
+      documentationUrl: 'http://url-example.net',
+      status: Mission.status.VALIDATED,
+    });
 
     beforeEach(function() {
       createMissionMock = vi.spyOn(usecases, 'createMission');
-      createMissionMock.mockResolvedValue(new Mission({
-        id: 1
-      }));
+
+      createMissionMock.mockResolvedValue({
+        mission: { ...deserializedMission, id: '1' },
+        warnings: ['Ca va pas du tout là !'],
+      });
     });
 
     it('should call the usecase with a domain object', async function() {
@@ -174,19 +192,6 @@ describe('Unit | Controller | missions controller', function() {
 
       // when
       await missionsController.create(request, hFake);
-
-      const deserializedMission = new Mission({
-        name_i18n: { fr: 'Mission impossible' },
-        competenceId: 'AZERTY',
-        thematicId: null,
-        learningObjectives_i18n: { fr: null },
-        validatedObjectives_i18n: { fr: 'Très bien' },
-        status: Mission.status.INACTIVE,
-        introductionMediaUrl: null,
-        introductionMediaType: null,
-        introductionMediaAlt: null,
-        documentationUrl: null,
-      });
       // then
       expect(createMissionMock).toHaveBeenCalledWith(deserializedMission);
     });
@@ -200,6 +205,12 @@ describe('Unit | Controller | missions controller', function() {
         {
           type: 'missions',
           id: '1',
+          attributes: {
+            ...attributes,
+            'created-at': undefined,
+            'thematic-ids': null,
+            warnings: ['Ca va pas du tout là !'],
+          }
         }
       );
     });

--- a/api/tests/unit/domain/services/mission-validator_test.js
+++ b/api/tests/unit/domain/services/mission-validator_test.js
@@ -1,0 +1,394 @@
+import { describe, expect, it } from 'vitest';
+import { describe as context } from '@vitest/runner';
+import {  Mission, Skill } from '../../../../lib/domain/models/index.js';
+import * as missionValidator from '../../../../lib/domain/services/mission-validator.js';
+import { InvalidMissionContentError, MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
+import { airtableBuilder } from '../../../test-helper.js';
+
+describe('Integration | Validator | Mission', function() {
+  describe('status validation', function() {
+    describe('when requested mission status is not VALIDATED', function() {
+      it('should not reject mission with not validated challenges', async () => {
+        const mockedLearningContent = {
+          skills: [
+            airtableBuilder.factory.buildSkill({ id: 'skillTuto1', level: 1, tubeId: 'tubeTuto1' }),
+          ],
+          tubes: [
+            airtableBuilder.factory.buildTube({ id: 'tubeTuto1', name: '@Pix1D-recherche_di' }),
+          ],
+          thematics: [
+            airtableBuilder.factory.buildThematic({
+              id: 'Thematic',
+              tubeIds: ['tubeTuto1']
+            }),]
+        };
+        airtableBuilder.mockLists(mockedLearningContent);
+
+        // given
+        const mission = new Mission({
+          name_i18n: { fr: 'Updated mission' },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n: { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMediaUrl: null,
+          introductionMediaType: null,
+          introductionMediaAlt: null,
+          documentationUrl: null,
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        const promise = missionValidator.validate(mission);
+
+        // then
+        await expect(promise).resolves.not.toThrow();
+      });
+    });
+
+    describe('when requested mission status is VALIDATED', function() {
+      context('When there is no thematic', function() {
+        it('throws InvalidMissionContentError', async () => {
+          const mockedLearningContent = {
+            tubes: [
+              airtableBuilder.factory.buildTube({ id: 'tubeFromOtherThematic' }),
+            ],
+            thematics: [
+              airtableBuilder.factory.buildThematic({
+                id: 'Thematic',
+                tubeIds: []
+              })]
+          };
+
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          // given
+          const mission = new Mission({
+            name_i18n: { fr: 'Updated mission' },
+            competenceId: 'QWERTY',
+            thematicIds: '',
+            learningObjectives_i18n: { fr: null },
+            validatedObjectives_i18n: { fr: 'Très bien' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2023-12-25')
+          });
+
+          // when
+          const promise = missionValidator.validate(mission);
+
+          // then
+          await expect(promise).rejects.to.deep.equal(new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de thématique'));
+        });
+      });
+
+      context('When there is no tubes', function() {
+        it('throws InvalidMissionContentError', async () => {
+          const mockedLearningContent = {
+            tubes: [
+              airtableBuilder.factory.buildTube({ id: 'tubeFromOtherThematic' }),
+            ],
+            thematics: [
+              airtableBuilder.factory.buildThematic({
+                id: 'Thematic',
+                tubeIds: []
+              })]
+          };
+
+          airtableBuilder.mockLists(mockedLearningContent);
+
+          // given
+          const mission = new Mission({
+            name_i18n: { fr: 'Updated mission' },
+            competenceId: 'QWERTY',
+            thematicIds: 'Thematic',
+            learningObjectives_i18n: { fr: null },
+            validatedObjectives_i18n: { fr: 'Très bien' },
+            status: Mission.status.VALIDATED,
+            createdAt: new Date('2023-12-25')
+          });
+
+          // when
+          const promise = missionValidator.validate(mission);
+
+          // then
+          await expect(promise).rejects.to.deep.equal(new InvalidMissionContentError('La mission ne peut pas être mise à jour car elle n\'a pas de sujet'));
+        });
+      });
+
+      describe('Skill cases', () => {
+        context('when a skill has 2 versions including one with "ACTIF" status', function() {
+          it('should not return a warning', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ACTIF
+            });
+            const skill1Bis = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill1Bis],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal([]);
+          });
+        });
+        context('when a skill has versions with only "ARCHIVE" or "PERIME" statuses', function() {
+          it('should not return a warning', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ARCHIVE
+            });
+            const skill1Bis = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.PERIME
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill1Bis],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal([]);
+          });
+        });
+        context('when a skill has a "en construction" status version but no "actif" status version', function() {
+          it('should return a warning', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ACTIF
+            });
+            const skill1Bis = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+            const skill2 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto2',
+              level: 2,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill1Bis, skill2],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal(['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
+          });
+        });
+        context('when there is several skills with "en construction"', function() {
+          it('should return multiple warnings', async () => {
+            const skill1 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+            const skill2 = airtableBuilder.factory.buildSkill({
+              id: 'skillTuto2',
+              level: 2,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION
+            });
+
+            const mockedLearningContent = {
+              skills: [skill1, skill2],
+              tubes: [
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+              ],
+              thematics: [
+                airtableBuilder.factory.buildThematic({
+                  id: 'Thematic1',
+                  tubeIds: ['tubeTuto']
+                }),
+              ],
+            };
+
+            airtableBuilder.mockLists(mockedLearningContent);
+
+            // given
+            const mission = new Mission({
+              name_i18n: { fr: 'Updated mission' },
+              competenceId: 'QWERTY',
+              thematicIds: 'Thematic1',
+              learningObjectives_i18n: { fr: null },
+              validatedObjectives_i18n: { fr: 'Très bien' },
+              introductionMediaUrl: null,
+              introductionMediaType: null,
+              introductionMediaAlt: null,
+              documentationUrl: null,
+              status: Mission.status.VALIDATED,
+              createdAt: new Date('2023-12-25')
+            });
+
+            // when
+            const warnings = await missionValidator.validate(mission);
+
+            // then
+            await expect(warnings).to.deep.equal(
+              [
+                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 1.',
+                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'
+              ]);
+          });
+        });
+      });
+    });
+  });
+
+  describe('introduction media validation', function() {
+    context('When the mission has a media url without a type', function() {
+      it('should return an error MissionIntroductionMediaError', async () => {
+        // given
+        const missionToSave = new Mission({
+          name_i18n: { fr: 'new mission' },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n: { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMediaType: null,
+          introductionMediaUrl: 'http://example.net',
+          introductionMediaAlt: null,
+          documentationUrl: null,
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        // when
+        const promise = missionValidator.validate(missionToSave);
+
+        // then
+        await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission n\'a pas de type pour le media d\'introduction.'));
+
+      });
+    });
+    context('When the mission has a media type without an url', function() {
+      it('should return an error MissionIntroductionMediaError', async () => {
+        // given
+        const missionToSave = new Mission({
+          name_i18n: { fr: 'new mission' },
+          competenceId: 'QWERTY',
+          thematicIds: 'Thematic',
+          learningObjectives_i18n: { fr: null },
+          validatedObjectives_i18n: { fr: 'Très bien' },
+          introductionMediaType: 'image',
+          introductionMediaUrl: null,
+          introductionMediaAlt: null,
+          documentationUrl: null,
+          status: Mission.status.INACTIVE,
+          createdAt: new Date('2023-12-25')
+        });
+
+        // when
+        const promise = missionValidator.validate(missionToSave);
+
+        // then
+        await expect(promise).rejects.to.deep.equal(new MissionIntroductionMediaError('Opération impossible car la mission ne peut avoir de type de média sans URL pour ce dernier.'));
+
+      });
+    });
+  });
+});
+

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -21,6 +21,9 @@ export default class MissionEditController extends Controller {
       this.model.mission.documentationUrl = formData.documentationUrl;
       await this.model.mission.save();
       this.notifications.success('Mission mise à jour avec succès.');
+      if (this.model.mission.hasWarnings()) {
+        this.notifications.warning(this.model.mission.warnings.join('<br>'), { clearDuration: 5000, htmlContent: true });
+      }
       this.router.transitionTo('authenticated.missions.mission');
     } catch (err) {
       this.model.mission.rollbackAttributes();

--- a/pix-editor/app/controllers/authenticated/missions/new.js
+++ b/pix-editor/app/controllers/authenticated/missions/new.js
@@ -11,6 +11,9 @@ export default class MissionController extends Controller {
     try {
       await this.model.mission.save({ adapterOptions: formData });
       this.notifications.success('Mission créé avec succès.');
+      if (this.model.mission.hasWarnings()) {
+        this.notifications.warning(this.model.mission.warnings.join('<br>'), { clearDuration: 5000, htmlContent: true });
+      }
       this.router.transitionTo('authenticated.missions.list');
     } catch {
       this.model.mission.deleteRecord();

--- a/pix-editor/app/controllers/authenticated/missions/new.js
+++ b/pix-editor/app/controllers/authenticated/missions/new.js
@@ -15,8 +15,12 @@ export default class MissionController extends Controller {
         this.notifications.warning(this.model.mission.warnings.join('<br>'), { clearDuration: 5000, htmlContent: true });
       }
       this.router.transitionTo('authenticated.missions.list');
-    } catch {
-      this.model.mission.deleteRecord();
+    } catch (err) {
+      if (err.errors?.[0]) {
+        await this.notifications.error(err.errors[0].detail);
+        return;
+      }
+
       await this.notifications.error('Une erreur est survenue lors de la création de la mission.');
     }
   }

--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -11,4 +11,9 @@ export default class Mission extends MissionSummary {
   @attr introductionMediaType;
   @attr introductionMediaAlt;
   @attr documentationUrl;
+  @attr warnings;
+
+  hasWarnings() {
+    return this.warnings?.length > 0;
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
La règle de vérification de l'état des épreuves avant passage de la mission à l'état Validée est incorrecte.

Elle contrôle que toutes les épreuves des thématiques de la missions sont validées, ce qui a pour conséquence qu’une mission ayant des épreuves archivées ne peut pas passer à l’état validée.

## :robot: Proposition
La règle de validation doit être plus fine et vérifier que pour chaque activité (sujet) et numéro d'épreuve (niveau): 
Il existe un unique acquis validé contenant au moins une épreuve validée.
Ou sinon, tous les acquis sont archivés
On ne bloque pas la création/mise à jour mais on renvoie des alertes pour les acquis 'problématiques'

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
En création et modification, enregistrer une mission: 

- à l'état expérimental, sans thématique : enregistrement ok
- à l'état validé, sans thématique : une erreur empêche l'enregistrement
- à l'état validé, avec des acquis non actifs : enregistrement ok mais warnings affiché
- à l'état validé, avec des acquis validés pour chaque activité/numéro  : enregistrement ok sans warnings.
