### PR TITLE
[BUGFIX] La moulinette des URLs KO ne marche plus pour les tutoriels (PIX-15320)

### DIFF
--- a/api/db/migrations/20241118095718_drop-primary-column-in-tutorial-ko-urls.js
+++ b/api/db/migrations/20241118095718_drop-primary-column-in-tutorial-ko-urls.js
@@ -1,0 +1,9 @@
+const TABLE_NAME = 'tutorial_ko_urls';
+
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropPrimary('tutorial_ko_urls_pkey');
+  });
+}
+
+export async function down() {}

--- a/api/db/migrations/20241118100619_add-primary-and-tutorial-id-columns-in-table-tutorial_ko_urls.js
+++ b/api/db/migrations/20241118100619_add-primary-and-tutorial-id-columns-in-table-tutorial_ko_urls.js
@@ -1,0 +1,10 @@
+const TABLE_NAME = 'tutorial_ko_urls';
+
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.increments('id').primary();
+    table.string('tutorialId').notNullable();
+  });
+}
+
+export async function down() {}

--- a/api/lib/infrastructure/repositories/url-repository.js
+++ b/api/lib/infrastructure/repositories/url-repository.js
@@ -106,15 +106,16 @@ const CONTINUOUS_FAILURE_MINIMUM_COUNT = 2;
 async function keepUrlsThatFailedAtLeastTwiceInARow(dataToUpload) {
   const finalDataToUpload = [];
   await knex.transaction(async (trx) => {
-    const currentTutorialKoUrlsInDB = await trx(TUTORIAL_KO_URLS_TABLE_NAME);
+    const tutorialKoUrlsInDB = await trx(TUTORIAL_KO_URLS_TABLE_NAME);
 
     const tutorialKoUrlsToInsertInDB = [];
     for (const itemToUpload of dataToUpload) {
-      const [,,,currentUrl] = itemToUpload;
-      let currentContinuousKoCount = currentTutorialKoUrlsInDB.find(({ url }) => url === currentUrl)?.continuousKoCount ?? 0;
+      const [,,currentTutorialId,currentUrl] = itemToUpload;
+      let currentContinuousKoCount = tutorialKoUrlsInDB.find(({ tutorialId, url }) => url === currentUrl && tutorialId === currentTutorialId)?.continuousKoCount ?? 0;
       ++currentContinuousKoCount;
       tutorialKoUrlsToInsertInDB.push({
         url: currentUrl,
+        tutorialId: currentTutorialId,
         continuousKoCount: currentContinuousKoCount,
       });
       if (currentContinuousKoCount >= CONTINUOUS_FAILURE_MINIMUM_COUNT) {
@@ -123,7 +124,7 @@ async function keepUrlsThatFailedAtLeastTwiceInARow(dataToUpload) {
     }
 
     await trx(TUTORIAL_KO_URLS_TABLE_NAME).del();
-    await trx(TUTORIAL_KO_URLS_TABLE_NAME).insert(tutorialKoUrlsToInsertInDB);
+    await trx.batchInsert(TUTORIAL_KO_URLS_TABLE_NAME, tutorialKoUrlsToInsertInDB);
   });
   return finalDataToUpload;
 }


### PR DESCRIPTION
## :fallen_leaf: Problème
Je pensais à tort que les URLs étaient uniques avant d'être passées en moulinette.
Ce n'est vrai que pour les épreuves, pas les tutos.
Le problème c'est que la table pour se souvenir de quelle url a pété la veille, sa primary key c'est l'url, donc ça fait PAF au moment d'insert les données dedans.

## :chestnut: Proposition
Ne plus mettre la colonne url comme étant la primary.
Ajouter une colonne id qui sera la primary.
Ajouter aussi une colonne tutorialId pour se souvenir de quel ID de tuto il s'agit. Je fais ça car je me dis que c'est peut être intentionnel le fait de pas uniciser les urls des tutos, donc pour vérifier que je re-check bien la même "url" que la veille, je considère une url comme étant un couple url / tutorialId

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
