### PR TITLE
[BUGFIX] Impossible d'afficher une épreuve lorsque l'embedURL de l'épreuve est invalide (PIX-14419)

### DIFF
--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -61,6 +61,7 @@ export class LocalizedChallenge {
 
   get defaultEmbedUrl() {
     if (!this.#primaryEmbedUrl) return null;
+    if (!URL.canParse(this.#primaryEmbedUrl)) return null;
 
     const url = new URL(this.#primaryEmbedUrl);
     if (hasLocaleInFirstPathSegment(url)) {

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -66,6 +66,36 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         expect(localizedChallenge).toHaveProperty('defaultEmbedUrl', 'http://test.com/pix-embed/to/page.html?lang=ar');
       });
     });
+
+    describe('when URL is invalid', () => {
+      it('should be null', () => {
+        // given
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'alternativeId',
+          challengeId: 'challengeId',
+          locale: 'ai',
+          primaryEmbedUrl: '<iframe src="https://figma.com/want-to-use-our-ai"></iframe>',
+        });
+
+        // then
+        expect(localizedChallenge).toHaveProperty('defaultEmbedUrl', null);
+      });
+    });
+
+    describe('when primaryEmbedUrl is null', () => {
+      it('should be null', () => {
+        // given
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'alternativeId',
+          challengeId: 'challengeId',
+          locale: 'ai',
+          primaryEmbedUrl: null,
+        });
+
+        // then
+        expect(localizedChallenge).toHaveProperty('defaultEmbedUrl', null);
+      });
+    });
   });
 
   describe('static buildPrimary', function() {

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -182,7 +182,14 @@
     @edition={{@edition}}
     @label="URL"
     @id="challenge-embed-url"
+    @change={{@checkEmbedURL}}
   />
+  {{#if @invalidEmbedURL}}
+    <p class="ui red message" data-test-invalid-embed-url>
+      URL invalide :
+      {{@invalidEmbedURL}}
+    </p>
+  {{/if}}
   <Field::Input
     @value={{@challenge.embedHeight}}
     @edition={{@edition}}

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -21,6 +21,7 @@ export default class LocalizedController extends Controller {
   @tracked displayUrlsToConsultField = false;
 
   @tracked urlsToConsult = '';
+  @tracked invalidEmbedURL = '';
   @tracked invalidUrlsToConsult = '';
   helpUrlsToConsult = '<p>Séparer les liens par un retour à la ligne</p>';
 
@@ -176,6 +177,7 @@ export default class LocalizedController extends Controller {
     this.urlsToConsult = this.localizedChallenge.urlsToConsult?.join('\n') ?? '';
     this.displayUrlsToConsultField = false;
     this.invalidUrlsToConsult = '';
+    this.invalidEmbedURL = '';
     await this.localizedChallenge.files;
     this.localizedChallenge.files.forEach((file) => file.rollbackAttributes());
     this.deletedFiles = [];
@@ -357,5 +359,19 @@ export default class LocalizedController extends Controller {
     }
     this.deletedFiles = [];
     return challenge;
+  }
+
+  @action
+  checkEmbedURL() {
+    this.invalidEmbedURL = '';
+    let embedURL = this.localizedChallenge.embedURL;
+    embedURL = embedURL.trim();
+    try {
+      new URL(embedURL);
+      return true;
+    } catch {
+      this.localizedChallenge.embedURL = '';
+      this.invalidEmbedURL = embedURL;
+    }
   }
 }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -35,6 +35,7 @@ export default class SingleController extends Controller {
   @service store;
 
   @tracked invalidUrlsToConsult = '';
+  @tracked invalidEmbedURL = '';
   @tracked urlsToConsult = '';
 
   deletedFiles = [];
@@ -199,6 +200,7 @@ export default class SingleController extends Controller {
     this.challenge.files.forEach((file) => file.rollbackAttributes());
     this.urlsToConsult = this.challenge.urlsToConsult?.join('\n') ?? '';
     this.invalidUrlsToConsult = '';
+    this.invalidEmbedURL = '';
     this.deletedFiles = [];
     if (!this.wasMaximized) {
       this.minimize();
@@ -750,5 +752,19 @@ export default class SingleController extends Controller {
     this.changelogCallback = callback;
     this.changelogDefault = defaultMessage;
     this.displayChangeLog = true;
+  }
+
+  @action
+  checkEmbedURL() {
+    this.invalidEmbedURL = '';
+    let embedURL = this.challenge.embedURL;
+    embedURL = embedURL.trim();
+    try {
+      new URL(embedURL);
+      return true;
+    } catch {
+      this.challenge.embedURL = null;
+      this.invalidEmbedURL = embedURL;
+    }
   }
 }

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.hbs
@@ -46,11 +46,18 @@
         @value={{this.localizedChallenge.embedURL}}
         @edition={{this.edition}}
         @placeholder="Url de l'embed"
+        @change={{this.checkEmbedURL}}
       />
       {{#if this.shouldDisplayPrimaryEmbedUrl }}
         <div class="ui  blue message">
          <p data-testid="default-embed-url">Embed URL auto-générée : {{this.localizedChallenge.defaultEmbedURL}}</p>
         </div>
+      {{/if}}
+      {{#if this.invalidEmbedURL}}
+        <p class="ui red message" data-test-invalid-embed-url>
+          URL invalide :
+          {{this.invalidEmbedURL}}
+        </p>
       {{/if}}
       <Field::Select
         @title="Géographie"

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -69,6 +69,8 @@
                      @setDisplayUrlsToConsultField={{this.setDisplayUrlsToConsultField}}
                      @urlsToConsult={{this.urlsToConsult}}
                      @setUrlsToConsult={{this.setUrlsToConsult}}
+                     @invalidEmbedURL={{this.invalidEmbedURL}}
+                     @checkEmbedURL={{this.checkEmbedURL}}
     />
   </div>
 <div class="ui vertical compact labeled icon menu challenge-menu">

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -13,9 +13,10 @@ module('Integration | Component | challenge-form', function(hooks) {
     // Given
     const challengeData = EmberObject.create({ type: 'QROC', isTextBased: true, isPrototype: true });
     this.set('challengeData', challengeData);
+    this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}}/>`);
+    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @checkEmbedURL={{this.checkEmbedURL}}/>`);
 
     // Then
     ['data-test-format-field', 'data-test-tolerence-fields', 'data-test-suggestion-field'].forEach((field) => {
@@ -27,9 +28,10 @@ module('Integration | Component | challenge-form', function(hooks) {
     // Given
     const challengeData = EmberObject.create({ autoReply: true, isTextBased: true, isPrototype: true });
     this.set('challengeData', challengeData);
+    this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}}/>`);
+    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @checkEmbedURL={{this.checkEmbedURL}}/>`);
 
     // Then
     ['data-test-format-field', 'data-test-tolerence-fields', 'data-test-suggestion-field'].forEach((field) => {
@@ -45,9 +47,10 @@ module('Integration | Component | challenge-form', function(hooks) {
       genealogy: 'Prototype 1',
     });
     this.set('challengeData', challengeData);
+    this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}/>`);
+    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}} @checkEmbedURL={{this.checkEmbedURL}}/>`);
 
     await click(find('[data-test-select-type] .ember-basic-dropdown-trigger'));
     await click(findAll('.ember-power-select-option')[1]);
@@ -69,9 +72,10 @@ module('Integration | Component | challenge-form', function(hooks) {
       genealogy: 'Prototype 1',
     });
     this.set('challengeData', challengeData);
+    this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}/>`);
+    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}  @checkEmbedURL={{this.checkEmbedURL}}/>`);
 
     await click(find('[data-test-select-type] .ember-basic-dropdown-trigger'));
     await click(findAll('.ember-power-select-option')[0]);


### PR DESCRIPTION
## :unicorn: Problème
Aller sur une modification d'épreuve
Mettre un embedUrl invalide
Sauvegarder
Recharger la page
Boum 💥 

## :robot: Proposition
Valider la saisie
pour le proto
pour la décli
pour le localized

## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
Essayer de reproduire le bug sur ces trois formulaires
