### PR TITLE
[BUGFIX] Corriger l'affichage d'erreur lors de l'édition ou de la création d'un test statique (PIX-15179)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -52,16 +52,8 @@ export class InvalidStaticCourseCreationOrUpdateError extends DomainError {
     return this.errors.length > 0;
   }
 
-  addMandatoryFieldError({ field }) {
-    this.errors.push({ field, code: 'MANDATORY_FIELD' });
-  }
-
-  addUnknownResourcesError({ field, unknownResources }) {
-    this.errors.push({ field, data: unknownResources, code: 'UNKNOWN_RESOURCES' });
-  }
-
-  addDuplicatesForbiddenError({ field, duplicates }) {
-    this.errors.push({ field, data: duplicates, code: 'DUPLICATES_FORBIDDEN' });
+  addError({ attribute, detail }) {
+    this.errors.push({ attribute, detail });
   }
 }
 

--- a/api/lib/domain/models/StaticCourse.js
+++ b/api/lib/domain/models/StaticCourse.js
@@ -129,19 +129,19 @@ function validateAttributes({ name, challengeIds, tagIds }, allChallengeIds, all
 
 function checkName(name, validationError) {
   if (name.length === 0) {
-    validationError.addMandatoryFieldError({ field: 'name' });
+    validationError.addError({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
   }
 }
 
 function checkChallengeIds(challengeIds, allChallengeIds, validationError) {
   if (challengeIds.length === 0) {
-    validationError.addMandatoryFieldError({ field: 'challengeIds' });
+    validationError.addError({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
     return;
   }
 
   const notFoundChallengeIds = _.difference(challengeIds, allChallengeIds);
   if (notFoundChallengeIds.length > 0) {
-    validationError.addUnknownResourcesError({ field: 'challengeIds', unknownResources: notFoundChallengeIds });
+    validationError.addError({ attribute: 'challengeIds', detail: `Les IDs d'épreuve suivants n'existent pas : ${notFoundChallengeIds.join(', ')}` });
   }
 
   const challengeOccurrencesMap = _.countBy(challengeIds);
@@ -152,7 +152,7 @@ function checkChallengeIds(challengeIds, allChallengeIds, validationError) {
     }
   }
   if (duplicateChallengeIds.length > 0) {
-    validationError.addDuplicatesForbiddenError({ field: 'challengeIds', duplicates: duplicateChallengeIds });
+    validationError.addError({ attribute: 'challengeIds', detail: `Les IDs d'épreuve suivants sont en doublon : ${duplicateChallengeIds.join(', ')}` });
   }
 }
 
@@ -160,7 +160,7 @@ function checkTagIds(tagIds, allTagIds, validationError) {
 
   const notFoundTagIds = _.difference(tagIds, allTagIds);
   if (notFoundTagIds.length > 0) {
-    validationError.addUnknownResourcesError({ field: 'tagIds', unknownResources: notFoundTagIds });
+    validationError.addError({ attribute: 'tagIds', detail: `Les tags suivants n'existent pas : ${notFoundTagIds.join(', ')}` });
   }
 
   const tagOccurrencesMap = _.countBy(tagIds);
@@ -171,6 +171,6 @@ function checkTagIds(tagIds, allTagIds, validationError) {
     }
   }
   if (duplicateTagIds.length > 0) {
-    validationError.addDuplicatesForbiddenError({ field: 'tagIds', duplicates: duplicateTagIds.map((tagId) => parseInt(tagId)) });
+    validationError.addError({ attribute: 'tagIds', detail: `Les tags suivants sont en doublon : ${duplicateTagIds.join(', ')}` });
   }
 }

--- a/api/lib/infrastructure/errors.js
+++ b/api/lib/infrastructure/errors.js
@@ -7,10 +7,13 @@ export class InfrastructureError extends Error {
 }
 
 export class UnprocessableEntityError extends InfrastructureError {
-  constructor(message) {
+  constructor({ message, attribute, code, detail }) {
     super(message);
     this.title = 'Unprocessable entity';
     this.status = 422;
+    this.attribute = attribute;
+    this.code = code;
+    this.detail = detail;
   }
 }
 

--- a/api/lib/infrastructure/errors.js
+++ b/api/lib/infrastructure/errors.js
@@ -7,12 +7,11 @@ export class InfrastructureError extends Error {
 }
 
 export class UnprocessableEntityError extends InfrastructureError {
-  constructor({ message, attribute, code, detail }) {
+  constructor({ message, attribute, detail }) {
     super(message);
     this.title = 'Unprocessable entity';
     this.status = 422;
     this.attribute = attribute;
-    this.code = code;
     this.detail = detail;
   }
 }

--- a/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
@@ -16,7 +16,6 @@ export function serialize(infrastructureError) {
         title: error.title,
         detail: error.detail ?? error.message,
         source,
-        code: error.code,
       };
     }),
   );

--- a/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
@@ -1,11 +1,23 @@
 import JsonapiSerializer from 'jsonapi-serializer';
+import _ from 'lodash';
 
 const { Error: JSONAPIError } = JsonapiSerializer;
 
 export function serialize(infrastructureError) {
-  return JSONAPIError({
-    status: `${infrastructureError.status}`,
-    title: infrastructureError.title,
-    detail: infrastructureError.message
-  });
+  if (!Array.isArray(infrastructureError)) infrastructureError = [infrastructureError];
+
+  return JSONAPIError(
+    infrastructureError.map((error) => {
+      const source = error.attribute ?
+        { pointer: `/data/attributes/${_.kebabCase(error.attribute)}` } :
+        undefined;
+      return {
+        status: `${error.status}`,
+        title: error.title,
+        detail: error.detail ?? error.message,
+        source,
+        code: error.code,
+      };
+    }),
+  );
 }

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -44,7 +44,7 @@ function _mapToInfrastructureError(error) {
     };
   }
   if (error instanceof DomainErrors.InvalidStaticCourseCreationOrUpdateError) {
-    const infraErrors = error.errors.map((error) => new InfraErrors.UnprocessableEntityError({ detail: error.data, attribute: error.field, code: error.code }));
+    const infraErrors = error.errors.map((error) => new InfraErrors.UnprocessableEntityError({ detail: error.detail, attribute: error.attribute }));
     return {
       infraErrors,
       statusCode: 422,

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -1,43 +1,59 @@
-import _ from 'lodash';
-import JsonapiSerializer from 'jsonapi-serializer';
 import * as DomainErrors from '../../domain/errors.js';
 import * as InfraErrors from '../errors.js';
 import { errorSerializer } from '../serializers/jsonapi/index.js';
 
-const { Error: JSONAPIError } = JsonapiSerializer;
-
 export function send(h, error) {
-  if (error instanceof DomainErrors.InvalidStaticCourseCreationOrUpdateError) {
-    const jsonApiError = new JSONAPIError(
-      error.errors.map((err) => ({
-        code: err.code,
-        detail: err.data,
-        source: {
-          pointer: `/data/attributes/${_.kebabCase(err.field)}`,
-        },
-      }))
-    );
-    return h.response(jsonApiError).code(422);
-  }
+  const { infraErrors, statusCode } = _mapToInfrastructureError(error);
 
-  const infraError = _mapToInfrastructureError(error);
-  return h.response(errorSerializer.serialize(infraError)).code(infraError.status);
+  return h.response(errorSerializer.serialize(infraErrors)).code(statusCode);
 }
 
 function _mapToInfrastructureError(error) {
   if (error instanceof InfraErrors.InfrastructureError) {
-    return error;
+    return {
+      infraErrors: [error],
+      statusCode: error.status,
+    };
   }
-
   if (error instanceof DomainErrors.NotFoundError) {
-    return new InfraErrors.NotFoundError(error.message);
+    const infraError = new InfraErrors.NotFoundError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
   }
   if (error instanceof DomainErrors.UserNotFoundError) {
-    return new InfraErrors.NotFoundError(error.message);
+    const infraError = new InfraErrors.NotFoundError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
   }
   if (error instanceof DomainErrors.StaticCourseIsInactiveError) {
-    return new InfraErrors.ConflictError(error.message);
+    const infraError = new InfraErrors.ConflictError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
+  if (error instanceof DomainErrors.ForbiddenError) {
+    const infraError = new InfraErrors.ForbiddenError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
+  if (error instanceof DomainErrors.InvalidStaticCourseCreationOrUpdateError) {
+    const infraErrors = error.errors.map((error) => new InfraErrors.UnprocessableEntityError({ detail: error.data, attribute: error.field, code: error.code }));
+    return {
+      infraErrors,
+      statusCode: 422,
+    };
   }
 
-  return new InfraErrors.InfrastructureError(error.message);
+  const infraError = new InfraErrors.InfrastructureError(error.message);
+  return {
+    infraErrors: [infraError],
+    statusCode: infraError.status,
+  };
 }

--- a/api/tests/unit/application/static-courses/static-courses_test.js
+++ b/api/tests/unit/application/static-courses/static-courses_test.js
@@ -269,11 +269,11 @@ describe('Unit | Controller | static courses controller', function() {
 
         // then
         expect(error0).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error0.errors[0]).to.deep.equal({ field: 'name', code: 'MANDATORY_FIELD' });
+        expect(error0.errors[0]).toStrictEqual({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
         expect(error1).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error1.errors[0]).to.deep.equal({ field: 'name', code: 'MANDATORY_FIELD' });
+        expect(error1.errors[0]).toStrictEqual({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
         expect(error2).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error2.errors[0]).to.deep.equal({ field: 'name', code: 'MANDATORY_FIELD' });
+        expect(error2.errors[0]).toStrictEqual({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
         expect(saveStub).not.toHaveBeenCalled();
       });
 
@@ -365,13 +365,13 @@ describe('Unit | Controller | static courses controller', function() {
 
         // then
         expect(error0).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error0.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error0.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(error1).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error1.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error1.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(error2).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error2.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error2.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(error3).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error3.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error3.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(saveStub).not.toHaveBeenCalled();
       });
 
@@ -524,11 +524,11 @@ describe('Unit | Controller | static courses controller', function() {
 
         // then
         expect(error0).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error0.errors[0]).to.deep.equal({ field: 'name', code: 'MANDATORY_FIELD' });
+        expect(error0.errors[0]).toStrictEqual({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
         expect(error1).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error1.errors[0]).to.deep.equal({ field: 'name', code: 'MANDATORY_FIELD' });
+        expect(error1.errors[0]).toStrictEqual({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
         expect(error2).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error2.errors[0]).to.deep.equal({ field: 'name', code: 'MANDATORY_FIELD' });
+        expect(error2.errors[0]).toStrictEqual({ attribute: 'name', detail: 'Le champ "Nom" est obligatoire' });
         expect(saveStub).not.toHaveBeenCalled();
       });
 
@@ -627,13 +627,13 @@ describe('Unit | Controller | static courses controller', function() {
 
         // then
         expect(error0).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error0.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error0.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(error1).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error1.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error1.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(error2).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error2.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error2.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(error3).to.be.instanceOf(InvalidStaticCourseCreationOrUpdateError);
-        expect(error3.errors[0]).to.deep.equal({ field: 'challengeIds', code: 'MANDATORY_FIELD' });
+        expect(error3.errors[0]).toStrictEqual({ attribute: 'challengeIds', detail: 'Le champ "IDs des épreuves" est obligatoire' });
         expect(saveStub).not.toHaveBeenCalled();
       });
 

--- a/api/tests/unit/domain/models/StaticCourse_test.js
+++ b/api/tests/unit/domain/models/StaticCourse_test.js
@@ -99,7 +99,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'MANDATORY_FIELD', field: 'name' },
+            {
+              attribute: 'name',
+              detail: 'Le champ "Nom" est obligatoire',
+            },
           ]);
         });
       });
@@ -124,7 +127,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants n\'existent pas : xchalLOL, chalDEFF',
+            },
           ]);
         });
 
