### PR TITLE
[BUGFIX] Erreur 500 sur le endpoint /competences/{id}/overviews/challenges-production (PIX-15211)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -23,7 +23,6 @@ export const tubeDatasource = datasource.extend({
       airtableId: airtableRecord.id,
       name: airtableRecord.get('Nom'),
       index: airtableRecord.get('Index'),
-      // FIXME remplacer par Competence (via Thematique) (id persistant) ?
       competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
     };
   },
@@ -31,7 +30,7 @@ export const tubeDatasource = datasource.extend({
   async listByCompetenceId(competenceId) {
     const airtableRawObjects = await findRecords(this.tableName, {
       fields: this.usedFields,
-      filterByFormula: `{Competence (via Thematique) (id persistant)} = ${stringValue(competenceId)}`,
+      filterByFormula: `{Competences (id persistant)} = ${stringValue(competenceId)}`,
     });
     if (airtableRawObjects.length === 0) return undefined;
     return airtableRawObjects.map(this.fromAirTableObject);

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -74,7 +74,7 @@ describe('Acceptance | Route | competence-overviews', () => {
           fields: {
             '': tubeDatasource.usedFields,
           },
-          filterByFormula: `{Competence (via Thematique) (id persistant)} = "${competenceId}"`
+          filterByFormula: `{Competences (id persistant)} = "${competenceId}"`
         })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: airtableTubes });

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -158,7 +158,7 @@ describe('Integration | Repository | tube-repository', () => {
       await databaseBuilder.commit();
       vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Tubes') expect.unreachable('Airtable tableName should be Tubes');
-        if (options?.filterByFormula !==  `{Competence (via Thematique) (id persistant)} = ${stringValue(tube1.competenceId)}`) expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !==  `{Competences (id persistant)} = ${stringValue(tube1.competenceId)}`) expect.unreachable('Wrong filterByFormula');
         return [{
           id: 'airtableTubeId1',
           fields: {


### PR DESCRIPTION
## :fallen_leaf: Problème
La datasource pour les tubes utilise une colonne Airtable qui est dépréciée.

## :chestnut: Proposition
Cesser d’utiliser cette colonne.

## :jack_o_lantern: Remarques
La colonne était dépréciée mais seulement sur le Airtable de prod...

## :wood: Pour tester
Charger la vue production challenges.