### PR TITLE
[FEATURE] Je veux pouvoir supprimer une URL de la liste blanche (PIX-15181)

### DIFF
--- a/api/lib/application/types.js
+++ b/api/lib/application/types.js
@@ -1,5 +1,10 @@
 import Joi from 'joi';
 
+const postgreSQLSequenceDefaultStart = 1;
+const postgreSQLSequenceEnd = 2 ** 31 - 1;
+
+const schemaPositiveInteger32bits = Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceEnd);
+
 export const Types = Object.freeze({
   competenceId() {
     return Joi.string().pattern(/^(rec|competence)[a-zA-Z0-9]+$/);
@@ -7,4 +12,7 @@ export const Types = Object.freeze({
   locale() {
     return Joi.string().pattern(/^[a-z]{2}(-[a-z]{2})?$/);
   },
+  whitelistedUrlId() {
+    return schemaPositiveInteger32bits;
+  }
 });

--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -1,6 +1,9 @@
+import Joi from 'joi';
 import * as securityPreHandlers from '../security-pre-handlers.js';
-import { whitelistedUrlReadRepository } from '../../infrastructure/repositories/index.js';
+import { whitelistedUrlReadRepository, whitelistedUrlRepository } from '../../infrastructure/repositories/index.js';
 import * as whitelistedUrlSerializer from '../../infrastructure/serializers/jsonapi/whitelisted-url-serializer.js';
+import { NotFoundWhitelistedUrlError } from '../../domain/errors.js';
+import { Types } from '../types.js';
 
 export async function register(server) {
   server.route([
@@ -12,6 +15,29 @@ export async function register(server) {
         handler: async function(request, h) {
           const whitelistedUrls_read = await whitelistedUrlReadRepository.list();
           return h.response(whitelistedUrlSerializer.serialize(whitelistedUrls_read));
+        },
+      },
+    },{
+      method: 'DELETE',
+      path: '/api/whitelisted-urls/{whitelistedUrlId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            whitelistedUrlId: Types.whitelistedUrlId().required(),
+          }),
+        },
+        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        handler: async function(request, h) {
+          const authenticatedUser = request.auth.credentials.user;
+          const whitelistedUrlId = request.params.whitelistedUrlId;
+          const whitelistedUrlToDelete = await whitelistedUrlRepository.find(whitelistedUrlId);
+          if (!whitelistedUrlToDelete) {
+            throw new NotFoundWhitelistedUrlError(`L'URL whitelistée d'id ${whitelistedUrlId} n'existe pas`);
+          }
+          whitelistedUrlToDelete.canDelete(authenticatedUser);
+          whitelistedUrlToDelete.delete(authenticatedUser);
+          await whitelistedUrlRepository.save(whitelistedUrlToDelete);
+          return h.response().code(204);
         },
       },
     },

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -57,4 +57,22 @@ export class InvalidStaticCourseCreationOrUpdateError extends DomainError {
   }
 }
 
+export class NotFoundWhitelistedUrlError extends NotFoundError {
+  constructor(message) {
+    super(message);
+  }
+}
+
+export class CommandWhitelistedUrlConflictError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
+export class CommandWhitelistedUrlForbiddenError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 export class ForbiddenError extends DomainError {}

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -16,4 +16,18 @@ export class User {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }
+
+  static get ROLES() {
+    return {
+      READPIXONLY: 'readpixonly',
+      READONLY: 'readonly',
+      REPLICATOR: 'replicator',
+      EDITOR: 'editor',
+      ADMIN: 'admin',
+    };
+  };
+
+  get isAdmin() {
+    return this.access === User.ROLES.ADMIN;
+  }
 }

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -1,8 +1,48 @@
+import { CommandWhitelistedUrlConflictError, CommandWhitelistedUrlForbiddenError, } from '../errors.js';
+
 export class WhitelistedUrl {
+  constructor({
+    id,
+    createdBy,
+    latestUpdatedBy,
+    deletedBy,
+    createdAt,
+    updatedAt,
+    deletedAt,
+    url,
+    relatedSkillNames,
+    comment,
+    checkType,
+  }) {
+    this.id = id;
+    this.createdBy = createdBy;
+    this.latestUpdatedBy = latestUpdatedBy;
+    this.deletedBy = deletedBy;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.deletedAt = deletedAt;
+    this.url = url;
+    this.relatedSkillNames = relatedSkillNames;
+    this.comment = comment;
+    this.checkType = checkType;
+  }
   static get CHECK_TYPES() {
     return {
       EXACT_MATCH: 'exact_match',
       STARTS_WITH: 'starts_with',
     };
+  }
+
+  canDelete(user) {
+    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour supprimer cette URL whitelistée');
+    if (this.deletedAt) throw new CommandWhitelistedUrlConflictError('L\'URL whitelistée a déjà été supprimée');
+  }
+
+  delete(user) {
+    const operationDate = new Date();
+    this.latestUpdatedBy = user.id;
+    this.deletedBy = user.id;
+    this.updatedAt = operationDate;
+    this.deletedAt = operationDate;
   }
 }

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -16,3 +16,4 @@ export * as tubeRepository from './tube-repository.js';
 export * as urlRepository from './url-repository.js';
 export * as userRepository from './user-repository.js';
 export * as whitelistedUrlReadRepository from './whitelisted-url-read-repository.js';
