### PR TITLE
[BUGFIX] Supprimer le champ  `url externe à consulter` casse l'enregistrement de l'épreuve (PIX-14455).

### DIFF
--- a/pix-editor/app/components/field/toggle-field.js
+++ b/pix-editor/app/components/field/toggle-field.js
@@ -21,7 +21,6 @@ export default class FieldToggleFieldComponent extends Component {
   async toggleFieldDisplay() {
     if (this.shouldDisplayField) {
       await this.confirm.ask('Suppression', `Êtes-vous sûr de vouloir supprimer ${this.args.confirmText} ?`);
-      this.args.model.set(`${this.args.modelField}`, '');
       this.args.setDisplayField(false);
     } else {
       this.args.setDisplayField(true);

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -134,8 +134,13 @@ export default class LocalizedController extends Controller {
   }
 
   @action
-  setDisplayUrlsToConsultField(value) {
-    this.displayUrlsToConsultField = value;
+  setDisplayUrlsToConsultField(boolean) {
+    this.displayUrlsToConsultField = boolean;
+    if (!boolean) {
+      this.challenge.urlsToConsult = null;
+      this.urlsToConsult = '';
+      this.invalidUrlsToConsult = '';
+    }
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -130,18 +130,29 @@ export default class SingleController extends Controller {
   }
 
   @action
-  setDisplayAlternativeInstructionsField(value) {
-    this.displayAlternativeInstructionsField = value;
+  setDisplayAlternativeInstructionsField(boolean) {
+    this.displayAlternativeInstructionsField = boolean;
+    if (!boolean) {
+      this.challenge.alternativeInstruction = '';
+    }
   }
 
   @action
-  setDisplaySolutionToDisplayField(value) {
-    this.displaySolutionToDisplayField = value;
+  setDisplaySolutionToDisplayField(boolean) {
+    this.displaySolutionToDisplayField = boolean;
+    if (!boolean) {
+      this.challenge.solutionToDisplay = '';
+    }
   }
 
   @action
-  setDisplayUrlsToConsultField(value) {
-    this.displayUrlsToConsultField = value;
+  setDisplayUrlsToConsultField(boolean) {
+    this.displayUrlsToConsultField = boolean;
+    if (!boolean) {
+      this.challenge.urlsToConsult = null;
+      this.urlsToConsult = '';
+      this.invalidUrlsToConsult = '';
+    }
   }
 
   @action

--- a/pix-editor/tests/integration/components/field/toggle-field-test.js
+++ b/pix-editor/tests/integration/components/field/toggle-field-test.js
@@ -162,7 +162,6 @@ module('Integration | Component | field/toggle-field', function(hooks) {
 
       // then
       assert.ok(setDisplayFieldStub.calledWith(false));
-      assert.strictEqual(this.modelData.someField, '');
       assert.ok(confirmAskStub.calledWith('Suppression', 'Êtes-vous sûr de vouloir supprimer le champ ?'));
     });
   });

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -342,16 +342,18 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
   test('it should cancel edition', async function(assert) {
     // given
     controller.edition = true;
+    controller.wasMaximized = true;
     controller.displayAlternativeInstructionsField = true;
     controller.displaySolutionToDisplayField = true;
-    controller.wasMaximized = true;
+    controller.displayUrlsToConsultField = true;
+    controller.urlsToConsult = 'http:://other-test.com';
     const rollbackAttributesStub = sinon.stub();
-    const challenge = EmberObject.create({
+    controller.model = EmberObject.create({
       id: 'recChallenge',
       files: [],
+      urlsToConsult: ['http:://test.com'],
       rollbackAttributes: rollbackAttributesStub,
     });
-    controller.model = challenge;
 
     // when
     await controller.cancelEdit();
@@ -359,6 +361,8 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     // then
     assert.notOk(controller.displayAlternativeInstructionsField);
     assert.notOk(controller.displaySolutionToDisplayField);
+    assert.notOk(controller.displayUrlsToConsultField);
+    assert.strictEqual(controller.urlsToConsult, 'http:://test.com');
     assert.notOk(controller.edition);
     assert.ok(rollbackAttributesStub.calledOnce);
     assert.ok(messageStub.calledWith('Modification annulée'));
@@ -421,6 +425,29 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       // then
       assert.ok(deleteRecordStub.calledOnce);
       assert.strictEqual(controller.deletedFiles.length, 1);
+    });
+  });
+
+  module('#UrlsToConsult', function() {
+    test('it should reset urlToConsult when urlToConsultField is closed', function(assert) {
+      // given
+      controller.displayUrlsToConsultField = true;
+      controller.urlsToConsult = 'http:://other-test.com';
+      controller.invalidUrlsToConsult = 'wrong-test.com';
+      controller.model = EmberObject.create({
+        id: 'recChallenge',
+        files: [],
+        urlsToConsult: ['http:://test.com'],
+      });
+
+      // when
+      controller.setDisplayUrlsToConsultField(false);
+
+      // then
+      assert.notOk(controller.displayUrlsToConsultField);
+      assert.strictEqual(controller.model.urlsToConsult, null);
+      assert.notOk(controller.urlsToConsult);
+      assert.notOk(controller.invalidUrlsToConsult);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
l'attribut `urlToConsult` est un tableau.
Lorsque l'on clique sur le bouton `Supprimer les URLs à consulter` nous changeons le type de l'attribut en assignant une chaîne de caractère vide, ce qui empêche la sauvegarde du `localizedChallenge` sur notre base PG mais pas l'enregistrement du `challenge` sur airtable.
Donc la consultation de l'épreuves devient impossible et casse l'application.

## :robot: Proposition
Lors du clique sur le bouton `Supprimer les URLs à consulter` assigner une valeur `null` à l'attribut `urlToConsult`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer une épreuve en ayant remplis le champ `url externe à consulté` puis supprimer le champ en utilisant le bouton et vérifier que l'épreuve s'enregistre sans soucis.
Jouer avec les différentes possibilité du champ, modifier / ajouter / supprimer.
