### PR TITLE
[BUGFIX] Ascenseur remonte tout seul lors de l'édition d'une épreuve proposée, lorsqu'on souhaite modifier la valeur d'un champ "Qualité" (PIX-14877)

### DIFF
--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -58,13 +58,15 @@
           <:default as |option|>{{option.label}}</:default>
         </PixMultiSelect>
         <PixToggle
-          @inline={{true}}
-          @onLabel="Actifs"
-          @offLabel="Tous"
+          @inlineLabel={{true}}
           @toggled={{this.showActiveOnly}}
           @onChange={{this.toggleShowActiveOnly}}
           @screenReaderOnly={{true}}
-        ><:label>Statut</:label></PixToggle>
+        >
+          <:label>Statut</:label>
+          <:on>Actifs</:on>
+          <:off>Tous</:off>
+        </PixToggle>
         <PixButton
           @type="submit"
         >
@@ -122,7 +124,7 @@
                 <:triggerElement>
                   <PixIconButton
                     @triggerAction={{fn this.copyStaticCoursePreviewUrl staticCourseSummary}}
-                    @icon="copy"
+                    @iconName="copy"
                     @iconPrefix="far"
                     @ariaLabel="copier le lien vers la preview"
                     class="icon"

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
@@ -54,7 +54,7 @@
         <PixButton
           @triggerAction={{fn this.copyStaticCoursePreviewUrl this.model.staticCourse}}
           @iconBefore="copy"
-          @prefixIconBefore="far"
+          @plainIconBefore="far"
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
           @isDisabled={{not this.model.staticCourse.isActive}}

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^3.0.6",
         "@1024pix/eslint-plugin": "^1.3.1",
-        "@1024pix/pix-ui": "^46.12.16",
+        "@1024pix/pix-ui": "^47.0.3",
         "@1024pix/stylelint-config": "~5.0.2",
         "@babel/eslint-parser": "^7.25.1",
         "@babel/plugin-proposal-decorators": "^7.22.7",
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "46.12.16",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-46.12.16.tgz",
-      "integrity": "sha512-Dp4WBqgLckLFdd3TRLPiXbBgc7S/8JLvF2HFPvFAPVnDNw7iMXY0a23yiA6/NHabvDToGmRkCz2EhthBj2TnNw==",
+      "version": "47.0.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-47.0.3.tgz",
+      "integrity": "sha512-C2fRz1don8Z9lsK66fm8tIMyaYiZlCRXm0obY+NlnbrAe9L5ygvab1FpmBt0nH+kbzYqRRaR1/lW8PQg4cGKcg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^3.0.6",
     "@1024pix/eslint-plugin": "^1.3.1",
-    "@1024pix/pix-ui": "^46.12.16",
+    "@1024pix/pix-ui": "^47.0.3",
     "@1024pix/stylelint-config": "~5.0.2",
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-proposal-decorators": "^7.22.7",


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire le bug :
- Se rendre sur la page de modification (ou de création) d'épreuve prototype proposée
- Essayer de modifier la valeur du champ "Daltonien" (par exemple)
- Constater qu'on se fait scroll top ! 😢 

## :robot: Proposition
Le bug venait de PixUI et a été corrigé dans la release v47.0.3
On a donc mis à jour PixUI et c'est bon !

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Essayer de reproduire le bug et ne pas y arriver + petit tour de l'appli pour voir si les composants PixUi sont ok (particulièrement utilisés dans le scope missions et static courses)
