### PR TITLE
[FEATURE] Donner accès à la V2 de la vue "Épreuves -> Production" (PIX-15288)

### DIFF
--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -1,7 +1,7 @@
 <div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite"""}}">
-  <div class="checkbox-v2-container">
-    <h1 class="header">Pix Editor</h1>
-    <PixToggle @size="small" @screenReaderOnly={{true}} @onChange={{this.switchVersion}} @toggled={{this.isSwitchVersionActive}}>
+  <div class="main-sidebar__header">
+    <h1>Pix Editor</h1>
+    <PixToggle @size="small" @screenReaderOnly={{true}} @onChange={{this.switchVersion}} @toggled={{this.isV2}}>
       <:label>changer de version</:label>
       <:off>V1</:off>
       <:on>V2</:on>

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -1,9 +1,11 @@
 <div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite"""}}">
   <div class="checkbox-v2-container">
     <h1 class="header">Pix Editor</h1>
-    <PixCheckbox>
-      <:label>V2</:label>
-    </PixCheckbox>
+    <PixToggle @size="small" @screenReaderOnly={{true}} @onChange={{this.switchVersion}} @toggled={{this.isSwitchVersionActive}}>
+      <:label>changer de version</:label>
+      <:off>V1</:off>
+      <:on>V2</:on>
+    </PixToggle>
   </div>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
   <Sidebar::Search @displaySearch={{this.maySearch}} @close={{@close}} />

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -1,6 +1,10 @@
-<div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite"
-                                                                                                 ""}}">
-  <h1 class="header">Pix Editor</h1>
+<div class="ui inverted left wide sidebar {{if @open "visible "}}main-sidebar menu vertical {{if this.config.lite "lite"""}}">
+  <div class="checkbox-v2-container">
+    <h1 class="header">Pix Editor</h1>
+    <PixCheckbox>
+      <:label>V2</:label>
+    </PixCheckbox>
+  </div>
   <p class="legal-mention" style="margin: 0;">Confidentiel - secret - ne pas divulguer</p>
   <Sidebar::Search @displaySearch={{this.maySearch}} @close={{@close}} />
   <Sidebar::Navigation @displayFrameworkList={{this.maySwitchFramework}} @close={{@close}}/>

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -1,5 +1,7 @@
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import ENV from 'pixeditor/config/environment';
 
 import FrameworkModel from '../../models/framework';
@@ -9,6 +11,14 @@ export default class SidebarMain extends Component {
   @service access;
   @service config;
   @service currentData;
+  @service versionManager;
+
+  @tracked isSwitchVersionActive;
+
+  constructor(...args) {
+    super(...args);
+    this.isSwitchVersionActive = this.versionManager.isV2();
+  }
 
   get author() {
     return this.config.author;
@@ -44,6 +54,12 @@ export default class SidebarMain extends Component {
 
   get shouldShowMissionsLink() {
     return this.currentData?.getFramework()?.name.toLowerCase() === FrameworkModel.pix1DFrameworkName.toLowerCase();
+  }
+
+  @action
+  switchVersion() {
+    this.isSwitchVersionActive = !this.isSwitchVersionActive;
+    this.versionManager.setVersion(this.isSwitchVersionActive);
   }
 }
 

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import ENV from 'pixeditor/config/environment';
 
 import FrameworkModel from '../../models/framework';
@@ -13,11 +12,8 @@ export default class SidebarMain extends Component {
   @service currentData;
   @service versionManager;
 
-  @tracked isSwitchVersionActive;
-
   constructor(...args) {
     super(...args);
-    this.isSwitchVersionActive = this.versionManager.isV2();
   }
 
   get author() {
@@ -56,10 +52,13 @@ export default class SidebarMain extends Component {
     return this.currentData?.getFramework()?.name.toLowerCase() === FrameworkModel.pix1DFrameworkName.toLowerCase();
   }
 
+  get isV2() {
+    return this.versionManager.isV2;
+  }
+
   @action
   switchVersion() {
-    this.isSwitchVersionActive = !this.isSwitchVersionActive;
-    this.versionManager.setVersion(this.isSwitchVersionActive);
+    this.versionManager.toggleV2();
   }
 }
 

--- a/pix-editor/app/models/competence-overview.js
+++ b/pix-editor/app/models/competence-overview.js
@@ -6,4 +6,16 @@ export default class CompetenceOverviewModel extends Model {
   @attr() thematicOverviews;
   @attr('number') tubesCount;
   @attr('number') skillsCount;
+
+  get competencePixId() {
+    return this.id.split(':')[0];
+  }
+
+  get view() {
+    return this.id.split(':')[1].split('-')[1];
+  }
+
+  get locale() {
+    return this.id.split(':')[2];
+  }
 }

--- a/pix-editor/app/routes/authenticated/competence/prototypes.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes.js
@@ -54,10 +54,10 @@ export default class PrototypesRoute extends Route {
     // QUESTION: est-ce nécessaire ?
     this.currentData.setPrototype(null);
 
-    const isToggled = this.versionManager.isV2();
+    if (!this.versionManager.isV2) return;
     const view = transition.to.queryParams.view;
     const goingToProduction = view === 'production' || !view;
-    if (goingToProduction && isToggled) {
+    if (goingToProduction) {
       const competence_id = model.competencePixId;
       const locale = model.locale;
       const overview = 'challenges-production';

--- a/pix-editor/app/routes/authenticated/competence/prototypes.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes.js
@@ -7,6 +7,7 @@ export default class PrototypesRoute extends Route {
   @service currentData;
   @service store;
   @service router;
+  @service versionManager;
 
   refreshing = false;
 
@@ -49,9 +50,20 @@ export default class PrototypesRoute extends Route {
 
   }
 
-  afterModel() {
+  afterModel(model, transition) {
     // QUESTION: est-ce nécessaire ?
     this.currentData.setPrototype(null);
+
+    const isToggled = this.versionManager.isV2();
+    const view = transition.to.queryParams.view;
+    const goingToProduction = view === 'production' || !view;
+    if (goingToProduction && isToggled) {
+      const competence_id = model.competencePixId;
+      const locale = model.locale;
+      const overview = 'challenges-production';
+
+      this.router.transitionTo('authenticated.v2.competence-overview', competence_id, overview, { queryParams: { locale } });
+    }
   }
 
   @action

--- a/pix-editor/app/routes/authenticated/v2/competence-overview.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview.js
@@ -28,14 +28,13 @@ export default class CompetenceOverviewRoute extends Route {
   }
 
   afterModel(model) {
-    const isV1 = !this.versionManager.isV2();
-    if (isV1) {
-      const { competenceOverview } = model;
-      const competence_id = competenceOverview.airtableId;
-      const locale = competenceOverview.locale;
-      const view = competenceOverview.view;
+    if (this.versionManager.isV2) return;
 
-      this.router.transitionTo('authenticated.competence.prototypes', competence_id, { queryParams: { languageFilter: locale, view } });
-    }
+    const { competenceOverview } = model;
+    const competence_id = competenceOverview.airtableId;
+    const locale = competenceOverview.locale;
+    const view = competenceOverview.view;
+
+    this.router.transitionTo('authenticated.competence.prototypes', competence_id, { queryParams: { languageFilter: locale, view } });
   }
 }

--- a/pix-editor/app/routes/authenticated/v2/competence-overview.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview.js
@@ -3,7 +3,9 @@ import { inject as service } from '@ember/service';
 
 export default class CompetenceOverviewRoute extends Route {
 
+  @service router;
   @service store;
+  @service versionManager;
 
   queryParams = {
     locale: {
@@ -23,5 +25,17 @@ export default class CompetenceOverviewRoute extends Route {
       competenceOverview,
       locale,
     };
+  }
+
+  afterModel(model) {
+    const isV1 = !this.versionManager.isV2();
+    if (isV1) {
+      const { competenceOverview } = model;
+      const competence_id = competenceOverview.airtableId;
+      const locale = competenceOverview.locale;
+      const view = competenceOverview.view;
+
+      this.router.transitionTo('authenticated.competence.prototypes', competence_id, { queryParams: { languageFilter: locale, view } });
+    }
   }
 }

--- a/pix-editor/app/services/version-manager.js
+++ b/pix-editor/app/services/version-manager.js
@@ -1,0 +1,14 @@
+import Service, { inject as service } from '@ember/service';
+
+export default class VersionManagerService extends Service {
+  @service router;
+
+  isV2() {
+    return JSON.parse(window.localStorage.getItem('version-toggle')) ?? false;
+  }
+
+  setVersion(isVersionToggled) {
+    window.localStorage.setItem('version-toggle', JSON.stringify(isVersionToggled));
+    this.router.refresh();
+  }
+}

--- a/pix-editor/app/services/version-manager.js
+++ b/pix-editor/app/services/version-manager.js
@@ -1,14 +1,26 @@
 import Service, { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+const V2_STORAGE_KEY = 'v2';
 
 export default class VersionManagerService extends Service {
   @service router;
+  @tracked isV2;
 
-  isV2() {
-    return JSON.parse(window.localStorage.getItem('version-toggle')) ?? false;
+  constructor(properties, windowRef = window) {
+    super(properties);
+    this.isV2 = this.getV2(windowRef);
   }
 
-  setVersion(isVersionToggled) {
-    window.localStorage.setItem('version-toggle', JSON.stringify(isVersionToggled));
+  toggleV2(windowRef = window) {
+    const newValue = !this.getV2(windowRef);
+    this.isV2 = newValue;
+    windowRef.localStorage.setItem(V2_STORAGE_KEY, JSON.stringify(newValue));
     this.router.refresh();
+  }
+
+  getV2(windowRef = window) {
+    const stringValue = windowRef.localStorage.getItem(V2_STORAGE_KEY) ?? 'false';
+    return JSON.parse(stringValue);
   }
 }

--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -5,12 +5,21 @@
     transition: transform 0.5s, visibility 0.5s;
   }
 
-  h1.header {
-    height: 50px;
-    margin: 0;
-    padding: 15px 5px;
+  .checkbox-v2-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 15px 15px 15px 5px;
     color: #ffffff;
-    font-size: 25px;
+
+    h1.header {
+      margin: 0;
+      font-size: 25px;
+    }
+
+    label span {
+      color: #ffffff;
+    }
   }
 
   .legal-mention {

--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -5,14 +5,14 @@
     transition: transform 0.5s, visibility 0.5s;
   }
 
-  .checkbox-v2-container {
+  &__header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 15px 15px 15px 5px;
     color: #ffffff;
 
-    h1.header {
+    h1 {
       margin: 0;
       font-size: 25px;
     }

--- a/pix-editor/tests/acceptance/missions/creation-test.js
+++ b/pix-editor/tests/acceptance/missions/creation-test.js
@@ -21,7 +21,7 @@ module('Acceptance | Missions | Creation', function(hooks) {
     this.server.create('mission-summary', { name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
   });
 
-  module.skip('when user does not have write access', function(hooks) {
+  module('when user does not have write access', function(hooks) {
 
     hooks.beforeEach(function() {
       this.server.create('user', { trigram: 'ABC', access: 'readonly' });

--- a/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
@@ -10,7 +10,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function() {
-    window.localStorage.setItem('version-toggle', 'true');
+    window.localStorage.setItem('v2', 'true');
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });

--- a/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
@@ -10,6 +10,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function() {
+    window.localStorage.setItem('version-toggle', 'true');
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });

--- a/pix-editor/tests/acceptance/v2/navigation-v1-v2_test.js
+++ b/pix-editor/tests/acceptance/v2/navigation-v1-v2_test.js
@@ -1,0 +1,108 @@
+import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../setup-application-rendering';
+
+module('Acceptance | navigation-v1-v2', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.lookup('service:store');
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    this.server.create('competence', { id: 'recCompetence1', pixId: 'competence1', rawTubeIds: [], rawThemeIds: [], code: '1.1', title: 'ma compétence' });
+    this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1'] });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+
+    this.server.create('competence-overview', {
+      id: 'competence1:challenges-production',
+      airtableId: 'recCompetence1',
+      name: '1.1 ma compétence',
+      thematicOverviews: [{
+        id: 'thematic1',
+        name: 'thematic name',
+        tubeOverviews: [{
+          id: 'tube1',
+          name: '@tube',
+          skillOverviews: [{
+            id: 'skill1',
+            name: '@tube1',
+            prototypeId: 'prototype1',
+            isPrototypeDeclinable: true,
+            proposedChallengesCount: 1,
+            validatedChallengesCount: 1,
+          }, null, null, null, null, null, null],
+        }],
+      }],
+    });
+    this.server.create('competence-overview', {
+      id: 'competence1:challenges-production:nl',
+      airtableId: 'recCompetence1',
+      name: '1.1 ma compétence',
+      thematicOverviews: [{
+        id: 'thematic1',
+        name: 'thematic name',
+        tubeOverviews: [{
+          id: 'tube1',
+          name: '@tube',
+          skillOverviews: [{
+            id: 'skill1',
+            name: '@tube1',
+            prototypeId: 'prototype1',
+            isPrototypeDeclinable: true,
+            proposedChallengesCount: 0,
+            validatedChallengesCount: 1,
+          }, null, null, null, null, null, null],
+        }],
+      }],
+    });
+
+    return authenticateSession();
+  });
+
+  test('should navigate to v2 route if v2 is enabled', async function(assert) {
+    // when
+    await visit('/');
+
+    // then
+    await clickByText('V2');
+    await clickByText('1. Information et données');
+    await clickByText('1.1 ma compétence');
+
+    assert.strictEqual(currentURL(), '/v2/competences/competence1/challenges-production');
+  });
+
+  test('should upgrade route to v2 when toggling v2 on upgradable v1 route', async function(assert) {
+    // when
+    await visit('/competence/recCompetence1/prototypes?view=production');
+    await clickByText('V2');
+
+    // then
+    assert.strictEqual(currentURL(), '/v2/competences/competence1/challenges-production');
+  });
+
+  test('should downgrade route to v1 when toggling v1 on a v2 route', async function(assert) {
+    // when
+    await visit('/');
+    await clickByText('V2');
+    await visit('/v2/competences/competence1/challenges-production');
+    await clickByText('V2');
+
+    // then
+    assert.strictEqual(currentURL(), '/competence/recCompetence1/prototypes?view=production');
+  });
+
+  test('should remember selected language when switching from/to v2', async function(assert) {
+    // when
+    await visit('/competence/recCompetence1/prototypes?view=production&languageFilter=nl');
+    await clickByText('V2');
+
+    // then
+    assert.strictEqual(currentURL(), '/v2/competences/competence1/challenges-production?locale=nl');
+  });
+});

--- a/pix-editor/tests/setup-application-rendering.js
+++ b/pix-editor/tests/setup-application-rendering.js
@@ -4,4 +4,8 @@ import { setupApplicationTest as emberSetupApplicationTest } from 'ember-qunit';
 export function setupApplicationTest(hooks) {
   emberSetupApplicationTest(hooks);
   setupIntl(hooks, 'fr');
+
+  hooks.beforeEach(function() {
+    window.localStorage.removeItem('version-toggle');
+  });
 }

--- a/pix-editor/tests/setup-application-rendering.js
+++ b/pix-editor/tests/setup-application-rendering.js
@@ -6,6 +6,6 @@ export function setupApplicationTest(hooks) {
   setupIntl(hooks, 'fr');
 
   hooks.beforeEach(function() {
-    window.localStorage.removeItem('version-toggle');
+    window.localStorage.removeItem('v2');
   });
 }


### PR DESCRIPTION
## :fallen_leaf: Problème
La V2 de la route "Épreuves -> Production" est accessible seulement en modifiant manuellement l'URL.

## :chestnut: Proposition
Ajouter un interrupteur permettant de basculer entre la V1 et la V2.

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
- Accéder à la route "Épreuves -> Production".
- Cliquer sur l'interrupteur en haut dans la barre latérale de gauche.
- Constater qu'on navigue vers la V2 de cette vue.
- Essayer de casser le système? 🤷
