### PR TITLE
[FEATURE] Je veux pouvoir modifier une URL de la liste blanche (PIX-15183)

### DIFF
--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -66,6 +66,40 @@ export async function register(server) {
         },
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/whitelisted-urls/{whitelistUrlId}',
+      config: {
+        validate: {
+          params: Joi.object({
+            whitelistUrlId: Types.whitelistedUrlId().required(),
+          }),
+        },
+        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        handler: async function(request, h) {
+          const authenticatedUser = request.auth.credentials.user;
+          const attributes = request.payload.data.attributes;
+          const whitelistedUrlId = request.params.whitelistUrlId;
+          const updateCommand = {
+            url: attributes['url'] ?? null,
+            relatedSkillNames: attributes['related-skill-names'] ?? null,
+            comment: attributes['comment'] ?? null,
+            checkType: attributes['check-type'] ?? null,
+          };
+          const whitelistedUrlToUpdate = await whitelistedUrlRepository.find(whitelistedUrlId);
+          if (!whitelistedUrlToUpdate) {
+            throw new NotFoundWhitelistedUrlError(`L'URL whitelistée d'id ${whitelistedUrlId} n'existe pas`);
+          }
+          const existingWhitelistedUrls = await whitelistedUrlReadRepository.list();
+          const existingWhitelistedUrlsExceptUpdatedOne = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.id !== whitelistedUrlId);
+          whitelistedUrlToUpdate.canUpdate(updateCommand, authenticatedUser, existingWhitelistedUrlsExceptUpdatedOne);
+          whitelistedUrlToUpdate.update(updateCommand, authenticatedUser);
+          await whitelistedUrlRepository.save(whitelistedUrlToUpdate);
+          const updatedWhitelistedUrl = await whitelistedUrlReadRepository.find(whitelistedUrlId);
+          return h.response(whitelistedUrlSerializer.serialize(updatedWhitelistedUrl));
+        },
+      },
+    },
   ]);
 }
 

