### PR TITLE
[FEATURE] Route pour récupérer les données de la page "Épreuves -> En Production" (PIX-14423)

### DIFF
--- a/api/lib/application/competences/index.js
+++ b/api/lib/application/competences/index.js
@@ -1,0 +1,5 @@
+import * as competenceOverviewsRoute from './overviews.js';
+
+export const competenceRoutes = [
+  competenceOverviewsRoute,
+];

--- a/api/lib/application/competences/overviews.js
+++ b/api/lib/application/competences/overviews.js
@@ -1,0 +1,41 @@
+import Joi from 'joi';
+import Boom from '@hapi/boom';
+import * as Sentry from '@sentry/node';
+import { logger } from '../../infrastructure/logger.js';
+import { getCompetenceChallengesProductionOverview } from '../../domain/usecases/index.js';
+import { competenceOverviewSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
+import { Types } from '../types.js';
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/competences/{competenceId}/overviews/challenges-production',
+      config: {
+        validate: {
+          params: Joi.object({
+            competenceId: Types.competenceId().required(),
+          }),
+          query: Joi.object({
+            locale: Types.locale(),
+          }),
+        },
+        handler: async function(request) {
+          try {
+            const competenceId = request.params.competenceId;
+            const locale = request.query.locale;
+
+            const competenceOverview = await getCompetenceChallengesProductionOverview({ competenceId, locale });
+            return competenceOverviewSerializer.serialize(competenceOverview);
+          } catch (err) {
+            logger.error(err);
+            Sentry.captureException(err);
+            return Boom.internal(err);
+          }
+        },
+      },
+    },
+  ]);
+}
+
+export const name = 'competence-overviews';

--- a/api/lib/application/types.js
+++ b/api/lib/application/types.js
@@ -1,0 +1,10 @@
+import Joi from 'joi';
+
+export const Types = Object.freeze({
+  competenceId() {
+    return Joi.string().pattern(/^(rec|competence)[a-zA-Z0-9]+$/);
+  },
+  locale() {
+    return Joi.string().pattern(/^[a-z]{2}(-[a-z]{2})?$/);
+  },
+});

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -255,6 +255,10 @@ export class Challenge {
     return getCountryCode(this.geography);
   }
 
+  get isDeclinable() {
+    return this.declinable !== Challenge.DECLINABLES.NON;
+  }
+
   get #primaryLocalizedChallenge() {
     return this.localizedChallenges.find(({ locale }) => locale === this.primaryLocale);
   }

--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -5,6 +5,7 @@ export class Tube {
     name,
     practicalTitle_i18n,
     practicalDescription_i18n,
+    index,
     competenceId,
   }) {
     this.id = id;
@@ -12,6 +13,7 @@ export class Tube {
     this.name = name;
     this.practicalTitle_i18n = practicalTitle_i18n;
     this.practicalDescription_i18n = practicalDescription_i18n;
+    this.index = index;
     this.competenceId = competenceId;
   }
 }

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -7,18 +7,42 @@ export class CompetenceOverview {
     this.thematicOverviews = thematicOverviews;
   }
 
-  static buildForChallengesProduction({ competenceId, thematics }) {
+  static buildForChallengesProduction({ competenceId, thematics, tubes }) {
+    const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
+
     return new CompetenceOverview({
       id: `${competenceId}-challenges-production-fr`,
-      thematicOverviews: thematics.sort(byIndex).map((thematic) => new ThematicOverview({
-        airtableId: thematic.airtableId,
-        name: thematic.name_i18n.fr,
-      })),
+      thematicOverviews: thematics
+        .sort(byIndex)
+        .map((thematic) => new ThematicOverview({
+          airtableId: thematic.airtableId,
+          name: thematic.name_i18n.fr,
+          tubeOverviews: thematic.tubeIds
+            .map((tubeId) => tubesById[tubeId])
+            .sort(byIndex)
+            .map((tube) => new TubeOverview({
+              airtableId: tube.airtableId,
+              name: tube.name,
+            }))
+        }))
+        .filter((thematicOverview) => thematicOverview.tubeOverviews.length),
     });
   }
 }
 
 class ThematicOverview {
+  constructor({
+    airtableId,
+    name,
+    tubeOverviews,
+  }) {
+    this.airtableId = airtableId;
+    this.name = name;
+    this.tubeOverviews = tubeOverviews;
+  }
+}
+
+class TubeOverview {
   constructor({
     airtableId,
     name,

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -1,4 +1,4 @@
-import { Challenge } from '../models';
+import { Challenge } from '../models/index.js';
 
 export class CompetenceOverview {
   constructor({
@@ -21,7 +21,7 @@ export class CompetenceOverview {
           airtableId: thematic.airtableId,
           name: thematic.name_i18n.fr,
           tubeOverviews: thematic.tubeIds
-            .map((tubeId) => tubesById[tubeId])
+            ?.map((tubeId) => tubesById[tubeId])
             .sort(byIndex)
             .map((tube) => new TubeOverview({
               airtableId: tube.airtableId,
@@ -29,9 +29,9 @@ export class CompetenceOverview {
               skillOverviews: skillsByTubeIdAndLevel[tube.id]
                 ?.map((skill) => SkillOverview.buildForChallengesProduction({ skill, challenges })),
             }))
-            .filter((tubeOverview) => tubeOverview.skillOverviews)
+            .filter((tubeOverview) => !tubeOverview.isEmpty)
         }))
-        .filter((thematicOverview) => thematicOverview.tubeOverviews.length),
+        .filter((thematicOverview) => !thematicOverview.isEmpty),
     });
   }
 }
@@ -46,6 +46,10 @@ class ThematicOverview {
     this.name = name;
     this.tubeOverviews = tubeOverviews;
   }
+
+  get isEmpty() {
+    return !this.tubeOverviews || this.tubeOverviews.length === 0;
+  }
 }
 
 class TubeOverview {
@@ -57,6 +61,10 @@ class TubeOverview {
     this.airtableId = airtableId;
     this.name = name;
     this.skillOverviews = skillOverviews;
+  }
+
+  get isEmpty() {
+    return !this.skillOverviews || this.skillOverviews.length === 0;
   }
 }
 

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -1,0 +1,33 @@
+export class CompetenceOverview {
+  constructor({
+    id,
+    thematicOverviews,
+  }) {
+    this.id = id;
+    this.thematicOverviews = thematicOverviews;
+  }
+
+  static buildForChallengesProduction({ competenceId, thematics }) {
+    return new CompetenceOverview({
+      id: `${competenceId}-challenges-production-fr`,
+      thematicOverviews: thematics.sort(byIndex).map((thematic) => new ThematicOverview({
+        airtableId: thematic.airtableId,
+        name: thematic.name_i18n.fr,
+      })),
+    });
+  }
+}
+
+class ThematicOverview {
+  constructor({
+    airtableId,
+    name,
+  }) {
+    this.airtableId = airtableId;
+    this.name = name;
+  }
+}
+
+function byIndex({ index: index1 }, { index: index2 }) {
+  return index1 - index2;
+}

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -9,12 +9,12 @@ export class CompetenceOverview {
     this.thematicOverviews = thematicOverviews;
   }
 
-  static buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges }) {
+  static buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges, locale }) {
     return new CompetenceOverview({
       id: `${competenceId}-challenges-production-fr`,
       thematicOverviews: thematics
         .sort(byIndex)
-        .map((thematic) => ThematicOverview.buildForChallengesProduction({ thematic, tubes, skills, challenges }))
+        .map((thematic) => ThematicOverview.buildForChallengesProduction({ thematic, tubes, skills, challenges, locale }))
         .filter((thematicOverview) => !thematicOverview.isEmpty),
     });
   }
@@ -31,7 +31,7 @@ class ThematicOverview {
     this.tubeOverviews = tubeOverviews;
   }
 
