### PR TITLE
[FEATURE] Je veux pouvoir ajouter une URL à la liste blanche (PIX-15182)

### DIFF
--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -1,9 +1,10 @@
 import Joi from 'joi';
 import * as securityPreHandlers from '../security-pre-handlers.js';
+import { Types } from '../types.js';
 import { whitelistedUrlReadRepository, whitelistedUrlRepository } from '../../infrastructure/repositories/index.js';
 import * as whitelistedUrlSerializer from '../../infrastructure/serializers/jsonapi/whitelisted-url-serializer.js';
 import { NotFoundWhitelistedUrlError } from '../../domain/errors.js';
-import { Types } from '../types.js';
+import { WhitelistedUrl } from '../../domain/models/index.js';
 
 export async function register(server) {
   server.route([
@@ -17,7 +18,8 @@ export async function register(server) {
           return h.response(whitelistedUrlSerializer.serialize(whitelistedUrls_read));
         },
       },
-    },{
+    },
+    {
       method: 'DELETE',
       path: '/api/whitelisted-urls/{whitelistedUrlId}',
       config: {
@@ -38,6 +40,29 @@ export async function register(server) {
           whitelistedUrlToDelete.delete(authenticatedUser);
           await whitelistedUrlRepository.save(whitelistedUrlToDelete);
           return h.response().code(204);
+        },
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/whitelisted-urls',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        handler: async function(request, h) {
+          const authenticatedUser = request.auth.credentials.user;
+          const attributes = request.payload.data.attributes;
+          const creationCommand = {
+            url: attributes['url'] ?? null,
+            relatedSkillNames: attributes['related-skill-names'] ?? null,
+            comment: attributes['comment'] ?? null,
+            checkType: attributes['check-type'] ?? null,
+          };
+          const existingWhitelistedUrls = await whitelistedUrlRepository.list();
+          WhitelistedUrl.canCreate(creationCommand, authenticatedUser, existingWhitelistedUrls);
+          const whitelistedUrlToCreate = WhitelistedUrl.create(creationCommand, authenticatedUser);
+          const id = await whitelistedUrlRepository.save(whitelistedUrlToCreate);
+          const createdWhitelistedUrl_read = await whitelistedUrlReadRepository.find(id);
+          return h.response(whitelistedUrlSerializer.serialize(createdWhitelistedUrl_read)).created();
         },
       },
     },

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -75,4 +75,11 @@ export class CommandWhitelistedUrlForbiddenError extends DomainError {
   }
 }
 