+export * as whitelistedUrlRepository from './whitelisted-url-repository.js';

--- a/api/lib/infrastructure/repositories/whitelisted-url-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-repository.js
@@ -1,0 +1,38 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { WhitelistedUrl } from '../../domain/models/index.js';
+
+export async function find(id) {
+  const whitelistedUrlDto = await knex('whitelisted_urls')
+    .select(['id', 'createdBy', 'latestUpdatedBy', 'deletedBy', 'createdAt', 'updatedAt', 'deletedAt', 'url', 'relatedSkillNames', 'comment', 'checkType'])
+    .where({ id })
+    .first();
+
+  if (!whitelistedUrlDto) return null;
+  return toDomain(whitelistedUrlDto);
+}
+
+export async function save(whitelistedUrl) {
+  const dataToSave = adaptModelToDB(whitelistedUrl);
+  const id = whitelistedUrl.id;
+  await knex('whitelisted_urls').update(dataToSave).where({ id });
+  return id;
+}
+
+function toDomain(whitelistedUrlDto) {
+  return new WhitelistedUrl(whitelistedUrlDto);
+}
+
+function adaptModelToDB(whitelistedUrl) {
+  return {
+    createdBy: whitelistedUrl.createdBy,
+    latestUpdatedBy: whitelistedUrl.latestUpdatedBy,
+    deletedBy: whitelistedUrl.deletedBy,
+    createdAt: whitelistedUrl.createdAt,
+    updatedAt: whitelistedUrl.updatedAt,
+    deletedAt: whitelistedUrl.deletedAt,
+    url: whitelistedUrl.url,
+    relatedSkillNames: whitelistedUrl.relatedSkillNames,
+    comment: whitelistedUrl.comment,
+    checkType: whitelistedUrl.checkType,
+  };
+}

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -50,6 +50,20 @@ function _mapToInfrastructureError(error) {
       statusCode: 422,
     };
   }