-  static buildForChallengesProduction({ thematic, tubes, skills, challenges }) {
+  static buildForChallengesProduction({ thematic, tubes, skills, challenges, locale }) {
     const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
 
     return new ThematicOverview({
@@ -40,7 +40,7 @@ class ThematicOverview {
       tubeOverviews: thematic.tubeIds
         ?.map((tubeId) => tubesById[tubeId])
         .sort(byIndex)
-        .map((tube) => TubeOverview.buildForChallengesProduction({ tube, skills, challenges }))
+        .map((tube) => TubeOverview.buildForChallengesProduction({ tube, skills, challenges, locale }))
         .filter((tubeOverview) => !tubeOverview.isEmpty)
     });
   }
@@ -61,14 +61,14 @@ class TubeOverview {
     this.skillOverviews = skillOverviews;
   }
 
-  static buildForChallengesProduction({ tube, skills, challenges }) {
+  static buildForChallengesProduction({ tube, skills, challenges, locale }) {
     const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
 
     return new TubeOverview({
       airtableId: tube.airtableId,
       name: tube.name,
       skillOverviews: skillsByTubeIdAndLevel[tube.id]
-        ?.map((skill) => SkillOverview.buildForChallengesProduction({ skill, challenges })),
+        ?.map((skill) => SkillOverview.buildForChallengesProduction({ skill, challenges, locale })),
     });
   }
 
@@ -94,10 +94,11 @@ class SkillOverview {
     this.validatedChallengesCount = validatedChallengesCount;
   }
 
-  static buildForChallengesProduction({ skill, challenges }) {
+  static buildForChallengesProduction({ skill, challenges, locale }) {
     if (!skill) return null;
 
     const productionPrototype = challenges.find(isProductionPrototypeOf(skill));
+
     const productionChallenges = challenges.filter(hasSkillIdAndVersionOf(productionPrototype));
 
     return new SkillOverview({
@@ -105,8 +106,8 @@ class SkillOverview {
       name: skill.name,
       prototypeId: productionPrototype?.id,
       isPrototypeDeclinable: productionPrototype?.isDeclinable,
-      proposedChallengesCount: countByStatus(productionChallenges, Challenge.STATUSES.PROPOSE),
-      validatedChallengesCount: countByStatus(productionChallenges, Challenge.STATUSES.VALIDE),
+      proposedChallengesCount: countChallengesByStatusAndLocale(productionChallenges, Challenge.STATUSES.PROPOSE, locale),
+      validatedChallengesCount: countChallengesByStatusAndLocale(productionChallenges, Challenge.STATUSES.VALIDE, locale),
     });
   }
 }
@@ -140,6 +141,10 @@ function hasSkillIdAndVersionOf({ skillId, version } = {}) {
   return (challenge) => challenge.skillId === skillId && challenge.version === version;
 }
 
-function countByStatus(items, status) {
-  return items.reduce((count, item) => item.status === status ? count + 1 : count, 0);
+function countChallengesByStatusAndLocale(challenges, status, locale) {
+  return challenges.reduce((count, challenge) => {
+    if (challenge.status !== status) return count;
+    if (locale && challenge.locale !== locale) return count;
+    return count + 1;
+  }, 0);
 }

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -10,27 +10,11 @@ export class CompetenceOverview {
   }
 
   static buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges }) {
-    const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
-    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
-
     return new CompetenceOverview({
       id: `${competenceId}-challenges-production-fr`,
       thematicOverviews: thematics
         .sort(byIndex)
-        .map((thematic) => new ThematicOverview({
-          airtableId: thematic.airtableId,
-          name: thematic.name_i18n.fr,
-          tubeOverviews: thematic.tubeIds
-            ?.map((tubeId) => tubesById[tubeId])
-            .sort(byIndex)
-            .map((tube) => new TubeOverview({
-              airtableId: tube.airtableId,
-              name: tube.name,
-              skillOverviews: skillsByTubeIdAndLevel[tube.id]
-                ?.map((skill) => SkillOverview.buildForChallengesProduction({ skill, challenges })),
-            }))
-            .filter((tubeOverview) => !tubeOverview.isEmpty)
-        }))
+        .map((thematic) => ThematicOverview.buildForChallengesProduction({ thematic, tubes, skills, challenges }))
         .filter((thematicOverview) => !thematicOverview.isEmpty),
     });
   }
@@ -47,6 +31,20 @@ class ThematicOverview {
     this.tubeOverviews = tubeOverviews;
   }
 
+  static buildForChallengesProduction({ thematic, tubes, skills, challenges }) {
+    const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
+
+    return new ThematicOverview({
+      airtableId: thematic.airtableId,
+      name: thematic.name_i18n.fr,
+      tubeOverviews: thematic.tubeIds
+        ?.map((tubeId) => tubesById[tubeId])
+        .sort(byIndex)
+        .map((tube) => TubeOverview.buildForChallengesProduction({ tube, skills, challenges }))
+        .filter((tubeOverview) => !tubeOverview.isEmpty)
+    });
+  }
+
   get isEmpty() {
     return !this.tubeOverviews || this.tubeOverviews.length === 0;
   }
@@ -61,6 +59,17 @@ class TubeOverview {
     this.airtableId = airtableId;
     this.name = name;
     this.skillOverviews = skillOverviews;
+  }
+
+  static buildForChallengesProduction({ tube, skills, challenges }) {
+    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
+
+    return new TubeOverview({
+      airtableId: tube.airtableId,
+      name: tube.name,
+      skillOverviews: skillsByTubeIdAndLevel[tube.id]
+        ?.map((skill) => SkillOverview.buildForChallengesProduction({ skill, challenges })),
+    });
   }
 
   get isEmpty() {
@@ -87,8 +96,10 @@ class SkillOverview {
 
   static buildForChallengesProduction({ skill, challenges }) {
     if (!skill) return null;
+
     const productionPrototype = challenges.find(isProductionPrototypeOf(skill));
     const productionChallenges = challenges.filter(hasSkillIdAndVersionOf(productionPrototype));
+
     return new SkillOverview({
       airtableId: skill.airtableId,
       name: skill.name,

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -1,3 +1,5 @@
+import { Challenge } from '../models';
+
 export class CompetenceOverview {
   constructor({
     id,
@@ -7,7 +9,7 @@ export class CompetenceOverview {
     this.thematicOverviews = thematicOverviews;
   }
 
-  static buildForChallengesProduction({ competenceId, thematics, tubes, skills }) {
+  static buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges }) {
     const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
     const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
 
@@ -25,10 +27,7 @@ export class CompetenceOverview {
               airtableId: tube.airtableId,
               name: tube.name,
               skillOverviews: skillsByTubeIdAndLevel[tube.id]
-                ?.map((skill) => skill && new SkillOverview({
-                  airtableId: skill.airtableId,
-                  name: skill.name,
-                })),
+                ?.map((skill) => SkillOverview.buildForChallengesProduction({ skill, challenges })),
             }))
             .filter((tubeOverview) => tubeOverview.skillOverviews)
         }))
@@ -65,9 +64,31 @@ class SkillOverview {
   constructor({
     airtableId,
     name,
+    prototypeId,
+    isPrototypeDeclinable,
+    proposedChallengesCount,
+    validatedChallengesCount,
   }) {
     this.airtableId = airtableId;
     this.name = name;
+    this.prototypeId = prototypeId;
+    this.isPrototypeDeclinable = isPrototypeDeclinable;
+    this.proposedChallengesCount = proposedChallengesCount;
+    this.validatedChallengesCount = validatedChallengesCount;
+  }
+
+  static buildForChallengesProduction({ skill, challenges }) {
+    if (!skill) return null;
+    const productionPrototype = challenges.find(isProductionPrototypeOf(skill));
+    const productionChallenges = challenges.filter(hasSkillIdAndVersionOf(productionPrototype));
+    return new SkillOverview({
+      airtableId: skill.airtableId,
+      name: skill.name,
+      prototypeId: productionPrototype?.id,
+      isPrototypeDeclinable: productionPrototype?.isDeclinable,
+      proposedChallengesCount: countByStatus(productionChallenges, Challenge.STATUSES.PROPOSE),
+      validatedChallengesCount: countByStatus(productionChallenges, Challenge.STATUSES.VALIDE),
+    });
   }
 }
 
@@ -86,4 +107,20 @@ function arrangeSkillsByTubeIdAndLevel(skills) {
   }
 
   return skillsByTubeIdAndLevel;
+}
+
+function isProductionPrototypeOf(skill) {
+  return (challenge) => {
+    return challenge.skillId === skill.id
+      && challenge.genealogy === Challenge.GENEALOGIES.PROTOTYPE
+      && challenge.status === Challenge.STATUSES.VALIDE;
+  };
+}
+
+function hasSkillIdAndVersionOf({ skillId, version } = {}) {
+  return (challenge) => challenge.skillId === skillId && challenge.version === version;
+}
+
+function countByStatus(items, status) {
+  return items.reduce((count, item) => item.status === status ? count + 1 : count, 0);
 }

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -143,8 +143,17 @@ function hasSkillIdAndVersionOf({ skillId, version } = {}) {
 
 function countChallengesByStatusAndLocale(challenges, status, locale) {
   return challenges.reduce((count, challenge) => {
-    if (challenge.status !== status) return count;
-    if (locale && challenge.locale !== locale) return count;
-    return count + 1;
+    const localeChallenge = getChallengeForLocale(challenge, locale);
+
+    if (!localeChallenge) return count;
+
+    return localeChallenge.status === status ? count + 1 : count;
   }, 0);
+}
+
+function getChallengeForLocale(challenge, locale) {
+  if (!locale) return challenge;
+  if (challenge.locales.includes(locale)) return challenge;
+  if (challenge.alternativeLocales.includes(locale)) return challenge.translate(locale);
+  return undefined;
 }

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -7,8 +7,9 @@ export class CompetenceOverview {
     this.thematicOverviews = thematicOverviews;
   }
 
-  static buildForChallengesProduction({ competenceId, thematics, tubes }) {
+  static buildForChallengesProduction({ competenceId, thematics, tubes, skills }) {
     const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
+    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
 
     return new CompetenceOverview({
       id: `${competenceId}-challenges-production-fr`,
@@ -23,7 +24,13 @@ export class CompetenceOverview {
             .map((tube) => new TubeOverview({
               airtableId: tube.airtableId,
               name: tube.name,
+              skillOverviews: skillsByTubeIdAndLevel[tube.id]
+                ?.map((skill) => skill && new SkillOverview({
+                  airtableId: skill.airtableId,
+                  name: skill.name,
+                })),
             }))
+            .filter((tubeOverview) => tubeOverview.skillOverviews)
         }))
         .filter((thematicOverview) => thematicOverview.tubeOverviews.length),
     });
@@ -46,6 +53,18 @@ class TubeOverview {
   constructor({
     airtableId,
     name,
+    skillOverviews,
+  }) {
+    this.airtableId = airtableId;
+    this.name = name;
+    this.skillOverviews = skillOverviews;
+  }
+}
+
+class SkillOverview {
+  constructor({
+    airtableId,
+    name,
   }) {
     this.airtableId = airtableId;
     this.name = name;
@@ -54,4 +73,17 @@ class TubeOverview {
 
 function byIndex({ index: index1 }, { index: index2 }) {
   return index1 - index2;
+}
+
+function arrangeSkillsByTubeIdAndLevel(skills) {
+  const skillsByTubeIdAndLevel = {};
+
+  for (const skill of skills) {
+    if (!skillsByTubeIdAndLevel[skill.tubeId]) {
+      skillsByTubeIdAndLevel[skill.tubeId] = new Array(7).fill(null);
+    }
+    skillsByTubeIdAndLevel[skill.tubeId][skill.level - 1] = skill;
+  }
+
+  return skillsByTubeIdAndLevel;
 }

--- a/api/lib/domain/readmodels/index.js
+++ b/api/lib/domain/readmodels/index.js
@@ -1,4 +1,5 @@
 export * from './ChallengeSummary.js';
+export * from './CompetenceOverview.js';
 export * from './MissionSummary.js';
 export * from './StaticCourse.js';
 export * from './StaticCourseSummary.js';

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -1,0 +1,9 @@
+import {
+  thematicRepository
+} from '../../infrastructure/repositories/index.js';
+import { CompetenceOverview } from '../readmodels/index.js';
+
+export async function getCompetenceChallengesProductionOverview({ competenceId }) {
+  const thematics = await thematicRepository.listByCompetenceId(competenceId);
+  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics });
+}

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -1,9 +1,16 @@
 import {
-  thematicRepository
+  thematicRepository,
+  tubeRepository,
 } from '../../infrastructure/repositories/index.js';
 import { CompetenceOverview } from '../readmodels/index.js';
 
 export async function getCompetenceChallengesProductionOverview({ competenceId }) {
-  const thematics = await thematicRepository.listByCompetenceId(competenceId);
-  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics });
+  const [
+    thematics,
+    tubes,
+  ] = await Promise.all([
+    thematicRepository.listByCompetenceId(competenceId),
+    tubeRepository.listByCompetenceId(competenceId),
+  ]);
+  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes });
 }

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -13,7 +13,7 @@ export async function getCompetenceChallengesProductionOverview({ competenceId }
   ] = await Promise.all([
     thematicRepository.listByCompetenceId(competenceId),
     tubeRepository.listByCompetenceId(competenceId),
-    skillRepository.listByCompetenceId(competenceId),
+    skillRepository.listActiveByCompetenceId(competenceId),
   ]);
   return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills });
 }

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -2,6 +2,7 @@ import {
   thematicRepository,
   tubeRepository,
   skillRepository,
+  challengeRepository,
 } from '../../infrastructure/repositories/index.js';
 import { CompetenceOverview } from '../readmodels/index.js';
 
