### PR TITLE
[TECH] Ajouter les attributs "title" et "airtableId" dans le modèle "CompetenceOverview" (PIX-15307)

### DIFF
--- a/api/lib/application/competences/overviews.js
+++ b/api/lib/application/competences/overviews.js
@@ -2,7 +2,10 @@ import Joi from 'joi';
 import Boom from '@hapi/boom';
 import * as Sentry from '@sentry/node';
 import { logger } from '../../infrastructure/logger.js';
-import { getCompetenceChallengesProductionOverview, getCompetenceChallengesWorkbenchOverview } from '../../domain/usecases/index.js';
+import {
+  getCompetenceChallengesProductionOverview,
+  getCompetenceChallengesWorkbenchOverview
+} from '../../domain/usecases/index.js';
 import { competenceOverviewSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import { Types } from '../types.js';
 

--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -3,19 +3,25 @@ import { Challenge } from '../models/index.js';
 export class CompetenceOverview {
   constructor({
     id,
+    airtableId,
+    name,
     thematicOverviews,
   }) {
     this.id = id;
+    this.airtableId = airtableId;
+    this.name = name;
     this.thematicOverviews = thematicOverviews;
     this.tubesCount = sumBy(thematicOverviews, ({ tubesCount }) => tubesCount);
     this.skillsCount = sumBy(thematicOverviews, ({ skillsCount }) => skillsCount);
   }
 
-  static buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges, locale }) {
-    let id = `${competenceId}:challenges-production`;
+  static buildForChallengesProduction({ competence, thematics, tubes, skills, challenges, locale }) {
+    let id = `${competence.id}:challenges-production`;
     if (locale) id += `:${locale}`;
     return new CompetenceOverview({
       id,
+      airtableId: competence.airtableId,
+      name: `${competence.index} ${competence.name_i18n['fr']}`,
       thematicOverviews: thematics
         .sort(byIndex)
         .map((thematic) => ThematicOverview.buildForChallengesProduction({ thematic, tubes, skills, challenges, locale }))
@@ -23,11 +29,13 @@ export class CompetenceOverview {
     });
   }
 
-  static buildForChallengesWorkbench({ competenceId, thematics, tubes, skills, challenges }) {
-    const id = `${competenceId}:challenges-workbench`;
+  static buildForChallengesWorkbench({ competence, thematics, tubes, skills, challenges }) {
+    const id = `${competence.id}:challenges-workbench`;
     const skillsWithoutWorkbench = skills.filter(({ name }) => name !== '@workbench');
     return new CompetenceOverview({
       id,
+      airtableId: competence.airtableId,
+      name: `${competence.index} ${competence.name_i18n['fr']}`,
       thematicOverviews: thematics
         .sort(byIndex)
         .map((thematic) => ThematicOverview.buildForChallengesWorkbench({ thematic, tubes, skills: skillsWithoutWorkbench, challenges }))
@@ -45,6 +53,18 @@ class ThematicOverview {
     this.airtableId = airtableId;
     this.name = name;
     this.tubeOverviews = tubeOverviews;
+  }
+
+  get isEmpty() {
+    return !this.tubeOverviews || this.tubeOverviews.length === 0;
+  }
+
+  get tubesCount() {
+    return this.isEmpty ? 0 : this.tubeOverviews.length;
+  }
+
+  get skillsCount() {
+    return this.isEmpty ? 0 : sumBy(this.tubeOverviews, ({ skillsCount }) => skillsCount);
   }
 
   static buildForChallengesProduction({ thematic, tubes, skills, challenges, locale }) {
@@ -74,18 +94,6 @@ class ThematicOverview {
         .filter((tubeOverview) => !tubeOverview.isEmpty)
     });
   }
-
-  get isEmpty() {
-    return !this.tubeOverviews || this.tubeOverviews.length === 0;
-  }
-
-  get tubesCount() {
-    return this.isEmpty ? 0 : this.tubeOverviews.length;
-  }
-
-  get skillsCount() {
-    return this.isEmpty ? 0 : sumBy(this.tubeOverviews, ({ skillsCount }) => skillsCount);
-  }
 }
 
 class TubeOverview {
@@ -97,6 +105,14 @@ class TubeOverview {
     this.airtableId = airtableId;
     this.name = name;
     this.skillOverviews = skillOverviews;
+  }
+
+  get isEmpty() {
+    return !this.skillOverviews || this.skillOverviews.length === 0;
+  }
+
+  get skillsCount() {
+    return this.isEmpty ? 0 : sumBy(this.skillOverviews, (skillOverview) => skillOverview === null ? 0 : 1);
   }
 
   static buildForChallengesProduction({ tube, skills, challenges, locale }) {
@@ -119,14 +135,6 @@ class TubeOverview {
       skillOverviews: skillsByTubeIdAndLevel[tube.id]
         ?.map((skills) => SkillOverview.buildForChallengesWorkbench({ skills, challenges })),
     });
-  }
-
-  get isEmpty() {
-    return !this.skillOverviews || this.skillOverviews.length === 0;
-  }
-
-  get skillsCount() {
-    return this.isEmpty ? 0 : sumBy(this.skillOverviews, (skillOverview) => skillOverview === null ? 0 : 1);
   }
 }
 

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -1,22 +1,25 @@
 import {
+  challengeRepository,
+  competenceRepository,
+  skillRepository,
   thematicRepository,
   tubeRepository,
-  skillRepository,
-  challengeRepository,
 } from '../../infrastructure/repositories/index.js';
 import { CompetenceOverview } from '../readmodels/index.js';
 
 export async function getCompetenceChallengesProductionOverview({ competenceId, locale }) {
   const [
+    competence,
     thematics,
     tubes,
     skills,
     challenges,
   ] = await Promise.all([
+    competenceRepository.get(competenceId),
     thematicRepository.listByCompetenceId(competenceId),
     tubeRepository.listByCompetenceId(competenceId),
     skillRepository.listActiveByCompetenceId(competenceId),
     challengeRepository.listActiveOrDraftByCompetenceId(competenceId),
   ]);
-  return CompetenceOverview.buildForChallengesProduction({ competenceId, thematics, tubes, skills, challenges, locale });
+  return CompetenceOverview.buildForChallengesProduction({ competence, thematics, tubes, skills, challenges, locale });
 }

--- a/api/lib/domain/usecases/get-competence-challenges-workbench-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-workbench-overview.js
@@ -1,22 +1,25 @@
 import {
+  challengeRepository,
+  competenceRepository,
+  skillRepository,
   thematicRepository,
   tubeRepository,
-  skillRepository,
-  challengeRepository,
 } from '../../infrastructure/repositories/index.js';
 import { CompetenceOverview } from '../readmodels/index.js';
 
 export async function getCompetenceChallengesWorkbenchOverview({ competenceId }) {
   const [
+    competence,
     thematics,
     tubes,
     skills,
     challenges,
   ] = await Promise.all([
+    competenceRepository.get(competenceId),
     thematicRepository.listByCompetenceId(competenceId),
     tubeRepository.listByCompetenceId(competenceId),
     skillRepository.listByCompetenceId(competenceId),
     challengeRepository.listPrototypesByCompetenceId(competenceId),
   ]);
-  return CompetenceOverview.buildForChallengesWorkbench({ competenceId, thematics, tubes, skills, challenges });
+  return CompetenceOverview.buildForChallengesWorkbench({ competence, thematics, tubes, skills, challenges });
 }

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { competenceDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as competenceTranslations from '../translations/competence.js';
-import { Competence } from '../../domain/models/Competence.js';
+import { Competence } from '../../domain/models/index.js';
 
 const model = 'competence';
 
@@ -21,6 +21,15 @@ export async function getMany(ids) {
     translationRepository.listByEntities(model, ids),
   ]);
   return toDomainList(datasourceCompetences, translations);
+}
+
+export async function get(id) {
+  const [[competenceDTO], translations] = await Promise.all([
+    competenceDatasource.filter({ filter: { ids: [id] } }),
+    translationRepository.listByEntity(model, id),
+  ]);
+  if (!competenceDTO) return null;
+  return toDomain(competenceDTO, translations);
 }
 
 function toDomainList(datasourceCompetences, translations) {

--- a/api/lib/infrastructure/serializers/jsonapi/competence-overview-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/competence-overview-serializer.js
@@ -4,6 +4,8 @@ const { Serializer } = JsonapiSerializer;
 
 const serializer = new Serializer('competence-overview', {
   attributes: [
+    'airtableId',
+    'name',
     'thematicOverviews',
     'tubesCount',
     'skillsCount',

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -1,17 +1,13 @@
-import {  beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
-import {
-  airtableBuilder,
-  databaseBuilder,
-  domainBuilder,
-  generateAuthorizationHeader,
-} from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import {
   challengeDatasource,
+  competenceDatasource,
   skillDatasource,
   thematicDatasource,
-  tubeDatasource
+  tubeDatasource,
 } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import { Challenge, LocalizedChallenge, Skill } from '../../../../lib/domain/models/index.js';
 import { LOCALE } from '../../../../lib/domain/constants.js';
@@ -25,10 +21,30 @@ describe('Acceptance | Route | competence-overviews', () => {
   });
 
   describe('GET /competences/:id/overviews/challenges-production', () => {
-    let competenceId, airtableThematicsScope, airtableTubesScope, airtableSkillsScope, airtableChallengesScope;
+    let competenceId, airtableCompetencesScope, airtableThematicsScope, airtableTubesScope, airtableSkillsScope, airtableChallengesScope;
 
     beforeEach(async function() {
       competenceId = 'recCompetence1';
+
+      const airtableCompetences = [
+        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({ id: competenceId, airtableId: 'recAirtableCompetence1', index: '2.2' })),
+      ];
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.recCompetence1.name',
+        locale: 'fr',
+        value: 'Mon super titre',
+      });
+
+      airtableCompetencesScope = nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Competences')
+        .query({
+          fields: {
+            '': competenceDatasource.usedFields,
+          },
+          filterByFormula: `OR("${competenceId}" = {id persistant})`,
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: airtableCompetences });
 
       const airtableThematics = [
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic1', airtableId: 'recAirtableThematic1', index: 2, tubeIds: ['recTube1', 'recTube2', 'recTube3'] })),
@@ -164,6 +180,8 @@ describe('Acceptance | Route | competence-overviews', () => {
             type: 'competence-overviews',
             id: `${competenceId}:challenges-production`,
             attributes: {
+              'airtable-id': 'recAirtableCompetence1',
+              'name': '2.2 Mon super titre',
               'tubes-count': 4,
               'skills-count': 5,
               'thematic-overviews': [
@@ -271,6 +289,7 @@ describe('Acceptance | Route | competence-overviews', () => {
           },
         });
 
+        expect(airtableCompetencesScope.isDone()).toBe(true);
         expect(airtableThematicsScope.isDone()).toBe(true);
         expect(airtableTubesScope.isDone()).toBe(true);
         expect(airtableSkillsScope.isDone()).toBe(true);
@@ -303,6 +322,8 @@ describe('Acceptance | Route | competence-overviews', () => {
             type: 'competence-overviews',
             id: `${competenceId}:challenges-production:en`,
             attributes: {
+              'airtable-id': 'recAirtableCompetence1',
+              'name': '2.2 Mon super titre',
               'tubes-count': 4,
               'skills-count': 5,
               'thematic-overviews': [
@@ -410,6 +431,7 @@ describe('Acceptance | Route | competence-overviews', () => {
           },
         });
 
+        expect(airtableCompetencesScope.isDone()).toBe(true);
         expect(airtableThematicsScope.isDone()).toBe(true);
         expect(airtableTubesScope.isDone()).toBe(true);
         expect(airtableSkillsScope.isDone()).toBe(true);
@@ -419,10 +441,30 @@ describe('Acceptance | Route | competence-overviews', () => {
   });
 
   describe('GET /competences/:id/overviews/challenges-workbench', () => {
-    let competenceId, airtableThematicsScope, airtableTubesScope, airtableSkillsScope, airtableChallengesScope;
+    let competenceId, airtableCompetencesScope, airtableThematicsScope, airtableTubesScope, airtableSkillsScope, airtableChallengesScope;
 
     beforeEach(async function() {
       competenceId = 'recCompetence1';
+
+      const airtableCompetences = [
+        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({ id: competenceId, airtableId: 'recAirtableCompetence1', index: '2.2' })),
+      ];
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.recCompetence1.name',
+        locale: 'fr',
+        value: 'Mon super titre',
+      });
+
+      airtableCompetencesScope = nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Competences')
+        .query({
+          fields: {
+            '': competenceDatasource.usedFields,
+          },
+          filterByFormula: `OR("${competenceId}" = {id persistant})`,
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: airtableCompetences });
 
       const airtableThematics = [
         airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({ id: 'recThematic1', airtableId: 'recAirtableThematic1', index: 2, tubeIds: ['recTube1', 'recTube2'] })),
@@ -554,6 +596,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           type: 'competence-overviews',
           id: `${competenceId}:challenges-workbench`,
           attributes: {
+            'airtable-id': 'recAirtableCompetence1',
+            'name': '2.2 Mon super titre',
             'tubes-count': 3,
             'skills-count': 5,
             'thematic-overviews': [
@@ -648,6 +692,7 @@ describe('Acceptance | Route | competence-overviews', () => {
         },
       });
 
+      expect(airtableCompetencesScope.isDone()).toBe(true);
       expect(airtableThematicsScope.isDone()).toBe(true);
       expect(airtableTubesScope.isDone()).toBe(true);
       expect(airtableSkillsScope.isDone()).toBe(true);

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -113,4 +113,106 @@ describe('Integration | Repository | competence-repository', () => {
       airtableScope.done();
     });
   });
+
+  describe('#get', () => {
+    it('should return the competence by its id', async () => {
+      // given
+      const competenceId = 'competence2';
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns([
+        airtableBuilder.factory.buildCompetence({
+          id: 'competence2',
+          index: '1.2',
+          origin: 'Pix',
+          areaId: 'area2',
+          skillIds: ['skill3', 'skill4'],
+          thematicIds: ['thematic3', 'thematic4'],
+        }),
+      ]).activate().nockScope;
+
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence1.name',
+        locale: 'fr',
+        value: 'Nom compétence 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence1.description',
+        locale: 'fr',
+        value: 'Description compétence 1',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence1.name',
+        locale: 'en',
+        value: 'Competence 1 name',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence1.description',
+        locale: 'en',
+        value: 'Competence 1 description',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence2.name',
+        locale: 'fr',
+        value: 'Nom compétence 2',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence2.description',
+        locale: 'fr',
+        value: 'Description compétence 2',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence2.name',
+        locale: 'en',
+        value: 'Competence 2 name',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence2.description',
+        locale: 'en',
+        value: 'Competence 2 description',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const competence = await competenceRepository.get(competenceId);
+
+      // then
+      expect(competence).toStrictEqual(domainBuilder.buildCompetence({
+        id: 'competence2',
+        airtableId: 'competence2',
+        index: '1.2',
+        origin: 'Pix',
+        areaId: 'area2',
+        skillIds: ['skill3', 'skill4'],
+        thematicIds: ['thematic3', 'thematic4'],
+        name_i18n: {
+          fr: 'Nom compétence 2',
+          en: 'Competence 2 name',
+        },
+        description_i18n:  {
+          fr: 'Description compétence 2',
+          en: 'Competence 2 description',
+        }
+      }));
+      airtableScope.done();
+    });
+
+    it('should return null when no competence with id found', async () => {
+      // given
+      const competenceId = 'coucouMaman';
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns([]).activate().nockScope;
+      databaseBuilder.factory.buildTranslation({
+        key: 'competence.competence1.name',
+        locale: 'fr',
+        value: 'Nom compétence 1',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const competence = await competenceRepository.get(competenceId);
+
+      // then
+      expect(competence).toStrictEqual(null);
+      airtableScope.done();
+    });
+  });
 });

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -1,5 +1,6 @@
 export function buildCompetence({
   id = 'competenceid1',
+  airtableId,
   index,
   areaId,
   skillIds,
@@ -7,7 +8,7 @@ export function buildCompetence({
   origin,
 } = {}) {
   return {
-    id,
+    id: airtableId ?? id,
     'fields': {
       'id persistant': id,
       'Sous-domaine': index,

--- a/pix-editor/app/models/competence-overview.js
+++ b/pix-editor/app/models/competence-overview.js
@@ -1,6 +1,8 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class CompetenceOverviewModel extends Model {
+  @attr() airtableId;
+  @attr() name;
   @attr() thematicOverviews;
   @attr('number') tubesCount;
   @attr('number') skillsCount;


### PR DESCRIPTION
## :fallen_leaf: Problème
Il nous manque des données dans le competence overview.
Il manque son titre pour afficher dans le header.
Il manque le airtableId pour naviguer correctement côté front.

## :chestnut: Proposition
Les ajouter dans le modèle back et front

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Regarder dans l'appel réseau de retour de la competence overview si les attributs sont là.
Mieux, regarder dans le ember plugin du navigateur car ça voudra dire que c'est bien descendu jusqu'au modèle.
