### PR TITLE
[BUGFIX] Permettre la recherche avec un guillemet simple (PIX-14047)

### DIFF
--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -67,3 +67,7 @@ export async function deleteRecords(tableName, recordIds) {
   logger.info({ tableName }, 'Deleting records in Airtable');
   return _airtableClient().table(tableName).destroy(recordIds);
 }
+
+export function stringValue(value) {
+  return value;
+}

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -69,5 +69,10 @@ export async function deleteRecords(tableName, recordIds) {
 }
 
 export function stringValue(value) {
-  return value;
+  return `"${
+    value.replace(/\r/g, '')
+      .replace(/["\\]/g, '\\$&')
+      .replace(/\n/g, '\\n')
+      .replace(/\t/g, '\\t')
+  }"`;
 }

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,5 +1,5 @@
 import { datasource } from './datasource.js';
-import { findRecords } from '../../airtable.js';
+import { findRecords, stringValue } from '../../airtable.js';
 import { convertLanguagesToLocales, convertLocalesToLanguages } from '../../../domain/services/convert-locales.js';
 
 // Cet import m'embête un peu qu'en pensez-vous ?
@@ -161,10 +161,10 @@ export const challengeDatasource = datasource.extend({
   async search(params) {
     const options = {
       fields: this.usedFields,
-      filterByFormula: `FIND('${_escapeQuery(params.filter.search)}', LOWER(CONCATENATE({Embed URL})))`
+      filterByFormula: `FIND(${stringValue(params.filter.search)}, LOWER(CONCATENATE({Embed URL})))`
     };
     if (params.filter.ids && params.filter.ids.length > 0) {
-      options.filterByFormula = 'OR(' + options.filterByFormula + ', ' + params.filter.ids.map((id) => `'${id}' = {id persistant}`).join(',') + ')';
+      options.filterByFormula = 'OR(' + options.filterByFormula + ', ' + params.filter.ids.map((id) => `${stringValue(id)} = {id persistant}`).join(',') + ')';
     }
     if (params.page && params.page.size) {
       options.maxRecords = params.page.size;

--- a/api/lib/infrastructure/datasources/airtable/datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/datasource.js
@@ -17,7 +17,7 @@ const _DatasourcePrototype = {
 
   async filter({ filter: { ids, formula } }) {
     const filterByFormula = ids ? (
-      'OR(' + ids.map((id) => `'${id}' = {id persistant}`).join(',') + ')'
+      'OR(' + ids.map((id) => `${airtable.stringValue(id)} = {id persistant}`).join(',') + ')'
     ) : formula;
     const airtableRawObjects = await airtable.findRecords(
       this.tableName,

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -250,7 +250,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           fields: {
             '': challengeAirtableFields,
           },
-          filterByFormula: 'OR(\'1\' = {id persistant},\'2\' = {id persistant})'
+          filterByFormula: 'OR("1" = {id persistant},"2" = {id persistant})'
         })
         .reply(200, {
           records: [
@@ -527,7 +527,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
             '': challengeAirtableFields,
           },
           maxRecords: 100,
-          filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))',
+          filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
         })
         .reply(200, {
           records: []
@@ -554,7 +554,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           fields: {
             '': challengeAirtableFields,
           },
-          filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))',
+          filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
           maxRecords: 20,
         })
         .reply(200, {
@@ -600,7 +600,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           fields: {
             '': challengeAirtableFields,
           },
-          filterByFormula: 'OR(\'recChallengeId1\' = {id persistant})'
+          filterByFormula: 'OR("recChallengeId1" = {id persistant})'
         })
         .reply(200, {
           records: [
@@ -758,7 +758,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           fields: {
             '': challengeAirtableFields,
           },
-          filterByFormula: 'OR(\'recChallengeId2\' = {id persistant})'
+          filterByFormula: 'OR("recChallengeId2" = {id persistant})'
         })
         .reply(200, {
           records: []

--- a/api/tests/unit/infrastructure/airtable_test.js
+++ b/api/tests/unit/infrastructure/airtable_test.js
@@ -3,7 +3,7 @@ import * as airtable from '../../../lib/infrastructure/airtable.js';
 
 describe('Unit | Infrastructure | Airtable', () => {
   describe('#stringValue', () => {
-    it.fails('should prepare a string value for airtable formula', async () => {
+    it('should prepare a string value for airtable formula', async () => {
       // given
       const rawStrings = [
         'coucou',

--- a/api/tests/unit/infrastructure/airtable_test.js
+++ b/api/tests/unit/infrastructure/airtable_test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import * as airtable from '../../../lib/infrastructure/airtable.js';
+
+describe('Unit | Infrastructure | Airtable', () => {
+  describe('#stringValue', () => {
+    it.fails('should prepare a string value for airtable formula', async () => {
+      // given
+      const rawStrings = [
+        'coucou',
+        '\\\'"\n\r\t coucou \\\'"\n\r\t',
+      ];
+
+      // when
+      const airtableStringValues = rawStrings.map((rawString) => airtable.stringValue(rawString));
+
+      // then
+      expect(airtableStringValues).toStrictEqual([
+        '"coucou"',
+        '"\\\\\'\\"\\n\\t coucou \\\\\'\\"\\n\\t"',
+      ]);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -241,7 +241,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
-        filterByFormula: 'FIND(\'query term\', LOWER(CONCATENATE({Embed URL})))'
+        filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))'
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');
@@ -266,23 +266,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
-        filterByFormula: 'OR(FIND(\'query term\', LOWER(CONCATENATE({Embed URL}))), \'challengeId1\' = {id persistant})'
+        filterByFormula: 'OR(FIND("query term", LOWER(CONCATENATE({Embed URL}))), "challengeId1" = {id persistant})'
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');
-    });
-
-    it('should escape the query', async () => {
-      vi.spyOn(airtable, 'findRecords')
-        .mockResolvedValue([]);
-
-      challengeDatasource.usedFields = Symbol('used fields');
-      await challengeDatasource.search({ filter: { search: 'query \' term' } });
-
-      expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
-        fields: challengeDatasource.usedFields,
-        filterByFormula: 'FIND(\'query \\\' term\', LOWER(CONCATENATE({Embed URL})))'
-      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/datasources/airtable/datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/datasource_test.js
@@ -73,7 +73,27 @@ describe('Unit | Infrastructure | Datasource | Airtable | datasource', () => {
         'Airtable_table',
         {
           fields: ['Shi', 'Foo', 'Me'],
-          filterByFormula: 'OR(\'1\' = {id persistant},\'2\' = {id persistant})',
+          filterByFormula: 'OR("1" = {id persistant},"2" = {id persistant})',
+        }
+      );
+    });
+
+    it('should escape the query', async () => {
+      // given
+      vi.spyOn(airtable, 'findRecords').mockImplementation(async (tableName, options) => {
+        const returnValue = [{ id: 1, tableName, ...options }];
+        return returnValue;
+      });
+
+      // when
+      await someDatasource.filter({ filter: { ids: ['1\'', '2\''] } });
+
+      // then
+      expect(airtable.findRecords).toHaveBeenCalledWith(
+        'Airtable_table',
+        {
+          fields: ['Shi', 'Foo', 'Me'],
+          filterByFormula: 'OR("1\'" = {id persistant},"2\'" = {id persistant})',
         }
       );
     });

--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -10,9 +10,18 @@ export default class SidebarSearchComponent extends Component {
   @service store;
   @service router;
 
+  #stringValue(value) {
+    return `"${
+      value.replace(/\r/g, '')
+        .replace(/["\\]/g, '\\$&')
+        .replace(/\n/g, '\\n')
+        .replace(/\t/g, '\\t')
+    }"`;
+  }
+
   async searchSkillsByName(skillName) {
     const skills = await this.store.query('skill', {
-      filterByFormula: `FIND('${skillName.toLowerCase()}', LOWER(Nom))`,
+      filterByFormula: `FIND(${this.#stringValue(skillName.toLowerCase())}, LOWER(Nom))`,
       maxRecords: 20,
       sort: [{ field: 'Nom', direction: 'asc' }],
     });

--- a/pix-editor/tests/unit/component/sidebar/search-test.js
+++ b/pix-editor/tests/unit/component/sidebar/search-test.js
@@ -1,0 +1,33 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | sidebar/search', function(hooks) {
+  setupTest(hooks);
+  let component;
+
+  hooks.beforeEach(function() {
+    component = createGlimmerComponent('component:sidebar/search');
+  });
+
+  module('#searchSkillsByName', function() {
+    test('it should escape skill name', function(assert) {
+    // given
+      const queryStub = sinon.stub().resolves([]);
+
+      component.store = { query: queryStub };
+
+      // when
+      component.searchSkillsByName('\\\'"\t coucou \\\'"\t');
+
+      // then
+      assert.ok(queryStub.calledWith('skill', {
+        filterByFormula: 'FIND("\\\\\'\\"\\t coucou \\\\\'\\"\\t", LOWER(Nom))',
+        maxRecords: 20,
+        sort: [{ field: 'Nom', direction: 'asc' }],
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les recherches contenant des guillemets simples `'` causent des erreurs 500 ou 422 en fonction du type de la recherche (challenge ou skill). Ce guillemet n'est pas échappé dans la requête à Airtable.

## :robot: Proposition
Échapper les paramètres des formules sur les requêtes à Airtable.

## :rainbow: Remarques
On duplique la fonction `stringValue()` pour les acquis (skills) côté front, et les challenges côté back.

## :100: Pour tester
- Faire une recherche contenant des guillemets simples ou doubles dans la sidebar de Pix Editor (exemples: `@acq'is`, `rec"herche`, `te" 'st`).
- Constater que le serveur ne renvoie pas d'erreur, et simplement une liste vide.
