### PR TITLE
[FEATURE] Faire en sorte que les déclis portent les valeurs de qualité de leur prototype dans la release et répli (PIX-14679)

### DIFF
--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -36,6 +36,11 @@ function _fillAlternativeQualityFields(challenge, prototype) {
   const fieldsToOverride = [
     'accessibility1',
     'accessibility2',
+    'requireGafamWebsiteAccess',
+    'isIncompatibleIpadCertif',
+    'deafAndHardOfHearing',
+    'isAwarenessChallenge',
+    'toRephrase',
   ];
 
   for (const field of fieldsToOverride) {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -24,7 +24,7 @@ async function mockCurrentContent() {
     version:1,
     genealogy: Challenge.GENEALOGIES.PROTOTYPE,
     accessibility1: Challenge.ACCESSIBILITY1.OK,
-    accessibility2: Challenge.ACCESSIBILITY2.OK
+    accessibility2: Challenge.ACCESSIBILITY2.OK,
   });
 
   const alternativeChallenge = domainBuilder.buildChallenge({
@@ -102,20 +102,13 @@ async function mockCurrentContent() {
   };
   delete expectedChallenge.localizedChallenges;
 
-  const expectedPrimaryAlternativeQualityAttributes = {
-    requireGafamWebsiteAccess: false,
-    isIncompatibleIpadCertif: true,
-    deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
-    isAwarenessChallenge: true,
-    toRephrase: false,
-  };
   const expectedAlternativeChallenge = {
     ...alternativeChallenge,
     area: 'Neutre',
     files: [],
     accessibility1: challenge.accessibility1,
     accessibility2: challenge.accessibility2,
-    ...expectedPrimaryAlternativeQualityAttributes,
+    ...expectedPrimaryProtoQualityAttributes,
   };
   delete expectedAlternativeChallenge.localizedChallenges;
 
@@ -230,7 +223,11 @@ async function mockCurrentContent() {
     locale: 'fr',
     embedUrl: alternativeChallenge.embedUrl,
     status: LocalizedChallenge.STATUSES.PLAY,
-    ...expectedPrimaryAlternativeQualityAttributes,
+    requireGafamWebsiteAccess: false,
+    isIncompatibleIpadCertif: true,
+    deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+    isAwarenessChallenge: true,
+    toRephrase: false,
   });
   databaseBuilder.factory.buildLocalizedChallenge({
     id: 'localized-challenge-id',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -510,7 +510,8 @@ async function mockContentForRelease() {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
-      }, {
+      },
+      {
         id: 'recChallenge0_1',
         instruction: 'Consigne du Challenge - fr-fr',
         proposals: 'Propositions du Challenge - fr-fr',
@@ -540,10 +541,10 @@ async function mockContentForRelease() {
         illustrationUrl: null,
         accessibility1: ChallengeForRelease.ACCESSIBILITY1.RAS,
         accessibility2: ChallengeForRelease.ACCESSIBILITY2.OK,
-        requireGafamWebsiteAccess: false,
+        requireGafamWebsiteAccess: true,
         isIncompatibleIpadCertif: true,
-        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
-        isAwarenessChallenge: false,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+        isAwarenessChallenge: true,
         toRephrase: true,
       },],
     tutorials: [{
@@ -615,12 +616,14 @@ async function mockContentForRelease() {
     challenges: [
       buildChallenge({
         ...expectedCurrentContent.challenges[0],
-        files: attachments.map(({ id: fileId, localizedChallengeId }) => ({ fileId, localizedChallengeId }))
+        files: attachments.map(({ id: fileId, localizedChallengeId }) => ({ fileId, localizedChallengeId })),
+        version: 8,
       }),
       buildChallenge({
         ...expectedCurrentContent.challenges[1],
         accessibility1: ChallengeForRelease.ACCESSIBILITY1.KO,
         accessibility2: ChallengeForRelease.ACCESSIBILITY2.KO,
+        version: 8,
       }),
     ],
     competences: [buildCompetence(expectedCurrentContent.competences[0])],
@@ -719,16 +722,17 @@ async function mockContentForRelease() {
       value: challenge.illustrationAlt,
     });
 
+    const isAlternative = challenge.genealogy === 'Décliné 1';
     databaseBuilder.factory.buildLocalizedChallenge({
       id: challenge.id,
       challengeId: challenge.id,
       locale: 'fr-fr',
       embedUrl: challenge.embedUrl,
-      requireGafamWebsiteAccess: challenge.requireGafamWebsiteAccess,
-      isIncompatibleIpadCertif: challenge.isIncompatibleIpadCertif,
-      deafAndHardOfHearing: challenge.deafAndHardOfHearing,
-      isAwarenessChallenge: challenge.isAwarenessChallenge,
-      toRephrase: challenge.toRephrase,
+      requireGafamWebsiteAccess: isAlternative ? !challenge.requireGafamWebsiteAccess : challenge.requireGafamWebsiteAccess,
+      isIncompatibleIpadCertif: isAlternative ? !challenge.isIncompatibleIpadCertif : challenge.isIncompatibleIpadCertif,
+      isAwarenessChallenge: isAlternative ? !challenge.isAwarenessChallenge : challenge.isAwarenessChallenge,
+      toRephrase: isAlternative ? !challenge.toRephrase : challenge.toRephrase,
+      deafAndHardOfHearing: isAlternative ? LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS : challenge.deafAndHardOfHearing,
     });
   }
 
@@ -854,7 +858,7 @@ describe('Acceptance | Controller | release-controller', () => {
     });
 
     context('nominal case', () => {
-      it.fails('should create the release', async () => {
+      it('should create the release', async () => {
         // Given
         const user = databaseBuilder.factory.buildAdminUser();
         databaseBuilder.factory.buildMission({

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -854,7 +854,7 @@ describe('Acceptance | Controller | release-controller', () => {
     });
 
     context('nominal case', () => {
-      it('should create the release', async () => {
+      it.fails('should create the release', async () => {
         // Given
         const user = databaseBuilder.factory.buildAdminUser();
         databaseBuilder.factory.buildMission({

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -366,13 +366,14 @@ function buildChallengeTranslationsAndLocalizedChallenge(challenge, locale, loca
   });
 
   const isPrimary = localizedChallengeId === challenge.id;
+  const isAlternative = challenge.genealogy === 'Décliné 1';
   databaseBuilder.factory.buildLocalizedChallenge({
     id: localizedChallengeId,
     challengeId: challenge.id,
     locale,
     embedUrl: isPrimary ? challenge.embedUrl : null,
     status: LocalizedChallenge.STATUSES.PLAY,
-    requireGafamWebsiteAccess: isPrimary,
+    requireGafamWebsiteAccess: !isAlternative,
     isIncompatibleIpadCertif: isPrimary,
     deafAndHardOfHearing: isPrimary ? LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK : LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
     isAwarenessChallenge: isPrimary,
@@ -674,7 +675,7 @@ function _mockRichAirtableContent() {
     locales: ['en'],
     airtableId: 'challenge121212',
     skills: 'challenge121212 skills',
-    genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+    genealogy: ChallengeForRelease.GENEALOGIES.DECLINAISON,
     pedagogy: Challenge.PEDAGOGIES.Q_SITUATION,
     author: 'challenge121212 author',
     declinable: Challenge.DECLINABLES.FACILEMENT,
@@ -1097,7 +1098,7 @@ function _getRichCurrentContentDTO() {
       },
       competenceId: 'competence12',
       isMobileCompliant: true,
-      isTabletCompliant: false,
+      isTabletCompliant: true,
       thematicId: 'thematic121',
       skillIds: ['skill12121'],
     },
@@ -1289,7 +1290,7 @@ function _getRichCurrentContentDTO() {
       autoReply: true,
       locales: ['en'],
       alternativeInstruction: 'challenge121212 alternativeInstruction en',
-      genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      genealogy: ChallengeForRelease.GENEALOGIES.DECLINAISON,
       responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
       focusable: 'challenge121212 focusable',
       delta: 123,
@@ -1300,7 +1301,7 @@ function _getRichCurrentContentDTO() {
       alternativeVersion: 'challenge121212 alternativeVersion',
       accessibility1: ChallengeForRelease.ACCESSIBILITY1.KO,
       accessibility2: ChallengeForRelease.ACCESSIBILITY2.OK,
-      requireGafamWebsiteAccess: true,
+      requireGafamWebsiteAccess: false,
       isIncompatibleIpadCertif: true,
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -152,7 +152,7 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
   });
 
   describe('#fillAlternativeFieldsFromProto', () => {
-    it('should fill same accessibility1 and accessibility2 from prototype for all challenges by skill and version', () => {
+    it('should fill same quality attributes from prototype for all challenges by skill and version', () => {
       // given
       const skill1 = {
         id: 'skill1',
@@ -163,7 +163,6 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         id: 'skill2',
         name: 'skill2',
       };
-
       const challengeProto1Skill1DTO = {
         id: 'challengeProto1Skill1',
         skillId: skill1.id,
@@ -174,6 +173,15 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeProto1Skill1',
+          challengeId: 'challengeProto1Skill1',
+          requireGafamWebsiteAccess: true,
+          isIncompatibleIpadCertif: true,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+          isAwarenessChallenge: false,
+          toRephrase: false,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -191,6 +199,10 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeAlternative1Skill1',
+          challengeId: 'challengeAlternative1Skill1',
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.RAS,
@@ -209,6 +221,15 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeProto2Skill1',
+          challengeId: 'challengeProto2Skill1',
+          requireGafamWebsiteAccess: false,
+          isIncompatibleIpadCertif: false,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+          isAwarenessChallenge: true,
+          toRephrase: true,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.KO,
@@ -226,6 +247,10 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeAlternative2Skill1',
+          challengeId: 'challengeAlternative2Skill1',
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -244,6 +269,15 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeProto1Skill2',
+          challengeId: 'challengeProto1Skill2',
+          requireGafamWebsiteAccess: true,
+          isIncompatibleIpadCertif: true,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+          isAwarenessChallenge: true,
+          toRephrase: true,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.RAS,
@@ -261,6 +295,10 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeAlternative1Skill2',
+          challengeId: 'challengeAlternative1Skill2',
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -293,25 +331,46 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
 
       // then
       expect(challengeProto1Skill1).to.deep.equal(domainBuilder.buildChallenge(challengeProto1Skill1DTO));
-      expect(challengeAlternative1Skill1).to.deep.equal(domainBuilder.buildChallenge({
-        ...challengeAlternative1Skill1DTO,
-        accessibility1: challengeProto1Skill1DTO.accessibility1,
-        accessibility2: challengeProto1Skill1DTO.accessibility2,
-      }));
+      expect(challengeAlternative1Skill1).to.deep.equal({
+        ...domainBuilder.buildChallenge({
+          ...challengeAlternative1Skill1DTO,
+          accessibility1: challengeProto1Skill1DTO.accessibility1,
+          accessibility2: challengeProto1Skill1DTO.accessibility2,
+        }),
+        requireGafamWebsiteAccess: challengeProto1Skill1.requireGafamWebsiteAccess,
+        isIncompatibleIpadCertif: challengeProto1Skill1.isIncompatibleIpadCertif,
+        deafAndHardOfHearing: challengeProto1Skill1.deafAndHardOfHearing,
+        isAwarenessChallenge: challengeProto1Skill1.isAwarenessChallenge,
+        toRephrase: challengeProto1Skill1.toRephrase,
+      });
 
       expect(challengeProto2Skill1).to.deep.equal(domainBuilder.buildChallenge(challengeProto2Skill1DTO));
-      expect(challengeAlternative2Skill1).to.deep.equal(domainBuilder.buildChallenge({
-        ...challengeAlternative2Skill1DTO,
-        accessibility1: challengeProto2Skill1DTO.accessibility1,
-        accessibility2: challengeProto2Skill1DTO.accessibility2,
-      }));
+      expect(challengeAlternative2Skill1).to.deep.equal({
+        ...domainBuilder.buildChallenge({
+          ...challengeAlternative2Skill1DTO,
+          accessibility1: challengeProto2Skill1DTO.accessibility1,
+          accessibility2: challengeProto2Skill1DTO.accessibility2,
+        }),
+        requireGafamWebsiteAccess: challengeProto2Skill1.requireGafamWebsiteAccess,
+        isIncompatibleIpadCertif: challengeProto2Skill1.isIncompatibleIpadCertif,
+        deafAndHardOfHearing: challengeProto2Skill1.deafAndHardOfHearing,
+        isAwarenessChallenge: challengeProto2Skill1.isAwarenessChallenge,
+        toRephrase: challengeProto2Skill1.toRephrase,
+      });
 
       expect(challengeProto1Skill2).to.deep.equal(domainBuilder.buildChallenge(challengeProto1Skill2DTO));
-      expect(challengeAlternative1Skill2).to.deep.equal(domainBuilder.buildChallenge({
-        ...challengeAlternative1Skill2DTO,
-        accessibility1: challengeProto1Skill2DTO.accessibility1,
-        accessibility2: challengeProto1Skill2DTO.accessibility2,
-      }));
+      expect(challengeAlternative1Skill2).to.deep.equal({
+        ...domainBuilder.buildChallenge({
+          ...challengeAlternative1Skill2DTO,
+          accessibility1: challengeProto1Skill2DTO.accessibility1,
+          accessibility2: challengeProto1Skill2DTO.accessibility2,
+        }),
+        requireGafamWebsiteAccess: challengeProto1Skill2.requireGafamWebsiteAccess,
+        isIncompatibleIpadCertif: challengeProto1Skill2.isIncompatibleIpadCertif,
+        deafAndHardOfHearing: challengeProto1Skill2.deafAndHardOfHearing,
+        isAwarenessChallenge: challengeProto1Skill2.isAwarenessChallenge,
+        toRephrase: challengeProto1Skill2.toRephrase,
+      });
     });
 
     it('shouldn\'t alter challenges from workbench', () => {
@@ -331,12 +390,22 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeProtoWorkbench1',
+          challengeId: 'challengeProtoWorkbench1',
+          requireGafamWebsiteAccess: true,
+          isIncompatibleIpadCertif: true,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+          isAwarenessChallenge: true,
+          toRephrase: true,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
         accessibility2: Challenge.ACCESSIBILITY2.KO,
         version: null,
-        genealogy: Challenge.GENEALOGIES.PROTOTYPE
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+
       };
 
       const challengeProtoWorkbench2DTO  = {
@@ -349,6 +418,15 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeProtoWorkbench2',
+          challengeId: 'challengeProtoWorkbench2',
+          requireGafamWebsiteAccess: false,
+          isIncompatibleIpadCertif: false,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+          isAwarenessChallenge: false,
+          toRephrase: false,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.KO,
@@ -392,6 +470,15 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeAlternative3Skill1',
+          challengeId: 'challengeAlternative3Skill1',
+          requireGafamWebsiteAccess: true,
+          isIncompatibleIpadCertif: true,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+          isAwarenessChallenge: true,
+          toRephrase: true,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -410,6 +497,15 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             proposals: 'Propositions',
           },
         },
+        localizedChallenges: [domainBuilder.buildLocalizedChallenge({
+          id: 'challengeAlternative3Skill1',
+          challengeId: 'challengeAlternative3Skill1',
+          requireGafamWebsiteAccess: false,
+          isIncompatibleIpadCertif: false,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+          isAwarenessChallenge: false,
+          toRephrase: false,
+        })],
         locales: ['fr', 'fr-fr'],
         files: [],
         accessibility1: Challenge.ACCESSIBILITY1.KO,


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'ici, les nouveaux champs de qualité des épreuves étaient portées par chaque épreuve (proto et déclis). Or, la valeur qui compte est celle des prototypes, à reporter donc pour les versions déclinées.

## :robot: Proposition
Ne pas lire les valeurs des champs qualité des déclinaisons et reporter celles du prototype concerné pour la release et la répli.

## :rainbow: Remarques
RAS

## :100: Pour tester
1/ Créer un prototype avec des champs qualité choisis, puis le valider.
2/ Créer une déclinaison (qui prendra par défaut les valeurs du proto)
3/ Modifier les valeurs des champs qualité du prototype (sur la page de l'acquis correspondant). 

> ⚠️  A ce stade, le proto et sa décli n'ont plus les mêmes valeurs de qualité (c'est important pour la suite de l'histoire)

4/ Créer une release
5/ Vérifier que le proto et la décli portent les valeurs modifiées du proto.
6/ 🎉 
