### PR TITLE
[TECH] Valider le type de l'id dans la route `GET /api/releases/:id` (PIX-14706)

### DIFF
--- a/api/lib/application/releases.js
+++ b/api/lib/application/releases.js
@@ -1,8 +1,11 @@
 import Boom from '@hapi/boom';
+import Joi from 'joi';
 import { releaseRepository } from '../infrastructure/repositories/index.js';
 import { queue as createReleaseQueue } from '../infrastructure/scheduled-jobs/release-job.js';
 import { promiseStreamer } from '../infrastructure/utils/promise-streamer.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
+
+const releaseIdType = Joi.number().greater(-2147483648).less(2147483647).required();
 
 export async function register(server) {
   server.route([
@@ -46,6 +49,11 @@ export async function register(server) {
       method: 'GET',
       path: '/api/releases/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: releaseIdType,
+          })
+        },
         handler: async function(request) {
           const release = await releaseRepository.getRelease(request.params.id);
           if (release) {


### PR DESCRIPTION
## :unicorn: Problème
Le type de l'id de la release n'est pas validé dans la route `/api/releases/:id`. De ce fait, les requêtes avec un id n'étant pas un nombre entier provoquent une erreur 500 au moment de la requête knex (la colonne `id` de la table `releases` a un type `integer`). 

## :robot: Proposition
Vérifier que l'id soit un nombre valide, et renvoyer une erreur 400 si ce n'est pas le cas.

## :rainbow: Remarques
Au passage, on vérifie aussi si le nombre est bien compris entre -2147483648 et +2147483647 (les limites du type `integer` de Postgres).

## :100: Pour tester
- Générer une release en local (`curl -X POST http://localhost:3002/api/releases -H "Authorization: Bearer {TOKEN}"`
- Récupérer l'id de cette release.
- Vérifier qu'on puisse toujours récupérer le contenu de cette release (`curl http://localhost:3002/api/releases/{ID_DE_LA_RELEASE} -H "Authorization: Bearer {TOKEN}"`)
- Essayer de récupérer une release avec un id non valide (`curl http://localhost:3002/api/releases/ID_NON_VALIDE -H "Authorization: Bearer {TOKEN}"`)
- Constater qu'une erreur 400 est renvoyée.
