### PR TITLE
[FEATURE] Prendre en compte la whitelist des URLs dans la moulinette (PIX-6043)

### DIFF
--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -104,7 +104,7 @@ export class WhitelistedUrl {
     this.checkType = updateCommand.checkType;
   }
 
-  isMatching(url) {
+  matches(url) {
     if (this.checkType === WhitelistedUrl.CHECK_TYPES.EXACT_MATCH) return url === this.url;
     if (this.checkType === WhitelistedUrl.CHECK_TYPES.STARTS_WITH) return url.startsWith(this.url);
     return false;

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -103,6 +103,12 @@ export class WhitelistedUrl {
     this.comment = updateCommand.comment;
     this.checkType = updateCommand.checkType;
   }
+
+  isMatching(url) {
+    if (this.checkType === WhitelistedUrl.CHECK_TYPES.EXACT_MATCH) return url === this.url;
+    if (this.checkType === WhitelistedUrl.CHECK_TYPES.STARTS_WITH) return url.startsWith(this.url);
+    return false;
+  }
 }
 
 function isUrlValid(url) {

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -61,7 +61,7 @@ async function checkAndUploadKOUrlsFromChallenges(release, { urlRepository, loca
   const operativeChallenges = release.operativeChallenges;
   const localizedChallengesById = _.keyBy(await localizedChallengeRepository.list(), 'id');
   const urlList = findUrlsFromChallenges(operativeChallenges, release, localizedChallengesById, UrlUtils);
-  const finalUrlList = urlList.filter(({ url }) => whitelistedUrls.every((whitelistedUrl) => !whitelistedUrl.isMatching(url)));
+  const finalUrlList = urlList.filter(({ url }) => !whitelistedUrls.some((whitelistedUrl) => whitelistedUrl.matches(url)));
   const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(finalUrlList);
   const formattedKOChallengeUrls = keepAndFormatKOUrls(analyzedUrls);
   await urlRepository.updateChallenges(formattedKOChallengeUrls);
@@ -70,7 +70,7 @@ async function checkAndUploadKOUrlsFromChallenges(release, { urlRepository, loca
 async function checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils }, whitelistedUrls) {
   const tutorials = release.content.tutorials;
   const urlList = findUrlsFromTutorials(tutorials, release);
-  const finalUrlList = urlList.filter(({ url }) => whitelistedUrls.every((whitelistedUrl) => !whitelistedUrl.isMatching(url)));
+  const finalUrlList = urlList.filter(({ url }) => !whitelistedUrls.some((whitelistedUrl) => whitelistedUrl.matches(url)));
   const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(finalUrlList);
   const formattedKOTutorialUrls = keepAndFormatKOUrls(analyzedUrls);
   await urlRepository.updateTutorials(formattedKOTutorialUrls);

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 
-export async function validateUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, UrlUtils }) {
+export async function validateUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository, UrlUtils }) {
   const release = await releaseRepository.getLatestRelease();
+  const whitelistedUrls = await whitelistedUrlRepository.list();
+  const activeWhitelistedUrls = whitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive);
 
-  await checkAndUploadKOUrlsFromChallenges(release, { urlRepository, localizedChallengeRepository, UrlUtils });
-  await checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils });
+  await checkAndUploadKOUrlsFromChallenges(release, { urlRepository, localizedChallengeRepository, UrlUtils }, activeWhitelistedUrls);
+  await checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils }, activeWhitelistedUrls);
 }
 
 function findUrlsFromChallenges(challenges, release, localizedChallengesById, UrlUtils) {
@@ -55,19 +57,21 @@ function keepAndFormatKOUrls(analyzedLines) {
   });
 }
 
-async function checkAndUploadKOUrlsFromChallenges(release, { urlRepository, localizedChallengeRepository, UrlUtils }) {
+async function checkAndUploadKOUrlsFromChallenges(release, { urlRepository, localizedChallengeRepository, UrlUtils }, whitelistedUrls) {
   const operativeChallenges = release.operativeChallenges;
   const localizedChallengesById = _.keyBy(await localizedChallengeRepository.list(), 'id');
   const urlList = findUrlsFromChallenges(operativeChallenges, release, localizedChallengesById, UrlUtils);
-  const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(urlList);
+  const finalUrlList = urlList.filter(({ url }) => whitelistedUrls.every((whitelistedUrl) => !whitelistedUrl.isMatching(url)));
+  const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(finalUrlList);
   const formattedKOChallengeUrls = keepAndFormatKOUrls(analyzedUrls);
   await urlRepository.updateChallenges(formattedKOChallengeUrls);
 }
 
-async function checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils }) {
+async function checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils }, whitelistedUrls) {
   const tutorials = release.content.tutorials;
   const urlList = findUrlsFromTutorials(tutorials, release);
-  const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(urlList);
+  const finalUrlList = urlList.filter(({ url }) => whitelistedUrls.every((whitelistedUrl) => !whitelistedUrl.isMatching(url)));
+  const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(finalUrlList);
   const formattedKOTutorialUrls = keepAndFormatKOUrls(analyzedUrls);
   await urlRepository.updateTutorials(formattedKOTutorialUrls);
 }

--- a/api/lib/infrastructure/scheduled-jobs/check-urls-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/check-urls-job-processor.js
@@ -1,8 +1,13 @@
 import './job-process.js';
 import { validateUrlsFromRelease } from '../../domain/usecases/index.js';
-import { localizedChallengeRepository, releaseRepository, urlRepository } from '../repositories/index.js';
+import {
+  localizedChallengeRepository,
+  releaseRepository,
+  urlRepository,
+  whitelistedUrlRepository
+} from '../repositories/index.js';
 import * as UrlUtils from '../utils/url-utils.js';
 
 export default function checkUrlsJobProcessor() {
-  return validateUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, UrlUtils });
+  return validateUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository, UrlUtils });
 }

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -756,7 +756,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
     });
   });
 
