### PR TITLE
[BUGFIX] Toutes les compétences ne sont pas chargées (PIX-15300)

### DIFF
--- a/pix-editor/app/adapters/airtable.js
+++ b/pix-editor/app/adapters/airtable.js
@@ -60,8 +60,10 @@ export default class AirtableAdapter extends RESTAdapter {
     const serializer = store.serializerFor(type.modelName);
     const responses = await Promise.all(chunk(ids, maxIds).map((chunkedIds) => {
       const recordsText = 'OR(' + chunkedIds.map((id) => `{${serializer.primaryKey}} = '${id}'`).join(',') + ')';
+      const query = { filterByFormula: recordsText };
+      if (this.fields) query.fields = this.fields;
       const url = this.buildURL(type.modelName, chunkedIds, snapshots, 'findMany');
-      return this.ajax(url, 'GET', { data: { filterByFormula: recordsText } });
+      return this.ajax(url, 'GET', { data: query });
     }));
     return responses.reduce((acc, response) => {
       acc.records.push(...response.records);
@@ -88,7 +90,10 @@ export default class AirtableAdapter extends RESTAdapter {
   buildQuery(snapshot) {
     const query = super.buildQuery(snapshot);
 
-    if (this.sort && !snapshot.id) query.sort = this.sort;
+    if (snapshot.id) return query;
+
+    if (this.fields) query.fields = this.fields;
+    if (this.sort) query.sort = this.sort;
 
     return query;
   }

--- a/pix-editor/app/adapters/airtable.js
+++ b/pix-editor/app/adapters/airtable.js
@@ -48,7 +48,7 @@ export default class AirtableAdapter extends RESTAdapter {
 
   coalesceFindRequests = true;
 
-  groupRecordsForFindMany(store, snapshots) {
+  groupRecordsForFindMany(_store, snapshots) {
     const groups = [];
     for (let i = 0; i < snapshots.length; i += 100) {
       groups.push(snapshots.slice(i, i + 100));
@@ -69,7 +69,31 @@ export default class AirtableAdapter extends RESTAdapter {
     });
   }
 
-  ajax() {
-    return this.ajaxQueue.add(() => super.ajax(...arguments));
+  async findAll(_store, type, _sinceToken, snapshotRecordArray) {
+    const query = this.buildQuery(snapshotRecordArray);
+    const url = this.buildURL(type.modelName, null, snapshotRecordArray, 'findAll');
+
+    const records = [];
+
+    let res;
+    do {
+      query.offset = res?.offset;
+      res = await this.ajax(url, 'GET', { data: query });
+      records.push(...res.records);
+    } while (res.offset);
+
+    return { records };
+  }
+
+  buildQuery(snapshot) {
+    const query = super.buildQuery(snapshot);
+
+    if (this.sort && !snapshot.id) query.sort = this.sort;
+
+    return query;
+  }
+
+  ajax(...args) {
+    return this.ajaxQueue.add(() => super.ajax(...args));
   }
 }

--- a/pix-editor/app/adapters/attachment.js
+++ b/pix-editor/app/adapters/attachment.js
@@ -1,8 +1,18 @@
 import AirtableAdapter from './airtable';
 
 export default class AttachmentAdapter extends AirtableAdapter {
+
+  fields = [
+    'Record ID',
+    'filename',
+    'url',
+    'mimeType',
+    'size',
+    'type',
+    'localizedChallengeId',
+  ];
+
   pathForType() {
     return 'Attachments';
   }
-
 }

--- a/pix-editor/app/adapters/competence.js
+++ b/pix-editor/app/adapters/competence.js
@@ -1,12 +1,10 @@
 import AirtableAdapter from './airtable';
 
 export default class CompetenceAdapter extends AirtableAdapter {
-  findAll(store, type, sinceToken) {
-    return this.query(store, type, { since: sinceToken, sort: [{ field: 'Sous-domaine', direction: 'asc' }] });
-  }
+
+  sort = [{ field: 'Sous-domaine', direction: 'asc' }];
 
   pathForType() {
     return 'Competences';
   }
-
 }

--- a/pix-editor/app/adapters/competence.js
+++ b/pix-editor/app/adapters/competence.js
@@ -2,6 +2,15 @@ import AirtableAdapter from './airtable';
 
 export default class CompetenceAdapter extends AirtableAdapter {
 
+  fields = [
+    'Record ID',
+    'Sous-domaine',
+    'Thematiques',
+    'Tubes',
+    'id persistant',
+    'Origine',
+    'Domaine',
+  ];
   sort = [{ field: 'Sous-domaine', direction: 'asc' }];
 
   pathForType() {

--- a/pix-editor/app/adapters/note.js
+++ b/pix-editor/app/adapters/note.js
@@ -1,10 +1,6 @@
-import { inject as service } from '@ember/service';
-
 import AirtableAdapter from './airtable';
 
 export default class NoteAdapter extends AirtableAdapter {
-
-  @service config;
 
   namespace = '/api/airtable/changelog';
 

--- a/pix-editor/app/adapters/skill.js
+++ b/pix-editor/app/adapters/skill.js
@@ -2,6 +2,24 @@ import AirtableAdapter from './airtable';
 
 export default class SkillAdapter extends AirtableAdapter {
 
+  fields = [
+    'Record Id',
+    'Nom',
+    'Statut de l\'indice',
+    'Epreuves (id persistant)',
+    'Date',
+    'Description',
+    'Statut de la description',
+    'Comprendre',
+    'En savoir plus',
+    'Tube',
+    'Level',
+    'Status',
+    'Internationalisation',
+    'id persistant',
+    'Version',
+  ];
+
   urlForCreateRecord(model, snapshot) {
     if (snapshot.adapterOptions?.clone) return '/api/skills/clone';
     return super.urlForCreateRecord(model, snapshot);

--- a/pix-editor/app/adapters/theme.js
+++ b/pix-editor/app/adapters/theme.js
@@ -2,6 +2,14 @@ import AirtableAdapter from './airtable';
 
 export default class ThemeAdapter extends AirtableAdapter {
 
+  fields = [
+    'Record Id',
+    'id persistant',
+    'Tubes',
+    'Competence',
+    'Index',
+  ];
+
   pathForType() {
     return 'Thematiques';
   }

--- a/pix-editor/app/adapters/tube.js
+++ b/pix-editor/app/adapters/tube.js
@@ -2,6 +2,16 @@ import AirtableAdapter from './airtable';
 
 export default class TubeAdapter extends AirtableAdapter {
 
+  fields = [
+    'Record Id',
+    'Nom',
+    'Competences',
+    'Acquis',
+    'Thematique',
+    'id persistant',
+    'Index',
+  ];
+
   pathForType() {
     return 'Tubes';
   }

--- a/pix-editor/app/adapters/tutorial.js
+++ b/pix-editor/app/adapters/tutorial.js
@@ -2,6 +2,22 @@ import AirtableAdapter from './airtable';
 
 export default class TutorialAdapter extends AirtableAdapter {
 
+  fields = [
+    'Record ID',
+    'Titre',
+    'Durée',
+    'Source',
+    'Format',
+    'Lien',
+    'License',
+    'Tags',
+    'niveau',
+    'Date maj',
+    'CoupDeCoeur',
+    'id persistant',
+    'Langue',
+  ];
+
   pathForType() {
     return 'Tutoriels';
   }


### PR DESCRIPTION
## :fallen_leaf: Problème
La méthode `findAll()` du store ember-data ne sait pas gérer la pagination de l’API Airtable, on ne récupère donc que les 100 premières compétences...

## :chestnut: Proposition
Gérer la pagination dans l’adapter Airtable.
En bonus, donner la liste des champs à récupérer à Airtable, afin de réduire la taille des payloads de réponse.

## :jack_o_lantern: Remarques
Remplace #815 qui manquait d’ambition.

## :wood: Pour tester
Trop peu de compétences en RA pour valider la correction.
Simplement vérifier que les compétences présentes en RA sont bien chargées.
Vérifier que le chargement des différentes entités passant par le proxy Airtable fonctionne toujours.

Test possible en local : dans la méthode `buildQuery` de l’adapter Airtable, ajouter la ligne suivante :
```js
query.pageSize = 8;
```
Puis vérifier que les compétences sont récupérées en 3 requêtes successives.