@@ -147,7 +153,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalJKF', 'chalABC'] },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants sont en doublon : chalJKF, chalABC',
+            },
           ]);
         });
 
@@ -170,7 +179,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'MANDATORY_FIELD', field: 'challengeIds' },
+            {
+              attribute: 'challengeIds',
+              detail: 'Le champ "IDs des épreuves" est obligatoire',
+            }
           ]);
         });
       });
@@ -194,7 +206,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'UNKNOWN_RESOURCES', field: 'tagIds', data: [789] },
+            {
+              attribute: 'tagIds',
+              detail: 'Les tags suivants n\'existent pas : 789',
+            }
           ]);
         });
 
@@ -217,7 +232,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'DUPLICATES_FORBIDDEN', field: 'tagIds', data: [123] },
+            {
+              attribute: 'tagIds',
+              detail: 'Les tags suivants sont en doublon : 123',
+            }
           ]);
         });
       });
@@ -242,9 +260,19 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'MANDATORY_FIELD', field: 'name' },
-            { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
-            { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalGHI'] },
+            {
+              attribute: 'name',
+              detail: 'Le champ "Nom" est obligatoire',
+            },
+
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants n\'existent pas : xchalLOL, chalDEFF',
+            },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants sont en doublon : chalGHI',
+            },
           ]);
         });
       });
