### PR TITLE
[BUGFIX] Crash de l’appli lorsqu’on rafraîchit sur détail acquis/épreuve (PIX-14085)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -28,7 +28,6 @@ export default class SingleController extends Controller {
   @service currentData;
   @service filePath;
   @service intl;
-  defaultSaveChangelog = this.intl.t('prototype.changelog.update-message');
   @service loader;
   @service notify;
   @service router;
@@ -119,6 +118,10 @@ export default class SingleController extends Controller {
 
   get localizedChallengeLinkRoute() {
     return this.challenge.get('isPrototype') ? 'authenticated.competence.prototypes.localized' : 'authenticated.competence.prototypes.single.alternatives.localized';
+  }
+
+  get defaultSaveChangelog() {
+    return this.intl.t('prototype.changelog.update-message');
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -8,7 +8,6 @@ export default class SingleController extends Controller {
 
   wasMaximized = false;
   changelogCallback = null;
-  defaultSaveChangelog = this.intl.t('skill.changelog.update-message');
 
   @tracked edition = false;
   @tracked displaySelectLocation = false;
@@ -69,6 +68,10 @@ export default class SingleController extends Controller {
 
   get airtableUrl() {
     return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableSkills}/${this.skill.id}`;
+  }
+
+  get defaultSaveChangelog() {
+    return this.intl.t('skill.changelog.update-message');
   }
 
   @action


### PR DESCRIPTION
## :unicorn: Problème
Impossible de rafraîchir la page quand on est sur détail Acquis ou Épreuve.

Il y a un appel à ember-intl qui est fait trop tôt.

## :robot: Proposition
Rendre l’appel à ember-intl lazy.

## :rainbow: Remarques
N/A

## :100: Pour tester
Aller sur le détail d’un acquis et rafraîchir la page.
Aller sur le détail d’une épreuve et rafraîchir la page.
Vérifier également que le message de changelog par défaut fonctionne toujours.