+export class CommandWhitelistedUrlError extends DomainError {
+  constructor({ message, attribute = 'irrelevant' }) {
+    super(message);
+    this.attribute = attribute;
+  }
+}
+
 export class ForbiddenError extends DomainError {}

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -1,4 +1,8 @@
-import { CommandWhitelistedUrlConflictError, CommandWhitelistedUrlForbiddenError, } from '../errors.js';
+import {
+  CommandWhitelistedUrlConflictError,
+  CommandWhitelistedUrlError,
+  CommandWhitelistedUrlForbiddenError,
+} from '../errors.js';
 
 export class WhitelistedUrl {
   constructor({
@@ -26,11 +30,38 @@ export class WhitelistedUrl {
     this.comment = comment;
     this.checkType = checkType;
   }
+
   static get CHECK_TYPES() {
     return {
       EXACT_MATCH: 'exact_match',
       STARTS_WITH: 'starts_with',
     };
+  }
+
+  static canCreate(creationCommand, user, existingWhitelistedUrls) {
+    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour créer une URL whitelistée');
+    if (!isUrlValid(creationCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
+    if (!isRelatedSkillNamesValid(creationCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
+    if (!isCommentValid(creationCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
+    if (!isCheckTypeValid(creationCommand.checkType)) throw new CommandWhitelistedUrlError({ message: `Type de check invalide. Valeurs parmi : ${Object.values(WhitelistedUrl.CHECK_TYPES).join(', ')}`, attribute: 'checkType' });
+    if (!isUrlUnique(creationCommand.url, existingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
+  }
+
+  static create(creationCommand, user) {
+    const operationDate = new Date();
+    return new WhitelistedUrl({
+      id: null,
+      createdBy: user.id,
+      latestUpdatedBy: user.id,
+      deletedBy: null,
+      createdAt: operationDate,
+      updatedAt: operationDate,
+      deletedAt: null,
+      url: creationCommand.url,
+      relatedSkillNames: creationCommand.relatedSkillNames,
+      comment: creationCommand.comment,
+      checkType: creationCommand.checkType,
+    });
   }
 
   canDelete(user) {
@@ -45,4 +76,33 @@ export class WhitelistedUrl {
     this.updatedAt = operationDate;
     this.deletedAt = operationDate;
   }
+}
+
+function isUrlValid(url) {
+  try {
+    new URL(url);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function isRelatedSkillNamesValid(relatedSkillNames) {
+  const skillsSeparatedByCommaRegex = /^(@[A-Za-z]+[0-9])(,(@[A-Za-z]+[0-9]))*/;
+  if (!relatedSkillNames) return true;
+  return skillsSeparatedByCommaRegex.test(relatedSkillNames);
+}
+
+function isCommentValid(comment) {
+  if (comment == null) return true;
+  return typeof comment === 'string';
+}
+
+function isCheckTypeValid(checkType) {
+  if (typeof checkType === 'string') return Object.values(WhitelistedUrl.CHECK_TYPES).includes(checkType);
+  return false;
+}
+
+function isUrlUnique(url, existingWhitelistedUrls) {
+  return existingWhitelistedUrls.every((whitelistedUrl) => whitelistedUrl.url !== url);
 }

--- a/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
@@ -1,8 +1,8 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { WhitelistedUrl } from '../../domain/readmodels/WhitelistedUrl.js';
 
-export async function list() {
-  const whitelistedUrlDtos = await knex('whitelisted_urls')
+function buildBaseReadQuery() {
+  return knex('whitelisted_urls')
     .select({
       id: 'whitelisted_urls.id',
       createdAt: 'whitelisted_urls.createdAt',
@@ -16,10 +16,23 @@ export async function list() {
     })
     .leftJoin('users as users_for_creation', 'users_for_creation.id', 'whitelisted_urls.createdBy')
     .leftJoin('users as users_for_update', 'users_for_update.id', 'whitelisted_urls.latestUpdatedBy')
-    .whereNull('deletedAt')
+    .whereNull('deletedAt');
+}
+
+export async function list() {
+  const whitelistedUrlDtos = await buildBaseReadQuery()
     .orderBy('url');
 
   return toDomainList(whitelistedUrlDtos);
+}
+
+export async function find(id) {
+  const whitelistedUrlDto = await buildBaseReadQuery()
+    .where('whitelisted_urls.id', id)
+    .first();
+
+  if (!whitelistedUrlDto) return null;
+  return toDomain(whitelistedUrlDto);
 }
 
 function toDomainList(whitelistedUrlDtos) {

--- a/api/lib/infrastructure/repositories/whitelisted-url-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-repository.js
@@ -1,9 +1,32 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { WhitelistedUrl } from '../../domain/models/index.js';
 
+function buildBaseReadQuery() {
+  return knex('whitelisted_urls')
+    .select([
+      'id',
+      'createdBy',
+      'latestUpdatedBy',
+      'deletedBy',
+      'createdAt',
+      'updatedAt',
+      'deletedAt',
+      'url',
+      'relatedSkillNames',
+      'comment',
+      'checkType'
+    ]);
+}
+
+export async function list() {
+  const whitelistedUrlDtos = await buildBaseReadQuery()
+    .orderBy('url');
+
+  return toDomainList(whitelistedUrlDtos);
+}
+
 export async function find(id) {
-  const whitelistedUrlDto = await knex('whitelisted_urls')
-    .select(['id', 'createdBy', 'latestUpdatedBy', 'deletedBy', 'createdAt', 'updatedAt', 'deletedAt', 'url', 'relatedSkillNames', 'comment', 'checkType'])
+  const whitelistedUrlDto = await buildBaseReadQuery()
     .where({ id })
     .first();
 
@@ -13,9 +36,20 @@ export async function find(id) {
 
 export async function save(whitelistedUrl) {
   const dataToSave = adaptModelToDB(whitelistedUrl);
-  const id = whitelistedUrl.id;
-  await knex('whitelisted_urls').update(dataToSave).where({ id });
+  let id;
+  if (whitelistedUrl.id) {
+    id = whitelistedUrl.id;
+    await knex('whitelisted_urls').update(dataToSave).where({ id });
+  } else {
+    const dataInserted = await knex('whitelisted_urls')
+      .insert(dataToSave, ['id']);
+    id = dataInserted[0].id;
+  }
   return id;
+}
+
+function toDomainList(whitelistedUrlDtos) {
+  return whitelistedUrlDtos.map(toDomain);
 }
 
 function toDomain(whitelistedUrlDto) {

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -64,6 +64,13 @@ function _mapToInfrastructureError(error) {
       statusCode: infraError.status,
     };
   }
+  if (error instanceof DomainErrors.CommandWhitelistedUrlError) {
+    const infraError = new InfraErrors.UnprocessableEntityError({ message: error.message, attribute: error.attribute });
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
 
   const infraError = new InfraErrors.InfrastructureError(error.message);
   return {

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -1,9 +1,22 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
-describe('Acceptance | Controller | whitelisted-urls', () => {
+describe('Acceptance | Controller | whitelisted-urls', () => {let now;
+  beforeEach(function() {
+    now = new Date('2024-10-29T03:04:00Z');
+    vi.useFakeTimers({
+      now,
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(function() {
+    vi.useRealTimers();
+    return knex('whitelisted_urls').del();
+  });
+
   describe('GET /whitelisted-urls', () => {
     let adminUser, server;
     beforeEach(async function() {
@@ -263,6 +276,144 @@ describe('Acceptance | Controller | whitelisted-urls', () => {
       const exists = await knex('whitelisted_urls').where({ id: 123 }).whereNotNull('deletedAt').first();
       expect(response.statusCode).to.equal(204);
       expect(exists.id).to.equal(123);
+    });
+  });
+  describe('POST /whitelisted-urls', () => {
+    let adminUser, server, validPayload;
+    beforeEach(async function() {
+      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@morse2,@saumon5',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: adminUser.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@truite2',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      await databaseBuilder.commit();
+      server = await createServer();
+      validPayload = {
+        data: {
+          attributes: {
+            url: 'https://super-casserole.com',
+            'related-skill-names': '@feutre2,@crayon1',
+            comment: 'Un super commentaire',
+            'check-type': WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+          },
+        },
+      };
+    });
+
+    it('should return a 403 status code when user is not admin', async () => {
+      // given
+      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/whitelisted-urls',
+        headers: generateAuthorizationHeader(notAdminUser),
+        payload: validPayload,
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            code: 403,
+            detail: 'Missing or insufficient permissions.',
+            title: 'Forbidden access',
+          },
+        ],
+      });
+    });
+
+    it('should return a 422 status code when creation command in invalid', async () => {
+      // when
+      const invalidPayload = JSON.parse(JSON.stringify(validPayload));
+      invalidPayload.data.attributes.url = 'je ne suis pas une bonne url';
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/whitelisted-urls',
+        headers: generateAuthorizationHeader(adminUser),
+        payload: invalidPayload,
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(422);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            status: '422',
+            title: 'Unprocessable entity',
+            detail: 'URL invalide',
+            source: { pointer: '/data/attributes/url' },
+          },
+        ],
+      });
+    });
+
+    it('should return a 201 status code and the serialized created whitelisted url', async () => {
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/whitelisted-urls',
+        headers: generateAuthorizationHeader(adminUser),
+        payload: validPayload,
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(201);
+      const [id] = await knex('whitelisted_urls').pluck('id').where('createdAt', now);
+      expect(response.result).toStrictEqual({
+        data: {
+          type: 'whitelisted-urls',
+          id: id.toString(),
+          attributes: {
+            'created-at': now,
+            'updated-at': now,
+            'creator-name': 'Madame Admin',
+            'latest-updator-name': 'Madame Admin',
+            url: 'https://super-casserole.com',
+            'related-skill-names': '@feutre2,@crayon1',
+            comment: 'Un super commentaire',
+            'check-type': 'exact_match',
+          },
+        },
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/whitelisted-url-read-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/whitelisted-url-read-repository_test.js
@@ -121,4 +121,159 @@ describe('Integration | Repository | whitelisted-url-read-repository', () => {
       expect(whitelistedUrls_read).toStrictEqual([]);
     });
   });
+
+  describe('#find', () => {
+
+    it('should retrieve given read whitelisted url by its id', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrl = await whitelistedUrlReadRepository.find(123);
+
+      // then
+      expect(whitelistedUrl).toStrictEqual(domainBuilder.buildWhitelistedUrlRead({
+        id: 123,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        creatorName: 'Madame Admin 1',
+        latestUpdatorName: 'Madame Admin 2',
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      }));
+    });
+
+    it('should return null when whitelisted url has been deleted', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrl = await whitelistedUrlReadRepository.find(789);
+
+      // then
+      expect(whitelistedUrl).toStrictEqual(null);
+    });
+
+    it('should return null when no entity found for id', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2024-01-01'),
+        deletedAt: new Date('2024-01-01'),
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrl = await whitelistedUrlReadRepository.find(777);
+
+      // then
+      expect(whitelistedUrl).toStrictEqual(null);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
@@ -1,9 +1,111 @@
-import { describe, expect, it } from 'vitest';
-import { databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as whitelistedUrlRepository from '../../../../lib/infrastructure/repositories/whitelisted-url-repository.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
 describe('Integration | Repository | whitelisted-url-repository', () => {
+  describe('#list', () => {
+
+    it('should retrieve all whitelisted urls ordered by url', async () => {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@bidule3,@chose2',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser1.id,
+        deletedBy: adminUser1.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@ours8',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const whitelistedUrls = await whitelistedUrlRepository.list();
+
+      // then
+      expect(whitelistedUrls).toStrictEqual([
+        domainBuilder.buildWhitelistedUrl({
+          id: 456,
+          createdBy: null,
+          latestUpdatedBy: null,
+          deletedBy: null,
+          createdAt: new Date('2020-12-12'),
+          updatedAt: new Date('2022-08-08'),
+          deletedAt: null,
+          url: 'https://www.editor.pix.fr',
+          relatedSkillNames: null,
+          comment: 'Mon site préféré',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        }),
+        domainBuilder.buildWhitelistedUrl({
+          id: 123,
+          createdBy: adminUser1.id,
+          latestUpdatedBy: adminUser2.id,
+          deletedBy: null,
+          createdAt: new Date('2020-01-01'),
+          updatedAt: new Date('2022-02-02'),
+          deletedAt: null,
+          url: 'https://www.google.com',
+          relatedSkillNames: '@bidule3,@chose2',
+          comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        }),
+        domainBuilder.buildWhitelistedUrl({
+          id: 789,
+          createdBy: adminUser1.id,
+          latestUpdatedBy: adminUser1.id,
+          deletedBy: adminUser1.id,
+          createdAt: new Date('2020-01-01'),
+          updatedAt: new Date('2022-02-02'),
+          deletedAt: new Date('2023-01-01'),
+          url: 'https://www.les-fruits-c-super-bon',
+          relatedSkillNames: '@ours8',
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        }),
+      ]);
+    });
+
+    it('should return an empty array when no whitelisted url in database', async () => {
+      // when
+      const whitelistedUrls = await whitelistedUrlRepository.list();
+
+      // then
+      expect(whitelistedUrls).toStrictEqual([]);
+    });
+  });
 
   describe('#find', () => {
 
@@ -110,6 +212,11 @@ describe('Integration | Repository | whitelisted-url-repository', () => {
     });
   });
   describe('#save', function() {
+
+    afterEach(function() {
+      return knex('whitelisted_urls').del();
+    });
+
     it('should update the whitelisted url', async function() {
       // given
       const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
@@ -148,6 +255,36 @@ describe('Integration | Repository | whitelisted-url-repository', () => {
       // then
       const savedWhitelistedUrl = await whitelistedUrlRepository.find(123);
       expect(savedWhitelistedUrl).toStrictEqual(whitelistedUrlToSave);
+    });
+
+    it('should insert a new whitelisted url', async function() {
+      // given
+      const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin' });
+      const adminUser2 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 2', access: 'admin' });
+      await databaseBuilder.commit();
+      const whitelistedUrlToSave = domainBuilder.buildWhitelistedUrl({
+        id: null,
+        createdBy: adminUser1.id,
+        latestUpdatedBy: adminUser2.id,
+        deletedBy: adminUser2.id,
+        createdAt: new Date('2022-02-02'),
+        updatedAt: new Date('2023-03-03'),
+        deletedAt: new Date('2024-04-04'),
+        url: 'https://www.bing.com',
+        relatedSkillNames: '@morse8',
+        comment: 'Je viens de créer cette entrée',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+
+      // when
+      const id = await whitelistedUrlRepository.save(whitelistedUrlToSave);
+
+      // then
+      const savedWhitelistedUrl = await whitelistedUrlRepository.find(id);
+      expect(savedWhitelistedUrl).toStrictEqual(domainBuilder.buildWhitelistedUrl({
+        ...whitelistedUrlToSave,
+        id,
+      }));
     });
   });
 });

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { User } from '../../../../lib/domain/models/index.js';
+import { User, WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 import {
   CommandWhitelistedUrlConflictError,
+  CommandWhitelistedUrlError,
   CommandWhitelistedUrlForbiddenError,
 } from '../../../../lib/domain/errors.js';
 
@@ -110,6 +111,264 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         url: 'https://www.google.com',
         relatedSkillNames: '@noix2,@chose8',
         comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+      }));
+    });
+  });
+
+  describe('#static canCreate', () => {
+    describe('can', function() {
+      it('should not throw when all conditions are reunited', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrl({
+          url: 'https://www.painperdu.com',
+        })];
+        const creationCommand1 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        };
+        const creationCommand2 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: '@choix1,@creux7',
+          comment: 'COucou',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+
+        // when
+        WhitelistedUrl.canCreate(creationCommand1, user, existingWhitelistedUrls);
+        WhitelistedUrl.canCreate(creationCommand2, user, []);
+
+        // then
+        expect(true).to.be.true;
+      });
+    });
+    describe('cannot', function() {
+      it('should throw a CommandWhitelistedUrlForbiddenError when user is not admin', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
+        const creationCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+
+        // when
+        try {
+          WhitelistedUrl.canCreate(creationCommand, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlForbiddenError(
+            'L\'utilisateur n\'a pas les droits pour créer une URL whitelistée'
+          ));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when url is not valid in creation command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const creationCommand1 = {
+          url: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const creationCommand2 = {
+          url: 'www.missing-protocol.com',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const creationCommand3 = {
+          url: 123456,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+
+        // when
+        try {
+          WhitelistedUrl.canCreate(creationCommand1, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'URL invalide',
+            attribute: 'url',
+          }));
+        }
+        try {
+          WhitelistedUrl.canCreate(creationCommand2, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'URL invalide',
+            attribute: 'url',
+          }));
+        }
+        try {
+          WhitelistedUrl.canCreate(creationCommand3, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'URL invalide',
+            attribute: 'url',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when relatedSkillNames is not in valid format in creation command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const creationCommand1 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: 123456.12,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const creationCommand2 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: 'je ne suis pas une suite d acquis',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+
+        // when
+        try {
+          WhitelistedUrl.canCreate(creationCommand1, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide',
+            attribute: 'relatedSkillNames',
+          }));
+        }
+        try {
+          WhitelistedUrl.canCreate(creationCommand2, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide',
+            attribute: 'relatedSkillNames',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when comment is not in valid format in creation command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const creationCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: 123,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+
+        // when
+        try {
+          WhitelistedUrl.canCreate(creationCommand, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'Commentaire invalide. Doit être un texte ou vide',
+            attribute: 'comment',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when checkType is not valid in creation command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const creationCommand1 = {
+          url: 'https://www.brioche.com',
+          checkType: 'autre_type',
+        };
+        const creationCommand2 = {
+          url: 'https://www.brioche.com',
+          checkType: null,
+        };
+        const creationCommand3 = {
+          url: 'https://www.brioche.com',
+          checkType: 456789,
+        };
+
+        // when
+        const allowedValues = Object.values(WhitelistedUrl.CHECK_TYPES).join(', ');
+        try {
+          WhitelistedUrl.canCreate(creationCommand1, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: `Type de check invalide. Valeurs parmi : ${allowedValues}`,
+            attribute: 'checkType',
+          }));
+        }
+        try {
+          WhitelistedUrl.canCreate(creationCommand2, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: `Type de check invalide. Valeurs parmi : ${allowedValues}`,
+            attribute: 'checkType',
+          }));
+        }
+        try {
+          WhitelistedUrl.canCreate(creationCommand3, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: `Type de check invalide. Valeurs parmi : ${allowedValues}`,
+            attribute: 'checkType',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlConflictError when url has already been whitelisted (case sensitive, exact match)', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrl({
+          url: 'https://www.brioche.com',
+        })];
+        const creationCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+
+        // when
+        try {
+          WhitelistedUrl.canCreate(creationCommand, user, existingWhitelistedUrls);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlConflictError(
+            'URL déjà whitelistée'
+          ));
+        }
+      });
+    });
+  });
+
+  describe('#static create', () => {
+    it('should return a newly created whitelisted url', function() {
+      // given
+      const user = domainBuilder.buildUser({ id: 444, access: User.ROLES.ADMIN });
+      const creationCommand = {
+        url: 'https://www.brioche.com',
+        relatedSkillNames: '@proie2,@cancre5',
+        comment: 'coucou maman',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      };
+
+      // when
+      const createdWhitelistedUrl = WhitelistedUrl.create(creationCommand, user);
+
+      // then
+      expect(createdWhitelistedUrl).toStrictEqual(domainBuilder.buildWhitelistedUrl({
+        id: null,
+        createdBy: 444,
+        latestUpdatedBy: 444,
+        deletedBy: null,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+        url: 'https://www.brioche.com',
+        relatedSkillNames: '@proie2,@cancre5',
+        comment: 'coucou maman',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
       }));
     });
   });

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -159,6 +159,21 @@ describe('Unit | Infrastructure | ErrorManager', function() {
             ],
           });
         }
+        else if (domainErrorName === 'CommandWhitelistedUrlError') {
+          const errorCommandWhitelistedUrl = new domainErrorClass({ message, attribute });
+          const responseCommandWhitelistedUrl = send(hFake, errorCommandWhitelistedUrl);
+          expect(responseCommandWhitelistedUrl.statusCode, expectErrorMessage).toStrictEqual(422);
+          expect(responseCommandWhitelistedUrl.source).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                detail: 'error message',
+                source: { pointer: '/data/attributes/attribute-in-error' },
+              },
+            ],
+          });
+        }
         else {
           expect(true, `Conversion for ${domainErrorName} not tested`).to.be.false;
         }

--- a/pix-editor/app/components/form/whitelisted-url.hbs
+++ b/pix-editor/app/components/form/whitelisted-url.hbs
@@ -1,0 +1,73 @@
+<form {{on "submit" this.onSubmitClicked}} class="form">
+  <Card class="new-whitelisted-url-form-field" @title="1. Détails de l'URL">
+    <div class="new-whitelisted-url-details">
+      <PixSelect
+        @id="whitelisted-url-check-type"
+        @errorMessage={{this.checkType.errorMessage}}
+        @requiredLabel={{this.checkType.errorMessage}}
+        @validationStatus={{this.checkType.state}}
+        @value={{this.checkType.value}}
+        @options={{this.checkTypeOptions}}
+        @hideDefaultOption={{true}}
+        @onChange={{this.updateCheckType}}
+      >
+        <:label>Type de comparaison d'URL</:label>
+      </PixSelect>
+      <PixInput
+        @id="whitelisted-url-link"
+        @errorMessage={{this.url.errorMessage}}
+        @requiredLabel={{this.url.errorMessage}}
+        @validationStatus={{this.url.state}}
+        @value={{this.url.value}}
+        placeholder="https://example.org"
+        {{on "input" this.updateUrl}}
+      >
+        <:label>URL à whitelister</:label>
+      </PixInput>
+    </div>
+  </Card>
+  <Card class="new-whitelisted-url-form-field" @title="2. Informations additionnelles">
+    <PixInput
+      @id="whitelisted-url-related-skill-names"
+      @errorMessage={{this.relatedSkillNames.errorMessage}}
+      @validationStatus={{this.relatedSkillNames.state}}
+      @value={{this.relatedSkillNames.value}}
+      placeholder="@exemple1,@test3, ..."
+      {{on "input" this.updateRelatedSkillNames}}
+    >
+      <:label>Nom des acquis concernés, séparés par des virgules</:label>
+    </PixInput>
+    <PixTextarea
+      @id="whitelisted-url-comment"
+      @maxlength="1024"
+      rows="5"
+      @value={{this.comment.value}}
+      {{on "input" this.updateComment}}
+    >
+      <:label>Commentaire explicatif</:label>
+    </PixTextarea>
+  </Card>
+  <div class="form-error">
+    {{#each this.errorMessages as |errorMessage|}}
+      {{errorMessage}}<br/>
+    {{/each}}
+  </div>
+  <div class="page-actions">
+    <PixButton
+      @variant="secondary"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @triggerAction={{@onFormCancelled}}
+    >
+      {{@cancelButtonText}}
+    </PixButton>
+    <PixButton
+      @backgroundColor="blue"
+      @type="submit"
+      @isDisabled={{this.isFormInvalid}}
+      @isLoading={{this.isSubmitting}}
+    >
+      {{@submitButtonText}}
+    </PixButton>
+  </div>
+</form>

--- a/pix-editor/app/components/form/whitelisted-url.js
+++ b/pix-editor/app/components/form/whitelisted-url.js
@@ -1,0 +1,233 @@
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class WhitelistedUrlForm extends Component {
+  @service store;
+
+  @tracked url = new UrlField();
+  @tracked comment = new CommentField();
+  @tracked relatedSkillNames = new RelatedSkillNamesField();
+  @tracked checkType = new CheckTypeField();
+  @tracked isFormInvalid = true;
+  @tracked isSubmitting = false;
+  @tracked errorMessages = A([]);
+
+  checkTypeOptions = [
+    {
+      value: 'exact_match',
+      label: 'Strictement égale à',
+    },
+    {
+      value: 'starts_with',
+      label: 'Commence par',
+    },
+  ];
+
+  constructor(...args) {
+    super(...args);
+
+    if (this.args.initialUrl.length > 0) {
+      this.url.setValue(this.args.initialUrl);
+      this.url.validate();
+    }
+    if (this.args.initialComment.length > 0) {
+      this.comment.setValue(this.args.initialComment);
+      this.comment.validate();
+    }
+    if (this.args.initialRelatedSkillNames.length > 0) {
+      this.relatedSkillNames.setValue(this.args.relatedSkillNames);
+      this.relatedSkillNames.validate();
+    }
+    if (this.args.initialCheckType.length > 0) {
+      this.checkType.setValue(this.args.initialCheckType);
+    } else {
+      this.checkType.setValue(this.checkTypeOptions[0].value);
+    }
+    this.checkType.validate();
+    this.checkFormValidity();
+  }
+
+  @action
+  async onSubmitClicked(event) {
+    event.preventDefault();
+    this.errorMessages.length = 0;
+    this.isSubmitting = true;
+    const formData = {
+      url: this.url.getValueForSubmit(),
+      comment: this.comment.getValueForSubmit(),
+      relatedSkillNames: this.relatedSkillNames.getValueForSubmit(),
+      checkType: this.checkType.getValueForSubmit(),
+    };
+    try {
+      await this.args.onFormSubmitted(formData);
+    } catch (err) {
+      this.errorMessages.pushObjects(err.message.split('\n'));
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  @action
+  updateUrl(event) {
+    this.url.setValue(event.target.value);
+    this.url.validate();
+    this.checkFormValidity();
+  }
+
+  @action
+  updateComment(event) {
+    this.comment.setValue(event.target.value);
+    this.comment.validate();
+    this.checkFormValidity();
+  }
+
+  @action
+  updateRelatedSkillNames(event) {
+    this.relatedSkillNames.setValue(event.target.value);
+    this.relatedSkillNames.validate();
+    this.checkFormValidity();
+  }
+
+  @action
+  updateCheckType(value) {
+    this.checkType.setValue(value);
+    this.checkType.validate();
+    this.checkFormValidity();
+  }
+
+  checkFormValidity() {
+    this.isFormInvalid = !this.url.isValid || !this.relatedSkillNames.isValid || !this.checkType.isValid || !this.comment.isValid;
+  }
+}
+
+class FormField {
+  static STATES = {
+    DEFAULT: 'default',
+    SUCCESS: 'success',
+    ERROR: 'error',
+  };
+
+  @tracked state;
+  @tracked value;
+  @tracked errorMessage;
+
+  constructor({ state = FormField.STATES.DEFAULT, value = '', errorMessage = '' } = {}) {
+    this.state = state;
+    this.value = value;
+    this.errorMessage = errorMessage;
+  }
+
+  get isError() {
+    return this.state === FormField.STATES.ERROR;
+  }
+
+  get isValid() {
+    return this.state === FormField.STATES.SUCCESS;
+  }
+
+  setValue(value) {
+    this.value = value;
+  }
+
+  validate() { throw new Error('implement me');}
+
+  getValueForSubmit() { throw new Error('implement me');}
+}
+
+class UrlField extends FormField {
+  constructor() {
+    super();
+  }
+
+  validate() {
+    if (this.value.trim().length > 0) {
+      try {
+        new URL(this.value);
+        this.state = FormField.STATES.SUCCESS;
+        this.errorMessage = '';
+      } catch {
+        this.state = FormField.STATES.ERROR;
+        this.errorMessage = 'L\'URL n\'est pas valide';
+      }
+    } else {
+      this.state = FormField.STATES.ERROR;
+      this.errorMessage = 'L\'URL est obligatoire';
+    }
+  }
+
+  getValueForSubmit() { return this.value.trim(); }
+}
+
+class CommentField extends FormField {
+
+  get isValid() { return true; };
+
+  validate() { this.state = FormField.STATES.SUCCESS; }
+
+  getValueForSubmit() { return this.value.trim(); }
+}
+
+class RelatedSkillNamesField extends FormField {
+  constructor() {
+    super();
+  }
+
+  get isValid() {
+    return this.state === FormField.STATES.SUCCESS || this.state === FormField.STATES.DEFAULT;
+  }
+
+  validate() {
+    const relatedSkillNames = this.getValueForSubmit();
+
+    if (relatedSkillNames.length === 0) {
+      this.state = FormField.STATES.DEFAULT;
+      this.errorMessage = '';
+      return;
+    }
+
+    const hasAnyMalformedNames = relatedSkillNames.split(',')
+      .filter((name) => name !== '')
+      .some((name) => !name.match(/^@[A-Za-z]+\d$/));
+    if (hasAnyMalformedNames) {
+      this.state = FormField.STATES.ERROR;
+      this.errorMessage = 'Les noms d\'acquis doivent être séparés par des virgules et ne peuvent pas être vides.';
+      return;
+    }
+
+    this.state = FormField.STATES.SUCCESS;
+    this.errorMessage = '';
+  }
+
+  getValueForSubmit() {
+    return this.value.trim()
+      .split(',')
+      .map((name) => name.trim())
+      .filter((name) => name !== '')
+      .join(',');
+  }
+}
+
+class CheckTypeField extends FormField {
+  static OPTIONS = ['starts_with', 'exact_match'];
+
+  constructor() {
+    super();
+  }
+
+  validate() {
+    if (CheckTypeField.OPTIONS.includes(this.value)) {
+      this.state = FormField.STATES.SUCCESS;
+      this.errorMessage = '';
+    } else {
+      this.state = FormField.STATES.ERROR;
+      this.errorMessage = 'Type de comparaison non reconnu';
+    }
+  }
+
+  getValueForSubmit() {
+    return this.value;
+  }
+}

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/new.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/new.js
@@ -1,0 +1,30 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class NewWhitelistedUrlController extends Controller {
+  @service store;
+  @service router;
+  @service notifications;
+
+  @action
+  async createWhitelistedUrl(formData) {
+    const whitelistedUrl = this.store.createRecord('whitelisted-url', formData);
+    try {
+      await whitelistedUrl.save();
+      this.notifications.success('URL ajoutée à la whitelist avec succès.');
+      this.router.transitionTo('authenticated.whitelisted-urls.list');
+    } catch (err) {
+      whitelistedUrl.deleteRecord();
+      await this.notifications.error('Une erreur est survenue lors de l\'ajout de l\'URL à la whitelist');
+      const knownErrors = err?.errors.map((error) => error.detail).join('\n');
+      const finalErrors = knownErrors ?? JSON.stringify(err);
+      throw new Error(finalErrors);
+    }
+  }
+
+  @action
+  async goBackToList() {
+    this.router.transitionTo('authenticated.whitelisted-urls.list');
+  }
+}

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -78,6 +78,7 @@ Router.map(function() {
     this.route('synchronize-translations');
     this.route('whitelisted-urls', function() {
       this.route('list', { path: '/' });
+      this.route('new');
     });
   });
 });

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
@@ -18,6 +18,7 @@ export default class WhitelistedUrlsRoute extends Route {
     const whitelistedUrls = await this.store.findAll('whitelisted-url', { reload: true });
     return {
       whitelistedUrls,
+      mayCreateWhitelistedUrl: this.access.mayCreateOrEditWhitelistedUrl(),
     };
   }
 }

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/new.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/new.js
@@ -1,0 +1,19 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class WhitelistedUrlNewRoute extends Route {
+  @service access;
+  @service router;
+  @service store;
+
+  beforeModel() {
+    if (!this.access.mayCreateOrEditWhitelistedUrl()) {
+      this.router.transitionTo('authenticated.whitelisted-urls.list');
+    }
+  }
+
+  async model() {
+    const whitelistedUrls = await this.store.findAll('whitelisted-url', { reload: true });
+    return { whitelistedUrls };
+  }
+}

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -161,6 +161,10 @@ export default class AccessService extends Service {
     return this.isAdmin();
   }
 
+  mayCreateOrEditWhitelistedUrl() {
+    return this.isAdmin();
+  }
+
   mayCreateOrEditStaticCourse() {
     return this.isEditor();
   }

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -28,6 +28,7 @@
 @import 'authenticated/static-courses/list';
 @import 'authenticated/static-courses/static-course';
 @import 'authenticated/whitelisted-urls/list';
+@import 'authenticated/whitelisted-urls/new';
 @import 'authenticated/synchronize-translations';
 @import 'components/card';
 @import 'components/login-form';

--- a/pix-editor/app/styles/authenticated/whitelisted-urls/new.scss
+++ b/pix-editor/app/styles/authenticated/whitelisted-urls/new.scss
@@ -1,0 +1,13 @@
+.new-whitelisted-url-details {
+  display: flex;
+  gap: 1.5rem;
+}
+
+#whitelisted-url-check-type span {
+  margin-block: 0;
+}
+
+
+#whitelisted-url-link {
+  display: block;
+}

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
@@ -1,5 +1,30 @@
 <header class="page-header">
   <h1 class="page-title">Whitelist de la moulinette des URLs cassées</h1>
+  <div class="page-actions">
+    <PixTooltip
+      @id='create-whitelisted-url-tooltip'
+      @position="bottom-left"
+      @hide={{this.model.mayCreateWhitelistedUrl}}
+    >
+      <:triggerElement>
+        <PixButtonLink
+          @route="authenticated.whitelisted-urls.new"
+          @backgroundColor="blue"
+          @isDisabled={{not this.model.mayCreateWhitelistedUrl}}
+          aria-describedby='create-whitelisted-url-tooltip'
+          class="pix-button-link-with-icon white-font"
+        >
+          <FaIcon @icon="plus" @prefix="fas">
+          </FaIcon>
+          Ajouter une nouvelle URL
+        </PixButtonLink>
+      </:triggerElement>
+
+      <:tooltip>
+        Vous n'avez pas les droits suffisants pour ajouter une URL.
+      </:tooltip>
+    </PixTooltip>
+  </div>
 </header>
 <main class="page-body">
   <section class="page-section">

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/new.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/new.hbs
@@ -1,0 +1,17 @@
+<header class="page-header">
+  <h1 class="page-title">Ajout d'une URL whitelistée</h1>
+</header>
+<main class="page-body">
+  <section class="page-section">
+    <Form::WhitelistedUrl
+      @initialUrl=""
+      @initialComment=""
+      @initialRelatedSkillNames=""
+      @initialCheckType=""
+      @cancelButtonText="Annuler"
+      @onFormCancelled={{this.goBackToList}}
+      @submitButtonText={{"Ajouter l'URL à la whitelist"}}
+      @onFormSubmitted={{this.createWhitelistedUrl}}
+    />
+  </section>
+</main>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -456,6 +456,19 @@ function routes() {
 
   this.get('/whitelisted-urls');
   this.delete('/whitelisted-urls/:id');
+  this.post('/whitelisted-urls', function(schema, request) {
+    const whitelistedUrl = JSON.parse(request.requestBody).data.attributes;
+    return schema.create('whitelisted-url', {
+      url: whitelistedUrl.url,
+      relatedSkillNames: whitelistedUrl['related-skill-names'],
+      checkType: whitelistedUrl['check-type'],
+      comment: whitelistedUrl.comment,
+      creatorName: 'TEST USER',
+      createdAt: new Date().toISOString(),
+      latestUpdatorName: 'TEST USER',
+      updatedAt: new Date().toISOString(),
+    });
+  });
 }
 
 function _serializeModel(instance, modelName) {

--- a/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
@@ -1,0 +1,96 @@
+import { clickByName, clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../setup-application-rendering';
+
+module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    const notifications = this.owner.lookup('service:notifications');
+    notifications.setDefaultClearDuration(50);
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+    this.server.create('whitelisted-url', {
+      id: 1,
+      createdAt: new Date('2020-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      creatorName: null,
+      latestUpdatorName: 'Ma maman',
+      url: 'http://pipeau-la-grenouille.fr',
+      relatedSkillNames: '@noix2,@souris8',
+      checkType: 'starts_with',
+      comment: 'Les grenouilles sont jolies',
+    });
+    this.server.create('whitelisted-url', {
+      id: 2,
+      createdAt: new Date('2020-02-02'),
+      updatedAt: new Date('2021-02-02'),
+      creatorName: 'Mon chat',
+      latestUpdatorName: null,
+      url: 'http://chats.fr',
+      relatedSkillNames: null,
+      checkType: 'exact_match',
+      comment: 'MIAOU',
+    });
+    this.server.create('whitelisted-url', {
+      id: 3,
+      createdAt: new Date('2020-03-03'),
+      updatedAt: new Date('2021-03-03'),
+      creatorName: 'Mon chien',
+      latestUpdatorName: null,
+      url: 'http://chiens.fr',
+      relatedSkillNames: '@noix3',
+      checkType: 'exact_match',
+      comment: 'OUAF',
+    });
+
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
+    return authenticateSession();
+  });
+
+  test('should create a whitelisted url', async function(assert) {
+    // given
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('Ajouter une nouvelle URL');
+
+    // when
+    await fillByLabel('URL à whitelister', 'https://example.org');
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
+    await fillByLabel('Commentaire explicatif', 'Test de création');
+    await clickByName('Ajouter l\'URL à la whitelist');
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls');
+    assert.dom(screen.getByText('Test de création')).exists();
+    assert.dom(screen.getByText('https://example.org')).exists();
+    assert.dom(screen.getByText('@test1,@test2')).exists();
+    assert.strictEqual(screen.getAllByText('Strictement égale à').length, 3);
+  });
+
+  test('should create a whitelisted url without comment and different check type', async function(assert) {
+    // given
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('Ajouter une nouvelle URL');
+
+    // when
+    await clickByName('Type de comparaison d\'URL');
+    await clickByText('Commence par');
+    await fillByLabel('URL à whitelister', 'https://example.org');
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
+    await clickByName('Ajouter l\'URL à la whitelist');
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls');
+    assert.dom(screen.queryByText('Test de création')).doesNotExist();
+    assert.dom(screen.getByText('https://example.org')).exists();
+    assert.dom(screen.getByText('@test1,@test2')).exists();
+    assert.strictEqual(screen.getAllByText('Commence par').length, 2);
+  });
+});

--- a/pix-editor/tests/integration/components/form/whitelisted-url-test.js
+++ b/pix-editor/tests/integration/components/form/whitelisted-url-test.js
@@ -1,0 +1,136 @@
+import { clickByName, clickByText, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | Form | whitelisted-url', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('should submit correctly formed whitelisted url', async function(assert) {
+
+    const onSubmit = sinon.spy(() => {});
+
+    this.set('submitButtonText', 'Ajouter l\'URL à la whitelist');
+    this.set('createWhitelistedUrl', onSubmit);
+
+    const screen = await render(
+      hbs`<Form::WhitelistedUrl
+        @initialUrl=""
+        @initialComment=""
+        @initialRelatedSkillNames=""
+        @initialCheckType=""
+        @submitButtonText={{this.submitButtonText}}
+        @onFormSubmitted={{this.createWhitelistedUrl}}
+      />`);
+
+    await fillByLabel('URL à whitelister', 'https://example.org');
+
+    const submitButton = screen.getByRole('button', { name: 'Ajouter l\'URL à la whitelist' });
+    await click(submitButton);
+    assert.ok(onSubmit.calledOnce);
+    assert.deepEqual(onSubmit.args[0][0], {
+      checkType: 'exact_match',
+      url: 'https://example.org',
+      comment: '',
+      relatedSkillNames: '',
+    });
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
+    await click(submitButton);
+    assert.ok(onSubmit.calledTwice);
+    assert.strictEqual(onSubmit.args[1][0].relatedSkillNames, '@test1,@test2');
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', ' @test1,  ,,@test2  ');
+    await click(submitButton);
+    assert.ok(onSubmit.calledThrice);
+    assert.strictEqual(onSubmit.args[2][0].relatedSkillNames, '@test1,@test2');
+
+    await clickByName('Type de comparaison d\'URL');
+    await clickByText('Commence par');
+    await click(submitButton);
+    assert.strictEqual(onSubmit.callCount, 4);
+    assert.strictEqual(onSubmit.args[3][0].checkType, 'starts_with');
+  });
+
+  test('should enable add url button when mandatory information has been given', async function(assert) {
+
+    this.set('submitButtonText', 'Ajouter l\'URL à la whitelist');
+
+    const screen = await render(
+      hbs`<Form::WhitelistedUrl
+        @initialUrl=""
+        @initialComment=""
+        @initialRelatedSkillNames=""
+        @initialCheckType=""
+        @submitButtonText={{this.submitButtonText}}
+      />`);
+
+    await fillByLabel('URL à whitelister', 'https://example.org');
+
+    const button = screen.getByRole('button', { name: 'Ajouter l\'URL à la whitelist' });
+    assert.dom(button).doesNotHaveAttribute('disabled');
+  });
+
+  test('should disable create mission button when no complete informations', async function(assert) {
+
+    this.set('submitButtonText', 'Ajouter l\'URL à la whitelist');
+
+    const screen = await render(
+      hbs`<Form::WhitelistedUrl
+        @initialUrl=""
+        @initialComment=""
+        @initialRelatedSkillNames=""
+        @initialCheckType=""
+        @submitButtonText={{this.submitButtonText}}
+      />`);
+
+    const button = screen.getByRole('button', { name: 'Ajouter l\'URL à la whitelist' });
+    assert.dom(button).hasAttribute('disabled');
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
+    await fillByLabel('Commentaire explicatif', 'Ça rend la chose plus claire');
+    assert.dom(button).hasAttribute('disabled');
+  });
+
+  test('should display errors when input values are unexpected', async function(assert) {
+    const screen = await render(
+      hbs`<Form::WhitelistedUrl
+        @initialUrl=""
+        @initialComment=""
+        @initialRelatedSkillNames=""
+        @initialCheckType=""
+        @submitButtonText={{this.submitButtonText}}
+      />`);
+
+    await fillByLabel('URL à whitelister', '');
+    const urlErrorMandatoryField = screen.getByText('L\'URL est obligatoire');
+    assert.dom(urlErrorMandatoryField).isVisible();
+
+    await fillByLabel('* URL à whitelister', 'chouchou beignets');
+    const urlErrorInvalidUrl = screen.getByText('L\'URL n\'est pas valide');
+    assert.dom(urlErrorInvalidUrl).isVisible();
+
+    await fillByLabel('* URL à whitelister', 'https://example.org');
+    assert.dom(urlErrorInvalidUrl).isNotVisible();
+    assert.dom(urlErrorMandatoryField).isNotVisible();
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', 'test');
+    const skillNamesError = screen.getByText('Les noms d\'acquis doivent être séparés par des virgules et ne peuvent pas être vides.');
+    assert.dom(skillNamesError).isVisible();
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test');
+    assert.dom(skillNamesError).isVisible();
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test,@abc');
+    assert.dom(skillNamesError).isVisible();
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test,@abc1');
+    assert.dom(skillNamesError).isVisible();
+
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test2,@abc1');
+    assert.dom(skillNamesError).isNotVisible();
+  });
+});

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -174,4 +174,28 @@ module('Unit | Service | access', function(hooks) {
       assert.ok(accessResult);
     });
   });
+
+  module('mayCreateOrEditWhitelistedUrl', function() {
+    test('it should return `false` when is not admin', function(assert) {
+      // given
+      _stubAccessLevel(EDITOR, this.owner);
+
+      //when
+      const accessResult = accessService.mayCreateOrEditWhitelistedUrl();
+
+      //then
+      assert.notOk(accessResult);
+    });
+
+    test('it should return `true` when is admin', function(assert) {
+      // given
+      _stubAccessLevel(ADMIN, this.owner);
+
+      //when
+      const accessResult = accessService.mayCreateOrEditWhitelistedUrl();
+
+      //then
+      assert.ok(accessResult);
+    });
+  });
 });


### PR DESCRIPTION
Moulinette URLS ticket 4

## :fallen_leaf: Problème
Pour la moulinette des URLs cassées, le métier maintient à part des macros et autres outils sur google sheet pour ignorer une liste fixe d'urls qu'ils ne souhaitent pas traiter.

## :chestnut: Proposition
Pouvoir ajouter une URL à la liste blanche

## :jack_o_lantern: Remarques

## :wood: Pour tester
Faire des ajouts et des suppressions et voir si tout est OK