@@ -381,7 +409,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'MANDATORY_FIELD', field: 'name' },
+            {
+              attribute: 'name',
+              detail: 'Le champ "Nom" est obligatoire',
+            }
           ]);
         });
       });
@@ -405,7 +436,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants n\'existent pas : xchalLOL, chalDEFF',
+            }
           ]);
         });
 
@@ -427,7 +461,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalJKF', 'chalABC'] },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants sont en doublon : chalJKF, chalABC',
+            }
           ]);
         });
 
@@ -449,7 +486,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'MANDATORY_FIELD', field: 'challengeIds' },
+            {
+              attribute: 'challengeIds',
+              detail: 'Le champ "IDs des épreuves" est obligatoire',
+            }
           ]);
         });
       });
@@ -473,7 +513,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'UNKNOWN_RESOURCES', field: 'tagIds', data: [1574, 888] },
+            {
+              attribute: 'tagIds',
+              detail: 'Les tags suivants n\'existent pas : 1574, 888',
+            }
           ]);
         });
 
@@ -495,7 +538,10 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'DUPLICATES_FORBIDDEN', field: 'tagIds', data: [123] },
+            {
+              attribute: 'tagIds',
+              detail: 'Les tags suivants sont en doublon : 123',
+            }
           ]);
         });
       });
