### PR TITLE
[FEATURE] :sparkles: Ajoute un champ pour spécifier l'image de la carte de mission (pix-14588)

### DIFF
--- a/api/db/migrations/20241004083929_add-card-image-to-mission.js
+++ b/api/db/migrations/20241004083929_add-card-image-to-mission.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'missions';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('cardImageUrl').nullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn('cardImageUrl');
+  });
+}

--- a/api/db/seeds/data/missions.js
+++ b/api/db/seeds/data/missions.js
@@ -3,6 +3,7 @@ import { Mission } from '../../../lib/domain/models/Mission.js';
 export function buildMissions(databaseBuilder) {
   databaseBuilder.factory.buildMission({
     name: 'Mission test active',
+    cardImageUrl: 'https://example.net/image.png',
     competenceId: 'competence1NC9NE3IIOa0ym',
     learningObjectives: 'Que tu sois le meilleur',
     thematicIds: 'recOO8OsMJpe5cZzi,recOO8OsMJpe5cZzi',
@@ -13,6 +14,7 @@ export function buildMissions(databaseBuilder) {
 
   databaseBuilder.factory.buildMission({
     name: 'Mission test inactive',
+    cardImageUrl: 'https://example.net/image.png',
     competenceId: 'competence2k2eVZ2GRLwqFL',
     learningObjectives: 'Y\'en a plus',
     thematicIds: 'rec98EBX88mkQR3gx,rec98EBX88mkQR3gx',
@@ -22,6 +24,7 @@ export function buildMissions(databaseBuilder) {
   });
   databaseBuilder.factory.buildMission({
     name: 'Mission test inactive',
+    cardImageUrl: 'https://example.net/image.png',
     competenceId: 'competence1NC9NE3IIOa0ym',
     learningObjectives: 'Y\'en a plus',
     thematicIds: 'recOO8OsMJpe5cZzi,recj6ITlVfU0vByrR,recRSPkFIgrY6Ps61',
@@ -31,6 +34,7 @@ export function buildMissions(databaseBuilder) {
   });
   databaseBuilder.factory.buildMission({
     name: 'Mission test expérimentale',
+    cardImageUrl: 'https://example.net/image.png',
     competenceId: 'competence1NC9NE3IIOa0ym',
     learningObjectives: 'Y\'en a plus',
     thematicIds: 'recOO8OsMJpe5cZzi,recj6ITlVfU0vByrR,recRSPkFIgrY6Ps61',

--- a/api/lib/domain/models/Mission.js
+++ b/api/lib/domain/models/Mission.js
@@ -2,6 +2,7 @@ export class Mission {
   constructor({
     id,
     name_i18n,
+    cardImageUrl,
     competenceId,
     thematicIds,
     createdAt,
@@ -15,6 +16,7 @@ export class Mission {
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
+    this.cardImageUrl = cardImageUrl;
     this.competenceId = competenceId;
     this.thematicIds = thematicIds;
     this.createdAt = createdAt;

--- a/api/lib/domain/models/release/MissionForRelease.js
+++ b/api/lib/domain/models/release/MissionForRelease.js
@@ -2,6 +2,7 @@ export class MissionForRelease {
   constructor({
     id,
     name_i18n,
+    cardImageUrl,
     competenceId,
     learningObjectives_i18n,
     validatedObjectives_i18n,
@@ -14,6 +15,7 @@ export class MissionForRelease {
   }) {
     this.id = id;
     this.name_i18n = name_i18n;
+    this.cardImageUrl = cardImageUrl;
     this.competenceId = competenceId;
     this.learningObjectives_i18n = learningObjectives_i18n;
     this.validatedObjectives_i18n = validatedObjectives_i18n;

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -49,6 +49,7 @@ export async function listActive() {
 export async function save(mission) {
   const [insertedMission] = await knex('missions').insert({
     id: mission.id,
+    cardImageUrl: mission.cardImageUrl,
     competenceId: mission.competenceId,
     thematicIds: mission.thematicIds,
     status: mission.status,
@@ -69,6 +70,7 @@ function _toDomain(mission, translations) {
   const translationsByMissionId = _.groupBy(translations, 'entityId');
   return new Mission({
     id: mission.id,
+    cardImageUrl: mission.cardImageUrl,
     createdAt: mission.createdAt,
     status: mission.status,
     competenceId: mission.competenceId,

--- a/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/mission-serializer.js
@@ -31,6 +31,7 @@ export function serializeMission(mission, warnings) {
     },
     attributes: [
       'name',
+      'cardImageUrl',
       'competenceId',
       'thematicIds',
       'learningObjectives',
@@ -51,6 +52,7 @@ export function deserializeMission(attributes) {
   return new Mission({
     id: attributes.id,
     name_i18n: { fr: attributes.name  },
+    cardImageUrl: attributes['card-image-url'] || null,
     competenceId: attributes['competence-id'],
     thematicIds: attributes['thematic-ids'],
     learningObjectives_i18n:  { fr:  attributes['learning-objectives'] },

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -18,7 +18,7 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
 
     //given
     const user = databaseBuilder.factory.buildAdminUser();
-    const mission = databaseBuilder.factory.buildMission({ name: 'Condor', status: Mission.status.VALIDATED, competenceId: 'recCompetence0', thematicIds: null, validatedObjectives: 'Être forte', learningObjectives: 'Être imbattable', createdAt: new Date('2024-01-01') });
+    const mission = databaseBuilder.factory.buildMission({ name: 'Condor', cardImageUrl: 'https://example.com/image.png', status: Mission.status.VALIDATED, competenceId: 'recCompetence0', thematicIds: null, validatedObjectives: 'Être forte', learningObjectives: 'Être imbattable', createdAt: new Date('2024-01-01') });
     await databaseBuilder.commit();
 
     //when
@@ -36,6 +36,7 @@ describe('Acceptance | API | mission | GET /api/missions', function() {
         id: mission.id.toString(),
         attributes: {
           name: 'Condor',
+          'card-image-url': 'https://example.com/image.png',
           status: Mission.status.VALIDATED,
           'competence-id': 'recCompetence0',
           'thematic-ids': null,

--- a/api/tests/acceptance/application/mission/post_mission_test.js
+++ b/api/tests/acceptance/application/mission/post_mission_test.js
@@ -25,6 +25,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
         data: {
           attributes: {
             name: 'Mission impossible',
+            'card-image-url': 'https://example.com/image.png',
             'competence-id': 'AZERTY',
             'thematic-id': null,
             status: Mission.status.INACTIVE,
@@ -52,6 +53,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
           type: 'missions',
           id: missionId.toString(),
           'attributes': {
+            'card-image-url': 'https://example.com/image.png',
             'competence-id': 'AZERTY',
             'documentation-url': null,
             'introduction-media-alt': null,
@@ -79,6 +81,7 @@ describe('Acceptance | API | mission | POST /api/missions', function() {
         data: {
           attributes: {
             name: 'Mission impossible',
+            'card-image-url': 'https://example.com/image.png',
             'competence-id': 'AZERTY',
             'thematic-id': null,
             status: Mission.status.INACTIVE,

--- a/api/tests/acceptance/application/mission/put_mission_test.js
+++ b/api/tests/acceptance/application/mission/put_mission_test.js
@@ -26,6 +26,7 @@ describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
         data: {
           attributes: {
             name: 'Mission à mettre à jour',
+            'card-image-url': 'https://example.com/image.png',
             'competence-id': 'TYUI',
             'thematic-ids': '',
             status: Mission.status.EXPERIMENTAL,
@@ -54,6 +55,7 @@ describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
           type: 'missions',
           id: missionId.toString(),
           'attributes': {
+            'card-image-url': 'https://example.com/image.png',
             'competence-id': 'TYUI',
             'documentation-url': null,
             'introduction-media-alt': null,
@@ -82,6 +84,7 @@ describe('Acceptance | API | mission | PATCH /api/missions/{id}', function() {
         data: {
           attributes: {
             name: 'Mission impossible',
+            'card-image-url': 'https://example.com/image.png',
             'competence-id': 'AZERTY',
             'thematic-id': null,
             status: Mission.status.INACTIVE,

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -156,6 +156,7 @@ async function mockCurrentContent() {
     missions: [{
       id: 1,
       name_i18n: { fr: 'Ma première mission' },
+      cardImageUrl: 'https://example.com/image0.png',
       competenceId: 'competenceId',
       thematicIds: 'thematicId,thematicId',
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
@@ -173,6 +174,7 @@ async function mockCurrentContent() {
     }, {
       id: 2,
       name_i18n: { fr: 'Alt name' },
+      cardImageUrl: 'https://example.com/image1.png',
       competenceId: 'competenceId',
       thematicIds: 'thematicId,thematicId',
       learningObjectives_i18n: { fr: 'Alt objectives' },
@@ -236,6 +238,7 @@ async function mockCurrentContent() {
   databaseBuilder.factory.buildMission({
     id: 1,
     name: 'Ma première mission',
+    cardImageUrl: 'https://example.com/image0.png',
     competenceId: 'competenceId',
     thematicIds: 'thematicId,thematicId',
     learningObjectives: 'Que tu sois le meilleur',
@@ -249,6 +252,7 @@ async function mockCurrentContent() {
   databaseBuilder.factory.buildMission({
     id: 2,
     name: 'Alt name',
+    cardImageUrl: 'https://example.com/image1.png',
     competenceId: 'competenceId',
     thematicIds: 'thematicId,thematicId',
     learningObjectives: 'Alt objectives',
@@ -262,6 +266,7 @@ async function mockCurrentContent() {
   databaseBuilder.factory.buildMission({
     id: 3,
     name: 'Alt name',
+    cardImageUrl: 'https://example.com/image2.png',
     competenceId: 'competenceId',
     thematicIds: 'thematicId,thematicId',
     learningObjectives: 'Alt objectives',
@@ -500,6 +505,7 @@ async function mockContentForRelease() {
     missions: [new MissionForRelease({
       id: 1,
       name_i18n: { fr: 'Ma première mission' },
+      cardImageUrl: 'https://example.com/image2.png',
       competenceId: 'competenceId',
       learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
       validatedObjectives_i18n: { fr: 'Rien' },
@@ -511,6 +517,7 @@ async function mockContentForRelease() {
     }), new MissionForRelease({
       id: 2,
       name_i18n: { fr: 'Alt name' },
+      cardImageUrl: 'https://example.com/image2.png',
       competenceId: 'competenceId',
       learningObjectives_i18n: { fr: 'Alt objectives' },
       validatedObjectives_i18n: { fr: 'Alt validated objectives' },
@@ -779,6 +786,7 @@ describe('Acceptance | Controller | release-controller', () => {
         databaseBuilder.factory.buildMission({
           id: 1,
           name: 'Ma première mission',
+          cardImageUrl: 'https://example.com/image2.png',
           competenceId: 'competenceId',
           thematicIds: 'thematicId,thematicId',
           learningObjectives: 'Que tu sois le meilleur',
@@ -792,6 +800,7 @@ describe('Acceptance | Controller | release-controller', () => {
         databaseBuilder.factory.buildMission({
           id: 2,
           name: 'Alt name',
+          cardImageUrl: 'https://example.com/image2.png',
           competenceId: 'competenceId',
           thematicIds: 'thematicId,thematicId',
           learningObjectives: 'Alt objectives',
@@ -805,6 +814,7 @@ describe('Acceptance | Controller | release-controller', () => {
         databaseBuilder.factory.buildMission({
           id: 3,
           name: 'Alt name',
+          cardImageUrl: 'https://example.com/image2.png',
           competenceId: 'competenceId',
           thematicIds: 'thematicId,thematicId',
           learningObjectives: 'Alt objectives',

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -34,6 +34,7 @@ describe('Integration | Repository | mission-repository', function() {
         expect(result).to.deep.equal(new Mission({
           id: 1,
           name_i18n: { fr: 'Ma première mission' },
+          cardImageUrl: null,
           competenceId: 'competenceId',
           thematicIds: 'thematicIds',
           learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
@@ -51,9 +52,10 @@ describe('Integration | Repository | mission-repository', function() {
   describe('#findAllMissions', function() {
     context('When there are missions', function() {
       it('should return all missions', async function() {
-        databaseBuilder.factory.buildMission({ id: 1, status: Mission.status.VALIDATED });
+        databaseBuilder.factory.buildMission({ id: 1, cardImageUrl: null, status: Mission.status.VALIDATED });
         databaseBuilder.factory.buildMission({
           id: 2,
+          cardImageUrl: 'https://images.pix.fr/mission-card-image.png',
           name: 'Alt name',
           status: Mission.status.INACTIVE,
           learningObjectives: 'Alt objectives',
@@ -65,6 +67,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         expect(results.missions).to.deep.equal([new Mission({
           id: 1,
+          cardImageUrl: null,
           name_i18n: { fr: 'Ma première mission' },
           competenceId: 'competenceId',
           thematicIds: 'thematicIds',
@@ -78,6 +81,7 @@ describe('Integration | Repository | mission-repository', function() {
           createdAt: new Date('2010-01-04'),
         }), new Mission({
           id: 2,
+          cardImageUrl: 'https://images.pix.fr/mission-card-image.png',
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicIds',
@@ -156,6 +160,7 @@ describe('Integration | Repository | mission-repository', function() {
     it('should return all active missions', async function() {
       databaseBuilder.factory.buildMission({
         id: 2,
+        cardImageUrl: 'https://example.com/image.png',
         name: 'Alt name',
         status: Mission.status.VALIDATED,
         learningObjectives: 'Alt objectives',
@@ -165,6 +170,7 @@ describe('Integration | Repository | mission-repository', function() {
 
       databaseBuilder.factory.buildMission({
         id: 3,
+        cardImageUrl: null,
         name: 'inactive name',
         status: Mission.status.INACTIVE,
         learningObjectives: 'Alt objectives',
@@ -178,6 +184,7 @@ describe('Integration | Repository | mission-repository', function() {
 
       expect(result).to.deep.equal([new Mission({
         id: 2,
+        cardImageUrl: 'https://example.com/image.png',
         name_i18n: { fr: 'Alt name' },
         competenceId: 'competenceId',
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
@@ -197,6 +204,7 @@ describe('Integration | Repository | mission-repository', function() {
     context('Mission creation', function() {
       it('should store mission', async function() {
         const mission = new Mission({
+          cardImageUrl: null,
           name_i18n: { fr: 'Mission impossible' },
           competenceId: 'AZERTY',
           thematicIds: 'QWERTY',
@@ -233,6 +241,7 @@ describe('Integration | Repository | mission-repository', function() {
       it('should store I18n for mission', async function() {
 
         const mission = new Mission({
+          cardImageUrl: null,
           name_i18n: { fr: 'Mission impossible' },
           competenceId: 'AZERTY',
           thematicIds: 'QWERTY',
@@ -283,6 +292,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         const missionToUpdate = new Mission({
           id: savedMission.id,
+          cardImageUrl: null,
           name_i18n: { fr: 'Updated mission' },
           competenceId: 'QWERTY',
           thematicIds: 'Thematic',
@@ -327,6 +337,7 @@ describe('Integration | Repository | mission-repository', function() {
 
         const missionToUpdate = new Mission({
           id: savedMission.id,
+          cardImageUrl: null,
           name_i18n: { fr: 'Updated mission' },
           competenceId: 'QWERTY',
           thematicIds: 'Thematic',

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -5,6 +5,7 @@ import { buildTranslation } from './build-translation.js';
 export function buildMission({
   id = databaseBuffer.nextId++,
   name = 'Ma première mission',
+  cardImageUrl = null,
   competenceId = 'competenceId',
   learningObjectives = 'Que tu sois le meilleur',
   thematicIds = 'thematicIds',
@@ -18,7 +19,7 @@ export function buildMission({
   createdAt = new Date('2010-01-04'),
 } = {}) {
 
-  const values = { id, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, documentationUrl };
+  const values = { id, cardImageUrl, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, documentationUrl };
 
   buildTranslation({
     key: `mission.${id}.name`,

--- a/api/tests/tooling/domain-builder/factory/build-mission.js
+++ b/api/tests/tooling/domain-builder/factory/build-mission.js
@@ -3,6 +3,7 @@ import { Mission } from '../../../../lib/domain/models/index.js';
 export function buildMission({
   id = 3,
   name = 'Ma mission',
+  cardImageUrl = null,
   competenceId = 'recCompetence1',
   thematicIds = 'recThematic1',
   createdAt = new Date('2023-10-14'),
@@ -17,6 +18,7 @@ export function buildMission({
   return new Mission ({
     id,
     name_i18n: { fr: name },
+    cardImageUrl,
     competenceId,
     thematicIds,
     createdAt,

--- a/api/tests/unit/application/missions/mission-controller_test.js
+++ b/api/tests/unit/application/missions/mission-controller_test.js
@@ -153,6 +153,7 @@ describe('Unit | Controller | missions controller', function() {
     let createMissionMock;
     const attributes = {
       name: 'Mission possible',
+      'card-image-url': null,
       'competence-id': 'AZERTY',
       status: Mission.status.VALIDATED,
       'learning-objectives': null,
@@ -166,6 +167,7 @@ describe('Unit | Controller | missions controller', function() {
 
     const request = { payload: { data: { attributes } } };
     const deserializedMission = new Mission({
+      cardImageUrl: null,
       name_i18n: { fr: 'Mission possible' },
       competenceId: 'AZERTY',
       thematicIds: null,
@@ -220,6 +222,7 @@ describe('Unit | Controller | missions controller', function() {
     let updateMissionMock;
     const attributes = {
       name: 'Mission possible',
+      'card-image-url': null,
       'competence-id': 'QWERTY',
       status: Mission.status.VALIDATED,
       'learning-objectives': 'apprendre à éviter les lasers',
@@ -237,6 +240,7 @@ describe('Unit | Controller | missions controller', function() {
     const request = { payload: { data: { attributes } }, params: { id: missionId } };
     const deserializedMission = new Mission({
       id: missionId,
+      cardImageUrl: null,
       name_i18n: { fr: 'Mission possible' },
       competenceId: 'QWERTY',
       thematicId: null,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/mission-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/mission-serializer_test.js
@@ -10,6 +10,7 @@ describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
         id: 12,
         learningObjectives_i18n: { fr: 'learning objectives-value', },
         name_i18n: { fr: 'Mission Name', },
+        cardImageUrl: 'card-image-url',
         validatedObjectives_i18n: { fr: 'validated-objectives-value', },
         competenceId: 'rec12E12EFZF',
         thematicIds: 'someThematicIds',
@@ -25,6 +26,7 @@ describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
       const attributes = {
         id: expectedMission.id,
         name: expectedMission.name_i18n.fr,
+        'card-image-url': expectedMission.cardImageUrl,
         'competence-id': expectedMission.competenceId,
         'thematic-ids': expectedMission.thematicIds,
         'learning-objectives': expectedMission.learningObjectives_i18n.fr,
@@ -46,12 +48,14 @@ describe('Unit | Serializer | JSONAPI | mission-serializer', () => {
 
       const attributes = {
         id: expectedMission.id,
+        'card-image-url': '',
         'introduction-media-url': '',
         'introduction-media-type': '',
         'documentation-url': '',
       };
       const deserializedMission = deserializeMission(attributes);
 
+      expect(deserializedMission.cardImageUrl).to.be.null;
       expect(deserializedMission.introductionMediaUrl).to.be.null;
       expect(deserializedMission.introductionMediaType).to.be.null;
       expect(deserializedMission.documentationUrl).to.be.null;

--- a/api/tests/unit/infrastructure/transformers/mission-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/mission-transformer_test.js
@@ -137,6 +137,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
           expect(result).to.deep.equal([{
             id: 2,
+            cardImageUrl: null,
             name_i18n: { fr: 'Alt name' },
             competenceId: 'competenceId',
             thematicIds: 'thematicStep1,thematicStep2,thematicDefiVide',
@@ -211,6 +212,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
           expect(result).to.deep.equal([{
             id: 2,
+            cardImageUrl: null,
             name_i18n: { fr: 'Alt name' },
             competenceId: 'competenceId',
             thematicIds: 'thematicStep1,thematicDefiVide',
@@ -310,6 +312,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -383,6 +386,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -461,6 +465,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -506,6 +511,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -550,6 +556,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -592,6 +599,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -633,6 +641,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -671,6 +680,7 @@ describe('Unit | Transformer | mission-transformer', function() {
 
         expect(result).to.deep.equal([{
           id: 2,
+          cardImageUrl: null,
           name_i18n: { fr: 'Alt name' },
           competenceId: 'competenceId',
           thematicIds: 'thematicStep1,thematicDefiVide',
@@ -709,6 +719,7 @@ describe('Unit | Transformer | mission-transformer', function() {
         expect(result).to.deep.equal([{
           id: 2,
           name_i18n: { fr: 'Alt name' },
+          cardImageUrl: null,
           competenceId: 'competenceId',
           thematicIds: null,
           learningObjectives_i18n: { fr: 'Alt objectives' },

--- a/pix-editor/app/adapters/mission.js
+++ b/pix-editor/app/adapters/mission.js
@@ -12,6 +12,7 @@ function preparePayloadForCreateAndUpdate(payload, adapterOptions) {
   payload.data.attributes = {};
   payload.data.attributes.name = adapterOptions.name;
   payload.data.attributes.status = adapterOptions.status;
+  payload.data.attributes['card-image-url'] = adapterOptions.cardImageUrl;
   payload.data.attributes['competence-id'] = adapterOptions.competenceId;
   payload.data.attributes['thematic-ids'] = adapterOptions.thematicIds;
   payload.data.attributes['learning-objectives'] = adapterOptions.learningObjectives;

--- a/pix-editor/app/components/form/mission.hbs
+++ b/pix-editor/app/components/form/mission.hbs
@@ -11,6 +11,13 @@
     >
       <:label>Nom de la mission</:label>
     </PixInput>
+    <PixInput
+      @id="mission-card-image-url"
+      @value={{this.cardImageUrl}}
+      {{on "change" this.updateCardImageUrl}}
+      >
+      <:label>URL de l'image de la carte</:label>
+    </PixInput>
     <PixSelect
       @options={{this.statusOptions}}
       @value={{this.selectedStatus}}

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -11,6 +11,7 @@ export default class MissionForm extends Component {
   @service store;
 
   @tracked name = new NameField();
+  @tracked cardImageUrl = null;
   @tracked thematicIds = new ThematicIdsField();
   @tracked selectedCompetenceId = new CompetenceIdField();
   @tracked selectedStatus = 'ACTIVE';
@@ -29,6 +30,7 @@ export default class MissionForm extends Component {
     if (this.editMode()) {
       this.name.setValue(this.args.mission.name);
       this.name.validate();
+      this.cardImageUrl = this.args.mission.cardImageUrl;
       this.selectedStatus = this.args.mission.status;
       this.validatedObjectives = this.args.mission.validatedObjectives;
       this.learningObjectives = this.args.mission.learningObjectives;
@@ -79,6 +81,7 @@ export default class MissionForm extends Component {
     this.isSubmitting = true;
     const formData = {
       name: this.name.getValueForSubmit(),
+      cardImageUrl: this.cardImageUrl,
       competenceId: this.selectedCompetenceId.value,
       thematicIds: this.thematicIds.getValueForSubmit(),
       status: this.selectedStatus,
@@ -109,6 +112,11 @@ export default class MissionForm extends Component {
   validateName() {
     this.name.validate();
     this.checkFormValidity();
+  }
+
+  @action
+  updateCardImageUrl(event) {
+    this.cardImageUrl = event.target.value;
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -10,6 +10,7 @@ export default class MissionEditController extends Controller {
   async submitMission(formData) {
     try {
       this.model.mission.name = formData.name;
+      this.model.mission.cardImageUrl = formData.cardImageUrl;
       this.model.mission.competenceId = formData.competenceId;
       this.model.mission.status = formData.status;
       this.model.mission.thematicIds = formData.thematicIds;

--- a/pix-editor/app/models/mission.js
+++ b/pix-editor/app/models/mission.js
@@ -3,6 +3,7 @@ import { attr } from '@ember-data/model';
 import MissionSummary from './mission-summary';
 
 export default class Mission extends MissionSummary {
+  @attr cardImageUrl;
   @attr competenceId;
   @attr thematicIds;
   @attr learningObjectives;

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -17,6 +17,7 @@
     <Card class="mission-details__card-information" @title="1. Informations">
       <ul>
         <li><span class="bold">Nom : </span>{{this.model.mission.name}}</li>
+        <li><span class="bold">Image carte : </span>{{this.model.mission.cardImageUrl}}</li>
         <li>
           <span class="bold">Compétence : </span>
             {{this.model.competence}}

--- a/pix-editor/tests/acceptance/missions/creation-test.js
+++ b/pix-editor/tests/acceptance/missions/creation-test.js
@@ -73,6 +73,8 @@ module('Acceptance | Missions | Creation', function(hooks) {
       await fillByLabel('* Nom de la mission', 'Nouvelle mission de test');
       await triggerEvent(find('#mission-name'), 'keyup', '');
 
+      await fillByLabel('URL de l\'image de la carte', 'https://example.pix.fr/ma-image.png');
+
       await clickByText('Compétence');
       await screen.findByRole('listbox');
 

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -24,6 +24,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
     this.server.create('mission', {
       id: 2,
       name: 'Mission 1',
+      cardImageUrl: 'https://example.net/card-image.png',
       competenceId: 'recCompetence1.1',
       createdAt: '2023/12/11',
       status: 'VALIDATED',
@@ -53,6 +54,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       this.server.create('mission', {
         id: 3,
         name: 'Mission',
+        cardImageUrl: 'https://example.net/card-image.png',
         competenceId: 'recCompetence1.1',
         thematicIds: '',
         createdAt: '2023/12/11',
@@ -67,6 +69,8 @@ module('Acceptance | Missions | Edit', function(hooks) {
       await fillByLabel('* Nom de la mission', 'Nouvelle mission de test');
       await triggerEvent(find('#mission-name'), 'keyup', '');
 
+      await fillByLabel('URL de l\'image de la carte', 'https://images.pix.fr/badges/Pix_Plus-Donnee-Visualisation_des_donnees.svg.svg');
+
       await clickByText('Compétence');
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Notre compétence' }));
@@ -78,6 +82,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       // then
       assert.strictEqual(currentURL(), '/missions/3');
       assert.dom(screen.getByText('Nouvelle mission de test')).exists();
+      assert.dom(screen.getByText('https://images.pix.fr/badges/Pix_Plus-Donnee-Visualisation_des_donnees.svg.svg')).exists();
       assert.dom(screen.getByText('http://example.com')).exists();
       assert.dom(screen.getByText('http://doc.com')).exists();
     });
@@ -87,6 +92,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       this.server.create('mission', {
         id: 3,
         name: 'Mission',
+        cardImageUrl: 'https://example.net/image.png',
         competenceId: 'recCompetence1.1',
         thematicIds: '',
         createdAt: '2023/12/11',

--- a/pix-editor/tests/integration/components/form/missions-test.js
+++ b/pix-editor/tests/integration/components/form/missions-test.js
@@ -23,6 +23,8 @@ module('Integration | Component | mission', function(hooks) {
     await fillByLabel('* Nom de la mission', 'Nouvelle mission de test');
     await triggerEvent(find('#mission-name'), 'keyup', '');
 
+    await fillByLabel('URL de l\'image de la carte', 'https://images.pix.fr/badges/Pix_Plus-Donnee-Visualisation_des_donnees.svg.svg');
+
     await clickByText('Compétence');
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'Notre compétence' }));


### PR DESCRIPTION
## :unicorn: Problème

L'image sur la carte de la mission est toujours la même par thématique

![image](https://github.com/user-attachments/assets/67b778e5-3330-4b56-92d8-9ff75a6b4d07)

Ça n'aide pas les élèves qui ont des difficultés de lecture à se repérer dans la liste des missions.

## :robot: Proposition

Permettre aux personnes du contenu de spécifier une image pour chaque carte de mission.

## :rainbow: Remarques


## :100: Pour tester

Se connecter à Pix Editor, aller dans la page de gestion des missions (selectionner Pix, puis les missions dans le bas du menu).
- Choisir une mission, visualiser l'URL de l'image de la carte, modifier la mission pour changer l'image de la carte.
- Créer une nouvelle mission avec une image de carte.

Faire une release, l'URL de l'image est renseignée dans la mission.
