### PR TITLE
[BUGFIX] Le champ embedURL n'était pas prérempli lorsqu'on crée une déclinaison ou qu'on duplique une épreuve (PIX-14926)

### DIFF
--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -253,7 +253,7 @@ export default class ChallengeModel extends Model {
   }
 
   async duplicate() {
-    const ignoredFields = ['skill', 'author', 'airtableId'];
+    const ignoredFields = ['skill', 'author', 'airtableId', 'updatedAt', 'archivedAt', 'madeObsoleteAt', 'validatedAt'];
     if (this.isPrototype) {
       ignoredFields.push('version');
     } else {
@@ -271,7 +271,7 @@ export default class ChallengeModel extends Model {
   }
 
   async copyForDifferentSkill() {
-    const ignoredFields = ['skill', 'airtableId'];
+    const ignoredFields = ['skill', 'airtableId', 'updatedAt', 'archivedAt', 'madeObsoleteAt', 'validatedAt'];
     const data = this._getJSON(ignoredFields);
 
     data.status = 'proposé';
@@ -339,7 +339,7 @@ export default class ChallengeModel extends Model {
     const rawSerializedData = structuredClone(this.serialize({ idIncluded: false }));
     const data = {};
     for (const [key, value] of Object.entries(rawSerializedData.data.attributes)) {
-      const newKey = _.camelCase(key);
+      const newKey = key === 'embed-url' ? 'embedURL' : _.camelCase(key);
       data[newKey] = value;
     }
     return data;

--- a/pix-editor/tests/unit/models/challenge-test.js
+++ b/pix-editor/tests/unit/models/challenge-test.js
@@ -20,10 +20,44 @@ module('Unit | Model | challenge', function(hooks) {
     this.owner.register('service:config', ConfigService);
 
     idGeneratorStub = { newId: sinon.stub().returns('generatedId') };
-
     prototype = {
       id: 'pix_1',
       airtableId: 'rec_1',
+      instruction: 'proto instruction',
+      alternativeInstruction: 'proto alternativeInstruction',
+      type: 'proto type',
+      format: 'proto format',
+      proposals: 'proto proposals',
+      solution: 'proto solution',
+      solutionToDisplay: 'proto solutionToDisplay',
+      t1Status: 'proto t1Status',
+      t2Status: 'proto t2Status',
+      t3Status: 'proto t3Status',
+      pedagogy: 'proto pedagogy',
+      declinable: 'proto declinable',
+      preview: 'proto preview',
+      timer: 123,
+      embedURL: 'proto embedURL',
+      embedTitle: 'proto embedTitle',
+      embedHeight: 500,
+      alternativeVersion: 5,
+      accessibility1: 'proto accessibility1',
+      accessibility2: 'proto accessibility2',
+      spoil: 'proto spoil',
+      responsive: 'proto responsive',
+      locales: ['fr'],
+      alternativeLocales: ['fr'],
+      geography: 'proto geography',
+      urlsToConsult: ['some', 'url'],
+      autoReply: 'proto autoReply',
+      focusable: 'proto focusable',
+      illustrationAlt: 'proto illustrationAlt',
+      updatedAt: new Date('2020-01-01'),
+      validatedAt: new Date('2020-01-01'),
+      archivedAt: new Date('2020-01-01'),
+      madeObsoleteAt: new Date('2020-01-01'),
+      shuffled: true,
+      contextualizedFields: ['oui', 'non'],
       status: 'validé',
       genealogy: 'Prototype 1',
       author: 'DEV',
@@ -44,6 +78,47 @@ module('Unit | Model | challenge', function(hooks) {
       alternativeVersion: 1,
       skill: store.createRecord('skill', {}),
       idGenerator: idGeneratorStub,
+      instruction: 'alternative instruction',
+      alternativeInstruction: 'alternative alternativeInstruction',
+      type: 'alternative type',
+      format: 'alternative format',
+      proposals: 'alternative proposals',
+      solution: 'alternative solution',
+      solutionToDisplay: 'alternative solutionToDisplay',
+      t1Status: 'alternative t1Status',
+      t2Status: 'alternative t2Status',
+      t3Status: 'alternative t3Status',
+      pedagogy: 'alternative pedagogy',
+      declinable: 'alternative declinable',
+      preview: 'alternative preview',
+      timer: 123,
+      embedURL: 'alternative embedURL',
+      embedTitle: 'alternative embedTitle',
+      embedHeight: 500,
+      accessibility1: 'alternative accessibility1',
+      accessibility2: 'alternative accessibility2',
+      spoil: 'alternative spoil',
+      responsive: 'alternative responsive',
+      locales: ['fr'],
+      alternativeLocales: ['fr'],
+      geography: 'alternative geography',
+      urlsToConsult: ['some', 'url'],
+      autoReply: 'alternative autoReply',
+      focusable: 'alternative focusable',
+      illustrationAlt: 'alternative illustrationAlt',
+      updatedAt: new Date('2020-01-01'),
+      validatedAt: new Date('2020-01-01'),
+      archivedAt: new Date('2020-01-01'),
+      madeObsoleteAt: new Date('2020-01-01'),
+      shuffled: true,
+      contextualizedFields: ['oui', 'non'],
+      genealogy: 'Décliné 1',
+      version: 1,
+      requireGafamWebsiteAccess: true,
+      isIncompatibleIpadCertif: true,
+      deafAndHardOfHearing: 'OK',
+      isAwarenessChallenge: true,
+      toRephrase: true,
     };
   });
 
@@ -56,18 +131,54 @@ module('Unit | Model | challenge', function(hooks) {
       const clonedChallenge = await challenge.duplicate();
 
       // then
-      assert.strictEqual(clonedChallenge.constructor.modelName, 'challenge');
-      assert.strictEqual(clonedChallenge.id, 'generatedId');
-      assert.strictEqual(clonedChallenge.airtableId, undefined);
-      assert.strictEqual(clonedChallenge.status, 'proposé');
-      assert.deepEqual(clonedChallenge.author, ['NEW']);
-      assert.strictEqual(clonedChallenge.version, undefined);
-      assert.true(clonedChallenge.requireGafamWebsiteAccess);
-      assert.true(clonedChallenge.isIncompatibleIpadCertif);
-      assert.strictEqual(clonedChallenge.deafAndHardOfHearing, 'OK');
-      assert.true(clonedChallenge.isAwarenessChallenge);
-      assert.true(clonedChallenge.toRephrase);
-      assert.ok(clonedChallenge.skill);
+      assert.strictEqual(clonedChallenge.constructor.modelName, 'challenge', 'check modèle challenge');
+      assert.strictEqual(clonedChallenge.id, 'generatedId', 'champ id');
+      assert.strictEqual(clonedChallenge.airtableId, undefined, 'champ airtableId');
+      assert.strictEqual(clonedChallenge.instruction, prototype.instruction, 'champ instruction');
+      assert.strictEqual(clonedChallenge.alternativeInstruction, prototype.alternativeInstruction, 'champ alternativeInstruction');
+      assert.strictEqual(clonedChallenge.type, prototype.type, 'champ type');
+      assert.strictEqual(clonedChallenge.format, prototype.format, 'champ format');
+      assert.strictEqual(clonedChallenge.proposals, prototype.proposals, 'champ proposals');
+      assert.strictEqual(clonedChallenge.solution, prototype.solution, 'champ solution');
+      assert.strictEqual(clonedChallenge.solutionToDisplay, prototype.solutionToDisplay, 'champ solutionToDisplay');
+      assert.strictEqual(clonedChallenge.t1Status, prototype.t1Status, 'champ t1Status');
+      assert.strictEqual(clonedChallenge.t2Status, prototype.t2Status, 'champ t2Status');
+      assert.strictEqual(clonedChallenge.t3Status, prototype.t3Status, 'champ t3Status');
+      assert.strictEqual(clonedChallenge.pedagogy, prototype.pedagogy, 'champ pedagogy');
+      assert.strictEqual(clonedChallenge.declinable, prototype.declinable, 'champ declinable');
+      assert.strictEqual(clonedChallenge.preview, prototype.preview, 'champ preview');
+      assert.strictEqual(clonedChallenge.timer, prototype.timer, 'champ timer');
+      assert.strictEqual(clonedChallenge.embedURL, prototype.embedURL, 'champ embedURL');
+      assert.strictEqual(clonedChallenge.embedTitle, prototype.embedTitle, 'champ embedTitle');
+      assert.strictEqual(clonedChallenge.embedHeight, prototype.embedHeight, 'champ embedHeight');
+      assert.strictEqual(clonedChallenge.alternativeVersion, prototype.alternativeVersion, 'champ alternativeVersion');
+      assert.strictEqual(clonedChallenge.accessibility1, prototype.accessibility1, 'champ accessibility1');
+      assert.strictEqual(clonedChallenge.accessibility2, prototype.accessibility2, 'champ accessibility2');
+      assert.strictEqual(clonedChallenge.spoil, prototype.spoil, 'champ spoil');
+      assert.strictEqual(clonedChallenge.responsive, prototype.responsive, 'champ responsive');
+      assert.deepEqual(clonedChallenge.locales, prototype.locales, 'champ locales');
+      assert.deepEqual(clonedChallenge.alternativeLocales, prototype.alternativeLocales, 'champ alternativeLocales');
+      assert.strictEqual(clonedChallenge.geography, prototype.geography, 'champ geography');
+      assert.deepEqual(clonedChallenge.urlsToConsult, prototype.urlsToConsult, 'champ urlsToConsult');
+      assert.strictEqual(clonedChallenge.autoReply, prototype.autoReply, 'champ autoReply');
+      assert.strictEqual(clonedChallenge.focusable, prototype.focusable, 'champ focusable');
+      assert.strictEqual(clonedChallenge.illustrationAlt, prototype.illustrationAlt, 'champ illustrationAlt');
+      assert.strictEqual(clonedChallenge.updatedAt, undefined, 'champ updatedAt');
+      assert.strictEqual(clonedChallenge.validatedAt, undefined, 'champ validatedAt');
+      assert.strictEqual(clonedChallenge.archivedAt, undefined, 'champ archivedAt');
+      assert.strictEqual(clonedChallenge.madeObsoleteAt, undefined, 'champ madeObsoleteAt');
+      assert.strictEqual(clonedChallenge.shuffled, prototype.shuffled, 'champ shuffled');
+      assert.deepEqual(clonedChallenge.contextualizedFields, prototype.contextualizedFields, 'champ contextualizedFields');
+      assert.strictEqual(clonedChallenge.status, 'proposé', 'champ status');
+      assert.strictEqual(clonedChallenge.genealogy, prototype.genealogy, 'champ genealogy');
+      assert.deepEqual(clonedChallenge.author, ['NEW'], 'champ author');
+      assert.strictEqual(clonedChallenge.version, undefined, 'champ version');
+      assert.ok(clonedChallenge.skill, 'champ skill');
+      assert.strictEqual(clonedChallenge.requireGafamWebsiteAccess, prototype.requireGafamWebsiteAccess, 'champ requireGafamWebsiteAccess');
+      assert.strictEqual(clonedChallenge.isIncompatibleIpadCertif, prototype.isIncompatibleIpadCertif, 'champ isIncompatibleIpadCertif');
+      assert.strictEqual(clonedChallenge.deafAndHardOfHearing, prototype.deafAndHardOfHearing, 'champ deafAndHardOfHearing');
+      assert.strictEqual(clonedChallenge.isAwarenessChallenge, prototype.isAwarenessChallenge, 'champ isAwarenessChallenge');
+      assert.strictEqual(clonedChallenge.toRephrase, prototype.toRephrase, 'champ toRephrase');
     });
 
     test('it should duplicate challenge to create new alternative version', async function(assert) {
@@ -78,12 +189,54 @@ module('Unit | Model | challenge', function(hooks) {
       const clonedChallenge = await challenge.duplicate();
 
       // then
-      assert.strictEqual(clonedChallenge.constructor.modelName, 'challenge');
-      assert.strictEqual(clonedChallenge.id, 'generatedId');
-      assert.strictEqual(clonedChallenge.status, 'proposé');
-      assert.deepEqual(clonedChallenge.author, ['NEW']);
-      assert.strictEqual(clonedChallenge.alternativeVersion, undefined);
-      assert.ok(clonedChallenge.skill);
+      assert.strictEqual(clonedChallenge.constructor.modelName, 'challenge', 'check modèle challenge');
+      assert.strictEqual(clonedChallenge.id, 'generatedId', 'champ id');
+      assert.strictEqual(clonedChallenge.airtableId, undefined, 'champ airtableId');
+      assert.strictEqual(clonedChallenge.instruction, alternative.instruction, 'champ instruction');
+      assert.strictEqual(clonedChallenge.alternativeInstruction, alternative.alternativeInstruction, 'champ alternativeInstruction');
+      assert.strictEqual(clonedChallenge.type, alternative.type, 'champ type');
+      assert.strictEqual(clonedChallenge.format, alternative.format, 'champ format');
+      assert.strictEqual(clonedChallenge.proposals, alternative.proposals, 'champ proposals');
+      assert.strictEqual(clonedChallenge.solution, alternative.solution, 'champ solution');
+      assert.strictEqual(clonedChallenge.solutionToDisplay, alternative.solutionToDisplay, 'champ solutionToDisplay');
+      assert.strictEqual(clonedChallenge.t1Status, alternative.t1Status, 'champ t1Status');
+      assert.strictEqual(clonedChallenge.t2Status, alternative.t2Status, 'champ t2Status');
+      assert.strictEqual(clonedChallenge.t3Status, alternative.t3Status, 'champ t3Status');
+      assert.strictEqual(clonedChallenge.pedagogy, alternative.pedagogy, 'champ pedagogy');
+      assert.strictEqual(clonedChallenge.declinable, alternative.declinable, 'champ declinable');
+      assert.strictEqual(clonedChallenge.preview, alternative.preview, 'champ preview');
+      assert.strictEqual(clonedChallenge.timer, alternative.timer, 'champ timer');
+      assert.strictEqual(clonedChallenge.embedURL, alternative.embedURL, 'champ embedURL');
+      assert.strictEqual(clonedChallenge.embedTitle, alternative.embedTitle, 'champ embedTitle');
+      assert.strictEqual(clonedChallenge.embedHeight, alternative.embedHeight, 'champ embedHeight');
+      assert.strictEqual(clonedChallenge.alternativeVersion, undefined, 'champ alternativeVersion');
+      assert.strictEqual(clonedChallenge.accessibility1, alternative.accessibility1, 'champ accessibility1');
+      assert.strictEqual(clonedChallenge.accessibility2, alternative.accessibility2, 'champ accessibility2');
+      assert.strictEqual(clonedChallenge.spoil, alternative.spoil, 'champ spoil');
+      assert.strictEqual(clonedChallenge.responsive, alternative.responsive, 'champ responsive');
+      assert.deepEqual(clonedChallenge.locales, alternative.locales, 'champ locales');
+      assert.deepEqual(clonedChallenge.alternativeLocales, alternative.alternativeLocales, 'champ alternativeLocales');
+      assert.strictEqual(clonedChallenge.geography, alternative.geography, 'champ geography');
+      assert.deepEqual(clonedChallenge.urlsToConsult, alternative.urlsToConsult, 'champ urlsToConsult');
+      assert.strictEqual(clonedChallenge.autoReply, alternative.autoReply, 'champ autoReply');
+      assert.strictEqual(clonedChallenge.focusable, alternative.focusable, 'champ focusable');
+      assert.strictEqual(clonedChallenge.illustrationAlt, alternative.illustrationAlt, 'champ illustrationAlt');
+      assert.strictEqual(clonedChallenge.updatedAt, undefined, 'champ updatedAt');
+      assert.strictEqual(clonedChallenge.validatedAt, undefined, 'champ validatedAt');
+      assert.strictEqual(clonedChallenge.archivedAt, undefined, 'champ archivedAt');
+      assert.strictEqual(clonedChallenge.madeObsoleteAt, undefined, 'champ madeObsoleteAt');
+      assert.strictEqual(clonedChallenge.shuffled, alternative.shuffled, 'champ shuffled');
+      assert.deepEqual(clonedChallenge.contextualizedFields, alternative.contextualizedFields, 'champ contextualizedFields');
+      assert.strictEqual(clonedChallenge.status, 'proposé', 'champ status');
+      assert.strictEqual(clonedChallenge.genealogy, alternative.genealogy, 'champ genealogy');
+      assert.deepEqual(clonedChallenge.author, ['NEW'], 'champ author');
+      assert.strictEqual(clonedChallenge.version, alternative.version, 'champ version');
+      assert.ok(clonedChallenge.skill, 'champ skill');
+      assert.strictEqual(clonedChallenge.requireGafamWebsiteAccess, alternative.requireGafamWebsiteAccess, 'champ requireGafamWebsiteAccess');
+      assert.strictEqual(clonedChallenge.isIncompatibleIpadCertif, alternative.isIncompatibleIpadCertif, 'champ isIncompatibleIpadCertif');
+      assert.strictEqual(clonedChallenge.deafAndHardOfHearing, alternative.deafAndHardOfHearing, 'champ deafAndHardOfHearing');
+      assert.strictEqual(clonedChallenge.isAwarenessChallenge, alternative.isAwarenessChallenge, 'champ isAwarenessChallenge');
+      assert.strictEqual(clonedChallenge.toRephrase, alternative.toRephrase, 'champ toRephrase');
     });
 
     test('it should clone the attachments', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Pour reproduire :
- choisir un prototype et remplir son champ embedURL si ce n'est pas le cas
- créer une nouvelle déclinaison depuis ce proto
- constater que dans le formulaire prérempli le champ embedURL est vide

## :robot: Proposition
A la duplication, on passe par une sérialisation / désérialisation en JSON.
Les attributs du modèles étaient reconvertis de snake case en camel case. Donc, lorsqu'on passait 'embed-url' en camelCase ça donnait 'embedUrl', mais l'attribut dans le modèle c'est 'embedURL'. Il faut donc gérer le cas à part.
+ Ignorer les dates lors de duplication
+ Améliorer test unitaire de duplication pour check davantage de champs

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Essayer de reproduire le bug
