### PR TITLE
[FEATURE] Ajouter l'option `Acquis non pertinent` au select `Sourds et malentendants` (PIX-14996).

### DIFF
--- a/api/db/migrations/20241025085413_alter-column-death-and-hard-of-hearing-extend-length.js
+++ b/api/db/migrations/20241025085413_alter-column-death-and-hard-of-hearing-extend-length.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'localized_challenges';
+const COLUMN_NAME = 'deafAndHardOfHearing';
+
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string(COLUMN_NAME, 30).defaultTo('RAS').notNullable().alter();
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string(COLUMN_NAME, 10).defaultTo('RAS').notNullable().alter();
+  });
+}

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -51,6 +51,7 @@ export class LocalizedChallenge {
       OK: 'OK',
       KO: 'KO',
       RAS: 'RAS',
+      ACQUIS_NON_PERTINENT: 'Acquis Non Pertinent',
     };
   }
 

--- a/pix-editor/app/components/field/quality.js
+++ b/pix-editor/app/components/field/quality.js
@@ -27,6 +27,7 @@ export default class Quality extends Component {
   deafAndHardOfHearingOptions = [
     { value: 'RAS', label: 'RAS' },
     { value: 'OK', label: 'OK' },
+    { value: 'Acquis Non Pertinent', label: 'Acquis Non Pertinent' },
     { value: 'KO', label: 'KO' },
   ];
 }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons besoin d'une nouvelle option pour qualifier le champ `Sourds et malentendants`.

## :robot: Proposition
Ajouter l'option `Acquis non pertinent` au select `Sourds et malentendants`.

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Creer un prototype en sélectionnant l'option  `Acquis non pertinent` au select `Sourds et malentendants`.
Le faire sur la modification d'un acquis actif.