@@ -10,10 +11,12 @@ export async function getCompetenceChallengesProductionOverview({ competenceId }
     thematics,
     tubes,
     skills,
+    challenges,
   ] = await Promise.all([
     thematicRepository.listByCompetenceId(competenceId),
     tubeRepository.listByCompetenceId(competenceId),
     skillRepository.listActiveByCompetenceId(competenceId),
+    challengeRepository.listActiveOrDraftByCompetenceId(competenceId),
   ]);
-  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills });
+  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges });
 }

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -1,6 +1,7 @@
 import {
   thematicRepository,
   tubeRepository,
+  skillRepository,
 } from '../../infrastructure/repositories/index.js';
 import { CompetenceOverview } from '../readmodels/index.js';
 
@@ -8,9 +9,11 @@ export async function getCompetenceChallengesProductionOverview({ competenceId }
   const [
     thematics,
     tubes,
+    skills,
   ] = await Promise.all([
     thematicRepository.listByCompetenceId(competenceId),
     tubeRepository.listByCompetenceId(competenceId),
+    skillRepository.listByCompetenceId(competenceId),
   ]);
-  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes });
+  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills });
 }

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -6,7 +6,7 @@ import {
 } from '../../infrastructure/repositories/index.js';
 import { CompetenceOverview } from '../readmodels/index.js';
 
-export async function getCompetenceChallengesProductionOverview({ competenceId }) {
+export async function getCompetenceChallengesProductionOverview({ competenceId, locale }) {
   const [
     thematics,
     tubes,
@@ -18,5 +18,5 @@ export async function getCompetenceChallengesProductionOverview({ competenceId }
     skillRepository.listActiveByCompetenceId(competenceId),
     challengeRepository.listActiveOrDraftByCompetenceId(competenceId),
   ]);
-  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges });
+  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges, locale });
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -6,6 +6,7 @@ export * from './export-external-urls-from-release.js';
 export * from './export-translations.js';
 export * from './find-all-missions.js';
 export * from './get-phrase-translations-url.js';
+export * from './get-competence-challenges-production-overview.js';
 export * from './import-translations.js';
 export * from './modify-localized-challenge.js';
 export * from './preview-challenge.js';

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -3,7 +3,7 @@ import { findRecords, stringValue } from '../../airtable.js';
 import { convertLanguagesToLocales, convertLocalesToLanguages } from '../../../domain/services/convert-locales.js';
 
 // Cet import m'embête un peu qu'en pensez-vous ?
