### PR TITLE
[FEATURE] Pour les tutoriels, ne faire remonter que les URLs qui ont été KO au moins deux fois d'affilé dans la moulinette (PIX-15002)

### DIFF
--- a/api/db/migrations/20241114093733_create-tutorial-ko-urls-table.js
+++ b/api/db/migrations/20241114093733_create-tutorial-ko-urls-table.js
@@ -1,0 +1,12 @@
+const TABLE_NAME = 'tutorial_ko_urls';
+
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.text('url').notNullable().primary();
+    table.integer('continuousKoCount').notNullable().defaultTo(0);
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/lib/infrastructure/repositories/url-repository.js
+++ b/api/lib/infrastructure/repositories/url-repository.js
@@ -1,6 +1,7 @@
 import { google } from 'googleapis';
 import { logger } from '../logger.js';
 import * as config from '../../config.js';
+import { knex } from '../../../db/knex-database-connection.js';
 
 const sheets = google.sheets('v4');
 
@@ -90,11 +91,39 @@ export function updateChallenges(dataToUpload) {
   return sendDataToGoogleSheet(dataToUpload, config.checkUrlsJobs.challengesSheetName);
 }
 
-export function updateTutorials(dataToUpload) {
-  return sendDataToGoogleSheet(dataToUpload, config.checkUrlsJobs.tutorialsSheetName);
+export async function updateTutorials(dataToUpload) {
+  const finalDataToUpload = await keepUrlsThatFailedAtLeastTwiceInARow(dataToUpload);
+  return sendDataToGoogleSheet(finalDataToUpload, config.checkUrlsJobs.tutorialsSheetName);
 }
 
 export function exportExternalUrls(dataToUpload) {
   const sheetName = new Date().toLocaleDateString('fr-FR');
   return addSheetToGoogleSheet(dataToUpload, sheetName, config.exportExternalUrlsJob.spreadsheetId);
+}
+
+const TUTORIAL_KO_URLS_TABLE_NAME = 'tutorial_ko_urls';
+const CONTINUOUS_FAILURE_MINIMUM_COUNT = 2;
+async function keepUrlsThatFailedAtLeastTwiceInARow(dataToUpload) {
+  const finalDataToUpload = [];
+  await knex.transaction(async (trx) => {
+    const currentTutorialKoUrlsInDB = await trx(TUTORIAL_KO_URLS_TABLE_NAME);
+
+    const tutorialKoUrlsToInsertInDB = [];
+    for (const itemToUpload of dataToUpload) {
+      const [,,,currentUrl] = itemToUpload;
+      let currentContinuousKoCount = currentTutorialKoUrlsInDB.find(({ url }) => url === currentUrl)?.continuousKoCount ?? 0;
+      ++currentContinuousKoCount;
+      tutorialKoUrlsToInsertInDB.push({
+        url: currentUrl,
+        continuousKoCount: currentContinuousKoCount,
+      });
+      if (currentContinuousKoCount >= CONTINUOUS_FAILURE_MINIMUM_COUNT) {
+        finalDataToUpload.push(itemToUpload);
+      }
+    }
+
+    await trx(TUTORIAL_KO_URLS_TABLE_NAME).del();
+    await trx(TUTORIAL_KO_URLS_TABLE_NAME).insert(tutorialKoUrlsToInsertInDB);
+  });
+  return finalDataToUpload;
 }

--- a/api/scripts/initialize-tutorial-ko-urls-table-content.js
+++ b/api/scripts/initialize-tutorial-ko-urls-table-content.js
@@ -1,0 +1,49 @@
+import 'dotenv/config';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { disconnect, knex } from '../db/knex-database-connection.js';
+import { google } from 'googleapis';
+import { logger } from '../lib/infrastructure/logger.js';
+import * as config from '../lib/config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+
+  const authInstance = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+    credentials: config.googleAuthCredentials,
+  });
+  const auth = await authInstance.getClient();
+  const sheets = google.sheets({ version: 'v4', auth });
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: config.checkUrlsJobs.spreadsheetId,
+    range: `${config.checkUrlsJobs.tutorialsSheetName}!A:Z`,
+  });
+  const values = res.data.values;
+  const dataToInsert = values.map((value) => ({
+    url: value[3],
+    continuousKoCount: 1,
+  }));
+  await knex('tutorial_ko_urls').insert(dataToInsert);
+
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();


### PR DESCRIPTION
## :fallen_leaf: Problème
Le métier ne veut voir que les URLs qui sont KO au moins deux fois d'affilé pour les tutos (apparemment c'est fréquent que les tutos soient juste down 🤷🏿 )

## :chestnut: Proposition
Appliquer cette règle.
Solution courante : écriture dans PG d'un compte de KO consécutifs par url distincte.
Solution alternative : j'ai hésité avec écrire une troisième feuille dans le google sheets des urls pour éviter de faire une entrée dans PG, mais vu que c'est accessible par bcp de monde j'ai peur qu'on me l'altère et que ça foire le truc.
Solution alteralternative : On pourrait aussi envisager d'écrire dans Redis si on a un Redis sur LCMS, ca devrait faire le travail.

J'attends vos avis sur la solution.

## :jack_o_lantern: Remarques
- Si une URL est nouvellement cassée, elle fait son entrée dans la table PG sans remonter dans la sheet.
- Si une URL est cassée ET qu'elle est déjà dans la table, son compteur s'incrémente ET remonte dans la sheet.
- Si une URL n'est plus cassée ET qu'elle était cassée avant, son compteur retombe à zéro (en fait l'entrée dans la table est supprimée mais ça revient au même) ET ne remonte pas dans la sheet.

Aussi, j'ai ajouté un script à exécuter en Prod après la MEP histoire qu'au jour 1 il n'y ait pas rien qui sorte dans le google sheet. (vu qu'aucune URL n'est considérée comme ayant été KO au moins une fois)

## :wood: Pour tester
Lancer la moulinette plusieurs fois et voir que les urls cassées pour les tutos ne remontent qu'après plusieurs lancements consécutifs
