### PR TITLE
[FEATURE] Permettre de consulter la liste des URLs sur liste blanche pour la moulinette (PIX-15180)

### DIFF
--- a/api/db/migrations/20241104214702_add-whitelisted-urls-table.js
+++ b/api/db/migrations/20241104214702_add-whitelisted-urls-table.js
@@ -1,0 +1,25 @@
+const TABLE_NAME = 'whitelisted_urls';
+
+export function up(knex) {
+  function table(t) {
+    t.increments('id').primary();
+    t.bigInteger('createdBy').references('users.id');
+    t.bigInteger('latestUpdatedBy').references('users.id');
+    t.bigInteger('deletedBy').references('users.id');
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('deletedAt').defaultTo(null);
+    t.text('url').notNullable();
+    t.string('checkType').notNullable();
+    t.string('relatedSkillNames');
+    t.text('comment');
+  }
+
+  return knex.schema
+    .createTable(TABLE_NAME, table);
+}
+
+export function down(knex) {
+  return knex.schema
+    .dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/whitelisted-urls.js
+++ b/api/db/seeds/data/whitelisted-urls.js
@@ -1,0 +1,40 @@
+import { WhitelistedUrl } from '../../../lib/domain/models/index.js';
+
+export function whitelistedUrlsBuilder(databaseBuilder, adminId) {
+  databaseBuilder.factory.buildWhitelistedUrl({
+    createdBy: adminId,
+    latestUpdatedBy: adminId,
+    deletedBy: null,
+    createdAt: new Date('2020-01-01'),
+    updatedAt: new Date('2022-02-02'),
+    deletedAt: null,
+    url: 'https://www.google.com',
+    relatedSkillNames: '@noix2,@coque8',
+    comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+    checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+  });
+  databaseBuilder.factory.buildWhitelistedUrl({
+    createdBy: null,
+    latestUpdatedBy: null,
+    deletedBy: null,
+    createdAt: new Date('2020-01-01'),
+    updatedAt: new Date('2022-02-02'),
+    deletedAt: null,
+    url: 'https://www.editor.pix.fr',
+    relatedSkillNames: null,
+    comment: 'Mon site préféré',
+    checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+  });
+  databaseBuilder.factory.buildWhitelistedUrl({
+    createdBy: adminId,
+    latestUpdatedBy: adminId,
+    deletedBy: adminId,
+    createdAt: new Date('2020-01-01'),
+    updatedAt: new Date('2022-02-02'),
+    deletedAt: new Date('2023-01-01'),
+    url: 'https://www.les-fruits-c-super-bon',
+    relatedSkillNames: '@chameau4',
+    comment: null,
+    checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+  });
+}

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -2,17 +2,18 @@ import { DatabaseBuilder } from '../../tests/tooling/database-builder/database-b
 import { localizedChallengesBuilder } from './data/localized-challenges.js';
 import { localizedChallengesAttachmentsBuilder } from './data/localized-challenges-attachments.js';
 import { staticCoursesBuilder } from './data/static-courses.js';
+import { whitelistedUrlsBuilder } from './data/whitelisted-urls.js';
 import { translationsBuilder } from './data/translations.js';
 import { buildMissions } from './data/missions.js';
 
 export async function seed(knex) {
   const databaseBuilder = new DatabaseBuilder({ knex });
-  databaseBuilder.factory.buildUser({
+  const adminId = databaseBuilder.factory.buildUser({
     trigram: 'DEV',
     name: 'Utilisateur pour le développement',
     access: 'admin',
     apiKey: process.env.REVIEW_APP_ADMIN_USER_API_KEY || adminUserApiKey,
-  });
+  }).id;
 
   databaseBuilder.factory.buildUser({
     trigram: 'EDI',
@@ -44,6 +45,8 @@ export async function seed(knex) {
   staticCoursesBuilder(databaseBuilder);
 
   buildMissions(databaseBuilder);
+
+  whitelistedUrlsBuilder(databaseBuilder, adminId);
 
   return databaseBuilder.commit();
 }

--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -1,5 +1,5 @@
 import * as securityPreHandlers from '../security-pre-handlers.js';
-import * as whitelistedUrlRepository from '../../infrastructure/repositories/whitelisted-url-repository.js';
+import { whitelistedUrlReadRepository } from '../../infrastructure/repositories/index.js';
 import * as whitelistedUrlSerializer from '../../infrastructure/serializers/jsonapi/whitelisted-url-serializer.js';
 
 export async function register(server) {
@@ -10,8 +10,8 @@ export async function register(server) {
       config: {
         pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
         handler: async function(request, h) {
-          const whitelistedUrls = await whitelistedUrlRepository.listRead();
-          return h.response(whitelistedUrlSerializer.serialize(whitelistedUrls));
+          const whitelistedUrls_read = await whitelistedUrlReadRepository.list();
+          return h.response(whitelistedUrlSerializer.serialize(whitelistedUrls_read));
         },
       },
     },

--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -1,0 +1,21 @@
+import * as securityPreHandlers from '../security-pre-handlers.js';
+import * as whitelistedUrlRepository from '../../infrastructure/repositories/whitelisted-url-repository.js';
+import * as whitelistedUrlSerializer from '../../infrastructure/serializers/jsonapi/whitelisted-url-serializer.js';
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/whitelisted-urls',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        handler: async function(request, h) {
+          const whitelistedUrls = await whitelistedUrlRepository.listRead();
+          return h.response(whitelistedUrlSerializer.serialize(whitelistedUrls));
+        },
+      },
+    },
+  ]);
+}
+
+export const name = 'whitelisted-urls';

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -1,0 +1,8 @@
+export class WhitelistedUrl {
+  static get CHECK_TYPES() {
+    return {
+      EXACT_MATCH: 'exact_match',
+      STARTS_WITH: 'starts_with',
+    };
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -9,3 +9,4 @@ export * from './StaticCourse.js';
 export * from './Thematic.js';
 export * from './Translation.js';
 export * from './User.js';
+export * from './WhitelistedUrl.js';

--- a/api/lib/domain/readmodels/WhitelistedUrl.js
+++ b/api/lib/domain/readmodels/WhitelistedUrl.js
@@ -1,0 +1,23 @@
+export class WhitelistedUrl {
+  constructor({
+    id,
+    createdAt,
+    updatedAt,
+    creatorName,
+    latestUpdatorName,
+    url,
+    relatedSkillNames,
+    comment,
+    checkType,
+  }) {
+    this.id = id;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.creatorName = creatorName;
+    this.latestUpdatorName = latestUpdatorName;
+    this.url = url;
+    this.relatedSkillNames = relatedSkillNames;
+    this.comment = comment;
+    this.checkType = checkType;
+  }
+}

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -15,3 +15,4 @@ export * as translationRepository from './translation-repository.js';
 export * as tubeRepository from './tube-repository.js';
 export * as urlRepository from './url-repository.js';
 export * as userRepository from './user-repository.js';
+export * as whitelistedUrlReadRepository from './whitelisted-url-read-repository.js';

--- a/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
@@ -1,7 +1,7 @@
 import { knex } from '../../../db/knex-database-connection.js';
-import { WhitelistedUrl as ReadWhitelistedUrl } from '../../domain/readmodels/WhitelistedUrl.js';
+import { WhitelistedUrl } from '../../domain/readmodels/WhitelistedUrl.js';
 
-export async function listRead() {
+export async function list() {
   const whitelistedUrlDtos = await knex('whitelisted_urls')
     .select({
       id: 'whitelisted_urls.id',
@@ -19,13 +19,13 @@ export async function listRead() {
     .whereNull('deletedAt')
     .orderBy('url');
 
-  return toDomainReadList(whitelistedUrlDtos);
+  return toDomainList(whitelistedUrlDtos);
 }
 
-function toDomainReadList(whitelistedUrlDtos) {
-  return whitelistedUrlDtos.map(toDomainRead);
+function toDomainList(whitelistedUrlDtos) {
+  return whitelistedUrlDtos.map(toDomain);
 }
 
-function toDomainRead(whitelistedUrlDto) {
-  return new ReadWhitelistedUrl(whitelistedUrlDto);
+function toDomain(whitelistedUrlDto) {
+  return new WhitelistedUrl(whitelistedUrlDto);
 }

--- a/api/lib/infrastructure/repositories/whitelisted-url-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-repository.js
@@ -1,0 +1,31 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { WhitelistedUrl as ReadWhitelistedUrl } from '../../domain/readmodels/WhitelistedUrl.js';
+
+export async function listRead() {
+  const whitelistedUrlDtos = await knex('whitelisted_urls')
+    .select({
+      id: 'whitelisted_urls.id',
+      createdAt: 'whitelisted_urls.createdAt',
+      updatedAt: 'whitelisted_urls.updatedAt',
+      url: 'whitelisted_urls.url',
+      relatedSkillNames: 'whitelisted_urls.relatedSkillNames',
+      comment: 'whitelisted_urls.comment',
+      checkType: 'whitelisted_urls.checkType',
+      creatorName: 'users_for_creation.name',
+      latestUpdatorName: 'users_for_update.name',
+    })
+    .leftJoin('users as users_for_creation', 'users_for_creation.id', 'whitelisted_urls.createdBy')
+    .leftJoin('users as users_for_update', 'users_for_update.id', 'whitelisted_urls.latestUpdatedBy')
+    .whereNull('deletedAt')
+    .orderBy('url');
+
+  return toDomainReadList(whitelistedUrlDtos);
+}
+
+function toDomainReadList(whitelistedUrlDtos) {
+  return whitelistedUrlDtos.map(toDomainRead);
+}
+
+function toDomainRead(whitelistedUrlDto) {
+  return new ReadWhitelistedUrl(whitelistedUrlDto);
+}

--- a/api/lib/infrastructure/serializers/jsonapi/whitelisted-url-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/whitelisted-url-serializer.js
@@ -1,0 +1,20 @@
+import JsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = JsonapiSerializer;
+
+const serializer = new Serializer('whitelisted-urls', {
+  attributes: [
+    'createdAt',
+    'updatedAt',
+    'creatorName',
+    'latestUpdatorName',
+    'url',
+    'relatedSkillNames',
+    'comment',
+    'checkType',
+  ],
+});
+
+export function serialize(whitelistedUrl) {
+  return serializer.serialize(whitelistedUrl);
+}

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -16,6 +16,7 @@ import * as staticRoute from './application/static/index.js';
 import * as translationsRoute from './application/translations.js';
 import * as embedsRoute from './application/embeds.js';
 import * as usersRoute from './application/users.js';
+import * as whitelistedUrlsRoute from './application/whitelisted-urls/index.js';
 
 export const routes = [
   airtableProxyRoute,
@@ -35,5 +36,6 @@ export const routes = [
   translationsRoute,
   embedsRoute,
   usersRoute,
+  whitelistedUrlsRoute,
   ...competenceRoutes,
 ];

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
+
+describe('Acceptance | Controller | whitelisted-urls', () => {
+  describe('GET /whitelisted-urls', () => {
+    let adminUser, server;
+    beforeEach(async function() {
+      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@morse2,@saumon5',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: adminUser.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@truite2',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      await databaseBuilder.commit();
+      server = await createServer();
+    });
+
+    it('should return a 403 status code when user is not admin', async () => {
+      // given
+      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/whitelisted-urls',
+        headers: generateAuthorizationHeader(notAdminUser)
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            code: 403,
+            detail: 'Missing or insufficient permissions.',
+            title: 'Forbidden access',
+          },
+        ],
+      });
+    });
+
+    it('should return the active whitelisted urls', async () => {
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/whitelisted-urls',
+        headers: generateAuthorizationHeader(adminUser)
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: [
+          {
+            type: 'whitelisted-urls',
+            id: '456',
+            attributes: {
+              'created-at': new Date('2020-12-12'),
+              'updated-at': new Date('2022-08-08'),
+              'creator-name': null,
+              'latest-updator-name': null,
+              'url': 'https://www.editor.pix.fr',
+              'related-skill-names': null,
+              'comment': 'Mon site préféré',
+              'check-type': 'exact_match',
+            },
+          },
+          {
+            type: 'whitelisted-urls',
+            id: '123',
+            attributes: {
+              'created-at': new Date('2020-01-01'),
+              'updated-at':new Date('2022-02-02'),
+              'creator-name': 'Madame Admin',
+              'latest-updator-name': 'Madame Admin',
+              'url': 'https://www.google.com',
+              'related-skill-names': '@morse2,@saumon5',
+              'comment': 'Je décide de whitelister ça car mon cousin travaille chez google',
+              'check-type': 'starts_with',
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/whitelisted-url-read-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/whitelisted-url-read-repository_test.js
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { databaseBuilder, domainBuilder } from '../../../test-helper.js';
-import * as whitelistedUrlRepository from '../../../../lib/infrastructure/repositories/whitelisted-url-repository.js';
+import * as whitelistedUrlReadRepository
+  from '../../../../lib/infrastructure/repositories/whitelisted-url-read-repository.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
-describe('Integration | Repository | whitelisted-url-repository', () => {
+describe('Integration | Repository | whitelisted-url-read-repository', () => {
 
-  describe('#listRead', () => {
+  describe('#list', () => {
 
     it('should retrieve active whitelisted url readmodels ordered by url', async () => {
       // given
@@ -53,11 +54,11 @@ describe('Integration | Repository | whitelisted-url-repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const whitelistedUrls = await whitelistedUrlRepository.listRead();
+      const whitelistedUrls_read = await whitelistedUrlReadRepository.list();
 
       // then
-      expect(whitelistedUrls).toStrictEqual([
-        domainBuilder.buildReadWhitelistedUrl({
+      expect(whitelistedUrls_read).toStrictEqual([
+        domainBuilder.buildWhitelistedUrlRead({
           id: 456,
           createdAt: new Date('2020-12-12'),
           updatedAt: new Date('2022-08-08'),
@@ -68,7 +69,7 @@ describe('Integration | Repository | whitelisted-url-repository', () => {
           comment: 'Mon site préféré',
           checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
         }),
-        domainBuilder.buildReadWhitelistedUrl({
+        domainBuilder.buildWhitelistedUrlRead({
           id: 123,
           createdAt: new Date('2020-01-01'),
           updatedAt: new Date('2022-02-02'),
@@ -114,11 +115,10 @@ describe('Integration | Repository | whitelisted-url-repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const whitelistedUrls = await whitelistedUrlRepository.listRead();
+      const whitelistedUrls_read = await whitelistedUrlReadRepository.list();
 
       // then
-      expect(whitelistedUrls).toStrictEqual([]);
+      expect(whitelistedUrls_read).toStrictEqual([]);
     });
   });
-
 });

--- a/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import * as whitelistedUrlRepository from '../../../../lib/infrastructure/repositories/whitelisted-url-repository.js';
+import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
+
+describe('Integration | Repository | whitelisted-url-repository', () => {
+
+  describe('#listRead', () => {
+
+    it('should retrieve active whitelisted url readmodels ordered by url', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrls = await whitelistedUrlRepository.listRead();
+
+      // then
+      expect(whitelistedUrls).toStrictEqual([
+        domainBuilder.buildReadWhitelistedUrl({
+          id: 456,
+          createdAt: new Date('2020-12-12'),
+          updatedAt: new Date('2022-08-08'),
+          creatorName: null,
+          latestUpdatorName: null,
+          url: 'https://www.editor.pix.fr',
+          relatedSkillNames: null,
+          comment: 'Mon site préféré',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        }),
+        domainBuilder.buildReadWhitelistedUrl({
+          id: 123,
+          createdAt: new Date('2020-01-01'),
+          updatedAt: new Date('2022-02-02'),
+          creatorName: 'Madame Admin 1',
+          latestUpdatorName: 'Madame Admin 2',
+          url: 'https://www.google.com',
+          relatedSkillNames: '@bidule3,@chose2',
+          comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        }),
+      ]);
+    });
+
+    it('should return an empty array when no active whitelisted urls found', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        deletedAt: new Date('2024-01-01'),
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrls = await whitelistedUrlRepository.listRead();
+
+      // then
+      expect(whitelistedUrls).toStrictEqual([]);
+    });
+  });
+
+});

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -3,9 +3,9 @@ import { databaseBuffer } from '../database-buffer.js';
 export function buildUser({
   id = databaseBuffer.nextId++,
   name,
-  trigram,
+  trigram = 'SOS',
   access,
-  apiKey,
+  apiKey = '463eed07-e872-42bf-8110-004fcba07a5b',
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {

--- a/api/tests/tooling/database-builder/factory/build-whitelisted-url.js
+++ b/api/tests/tooling/database-builder/factory/build-whitelisted-url.js
@@ -1,0 +1,25 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildWhitelistedUrl({
+  id = databaseBuffer.nextId++,
+  createdBy = null,
+  latestUpdatedBy = null,
+  deletedBy = null,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+  deletedAt = null,
+  url = 'https://mon-petit-chien.com',
+  relatedSkillNames = null,
+  comment = null,
+  checkType = 'exact_match',
+} = {}) {
+  if (createdBy && !latestUpdatedBy) {
+    latestUpdatedBy = createdBy;
+  }
+  const values = { id, createdBy, latestUpdatedBy, deletedBy, createdAt, updatedAt, deletedAt, url, relatedSkillNames, comment, checkType };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'whitelisted_urls',
+    values,
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -6,3 +6,4 @@ export * from './build-static-course.js';
 export * from './build-static-course-tag.js';
 export * from './build-translation.js';
 export * from './build-user.js';
+export * from './build-whitelisted-url.js';

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -1,0 +1,21 @@
+import { User } from '../../../../lib/domain/models/index.js';
+
+export function buildUser({
+  id = 123,
+  name = 'Bijou',
+  trigram = 'BOU',
+  apiKey = 'someApiKey',
+  access = 'editor',
+  createdAt = new Date('2020-01-01'),
+  updatedAt = new Date('2020-02-02'),
+} = {}) {
+  return new User({
+    id,
+    name,
+    trigram,
+    apiKey,
+    access,
+    createdAt,
+    updatedAt,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/build-whitelisted-url.js
+++ b/api/tests/tooling/domain-builder/factory/build-whitelisted-url.js
@@ -1,7 +1,7 @@
-import { WhitelistedUrl as ReadWhitelistedUrl } from '../../../../lib/domain/readmodels/WhitelistedUrl.js';
+import { WhitelistedUrl as WhitelistedUrlRead } from '../../../../lib/domain/readmodels/WhitelistedUrl.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
-export function buildReadWhitelistedUrl({
+export function buildWhitelistedUrlRead({
   id = 1,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2021-01-01'),
@@ -12,7 +12,7 @@ export function buildReadWhitelistedUrl({
   comment = 'Les grenouilles sont jolies',
   checkType = WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
 } = {}) {
-  return new ReadWhitelistedUrl({
+  return new WhitelistedUrlRead({
     id,
     createdAt,
     updatedAt,

--- a/api/tests/tooling/domain-builder/factory/build-whitelisted-url.js
+++ b/api/tests/tooling/domain-builder/factory/build-whitelisted-url.js
@@ -1,0 +1,26 @@
+import { WhitelistedUrl as ReadWhitelistedUrl } from '../../../../lib/domain/readmodels/WhitelistedUrl.js';
+import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
+
+export function buildReadWhitelistedUrl({
+  id = 1,
+  createdAt = new Date('2020-01-01'),
+  updatedAt = new Date('2021-01-01'),
+  creatorName = 'Ma maman',
+  latestUpdatorName = 'Ma maman',
+  url = 'http://pipeau-la-grenouille.fr',
+  relatedSkillNames = '@bidule4,@chose6',
+  comment = 'Les grenouilles sont jolies',
+  checkType = WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+} = {}) {
+  return new ReadWhitelistedUrl({
+    id,
+    createdAt,
+    updatedAt,
+    creatorName,
+    latestUpdatorName,
+    url,
+    relatedSkillNames,
+    comment,
+    checkType,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -27,6 +27,8 @@ export * from './build-translation.js';
 export * from './build-tube.js';
 export * from './build-tube-for-release.js';
 export * from './build-tutorial-for-release.js';
+export * from './build-user.js';
+export * from './build-whitelisted-url.js';
 export * from './datasource-objects/build-area-datasource-object.js';
 export * from './datasource-objects/build-attachment-datasource-object.js';
 export * from './datasource-objects/build-challenge-datasource-object.js';

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -26,6 +26,12 @@
         <i class="crosshairs icon"></i> Générateur de profil cible
       </LinkTo>
     {{/if}}
+    {{#if this.mayAccessWhitelistedUrls}}
+      <LinkTo data-test-whitelisted-urls-link @route="authenticated.whitelisted-urls" {{on "click" @close}}>
+        <FaIcon @icon="recycle" @prefix="fas"></FaIcon>
+        Whitelist moulinette des URLs
+      </LinkTo>
+    {{/if}}
     <Sidebar::Export @areas={{this.areas}}/>
     <LinkTo @route="authenticated.statistics" {{on "click" @close}}>
       <i class="chart bar icon"></i> Statistiques

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -22,6 +22,10 @@ export default class SidebarMain extends Component {
     return this.access.mayAccessStaticCourses();
   }
 
+  get mayAccessWhitelistedUrls() {
+    return this.access.mayAccessWhitelistedUrls();
+  }
+
   get mayGenerateTargetProfile() {
     return this.access.isReadOnly();
   }

--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -1,0 +1,101 @@
+<form {{on "submit" this.applyFilters}} class="filter-whitelisted-url-form">
+  <PixFilterBanner
+    @title="Filtres"
+    class="table-filter-banner"
+    @clearFiltersLabel="Réinitialiser les filtres"
+    @onClearFilters={{this.clearFilters}}
+    @isClearFilterButtonDisabled={{false}}
+  >
+    <PixInput
+      @id="whitelisted-url-filter-names"
+      placeholder="Nom d'acquis"
+      @screenReaderOnly={{true}}
+      @value={{@namesFilterValue}}
+      {{on "change" this.updateNamesFilterValue}}
+    >
+      <:label>Nom d'acquis</:label>
+    </PixInput>
+    <PixInput
+      @id="whitelisted-url-filter-url"
+      placeholder="URL"
+      @screenReaderOnly={{true}}
+      @value={{@urlFilterValue}}
+      {{on "change" this.updateUrlFilterValue}}
+    >
+      <:label>URL</:label>
+    </PixInput>
+    <PixButton
+      @type="submit"
+    >
+      Filtrer
+    </PixButton>
+  </PixFilterBanner>
+</form>
+<div class="panel-table-v2">
+  <table class="content-text content-text--small">
+    <colgroup class="table__column">
+      <col class="table__column--small" />
+      <col class="table__column" />
+      <col class="table__column--wide" />
+      <col class="table__column--wide" />
+      <col class="table__column--small" />
+      <col class="table__column--small" />
+    </colgroup>
+    <thead>
+    <tr>
+      <th>Nom des acquis concernés</th>
+      <th>Type de comparaison</th>
+      <th>URL</th>
+      <th>Commentaire</th>
+      <th>Créée le</th>
+      <th>Modifiée le</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{#each @whitelistedUrls as |whitelistedUrl|}}
+      <tr class="tr--clickable" aria-label="URL en liste blanche">
+        <td>
+          {{whitelistedUrl.relatedSkillNames}}
+        </td>
+        <td>
+          <PixTag class="whitelisted-url-check-type-tag" @color={{this.checkTypeColor whitelistedUrl.checkType}}>
+            {{this.formatCheckType whitelistedUrl.checkType}}
+          </PixTag>
+        </td>
+        <td>
+          {{whitelistedUrl.url}}
+        </td>
+        <td>
+          {{whitelistedUrl.comment}}
+        </td>
+        <td>
+          {{this.formatCreationString whitelistedUrl}}
+        </td>
+        <td>
+          {{this.formatUpdateString whitelistedUrl}}
+        </td>
+        <td class="actions">
+          <PixTooltip
+            @id='copy-whitelisted-url-link-tooltip'
+            @position="top"
+            @isInline={{true}}
+          >
+            <:triggerElement>
+              <PixIconButton
+                @triggerAction={{fn this.copyUrl whitelistedUrl}}
+                @iconName="copy"
+                @iconPrefix="far"
+                @ariaLabel="Copier l'URL whitelistée"
+                class="icon"
+                aria-describedby='copy-whitelisted-url-link-tooltip'
+              >
+              </PixIconButton>
+            </:triggerElement>
+            <:tooltip>Copier l’URL whitelistée</:tooltip>
+          </PixTooltip>
+        </td>
+      </tr>
+    {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/pix-editor/app/components/whitelisted-urls/list.js
+++ b/pix-editor/app/components/whitelisted-urls/list.js
@@ -1,0 +1,90 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class WhitelistedUrlList extends Component {
+  @tracked searchUrl;
+  @tracked searchNames;
+
+  constructor(...args) {
+    super(...args);
+    this.searchUrl = this.args.urlFilterValue;
+    this.searchNames = this.args.namesFilterValue;
+  }
+
+  formatCheckType = (checkType) => {
+    if (checkType === 'exact_match') {
+      return 'Strictement égale à';
+    } else {
+      return 'Commence par';
+    }
+  };
+
+  checkTypeColor = (checkType) => {
+    if (checkType === 'exact_match') {
+      return 'primary';
+    } else {
+      return 'secondary';
+    }
+  };
+
+  formatCreationString = (whitelistedUrl) => {
+    const date = new Date(whitelistedUrl.createdAt);
+    const DDMMYYYY = this.formatDateToDDMMYYY(date);
+    const HHMM = this.formatDateToHHMM(date);
+    if (!whitelistedUrl.creatorName) {
+      return `${DDMMYYYY} à ${HHMM}`;
+    }
+    return `${DDMMYYYY} à ${HHMM} par ${whitelistedUrl.creatorName} `;
+  };
+
+  formatUpdateString = (whitelistedUrl) => {
+    const date = new Date(whitelistedUrl.updatedAt);
+    const DDMMYYYY = this.formatDateToDDMMYYY(date);
+    const HHMM = this.formatDateToHHMM(date);
+    if (!whitelistedUrl.latestUpdatorName) {
+      return `${DDMMYYYY} à ${HHMM}`;
+    }
+    return `${DDMMYYYY} à ${HHMM} par ${whitelistedUrl.latestUpdatorName}`;
+  };
+
+  formatDateToDDMMYYY(date) {
+    const formater = new Intl.DateTimeFormat('fr');
+    return formater.format(date);
+  }
+
+  formatDateToHHMM(date) {
+    const formater = new Intl.DateTimeFormat('fr', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    return formater.format(date);
+  }
+
+  async copyUrl(whitelistedUrl) {
+    await navigator.clipboard.writeText(whitelistedUrl.url);
+  }
+
+  @action
+  async updateUrlFilterValue(event) {
+    this.searchUrl = event.target.value;
+  }
+
+  @action
+  async updateNamesFilterValue(event) {
+    this.searchNames = event.target.value;
+  }
+
+  @action
+  async clearFilters() {
+    this.searchUrl = null;
+    this.searchNames = null;
+    await this.args.onClearFiltersClicked();
+  }
+
+  @action
+  async applyFilters(event) {
+    event.preventDefault();
+    await this.args.onApplyFiltersClicked(this.searchUrl, this.searchNames);
+  }
+}

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -1,0 +1,111 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class WhitelistedUrlsController extends Controller {
+  @service router;
+  queryParams = ['url', 'names'];
+  @tracked searchUrl = '';
+  @tracked searchNames = '';
+  @tracked url = '';
+  @tracked names = '';
+
+  get filteredWhitelistedUrls() {
+    return this.model.whitelistedUrls.filter((whitelistedUrl) => {
+      const hasMatchingUrl = whitelistedUrl.url.includes(this.url ?? '');
+      let hasMatchingNames = true;
+      if (this.names) {
+        const urlNames = whitelistedUrl.relatedSkillNames ?? [];
+        const searchedNames = this.names.split(',');
+        hasMatchingNames = searchedNames.some((name) => urlNames.includes(name));
+      }
+      return hasMatchingUrl && hasMatchingNames;
+    });
+  }
+
+  formatCheckType = (checkType) => {
+    if (checkType === 'exact_match') {
+      return 'Strictement égale à';
+    } else {
+      return 'Commence par';
+    }
+  };
+
+  checkTypeColor = (checkType) => {
+    if (checkType === 'exact_match') {
+      return 'primary';
+    } else {
+      return 'secondary';
+    }
+  };
+
+  formatCreationString = (whitelistedUrl) => {
+    const date = new Date(whitelistedUrl.createdAt);
+    const DDMMYYYY = this.formatDateToDDMMYYY(date);
+    const HHMM = this.formatDateToHHMM(date);
+    if (!whitelistedUrl.creatorName) {
+      return `${DDMMYYYY} à ${HHMM}`;
+    }
+    return `${DDMMYYYY} à ${HHMM} par ${whitelistedUrl.creatorName} `;
+  };
+
+  formatUpdateString = (whitelistedUrl) => {
+    const date = new Date(whitelistedUrl.updatedAt);
+    const DDMMYYYY = this.formatDateToDDMMYYY(date);
+    const HHMM = this.formatDateToHHMM(date);
+    if (!whitelistedUrl.latestUpdatorName) {
+      return `${DDMMYYYY} à ${HHMM}`;
+    }
+    return `${DDMMYYYY} à ${HHMM} par ${whitelistedUrl.latestUpdatorName}`;
+  };
+
+  formatDateToDDMMYYY(date) {
+    const formater = new Intl.DateTimeFormat('fr');
+    return formater.format(date);
+  }
+
+  formatDateToHHMM(date) {
+    const formater = new Intl.DateTimeFormat('fr', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    return formater.format(date);
+  }
+
+  @action
+  async copyUrl(whitelistedUrl) {
+    await navigator.clipboard.writeText(whitelistedUrl.url);
+  }
+
+  @action
+  async goToEditWhitelistedUrl(whitelistedUrlId, event) {
+    event.preventDefault();
+    this.router.transitionTo('authenticated.whitelisted-urls.whitelisted-url.edit', whitelistedUrlId);
+  }
+
+  @action
+  async updateSearchUrl(event) {
+    this.searchUrl = event.target.value;
+  }
+
+  @action
+  async updateSearchNames(event) {
+    this.searchNames = event.target.value;
+  }
+
+  @action
+  clearFilters() {
+    this.searchUrl = '';
+    this.searchNames = '';
+    this.url = '';
+    this.names = '';
+  }
+
+  @action
+  async submitFilters(event) {
+    event.preventDefault();
+    this.url = this.searchUrl;
+    this.names = this.searchNames;
+  }
+}

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -6,8 +6,6 @@ import { tracked } from '@glimmer/tracking';
 export default class WhitelistedUrlsController extends Controller {
   @service router;
   queryParams = ['url', 'names'];
-  @tracked searchUrl = '';
-  @tracked searchNames = '';
   @tracked url = '';
   @tracked names = '';
 
@@ -24,88 +22,15 @@ export default class WhitelistedUrlsController extends Controller {
     });
   }
 
-  formatCheckType = (checkType) => {
-    if (checkType === 'exact_match') {
-      return 'Strictement égale à';
-    } else {
-      return 'Commence par';
-    }
-  };
-
-  checkTypeColor = (checkType) => {
-    if (checkType === 'exact_match') {
-      return 'primary';
-    } else {
-      return 'secondary';
-    }
-  };
-
-  formatCreationString = (whitelistedUrl) => {
-    const date = new Date(whitelistedUrl.createdAt);
-    const DDMMYYYY = this.formatDateToDDMMYYY(date);
-    const HHMM = this.formatDateToHHMM(date);
-    if (!whitelistedUrl.creatorName) {
-      return `${DDMMYYYY} à ${HHMM}`;
-    }
-    return `${DDMMYYYY} à ${HHMM} par ${whitelistedUrl.creatorName} `;
-  };
-
-  formatUpdateString = (whitelistedUrl) => {
-    const date = new Date(whitelistedUrl.updatedAt);
-    const DDMMYYYY = this.formatDateToDDMMYYY(date);
-    const HHMM = this.formatDateToHHMM(date);
-    if (!whitelistedUrl.latestUpdatorName) {
-      return `${DDMMYYYY} à ${HHMM}`;
-    }
-    return `${DDMMYYYY} à ${HHMM} par ${whitelistedUrl.latestUpdatorName}`;
-  };
-
-  formatDateToDDMMYYY(date) {
-    const formater = new Intl.DateTimeFormat('fr');
-    return formater.format(date);
-  }
-
-  formatDateToHHMM(date) {
-    const formater = new Intl.DateTimeFormat('fr', {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-    return formater.format(date);
+  @action
+  async applyFilters(urlFilterValue, namesFilterValue) {
+    this.url = urlFilterValue ?? '';
+    this.names = namesFilterValue ?? '';
   }
 
   @action
-  async copyUrl(whitelistedUrl) {
-    await navigator.clipboard.writeText(whitelistedUrl.url);
-  }
-
-  @action
-  async goToEditWhitelistedUrl(whitelistedUrlId, event) {
-    event.preventDefault();
-    this.router.transitionTo('authenticated.whitelisted-urls.whitelisted-url.edit', whitelistedUrlId);
-  }
-
-  @action
-  async updateSearchUrl(event) {
-    this.searchUrl = event.target.value;
-  }
-
-  @action
-  async updateSearchNames(event) {
-    this.searchNames = event.target.value;
-  }
-
-  @action
-  clearFilters() {
-    this.searchUrl = '';
-    this.searchNames = '';
+  async clearFilters() {
     this.url = '';
     this.names = '';
-  }
-
-  @action
-  async submitFilters(event) {
-    event.preventDefault();
-    this.url = this.searchUrl;
-    this.names = this.searchNames;
   }
 }

--- a/pix-editor/app/models/whitelisted-url.js
+++ b/pix-editor/app/models/whitelisted-url.js
@@ -1,0 +1,12 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class WhitelistedUrlModel extends Model {
+  @attr url;
+  @attr creatorName;
+  @attr latestUpdatorName;
+  @attr relatedSkillNames;
+  @attr checkType;
+  @attr comment;
+  @attr createdAt;
+  @attr updatedAt;
+}

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -76,5 +76,8 @@ Router.map(function() {
       });
     });
     this.route('synchronize-translations');
+    this.route('whitelisted-urls', function() {
+      this.route('list', { path: '/' });
+    });
   });
 });

--- a/pix-editor/app/routes/authenticated/whitelisted-urls.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class WhitelistedUrlsRoute extends Route {
+  @service access;
+  @service router;
+
+  beforeModel() {
+    if (!this.access.mayAccessWhitelistedUrls()) {
+      this.router.transitionTo('authenticated');
+    }
+  }
+}

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
@@ -20,14 +20,4 @@ export default class WhitelistedUrlsRoute extends Route {
       whitelistedUrls,
     };
   }
-
-  setupController(controller) {
-    super.setupController(...arguments);
-    if (controller.url) {
-      controller.searchUrl = controller.url;
-    }
-    if (controller.names) {
-      controller.searchNames = controller.names;
-    }
-  }
 }

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
@@ -1,0 +1,33 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class WhitelistedUrlsRoute extends Route {
+  queryParams = {
+    url: {
+      refreshModel: true,
+    },
+    names: {
+      refreshModel: true,
+    },
+  };
+
+  @service store;
+  @service access;
+
+  async model() {
+    const whitelistedUrls = await this.store.findAll('whitelisted-url', { reload: true });
+    return {
+      whitelistedUrls,
+    };
+  }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+    if (controller.url) {
+      controller.searchUrl = controller.url;
+    }
+    if (controller.names) {
+      controller.searchNames = controller.names;
+    }
+  }
+}

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -157,6 +157,10 @@ export default class AccessService extends Service {
     return level >= READ_ONLY;
   }
 
+  mayAccessWhitelistedUrls() {
+    return this.isAdmin();
+  }
+
   mayCreateOrEditStaticCourse() {
     return this.isEditor();
   }

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -27,6 +27,7 @@
 @import 'authenticated/missions/details';
 @import 'authenticated/static-courses/list';
 @import 'authenticated/static-courses/static-course';
+@import 'authenticated/whitelisted-urls/list';
 @import 'authenticated/synchronize-translations';
 @import 'components/card';
 @import 'components/login-form';

--- a/pix-editor/app/styles/authenticated/whitelisted-urls/list.scss
+++ b/pix-editor/app/styles/authenticated/whitelisted-urls/list.scss
@@ -1,0 +1,41 @@
+.filter-whitelisted-url-form {
+  .card__content{
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    label {
+      font-weight: 500;
+    }
+
+    .pix-input {
+      width: 100%;
+    }
+
+    .pix-textarea{
+      width: 100%;
+    }
+
+  }
+
+  &__select{
+    width: 100%;
+  }
+
+  &__label-text-area {
+    font-size: 1rem;
+    margin-top: 10px;
+  }
+
+  &__label {
+    margin-bottom: 4px;
+    color: rgb(23, 43, 77);
+    font-weight: 500;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+  }
+
+  &__description {
+    font-size: 0.825rem;
+  }
+}

--- a/pix-editor/app/templates/authenticated/whitelisted-urls.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls.hbs
@@ -1,0 +1,3 @@
+<div class="page">
+  {{outlet}}
+</div>

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
@@ -1,0 +1,108 @@
+<header class="page-header">
+  <h1 class="page-title">Whitelist de la moulinette des URLs cassées</h1>
+</header>
+<main class="page-body">
+  <section class="page-section">
+    <form {{on "submit" this.submitFilters}} class="filter-whitelisted-url-form">
+      <PixFilterBanner
+        @title="Filtres"
+        class="table-filter-banner"
+        @clearFiltersLabel="Réinitialiser les filtres"
+        @onClearFilters={{this.clearFilters}}
+        @isClearFilterButtonDisabled={{false}}
+      >
+        <PixInput
+          @id="whitelisted-url-filter-names"
+          placeholder="Nom d'acquis"
+          @screenReaderOnly={{true}}
+          @value={{this.searchNames}}
+          {{on "change" this.updateSearchNames}}
+        >
+          <:label>Nom d'acquis</:label>
+        </PixInput>
+        <PixInput
+          @id="whitelisted-url-filter-url"
+          placeholder="URL"
+          @screenReaderOnly={{true}}
+          @value={{this.searchUrl}}
+          {{on "change" this.updateSearchUrl}}
+        >
+          <:label>URL</:label>
+        </PixInput>
+        <PixButton
+          @type="submit"
+        >
+          Filtrer
+        </PixButton>
+      </PixFilterBanner>
+    </form>
+    <div class="panel-table-v2">
+      <table class="content-text content-text--small">
+        <colgroup class="table__column">
+          <col class="table__column--small" />
+          <col class="table__column" />
+          <col class="table__column--wide" />
+          <col class="table__column--wide" />
+          <col class="table__column--small" />
+          <col class="table__column--small" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>Nom des acquis concernés</th>
+            <th>Type de comparaison</th>
+            <th>URL</th>
+            <th>Commentaire</th>
+            <th>Créée le</th>
+            <th>Modifiée le</th>
+          </tr>
+        </thead>
+        <tbody>
+        {{#each this.filteredWhitelistedUrls as |whitelistedUrl|}}
+          <tr class="tr--clickable">
+            <td>
+              {{whitelistedUrl.relatedSkillNames}}
+            </td>
+            <td>
+              <PixTag class="whitelisted-url-check-type-tag" @color={{this.checkTypeColor whitelistedUrl.checkType}}>
+                {{this.formatCheckType whitelistedUrl.checkType}}
+              </PixTag>
+            </td>
+            <td>
+              {{whitelistedUrl.url}}
+            </td>
+            <td>
+              {{whitelistedUrl.comment}}
+            </td>
+            <td>
+              {{this.formatCreationString whitelistedUrl}}
+            </td>
+            <td>
+              {{this.formatUpdateString whitelistedUrl}}
+            </td>
+            <td class="actions">
+              <PixTooltip
+                @id='copy-whitelisted-url-link-tooltip'
+                @position="top"
+                @isInline={{true}}
+              >
+                <:triggerElement>
+                  <PixIconButton
+                    @triggerAction={{fn this.copyUrl whitelistedUrl}}
+                    @iconName="copy"
+                    @iconPrefix="far"
+                    @ariaLabel="Copier l'URL whitelistée"
+                    class="icon"
+                    aria-describedby='copy-whitelisted-url-link-tooltip'
+                  >
+                  </PixIconButton>
+                </:triggerElement>
+                <:tooltip>Copier l’URL whitelistée</:tooltip>
+              </PixTooltip>
+            </td>
+          </tr>
+        {{/each}}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
@@ -3,106 +3,12 @@
 </header>
 <main class="page-body">
   <section class="page-section">
-    <form {{on "submit" this.submitFilters}} class="filter-whitelisted-url-form">
-      <PixFilterBanner
-        @title="Filtres"
-        class="table-filter-banner"
-        @clearFiltersLabel="Réinitialiser les filtres"
-        @onClearFilters={{this.clearFilters}}
-        @isClearFilterButtonDisabled={{false}}
-      >
-        <PixInput
-          @id="whitelisted-url-filter-names"
-          placeholder="Nom d'acquis"
-          @screenReaderOnly={{true}}
-          @value={{this.searchNames}}
-          {{on "change" this.updateSearchNames}}
-        >
-          <:label>Nom d'acquis</:label>
-        </PixInput>
-        <PixInput
-          @id="whitelisted-url-filter-url"
-          placeholder="URL"
-          @screenReaderOnly={{true}}
-          @value={{this.searchUrl}}
-          {{on "change" this.updateSearchUrl}}
-        >
-          <:label>URL</:label>
-        </PixInput>
-        <PixButton
-          @type="submit"
-        >
-          Filtrer
-        </PixButton>
-      </PixFilterBanner>
-    </form>
-    <div class="panel-table-v2">
-      <table class="content-text content-text--small">
-        <colgroup class="table__column">
-          <col class="table__column--small" />
-          <col class="table__column" />
-          <col class="table__column--wide" />
-          <col class="table__column--wide" />
-          <col class="table__column--small" />
-          <col class="table__column--small" />
-        </colgroup>
-        <thead>
-          <tr>
-            <th>Nom des acquis concernés</th>
-            <th>Type de comparaison</th>
-            <th>URL</th>
-            <th>Commentaire</th>
-            <th>Créée le</th>
-            <th>Modifiée le</th>
-          </tr>
-        </thead>
-        <tbody>
-        {{#each this.filteredWhitelistedUrls as |whitelistedUrl|}}
-          <tr class="tr--clickable">
-            <td>
-              {{whitelistedUrl.relatedSkillNames}}
-            </td>
-            <td>
-              <PixTag class="whitelisted-url-check-type-tag" @color={{this.checkTypeColor whitelistedUrl.checkType}}>
-                {{this.formatCheckType whitelistedUrl.checkType}}
-              </PixTag>
-            </td>
-            <td>
-              {{whitelistedUrl.url}}
-            </td>
-            <td>
-              {{whitelistedUrl.comment}}
-            </td>
-            <td>
-              {{this.formatCreationString whitelistedUrl}}
-            </td>
-            <td>
-              {{this.formatUpdateString whitelistedUrl}}
-            </td>
-            <td class="actions">
-              <PixTooltip
-                @id='copy-whitelisted-url-link-tooltip'
-                @position="top"
-                @isInline={{true}}
-              >
-                <:triggerElement>
-                  <PixIconButton
-                    @triggerAction={{fn this.copyUrl whitelistedUrl}}
-                    @iconName="copy"
-                    @iconPrefix="far"
-                    @ariaLabel="Copier l'URL whitelistée"
-                    class="icon"
-                    aria-describedby='copy-whitelisted-url-link-tooltip'
-                  >
-                  </PixIconButton>
-                </:triggerElement>
-                <:tooltip>Copier l’URL whitelistée</:tooltip>
-              </PixTooltip>
-            </td>
-          </tr>
-        {{/each}}
-        </tbody>
-      </table>
-    </div>
+    <WhitelistedUrls::List
+      @whitelistedUrls={{this.filteredWhitelistedUrls}}
+      @urlFilterValue={{this.url}}
+      @namesFilterValue={{this.names}}
+      @onApplyFiltersClicked={{this.applyFilters}}
+      @onClearFiltersClicked={{this.clearFilters}}
+    />
   </section>
 </main>

--- a/pix-editor/config/icons.js
+++ b/pix-editor/config/icons.js
@@ -30,6 +30,7 @@ module.exports = function() {
       'plus',
       'power-off',
       'question-circle',
+      'recycle',
       'search',
       'share',
       'share-square',

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -456,6 +456,8 @@ function routes() {
     });
     return staticCourse;
   });
+
+  this.get('/whitelisted-urls');
 }
 
 function _serializeModel(instance, modelName) {

--- a/pix-editor/mirage/serializers/whitelisted-url.js
+++ b/pix-editor/mirage/serializers/whitelisted-url.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -1,5 +1,5 @@
-import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
-import { click, currentURL } from '@ember/test-helpers';
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
@@ -51,74 +51,19 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
     return authenticateSession();
   });
 
-  test('should display whitelisted urls by default when accessing list', async function(assert) {
+  test('should display whitelisted urls when accessing list', async function(assert) {
     // when
     const screen = await visit('/');
     await clickByName('Whitelist moulinette des URLs');
-    // FIXME Not great but better than a flaky test due to daytime savings hour change
-    const hour = Intl.DateTimeFormat('fr', { hour: 'numeric' })
-      .format(new Date('2020-01-01'))
-      .replaceAll(/[A-Za-z\s]/g, ''); // Remove trailing hour unit
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');
-
+    assert.strictEqual(
+      screen.getAllByRole('row', { name: 'URL en liste blanche' }).length,
+      3,
+    );
     assert.dom(screen.getByText('http://pipeau-la-grenouille.fr')).exists();
-    assert.dom(screen.getByText('Les grenouilles sont jolies')).exists();
-    assert.dom(screen.getByText(`01/01/2020 à ${hour}:00`)).exists();
-    assert.dom(screen.getByText(`01/01/2021 à ${hour}:00 par Ma maman`)).exists();
-    assert.dom(screen.getByText('Commence par')).exists();
-
     assert.dom(screen.getByText('http://chats.fr')).exists();
-    assert.dom(screen.getByText('MIAOU')).exists();
-    assert.dom(screen.getByText(`02/02/2020 à ${hour}:00 par Mon chat`)).exists();
-    assert.dom(screen.getByText(`02/02/2021 à ${hour}:00`)).exists();
-
     assert.dom(screen.getByText('http://chiens.fr')).exists();
-    assert.dom(screen.getByText('OUAF')).exists();
-    assert.dom(screen.getByText(`03/03/2020 à ${hour}:00 par Mon chien`)).exists();
-    assert.dom(screen.getByText(`03/03/2021 à ${hour}:00`)).exists();
-
-    assert.strictEqual(screen.getAllByText('Strictement égale à').length, 2);
-  });
-
-  test('should display all whitelisted urls when accessing list and toggling URL filter', async function(assert) {
-    // when
-    const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
-    await fillByLabel('URL', 'chat');
-    await click(await screen.findByRole('button', { name: 'Filtrer' }));
-
-    // then
-    assert.strictEqual(currentURL(), '/whitelisted-urls?url=chat');
-    assert.dom(screen.getByText('MIAOU')).exists();
-    assert.dom(screen.queryByText('Les grenouilles sont jolies')).doesNotExist();
-  });
-
-  test('should display filtered whitelisted urls when accessing list and toggling basic skill name filter', async function(assert) {
-    // when
-    const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
-    await fillByLabel('Nom d\'acquis', 'souris');
-    await click(await screen.findByRole('button', { name: 'Filtrer' }));
-
-    // then
-    assert.strictEqual(currentURL(), '/whitelisted-urls?names=souris');
-    assert.dom(screen.getByText('Les grenouilles sont jolies')).exists();
-    assert.dom(screen.queryByText('MIAOU')).doesNotExist();
-  });
-
-  test('should display filtered whitelisted urls when accessing list and toggling advanced skill name filter', async function(assert) {
-    // when
-    const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
-    await fillByLabel('Nom d\'acquis', 'souris,noix');
-    await click(await screen.findByRole('button', { name: 'Filtrer' }));
-
-    // then
-    assert.strictEqual(currentURL(), `/whitelisted-urls?names=${encodeURIComponent('souris,noix')}`);
-    assert.dom(screen.getByText('Les grenouilles sont jolies')).exists();
-    assert.dom(screen.getByText('OUAF')).exists();
-    assert.dom(screen.queryByText('MIAOU')).doesNotExist();
   });
 });

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -1,0 +1,124 @@
+import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../setup-application-rendering';
+
+module('Acceptance | Whitelisted URLs | List', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+    this.server.create('whitelisted-url', {
+      id: 1,
+      createdAt: new Date('2020-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      creatorName: null,
+      latestUpdatorName: 'Ma maman',
+      url: 'http://pipeau-la-grenouille.fr',
+      relatedSkillNames: '@noix2,@souris8',
+      checkType: 'starts_with',
+      comment: 'Les grenouilles sont jolies',
+    });
+    this.server.create('whitelisted-url', {
+      id: 2,
+      createdAt: new Date('2020-02-02'),
+      updatedAt: new Date('2021-02-02'),
+      creatorName: 'Mon chat',
+      latestUpdatorName: null,
+      url: 'http://chats.fr',
+      relatedSkillNames: null,
+      checkType: 'exact_match',
+      comment: 'MIAOU',
+    });
+    this.server.create('whitelisted-url', {
+      id: 3,
+      createdAt: new Date('2020-03-03'),
+      updatedAt: new Date('2021-03-03'),
+      creatorName: 'Mon chien',
+      latestUpdatorName: null,
+      url: 'http://chiens.fr',
+      relatedSkillNames: '@noix3',
+      checkType: 'exact_match',
+      comment: 'OUAF',
+    });
+
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
+    return authenticateSession();
+  });
+
+  test('should display whitelisted urls by default when accessing list', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    // FIXME Not great but better than a flaky test due to daytime savings hour change
+    const hour = Intl.DateTimeFormat('fr', { hour: 'numeric' })
+      .format(new Date('2020-01-01'))
+      .replaceAll(/[A-Za-z\s]/g, ''); // Remove trailing hour unit
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls');
+
+    assert.dom(screen.getByText('http://pipeau-la-grenouille.fr')).exists();
+    assert.dom(screen.getByText('Les grenouilles sont jolies')).exists();
+    assert.dom(screen.getByText(`01/01/2020 à ${hour}:00`)).exists();
+    assert.dom(screen.getByText(`01/01/2021 à ${hour}:00 par Ma maman`)).exists();
+    assert.dom(screen.getByText('Commence par')).exists();
+
+    assert.dom(screen.getByText('http://chats.fr')).exists();
+    assert.dom(screen.getByText('MIAOU')).exists();
+    assert.dom(screen.getByText(`02/02/2020 à ${hour}:00 par Mon chat`)).exists();
+    assert.dom(screen.getByText(`02/02/2021 à ${hour}:00`)).exists();
+
+    assert.dom(screen.getByText('http://chiens.fr')).exists();
+    assert.dom(screen.getByText('OUAF')).exists();
+    assert.dom(screen.getByText(`03/03/2020 à ${hour}:00 par Mon chien`)).exists();
+    assert.dom(screen.getByText(`03/03/2021 à ${hour}:00`)).exists();
+
+    assert.strictEqual(screen.getAllByText('Strictement égale à').length, 2);
+  });
+
+  test('should display all whitelisted urls when accessing list and toggling URL filter', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await fillByLabel('URL', 'chat');
+    await click(await screen.findByRole('button', { name: 'Filtrer' }));
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls?url=chat');
+    assert.dom(screen.getByText('MIAOU')).exists();
+    assert.dom(screen.queryByText('Les grenouilles sont jolies')).doesNotExist();
+  });
+
+  test('should display filtered whitelisted urls when accessing list and toggling basic skill name filter', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await fillByLabel('Nom d\'acquis', 'souris');
+    await click(await screen.findByRole('button', { name: 'Filtrer' }));
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls?names=souris');
+    assert.dom(screen.getByText('Les grenouilles sont jolies')).exists();
+    assert.dom(screen.queryByText('MIAOU')).doesNotExist();
+  });
+
+  test('should display filtered whitelisted urls when accessing list and toggling advanced skill name filter', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await fillByLabel('Nom d\'acquis', 'souris,noix');
+    await click(await screen.findByRole('button', { name: 'Filtrer' }));
+
+    // then
+    assert.strictEqual(currentURL(), `/whitelisted-urls?names=${encodeURIComponent('souris,noix')}`);
+    assert.dom(screen.getByText('Les grenouilles sont jolies')).exists();
+    assert.dom(screen.getByText('OUAF')).exists();
+    assert.dom(screen.queryByText('MIAOU')).doesNotExist();
+  });
+});

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -1,0 +1,220 @@
+import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | whitelisted-urls/list', function(hooks) {
+  setupIntlRenderingTest(hooks);
+  let store, whitelistedUrl1, whitelistedUrl2, hour1_create, hour1_update, hour2_create;
+  let onApplyFiltersClickedStub, onClearFiltersClickedStub;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+    whitelistedUrl1 = store.createRecord('whitelisted-url', {
+      id: 1,
+      url: 'https://foo.com',
+      creatorName: 'Laura le chocolat',
+      latestUpdatorName: 'Iris l\'anis',
+      relatedSkillNames: '',
+      checkType: 'exact_match',
+      comment: 'Un commentaire sur Laura',
+      createdAt: new Date('2020-01-01T09:00:00Z'),
+      updatedAt: new Date('2021-01-01T09:00:00Z'),
+    });
+    // FIXME Not great but better than a flaky test due to daytime savings hour change
+    hour1_create = Intl.DateTimeFormat('fr', { hour: 'numeric' })
+      .format(new Date('2020-01-01T09:00:00Z'))
+      .replaceAll(/[A-Za-z\s]/g, '');
+    hour1_update = Intl.DateTimeFormat('fr', { hour: 'numeric' })
+      .format(new Date('2021-01-01T09:00:00Z'))
+      .replaceAll(/[A-Za-z\s]/g, '');
+    whitelistedUrl2 = store.createRecord('whitelisted-url', {
+      id: 2,
+      url: 'https://bar.com',
+      creatorName: 'Fael le miel',
+      latestUpdatorName: null,
+      relatedSkillNames: '@fruit4,@legume5',
+      checkType: 'starts_with',
+      comment: 'Un commentaire sur Fael',
+      createdAt: new Date('2021-12-01T12:00:00Z'),
+      updatedAt: null,
+    });
+    hour2_create = Intl.DateTimeFormat('fr', { hour: 'numeric' })
+      .format(new Date('2021-12-01T12:00:00Z'))
+      .replaceAll(/[A-Za-z\s]/g, '');
+    onApplyFiltersClickedStub = sinon.stub();
+    onClearFiltersClickedStub = sinon.stub();
+  });
+
+  test('it should display list of whitelisted urls passed in params and initialize filter inputs', async function(assert) {
+    // given
+    this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
+    this.urlFilterValue = 'initialUrlValue';
+    this.namesFilterValue = 'initialNamesValue';
+    this.onApplyFiltersClicked = onApplyFiltersClickedStub;
+    this.onClearFiltersClicked = onClearFiltersClickedStub;
+
+    // when
+    const screen = await render(hbs`
+      <WhitelistedUrls::List
+        @whitelistedUrls={{this.whitelistedUrls}}
+        @urlFilterValue={{this.urlFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+
+    // then
+    assert.ok(
+      screen.getByRole('columnheader', {
+        name: 'Nom des acquis concernés',
+      }),
+    );
+    assert.ok(
+      screen.getByRole('columnheader', {
+        name: 'Type de comparaison',
+      }),
+    );
+    assert.ok(
+      screen.getByRole('columnheader', {
+        name: 'URL',
+      }),
+    );
+    assert.ok(
+      screen.getByRole('columnheader', {
+        name: 'Commentaire',
+      }),
+    );
+    assert.ok(
+      screen.getByRole('columnheader', {
+        name: 'Créée le',
+      }),
+    );
+    assert.ok(
+      screen.getByRole('columnheader', {
+        name: 'Modifiée le',
+      }),
+    );
+    assert.strictEqual(
+      screen.getAllByRole('row', { name: 'URL en liste blanche' }).length,
+      2,
+    );
+    assert.ok(screen.getByRole('cell', { name: 'https://foo.com' }), 'https://foo.com');
+    assert.ok(screen.getByRole('cell', { name: 'Strictement égale à' }), 'Strictement égale à');
+    assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Laura' }), 'Un commentaire sur Laura');
+    assert.ok(screen.getByRole('cell', { name: `01/01/2020 à ${hour1_create}:00 par Laura le chocolat` }), `01/01/2020 à ${hour1_create}:00 par Laura le chocolat`);
+    assert.ok(screen.getByRole('cell', { name: `01/01/2021 à ${hour1_update}:00 par Iris l'anis` }), `01/01/2021 à ${hour1_update}:00 par Iris l'anis`);
+    assert.ok(screen.getByRole('cell', { name: '@fruit4,@legume5' }), '@fruit4,@legume5');
+    assert.ok(screen.getByRole('cell', { name: 'https://bar.com' }), 'https://bar.com');
+    assert.ok(screen.getByRole('cell', { name: 'Commence par' }), 'Commence par');
+    assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Fael' }), 'Un commentaire sur Fael');
+    assert.ok(screen.getByRole('cell', { name: `01/12/2021 à ${hour2_create}:00 par Fael le miel` }), `01/12/2021 à ${hour2_create}:00 par Fael le miel`);
+    assert.strictEqual(screen.getByLabelText('URL').value, 'initialUrlValue');
+    assert.strictEqual(screen.getByLabelText('Nom d\'acquis').value, 'initialNamesValue');
+  });
+
+  test('it should pass up typed url filter and keeping the previous names filter when applying', async function(assert) {
+    // given
+    this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
+    this.urlFilterValue = 'initialUrlValue';
+    this.namesFilterValue = 'initialNamesValue';
+    this.onApplyFiltersClicked = onApplyFiltersClickedStub;
+    this.onClearFiltersClicked = onClearFiltersClickedStub;
+
+    // when
+    const screen = await render(hbs`
+      <WhitelistedUrls::List
+        @whitelistedUrls={{this.whitelistedUrls}}
+        @urlFilterValue={{this.urlFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+    await fillByLabel('URL', 'different url value');
+    await clickByName('Filtrer');
+
+    // then
+    assert.strictEqual(screen.getByLabelText('Nom d\'acquis').value, 'initialNamesValue');
+    assert.strictEqual(screen.getByLabelText('URL').value, 'different url value');
+    sinon.assert.calledWithExactly(onApplyFiltersClickedStub, 'different url value', 'initialNamesValue');
+  });
+
+  test('it should pass up typed names filter and keeping the previous url filter when applying', async function(assert) {
+    // given
+    this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
+    this.urlFilterValue = 'initialUrlValue';
+    this.namesFilterValue = 'initialNamesValue';
+    this.onApplyFiltersClicked = onApplyFiltersClickedStub;
+    this.onClearFiltersClicked = onClearFiltersClickedStub;
+
+    // when
+    const screen = await render(hbs`
+      <WhitelistedUrls::List
+        @whitelistedUrls={{this.whitelistedUrls}}
+        @urlFilterValue={{this.urlFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+    await fillByLabel('Nom d\'acquis', 'different names value');
+    await clickByName('Filtrer');
+
+    // then
+    assert.strictEqual(screen.getByLabelText('Nom d\'acquis').value, 'different names value');
+    assert.strictEqual(screen.getByLabelText('URL').value, 'initialUrlValue');
+    sinon.assert.calledWithExactly(onApplyFiltersClickedStub, 'initialUrlValue', 'different names value');
+  });
+
+  test('it should pass up both typed names and url filters when applying', async function(assert) {
+    // given
+    this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
+    this.urlFilterValue = 'initialUrlValue';
+    this.namesFilterValue = 'initialNamesValue';
+    this.onApplyFiltersClicked = onApplyFiltersClickedStub;
+    this.onClearFiltersClicked = onClearFiltersClickedStub;
+
+    // when
+    const screen = await render(hbs`
+      <WhitelistedUrls::List
+        @whitelistedUrls={{this.whitelistedUrls}}
+        @urlFilterValue={{this.urlFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+    await fillByLabel('Nom d\'acquis', 'different names value');
+    await fillByLabel('URL', 'different url value');
+    await clickByName('Filtrer');
+
+    // then
+    assert.strictEqual(screen.getByLabelText('Nom d\'acquis').value, 'different names value');
+    assert.strictEqual(screen.getByLabelText('URL').value, 'different url value');
+    sinon.assert.calledWithExactly(onApplyFiltersClickedStub, 'different url value', 'different names value');
+  });
+
+  test('it should call arg function when clearing filters', async function(assert) {
+    // given
+    this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
+    this.urlFilterValue = 'initialUrlValue';
+    this.namesFilterValue = 'initialNamesValue';
+    this.onApplyFiltersClicked = onApplyFiltersClickedStub;
+    this.onClearFiltersClicked = onClearFiltersClickedStub;
+
+    // when
+    await render(hbs`
+      <WhitelistedUrls::List
+        @whitelistedUrls={{this.whitelistedUrls}}
+        @urlFilterValue={{this.urlFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+    await clickByName('Réinitialiser les filtres');
+
+    // then
+    sinon.assert.calledOnce(onClearFiltersClickedStub);
+    assert.ok(true);
+  });
+});

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -150,4 +150,28 @@ module('Unit | Service | access', function(hooks) {
     });
 
   });
+
+  module('mayAccessWhitelistedUrls', function() {
+    test('it should return `false` when is not admin', function(assert) {
+      // given
+      _stubAccessLevel(EDITOR, this.owner);
+
+      //when
+      const accessResult = accessService.mayAccessWhitelistedUrls();
+
+      //then
+      assert.notOk(accessResult);
+    });
+
+    test('it should return `true` when is admin', function(assert) {
+      // given
+      _stubAccessLevel(ADMIN, this.owner);
+
+      //when
+      const accessResult = accessService.mayAccessWhitelistedUrls();
+
+      //then
+      assert.ok(accessResult);
+    });
+  });
 });


### PR DESCRIPTION
Moulinette URLS ticket 2

## :fallen_leaf: Problème
Pour la moulinette des URLs cassées, le métier maintient à part des macros et autres outils sur google sheet pour ignorer une liste fixe d'urls qu'ils ne souhaitent pas traiter.

## :chestnut: Proposition
D'abord, pouvoir afficher une liste d'urls whitelistées.
Cette liste n'est pas encore prise en compte dans la moulinette (à venir).
C'est juste un affichage, l'édition de la liste ça va venir

## :jack_o_lantern: Remarques
Pas de pagination, on affiche tout

## :wood: Pour tester
Y'a des seeds, ajouter des enregistrements directement en BDD si on veut en voir plus.