--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -90,9 +90,8 @@ export async function register(server) {
           if (!whitelistedUrlToUpdate) {
             throw new NotFoundWhitelistedUrlError(`L'URL whitelistée d'id ${whitelistedUrlId} n'existe pas`);
           }
-          const existingWhitelistedUrls = await whitelistedUrlReadRepository.list();
-          const existingWhitelistedUrlsExceptUpdatedOne = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.id !== whitelistedUrlId);
-          whitelistedUrlToUpdate.canUpdate(updateCommand, authenticatedUser, existingWhitelistedUrlsExceptUpdatedOne);
+          const existingWhitelistedUrls = await whitelistedUrlRepository.list();
+          whitelistedUrlToUpdate.canUpdate(updateCommand, authenticatedUser, existingWhitelistedUrls);
           whitelistedUrlToUpdate.update(updateCommand, authenticatedUser);
           await whitelistedUrlRepository.save(whitelistedUrlToUpdate);
           const updatedWhitelistedUrl = await whitelistedUrlReadRepository.find(whitelistedUrlId);

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -1,4 +1,5 @@
 import {
+  NotFoundWhitelistedUrlError,
   CommandWhitelistedUrlConflictError,
   CommandWhitelistedUrlError,
   CommandWhitelistedUrlForbiddenError,
@@ -75,6 +76,26 @@ export class WhitelistedUrl {
     this.deletedBy = user.id;
     this.updatedAt = operationDate;
     this.deletedAt = operationDate;
+  }
+
+  canUpdate(updateCommand, user, existingReadWhitelistedUrls) {
+    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour mettre à jour cette URL whitelistée');
+    if (this.deletedAt) throw new NotFoundWhitelistedUrlError('L\'URL whitelistée n\'existe pas');
+    if (!isUrlValid(updateCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
+    if (!isRelatedSkillNamesValid(updateCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
+    if (!isCommentValid(updateCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
+    if (!isCheckTypeValid(updateCommand.checkType)) throw new CommandWhitelistedUrlError({ message: `Type de check invalide. Valeurs parmi : ${Object.values(WhitelistedUrl.CHECK_TYPES).join(', ')}`, attribute: 'checkType' });
+    if (!isUrlUnique(updateCommand.url, existingReadWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
+  }
+
+  update(updateCommand, user) {
+    const operationDate = new Date();
+    this.latestUpdatedBy = user.id;
+    this.updatedAt = operationDate;
+    this.url = updateCommand.url;
+    this.relatedSkillNames = updateCommand.relatedSkillNames;
+    this.comment = updateCommand.comment;
+    this.checkType = updateCommand.checkType;
   }
 }
 

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -1,8 +1,8 @@
 import {
-  NotFoundWhitelistedUrlError,
   CommandWhitelistedUrlConflictError,
   CommandWhitelistedUrlError,
   CommandWhitelistedUrlForbiddenError,
+  NotFoundWhitelistedUrlError,
 } from '../errors.js';
 
 export class WhitelistedUrl {
@@ -39,13 +39,18 @@ export class WhitelistedUrl {
     };
   }
 
+  get isActive() {
+    return this.deletedAt === null;
+  }
+
   static canCreate(creationCommand, user, existingWhitelistedUrls) {
+    const activeExistingWhitelistedUrls = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive);
     if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour créer une URL whitelistée');
     if (!isUrlValid(creationCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
     if (!isRelatedSkillNamesValid(creationCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
     if (!isCommentValid(creationCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
     if (!isCheckTypeValid(creationCommand.checkType)) throw new CommandWhitelistedUrlError({ message: `Type de check invalide. Valeurs parmi : ${Object.values(WhitelistedUrl.CHECK_TYPES).join(', ')}`, attribute: 'checkType' });
-    if (!isUrlUnique(creationCommand.url, existingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
+    if (!isUrlUnique(creationCommand.url, activeExistingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
   }
 
   static create(creationCommand, user) {
@@ -78,14 +83,15 @@ export class WhitelistedUrl {
     this.deletedAt = operationDate;
   }
 
-  canUpdate(updateCommand, user, existingReadWhitelistedUrls) {
+  canUpdate(updateCommand, user, existingWhitelistedUrls) {
+    const activeOtherExistingWhitelistedUrls = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive && whitelistedUrl.id !== this.id);
     if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour mettre à jour cette URL whitelistée');
     if (this.deletedAt) throw new NotFoundWhitelistedUrlError('L\'URL whitelistée n\'existe pas');
     if (!isUrlValid(updateCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
     if (!isRelatedSkillNamesValid(updateCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
     if (!isCommentValid(updateCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
     if (!isCheckTypeValid(updateCommand.checkType)) throw new CommandWhitelistedUrlError({ message: `Type de check invalide. Valeurs parmi : ${Object.values(WhitelistedUrl.CHECK_TYPES).join(', ')}`, attribute: 'checkType' });
-    if (!isUrlUnique(updateCommand.url, existingReadWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
+    if (!isUrlUnique(updateCommand.url, activeOtherExistingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
   }
 
   update(updateCommand, user) {

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -416,4 +416,141 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       });
     });
   });
+  describe('PATCH /whitelisted-urls/{whitelistedUrlId}', () => {
+    let adminUser, server, validPayload;
+    beforeEach(async function() {
+      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 123,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@morse2,@saumon5',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 456,
+        createdBy: null,
+        latestUpdatedBy: null,
+        deletedBy: null,
+        createdAt: new Date('2020-12-12'),
+        updatedAt: new Date('2022-08-08'),
+        deletedAt: null,
+        url: 'https://www.editor.pix.fr',
+        relatedSkillNames: null,
+        comment: 'Mon site préféré',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      databaseBuilder.factory.buildWhitelistedUrl({
+        id: 789,
+        createdBy: adminUser.id,
+        latestUpdatedBy: adminUser.id,
+        deletedBy: adminUser.id,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: new Date('2023-01-01'),
+        url: 'https://www.les-fruits-c-super-bon',
+        relatedSkillNames: '@truite2',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      await databaseBuilder.commit();
+      server = await createServer();
+      validPayload = {
+        data: {
+          attributes: {
+            url: 'https://super-casserole.com',
+            'related-skill-names': '@feutre2,@crayon1',
+            comment: 'Un super commentaire',
+            'check-type': 'starts_with',
+          },
+        },
+      };
+    });
+
+    it('should return a 403 status code when user is not admin', async () => {
+      // given
+      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/whitelisted-urls/456',
+        headers: generateAuthorizationHeader(notAdminUser),
+        payload: validPayload,
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            code: 403,
+            detail: 'Missing or insufficient permissions.',
+            title: 'Forbidden access',
+          },
+        ],
+      });
+    });
+
+    it('should return a 422 status code when update command in invalid', async () => {
+      // when
+      const invalidPayload = JSON.parse(JSON.stringify(validPayload));
+      invalidPayload.data.attributes.url = 'je ne suis pas une bonne url';
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/whitelisted-urls/456',
+        headers: generateAuthorizationHeader(adminUser),
+        payload: invalidPayload,
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(422);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            status: '422',
+            title: 'Unprocessable entity',
+            detail: 'URL invalide',
+            source: { pointer: '/data/attributes/url' },
+          },
+        ],
+      });
+    });
+
+    it('should return a 200 status code and the serialized updated whitelisted url', async () => {
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/whitelisted-urls/456',
+        headers: generateAuthorizationHeader(adminUser),
+        payload: validPayload,
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).toStrictEqual({
+        data: {
+          type: 'whitelisted-urls',
+          id: '456',
+          attributes: {
+            'created-at': new Date('2020-12-12'),
+            'updated-at': now,
+            'creator-name': null,
+            'latest-updator-name': 'Madame Admin',
+            url: 'https://super-casserole.com',
+            'related-skill-names': '@feutre2,@crayon1',
+            comment: 'Un super commentaire',
+            'check-type': 'starts_with',
+          },
+        },
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { User, WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 import {
+  NotFoundWhitelistedUrlError,
   CommandWhitelistedUrlConflictError,
   CommandWhitelistedUrlError,
   CommandWhitelistedUrlForbiddenError,
@@ -368,6 +369,330 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         url: 'https://www.brioche.com',
         relatedSkillNames: '@proie2,@cancre5',
         comment: 'coucou maman',
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      }));
+    });
+  });
+
+  describe('#canUpdate', () => {
+    describe('can', function() {
+      it('should not throw when all conditions are reunited', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrlRead({
+          url: 'https://www.painperdu.com',
+        })];
+        const updateCommand1 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const updateCommand2 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: '@choix1,@creux7',
+          comment: 'COucou',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        whitelistedUrlToUpdate.canUpdate(updateCommand1, user, existingWhitelistedUrls);
+        whitelistedUrlToUpdate.canUpdate(updateCommand2, user, []);
+
+        // then
+        expect(true).to.be.true;
+      });
+    });
+    describe('cannot', function() {
+      it('should throw a CommandWhitelistedUrlForbiddenError when user is not admin', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
+        const updateCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlForbiddenError(
+            'L\'utilisateur n\'a pas les droits pour mettre à jour cette URL whitelistée'
+          ));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when url is not valid in update command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const updateCommand1 = {
+          url: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const updateCommand2 = {
+          url: 'www.missing-protocol.com',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const updateCommand3 = {
+          url: 123456,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand1, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'URL invalide',
+            attribute: 'url',
+          }));
+        }
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand2, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'URL invalide',
+            attribute: 'url',
+          }));
+        }
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand3, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'URL invalide',
+            attribute: 'url',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when relatedSkillNames is not in valid format in update command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const updateCommand1 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: 123456.12,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const updateCommand2 = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: 'je ne suis pas une suite d acquis',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand1, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide',
+            attribute: 'relatedSkillNames',
+          }));
+        }
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand2, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide',
+            attribute: 'relatedSkillNames',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when comment is not in valid format in update command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const updateCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: 123,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: 'Commentaire invalide. Doit être un texte ou vide',
+            attribute: 'comment',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlError when checkType is not valid in update command', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const updateCommand1 = {
+          url: 'https://www.brioche.com',
+          checkType: 'autre_type',
+        };
+        const updateCommand2 = {
+          url: 'https://www.brioche.com',
+          checkType: null,
+        };
+        const updateCommand3 = {
+          url: 'https://www.brioche.com',
+          checkType: 456789,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        const allowedValues = Object.values(WhitelistedUrl.CHECK_TYPES).join(', ');
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand1, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: `Type de check invalide. Valeurs parmi : ${allowedValues}`,
+            attribute: 'checkType',
+          }));
+        }
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand2, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: `Type de check invalide. Valeurs parmi : ${allowedValues}`,
+            attribute: 'checkType',
+          }));
+        }
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand3, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlError({
+            message: `Type de check invalide. Valeurs parmi : ${allowedValues}`,
+            attribute: 'checkType',
+          }));
+        }
+      });
+
+      it('should throw a CommandWhitelistedUrlConflictError when url has already been whitelisted (case sensitive, exact match)', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrlRead({
+          url: 'https://www.brioche.com',
+        })];
+        const updateCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: null,
+          deletedAt: null,
+        });
+
+        // when
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand, user, existingWhitelistedUrls);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new CommandWhitelistedUrlConflictError(
+            'URL déjà whitelistée'
+          ));
+        }
+      });
+
+      it('should throw a NotFoundWhitelistedUrlError when whitelisted url is deleted', function() {
+        // given
+        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const updateCommand = {
+          url: 'https://www.brioche.com',
+          relatedSkillNames: null,
+          comment: null,
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        };
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          deletedBy: 123,
+          deletedAt: new Date('2020-01-01'),
+        });
+
+        // when
+        try {
+          whitelistedUrlToUpdate.canUpdate(updateCommand, user, []);
+          expect(false, 'Should have thrown').to.be.true;
+        } catch (err) {
+          expect(err).toStrictEqual(new NotFoundWhitelistedUrlError(
+            'L\'URL whitelistée n\'existe pas'
+          ));
+        }
+      });
+    });
+  });
+
+  describe('#update', function() {
+    it('should update the whitelisted url', function() {
+      // given
+      const user = domainBuilder.buildUser({ id: 888 });
+      const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+        id: 123,
+        createdBy: 777,
+        latestUpdatedBy: 999,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: new Date('2022-02-02'),
+        deletedAt: null,
+        url: 'https://www.google.com',
+        relatedSkillNames: '@noix2,@chose8',
+        comment: 'Je décide de whitelister ça car mon cousin travaille chez google',
+        checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+      });
+      const updateCommand = {
+        url: 'https://www.brioche.com',
+        relatedSkillNames: '@bidule4',
+        comment: null,
+        checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+      };
+
+      // when
+      whitelistedUrlToUpdate.update(updateCommand, user);
+
+      // then
+      expect(whitelistedUrlToUpdate).toStrictEqual(domainBuilder.buildWhitelistedUrl({
+        id: 123,
+        createdBy: 777,
+        latestUpdatedBy: 888,
+        deletedBy: null,
+        createdAt: new Date('2020-01-01'),
+        updatedAt: now,
+        deletedAt: null,
+        url: 'https://www.brioche.com',
+        relatedSkillNames: '@bidule4',
+        comment: null,
         checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
       }));
     });

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -2,10 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { User, WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 import {
-  NotFoundWhitelistedUrlError,
   CommandWhitelistedUrlConflictError,
   CommandWhitelistedUrlError,
   CommandWhitelistedUrlForbiddenError,
+  NotFoundWhitelistedUrlError,
 } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | WhitelistedUrl', () => {
@@ -20,6 +20,34 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
   afterEach(function() {
     vi.useRealTimers();
+  });
+
+  describe('#get isActive', function() {
+    it('should return true when WhitelistedUrl is not deleted', function() {
+      // given
+      const activeWhitelistedUrl = domainBuilder.buildWhitelistedUrl({
+        deletedAt: null,
+      });
+
+      // when
+      const isActive = activeWhitelistedUrl.isActive;
+
+      // then
+      expect(isActive).toStrictEqual(true);
+    });
+
+    it('should return false when WhitelistedUrl is deleted', function() {
+      // given
+      const activeWhitelistedUrl = domainBuilder.buildWhitelistedUrl({
+        deletedAt: new Date('2020-01-01'),
+      });
+
+      // when
+      const isActive = activeWhitelistedUrl.isActive;
+
+      // then
+      expect(isActive).toStrictEqual(false);
+    });
   });
 
   describe('#canDelete', () => {
@@ -121,9 +149,16 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       it('should not throw when all conditions are reunited', function() {
         // given
         const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
-        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrl({
-          url: 'https://www.painperdu.com',
-        })];
+        const existingWhitelistedUrls = [
+          domainBuilder.buildWhitelistedUrl({
+            url: 'https://www.painperdu.com',
+            deletedAt: null,
+          }),
+          domainBuilder.buildWhitelistedUrl({
+            url: 'https://www.brioche.com',
+            deletedAt: new Date('2020-01-01'),
+          }),
+        ];
         const creationCommand1 = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,
@@ -379,9 +414,22 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       it('should not throw when all conditions are reunited', function() {
         // given
         const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
-        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrlRead({
-          url: 'https://www.painperdu.com',
-        })];
+        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
+          url: 'https://www.url-origine.com',
+          deletedBy: null,
+          deletedAt: null,
+        });
+        const existingWhitelistedUrls = [
+          domainBuilder.buildWhitelistedUrl({
+            url: 'https://www.painperdu.com',
+            deletedAt: null,
+          }),
+          domainBuilder.buildWhitelistedUrl({
+            url: 'https://www.brioche.com',
+            deletedAt: new Date('2020-01-01'),
+          }),
+          whitelistedUrlToUpdate,
+        ];
         const updateCommand1 = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,
@@ -394,14 +442,17 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           comment: 'COucou',
           checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
         };
-        const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
-          deletedBy: null,
-          deletedAt: null,
-        });
+        const updateCommand3 = {
+          url: 'https://www.url-origine.com',
+          relatedSkillNames: '@fruit8',
+          comment: 'Update avec la même url mais je vérifie que je me conflicte pas avec moi-même',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        };
 
         // when
         whitelistedUrlToUpdate.canUpdate(updateCommand1, user, existingWhitelistedUrls);
         whitelistedUrlToUpdate.canUpdate(updateCommand2, user, []);
