### PR TITLE
[BUGFIX] Empêcher la création d'une déclinaison avec une version `undefined` (PIX-14943)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
@@ -50,7 +50,7 @@ export default class NewController extends Alternative {
   }
 
   async _setAlternativeVersion(challenge) {
-    const version = await this.currentData.getPrototype().getNextAlternativeVersion();
+    const version = this.currentData.getPrototype().getNextAlternativeVersion();
     challenge.alternativeVersion = version;
   }
 }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
@@ -31,10 +31,10 @@ export default class NewController extends Alternative {
       await this._handleIllustration(this.challenge);
       await this._handleAttachments(this.challenge);
       // create challenge without patching Pix API cache
+      this._setAlternativeVersion(this.challenge);
       await this._saveChallenge(this.challenge);
       await this._saveFiles(this.challenge);
-      await this._setAlternativeVersion(this.challenge);
-      // update challenge's alternative version and patch Pix API cache
+      // refresh Pix API cache (only done on PATCH route)
       await this._saveChallenge(this.challenge);
       this.edition = false;
       this.send('minimize');
@@ -49,7 +49,7 @@ export default class NewController extends Alternative {
     }
   }
 
-  async _setAlternativeVersion(challenge) {
+  _setAlternativeVersion(challenge) {
     const version = this.currentData.getPrototype().getNextAlternativeVersion();
     challenge.alternativeVersion = version;
   }

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -289,14 +289,8 @@ export default class ChallengeModel extends Model {
   }
 
   getNextAlternativeVersion() {
-    return this.alternatives.reduce((current, alternative) => {
-      const version = alternative.alternativeVersion;
-      if (!isNaN(version)) {
-        return Math.max(current, version);
-      } else {
-        return current;
-      }
-    }, 0) + 1;
+    const currentVersions = this.alternatives.map((alternative) => parseInt(alternative.alternativeVersion)).filter(Number.isInteger);
+    return Math.max(...currentVersions, 0) + 1;
   }
 
   baseNameUpdated() {

--- a/pix-editor/tests/unit/models/challenge-test.js
+++ b/pix-editor/tests/unit/models/challenge-test.js
@@ -325,4 +325,73 @@ module('Unit | Model | challenge', function(hooks) {
     });
 
   });
+
+  module('#getNextAlternativeVersion', function() {
+    test('it should return 1 if no other alternatives', function(assert) {
+      // given
+      const proto = store.createRecord('challenge', {
+        id: 'challengeProto',
+        genealogy: 'Prototype 1',
+        skill: store.createRecord('skill', {}),
+      });
+
+      // when
+      const nextAlternativeVersion = proto.getNextAlternativeVersion();
+
+      // then
+      assert.strictEqual(nextAlternativeVersion, 1);
+    });
+
+    test('it should return "highest current decli + 1" when there are alternatives', function(assert) {
+      // given
+      const skill = store.createRecord('skill', {});
+      const proto = store.createRecord('challenge', {
+        id: 'challengeProto',
+        genealogy: 'Prototype 1',
+        skill,
+      });
+      store.createRecord('challenge', {
+        id: 'challengeDécli1',
+        genealogy: 'Décliné 1',
+        alternativeVersion: 1,
+        skill,
+      });
+      store.createRecord('challenge', {
+        id: 'challengeDécli3',
+        genealogy: 'Décliné 1',
+        alternativeVersion: 3,
+        skill,
+      });
+      store.createRecord('challenge', {
+        id: 'challengeDécli4String',
+        genealogy: 'Décliné 1',
+        alternativeVersion: '4',
+        skill,
+      });
+      store.createRecord('challenge', {
+        id: 'challengeDécliNull',
+        genealogy: 'Décliné 1',
+        alternativeVersion: null,
+        skill,
+      });
+      store.createRecord('challenge', {
+        id: 'challengeDécliHello',
+        genealogy: 'Décliné 1',
+        alternativeVersion: 'hello',
+        skill,
+      });
+      store.createRecord('challenge', {
+        id: 'challengeDécliMinusOne',
+        genealogy: 'Décliné 1',
+        alternativeVersion: -1,
+        skill,
+      });
+
+      // when
+      const nextAlternativeVersion = proto.getNextAlternativeVersion();
+
+      // then
+      assert.strictEqual(nextAlternativeVersion, 5);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Certaines déclinaisons ont des versions `undefined`.
Cela ne devrait pas être le cas, l'attribut `alternativeVersion` devrait avoir un type `number`.

## :robot: Proposition
On suppose que ces déclinaisons erronées sont causées par un enregistrement interrompu (et donc un manque de garanties transactionnelles) :

La méthode `save` du controller `alternatives/new` effectue d'abord une requête POST pour enregistrer la déclinaison.
La propriété `alternativeVersion` était ensuite mise à jour, et une nouvelle requête PATCH était effectuée.
Le but principal du PATCH est de mettre à jour le cache Pix API.
Si la requête PATCH n'a pas lieu ou est interrompue à cause d'un erreur, la déclinaison se retrouve avec une version `undefined`. 

On propose de calculer l'`alternativeVersion` avant la première requête POST, afin que la déclinaison ne puisse **à aucun moment** avoir de version `undefined`.
On souhaite toujours effectuer la requête PATCH par la suite, afin de mettre à jour le cache.

## :rainbow: Remarques
Heureusement, ember-data effectue une requête PATCH même si le modèle n'a pas changé depuis le dernier POST, sinon on aurait dû faire une pirouette pour modifier le modèle d'une façon ou d'une autre (ce qui était fait avant avec `alternativeVersion`).

## :100: Pour tester
- Vérifier que les tests passent.
- Essayer de créer une déclinaison et constater qu'il n'y a pas d'erreur.


Pour les devs :
- Modifier le code pour provoquer une erreur après le POST mais avant le PATCH.
- Constater que la déclinaison a bien une `alternativeVersion`.
