### PR TITLE
[TECH] Récupérer la liste des embeds url depuis la release.

### DIFF
--- a/api/tests/tooling/domain-builder/factory/build-domain-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-domain-release.js
@@ -14,7 +14,7 @@ export const buildDomainRelease = function({
 };
 
 buildDomainRelease.withContent = function({
-  id,
+  id = 123,
   frameworksFromRelease,
   areasFromRelease,
   competencesFromRelease,
@@ -24,7 +24,7 @@ buildDomainRelease.withContent = function({
   challengesFromRelease,
   tutorialsFromRelease,
   missionsFromRelease,
-  createdAt,
+  createdAt = new Date('2020-01-01'),
 }) {
   return buildDomainRelease({
     id,

--- a/api/tests/unit/domain/usecases/get-embed-list_test.js
+++ b/api/tests/unit/domain/usecases/get-embed-list_test.js
@@ -1,74 +1,111 @@
-import {  describe, expect, it, } from 'vitest';
+import { describe, expect, it, } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { extractEmbedUrlFromChallenges } from '../../../../lib/domain/usecases/get-embed-list.js';
+import { findPixEpreuvesUrlsFromChallenges } from '../../../../lib/domain/usecases/get-embed-list.js';
 
-describe('Unit | Domain | Usecases | get-embed-list-from-challenge', function() {
+describe('Unit | Domain | Usecases | get-embed-list-from-release', function() {
 
-  it('should extract embed url from challenges', async () => {
+  it('should extract embed url from release', async () => {
     // given
-    const challengeWithEmbedUrl =  domainBuilder.buildChallenge({
+
+    const competence = domainBuilder.buildCompetenceForRelease({
+      id: 'competenceId',
+      name_i18n: {
+        fr: 'Ma competence',
+        en: 'My comptence'
+      },
+      origin: 'pix',
+    });
+
+    const tube = domainBuilder.buildTubeForRelease({
+      id: 'tubeId',
+      name: '@sujet',
+      competenceId: competence.id
+    });
+
+    const skill = domainBuilder.buildSkillForRelease({
+      id: 'skillId',
+      name: '@sujet1',
+      tubeId: tube.id,
+      competenceId: competence.id,
+    });
+
+    const challengeWithEmbedUrl =  domainBuilder.buildChallengeForRelease({
       id: 'challengeWithEmbedUrl',
       status: 'validé',
+      skillId: skill.id,
       embedUrl: 'https://epreuves.pix.fr/challengeWithEmbedUrl.html?mode=coucou&lang=fr'
     });
-    const challengeWithEmbedUrlDecli =  domainBuilder.buildChallenge({
+    const challengeWithEmbedUrlDecli =  domainBuilder.buildChallengeForRelease({
       id: 'challengeWithEmbedUrlDecli',
       status: 'archivé',
+      skillId: skill.id,
       embedUrl: 'https://epreuves.pix.fr/challengeWithEmbedUrl.html?mode=lilou&lang=en'
     });
-    const challengeWithEmbedUrlAstro =  domainBuilder.buildChallenge({
+    const challengeWithEmbedUrlAstro =  domainBuilder.buildChallengeForRelease({
       id: 'challengeWithEmbedUrlAstro',
       status: 'validé',
+      skillId: skill.id,
       embedUrl: 'https://epreuves.pix.fr/fr/challengeWithEmbedUrlAstro/coucou.html'
     });
-    const challengeWithEmbedUrlAstroDecli =  domainBuilder.buildChallenge({
+    const challengeWithEmbedUrlAstroDecli =  domainBuilder.buildChallengeForRelease({
       id: 'challengeWithEmbedUrlAstroDecli',
       status: 'périmé',
+      skillId: skill.id,
       embedUrl: 'https://epreuves.pix.fr/fr/challengeWithEmbedUrlAstro/lilou.html'
     });
-    const challengesWithInstruction = domainBuilder.buildChallenge({
+    const challengesWithInstruction = domainBuilder.buildChallengeForRelease({
       id: 'challengeWithInstruction',
       status: 'proposé',
+      skillId: skill.id,
       instruction: 'Salut clique [ici](https://epreuves.pix.fr/challengesWithInstruction.html) et ça sera bien'
     });
-    const challengesWithInstructionOneParam = domainBuilder.buildChallenge({
+    const challengesWithInstructionOneParam = domainBuilder.buildChallengeForRelease({
       id: 'challengeWithInstructionOneParam',
       status: 'proposé',
+      skillId: skill.id,
       instruction: 'Salut clique [ici](https://epreuves.pix.fr/challengesWithInstruction.html?lang=fr)heuuuu'
     });
-    const challengesWithInstructionTwoParam = domainBuilder.buildChallenge({
+    const challengesWithInstructionTwoParam = domainBuilder.buildChallengeForRelease({
       id: 'challengeWithInstructionTwoParam',
       status: 'proposé',
+      skillId: skill.id,
       instruction: 'Salut clique <a href="https://epreuves.pix.fr/challengesWithInstruction.html?mode=coucou&lang=fr">ici</a>.'
     });
-    const otherChallenge = domainBuilder.buildChallenge({
+    const otherChallenge = domainBuilder.buildChallengeForRelease({
       id: 'otherChallenge',
       status: 'validé',
+      skillId: skill.id,
     });
-    const challenges = [
-      challengeWithEmbedUrl,
-      challengeWithEmbedUrlDecli,
-      challengeWithEmbedUrlAstro,
-      challengeWithEmbedUrlAstroDecli,
-      challengesWithInstruction,
-      otherChallenge,
-      challengesWithInstructionOneParam,
-      challengesWithInstructionTwoParam,
-    ];
+
+    const release = domainBuilder.buildDomainRelease.withContent({
+      competencesFromRelease: [competence],
+      tubesFromRelease: [tube],
+      skillsFromRelease: [skill],
+      challengesFromRelease: [
+        challengeWithEmbedUrl,
+        challengeWithEmbedUrlDecli,
+        challengeWithEmbedUrlAstro,
+        challengeWithEmbedUrlAstroDecli,
+        challengesWithInstruction,
+        otherChallenge,
+        challengesWithInstructionOneParam,
+        challengesWithInstructionTwoParam,
+      ]
+    });
 
     // when
-    const result =  extractEmbedUrlFromChallenges(challenges);
+    const result = findPixEpreuvesUrlsFromChallenges(release);
 
     // then
 
     expect(result).toStrictEqual([
-      ['challengeWithInstruction','https://epreuves.pix.fr/challengesWithInstruction.html','proposé'],
-      ['challengeWithInstructionOneParam','https://epreuves.pix.fr/challengesWithInstruction.html?lang=fr','proposé'],
-      ['challengeWithInstructionTwoParam','https://epreuves.pix.fr/challengesWithInstruction.html?mode=coucou&lang=fr','proposé'],
-      ['challengeWithEmbedUrl','https://epreuves.pix.fr/challengeWithEmbedUrl.html?mode=coucou&lang=fr','validé'],
-      ['challengeWithEmbedUrlDecli','https://epreuves.pix.fr/challengeWithEmbedUrl.html?mode=lilou&lang=en','archivé'],
-      ['challengeWithEmbedUrlAstro','https://epreuves.pix.fr/fr/challengeWithEmbedUrlAstro/coucou.html','validé'],
-      ['challengeWithEmbedUrlAstroDecli','https://epreuves.pix.fr/fr/challengeWithEmbedUrlAstro/lilou.html','périmé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithInstruction', 'https://epreuves.pix.fr/challengesWithInstruction.html', 'proposé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithInstructionOneParam', 'https://epreuves.pix.fr/challengesWithInstruction.html?lang=fr', 'proposé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithInstructionTwoParam', 'https://epreuves.pix.fr/challengesWithInstruction.html?mode=coucou&lang=fr', 'proposé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithEmbedUrl', 'https://epreuves.pix.fr/challengeWithEmbedUrl.html?mode=coucou&lang=fr', 'validé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithEmbedUrlDecli', 'https://epreuves.pix.fr/challengeWithEmbedUrl.html?mode=lilou&lang=en', 'archivé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithEmbedUrlAstro', 'https://epreuves.pix.fr/fr/challengeWithEmbedUrlAstro/coucou.html', 'validé'],
+      ['pix', 'Ma competence', '@sujet1', 'challengeWithEmbedUrlAstroDecli', 'https://epreuves.pix.fr/fr/challengeWithEmbedUrlAstro/lilou.html', 'périmé'],
     ]);
   });
 });

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -5,7 +5,7 @@ describe('Unit | Utils | URL Utils', function() {
   describe('#findUrlsInMarkdown', function() {
     it('should return URLs in markdown text', function() {
       // given
-      const markdownText = 'instructions [link](https://example.net/) further instructions [other_link](https://other_example.net/)';
+      const markdownText = 'instructions [link](https://example.net/) further instructions [https://other_example.net?mode=a&lang=fr](https://other_example.net?mode=a&lang=fr) <a href="https://from_link_example.net?mode=a&lang=en">ici</a>';
 
       // when
       const urls = UrlUtils.findUrlsInMarkdown(markdownText);
@@ -13,7 +13,8 @@ describe('Unit | Utils | URL Utils', function() {
       // then
       expect(urls).toStrictEqual([
         'https://example.net/',
-        'https://other_example.net/',
+        'https://other_example.net?mode=a&lang=fr',
+        'https://from_link_example.net?mode=a&lang=en'
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Nous ne voulons pas être dépendant des tables `translation` et  `localized-challenge` pour générer la liste des embeds.

## :robot: Proposition
Récupérer la liste des urls depuis la derniere release.

## :rainbow: Remarques
Nous avons ajouter les colonnes origine, compétence et acquis dans notre csv.

## :100: Pour tester
Se rendre sur la partie admin de pix-editor et lancer l'export de la liste des embed.