@@ -520,9 +566,18 @@ describe('Unit | Domain | StaticCourse', function() {
           expect(commandResult.isFailure()).to.be.true;
           expect(commandResult.value).to.be.null;
           expect(commandResult.error.errors).toEqual([
-            { code: 'MANDATORY_FIELD', field: 'name' },
-            { code: 'UNKNOWN_RESOURCES', field: 'challengeIds', data: ['xchalLOL', 'chalDEFF'] },
-            { code: 'DUPLICATES_FORBIDDEN', field: 'challengeIds', data: ['chalGHI'] },
+            {
+              attribute: 'name',
+              detail: 'Le champ "Nom" est obligatoire',
+            },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants n\'existent pas : xchalLOL, chalDEFF',
+            },
+            {
+              attribute: 'challengeIds',
+              detail: 'Les IDs d\'épreuve suivants sont en doublon : chalGHI',
+            },
           ]);
         });
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
@@ -46,28 +46,15 @@ describe('Unit | Serializer | JSONAPI | error-serializer', () => {
               },
             ],
           });
-          // with code
-          const errorWithCode = new infraErrorClass({ message, code: 'erreur-robot-broken' });
-          const serializedErrorWithCode = serialize(errorWithCode);
-          expect(serializedErrorWithCode, `Bad serialization for ${infraErrorName} with code`).toStrictEqual({
-            errors: [
-              {
-                status: '422',
-                title: 'Unprocessable entity',
-                detail: 'error message',
-                code: 'erreur-robot-broken',
-              },
-            ],
-          });
           // with detail
-          const errorWithDetail = new infraErrorClass({ message, detail: [' un', 'detail '] });
+          const errorWithDetail = new infraErrorClass({ message, detail: 'un détail' });
           const serializedErrorWithDetail = serialize(errorWithDetail);
           expect(serializedErrorWithDetail, `Bad serialization for ${infraErrorName} with detail`).toStrictEqual({
             errors: [
               {
                 status: '422',
                 title: 'Unprocessable entity',
-                detail: [' un', 'detail '],
+                detail: 'un détail',
               },
             ],
           });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest';
