### PR TITLE
[BUGFIX]  Valider un prototype ne rend pas actif son acquis (PIX-14700).

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -600,6 +600,7 @@ export default class SingleController extends Controller {
 
   async _checkSkillValidation(challenge) {
     const skill = await challenge.skill;
+    await Promise.all([skill.tutoMore, skill.tutoSolution]);
     if (challenge.isPrototype && !skill.isActive) {
       await skill.activate();
       this._message(`Activation de l'acquis ${skill.name}`);
@@ -625,6 +626,7 @@ export default class SingleController extends Controller {
     if (!this._isProductionPrototype(challenge)) {
       return;
     }
+    await Promise.all([skill.tutoMore, skill.tutoSolution]);
     const prototypesStatusOtherVersion = this._getPrototypesStatusOtherVersion(skill, challenge);
     if (prototypesStatusOtherVersion.includes('proposé')) {
       return skill.deactivate();


### PR DESCRIPTION
## :unicorn: Problème
La validation ou la péremption d'un prototype n'est pas propager sur l'acquis et les déclinaisons.

## :robot: Proposition
Charger les relation de l'acquis avant sa modification.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur un acquis en construction, ajouter des tutoriels. se rendre sur la vue épreuve rafraichir le cache et valider l'épreuve > constater que l'acquis est devenu actif.
Répéter l'opération pour la péremption de l'épreuve.