-import { Challenge } from '../../../domain/models/index.js';
+import { Challenge, Skill } from '../../../domain/models/index.js';
 
 export const challengeDatasource = datasource.extend({
 
@@ -185,6 +185,15 @@ export const challengeDatasource = datasource.extend({
   async filterBySkillId(skillId) {
     const airtableRawObjects = await findRecords(this.tableName, {
       filterByFormula: `{Acquix (id persistant)} = ${stringValue(skillId)}`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
+  },
+
+  async listActiveOrDraftByCompetenceId(competenceId) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: this.usedFields,
+      filterByFormula: `AND({Compétences (via tube) (id persistant)} = ${stringValue(competenceId)}, {acquis} != ${stringValue(Skill.WORKBENCH_NAME)}, OR({Statut} = ${stringValue(Challenge.STATUSES.PROPOSE)}, {Statut} = ${stringValue(Challenge.STATUSES.VALIDE)}))`,
     });
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { datasource } from './datasource.js';
 import { findRecords, stringValue } from '../../airtable.js';
+import { Skill } from '../../../domain/models/Skill.js';
 
 export const skillDatasource = datasource.extend({
 
@@ -83,10 +84,10 @@ export const skillDatasource = datasource.extend({
     return airtableRawObjects.map(this.fromAirTableObject);
   },
 
-  async listByCompetenceId(competenceId) {
+  async listActiveByCompetenceId(competenceId) {
     const airtableRawObjects = await findRecords(this.tableName, {
       fields: this.usedFields,
-      filterByFormula: `{Compétence (via Tube) (id persistant)} = ${stringValue(competenceId)}`,
+      filterByFormula: `AND({Compétence (via Tube) (id persistant)} = ${stringValue(competenceId)}, {Status} = ${stringValue(Skill.STATUSES.ACTIF)})`,
     });
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -82,4 +82,13 @@ export const skillDatasource = datasource.extend({
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);
   },
+
+  async listByCompetenceId(competenceId) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: this.usedFields,
+      filterByFormula: `{Compétence (via Tube) (id persistant)} = ${stringValue(competenceId)}`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
+  },
 });

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -1,3 +1,4 @@
+import { findRecords, stringValue } from '../../airtable.js';
 import { datasource } from './datasource.js';
 
 export const thematicDatasource = datasource.extend({
@@ -23,5 +24,14 @@ export const thematicDatasource = datasource.extend({
       tubeIds: airtableRecord.get('Tubes (id persistant)'),
       index: airtableRecord.get('Index'),
     };
-  }
+  },
+
+  async listByCompetenceId(competenceId) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: this.usedFields,
+      filterByFormula: `{Competence (id persistant)} = ${stringValue(competenceId)}`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
+  },
 });

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { datasource } from './datasource.js';
+import { findRecords, stringValue } from '../../airtable.js';
 
 export const tubeDatasource = datasource.extend({
 
@@ -20,7 +21,17 @@ export const tubeDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.id,
       name: airtableRecord.get('Nom'),
+      // FIXME remplacer par Competence (via Thematique) (id persistant) ?
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };
+  },
+
+  async listByCompetenceId(competenceId) {
+    const airtableRawObjects = await findRecords(this.tableName, {
+      fields: this.usedFields,
+      filterByFormula: `{Competence (via Thematique) (id persistant)} = ${stringValue(competenceId)}`,
+    });
+    if (airtableRawObjects.length === 0) return undefined;
+    return airtableRawObjects.map(this.fromAirTableObject);
   },
 });

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -14,6 +14,7 @@ export const tubeDatasource = datasource.extend({
     'id persistant',
     'Nom',
     'Competences (id persistant)',
+    'Index',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -21,6 +22,7 @@ export const tubeDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.id,
       name: airtableRecord.get('Nom'),
+      index: airtableRecord.get('Index'),
       // FIXME remplacer par Competence (via Thematique) (id persistant) ?
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -151,6 +151,13 @@ export async function listBySkillId(skillId) {
   return toDomainList(challengeDTOs, translations, localizedChallenges);
 }
 
+export async function listActiveOrDraftByCompetenceId(competenceId) {
+  const challengeDTOs = await challengeDatasource.listActiveOrDraftByCompetenceId(competenceId);
+  if (!challengeDTOs) return [];
+  const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(challengeDTOs);
+  return toDomainList(challengeDTOs, translations, localizedChallenges);
+}
+
 async function loadTranslationsAndLocalizedChallengesForChallenges(challengeDtos) {
   return loadTranslationsAndLocalizedChallengesForChallengeIds(
     challengeDtos.map(({ id }) => id),

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -33,6 +33,13 @@ export async function listByTubeId(tubeId) {
   return toDomainList(datasourceSkills, translations);
 }
 
+export async function listByCompetenceId(competenceId) {
+  const datasourceSkills = await skillDatasource.listByCompetenceId(competenceId);
+  if (!datasourceSkills) return [];
+  const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
+  return toDomainList(datasourceSkills, translations);
+}
+
 export async function create(skill) {
   const airtableTubeId = (await tubeDatasource.getAirtableIdsByIds([skill.tubeId]))[skill.tubeId];
   const airtableTutorialAirtableIdsByIds = await tutorialDatasource.getAirtableIdsByIds(_.uniq([...skill.tutorialIds, ...skill.learningMoreTutorialIds]));

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -33,8 +33,8 @@ export async function listByTubeId(tubeId) {
   return toDomainList(datasourceSkills, translations);
 }
 
-export async function listByCompetenceId(competenceId) {
-  const datasourceSkills = await skillDatasource.listByCompetenceId(competenceId);
+export async function listActiveByCompetenceId(competenceId) {
+  const datasourceSkills = await skillDatasource.listActiveByCompetenceId(competenceId);
   if (!datasourceSkills) return [];
   const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
   return toDomainList(datasourceSkills, translations);

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -22,6 +22,13 @@ export async function getMany(ids) {
   return toDomainList(datasourceThematics, translations);
 }
 
+export async function listByCompetenceId(competenceId) {
+  const datasourceThematics = await thematicDatasource.listByCompetenceId(competenceId);
+  if (!datasourceThematics) return [];
+  const translations = await translationRepository.listByEntities(model, datasourceThematics.map(({ id }) => id));
+  return toDomainList(datasourceThematics, translations);
+}
+
 function toDomainList(datasourceThematics, translations) {
   const translationsByThematicId = _.groupBy(translations, 'entityId');
   return _.orderBy(datasourceThematics.map(

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -23,6 +23,13 @@ export async function get(id) {
   return toDomain(tubeDTO, translations);
 }
 
+export async function listByCompetenceId(competenceId) {
+  const datasourceTubes = await tubeDatasource.listByCompetenceId(competenceId);
+  if (!datasourceTubes) return [];
+  const translations = await translationRepository.listByEntities(model, datasourceTubes.map(({ id }) => id));
+  return toDomainList(datasourceTubes, translations);
+}
+
 function toDomainList(datasourceTubes, translations) {
   const translationsByTubeId = _.groupBy(translations, 'entityId');
   return datasourceTubes.map(

--- a/api/lib/infrastructure/serializers/jsonapi/competence-overview-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/competence-overview-serializer.js
@@ -1,0 +1,13 @@
+import JsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = JsonapiSerializer;
+
+const serializer = new Serializer('competence-overview', {
+  attributes: [
+    'thematicOverviews',
+  ],
+});
+
+export function serialize(config) {
+  return serializer.serialize(config);
+}

--- a/api/lib/infrastructure/serializers/jsonapi/index.js
+++ b/api/lib/infrastructure/serializers/jsonapi/index.js
@@ -1,4 +1,5 @@
 export * as challengeSerializer from './challenge-serializer.js';
+export * as competenceOverviewSerializer from './competence-overview-serializer.js';
 export * as configSerializer from './config-serializer.js';
 export * as errorSerializer from './error-serializer.js';
 export * as localizedChallengeSerializer from './localized-challenge-serializer.js';

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,5 +1,6 @@
 import * as airtableProxyRoute from './application/airtable-proxy.js';
 import * as challengesRoute from './application/challenges/index.js';
+import { competenceRoutes } from './application/competences/index.js';
 import * as configRoute from './application/config.js';
 import * as fileStorageTokenRoute from './application/file-storage-token/index.js';
 import * as healthcheckRoute from './application/healthcheck/index.js';
@@ -34,4 +35,5 @@ export const routes = [
   translationsRoute,
   embedsRoute,
   usersRoute,
+  ...competenceRoutes,
 ];

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -272,5 +272,137 @@ describe('Acceptance | Route | competence-overviews', () => {
         expect(airtableChallengesScope.isDone()).toBe(true);
       });
     });
+
+    describe('with language filter set to english', () => {
+      it('should respond status 200 and overview of competence’s production, localized and primary english challenges', async () => {
+        // given
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/competences/${competenceId}/overviews/challenges-production?locale=en`,
+          headers: generateAuthorizationHeader(user)
+        });
+
+        // then
+        expect(response.statusCode).toBe(200);
+
+        expect(response.result).toEqual({
+          data:{
+            type: 'competence-overviews',
+            id: `${competenceId}-challenges-production-fr`,
+            attributes: {
+              'thematic-overviews': [
+                {
+                  airtableId: 'recAirtableThematic2',
+                  name: 'Thématique 2',
+                  tubeOverviews: [
+                    {
+                      airtableId: 'recAirtableTube4',
+                      name: '@tube4',
+                      skillOverviews: [
+                        {
+                          airtableId: 'recAirtableSkill4',
+                          name: '@tube41',
+                          prototypeId: 'recChallenge4',
+                          validatedChallengesCount: 0,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: true,
+                        },
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                      ],
+                    },
+                    {
+                      airtableId: 'recAirtableTube5',
+                      name: '@tube5',
+                      skillOverviews: [
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        {
+                          airtableId: 'recAirtableSkill5',
+                          name: '@tube56',
+                          prototypeId: 'recChallenge5',
+                          validatedChallengesCount: 0,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: false,
+                        },
+                        null,
+                      ],
+                    },
+                  ],
+                },
+                {
+                  airtableId: 'recAirtableThematic1',
+                  name: 'Thématique 1',
+                  tubeOverviews: [
+                    {
+                      airtableId: 'recAirtableTube2',
+                      name: '@tube2',
+                      skillOverviews: [
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        {
+                          airtableId: 'recAirtableSkill3',
+                          name: '@tube27',
+                          prototypeId: 'recChallenge3',
+                          validatedChallengesCount: 0,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: true,
+                        },
+                      ],
+                    },
+                    {
+                      airtableId: 'recAirtableTube1',
+                      name: '@tube1',
+                      skillOverviews: [
+                        null,
+                        null,
+                        {
+                          airtableId: 'recAirtableSkill2',
+                          name: '@tube13',
+                          prototypeId: 'recChallenge2',
+                          validatedChallengesCount: 0,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: false,
+                        },
+                        {
+                          airtableId: 'recAirtableSkill1',
+                          name: '@tube14',
+                          prototypeId: 'recChallenge1',
+                          validatedChallengesCount: 1,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: true,
+                        },
+                        null,
+                        null,
+                        null,
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        });
+
+        expect(airtableThematicsScope.isDone()).toBe(true);
+        expect(airtableTubesScope.isDone()).toBe(true);
+        expect(airtableSkillsScope.isDone()).toBe(true);
+        expect(airtableChallengesScope.isDone()).toBe(true);
+      });
+    });
   });
 });

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -14,6 +14,7 @@ import {
   tubeDatasource
 } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import { Challenge, Skill } from '../../../../lib/domain/models/index.js';
+import { LOCALE } from '../../../../lib/domain/constants.js';
 
 describe('Acceptance | Route | competence-overviews', () => {
 
@@ -24,10 +25,10 @@ describe('Acceptance | Route | competence-overviews', () => {
   });
 
   describe('GET /competences/:id/overviews/challenges-production', () => {
+    let competenceId, airtableThematicsScope, airtableTubesScope, airtableSkillsScope, airtableChallengesScope;
 
-    it.fails('should respond status 200 and overview of competence’s production challenges', async () => {
-      // given
-      const competenceId = 'recCompetence1';
+    beforeEach(async function() {
+      competenceId = 'recCompetence1';
 
       const airtableThematics = [
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic1', airtableId: 'recAirtableThematic1', index: 2, tubeIds: ['recTube1', 'recTube2', 'recTube3'] })),
@@ -36,7 +37,7 @@ describe('Acceptance | Route | competence-overviews', () => {
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic4', airtableId: 'recAirtableThematic4', index: 4, tubeIds: ['recTube6'] })),
       ];
 
-      const airtableThematicsScope = nock('https://api.airtable.com')
+      airtableThematicsScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Thematiques')
         .query({
           fields: {
@@ -67,7 +68,7 @@ describe('Acceptance | Route | competence-overviews', () => {
         airtableBuilder.factory.buildTube(domainBuilder.buildTubeDatasourceObject({ id: 'recTube6', airtableId: 'recAirtableTube6', competenceId, name: '@tube6', index: 1 })),
       ];
 
-      const airtableTubesScope = nock('https://api.airtable.com')
+      airtableTubesScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Tubes')
         .query({
           fields: {
@@ -86,7 +87,7 @@ describe('Acceptance | Route | competence-overviews', () => {
         airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject({ id: 'recSkill5', airtableId: 'recAirtableSkill5', name: '@tube56', level: 6, status: Skill.STATUSES.ACTIF, competenceId, tubeId: 'recTube5' })),
       ];
 
-      const airtableSkillsScope = nock('https://api.airtable.com')
+      airtableSkillsScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Acquis')
         .query({
           fields: {
@@ -99,7 +100,7 @@ describe('Acceptance | Route | competence-overviews', () => {
 
       const airtableChallenges = [
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge1', airtableId: 'recAirtableChallenge1', skillId: 'recSkill1', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.FACILEMENT, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
-        airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge11', airtableId: 'recAirtableChallenge11', skillId: 'recSkill1', genealogy: Challenge.GENEALOGIES.DECLINAISON, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
+        airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge11', airtableId: 'recAirtableChallenge11', skillId: 'recSkill1', genealogy: Challenge.GENEALOGIES.DECLINAISON, version: 1, status: Challenge.STATUSES.VALIDE, locales: [LOCALE.FRENCH_FRANCE], competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge2', airtableId: 'recAirtableChallenge2', skillId: 'recSkill2', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.NON, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge3', airtableId: 'recAirtableChallenge3', skillId: 'recSkill3', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.FACILEMENT, version: 2, status: Challenge.STATUSES.VALIDE, competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge31', airtableId: 'recAirtableChallenge31', skillId: 'recSkill3', genealogy: Challenge.GENEALOGIES.DECLINAISON, version: 2, status: Challenge.STATUSES.PROPOSE, competenceId })),
@@ -107,23 +108,28 @@ describe('Acceptance | Route | competence-overviews', () => {
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge5', airtableId: 'recAirtableChallenge5', skillId: 'recSkill5', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.NON, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
       ];
 
+      const airtableEnglishChallenges = [
+        airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge12', airtableId: 'recAirtableChallenge12', skillId: 'recSkill1', genealogy: Challenge.GENEALOGIES.DECLINAISON, version: 1, status: Challenge.STATUSES.VALIDE, locales: [LOCALE.ENGLISH_SPOKEN], competenceId }))
+      ];
+
       const airtableNoiseChallenges = [
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge21', airtableId: 'recAirtableChallenge21', skillId: 'recSkill2', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.NON, version: 2, status: Challenge.STATUSES.PROPOSE, competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge22', airtableId: 'recAirtableChallenge22', skillId: 'recSkill22', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.NON, version: 1, status: Challenge.STATUSES.PROPOSE, competenceId })),
       ];
 
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge11', challengeId: 'recChallenge11', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge3', challengeId: 'recChallenge3', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge31', challengeId: 'recChallenge31', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge4', challengeId: 'recChallenge4', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge5', challengeId: 'recChallenge5', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge21', challengeId: 'recChallenge21', locale: 'fr' });
-      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge22', challengeId: 'recChallenge22', locale: 'fr' });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge1', challengeId: 'recChallenge1', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge11', challengeId: 'recChallenge11', locale: LOCALE.FRENCH_FRANCE });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge2', challengeId: 'recChallenge2', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge3', challengeId: 'recChallenge3', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge31', challengeId: 'recChallenge31', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge4', challengeId: 'recChallenge4', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge5', challengeId: 'recChallenge5', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge21', challengeId: 'recChallenge21', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge22', challengeId: 'recChallenge22', locale: LOCALE.FRENCH_SPOKEN });
+      databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge12', challengeId: 'recChallenge12', locale: LOCALE.ENGLISH_SPOKEN });
       await databaseBuilder.commit();
 
-      const airtableChallengesScope = nock('https://api.airtable.com')
+      airtableChallengesScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Epreuves')
         .query({
           fields: {
@@ -132,136 +138,139 @@ describe('Acceptance | Route | competence-overviews', () => {
           filterByFormula: `AND({Compétences (via tube) (id persistant)} = "${competenceId}", {acquis} != "@workbench", OR({Statut} = "${Challenge.STATUSES.PROPOSE}", {Statut} = "${Challenge.STATUSES.VALIDE}"))`
         })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-        .reply(200, { records: [...airtableChallenges, ...airtableNoiseChallenges] });
+        .reply(200, { records: [...airtableChallenges, ...airtableNoiseChallenges, ...airtableEnglishChallenges] });
 
-      await databaseBuilder.commit();
+    });
+    describe('without language filter', () => {
+      it('should respond status 200 and overview of competence’s production challenges that are primary', async () => {
+      // given
+        const server = await createServer();
 
-      const server = await createServer();
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/competences/${competenceId}/overviews/challenges-production`,
+          headers: generateAuthorizationHeader(user)
+        });
 
-      // when
-      const response = await server.inject({
-        method: 'GET',
-        url: `/api/competences/${competenceId}/overviews/challenges-production`,
-        headers: generateAuthorizationHeader(user)
-      });
+        // then
+        expect(response.statusCode).toBe(200);
 
-      // then
-      expect(response.statusCode).toBe(200);
-
-      expect(response.result).toEqual({
-        data:{
-          type: 'competence-overviews',
-          id: `${competenceId}-challenges-production-fr`,
-          attributes: {
-            'thematic-overviews': [
-              {
-                airtableId: 'recAirtableThematic2',
-                name: 'Thématique 2',
-                tubeOverviews: [
-                  {
-                    airtableId: 'recAirtableTube4',
-                    name: '@tube4',
-                    skillOverviews: [
-                      {
-                        airtableId: 'recAirtableSkill4',
-                        name: '@tube41',
-                        prototypeId: 'recChallenge4',
-                        validatedChallengesCount: 1,
-                        proposedChallengesCount: 0,
-                        isPrototypeDeclinable: true,
-                      },
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                    ],
-                  },
-                  {
-                    airtableId: 'recAirtableTube5',
-                    name: '@tube5',
-                    skillOverviews: [
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      {
-                        airtableId: 'recAirtableSkill5',
-                        name: '@tube56',
-                        prototypeId: 'recChallenge5',
-                        validatedChallengesCount: 1,
-                        proposedChallengesCount: 0,
-                        isPrototypeDeclinable: false,
-                      },
-                      null,
-                    ],
-                  },
-                ],
-              },
-              {
-                airtableId: 'recAirtableThematic1',
-                name: 'Thématique 1',
-                tubeOverviews: [
-                  {
-                    airtableId: 'recAirtableTube2',
-                    name: '@tube2',
-                    skillOverviews: [
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      null,
-                      {
-                        airtableId: 'recAirtableSkill3',
-                        name: '@tube27',
-                        prototypeId: 'recChallenge3',
-                        validatedChallengesCount: 1,
-                        proposedChallengesCount: 1,
-                        isPrototypeDeclinable: true,
-                      },
-                    ],
-                  },
-                  {
-                    airtableId: 'recAirtableTube1',
-                    name: '@tube1',
-                    skillOverviews: [
-                      null,
-                      null,
-                      {
-                        airtableId: 'recAirtableSkill2',
-                        name: '@tube13',
-                        prototypeId: 'recChallenge2',
-                        validatedChallengesCount: 1,
-                        proposedChallengesCount: 0,
-                        isPrototypeDeclinable: false,
-                      },
-                      {
-                        airtableId: 'recAirtableSkill1',
-                        name: '@tube14',
-                        prototypeId: 'recChallenge1',
-                        validatedChallengesCount: 2,
-                        proposedChallengesCount: 0,
-                        isPrototypeDeclinable: true,
-                      },
-                      null,
-                      null,
-                      null,
-                    ],
-                  },
-                ],
-              },
-            ],
+        expect(response.result).toEqual({
+          data:{
+            type: 'competence-overviews',
+            id: `${competenceId}-challenges-production-fr`,
+            attributes: {
+              'thematic-overviews': [
+                {
+                  airtableId: 'recAirtableThematic2',
+                  name: 'Thématique 2',
+                  tubeOverviews: [
+                    {
+                      airtableId: 'recAirtableTube4',
+                      name: '@tube4',
+                      skillOverviews: [
+                        {
+                          airtableId: 'recAirtableSkill4',
+                          name: '@tube41',
+                          prototypeId: 'recChallenge4',
+                          validatedChallengesCount: 1,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: true,
+                        },
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                      ],
+                    },
+                    {
+                      airtableId: 'recAirtableTube5',
+                      name: '@tube5',
+                      skillOverviews: [
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        {
+                          airtableId: 'recAirtableSkill5',
+                          name: '@tube56',
+                          prototypeId: 'recChallenge5',
+                          validatedChallengesCount: 1,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: false,
+                        },
+                        null,
+                      ],
+                    },
+                  ],
+                },
+                {
+                  airtableId: 'recAirtableThematic1',
+                  name: 'Thématique 1',
+                  tubeOverviews: [
+                    {
+                      airtableId: 'recAirtableTube2',
+                      name: '@tube2',
+                      skillOverviews: [
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        {
+                          airtableId: 'recAirtableSkill3',
+                          name: '@tube27',
+                          prototypeId: 'recChallenge3',
+                          validatedChallengesCount: 1,
+                          proposedChallengesCount: 1,
+                          isPrototypeDeclinable: true,
+                        },
+                      ],
+                    },
+                    {
+                      airtableId: 'recAirtableTube1',
+                      name: '@tube1',
+                      skillOverviews: [
+                        null,
+                        null,
+                        {
+                          airtableId: 'recAirtableSkill2',
+                          name: '@tube13',
+                          prototypeId: 'recChallenge2',
+                          validatedChallengesCount: 1,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: false,
+                        },
+                        {
+                          airtableId: 'recAirtableSkill1',
+                          name: '@tube14',
+                          prototypeId: 'recChallenge1',
+                          validatedChallengesCount: 3,
+                          proposedChallengesCount: 0,
+                          isPrototypeDeclinable: true,
+                        },
+                        null,
+                        null,
+                        null,
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
           },
-        },
-      });
+        });
 
-      expect(airtableThematicsScope.isDone()).toBe(true);
-      expect(airtableTubesScope.isDone()).toBe(true);
-      expect(airtableSkillsScope.isDone()).toBe(true);
-      expect(airtableChallengesScope.isDone()).toBe(true);
+        expect(airtableThematicsScope.isDone()).toBe(true);
+        expect(airtableTubesScope.isDone()).toBe(true);
+        expect(airtableSkillsScope.isDone()).toBe(true);
+        expect(airtableChallengesScope.isDone()).toBe(true);
+      });
     });
   });
 });

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -20,7 +20,7 @@ describe('Acceptance | Route | competence-overviews', () => {
 
   describe('GET /competences/:id/overviews/challenges-production', () => {
 
-    it.fails('should respond status 200 and overview of competence’s prodcution challenges', async () => {
+    it('should respond status 200 and overview of competence’s production challenges', async () => {
       // given
       const competenceId = 'recCompetence1';
 

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -20,7 +20,7 @@ describe('Acceptance | Route | competence-overviews', () => {
 
   describe('GET /competences/:id/overviews/challenges-production', () => {
 
-    it.fails('should respond status 200 and overview of competence’s production challenges', async () => {
+    it('should respond status 200 and overview of competence’s production challenges', async () => {
       // given
       const competenceId = 'recCompetence1';
 

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -13,7 +13,7 @@ import {
   thematicDatasource,
   tubeDatasource
 } from '../../../../lib/infrastructure/datasources/airtable/index.js';
-import { Challenge, Skill } from '../../../../lib/domain/models/index.js';
+import { Challenge, LocalizedChallenge, Skill } from '../../../../lib/domain/models/index.js';
 import { LOCALE } from '../../../../lib/domain/constants.js';
 
 describe('Acceptance | Route | competence-overviews', () => {
@@ -102,9 +102,11 @@ describe('Acceptance | Route | competence-overviews', () => {
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge1', airtableId: 'recAirtableChallenge1', skillId: 'recSkill1', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.FACILEMENT, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge11', airtableId: 'recAirtableChallenge11', skillId: 'recSkill1', genealogy: Challenge.GENEALOGIES.DECLINAISON, version: 1, status: Challenge.STATUSES.VALIDE, locales: [LOCALE.FRENCH_FRANCE], competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge2', airtableId: 'recAirtableChallenge2', skillId: 'recSkill2', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.NON, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
+
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge3', airtableId: 'recAirtableChallenge3', skillId: 'recSkill3', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.FACILEMENT, version: 2, status: Challenge.STATUSES.VALIDE, competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge31', airtableId: 'recAirtableChallenge31', skillId: 'recSkill3', genealogy: Challenge.GENEALOGIES.DECLINAISON, version: 2, status: Challenge.STATUSES.PROPOSE, competenceId })),
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge4', airtableId: 'recAirtableChallenge4', skillId: 'recSkill4', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.DIFFICILEMENT, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
+
         airtableBuilder.factory.buildChallenge(domainBuilder.buildChallengeDatasourceObject({ id: 'recChallenge5', airtableId: 'recAirtableChallenge5', skillId: 'recSkill5', genealogy: Challenge.GENEALOGIES.PROTOTYPE, declinable: Challenge.DECLINABLES.NON, version: 1, status: Challenge.STATUSES.VALIDE, competenceId })),
       ];
 
@@ -276,6 +278,11 @@ describe('Acceptance | Route | competence-overviews', () => {
     describe('with language filter set to english', () => {
       it('should respond status 200 and overview of competence’s production, localized and primary english challenges', async () => {
         // given
+        databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge3_en', challengeId: 'recChallenge3', status: LocalizedChallenge.STATUSES.PLAY, locale: LOCALE.ENGLISH_SPOKEN });
+        databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge31_en', challengeId: 'recChallenge31', status: LocalizedChallenge.STATUSES.PAUSE, locale: LOCALE.ENGLISH_SPOKEN });
+        databaseBuilder.factory.buildLocalizedChallenge({ id: 'recChallenge4_en', challengeId: 'recChallenge4', status: LocalizedChallenge.STATUSES.PAUSE, locale: LOCALE.ENGLISH_SPOKEN });
+        await databaseBuilder.commit();
+
         const server = await createServer();
 
         // when
@@ -307,7 +314,7 @@ describe('Acceptance | Route | competence-overviews', () => {
                           name: '@tube41',
                           prototypeId: 'recChallenge4',
                           validatedChallengesCount: 0,
-                          proposedChallengesCount: 0,
+                          proposedChallengesCount: 1,
                           isPrototypeDeclinable: true,
                         },
                         null,
@@ -358,8 +365,8 @@ describe('Acceptance | Route | competence-overviews', () => {
                           airtableId: 'recAirtableSkill3',
                           name: '@tube27',
                           prototypeId: 'recChallenge3',
-                          validatedChallengesCount: 0,
-                          proposedChallengesCount: 0,
+                          validatedChallengesCount: 1,
+                          proposedChallengesCount: 1,
                           isPrototypeDeclinable: true,
                         },
                       ],

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -91,7 +91,7 @@ describe('Acceptance | Route | competence-overviews', () => {
           fields: {
             '': skillDatasource.usedFields,
           },
-          filterByFormula: `{Compétence (via Tube) (id persistant)} = "${competenceId}"`
+          filterByFormula: `AND({Compétence (via Tube) (id persistant)} = "${competenceId}", {Status} = "${Skill.STATUSES.ACTIF}")`
         })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: airtableSkills });

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -1,0 +1,126 @@
+import {  beforeEach, describe, expect, it } from 'vitest';
+import nock from 'nock';
+import _ from 'lodash';
+import {
+  airtableBuilder,
+  databaseBuilder,
+  domainBuilder,
+  generateAuthorizationHeader,
+} from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { thematicDatasource } from '../../../../lib/infrastructure/datasources/airtable/thematic-datasource.js';
+
+describe('Acceptance | Route | competence-overviews', () => {
+
+  let user;
+  beforeEach(async function() {
+    user = databaseBuilder.factory.buildAdminUser();
+    await databaseBuilder.commit();
+  });
+
+  describe('GET /competences/:id/overviews/challenges-production', () => {
+
+    it.fails('should respond status 200 and overview of competence’s prodcution challenges', async () => {
+      // given
+      const competenceId = 'recCompetence1';
+
+      const airtableThematics = [
+        airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic1', airtableId: 'recAirtableThematic1', index:2 })),
+        airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic2', airtableId: 'recAirtableThematic2', index:1 })),
+      ];
+
+      const airtableThematicsScope = nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Thematiques')
+        .query({
+          fields: {
+            '': thematicDatasource.usedFields,
+          },
+          filterByFormula: `{Competence (id persistant)} = "${competenceId}"`
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: airtableThematics });
+
+      databaseBuilder.factory.buildTranslation({
+        key: `thematic.${airtableThematics[0].fields['id persistant']}.name`,
+        locale: 'fr',
+        value: 'Thématique 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `thematic.${airtableThematics[1].fields['id persistant']}.name`,
+        locale: 'fr',
+        value: 'Thématique 2',
+      });
+
+      // FIXME tubes
+      // FIXME skills
+      // FIXME challenges
+
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/competences/${competenceId}/overviews/challenges-production`,
+        headers: generateAuthorizationHeader(user)
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+
+      expect(response.result).toEqual({
+        data:{
+          type: 'competence-overviews',
+          id: `${competenceId}-challenges-production-fr`,
+          attributes: {
+            'thematic-overviews': [
+              {
+                airtableId: 'recAirtableThematic2',
+                name: 'Thématique 2',
+              },
+              {
+                airtableId: 'recAirtableThematic1',
+                name: 'Thématique 1',
+              },
+            ],
+          },
+        },
+      });
+
+      // {
+      //   id: 'recCompetence123-challenges-production-fr',
+      //   thematicOverviews: [ // sorted by index
+      //     {
+      //       airtableId: 'rec654',
+      //       name: 'theme',
+      //       tubeOverviews: [ // sorted by index
+      //         {
+      //           airtableId: 'rec987',
+      //           name: 'tube',
+      //           skillOverviews: [
+      //             null,
+      //             null,
+      //             {
+      //               airtableId: 'rec147',
+      //               name: '@skill3',
+      //               prototypeId: 'rec258',
+      //               validatedChallengesCount: 2,
+      //               proposedChallengesCount: 3,
+      //               isPrototypeDeclinable: true,
+      //             },
+      //             null,
+      //             null,
+      //             null,
+      //             null,
+      //           ],
+      //         },
+      //       ],
+      //     },
+      //   ],
+      // }
+
+      expect(airtableThematicsScope.isDone()).toBe(true);
+    });
+  });
+});

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -33,7 +33,7 @@ describe('Acceptance | Route | competence-overviews', () => {
       const airtableThematics = [
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic1', airtableId: 'recAirtableThematic1', index: 2, tubeIds: ['recTube1', 'recTube2', 'recTube3'] })),
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic2', airtableId: 'recAirtableThematic2', index: 1, tubeIds: ['recTube4', 'recTube5'] })),
-        airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic3', airtableId: 'recAirtableThematic3', index: 3, tubeIds: [] })),
+        airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic3', airtableId: 'recAirtableThematic3', index: 3, tubeIds: null })),
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic4', airtableId: 'recAirtableThematic4', index: 4, tubeIds: ['recTube6'] })),
       ];
 

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -130,6 +130,7 @@ async function mockCurrentContent() {
 
   const expectedTube = domainBuilder.buildTube();
   delete expectedTube.airtableId;
+  delete expectedTube.index;
 
   const expectedCurrentContent = {
     attachments: [

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
-import { Challenge, LocalizedChallenge } from '../../../../lib/domain/models/index.js';
+import { Challenge, LocalizedChallenge, Skill } from '../../../../lib/domain/models/index.js';
 import * as challengeRepository from '../../../../lib/infrastructure/repositories/challenge-repository.js';
 import { skillDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import _ from 'lodash';
@@ -394,6 +394,393 @@ describe('Integration | Repository | challenge-repository', () => {
 
       // when
       const challenges = await challengeRepository.listBySkillId('someSkillId');
+
+      // then
+      expect(challenges).toStrictEqual([]);
+    });
+  });
+
+  describe('#listActiveOrDraftByCompetenceId', () => {
+    it('should retrieve active & draft challenges by given competence id', async () => {
+      // given
+      const challengeDraftA_data = {
+        id: 'challengeDraftA_id',
+        localizedEsId: 'locES_challengeDraftA_id',
+        airtableId: 'airtableChallengeDraftA_id',
+        skillId: 'skillId',
+        competenceId: 'competenceId',
+        alpha: 1,
+        alphaAirtable: '1',
+        delta: 2,
+        deltaAirtable: '2',
+        type: 'type challengeDraftA',
+        t1StatusAirtable: 'Activé',
+        t1Status: true,
+        t2StatusAirtable: 'Désactivé',
+        t2Status: false,
+        t3StatusAirtable: 'Activé',
+        t3Status: true,
+        status: Challenge.STATUSES.PROPOSE,
+        embedUrl: 'embedUrl challengeDraftA',
+        embedHeight: 'embedHeight challengeDraftA',
+        timer: 789,
+        format: Challenge.FORMATS.MOTS,
+        autoReply: false,
+        localesAirtable: ['Francophone'],
+        locales: ['fr'],
+        focusable: 'focusable challengeDraftA',
+        skills: ['airtableSkillId'],
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+        pedagogy: Challenge.PEDAGOGIES.Q_SITUATION,
+        author: 'author challengeDraftA',
+        declinable: Challenge.DECLINABLES.FACILEMENT,
+        version: 'version challengeDraftA',
+        alternativeVersion: 'alternativeVersion challengeDraftA',
+        accessibility1: Challenge.ACCESSIBILITY1.KO,
+        accessibility2: Challenge.ACCESSIBILITY2.RAS,
+        spoil: Challenge.SPOILS.NON_SPOILABLE,
+        responsive: Challenge.RESPONSIVES.SMARTPHONE,
+        geography: 'geography challengeDraftA',
+        files: [],
+        validatedAt: null,
+        archivedAt: null,
+        createdAt: null,
+        updatedAt: null,
+        madeObsoleteAt: null,
+        shuffled: 'shuffled challengeDraftA',
+        contextualizedFields: [Challenge.CONTEXTUALIZED_FIELDS.EMBED],
+      };
+      const challengeActiveA_data = {
+        id: 'challengeActiveA_id',
+        airtableId: 'airtableChallengeActiveA_id',
+        skillId: 'skillId',
+        competenceId: 'competenceId',
+        alpha: 1,
+        alphaAirtable: '1',
+        delta: 2,
+        deltaAirtable: '2',
+        type: 'type challengeA',
+        t1StatusAirtable: 'Activé',
+        t1Status: true,
+        t2StatusAirtable: 'Désactivé',
+        t2Status: false,
+        t3StatusAirtable: 'Activé',
+        t3Status: true,
+        status: Challenge.STATUSES.VALIDE,
+        embedUrl: 'embedUrl challengeActiveA',
+        embedHeight: 'embedHeight challengeActiveA',
+        timer: 789,
+        format: Challenge.FORMATS.MOTS,
+        autoReply: false,
+        localesAirtable: ['Francophone'],
+        locales: ['fr'],
+        focusable: 'focusable challengeActiveA',
+        skills: ['airtableSkillId'],
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+        pedagogy: Challenge.PEDAGOGIES.Q_SITUATION,
+        author: 'author challengeActiveA',
+        declinable: Challenge.DECLINABLES.FACILEMENT,
+        version: 'version challengeActiveA',
+        alternativeVersion: 'alternativeVersion challengeActiveA',
+        accessibility1: Challenge.ACCESSIBILITY1.KO,
+        accessibility2: Challenge.ACCESSIBILITY2.RAS,
+        spoil: Challenge.SPOILS.NON_SPOILABLE,
+        responsive: Challenge.RESPONSIVES.SMARTPHONE,
+        geography: 'geography challengeActiveA',
+        files: [],
+        validatedAt: null,
+        archivedAt: null,
+        createdAt: null,
+        updatedAt: null,
+        madeObsoleteAt: null,
+        shuffled: 'shuffled challengeActiveA',
+        contextualizedFields: [Challenge.CONTEXTUALIZED_FIELDS.EMBED],
+      };
+      const primaryLoc_challengeDraftA_data = {
+        embedUrl: 'embedUrl primaryloc challengeA',
+        fileIds: ['attachmentDraftA'],
+        locale: 'fr',
+        status: null,
+        geography: 'FR',
+        urlsToConsult: ['http://primaryloc.challengeA'],
+      };
+      const primaryLoc_challengeActiveA_data = {
+        embedUrl: 'embedUrl primaryloc challengeActiveA',
+        fileIds: [],
+        locale: 'fr',
+        status: null,
+        geography: 'FR',
+        urlsToConsult: ['http://primaryloc.challengeActiveA'],
+      };
+      const esLoc_challengeDraftA_data = {
+        embedUrl: 'embedUrl esLoc challengeDraftA',
+        fileIds: ['attachmentDraftB'],
+        locale: 'es',
+        status: LocalizedChallenge.STATUSES.PAUSE,
+        geography: 'ES',
+        urlsToConsult: ['http://esLoc.challengeA'],
+      };
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeDraftA_id.instruction',
+        locale: 'fr',
+        value: 'instruction FR challengeDraftA',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeDraftA_id.instruction',
+        locale: 'es',
+        value: 'instruction ES challengeDraftA',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeDraftA_id.solution',
+        locale: 'fr',
+        value: 'solution FR challengeDraftA',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeActiveA_id.instruction',
+        locale: 'fr',
+        value: 'instruction FR challengeActiveA',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.challengeActiveA_id.solution',
+        locale: 'fr',
+        value: 'solution FR challengeActiveA',
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challengeDraftA_id',
+        challengeId: 'challengeDraftA_id',
+        ...primaryLoc_challengeDraftA_data,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'locES_challengeDraftA_id',
+        challengeId: 'challengeDraftA_id',
+        ...esLoc_challengeDraftA_data,
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challengeActiveA_id',
+        challengeId: 'challengeActiveA_id',
+        ...primaryLoc_challengeActiveA_data,
+      });
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: 'challengeDraftA_id',
+        attachmentId: 'attachmentDraftA',
+      });
+      databaseBuilder.factory.buildLocalizedChallengeAttachment({
+        localizedChallengeId: 'locES_challengeDraftA_id',
+        attachmentId: 'attachmentDraftB',
+      });
+      await databaseBuilder.commit();
+      vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
+        if (tableName !== 'Epreuves') expect.unreachable('Airtable tableName should be Epreuves');
+        if (options?.filterByFormula !==  `AND({Compétences (via tube) (id persistant)} = "${challengeDraftA_data.competenceId}", {acquis} != "${Skill.WORKBENCH_NAME}", OR({Statut} = "${Challenge.STATUSES.PROPOSE}", {Statut} = "${Challenge.STATUSES.VALIDE}"))`) expect.unreachable('Wrong filterByFormula');
+        return [
+          {
+            id: challengeDraftA_data.airtableId,
+            fields: {
+              'id persistant': challengeDraftA_data.id,
+              'Record ID': challengeDraftA_data.airtableId,
+              'Compétences (via tube) (id persistant)': [challengeDraftA_data.competenceId],
+              'Type d\'épreuve': challengeDraftA_data.type,
+              'T1 - Espaces, casse & accents': challengeDraftA_data.t1StatusAirtable,
+              'T2 - Ponctuation': challengeDraftA_data.t2StatusAirtable,
+              'T3 - Distance d\'édition': challengeDraftA_data.t3StatusAirtable,
+              'Statut': challengeDraftA_data.status,
+              'Embed URL': challengeDraftA_data.embedUrl,
+              'Embed height': challengeDraftA_data.embedHeight,
+              'Timer': challengeDraftA_data.timer,
+              'Format': challengeDraftA_data.format,
+              'Réponse automatique': challengeDraftA_data.autoReply,
+              'Langues': challengeDraftA_data.localesAirtable,
+              'Focalisée': challengeDraftA_data.focusable,
+              'Difficulté calculée': challengeDraftA_data.deltaAirtable,
+              'Discrimination calculée': challengeDraftA_data.alphaAirtable,
+              'Acquix': challengeDraftA_data.skills,
+              'Acquix (id persistant)': [challengeDraftA_data.skillId],
+              'Généalogie': challengeDraftA_data.genealogy,
+              'Type péda': challengeDraftA_data.pedagogy,
+              'Auteur': challengeDraftA_data.author,
+              'Déclinable': challengeDraftA_data.declinable,
+              'Version prototype': challengeDraftA_data.version,
+              'Version déclinaison': challengeDraftA_data.alternativeVersion,
+              'Non voyant': challengeDraftA_data.accessibility1,
+              'Daltonien': challengeDraftA_data.accessibility2,
+              'Spoil': challengeDraftA_data.spoil,
+              'Responsive': challengeDraftA_data.responsive,
+              'Géographie': challengeDraftA_data.geography,
+              'files': challengeDraftA_data.files,
+              'validated_at': challengeDraftA_data.validatedAt,
+              'archived_at': challengeDraftA_data.archivedAt,
+              'created_at': challengeDraftA_data.createdAt,
+              'made_obsolete_at': challengeDraftA_data.madeObsoleteAt,
+              'updated_at': challengeDraftA_data.updatedAt,
+              'shuffled': challengeDraftA_data.shuffled,
+              'contextualizedFields': challengeDraftA_data.contextualizedFields,
+            },
+            get: function(field) { return this.fields[field]; },
+          },
+          {
+            id: challengeActiveA_data.airtableId,
+            fields: {
+              'id persistant': challengeActiveA_data.id,
+              'Record ID': challengeActiveA_data.airtableId,
+              'Compétences (via tube) (id persistant)': [challengeActiveA_data.competenceId],
+              'Type d\'épreuve': challengeActiveA_data.type,
+              'T1 - Espaces, casse & accents': challengeActiveA_data.t1StatusAirtable,
+              'T2 - Ponctuation': challengeActiveA_data.t2StatusAirtable,
+              'T3 - Distance d\'édition': challengeActiveA_data.t3StatusAirtable,
+              'Statut': challengeActiveA_data.status,
+              'Embed URL': challengeActiveA_data.embedUrl,
+              'Embed height': challengeActiveA_data.embedHeight,
+              'Timer': challengeActiveA_data.timer,
+              'Format': challengeActiveA_data.format,
+              'Réponse automatique': challengeActiveA_data.autoReply,
+              'Langues': challengeActiveA_data.localesAirtable,
+              'Focalisée': challengeActiveA_data.focusable,
+              'Difficulté calculée': challengeActiveA_data.deltaAirtable,
+              'Discrimination calculée': challengeActiveA_data.alphaAirtable,
+              'Acquix': challengeActiveA_data.skills,
+              'Acquix (id persistant)': [challengeActiveA_data.skillId],
+              'Généalogie': challengeActiveA_data.genealogy,
+              'Type péda': challengeActiveA_data.pedagogy,
+              'Auteur': challengeActiveA_data.author,
+              'Déclinable': challengeActiveA_data.declinable,
+              'Version prototype': challengeActiveA_data.version,
+              'Version déclinaison': challengeActiveA_data.alternativeVersion,
+              'Non voyant': challengeActiveA_data.accessibility1,
+              'Daltonien': challengeActiveA_data.accessibility2,
+              'Spoil': challengeActiveA_data.spoil,
+              'Responsive': challengeActiveA_data.responsive,
+              'Géographie': challengeActiveA_data.geography,
+              'files': challengeActiveA_data.files,
+              'validated_at': challengeActiveA_data.validatedAt,
+              'archived_at': challengeActiveA_data.archivedAt,
+              'created_at': challengeActiveA_data.createdAt,
+              'made_obsolete_at': challengeActiveA_data.madeObsoleteAt,
+              'updated_at': challengeActiveA_data.updatedAt,
+              'shuffled': challengeActiveA_data.shuffled,
+              'contextualizedFields': challengeActiveA_data.contextualizedFields,
+            },
+            get: function(field) { return this.fields[field]; },
+          },
+        ];
+      });
+
+      // when
+      const challenges = await challengeRepository.listActiveOrDraftByCompetenceId(challengeDraftA_data.competenceId);
+
+      // then
+      expect(challenges).toStrictEqual([
+        domainBuilder.buildChallenge({
+          accessibility1: challengeDraftA_data.accessibility1,
+          accessibility2: challengeDraftA_data.accessibility2,
+          airtableId: challengeDraftA_data.airtableId,
+          alternativeVersion: challengeDraftA_data.alternativeVersion,
+          alpha: challengeDraftA_data.alpha,
+          archivedAt: challengeDraftA_data.archivedAt,
+          author: challengeDraftA_data.author,
+          autoReply: challengeDraftA_data.autoReply,
+          competenceId: challengeDraftA_data.competenceId,
+          contextualizedFields: challengeDraftA_data.contextualizedFields,
+          createdAt: challengeDraftA_data.createdAt,
+          declinable: challengeDraftA_data.declinable,
+          delta: challengeDraftA_data.delta,
+          embedHeight: challengeDraftA_data.embedHeight,
+          files: challengeDraftA_data.files,
+          focusable: challengeDraftA_data.focusable,
+          format: challengeDraftA_data.format,
+          genealogy: challengeDraftA_data.genealogy,
+          geography: challengeDraftA_data.geography,
+          id: challengeDraftA_data.id,
+          locales: challengeDraftA_data.locales,
+          localizedChallenges: [
+            domainBuilder.buildLocalizedChallenge({
+              id: challengeDraftA_data.localizedEsId,
+              challengeId: challengeDraftA_data.id,
+              ...esLoc_challengeDraftA_data,
+            }),
+            domainBuilder.buildLocalizedChallenge({
+              id: challengeDraftA_data.id,
+              challengeId: challengeDraftA_data.id,
+              ...primaryLoc_challengeDraftA_data,
+            }),
+          ],
+          madeObsoleteAt: challengeDraftA_data.madeObsoleteAt,
+          pedagogy: challengeDraftA_data.pedagogy,
+          responsive: challengeDraftA_data.responsive,
+          shuffled: challengeDraftA_data.shuffled,
+          skillId: challengeDraftA_data.skillId,
+          skills: challengeDraftA_data.skills,
+          spoil: challengeDraftA_data.spoil,
+          status: challengeDraftA_data.status,
+          t1Status: challengeDraftA_data.t1Status,
+          t2Status: challengeDraftA_data.t2Status,
+          t3Status: challengeDraftA_data.t3Status,
+          timer: challengeDraftA_data.timer,
+          translations: { fr: { instruction: 'instruction FR challengeDraftA', solution: 'solution FR challengeDraftA' }, es: { instruction : 'instruction ES challengeDraftA' } },
+          type: challengeDraftA_data.type,
+          updatedAt: challengeDraftA_data.updatedAt,
+          validatedAt: challengeDraftA_data.validatedAt,
+          version: challengeDraftA_data.version,
+        }),
+        domainBuilder.buildChallenge({
+          accessibility1: challengeActiveA_data.accessibility1,
+          accessibility2: challengeActiveA_data.accessibility2,
+          airtableId: challengeActiveA_data.airtableId,
+          alternativeVersion: challengeActiveA_data.alternativeVersion,
+          alpha: challengeActiveA_data.alpha,
+          archivedAt: challengeActiveA_data.archivedAt,
+          author: challengeActiveA_data.author,
+          autoReply: challengeActiveA_data.autoReply,
+          competenceId: challengeActiveA_data.competenceId,
+          contextualizedFields: challengeActiveA_data.contextualizedFields,
+          createdAt: challengeActiveA_data.createdAt,
+          declinable: challengeActiveA_data.declinable,
+          delta: challengeActiveA_data.delta,
+          embedHeight: challengeActiveA_data.embedHeight,
+          files: challengeActiveA_data.files,
+          focusable: challengeActiveA_data.focusable,
+          format: challengeActiveA_data.format,
+          genealogy: challengeActiveA_data.genealogy,
+          geography: challengeActiveA_data.geography,
+          id: challengeActiveA_data.id,
+          locales: challengeActiveA_data.locales,
+          localizedChallenges: [
+            domainBuilder.buildLocalizedChallenge({
+              id: challengeActiveA_data.id,
+              challengeId: challengeActiveA_data.id,
+              ...primaryLoc_challengeActiveA_data,
+            }),
+          ],
+          madeObsoleteAt: challengeActiveA_data.madeObsoleteAt,
+          pedagogy: challengeActiveA_data.pedagogy,
+          responsive: challengeActiveA_data.responsive,
+          shuffled: challengeActiveA_data.shuffled,
+          skillId: challengeActiveA_data.skillId,
+          skills: challengeActiveA_data.skills,
+          spoil: challengeActiveA_data.spoil,
+          status: challengeActiveA_data.status,
+          t1Status: challengeActiveA_data.t1Status,
+          t2Status: challengeActiveA_data.t2Status,
+          t3Status: challengeActiveA_data.t3Status,
+          timer: challengeActiveA_data.timer,
+          translations: { fr: { instruction: 'instruction FR challengeActiveA', solution: 'solution FR challengeActiveA' } },
+          type: challengeActiveA_data.type,
+          updatedAt: challengeActiveA_data.updatedAt,
+          validatedAt: challengeActiveA_data.validatedAt,
+          version: challengeActiveA_data.version,
+        }),
+      ]);
+    });
+
+    it('should return an empty array when no challenges found for provided competence id', async () => {
+      // given
+      vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
+        if (tableName !== 'Epreuves') expect.unreachable('Airtable tableName should be Epreuves');
+        if (options?.filterByFormula !== `AND({Compétences (via tube) (id persistant)} = "someCompetenceId", {acquis} != "${Skill.WORKBENCH_NAME}", OR({Statut} = "${Challenge.STATUSES.PROPOSE}", {Statut} = "${Challenge.STATUSES.VALIDE}"))`) expect.unreachable('Wrong filterByFormula');
+        return [];
+      });
+
+      // when
+      const challenges = await challengeRepository.listActiveOrDraftByCompetenceId('someCompetenceId');
 
       // then
       expect(challenges).toStrictEqual([]);

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -125,7 +125,7 @@ describe('Integration | Repository | skill-repository', () => {
     });
   });
 
-  describe('#listByCompetenceId', () => {
+  describe('#listActiveByCompetenceId', () => {
     it('should retrieve all skills by competence Id', async () => {
       // given
       const skill1 = {
@@ -138,7 +138,7 @@ describe('Integration | Repository | skill-repository', () => {
         learningMoreTutorialIds: ['tuto3', 'tuto4'],
         pixValue: 2.5,
         competenceId: 'competence1',
-        status: Skill.STATUSES.PERIME,
+        status: Skill.STATUSES.ACTIF,
         tubeId: 'tube1',
         level: 4,
         internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
@@ -159,7 +159,7 @@ describe('Integration | Repository | skill-repository', () => {
       await databaseBuilder.commit();
       vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Acquis') expect.unreachable('Airtable tableName should be Acquis');
-        if (options?.filterByFormula !== `{Compétence (via Tube) (id persistant)} = ${stringValue(skill1.competenceId)}`) expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !== `AND({Compétence (via Tube) (id persistant)} = ${stringValue(skill1.competenceId)}, {Status} = "${Skill.STATUSES.ACTIF}")`) expect.unreachable('Wrong filterByFormula');
         return [{
           id: skill1.airtableId,
           fields: {
@@ -183,7 +183,7 @@ describe('Integration | Repository | skill-repository', () => {
       });
 
       // when
-      const skills = await skillRepository.listByCompetenceId('competence1');
+      const skills = await skillRepository.listActiveByCompetenceId('competence1');
 
       // then
 
@@ -202,7 +202,7 @@ describe('Integration | Repository | skill-repository', () => {
           learningMoreTutorialIds: ['tuto3', 'tuto4'],
           pixValue: 2.5,
           competenceId: 'competence1',
-          status: Skill.STATUSES.PERIME,
+          status: Skill.STATUSES.ACTIF,
           tubeId: 'tube1',
           level: 4,
           internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -8,6 +8,8 @@ import {
 } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import { Skill } from '../../../../lib/domain/models/index.js';
 import { SkillForRelease } from '../../../../lib/domain/models/release/index.js';
+import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
+import { stringValue } from '../../../../lib/infrastructure/airtable.js';
 
 describe('Integration | Repository | skill-repository', () => {
 
@@ -120,6 +122,93 @@ describe('Integration | Repository | skill-repository', () => {
       ]);
 
       airtableScope.done();
+    });
+  });
+
+  describe('#listByCompetenceId', () => {
+    it('should retrieve all skills by competence Id', async () => {
+      // given
+      const skill1 = {
+        id: 'skill1',
+        airtableId: 'recId1',
+        name: 'Acquis 1',
+        description: 'Description Acquis 1',
+        hintStatus: SkillForRelease.HINT_STATUSES.VALIDE,
+        tutorialIds: ['tuto1', 'tuto2'],
+        learningMoreTutorialIds: ['tuto3', 'tuto4'],
+        pixValue: 2.5,
+        competenceId: 'competence1',
+        status: Skill.STATUSES.PERIME,
+        tubeId: 'tube1',
+        level: 4,
+        internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+        version: '1',
+      };
+
+      databaseBuilder.factory.buildTranslation({
+        key: 'skill.skill1.hint',
+        locale: 'fr',
+        value: 'Indice acquis 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'skill.skill1.hint',
+        locale: 'en',
+        value: 'Skill 1 hint',
+      });
+
+      await databaseBuilder.commit();
+      vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
+        if (tableName !== 'Acquis') expect.unreachable('Airtable tableName should be Acquis');
+        if (options?.filterByFormula !== `{Compétence (via Tube) (id persistant)} = ${stringValue(skill1.competenceId)}`) expect.unreachable('Wrong filterByFormula');
+        return [{
+          id: skill1.airtableId,
+          fields: {
+            'id persistant': skill1.id,
+            'Record Id': skill1.airtableId,
+            'Nom': skill1.name,
+            'Statut de l\'indice': skill1.hintStatus,
+            'Comprendre (id persistant)': skill1.tutorialIds,
+            'En savoir plus (id persistant)': skill1.learningMoreTutorialIds,
+            'PixValue': skill1.pixValue,
+            'Compétence (via Tube) (id persistant)': [skill1.competenceId],
+            'Status': skill1.status,
+            'Tube (id persistant)': [skill1.tubeId],
+            'Description': skill1.description,
+            'Level': skill1.level,
+            'Internationalisation': skill1.internationalisation,
+            'Version': skill1.version,
+          },
+          get: function(field) { return this.fields[field]; },
+        }];
+      });
+
+      // when
+      const skills = await skillRepository.listByCompetenceId('competence1');
+
+      // then
+
+      expect(skills).toEqual([
+        domainBuilder.buildSkill({
+          id: 'skill1',
+          airtableId: 'recId1',
+          name: 'Acquis 1',
+          description: 'Description Acquis 1',
+          hint_i18n: {
+            fr: 'Indice acquis 1',
+            en: 'Skill 1 hint',
+          },
+          hintStatus: SkillForRelease.HINT_STATUSES.VALIDE,
+          tutorialIds: ['tuto1', 'tuto2'],
+          learningMoreTutorialIds: ['tuto3', 'tuto4'],
+          pixValue: 2.5,
+          competenceId: 'competence1',
+          status: Skill.STATUSES.PERIME,
+          tubeId: 'tube1',
+          level: 4,
+          internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+          version: '1',
+        }),
+      ]);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
+import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
+import { stringValue } from '../../../../lib/infrastructure/airtable.js';
 
 describe('Integration | Repository | thematic-repository', () => {
 
@@ -75,6 +77,58 @@ describe('Integration | Repository | thematic-repository', () => {
       ]);
 
       airtableScope.done();
+    });
+  });
+
+  describe('#listByCompetenceId', () => {
+    it('should retrieve all thematics by competence id', async () => {
+      //given
+      const competenceId = 'competenceId1';
+      const thematicId = 'recThematic1';
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.recThematic1.name',
+        locale: 'fr',
+        value: 'Nom thématique 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.recThematic1.name',
+        locale: 'en',
+        value: 'Thematic 1 name',
+      });
+
+      await databaseBuilder.commit();
+      vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
+        if (tableName !== 'Thematiques') expect.unreachable('Airtable tableName should be Tubes');
+        if (options?.filterByFormula !==  `{Competence (id persistant)} = ${stringValue(competenceId)}`) expect.unreachable('Wrong filterByFormula');
+        return [{
+          id: 'recAirtableThematic1',
+          fields: {
+            'id persistant': thematicId,
+            'Competence (id persistant)': [competenceId],
+            'Tubes (id persistant)': ['tubeId1', 'tubeId2'],
+            'Index': 1,
+          },
+          get: function(field) { return this.fields[field]; },
+        }];
+      });
+
+      //when
+      const thematics = await thematicRepository.listByCompetenceId(competenceId);
+
+      //then
+      expect(thematics).toStrictEqual([
+        domainBuilder.buildThematic({
+          id: 'recThematic1',
+          airtableId: 'recAirtableThematic1',
+          name_i18n: {
+            fr: 'Nom thématique 1',
+            en: 'Thematic 1 name',
+          },
+          competenceId: 'competenceId1',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          index: 1,
+        })
+      ]);
     });
   });
 

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -1,12 +1,13 @@
 export function buildThematic(
   {
     id,
+    airtableId = id,
     competenceId,
     tubeIds,
     index,
   } = {}) {
   return {
-    id,
+    id: airtableId,
     'fields': {
       'id persistant': id,
       'Competence (id persistant)': [competenceId],

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -1,14 +1,17 @@
 export function buildTube({
   id,
+  airtableId = id,
   name,
+  index,
   competenceId,
 } = {}) {
 
   return {
-    id,
+    id: airtableId,
     'fields': {
       'id persistant': id,
       'Nom': name,
+      'Index': index,
       'Competences (id persistant)': [competenceId],
     },
   };

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
@@ -3,12 +3,14 @@ export function buildTubeDatasourceObject(
     id = 'recTIddrkopID23Fp',
     airtableId,
     name = '@Moteur',
+    index = 1,
     competenceId = 'recsvLz0W2ShyfD63',
   } = {}) {
   return {
     id,
     airtableId: airtableId ?? id,
     name,
+    index,
     competenceId,
   };
 }

--- a/api/tests/tooling/input-output-data-builder/factory/build-tube.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-tube.js
@@ -9,6 +9,7 @@ export function buildTube({
     fr: practicalDescriptionFrFr,
     en: practicalDescriptionEnUs,
   } = {},
+  index,
   competenceId,
 } = {}) {
   return {
@@ -20,6 +21,7 @@ export function buildTube({
       'Titre pratique en-us': practicalTitleEnUs,
       'Description pratique fr-fr': practicalDescriptionFrFr,
       'Description pratique en-us': practicalDescriptionEnUs,
+      'Index': index,
       'Competences (id persistant)': [competenceId],
     },
   };


### PR DESCRIPTION
## :fallen_leaf: Problème
Il n’existe pas de endpoint pour récupérer les infos permettant d’afficher la vue "Épreuves -> En Production" d’une compétence, le front interroge Airtable et calcule ces infos.

## :chestnut: Proposition
Créer un endpoint permettant de récupérer ces infos.

## :jack_o_lantern: Remarques
N/A

## :wood: Pour tester
N/A
