### PR TITLE
[BUGFIX] Permettre d'acceder au version traduite d'une déclinaison (PIX-14710)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence.js
+++ b/pix-editor/app/controllers/authenticated/competence.js
@@ -39,24 +39,6 @@ export default class CompetenceController extends Controller {
     return this.model;
   }
 
-  setSection(value) {
-    if (this.section !== value) {
-      this.section = value;
-    }
-  }
-
-  setView(value) {
-    if (this.view !== value) {
-      this.view = value;
-    }
-  }
-
-  maximizeLeft(value) {
-    if (this.leftMaximized !== value) {
-      this.leftMaximized = value;
-    }
-  }
-
   get displayGrid() {
     return this.section !== 'challenges' || this.view !== 'workbench-list';
   }
@@ -99,6 +81,24 @@ export default class CompetenceController extends Controller {
       }
     } else {
       return 'authenticated.competence.prototypes.single';
+    }
+  }
+
+  setSection(value) {
+    if (this.section !== value) {
+      this.section = value;
+    }
+  }
+
+  setView(value) {
+    if (this.view !== value) {
+      this.view = value;
+    }
+  }
+
+  maximizeLeft(value) {
+    if (this.leftMaximized !== value) {
+      this.leftMaximized = value;
     }
   }
 

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
@@ -39,7 +39,7 @@ export default class NewController extends Alternative {
       this.edition = false;
       this.send('minimize');
       this._message(`Déclinaison numéro ${this.challenge.alternativeVersion} enregistrée`);
-      this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', this.currentData.getCompetence(), this.currentData.getPrototype(), this.challenge);
+      this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', this.currentData.getCompetence(), this.currentData.getPrototype(), this.challenge.id);
     } catch (error) {
       console.error(error);
       Sentry.captureException(error);

--- a/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
@@ -19,6 +19,6 @@ export default class LocalizedPrototypeRoute extends Route {
 
   resetController(controller, _isExiting, _transition) {
     super.resetController(controller, _isExiting, _transition);
-    controller.send('cancelEdit');
+    if (controller.edition) controller.send('cancelEdit');
   }
 }

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
@@ -5,8 +5,16 @@ import { inject as service } from '@ember/service';
 export default class SingleRoute extends Route {
 
   @service store;
+  templateName = 'authenticated/competence/prototypes/single';
+
   model(params) {
     return this.store.findRecord('challenge', params.alternative_id);
+  }
+
+  async afterModel(model) {
+    super.afterModel(...arguments);
+    await model.localizedChallenges;
+    await model?.files;
   }
 
   setupController(controller) {
@@ -25,6 +33,4 @@ export default class SingleRoute extends Route {
       }
     }
   }
-
-  templateName = 'authenticated/competence/prototypes/single';
 }

