### PR TITLE
[BUGFIX] Pour les champs qualité, dans la liste des choix possibles on pouvait choisir une option "vide" (PIX-14925)

### DIFF
--- a/pix-editor/app/components/field/quality.hbs
+++ b/pix-editor/app/components/field/quality.hbs
@@ -32,8 +32,6 @@
       <:label>Spoil</:label>
     </PixSelect>
     <PixSelect
-      class="COUCOU"
-      data-test-mon-cul="oh-yea"
       data-test-responsive-challenge-id={{@challenge.id}}
       @options={{this.responsiveOptions}}
       @value={{@challenge.responsive}}

--- a/pix-editor/app/components/field/quality.hbs
+++ b/pix-editor/app/components/field/quality.hbs
@@ -7,6 +7,7 @@
       @value={{@challenge.accessibility1}}
       @onChange={{fn (mut @challenge.accessibility1)}}
       @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
     >
       <:label>Non voyant</:label>
     </PixSelect>
@@ -16,6 +17,7 @@
       @value={{@challenge.accessibility2}}
       @onChange={{fn (mut @challenge.accessibility2)}}
       @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
     >
       <:label>Daltonien</:label>
     </PixSelect>
@@ -25,6 +27,7 @@
       @value={{@challenge.spoil}}
       @onChange={{fn (mut @challenge.spoil)}}
       @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
     >
       <:label>Spoil</:label>
     </PixSelect>
@@ -36,6 +39,7 @@
       @value={{@challenge.responsive}}
       @onChange={{fn (mut @challenge.responsive)}}
       @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
     >
       <:label>Responsive</:label>
     </PixSelect>
@@ -45,6 +49,7 @@
       @value={{@challenge.deafAndHardOfHearing}}
       @onChange={{fn (mut @challenge.deafAndHardOfHearing)}}
       @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
     >
       <:label>Sourds et malentendants</:label>
     </PixSelect>


### PR DESCRIPTION
## :unicorn: Problème
Dérouler une liste de sélection d'un champ qualité (Daltonien par exemple)
Voir que dans la liste y'a un item vide sélectionnable.

## :robot: Proposition
Petit réglage de config autour des PixSelect

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Ne plus voir l'item vide
