### PR TITLE
[BUGFIX] Utilise l'ID persistant plutôt que le `RecordId` (pix-14380)

### DIFF
--- a/pix-editor/app/routes/authenticated/missions/mission/details.js
+++ b/pix-editor/app/routes/authenticated/missions/mission/details.js
@@ -12,7 +12,7 @@ export default class MissionDetailsRoute extends Route {
     let missionThematicNames;
     if (mission.thematicIds) {
       const pix1DThematics = await this.currentData.getThematicsFromPix1DFramework();
-      const thematicNameById = new Map(pix1DThematics.map((thematic) => [thematic.id, thematic.name]));
+      const thematicNameById = new Map(pix1DThematics.map((thematic) => [thematic.pixId, thematic.name]));
       const missionThematicIds = mission.thematicIds.split(',');
       missionThematicNames = missionThematicIds.map((thematicId) => thematicNameById.get(thematicId)).join(', ');
     }

--- a/pix-editor/tests/acceptance/missions/details_test.js
+++ b/pix-editor/tests/acceptance/missions/details_test.js
@@ -5,7 +5,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 
-module('Acceptance | Missions | Detail', function(hooks) {
+module('Acceptance | Missions | Details', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 


### PR DESCRIPTION
## :unicorn: Problème

L'utilisation des identifiants de thématique a changé. Pour retrouver le nom des thématiques, nous utilisons l'ancien identifiant. Pour les anciennes thématiques, ça ne pose pas de problème, les deux identifiants sont les mêmes, mais pour les nouvelles, ça ne fonctionne plus.

![image](https://github.com/user-attachments/assets/d9f8a5f5-cd72-4b73-a70f-928d75deb7c2)


## :robot: Proposition

Utilisé le nouvel identifiant.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
