### PR TITLE
[BUGFIX] Les pièces jointes des épreuves traduites ne s'affichent pas (PIX-14941)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -176,7 +176,7 @@ export default class LocalizedController extends Controller {
     this.urlsToConsult = this.localizedChallenge.urlsToConsult?.join('\n') ?? '';
     this.displayUrlsToConsultField = false;
     this.invalidUrlsToConsult = '';
-    await this.model.files;
+    await this.localizedChallenge.files;
     this.localizedChallenge.files.forEach((file) => file.rollbackAttributes());
     this.deletedFiles = [];
     if (!this.wasMaximized) {

--- a/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
@@ -10,6 +10,10 @@ export default class LocalizedPrototypeRoute extends Route {
     return { localizedChallenge, challenge };
   }
 
+  async afterModel(model) {
+    await model.localizedChallenge.files;
+  }
+
   setupController(controller, model) {
     super.setupController(...arguments);
     const localizedChallenge = model.localizedChallenge;


### PR DESCRIPTION
## :unicorn: Problème
1. Se rendre sur le [proto de @eval2](https://editor.integration.pix.fr/competence/rec4A7DmRkpyI7F9w/prototypes/rec4mYfhm45A222ab?view=production)

1. Afficher la version NL => la pièce jointe ne s’affiche pas

1. Entrer en modification => la pièce jointe ne s’affiche pas

1. Annuler => la version traduite s’affiche à nouveau en consultation avec la pièce jointe qui apparaît en haut du formulaire.

## :robot: Proposition
Charger les pièces jointes dans la méthode `afterModel` de la route `localized`.

## :rainbow: Remarques
Les pièces jointes s'affichaient avant seulement parce qu'on faisait un `this.localizedChallenge.forEach` qui allait les récupérer dans le fond, sans await.

## :100: Pour tester
Essayer de reproduire le problème sur la review app.