+import { serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/error-serializer.js';
+import * as AllInfraErrors from '../../../../../lib/infrastructure/errors.js';
+
+describe('Unit | Serializer | JSONAPI | error-serializer', () => {
+  describe('#serialize', () => {
+    it('should serialize an InfraError', () => {
+      const message = 'error message';
+      for (const [infraErrorName, infraErrorClass] of Object.entries(AllInfraErrors)) {
+        const error = new infraErrorClass(message);
+        const serializedError = serialize(error);
+        if (infraErrorName === 'InfrastructureError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '500',
+                title: 'Internal Server Error',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'UnprocessableEntityError') {
+          // without attribute
+          const errorWithoutAttribute = new infraErrorClass({ message });
+          const serializedErrorWithoutAttribute = serialize(errorWithoutAttribute);
+          expect(serializedErrorWithoutAttribute, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: 'error message',
+              },
+            ],
+          });
+          // with attribute
+          const errorWithAttribute = new infraErrorClass({ message, attribute: 'myAwesomeAttribute' });
+          const serializedErrorWithAttribute = serialize(errorWithAttribute);
+          expect(serializedErrorWithAttribute, `Bad serialization for ${infraErrorName} with attribute`).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: 'error message',
+                source: { pointer: '/data/attributes/my-awesome-attribute' },
+              },
+            ],
+          });
+          // with code
+          const errorWithCode = new infraErrorClass({ message, code: 'erreur-robot-broken' });
+          const serializedErrorWithCode = serialize(errorWithCode);
+          expect(serializedErrorWithCode, `Bad serialization for ${infraErrorName} with code`).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: 'error message',
+                code: 'erreur-robot-broken',
+              },
+            ],
+          });
+          // with detail
+          const errorWithDetail = new infraErrorClass({ message, detail: [' un', 'detail '] });
+          const serializedErrorWithDetail = serialize(errorWithDetail);
+          expect(serializedErrorWithDetail, `Bad serialization for ${infraErrorName} with detail`).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: [' un', 'detail '],
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'PreconditionFailedError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '421',
+                title: 'Precondition Failed',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'ConflictError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '409',
+                title: 'Conflict',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'MissingQueryParamError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Missing Query Parameter',
+                detail: 'Missing error message query parameter.',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'MissingQueryParamError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Missing error message query parameter.',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'NotFoundError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '404',
+                title: 'Not Found',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'UnauthorizedError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '401',
+                title: 'Unauthorized',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'ForbiddenError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '403',
+                title: 'Forbidden',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'BadRequestError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Bad Request',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else {
+          expect(true, `Serialization for ${infraErrorName} not tested`).to.be.false;
+        }
+      }
+    });
+
+    it('should serialize several InfraErrors', () => {
+      const message1 = 'error message 1';
+      const message2 = 'error message 2';
+      for (const [infraErrorName, infraErrorClass] of Object.entries(AllInfraErrors)) {
+        const error1 = new infraErrorClass(message1);
+        const error2 = new infraErrorClass(message2);
+        const serializedError = serialize([error1, error2]);
+        if (infraErrorName === 'InfrastructureError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '500',
+                title: 'Internal Server Error',
+                detail: 'error message 1',
+              },
+              {
+                status: '500',
+                title: 'Internal Server Error',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'UnprocessableEntityError') {
+          const error1Infra = new infraErrorClass({ message: message1 });
+          const error2Infra = new infraErrorClass({ message: message2 });
+          const serializedError = serialize([error1Infra, error2Infra]);
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: 'error message 1',
+              },
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'PreconditionFailedError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '421',
+                title: 'Precondition Failed',
+                detail: 'error message 1',
+              },
+              {
+                status: '421',
+                title: 'Precondition Failed',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'ConflictError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '409',
+                title: 'Conflict',
+                detail: 'error message 1',
+              },
+              {
+                status: '409',
+                title: 'Conflict',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'MissingQueryParamError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Missing Query Parameter',
+                detail: 'Missing error message 1 query parameter.',
+              },
+              {
+                status: '400',
+                title: 'Missing Query Parameter',
+                detail: 'Missing error message 2 query parameter.',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'MissingQueryParamError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Missing error message query parameter.',
+                detail: 'error message 1',
+              },
+              {
+                status: '400',
+                title: 'Missing error message query parameter.',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'NotFoundError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '404',
+                title: 'Not Found',
+                detail: 'error message 1',
+              },
+              {
+                status: '404',
+                title: 'Not Found',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'UnauthorizedError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '401',
+                title: 'Unauthorized',
+                detail: 'error message 1',
+              },
+              {
+                status: '401',
+                title: 'Unauthorized',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'ForbiddenError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '403',
+                title: 'Forbidden',
+                detail: 'error message 1',
+              },
+              {
+                status: '403',
+                title: 'Forbidden',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else if (infraErrorName === 'BadRequestError') {
+          expect(serializedError, `Bad serialization for ${infraErrorName}`).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Bad Request',
+                detail: 'error message 1',
+              },
+              {
+                status: '400',
+                title: 'Bad Request',
+                detail: 'error message 2',
+              },
+            ],
+          });
+        }
+        else {
+          expect(true, `Serialization for ${infraErrorName} not tested`).to.be.false;
+        }
+      }
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -1,70 +1,143 @@
 import { describe, expect, it } from 'vitest';
 import { hFake } from '../../../test-helper.js';
