### PR TITLE
[FEATURE] Patcher le cache quand on clone un acquis (PIX-13780)

### DIFF
--- a/api/lib/application/skills/skills.js
+++ b/api/lib/application/skills/skills.js
@@ -7,6 +7,8 @@ import {
   tubeRepository,
   userRepository,
 } from '../../infrastructure/repositories/index.js';
+import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
+
 import { generateNewId } from '../../infrastructure/utils/id-generator.js';
 import { cloneSkill } from '../../domain/usecases/index.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
@@ -25,6 +27,7 @@ export async function clone(request, h) {
         attachmentRepository,
         generateNewIdFnc: generateNewId,
         pixApiClient,
+        updatedRecordNotifier,
       },
     });
   } catch (err) {

--- a/api/lib/application/skills/skills.js
+++ b/api/lib/application/skills/skills.js
@@ -9,6 +9,7 @@ import {
 } from '../../infrastructure/repositories/index.js';
 import { generateNewId } from '../../infrastructure/utils/id-generator.js';
 import { cloneSkill } from '../../domain/usecases/index.js';
+import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 
 export async function clone(request, h) {
   const userId = extractUserIdFromRequest(request);
@@ -23,6 +24,7 @@ export async function clone(request, h) {
         tubeRepository,
         attachmentRepository,
         generateNewIdFnc: generateNewId,
+        pixApiClient,
       },
     });
   } catch (err) {

--- a/api/lib/infrastructure/event-notifier/updated-record-notifier.js
+++ b/api/lib/infrastructure/event-notifier/updated-record-notifier.js
@@ -4,5 +4,5 @@ export async function notify({ pixApiClient, updatedRecord, model }) {
   if (pixApiClient.isPixApiCachePatchingEnabled()) {
     return pixApiClient.request({ payload: updatedRecord, url: `/api/cache/${model}/${updatedRecord.id}` });
   }
-  logger.info(`Refreshing cache with ${JSON.stringify(updatedRecord)} for model ${model}`);
+  logger.info(`Would refresh cache with ${JSON.stringify(updatedRecord)} for model ${model}`);
 }


### PR DESCRIPTION
## :unicorn: Problème
Le endpoint de clonage d’acquis ne patch pas le cache de l’environnement de prévisualisation.

## :robot: Proposition
Patcher l’environnement de prévisualisation pour l’acquis et les challenges clonés.

## :rainbow: Remarques
N/A

## :100: Pour tester
On a fait un cUrl et on a réussi à prévisualiser ce qui avait été cloné.