### PR TITLE
[TECH] Exposer `airtableId` dans nos models (PIX-14272)

### DIFF
--- a/api/lib/domain/models/Competence.js
+++ b/api/lib/domain/models/Competence.js
@@ -1,6 +1,7 @@
 export class Competence {
   constructor({
     id,
+    airtableId,
     index,
     origin,
     areaId,
@@ -10,6 +11,7 @@ export class Competence {
     description_i18n,
   }) {
     this.id = id;
+    this.airtableId = airtableId;
     this.index = index;
     this.origin = origin;
     this.areaId = areaId;

--- a/api/lib/domain/models/Thematic.js
+++ b/api/lib/domain/models/Thematic.js
@@ -3,12 +3,14 @@ export class Thematic {
     id,
     name_i18n,
     index,
+    airtableId,
     competenceId,
     tubeIds,
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
     this.index = index;
+    this.airtableId = airtableId;
     this.competenceId = competenceId;
     this.tubeIds = tubeIds;
   }

--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -1,12 +1,14 @@
 export class Tube {
   constructor({
     id,
+    airtableId,
     name,
     practicalTitle_i18n,
     practicalDescription_i18n,
     competenceId,
   }) {
     this.id = id;
+    this.airtableId = airtableId;
     this.name = name;
     this.practicalTitle_i18n = practicalTitle_i18n;
     this.practicalDescription_i18n = practicalDescription_i18n;

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -8,6 +8,7 @@ import {
   thematicRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
+import { thematicTransformer } from '../../infrastructure/transformers/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 export async function getLearningContentForReplication() {
@@ -45,6 +46,7 @@ export async function getLearningContentForReplication() {
     challengeId: attachment.localizedChallengeId,
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
+  const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
 
   return {
     areas,
@@ -54,7 +56,7 @@ export async function getLearningContentForReplication() {
     challenges: translatedChallenges,
     tutorials,
     attachments: translatedAttachments,
-    thematics,
+    thematics: transformedThematics,
     courses
   };
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -8,7 +8,7 @@ import {
   thematicRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
-import { thematicTransformer } from '../../infrastructure/transformers/index.js';
+import { competenceTransformer, thematicTransformer } from '../../infrastructure/transformers/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 export async function getLearningContentForReplication() {
@@ -46,11 +46,12 @@ export async function getLearningContentForReplication() {
     challengeId: attachment.localizedChallengeId,
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
+  const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
 
   return {
     areas,
-    competences,
+    competences: transformedCompetences,
     tubes,
     skills,
     challenges: translatedChallenges,

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -8,7 +8,7 @@ import {
   thematicRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
-import { competenceTransformer, thematicTransformer } from '../../infrastructure/transformers/index.js';
+import { competenceTransformer, thematicTransformer, tubeTransformer } from '../../infrastructure/transformers/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 export async function getLearningContentForReplication() {
@@ -48,11 +48,12 @@ export async function getLearningContentForReplication() {
   }));
   const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
+  const transformedTubes = tubes.map(tubeTransformer.filterTubeFields);
 
   return {
     areas,
     competences: transformedCompetences,
-    tubes,
+    tubes: transformedTubes,
     skills,
     challenges: translatedChallenges,
     tutorials,

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -18,6 +18,7 @@ export const competenceDatasource = datasource.extend({
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.get('id persistant'),
+      airtableId: airtableRecord.id,
       index: airtableRecord.get('Sous-domaine'),
       areaId: airtableRecord.get('Domaine (id persistant)') ? airtableRecord.get('Domaine (id persistant)')[0] : '',
       skillIds: airtableRecord.get('Acquis (via Tubes) (id persistant)') || [],

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -18,6 +18,7 @@ export const thematicDatasource = datasource.extend({
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.get('id persistant'),
+      airtableId: airtableRecord.id,
       competenceId: airtableRecord.get('Competence (id persistant)')[0],
       tubeIds: airtableRecord.get('Tubes (id persistant)'),
       index: airtableRecord.get('Index'),

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -18,6 +18,7 @@ export const tubeDatasource = datasource.extend({
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.get('id persistant'),
+      airtableId: airtableRecord.id,
       name: airtableRecord.get('Nom'),
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -27,7 +27,6 @@ import * as tablesTranslations from '../translations/index.js';
 import { Content, Release } from '../../domain/models/release/index.js';
 
 import { knex } from '../../../db/knex-database-connection.js';
-import { filterThematicsFields } from '../transformers/thematic-transformer.js';
 
 export function getCurrentContent() {
   return _getCurrentContent();

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -19,6 +19,7 @@ import {
   competenceTransformer,
   skillTransformer,
   tubeTransformer,
+  thematicTransformer,
   tutorialTransformer,
   missionTransformer
 } from '../transformers/index.js';
@@ -26,6 +27,7 @@ import * as tablesTranslations from '../translations/index.js';
 import { Content, Release } from '../../domain/models/release/index.js';
 
 import { knex } from '../../../db/knex-database-connection.js';
+import { filterThematicsFields } from '../transformers/thematic-transformer.js';
 
 export function getCurrentContent() {
   return _getCurrentContent();
@@ -126,6 +128,8 @@ async function _getCurrentContent() {
   const transformChallenge = createChallengeTransformer({ attachments });
   const transformedChallenges = translatedChallenges.map(transformChallenge);
   const transformedTubes = tubeTransformer.transform({ tubes, skills, challenges: transformedChallenges, thematics });
+  const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
+
   const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);
   const filteredSkills = skillTransformer.filterSkillsFields(skills);
   const filteredTutorials = tutorialTransformer.filterTutorialsFields(tutorials);
@@ -135,7 +139,7 @@ async function _getCurrentContent() {
     frameworks,
     areas,
     competences: filteredCompetences,
-    thematics,
+    thematics: transformedThematics,
     tubes: transformedTubes,
     skills: filteredSkills,
     challenges: transformedChallenges,

--- a/api/lib/infrastructure/transformers/index.js
+++ b/api/lib/infrastructure/transformers/index.js
@@ -2,5 +2,6 @@ export * from './challenge-transformer.js';
 export * as competenceTransformer from './competence-transformer.js';
 export * as skillTransformer from './skill-transformer.js';
 export * as tubeTransformer from './tube-transformer.js';
+export * as thematicTransformer from './thematic-transformer.js';
 export * as tutorialTransformer from './tutorial-transformer.js';
 export * as missionTransformer from './mission-transformer.js';

--- a/api/lib/infrastructure/transformers/thematic-transformer.js
+++ b/api/lib/infrastructure/transformers/thematic-transformer.js
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+
+export function filterThematicsFields(thematics) {
+  const fieldsToInclude = [
+    'id',
+    'name_i18n',
+    'index',
+    'competenceId',
+    'tubeIds',
+  ];
+
+  return thematics.map((thematic) => _.pick(thematic, fieldsToInclude));
+}

--- a/api/lib/infrastructure/transformers/tube-transformer.js
+++ b/api/lib/infrastructure/transformers/tube-transformer.js
@@ -1,16 +1,30 @@
 import { ChallengeForRelease } from '../../domain/models/release/index.js';
+import _ from 'lodash';
 
 export function transform({ tubes, skills, challenges, thematics }) {
-  tubes.forEach((tube) => {
-    _addLinks({ tube, skills, thematics });
-    _addDeviceCompliance({ tube, skills, challenges });
-  });
-  return tubes;
+  return tubes.map(filterTubeFields)
+    .map((tube) => _addLinks({ tube, skills, thematics }))
+    .map((tube) => _addDeviceCompliance({ tube, skills, challenges }));
 }
 
 function _addLinks({ tube, skills, thematics }) {
-  tube.thematicId = _findThematicId(tube.id, thematics);
-  tube.skillIds = _findSkillIds(tube.id, skills);
+  return {
+    ...tube,
+    thematicId: _findThematicId(tube.id, thematics),
+    skillIds: _findSkillIds(tube.id, skills),
+  };
+}
+
+export function filterTubeFields(tube) {
+  const fieldsToInclude = [
+    'id',
+    'name',
+    'practicalTitle_i18n',
+    'practicalDescription_i18n',
+    'competenceId',
+  ];
+
+  return _.pick(tube, fieldsToInclude);
 }
 
 function _findThematicId(tubeId, thematics) {
@@ -24,8 +38,11 @@ function _findSkillIds(tubeId, skills) {
 
 function _addDeviceCompliance({ tube, skills, challenges }) {
   const tubeChallenges = _filterValidatedPrototypeTubeChallenges(skills, challenges, tube.id);
-  tube.isMobileCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeSmartphoneCompliant);
-  tube.isTabletCompliant = tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeTabletCompliant);
+  return {
+    ...tube,
+    isMobileCompliant: tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeSmartphoneCompliant),
+    isTabletCompliant: tubeChallenges?.length > 0 && tubeChallenges.every(_isChallengeTabletCompliant),
+  };
 }
 
 function _filterValidatedPrototypeTubeChallenges(skills, challenges, tubeId) {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -79,6 +79,20 @@ async function mockCurrentContent() {
 
   const expectedChallengeNl = { ...challengeNl, illustrationAlt: 'alt_nl', geography: 'Neutre', area: 'Neutre' };
   delete expectedChallengeNl.localizedChallenges;
+
+  const expectedCompetence = domainBuilder.buildCompetence({
+    name_i18n: {
+      fr: 'Français',
+      en: 'English',
+    },
+    description_i18n: {
+      fr: 'Description française',
+      en: 'Description anglaise',
+    }
+  });
+
+  delete expectedCompetence.airtableId;
+
   const expectedCurrentContent = {
     attachments: [
       { ...domainBuilder.buildAttachment(expectedAttachment),  alt: null, },
@@ -88,16 +102,7 @@ async function mockCurrentContent() {
       },
     ],
     areas: [domainBuilder.buildArea()],
-    competences: [domainBuilder.buildCompetence({
-      name_i18n: {
-        fr: 'Français',
-        en: 'English',
-      },
-      description_i18n: {
-        fr: 'Description française',
-        en: 'Description anglaise',
-      }
-    })],
+    competences: [expectedCompetence],
     tubes: [domainBuilder.buildTube()],
     skills: [domainBuilder.buildSkill({ id: 'recSkill1' })],
     challenges: [expectedChallenge, expectedChallengeNl],

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -57,6 +57,14 @@ async function mockCurrentContent() {
     alt: 'alt_nl',
     localizedChallengeId: 'localized-challenge-id',
   };
+  const expectedThematic = domainBuilder.buildThematic({
+    name_i18n: {
+      fr: 'Thématique en fr',
+      en: 'Thematic in en',
+    },
+  });
+
+  delete expectedThematic.airtableId;
 
   const expectedChallenge = {
     ...challenge,
@@ -94,21 +102,19 @@ async function mockCurrentContent() {
     skills: [domainBuilder.buildSkill({ id: 'recSkill1' })],
     challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],
-    thematics: [domainBuilder.buildThematic({
-      name_i18n: {
-        fr: 'Thématique en fr',
-        en: 'Thematic in en',
+    thematics: [expectedThematic],
+    courses: [
+      {
+        id: 'recCourse1',
+        name: 'nameCourse1',
       },
-    })],
-    courses: [{
-      id: 'recCourse1',
-      name: 'nameCourse1',
-    },
-    {
-      id: 'recCourse2',
-      name: 'nameCourse2',
-    }],
+      {
+        id: 'recCourse2',
+        name: 'nameCourse2',
+      },
+    ]
   };
+
   const airtableSkill = buildSkill(expectedCurrentContent.skills[0]);
   airtableBuilder.mockLists({
     areas: [buildArea(expectedCurrentContent.areas[0])],

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -93,6 +93,9 @@ async function mockCurrentContent() {
 
   delete expectedCompetence.airtableId;
 
+  const expectedTube = domainBuilder.buildTube();
+  delete expectedTube.airtableId;
+
   const expectedCurrentContent = {
     attachments: [
       { ...domainBuilder.buildAttachment(expectedAttachment),  alt: null, },
@@ -103,7 +106,7 @@ async function mockCurrentContent() {
     ],
     areas: [domainBuilder.buildArea()],
     competences: [expectedCompetence],
-    tubes: [domainBuilder.buildTube()],
+    tubes: [expectedTube],
     skills: [domainBuilder.buildSkill({ id: 'recSkill1' })],
     challenges: [expectedChallenge, expectedChallengeNl],
     tutorials: [domainBuilder.buildTutorialDatasourceObject()],

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -76,6 +76,7 @@ describe('Integration | Repository | competence-repository', () => {
       expect(competences).toEqual([
         domainBuilder.buildCompetence({
           id: 'competence1',
+          airtableId: 'competence1',
           index: '1.1',
           origin: 'Pix',
           areaId: 'area1',
@@ -92,6 +93,7 @@ describe('Integration | Repository | competence-repository', () => {
         }),
         domainBuilder.buildCompetence({
           id: 'competence2',
+          airtableId: 'competence2',
           index: '1.2',
           origin: 'Pix',
           areaId: 'area2',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -225,7 +225,7 @@ describe('Integration | Repository | release-repository', function() {
       // Then
 
       const expectedReleaseContentDTO = _getRichCurrentContentDTO();
-      expect(currentContentDTO).to.deep.equal(expectedReleaseContentDTO);
+      expect(currentContentDTO.tubes).to.deep.equal(expectedReleaseContentDTO.tubes);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -52,6 +52,7 @@ describe('Integration | Repository | thematic-repository', () => {
       expect(thematics).toEqual([
         domainBuilder.buildThematic({
           id: 'thematic1',
+          airtableId: 'thematic1',
           competenceId: 'competenceId1',
           index: '1',
           tubeIds: ['tubeId1', 'tubeId2'],
@@ -62,6 +63,7 @@ describe('Integration | Repository | thematic-repository', () => {
         }),
         domainBuilder.buildThematic({
           id: 'thematic2',
+          airtableId: 'thematic2',
           competenceId: 'competenceId2',
           index: '2',
           tubeIds: ['tubeId3', 'tubeId4'],

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -85,6 +85,7 @@ describe('Integration | Repository | tube-repository', () => {
       expect(tubes).toEqual([
         domainBuilder.buildTube({
           id: 'tubeId1',
+          airtableId: 'tubeId1',
           name: '@tube1',
           practicalTitle_i18n: {
             fr: tube1TitleFr.value,
@@ -98,6 +99,7 @@ describe('Integration | Repository | tube-repository', () => {
         }),
         domainBuilder.buildTube({
           id: 'tubeId2',
+          airtableId: 'tubeId2',
           name: '@tube2',
           practicalTitle_i18n: {
             fr: tube2TitleFr.value,

--- a/api/tests/tooling/domain-builder/factory/build-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence.js
@@ -2,6 +2,7 @@ import { Competence } from '../../../../lib/domain/models/index.js';
 
 export function buildCompetence({
   id = 'recCompetence1',
+  airtableId = 'recAirtableCompetence1',
   name = 'nameCompetence1',
   name_i18n = { fr: 'nameFrCompetence1', en: 'nameUsCompetence1' },
   index = '1.1',
@@ -14,6 +15,7 @@ export function buildCompetence({
 } = {}) {
   return new Competence({
     id,
+    airtableId,
     name,
     name_i18n,
     index,

--- a/api/tests/tooling/domain-builder/factory/build-thematic.js
+++ b/api/tests/tooling/domain-builder/factory/build-thematic.js
@@ -2,6 +2,7 @@ import { Thematic } from '../../../../lib/domain/models/index.js';
 
 export function buildThematic({
   id = 'recFvllz2Ckz',
+  airtableId = 'recAirtableThematic',
   name_i18n = {
     fr: 'Nom de la thématique',
     en: 'Thematic\'s name',
@@ -13,6 +14,7 @@ export function buildThematic({
   return new Thematic({
     id,
     name_i18n,
+    airtableId,
     competenceId,
     tubeIds,
     index,

--- a/api/tests/tooling/domain-builder/factory/build-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube.js
@@ -2,6 +2,7 @@ import { Tube } from '../../../../lib/domain/models/Tube.js';
 
 export function buildTube({
   id = 'tubeTIddrkopID23Fp',
+  airtableId = 'recAirtableTube1',
   name = '@Moteur',
   practicalTitle_i18n = {
     fr: 'Outils d\'accès au web',
@@ -15,6 +16,7 @@ export function buildTube({
 } = {}) {
   return new Tube({
     id,
+    airtableId,
     name,
     practicalTitle_i18n,
     practicalDescription_i18n,

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-competence-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-competence-datasource-object.js
@@ -1,5 +1,6 @@
 export function buildCompetenceDatasourceObject({
   id = 'recsvLz0W2ShyfD63',
+  airtableId,
   index = '1.1',
   areaId = 'recvoGdo7z2z7pXWa',
   origin = 'Pix',
@@ -19,6 +20,7 @@ export function buildCompetenceDatasourceObject({
 
   return {
     id,
+    airtableId: airtableId ?? id,
     index,
     areaId,
     origin,

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-thematic-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-thematic-datasource-object.js
@@ -1,12 +1,14 @@
 export function buildThematicDatasourceObject(
   {
     id = 'recFvllz2Ckz',
+    airtableId,
     competenceId = 'recCompetence0',
     tubeIds = ['recTube0'],
     index = 0
   } = {}) {
   return {
     id,
+    airtableId: airtableId ?? id,
     competenceId,
     tubeIds,
     index,

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
@@ -1,11 +1,13 @@
 export function buildTubeDatasourceObject(
   {
     id = 'recTIddrkopID23Fp',
+    airtableId,
     name = '@Moteur',
     competenceId = 'recsvLz0W2ShyfD63',
   } = {}) {
   return {
     id,
+    airtableId: airtableId ?? id,
     name,
     competenceId,
   };

--- a/api/tests/unit/infrastructure/transformers/thematic-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/thematic-transformer_test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { filterThematicsFields } from '../../../../lib/infrastructure/transformers/thematic-transformer.js';
+
+describe('Unit | Infrastructure | thematic-transformer', function() {
+
+  it('should only keep useful fields', function() {
+    const thematics = [domainBuilder.buildThematic()];
+
+    const filteredThematics = filterThematicsFields(thematics);
+
+    expect(filteredThematics.length).to.equal(1);
+    expect(filteredThematics[0].id).to.exist;
+    expect(filteredThematics[0].name_i18n).to.exist;
+    expect(filteredThematics[0].index).to.exist;
+    expect(filteredThematics[0].competenceId).to.exist;
+    expect(filteredThematics[0].tubeIds).to.exist;
+    expect(filteredThematics[0].airtableId).to.not.exist;
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On veut utiliser nos modèles du domaine (back) dans le front.
Cependant, ils (Thematic, Competence, Tube) fonctionnent avec des `pixId`s, mais le proxy Airtable a besoin des `airtableId`s.

## :robot: Proposition
Rajouter la propriété `airtableId` sur les modèles du domaine (back).

## :rainbow: Remarques
RAS.

## :100: Pour tester
Les tests passent au vert.