+  if (error instanceof DomainErrors.CommandWhitelistedUrlForbiddenError) {
+    const infraError = new InfraErrors.ForbiddenError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
+  if (error instanceof DomainErrors.CommandWhitelistedUrlConflictError) {
+    const infraError = new InfraErrors.ConflictError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
 
   const infraError = new InfraErrors.InfrastructureError(error.message);
   return {

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
@@ -118,6 +118,151 @@ describe('Acceptance | Controller | whitelisted-urls', () => {
           },
         ],
       });
+    });
+  });
+  describe('DELETE /whitelisted-urls/{whitelistedUrlId}', () => {
+    let adminUser, server;
+    beforeEach(async function() {
+      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@morse2,@saumon5',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: adminUser.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@truite2',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+      server = await createServer();
+    });
+
+    it('should return a 403 status code when user is not admin', async () => {
+      // given
+      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/api/whitelisted-urls/123456',
+        headers: generateAuthorizationHeader(notAdminUser)
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            code: 403,
+            detail: 'Missing or insufficient permissions.',
+            title: 'Forbidden access',
+          },
+        ],
+      });
+    });
+
+    it('should return a 400 status code when provided whitelisted url id is not in the right format', async () => {
+      // when
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/api/whitelisted-urls/coucoumaman',
+        headers: generateAuthorizationHeader(adminUser)
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(400);
+      expect(response.result).to.deep.equal({
+        error: 'Bad Request',
+        message: 'Invalid request params input',
+        statusCode: 400,
+      });
+    });
+
+    it('should return a 404 status code when provided whitelisted url id does not exist', async () => {
+      // when
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/api/whitelisted-urls/777',
+        headers: generateAuthorizationHeader(adminUser)
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(404);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            status: '404',
+            title: 'Not Found',
+            detail: 'L\'URL whitelistée d\'id 777 n\'existe pas',
+          },
+        ],
+      });
+    });
+
+    it('should return a 409 status code when provided whitelisted url id has already been deleted', async () => {
+      // when
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/api/whitelisted-urls/789',
+        headers: generateAuthorizationHeader(adminUser)
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(409);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            status: '409',
+            title: 'Conflict',
+            detail: 'L\'URL whitelistée a déjà été supprimée',
+          },
+        ],
+      });
+    });
+
+    it('should return a 204 status code and delete the active whitelisted url given by its id', async () => {
+      // when
+      const response = await server.inject({
+        method: 'DELETE',
+        url: '/api/whitelisted-urls/123',
+        headers: generateAuthorizationHeader(adminUser)
+      });
+
+      // Then
+      const exists = await knex('whitelisted_urls').where({ id: 123 }).whereNotNull('deletedAt').first();
+      expect(response.statusCode).to.equal(204);
+      expect(exists.id).to.equal(123);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import * as whitelistedUrlRepository from '../../../../lib/infrastructure/repositories/whitelisted-url-repository.js';
+import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
+
+describe('Integration | Repository | whitelisted-url-repository', () => {
+
+  describe('#find', () => {
+
+    it('should retrieve given whitelisted url by its id', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrl = await whitelistedUrlRepository.find(123);
+
+      // then
+      expect(whitelistedUrl).toStrictEqual(domainBuilder.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      }));
+    });
+
+    it('should return null when no entity found for id', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        deletedAt: new Date('2024-01-01'),
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrl = await whitelistedUrlRepository.find(777);
+
+      // then
+      expect(whitelistedUrl).toStrictEqual(null);
+    });
+  });
+  describe('#save', function() {
+    it('should update the whitelisted url', async function() {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      await databaseBuilder.commit();
+      const whitelistedUrlToSave = domainBuilder.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser2.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: adminUser2.id,
+        createdAt: new Date('2022-02-02'),
+        updatedAt: new Date('2023-03-03'),
+        deletedAt: new Date('2024-04-04'),
+        url: 'https://www.bing.com',
+        relatedSkillNames: '@morse8',
+        comment: 'Je viens de modifier le commentaire',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+
+      // when
+      await whitelistedUrlRepository.save(whitelistedUrlToSave);
+
+      // then
+      const savedWhitelistedUrl = await whitelistedUrlRepository.find(123);
+      expect(savedWhitelistedUrl).toStrictEqual(whitelistedUrlToSave);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-whitelisted-url.js
+++ b/api/tests/tooling/domain-builder/factory/build-whitelisted-url.js
@@ -24,3 +24,31 @@ export function buildWhitelistedUrlRead({
     checkType,
   });
 }
+
+export function buildWhitelistedUrl({
+  id = 1,
+  createdBy = 123,
+  latestUpdatedBy = 123,
+  deletedBy = null,
+  createdAt = new Date('2020-01-01'),
+  updatedAt = new Date('2022-01-01'),
+  deletedAt = null,
+  url = 'http://pipeau-la-grenouille.fr',
+  relatedSkillNames = '@bidule4,@chose6',
+  comment = 'Les grenouilles sont jolies',
+  checkType = WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+} = {}) {
+  return new WhitelistedUrl({
+    id,
+    createdBy,
+    latestUpdatedBy,
+    deletedBy,
+    createdAt,
+    updatedAt,
+    deletedAt,
+    url,
+    relatedSkillNames,
+    comment,
+    checkType,
+  });
+}

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { User } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | User', () => {
+  describe('#get isAdmin', () => {
+    it('should return true when user is admin', () => {
+      // given
+      const user = domainBuilder.buildUser({
+        access: User.ROLES.ADMIN,
+      });
+
+      // when
+      const isAdmin = user.isAdmin;
+
+      // then
+      expect(isAdmin).to.be.true;
+    });
+
+    it.each(Object.keys(User.ROLES).filter((roleKey) => User.ROLES[roleKey] !== User.ROLES.ADMIN)
+    )('should return false when role key is %s', (roleKey) => {
+      // given
+      const user  = domainBuilder.buildUser({
+        access: User.ROLES[roleKey],
+      });
+
+      // when
+      const isAdmin = user.isAdmin;
+
+      // then
+      expect(isAdmin).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { User } from '../../../../lib/domain/models/index.js';
+import {
+  CommandWhitelistedUrlConflictError,
+  CommandWhitelistedUrlForbiddenError,
+} from '../../../../lib/domain/errors.js';
+
+describe('Unit | Domain | WhitelistedUrl', () => {
+  let now;
+  beforeEach(function() {
+    now = new Date('2024-10-29T03:04:00Z');
+    vi.useFakeTimers({
+      now,
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(function() {
+    vi.useRealTimers();
+  });
+
+  describe('#canDelete', () => {
+    describe('can', function() {
+      it('should not throw when all conditions are reunited', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
+          deletedAt: null,
+          deletedBy: null,
+        });
+
+        // when
+        whitelistedUrlToDelete.canDelete(user);
+
+        // then
+        expect(true).to.be.true;
+      });
+    });
+    describe('cannot', function() {
+      it('should throw a CommandWhitelistedUrlForbiddenError when user is not admin', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
+        const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
+          deletedAt: null,
+          deletedBy: null,
+        });
+
+        // when
+        try {
+          whitelistedUrlToDelete.canDelete(user);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlForbiddenError(
+            'L\'utilisateur n\'a pas les droits pour supprimer cette URL whitelistée'
+          ));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlConflictError when whitelisted url has already been deleted', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
+          deletedAt: new Date('2021-01-01'),
+          deletedBy: 456,
+        });
+
+        // when
+        try {
+          whitelistedUrlToDelete.canDelete(user);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlConflictError(
+            'L\'URL whitelistée a déjà été supprimée'
+          ));
+        }
+      });
+    });
+  });
+
+  describe('#delete', function() {
+    it('should mark as deleted the whitelisted url', function() {
+      // given
+      const user = domainBuilder.buildUser({ id: 888 });
+      const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
+        id: 123,
+        createdBy: 777,
+        latestUpdatedBy: 999,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@noix2,@chose8',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+      });
+
+      // when
+      whitelistedUrlToDelete.delete(user);
+
+      // then
+      expect(whitelistedUrlToDelete).toStrictEqual(domainBuilder.buildWhitelistedUrl({
+        id: 123,
+        createdBy: 777,
+        latestUpdatedBy: 888,
+        deletedBy: 888,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: now,
+        deletedAt: now,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@noix2,@chose8',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+      }));
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -123,6 +123,42 @@ describe('Unit | Infrastructure | ErrorManager', function() {
             ],
           });
         }
+        else if (domainErrorName === 'NotFoundWhitelistedUrlError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(404);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '404',
+                title: 'Not Found',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'CommandWhitelistedUrlForbiddenError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(403);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '403',
+                title: 'Forbidden',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'CommandWhitelistedUrlConflictError') {
+          expect(response.statusCode, expectErrorMessage).toStrictEqual(409);
+          expect(response.source).toStrictEqual({
+            errors: [
+              {
+                status: '409',
+                title: 'Conflict',
+                detail: 'error message',
+              },
+            ],
+          });
+        }
         else {
           expect(true, `Conversion for ${domainErrorName} not tested`).to.be.false;
         }

--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -93,6 +93,23 @@
             </:triggerElement>
             <:tooltip>Copier l’URL whitelistée</:tooltip>
           </PixTooltip>
+          <PixTooltip
+            @id='delete-whitelisted-url-tooltip'
+            @position="top"
+            @isInline={{true}}
+          >
+            <:triggerElement>
+              <PixIconButton
+                @triggerAction={{fn this.args.onDeleteItemClicked whitelistedUrl}}
+                @iconName="delete"
+                @ariaLabel="Supprimer l'URL de la whitelist"
+                class="icon"
+                aria-describedby='delete-whitelisted-url-tooltip'
+              >
+              </PixIconButton>
+            </:triggerElement>
+            <:tooltip>Supprimer l'URL de la whitelist</:tooltip>
+        </PixTooltip>
         </td>
       </tr>
     {{/each}}

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -5,6 +5,9 @@ import { tracked } from '@glimmer/tracking';
 
 export default class WhitelistedUrlsController extends Controller {
   @service router;
+  @service confirm;
+  @service notifications;
+
   queryParams = ['url', 'names'];
   @tracked url = '';
   @tracked names = '';
@@ -32,5 +35,17 @@ export default class WhitelistedUrlsController extends Controller {
   async clearFilters() {
     this.url = '';
     this.names = '';
+  }
+
+  @action
+  async deleteUrl(whitelistedUrl) {
+    try {
+      await this.confirm.ask('Suppression', 'Êtes-vous sûr de vouloir supprimer cette URL de la whitelist ?');
+    } catch {
+      return;
+    }
+    await whitelistedUrl.destroyRecord().catch(() => {
+      this.notifications.error('Une erreur est survenue lors de la suppression de cette URL de la whitelist.');
+    });
   }
 }

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
@@ -9,6 +9,7 @@
       @namesFilterValue={{this.names}}
       @onApplyFiltersClicked={{this.applyFilters}}
       @onClearFiltersClicked={{this.clearFilters}}
+      @onDeleteItemClicked={{this.deleteUrl}}
     />
   </section>
 </main>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -458,6 +458,7 @@ function routes() {
   });
 
   this.get('/whitelisted-urls');
+  this.delete('/whitelisted-urls/:id');
 }
 
 function _serializeModel(instance, modelName) {

--- a/pix-editor/mirage/serializers/whitelisted-url.js
+++ b/pix-editor/mirage/serializers/whitelisted-url.js
@@ -1,3 +1,0 @@
-import ApplicationSerializer from './application';
-
-export default ApplicationSerializer.extend({});

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -1,5 +1,5 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
@@ -65,5 +65,20 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
     assert.dom(screen.getByText('http://pipeau-la-grenouille.fr')).exists();
     assert.dom(screen.getByText('http://chats.fr')).exists();
     assert.dom(screen.getByText('http://chiens.fr')).exists();
+  });
+
+  test('should delete delete whitelisted url', async function(assert) {
+    // when
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+
+    const deleteButtons = await screen.findAllByRole('button', { name: 'Supprimer l\'URL de la whitelist' });
+    await click(deleteButtons[0]);
+    await click(await screen.findByRole('button', { name: 'Oui' }));
+
+    // then
+    assert.dom(screen.getByText('OUAF')).exists();
+    assert.dom(screen.getByText('MIAOU')).exists();
+    assert.dom(screen.queryByText('Les grenouilles sont jolies')).doesNotExist();
   });
 });

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -8,7 +8,7 @@ import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 module('Integration | Component | whitelisted-urls/list', function(hooks) {
   setupIntlRenderingTest(hooks);
   let store, whitelistedUrl1, whitelistedUrl2, hour1_create, hour1_update, hour2_create;
-  let onApplyFiltersClickedStub, onClearFiltersClickedStub;
+  let onApplyFiltersClickedStub, onClearFiltersClickedStub, onDeleteItemClickedStub;
 
   hooks.beforeEach(async function() {
     store = this.owner.lookup('service:store');
@@ -46,6 +46,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
       .replaceAll(/[A-Za-z\s]/g, '');
     onApplyFiltersClickedStub = sinon.stub();
     onClearFiltersClickedStub = sinon.stub();
+    onDeleteItemClickedStub = sinon.stub();
   });
 
   test('it should display list of whitelisted urls passed in params and initialize filter inputs', async function(assert) {
@@ -55,6 +56,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.namesFilterValue = 'initialNamesValue';
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
+    this.onDeleteItemClicked = onDeleteItemClickedStub;
 
     // when
     const screen = await render(hbs`
@@ -64,7 +66,8 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
-        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
 
     // then
     assert.ok(
@@ -122,6 +125,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.namesFilterValue = 'initialNamesValue';
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
+    this.onDeleteItemClicked = onDeleteItemClickedStub;
 
     // when
     const screen = await render(hbs`
@@ -131,7 +135,8 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
-        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
     await fillByLabel('URL', 'different url value');
     await clickByName('Filtrer');
 
@@ -148,6 +153,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.namesFilterValue = 'initialNamesValue';
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
+    this.onDeleteItemClicked = onDeleteItemClickedStub;
 
     // when
     const screen = await render(hbs`
@@ -157,7 +163,8 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
-        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
     await fillByLabel('Nom d\'acquis', 'different names value');
     await clickByName('Filtrer');
 
@@ -174,6 +181,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.namesFilterValue = 'initialNamesValue';
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
+    this.onDeleteItemClicked = onDeleteItemClickedStub;
 
     // when
     const screen = await render(hbs`
@@ -183,7 +191,8 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
-        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
     await fillByLabel('Nom d\'acquis', 'different names value');
     await fillByLabel('URL', 'different url value');
     await clickByName('Filtrer');
@@ -201,6 +210,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.namesFilterValue = 'initialNamesValue';
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
+    this.onDeleteItemClicked = onDeleteItemClickedStub;
 
     // when
     await render(hbs`
@@ -210,7 +220,8 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
-        @onClearFiltersClicked={{this.onClearFiltersClicked}}/>`);
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
     await clickByName('Réinitialiser les filtres');
 
     // then


### PR DESCRIPTION
Moulinette URLS ticket 3

## :fallen_leaf: Problème
Pour la moulinette des URLs cassées, le métier maintient à part des macros et autres outils sur google sheet pour ignorer une liste fixe d'urls qu'ils ne souhaitent pas traiter.

## :chestnut: Proposition
Pouvoir supprimer une URL de la liste blanche

## :jack_o_lantern: Remarques

## :wood: Pour tester
Y'a des seeds, ajouter des enregistrements directement en BDD et faire des suppressions
