### PR TITLE
[FEATURE] Ajout des titres de thématique en tant que nom d'étapes dans les missions releasées (PIX-13849)

### DIFF
--- a/api/lib/domain/models/release/MissionForRelease.js
+++ b/api/lib/domain/models/release/MissionForRelease.js
@@ -38,10 +38,12 @@ class Content {
 
 class Step {
   constructor({
+    name_i18n,
     tutorialChallenges = [],
     trainingChallenges = [],
     validationChallenges = [],
   } = {}) {
+    this.name_i18n = name_i18n;
     this.tutorialChallenges = tutorialChallenges;
     this.trainingChallenges = trainingChallenges;
     this.validationChallenges = validationChallenges;

--- a/api/lib/infrastructure/transformers/mission-transformer.js
+++ b/api/lib/infrastructure/transformers/mission-transformer.js
@@ -25,6 +25,7 @@ export function transform({ missions, challenges, tubes, thematics, skills }) {
 
       if (index < thematicIds.length - 1) {
         content.steps.push({
+          name_i18n: thematic.name_i18n,
           tutorialChallenges: _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_di'),
           trainingChallenges: _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_en'),
           validationChallenges: _getChallengeIdsForActivity(mission.status, missionTubes, skills, challenges, '_va'),

--- a/api/tests/unit/infrastructure/transformers/mission-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/mission-transformer_test.js
@@ -66,10 +66,16 @@ describe('Unit | Transformer | mission-transformer', function() {
       thematics = [
         domainBuilder.buildThematic({
           id: 'thematicStep1',
+          name_i18n: {
+            fr: 'Thématique du step 1',
+          },
           tubeIds: ['tubeTuto1', 'tubeTraining1', 'tubeValidation1']
         }),
         domainBuilder.buildThematic({
           id: 'thematicStep2',
+          name_i18n: {
+            fr: 'Thématique du step 2',
+          },
           tubeIds: ['tubeTuto2', 'tubeTraining2', 'tubeValidation2']
         }),
         domainBuilder.buildThematic({
@@ -89,24 +95,24 @@ describe('Unit | Transformer | mission-transformer', function() {
         it('should return proposal and active challenges only', function() {
           challenges = [
             domainBuilder.buildChallenge({
-              id: 'challengeValidationValidé',
+              id: 'challengeValidationValidéStep1',
               status: Challenge.STATUSES.VALIDE,
               skillId: 'skillValidation1'
             }),
             domainBuilder.buildChallenge({
-              id: 'challengeValidationProposé',
-              status: Challenge.STATUSES.PROPOSE,
-              skillId: 'skillValidation1'
-            }),
-            domainBuilder.buildChallenge({
-              id: 'challengeValidationPérimé',
+              id: 'challengeValidationPériméStep1',
               status: Challenge.STATUSES.PERIME,
               skillId: 'skillValidation1'
             }),
             domainBuilder.buildChallenge({
-              id: 'challengeValidationArchivé',
+              id: 'challengeValidationProposéStep2',
+              status: Challenge.STATUSES.PROPOSE,
+              skillId: 'skillValidation2'
+            }),
+            domainBuilder.buildChallenge({
+              id: 'challengeValidationArchivéStep2',
               status: Challenge.STATUSES.ARCHIVE,
-              skillId: 'skillValidation1'
+              skillId: 'skillValidation2'
             }),
           ];
 
@@ -116,7 +122,7 @@ describe('Unit | Transformer | mission-transformer', function() {
             status: Mission.status.EXPERIMENTAL,
             learningObjectives: 'Alt objectives',
             validatedObjectives: 'Alt validated objectives',
-            thematicIds: 'thematicStep1,thematicDefiVide',
+            thematicIds: 'thematicStep1,thematicStep2,thematicDefiVide',
             competenceId: 'competenceId',
             createdAt: new Date('2010-01-04'),
           })];
@@ -127,7 +133,7 @@ describe('Unit | Transformer | mission-transformer', function() {
             id: 2,
             name_i18n: { fr: 'Alt name' },
             competenceId: 'competenceId',
-            thematicIds: 'thematicStep1,thematicDefiVide',
+            thematicIds: 'thematicStep1,thematicStep2,thematicDefiVide',
             learningObjectives_i18n: { fr: 'Alt objectives' },
             validatedObjectives_i18n: { fr: 'Alt validated objectives' },
             introductionMediaUrl: null,
@@ -138,10 +144,19 @@ describe('Unit | Transformer | mission-transformer', function() {
             createdAt: new Date('2010-01-04'),
             content: {
               steps: [{
+                name_i18n: { fr: 'Thématique du step 1' },
                 tutorialChallenges: [],
                 trainingChallenges: [],
                 validationChallenges: [
-                  ['challengeValidationValidé', 'challengeValidationProposé'],
+                  ['challengeValidationValidéStep1'],
+                ],
+              },
+              {
+                name_i18n: { fr: 'Thématique du step 2' },
+                tutorialChallenges: [],
+                trainingChallenges: [],
+                validationChallenges: [
+                  ['challengeValidationProposéStep2'],
                 ],
               }],
               dareChallenges: [],
@@ -203,6 +218,7 @@ describe('Unit | Transformer | mission-transformer', function() {
             createdAt: new Date('2010-01-04'),
             content: {
               steps: [{
+                name_i18n: { fr: 'Thématique du step 1' },
                 tutorialChallenges: [],
                 trainingChallenges: [],
                 validationChallenges: [
@@ -213,7 +229,6 @@ describe('Unit | Transformer | mission-transformer', function() {
             },
           }]);
         });
-
       });
     });
 
@@ -302,6 +317,7 @@ describe('Unit | Transformer | mission-transformer', function() {
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
+              name_i18n: { fr: 'Thématique du step 1' },
               tutorialChallenges: [],
               trainingChallenges: [],
               validationChallenges: [
@@ -374,6 +390,7 @@ describe('Unit | Transformer | mission-transformer', function() {
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
+              name_i18n: { fr: 'Thématique du step 1' },
               tutorialChallenges: [],
               trainingChallenges: [],
               validationChallenges: [
@@ -451,6 +468,7 @@ describe('Unit | Transformer | mission-transformer', function() {
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
+              name_i18n: { fr: 'Thématique du step 1' },
               tutorialChallenges: [],
               trainingChallenges: [],
               validationChallenges: [
@@ -495,6 +513,7 @@ describe('Unit | Transformer | mission-transformer', function() {
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
+              name_i18n: { fr: 'Thématique du step 1' },
               trainingChallenges: [],
               validationChallenges: [],
               tutorialChallenges: [],
@@ -538,6 +557,7 @@ describe('Unit | Transformer | mission-transformer', function() {
           createdAt: new Date('2010-01-04'),
           content: {
             steps: [{
+              name_i18n: { fr: 'Thématique du step 1' },
               trainingChallenges: [],
               validationChallenges: [],
               tutorialChallenges: [],


### PR DESCRIPTION
## :unicorn: Problème
Les étapes de missions n'ont pas de nom, ce qui ne permet pas de détailler les résultats obtenus par les élèves.

## :robot: Proposition
Ajouter dans les missions de la release des noms aux étapes, les titres des thématiques correspondantes.

## :100: Pour tester
Créer une release et vérifier la présence d'un nom correspondant au titre de la thématique de l'étape, pour chaque étapes de chaque mission.