+        whitelistedUrlToUpdate.canUpdate(updateCommand3, user, existingWhitelistedUrls);
 
         // then
         expect(true).to.be.true;
@@ -602,7 +653,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       it('should throw a CommandWhitelistedUrlConflictError when url has already been whitelisted (case sensitive, exact match)', function() {
         // given
         const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
-        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrlRead({
+        const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrl({
           url: 'https://www.brioche.com',
         })];
         const updateCommand = {

--- a/pix-editor/app/components/form/whitelisted-url.js
+++ b/pix-editor/app/components/form/whitelisted-url.js
@@ -38,7 +38,7 @@ export default class WhitelistedUrlForm extends Component {
       this.comment.validate();
     }
     if (this.args.initialRelatedSkillNames.length > 0) {
-      this.relatedSkillNames.setValue(this.args.relatedSkillNames);
+      this.relatedSkillNames.setValue(this.args.initialRelatedSkillNames);
       this.relatedSkillNames.validate();
     }
     if (this.args.initialCheckType.length > 0) {

--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -54,24 +54,24 @@
     <tbody>
     {{#each @whitelistedUrls as |whitelistedUrl|}}
       <tr class="tr--clickable" aria-label="URL en liste blanche">
-        <td>
+        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
           {{whitelistedUrl.relatedSkillNames}}
         </td>
-        <td>
+        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
           <PixTag class="whitelisted-url-check-type-tag" @color={{this.checkTypeColor whitelistedUrl.checkType}}>
             {{this.formatCheckType whitelistedUrl.checkType}}
           </PixTag>
         </td>
-        <td>
+        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
           {{whitelistedUrl.url}}
         </td>
-        <td>
+        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
           {{whitelistedUrl.comment}}
         </td>
-        <td>
+        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
           {{this.formatCreationString whitelistedUrl}}
         </td>
-        <td>
+        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
           {{this.formatUpdateString whitelistedUrl}}
         </td>
         <td class="actions">

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -26,6 +26,11 @@ export default class WhitelistedUrlsController extends Controller {
   }
 
   @action
+  goToEditWhitelistedUrl(whitelistedUrlId) {
+    this.router.transitionTo('authenticated.whitelisted-urls.whitelisted-url.edit', whitelistedUrlId);
+  }
+
+  @action
   async applyFilters(urlFilterValue, namesFilterValue) {
     this.url = urlFilterValue ?? '';
     this.names = namesFilterValue ?? '';

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/whitelisted-url/edit.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/whitelisted-url/edit.js
@@ -1,0 +1,32 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class EditWhitelistedUrlController extends Controller {
+  @service store;
+  @service router;
+  @service notifications;
+
+  @action
+  async editWhitelistedUrl(formData) {
+    try {
+      const { whitelistedUrl } = this.model;
+      for (const [property, value] of Object.entries(formData)) {
+        whitelistedUrl[property] = value;
+      }
+      await whitelistedUrl.save();
+      this.notifications.success('URL whitelistée modifiée avec succès.');
+      this.router.transitionTo('authenticated.whitelisted-urls.list');
+    } catch (err) {
+      await this.notifications.error('Une erreur est survenue lors de la modification de l\'URL whitelistée.');
+      const knownErrors = err?.errors.map((error) => error.detail).join('\n');
+      const finalErrors = knownErrors ?? JSON.stringify(err);
+      throw new Error(finalErrors);
+    }
+  }
+
+  @action
+  async goBackToList() {
+    this.router.transitionTo('authenticated.whitelisted-urls.list');
+  }
+}

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -79,6 +79,9 @@ Router.map(function() {
     this.route('whitelisted-urls', function() {
       this.route('list', { path: '/' });
       this.route('new');
+      this.route('whitelisted-url', { path: '/:whitelisted_url_id' }, function() {
+        this.route('edit');
+      });
     });
   });
 });

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class WhitelistedUrlRoute extends Route {
+  @service store;
+
+  async model(params) {
+    const whitelistedUrls = await this.store.findAll('whitelisted-url', { reload: true });
+    return whitelistedUrls.find((whitelistedUrl) => whitelistedUrl.id === params.whitelisted_url_id);
+  }
+}

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url/edit.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url/edit.js
@@ -1,0 +1,19 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class EditWhitelistedUrlRoute extends Route {
+  @service store;
+  @service access;
+  @service router;
+
+  beforeModel() {
+    if (!this.access.mayCreateOrEditWhitelistedUrl()) {
+      this.router.transitionTo('authenticated.whitelisted-urls.list');
+    }
+  }
+
+  async model() {
+    const whitelistedUrl = this.modelFor('authenticated.whitelisted-urls.whitelisted-url');
+    return { whitelistedUrl };
+  }
+}

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
@@ -35,6 +35,7 @@
       @onApplyFiltersClicked={{this.applyFilters}}
       @onClearFiltersClicked={{this.clearFilters}}
       @onDeleteItemClicked={{this.deleteUrl}}
+      @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
     />
   </section>
 </main>

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/whitelisted-url/edit.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/whitelisted-url/edit.hbs
@@ -1,0 +1,17 @@
+<header class="page-header">
+  <h1 class="page-title">Édition d'une URL whitelistée</h1>
+</header>
+<main class="page-body">
+  <section class="page-section">
+    <Form::WhitelistedUrl
+      @initialUrl={{this.model.whitelistedUrl.url}}
+      @initialComment={{this.model.whitelistedUrl.comment}}
+      @initialRelatedSkillNames={{this.model.whitelistedUrl.relatedSkillNames}}
+      @initialCheckType={{this.model.whitelistedUrl.checkType}}
+      @cancelButtonText="Annuler"
+      @onFormCancelled={{this.goBackToList}}
+      @submitButtonText={{"Modifier l'URL whitelistée"}}
+      @onFormSubmitted={{this.editWhitelistedUrl}}
+    />
+  </section>
+</main>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -456,6 +456,21 @@ function routes() {
 
   this.get('/whitelisted-urls');
   this.delete('/whitelisted-urls/:id');
+  this.patch('/whitelisted-urls/:id', function(schema, request) {
+    const attributes = JSON.parse(request.requestBody).data.attributes;
+    const whitelistedUrl = schema.whitelistedUrls.find(request.params.id);
+    whitelistedUrl.update({
+      url: attributes.url,
+      relatedSkillNames: attributes['related-skill-names'],
+      checkType: attributes['check-type'],
+      comment: attributes.comment,
+      creatorName: 'TEST USER',
+      createdAt: new Date().toISOString(),
+      latestUpdatorName: 'TEST USER',
+      updatedAt: new Date().toISOString(),
+    });
+    return whitelistedUrl;
+  });
   this.post('/whitelisted-urls', function(schema, request) {
     const whitelistedUrl = JSON.parse(request.requestBody).data.attributes;
     return schema.create('whitelisted-url', {

--- a/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
@@ -1,0 +1,90 @@
+import { clickByName, clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../setup-application-rendering';
+
+module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    const notifications = this.owner.lookup('service:notifications');
+    notifications.setDefaultClearDuration(50);
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+    this.server.create('whitelisted-url', {
+      id: 1,
+      createdAt: new Date('2020-01-01'),
+      updatedAt: new Date('2021-01-01'),
+      creatorName: null,
+      latestUpdatorName: 'Ma maman',
+      url: 'http://pipeau-la-grenouille.fr',
+      relatedSkillNames: '@noix2,@souris8',
+      checkType: 'starts_with',
+      comment: 'Les grenouilles sont jolies',
+    });
+    this.server.create('whitelisted-url', {
+      id: 2,
+      createdAt: new Date('2020-02-02'),
+      updatedAt: new Date('2021-02-02'),
+      creatorName: 'Mon chat',
+      latestUpdatorName: null,
+      url: 'http://chats.fr',
+      relatedSkillNames: '',
+      checkType: 'exact_match',
+      comment: 'MIAOU',
+    });
+    this.server.create('whitelisted-url', {
+      id: 3,
+      createdAt: new Date('2020-03-03'),
+      updatedAt: new Date('2021-03-03'),
+      creatorName: 'Mon chien',
+      latestUpdatorName: null,
+      url: 'http://chiens.fr',
+      relatedSkillNames: '@noix3',
+      checkType: 'exact_match',
+      comment: 'OUAF',
+    });
+
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
+    return authenticateSession();
+  });
+
+  test('should edit a whitelisted url', async function(assert) {
+    // given
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await clickByText('MIAOU');
+
+    // when
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@miaou1,@croquettes2');
+    await fillByLabel('Commentaire explicatif', 'MIAOU MIAOU');
+    await clickByName('Modifier l\'URL whitelistée');
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls');
+    assert.dom(screen.getByText('http://chats.fr')).exists();
+    assert.dom(screen.getByText('MIAOU MIAOU')).exists();
+    assert.dom(screen.getByText('@miaou1,@croquettes2')).exists();
+    assert.strictEqual(screen.getAllByText('Strictement égale à').length, 2);
+  });
+
+  test('should edit a whitelisted url\'s url', async function(assert) {
+    // given
+    const screen = await visit('/');
+    await clickByName('Whitelist moulinette des URLs');
+    await clickByText('OUAF');
+
+    // when
+    await fillByLabel('URL à whitelister', 'https://en.wikipedia.org/wiki/Dog');
+    await clickByName('Modifier l\'URL whitelistée');
+
+    // then
+    assert.strictEqual(currentURL(), '/whitelisted-urls');
+    assert.dom(screen.getByText('https://en.wikipedia.org/wiki/Dog')).exists();
+    assert.dom(screen.queryByText('http://chiens.fr')).doesNotExist();
+  });
+});

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -1,4 +1,4 @@
-import { clickByName, fillByLabel, render } from '@1024pix/ember-testing-library';
+import { clickByName, clickByText, fillByLabel, render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -8,7 +8,7 @@ import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 module('Integration | Component | whitelisted-urls/list', function(hooks) {
   setupIntlRenderingTest(hooks);
   let store, whitelistedUrl1, whitelistedUrl2, hour1_create, hour1_update, hour2_create;
-  let onApplyFiltersClickedStub, onClearFiltersClickedStub, onDeleteItemClickedStub;
+  let onApplyFiltersClickedStub, onClearFiltersClickedStub, onDeleteItemClickedStub, onEditStub;
 
   hooks.beforeEach(async function() {
     store = this.owner.lookup('service:store');
@@ -47,6 +47,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     onApplyFiltersClickedStub = sinon.stub();
     onClearFiltersClickedStub = sinon.stub();
     onDeleteItemClickedStub = sinon.stub();
+    onEditStub = sinon.stub();
   });
 
   test('it should display list of whitelisted urls passed in params and initialize filter inputs', async function(assert) {
@@ -57,6 +58,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
     this.onDeleteItemClicked = onDeleteItemClickedStub;
+    this.goToEditWhitelistedUrl = onEditStub;
 
     // when
     const screen = await render(hbs`
@@ -67,7 +69,9 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
         @onClearFiltersClicked={{this.onClearFiltersClicked}}
-        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}
+        @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
+      />`);
 
     // then
     assert.ok(
@@ -126,6 +130,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
     this.onDeleteItemClicked = onDeleteItemClickedStub;
+    this.goToEditWhitelistedUrl = onEditStub;
 
     // when
     const screen = await render(hbs`
@@ -136,7 +141,9 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
         @onClearFiltersClicked={{this.onClearFiltersClicked}}
-        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}
+        @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
+      />`);
     await fillByLabel('URL', 'different url value');
     await clickByName('Filtrer');
 
@@ -154,6 +161,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
     this.onDeleteItemClicked = onDeleteItemClickedStub;
+    this.goToEditWhitelistedUrl = onEditStub;
 
     // when
     const screen = await render(hbs`
@@ -164,7 +172,9 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
         @onClearFiltersClicked={{this.onClearFiltersClicked}}
-        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}
+        @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
+      />`);
     await fillByLabel('Nom d\'acquis', 'different names value');
     await clickByName('Filtrer');
 
@@ -182,6 +192,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
     this.onDeleteItemClicked = onDeleteItemClickedStub;
+    this.goToEditWhitelistedUrl = onEditStub;
 
     // when
     const screen = await render(hbs`
@@ -192,7 +203,9 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
         @onClearFiltersClicked={{this.onClearFiltersClicked}}
-        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}
+        @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
+      />`);
     await fillByLabel('Nom d\'acquis', 'different names value');
     await fillByLabel('URL', 'different url value');
     await clickByName('Filtrer');
@@ -211,6 +224,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     this.onApplyFiltersClicked = onApplyFiltersClickedStub;
     this.onClearFiltersClicked = onClearFiltersClickedStub;
     this.onDeleteItemClicked = onDeleteItemClickedStub;
+    this.goToEditWhitelistedUrl = onEditStub;
 
     // when
     await render(hbs`
@@ -221,11 +235,44 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         @namesFilterValue={{this.namesFilterValue}}
         @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
         @onClearFiltersClicked={{this.onClearFiltersClicked}}
-        @onDeleteItemClicked={{this.onDeleteItemClicked}}/>`);
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}
+        @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
+      />`);
     await clickByName('Réinitialiser les filtres');
 
     // then
     sinon.assert.calledOnce(onClearFiltersClickedStub);
     assert.ok(true);
+  });
+
+  test('it should call arg edit function when clicking on list item', async function(assert) {
+    // given
+    this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
+    this.urlFilterValue = 'initialUrlValue';
+    this.namesFilterValue = 'initialNamesValue';
+    this.onApplyFiltersClicked = onApplyFiltersClickedStub;
+    this.onClearFiltersClicked = onClearFiltersClickedStub;
+    this.onDeleteItemClicked = onDeleteItemClickedStub;
+    this.goToEditWhitelistedUrl = onEditStub;
+
+    // when
+    await render(hbs`
+      <WhitelistedUrls::List
+        @whitelistedUrls={{this.whitelistedUrls}}
+        @urlFilterValue={{this.urlFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @namesFilterValue={{this.namesFilterValue}}
+        @onApplyFiltersClicked={{this.onApplyFiltersClicked}}
+        @onClearFiltersClicked={{this.onClearFiltersClicked}}
+        @onDeleteItemClicked={{this.onDeleteItemClicked}}
+        @goToEditWhitelistedUrl={{this.goToEditWhitelistedUrl}}
+      />`);
+    await clickByText('Strictement égale à');
+    await clickByText('Un commentaire sur Laura');
+    await clickByText('https://foo.com');
+    await clickByText('@fruit4,@legume5');
+
+    // then
+    assert.strictEqual(onEditStub.callCount, 4);
   });
 });


### PR DESCRIPTION
Moulinette URLS ticket 5

## :fallen_leaf: Problème
Pour la moulinette des URLs cassées, le métier maintient à part des macros et autres outils sur google sheet pour ignorer une liste fixe d'urls qu'ils ne souhaitent pas traiter.

## :chestnut: Proposition
Pouvoir modifier une URL existante de la liste blanche.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
- Accéder à la liste des URLs whitelistées.
- Cliquer sur une des URLs dans la liste.
- Constater qu'on arrive sur sa page d'édition.
- Essayer de modifier des champs et d'enregistrer.
- Constater qu'on retourne sur la liste des URLs whitelistées.
- Constater que les informations ont bien été modifiées.