-import {
-  InvalidStaticCourseCreationOrUpdateError,
-  StaticCourseIsInactiveError,
-} from '../../../../lib/domain/errors.js';
+import * as AllDomainErrors from '../../../../lib/domain/errors.js';
 import { send } from '../../../../lib/infrastructure/utils/error-manager.js';
 
 describe('Unit | Infrastructure | ErrorManager', function() {
-  describe('#send', function() {
-
-    it('should convert InvalidStaticCourseCreationOrUpdateError', async function() {
-      // given
-      const error = new InvalidStaticCourseCreationOrUpdateError();
-      error.addMandatoryFieldError({ field: 'name' });
-      error.addDuplicatesForbiddenError({ field: 'challengeIds', duplicates: ['chalA', 'chalB'] });
-      error.addUnknownResourcesError({ field: 'challengeIds', unknownResources: ['chalC', 'chalD'] });
-
-      // when
-      const response = await send(hFake, error);
-
-      // then
-      expect(response.statusCode).to.equal(422);
-      expect(response.source).to.deep.equal({
-        errors: [
-          {
-            code: 'MANDATORY_FIELD',
-            source: {
-              pointer: '/data/attributes/name',
-            },
-          },
-          {
-            code: 'DUPLICATES_FORBIDDEN',
-            source: {
-              pointer: '/data/attributes/challenge-ids',
-            },
-            detail: ['chalA', 'chalB'],
-          },
-          {
-            code: 'UNKNOWN_RESOURCES',
-            source: {
-              pointer: '/data/attributes/challenge-ids',
-            },
-            detail: ['chalC', 'chalD'],
-          },
-        ],
-      });
-    });
-
-    it('should convert StaticCourseIsInactiveError', async function() {
-      // given
-      const error = new StaticCourseIsInactiveError();
-
-      // when
-      const response = await send(hFake, error);
-
-      // then
-      expect(response.statusCode).to.equal(409);
-      expect(response.source).to.deep.equal({
-        errors: [
-          {
-            detail: 'Opération impossible sur un test statique inactif.',
-            status: '409',
-            title: 'Conflict',
-          },
-        ],
-      });
+  describe('#send', () => {
+    it('should manage properly all DomainErrors into appropriate InfraError', () => {
+      const message = 'error message';
+      const attribute = 'attributeInError';
+      for (const [domainErrorName, domainErrorClass] of Object.entries(AllDomainErrors)) {
+        const error = new domainErrorClass(message, attribute);
+        const expectErrorMessage = `Domain Error ${domainErrorName} not properly converted into InfraError`;
+        const response = send(hFake, error);
+        if (domainErrorName === 'DomainError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(500);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '500',
+                title: 'Internal Server Error',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'NotFoundError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(404);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '404',
+                title: 'Not Found',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'UserNotFoundError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(404);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '404',
+                title: 'Not Found',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'MissionIntroductionMediaError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(500);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '500',
+                title: 'Internal Server Error',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'InvalidMissionContentError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(500);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '500',
+                title: 'Internal Server Error',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'StaticCourseIsInactiveError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(409);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '409',
+                title: 'Conflict',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'ForbiddenError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(403);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '403',
+                title: 'Forbidden',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'InvalidStaticCourseCreationOrUpdateError') {
+          const errorStaticCourse = new domainErrorClass();
+          errorStaticCourse.addMandatoryFieldError({ field: 'name' });
+          errorStaticCourse.addDuplicatesForbiddenError({ field: 'challengeIds', duplicates: ['chalA', 'chalB'] });
+          errorStaticCourse.addUnknownResourcesError({ field: 'challengeIds', unknownResources: ['chalC', 'chalD'] });
+          const responseStaticCourse = send(hFake, errorStaticCourse);
+          expect(responseStaticCourse.statusCode, expectErrorMessage).toStrictEqual(422);
+          expect(responseStaticCourse.source).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                code: 'MANDATORY_FIELD',
+                source: {
+                  pointer: '/data/attributes/name',
+                },
+              },
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                code: 'DUPLICATES_FORBIDDEN',
+                source: {
+                  pointer: '/data/attributes/challenge-ids',
+                },
+                detail: ['chalA', 'chalB'],
+              },
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                code: 'UNKNOWN_RESOURCES',
+                source: {
+                  pointer: '/data/attributes/challenge-ids',
+                },
+                detail: ['chalC', 'chalD'],
+              },
+            ],
+          });
+        }
+        else {
+          expect(true, `Conversion for ${domainErrorName} not tested`).to.be.false;
+        }
+      }
     });
   });
 });

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -98,9 +98,8 @@ describe('Unit | Infrastructure | ErrorManager', function() {
         }
         else if (domainErrorName === 'InvalidStaticCourseCreationOrUpdateError') {
           const errorStaticCourse = new domainErrorClass();
-          errorStaticCourse.addMandatoryFieldError({ field: 'name' });
-          errorStaticCourse.addDuplicatesForbiddenError({ field: 'challengeIds', duplicates: ['chalA', 'chalB'] });
-          errorStaticCourse.addUnknownResourcesError({ field: 'challengeIds', unknownResources: ['chalC', 'chalD'] });
+          errorStaticCourse.addError({ attribute: 'name', detail: 'Un texte détaillant une erreur' });
+          errorStaticCourse.addError({ attribute: 'challengeIds', detail: 'le détail d\'une autre erreur' });
           const responseStaticCourse = send(hFake, errorStaticCourse);
           expect(responseStaticCourse.statusCode, expectErrorMessage).toStrictEqual(422);
           expect(responseStaticCourse.source).toStrictEqual({
@@ -108,7 +107,7 @@ describe('Unit | Infrastructure | ErrorManager', function() {
               {
                 status: '422',
                 title: 'Unprocessable entity',
-                code: 'MANDATORY_FIELD',
+                detail: 'Un texte détaillant une erreur',
                 source: {
                   pointer: '/data/attributes/name',
                 },
@@ -116,20 +115,10 @@ describe('Unit | Infrastructure | ErrorManager', function() {
               {
                 status: '422',
                 title: 'Unprocessable entity',
-                code: 'DUPLICATES_FORBIDDEN',
                 source: {
                   pointer: '/data/attributes/challenge-ids',
                 },
-                detail: ['chalA', 'chalB'],
-              },
-              {
-                status: '422',
-                title: 'Unprocessable entity',
-                code: 'UNKNOWN_RESOURCES',
-                source: {
-                  pointer: '/data/attributes/challenge-ids',
-                },
-                detail: ['chalC', 'chalD'],
+                detail: 'le détail d\'une autre erreur',
               },
             ],
           });

--- a/pix-editor/app/controllers/authenticated/static-courses/new.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/new.js
@@ -17,10 +17,8 @@ export default class NewStaticCourseController extends Controller {
     } catch (err) {
       staticCourse.deleteRecord();
       await this.notifications.error('Une erreur est survenue lors de la création du test statique.');
-      const knownErrors = err?.errors;
-      const finalErrors = knownErrors
-        ? _cleanErrors(knownErrors)
-        : JSON.stringify(err);
+      const knownErrors = err?.errors.map((error) => error.detail).join('\n');
+      const finalErrors = knownErrors ?? JSON.stringify(err);
       throw new Error(finalErrors);
     }
   }
@@ -29,38 +27,4 @@ export default class NewStaticCourseController extends Controller {
   async goBackToList() {
     this.router.transitionTo('authenticated.static-courses.list');
   }
-}
-
-function _cleanErrors(errors) {
-  let cleanErrors = '';
-  for (const error of errors) {
-    if (error.code === 'MANDATORY_FIELD') {
-      if (error.source.pointer.endsWith('name'))
-        cleanErrors += 'Le nom est obligatoire.';
-      else if (error.source.pointer.endsWith('challenge-ids'))
-        cleanErrors += 'La présence d\'épreuves est requise pour pouvoir créer un test statique.';
-      else
-        cleanErrors += JSON.stringify(error);
-    } else if (error.source.pointer.endsWith('challenge-ids')) {
-      if (error.code === 'UNKNOWN_RESOURCES') {
-        cleanErrors += `Les épreuves suivantes n'existent pas : ${error.detail.join(', ')}.\n`;
-      } else if (error.code === 'DUPLICATES_FORBIDDEN') {
-        cleanErrors += `Les épreuves suivantes ont été ajoutées plusieurs fois : ${error.detail.join(', ')}.\n`;
-      } else {
-        cleanErrors += JSON.stringify(error);
-      }
-    } else if (error.source.pointer.endsWith('tag-ids')) {
-      if (error.code === 'UNKNOWN_RESOURCES') {
-        cleanErrors += `Les tags suivants n'existent pas : ${error.detail.join(', ')}.\n`;
-      } else if (error.code === 'DUPLICATES_FORBIDDEN') {
-        cleanErrors += `Les tags suivants ont été ajoutées plusieurs fois : ${error.detail.join(', ')}.\n`;
-      } else {
-        cleanErrors += JSON.stringify(error);
-      }
-    } else {
-      cleanErrors += JSON.stringify(error);
-    }
-    cleanErrors += '\n';
-  }
-  return cleanErrors;
 }

--- a/pix-editor/app/controllers/authenticated/static-courses/static-course/edit.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/static-course/edit.js
@@ -27,10 +27,8 @@ export default class EditStaticCourseController extends Controller {
       this.router.transitionTo('authenticated.static-courses.static-course.details', this.model.staticCourse.id);
     } catch (err) {
       await this.notifications.error('Une erreur est survenue lors de la modification du test statique.');
-      const knownErrors = err?.errors;
-      const finalErrors = knownErrors
-        ? _cleanErrors(knownErrors)
-        : JSON.stringify(err);
+      const knownErrors = err?.errors.map((error) => error.detail).join('\n');
+      const finalErrors = knownErrors ?? JSON.stringify(err);
       throw new Error(finalErrors);
     }
   }
@@ -39,38 +37,4 @@ export default class EditStaticCourseController extends Controller {
   async goBackToDetails() {
     this.router.transitionTo('authenticated.static-courses.static-course.details', this.model.staticCourse.id);
   }
-}
-
-function _cleanErrors(errors) {
-  let cleanErrors = '';
-  for (const error of errors) {
-    if (error.code === 'MANDATORY_FIELD') {
-      if (error.source.pointer.endsWith('name'))
-        cleanErrors += 'Le nom est obligatoire.';
-      else if (error.source.pointer.endsWith('challenge-ids'))
-        cleanErrors += 'La présence d\'épreuves est requise pour pouvoir créer un test statique.';
-      else
-        cleanErrors += JSON.stringify(error);
-    } else if (error.source.pointer.endsWith('challenge-ids')) {
-      if (error.code === 'UNKNOWN_RESOURCES') {
-        cleanErrors += `Les épreuves suivantes n'existent pas : ${error.detail.join(', ')}.\n`;
-      } else if (error.code === 'DUPLICATES_FORBIDDEN') {
-        cleanErrors += `Les épreuves suivantes ont été ajoutées plusieurs fois : ${error.detail.join(', ')}.\n`;
-      } else {
-        cleanErrors += JSON.stringify(error);
-      }
-    } else if (error.source.pointer.endsWith('tag-ids')) {
-      if (error.code === 'UNKNOWN_RESOURCES') {
-        cleanErrors += `Les tags suivants n'existent pas : ${error.detail.join(', ')}.\n`;
-      } else if (error.code === 'DUPLICATES_FORBIDDEN') {
-        cleanErrors += `Les tags suivants ont été ajoutées plusieurs fois : ${error.detail.join(', ')}.\n`;
-      } else {
-        cleanErrors += JSON.stringify(error);
-      }
-    } else {
-      cleanErrors += JSON.stringify(error);
-    }
-    cleanErrors += '\n';
-  }
-  return cleanErrors;
 }

--- a/pix-editor/app/serializers/application.js
+++ b/pix-editor/app/serializers/application.js
@@ -4,5 +4,4 @@ export default class ApplicationSerializer extends JSONAPISerializer {
   shouldSerializeHasMany() {
     return true;
   }
-
 }


### PR DESCRIPTION
Moulinette URLS ticket 1

## :fallen_leaf: Problème
Créer un test statique en indiquant des IDs d'épreuve qui n'existent pas, par exemple.
Constater que l'erreur affichée est on ne peut plus mystique !

## :chestnut: Proposition
Simplifier la gestion d'erreur côté back de la création et édition de test statique et s'assurer que le format de retour d'erreur est bien compliant jsonapi + ember (c.f. : https://api.emberjs.com/ember-data/release/classes/invaliderror/)

## :jack_o_lantern: Remarques
Amélioration et ajout de tests sur la conversion d'erreur domaine vers infra
On vire le champ "code" dans le retour d'erreur car de toute façon il n'est pas normalisé par ember (à moins de surcharger le truc mais je n'en ai aucune envie)

## :wood: Pour tester
Refaire la même manipulation et constater un message d'erreur plus lisible
