### PR TITLE
[BUGFIX] Toutes les compétences ne sont pas chargées (PIX-15300)

### DIFF
--- a/pix-editor/app/routes/authenticated.js
+++ b/pix-editor/app/routes/authenticated.js
@@ -16,10 +16,10 @@ export default class AuthenticatedRoute extends Route {
     const [frameworks, areas] = await Promise.all([
       this.store.findAll('framework'),
       this.store.findAll('area'),
-      this.store.findAll('competence'),
       this.config.load(),
     ]);
     if (frameworks) {
+      await Promise.all(areas.map((area) => area.competences));
       this.currentData.setFrameworks(frameworks);
       this.currentData.setAreas(areas);
       const pixFramework = frameworks.find((framework) => framework.name === 'Pix');


### PR DESCRIPTION
## :fallen_leaf: Problème
La méthode `findAll()` du store ember-data ne sait pas gérer la pagination de l’API Airtable, on ne récupère donc que les 100 premières compétences...

## :chestnut: Proposition
Ne pas utiliser `findAll()` mais demander le chargement des compétences par identifiant via la relation sur les domaines.

## :jack_o_lantern: Remarques
On remet le chargement des compétences en série et non plus en parallèle, tant pis.

## :wood: Pour tester
Trop peu de compétences en RA pour valider la correction.
Simplement vérifier que les compétences présentes en RA sont bien chargées.