--- a/pix-editor/tests/acceptance/localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/localized-challenge-test.js
@@ -10,78 +10,125 @@ module('Acceptance | Localized-Challenge', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
-    this.server.create('config', 'default');
-    this.server.create('user', { trigram: 'ABC' });
+  module('When interacting with a prototype', function(hooks) {
+    hooks.beforeEach(function() {
+      this.server.create('config', 'default');
+      this.server.create('user', { trigram: 'ABC' });
 
-    this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1', embedURL: 'https://mon-site.fr/my-link.html?lang=fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
-    this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'] });
-    this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
-    this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
-    this.server.create('competence', {
-      id: 'recCompetence1.1',
-      pixId: 'pixId recCompetence1.1',
-      rawThemeIds: ['recTheme1'],
-      rawTubeIds: ['recTube1'],
+      this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+      this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
+      this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+      this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'] });
+      this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+      this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+      this.server.create('competence', {
+        id: 'recCompetence1.1',
+        pixId: 'pixId recCompetence1.1',
+        rawThemeIds: ['recTheme1'],
+        rawTubeIds: ['recTube1'],
+      });
+      this.server.create('area', {
+        id: 'recArea1',
+        name: '1. Information et données',
+        code: '1',
+        competenceIds: ['recCompetence1.1'],
+      });
+      this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+      return authenticateSession();
     });
-    this.server.create('area', {
-      id: 'recArea1',
-      name: '1. Information et données',
-      code: '1',
-      competenceIds: ['recCompetence1.1'],
+
+    test('should display a default embedUrl if is empty but not for primary', async function(assert) {
+      // when
+      const screen = await visit('/');
+      await click(findAll('[data-test-area-item]')[0]);
+      await click(findAll('[data-test-competence-item]')[0]);
+      await click(findAll('[data-test-skill-cell-link]')[0]);
+      await clickByText('Version nl');
+
+      // then
+      assert.dom(await screen.queryByText('https://mon-site.fr/my-link.html?lang=nl', { exact: false })).exists();
     });
-    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
-    return authenticateSession();
+    test('should not display a default url if primary does not have any', async function(assert) {
+      // given
+      this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1', embedURL: null });
+      this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+      this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl' });
+      this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 1, tubeId: 'recTube1' });
+
+      // when
+      const screen = await visit('/');
+      await click(findAll('[data-test-area-item]')[0]);
+      await click(findAll('[data-test-competence-item]')[0]);
+      await click(findAll('[data-test-skill-cell-link]')[0]);
+      await clickByText('Version nl');
+
+      // then
+      assert.dom(await screen.queryByText('Embed URL auto-générée', { exact: false })).doesNotExist();
+    });
+    test('should display an embed url if localized challenge has one', async function(assert) {
+      // given
+      this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1' });
+      this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+      this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl', embedURL: 'https://mon-site.fr/my-nl-link.html' });
+      this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 1, tubeId: 'recTube1' });
+
+      // when
+      const screen = await visit('/');
+      await click(findAll('[data-test-area-item]')[0]);
+      await click(findAll('[data-test-competence-item]')[0]);
+      await click(findAll('[data-test-skill-cell-link]')[0]);
+      await clickByText('Version nl');
+
+      // then
+      const input = await screen.findByLabelText('Embed URL :');
+      assert.strictEqual(input.value, 'https://mon-site.fr/my-nl-link.html');
+    });
+
   });
 
-  test('should display a default embedUrl if is empty but not for primary', async function(assert) {
-    // when
-    const screen = await visit('/');
-    await click(findAll('[data-test-area-item]')[0]);
-    await click(findAll('[data-test-competence-item]')[0]);
-    await click(findAll('[data-test-skill-cell-link]')[0]);
-    await clickByText('Version nl');
+  module('When interacting with an alternative', function(hooks) {
+    hooks.beforeEach(function() {
+      this.server.create('config', 'default');
+      this.server.create('user', { trigram: 'ABC' });
 
-    // then
-    assert.dom(await screen.queryByText('https://mon-site.fr/my-link.html?lang=nl', { exact: false })).exists();
+      this.server.create('challenge', { id: 'recChallengeProto1', airtableId: 'airtableIdProto1', genealogy: 'Prototype 1', version: 1 });
+      this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Décliné 1', version: 1, instruction: 'Instruction de la déclinaison' });
+      this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
+      this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+      this.server.create('skill', { id: 'recSkill1', name: '@acquis2', challengeIds: ['recChallenge1', 'recChallengeProto1'] });
+      this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+      this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+      this.server.create('competence', {
+        id: 'recCompetence1.1',
+        title: 'Nom de compétence',
+        code: 1,
+        pixId: 'pixId recCompetence1.1',
+        rawThemeIds: ['recTheme1'],
+        rawTubeIds: ['recTube1'],
+      });
+      this.server.create('area', {
+        id: 'recArea1',
+        name: 'Nom du domaine',
+        code: '1',
+        competenceIds: ['recCompetence1.1'],
+      });
+      this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+      return authenticateSession();
+    });
+
+    test('should display a default embedUrl if is empty but not for primary', async function(assert) {
+      // when
+      const screen = await visit('/');
+      await clickByText('Nom du domaine');
+      await clickByText('1 Nom de compétence');
+      await clickByText('@acquis2');
+      await clickByText('Déclinaisons >>');
+      await clickByText('Instruction de la déclinaison');
+      await clickByText('Version nl');
+
+      // then
+      assert.dom(await screen.queryByText('https://mon-site.fr/my-link.html?lang=nl', { exact: false })).exists();
+    });
   });
-  test('should not display a default url if primary does not have any', async function(assert) {
-    // given
-    this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1', embedURL: null });
-    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl' });
-    this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 1, tubeId: 'recTube1' });
-
-    // when
-    const screen = await visit('/');
-    await click(findAll('[data-test-area-item]')[0]);
-    await click(findAll('[data-test-competence-item]')[0]);
-    await click(findAll('[data-test-skill-cell-link]')[0]);
-    await clickByText('Version nl');
-
-    // then
-    assert.dom(await screen.queryByText('Embed URL auto-générée', { exact: false })).doesNotExist();
-  });
-  test('should display an embed url if localized challenge has one', async function(assert) {
-    // given
-    this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1' });
-    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl', embedURL: 'https://mon-site.fr/my-nl-link.html' });
-    this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 1, tubeId: 'recTube1' });
-
-    // when
-    const screen = await visit('/');
-    await click(findAll('[data-test-area-item]')[0]);
-    await click(findAll('[data-test-competence-item]')[0]);
-    await click(findAll('[data-test-skill-cell-link]')[0]);
-    await clickByText('Version nl');
-
-    // then
-    const input = await screen.findByLabelText('Embed URL :');
-    assert.strictEqual(input.value, 'https://mon-site.fr/my-nl-link.html');
-  });
-
 });
 


### PR DESCRIPTION
## :unicorn: Problème
Le bouton permettant d’accéder a la version traduite d'une épreuve ne s'affiche pas lorsqu'il s'agit d'une déclinaison.

## :robot: Proposition
Charger la relation `localizedChallenge` du `challenge` sur la route affichant les déclinaisons.

## :rainbow: Remarques
RAS

## :100: Pour tester
Ajouter une traduction à une déclinaison et vérifier que l'on peu y accéder.