-  describe('#isMatching', function() {
+  describe('#matches', function() {
     describe('exact_match', function() {
       it('should match when url is exactly the same as the whitelisted', function() {
         // given
@@ -767,7 +767,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.true;
@@ -782,7 +782,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.false;
@@ -797,7 +797,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.false;
@@ -812,7 +812,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.false;
@@ -828,7 +828,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.true;
@@ -842,7 +842,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.true;
@@ -857,7 +857,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.false;
@@ -872,7 +872,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.false;
@@ -887,7 +887,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         });
 
         // when
-        const isMatching = whitelistedUrl.isMatching(url);
+        const isMatching = whitelistedUrl.matches(url);
 
         // then
         expect(isMatching).to.be.false;

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -755,4 +755,143 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       }));
     });
   });
+
+  describe('#isMatching', function() {
+    describe('exact_match', function() {
+      it('should match when url is exactly the same as the whitelisted', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://mOn-Bidet_orange.com/token=COUCOU',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.true;
+      });
+
+      it('should not match when url is not the same case-wise', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://MON-Bidet_orange.com/token=COUCOU',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.false;
+      });
+
+      it('should not match when url is just partially the same', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://mOn-Bidet_orange.com/token=C',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.false;
+      });
+
+      it('should not match when url is not the same', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://quelquechose-dautre',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.false;
+      });
+    });
+    describe('starts_with', function() {
+      it('should match when url is starts exactly with the same as the whitelisted', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://mOn-Bidet_orange.com/to',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.true;
+      });
+      it('should match when url is exactly the same', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://mOn-Bidet_orange.com/token=COUCOU',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.true;
+      });
+
+      it('should not match when url does not start the same case-wise', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://MON-Bidet_orange.com/to',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.false;
+      });
+
+      it('should not match when url is different even if they start similar', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://mOn-Bidet_orange.com/token=COUCOU_MAMAN',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.false;
+      });
+
+      it('should not match when url does not start the same at all', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://quelquechose-dautre',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.isMatching(url);
+
+        // then
+        expect(isMatching).to.be.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -3,10 +3,11 @@ import { domainBuilder } from '../../../test-helper.js';
 import { ChallengeForRelease } from '../../../../lib/domain/models/release/index.js';
 import { validateUrlsFromRelease } from '../../../../lib/domain/usecases/index.js';
 import * as UrlUtils from '../../../../lib/infrastructure/utils/url-utils.js';
+import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Usecases | Validate urls from release', function() {
   describe('#validateUrlsFromRelease', function() {
-    let releaseRepository, urlRepository, localizedChallengeRepository, mockedUrlUtils;
+    let releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository, mockedUrlUtils;
     const identifiedUrlChallenge1_1 = {
       id: 'Pix;competence 1.1;@mySkill1;challenge1;validé;fr',
       url: 'https://example.net/',
@@ -144,8 +145,8 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       });
       const wonderlandChallenge5Skill23 = domainBuilder.buildChallengeForRelease({
         id: 'challenge5',
-        instruction: 'instructions',
-        solutionToDisplay: '',
+        instruction: 'instructions https://ignorez-moi.fr',
+        solutionToDisplay: 'https://ignore-me.us/some-page',
         skillId: 'skill23',
         status: ChallengeForRelease.STATUSES.VALIDE,
         locales: ['nl'],
@@ -185,6 +186,12 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         domainBuilder.buildLocalizedChallenge({ id: 'challenge7', urlsToConsult: [] }),
       ];
       localizedChallengeRepository = { list: vi.fn().mockResolvedValue(localizedChallenges) };
+      const whitelistedUrls = [
+        domainBuilder.buildWhitelistedUrl({ url: 'https://ignorez-moi.fr', checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH, deletedAt: null }),
+        domainBuilder.buildWhitelistedUrl({ url: 'https://ignore-me.us', checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH, deletedAt: null }),
+        domainBuilder.buildWhitelistedUrl({ url: 'https://example.net/', checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH, deletedAt: new Date('2020-01-01') }),
+      ];
+      whitelistedUrlRepository = { list: vi.fn().mockResolvedValue(whitelistedUrls) };
       urlRepository = {
         updateChallenges: vi.fn(),
         updateTutorials: vi.fn(),
@@ -297,7 +304,7 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         ]);
 
       // when
-      await validateUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, UrlUtils: mockedUrlUtils });
+      await validateUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository, UrlUtils: mockedUrlUtils });
 
       // then
       expect(mockedUrlUtils.analyzeIdentifiedUrls.mock.calls[0]).toStrictEqual([[identifiedUrlChallenge1_1, identifiedUrlChallenge1_2, identifiedUrlChallenge1_3, identifiedUrlChallenge1_4, identifiedUrlChallenge1_5, identifiedUrlChallenge2_1, identifiedUrlChallenge2_2, identifiedUrlChallenge3_1, identifiedUrlChallenge4_1, identifiedUrlChallenge5_1 ]]);


### PR DESCRIPTION
## :unicorn: Problème
Pour la moulinette, il y a des URLs qu'on sait KO de base et qu'on souhaiterait ignorer dans le fichier de résultat pour faire moins de bruit.
On a une PR pour mettre en place une interface de gestion des urls à whitelister.
Maintenant l'idée c'est de prendre en compte cette liste dans le job.

## :robot: Proposition
Prendre les urls whitelistées actives
En tenir compte dans la moulinette (avec les deux types de check, exact match ou starts with)

## :rainbow: Remarques
Dépend de la PR pour l'interface de gestion

## :100: Pour tester
Tester de lancer le job avec des urls whitelistée
