### PR TITLE
[TECH] Script de comparaison des schémas des tables des différents environnements Airtable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ testem.log
 api/public/pix-editor/**
 **/.eslintcache
 api/.adminjs
+COMPARE_SCRIPT_*
 
 # ember-try
 **/.node_modules.ember-try/

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
     "db:seed": "knex --knexfile db/knexfile.js seed:run",
     "db:reset": "npm run db:prepare && npm run db:seed",
     "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
+    "airtable:compare-schemas": "node scripts/compare-airtable-schemas/fetch-schemas.js && node scripts/compare-airtable-schemas/compare-schemas.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preinstall": "npx check-engine && git config core.hooksPath .githooks || true",

--- a/api/scripts/compare-airtable-schemas/bases-to-compare.js
+++ b/api/scripts/compare-airtable-schemas/bases-to-compare.js
@@ -1,0 +1,7 @@
+// Slugs specified here will be used to find the baseId environment variable:
+// `AIRTABLE_BASE_${slug}`
+export default [
+  'REVIEW_APPS',
+  'INTEGRATION',
+  'PRODUCTION'
+];

--- a/api/scripts/compare-airtable-schemas/compare-schemas.js
+++ b/api/scripts/compare-airtable-schemas/compare-schemas.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { readFile, writeFile } from 'node:fs/promises';
+import { logger } from '../../lib/infrastructure/logger.js';
 import basesToCompare from './bases-to-compare.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -54,7 +55,7 @@ async function main() {
     for (const [base, identifiers] of basesIdentifiers) {
       const otherBasesIdentifiers = basesIdentifiers.filter(([b]) => b !== base);
       for (const [otherBase, otherIdentifiers] of otherBasesIdentifiers) {
-        console.info(`🧐 Comparing ${base} to ${otherBase} ...`);
+        logger.info(`🧐 Comparing ${base} to ${otherBase} ...`);
 
         const missingTablesInOtherBase = findMissingTables(identifiers, otherIdentifiers);
         const missingFieldsInOtherBase = findMissingFields(identifiers, otherIdentifiers, missingTablesInOtherBase);
@@ -71,7 +72,7 @@ async function main() {
       }
     }
   } catch (e) {
-    console.error(e);
+    logger.error(e);
     process.exitCode = 1;
   }
 }

--- a/api/scripts/compare-airtable-schemas/compare-schemas.js
+++ b/api/scripts/compare-airtable-schemas/compare-schemas.js
@@ -1,0 +1,77 @@
+import { fileURLToPath } from 'node:url';
+import { readFile, writeFile } from 'node:fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+function fromIdentifierToTableName(key) {
+  return key.split('.')[0];
+}
+
+function fromIdentifierToFieldName(key) {
+  return key.split('.').slice(0, 2).join('.');
+}
+
+function findMissingTables(aIdentifiers, bIdentifiers) {
+  const aTables = new Set(aIdentifiers.map(fromIdentifierToTableName));
+  const bTables = new Set(bIdentifiers.map(fromIdentifierToTableName));
+  return Array.from(aTables.difference(bTables));
+}
+
+function findMissingFields(aIdentifiers, bIdentifiers, alreadyMissingTables) {
+  const aTables = new Set(aIdentifiers
+    .filter((identifier) => {
+      const table = fromIdentifierToTableName(identifier);
+      return !alreadyMissingTables.includes(table);
+    })
+    .map(fromIdentifierToFieldName));
+  const bTables = new Set(bIdentifiers.map(fromIdentifierToFieldName));
+  return Array.from(aTables.difference(bTables));
+}
+
+function findDifferentFieldTypes(aIdentifiers, bIdentifiers, alreadyMissingTables, alreadyMissingFields) {
+  const aTables = new Set(aIdentifiers
+    .filter((identifier) => {
+      const table = fromIdentifierToTableName(identifier);
+      const field = fromIdentifierToFieldName(identifier);
+      return !(alreadyMissingTables.includes(table) || alreadyMissingFields.includes(field));
+    }));
+  const bTables = new Set(bIdentifiers);
+  return Array.from(aTables.difference(bTables));
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+  try {
+    const bases = ['RA', 'INTEG', 'PROD'];
+    const basesIdentifiers = [];
+    for (const base of bases) {
+      const rawFile = await readFile(`COMPARE_SCRIPT_schema_${base}.json`, { encoding: 'utf-8' });
+      const identifiers = JSON.parse(rawFile);
+      basesIdentifiers.push([base, identifiers]);
+    }
+
+    for (const [base, identifiers] of basesIdentifiers) {
+      const otherBasesIdentifiers = basesIdentifiers.filter(([b]) => b !== base);
+      for (const [otherBase, otherIdentifiers] of otherBasesIdentifiers) {
+        const missingTablesInOtherBase = findMissingTables(identifiers, otherIdentifiers);
+        const missingFieldsInOtherBase = findMissingFields(identifiers, otherIdentifiers, missingTablesInOtherBase);
+        const differentTypeInOtherBase = findDifferentFieldTypes(identifiers, otherIdentifiers, missingTablesInOtherBase, missingFieldsInOtherBase);
+
+        const res = {
+          missingTablesInOtherBase,
+          missingFieldsInOtherBase,
+          differentTypeInOtherBase,
+        };
+
+        const fileName = `COMPARE_SCRIPT_fields_in_${base}_but_not_in_${otherBase}.json`;
+        await writeFile(fileName, JSON.stringify(res, null, 2));
+      }
+    }
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/api/scripts/compare-airtable-schemas/compare-schemas.js
+++ b/api/scripts/compare-airtable-schemas/compare-schemas.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { readFile, writeFile } from 'node:fs/promises';
+import basesToCompare from './bases-to-compare.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const isLaunchedFromCommandLine = process.argv[1] === __filename;
@@ -43,9 +44,8 @@ function findDifferentFieldTypes(aIdentifiers, bIdentifiers, alreadyMissingTable
 async function main() {
   if (!isLaunchedFromCommandLine) return;
   try {
-    const bases = ['REVIEW_APPS', 'INTEGRATION', 'PRODUCTION'];
     const basesIdentifiers = [];
-    for (const base of bases) {
+    for (const base of basesToCompare) {
       const rawFile = await readFile(`COMPARE_SCRIPT_schema_keys_for_${base}.json`, { encoding: 'utf-8' });
       const identifiers = JSON.parse(rawFile);
       basesIdentifiers.push([base, identifiers]);

--- a/api/scripts/compare-airtable-schemas/compare-schemas.js
+++ b/api/scripts/compare-airtable-schemas/compare-schemas.js
@@ -43,10 +43,10 @@ function findDifferentFieldTypes(aIdentifiers, bIdentifiers, alreadyMissingTable
 async function main() {
   if (!isLaunchedFromCommandLine) return;
   try {
-    const bases = ['RA', 'INTEG', 'PROD'];
+    const bases = ['REVIEW_APPS', 'INTEGRATION', 'PRODUCTION'];
     const basesIdentifiers = [];
     for (const base of bases) {
-      const rawFile = await readFile(`COMPARE_SCRIPT_schema_${base}.json`, { encoding: 'utf-8' });
+      const rawFile = await readFile(`COMPARE_SCRIPT_schema_keys_for_${base}.json`, { encoding: 'utf-8' });
       const identifiers = JSON.parse(rawFile);
       basesIdentifiers.push([base, identifiers]);
     }
@@ -54,14 +54,16 @@ async function main() {
     for (const [base, identifiers] of basesIdentifiers) {
       const otherBasesIdentifiers = basesIdentifiers.filter(([b]) => b !== base);
       for (const [otherBase, otherIdentifiers] of otherBasesIdentifiers) {
+        console.info(`🧐 Comparing ${base} to ${otherBase} ...`);
+
         const missingTablesInOtherBase = findMissingTables(identifiers, otherIdentifiers);
         const missingFieldsInOtherBase = findMissingFields(identifiers, otherIdentifiers, missingTablesInOtherBase);
-        const differentTypeInOtherBase = findDifferentFieldTypes(identifiers, otherIdentifiers, missingTablesInOtherBase, missingFieldsInOtherBase);
+        const differentFieldTypesInOtherBase = findDifferentFieldTypes(identifiers, otherIdentifiers, missingTablesInOtherBase, missingFieldsInOtherBase);
 
         const res = {
-          missingTablesInOtherBase,
-          missingFieldsInOtherBase,
-          differentTypeInOtherBase,
+          [`missingTablesIn_${otherBase}`]: missingTablesInOtherBase,
+          [`missingFieldsIn_${otherBase}`]: missingFieldsInOtherBase,
+          [`differentFieldTypesIn_${otherBase}`]: differentFieldTypesInOtherBase,
         };
 
         const fileName = `COMPARE_SCRIPT_fields_in_${base}_but_not_in_${otherBase}.json`;

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -21,7 +21,21 @@ export async function fetchTableSchemas({ baseId, apiKey }) {
 }
 
 function getFieldKeys(table) {
-  return table.fields.map((field) => `${table.name}.${field.name}.${field.type}`);
+  return table.fields.map((field) => {
+    let key = `${table.name}.${field.name}.${field.type}`;
+    if (field.type === 'formula') {
+      let simplifiedFormula = field.options.formula;
+      for (const [i, fieldId] of field.options.referencedFieldIds.toSorted().entries()) {
+        simplifiedFormula = simplifiedFormula.replaceAll(fieldId, `fieldNumber${i + 1}`);
+      }
+      key += `=\`${simplifiedFormula}\``;
+    }
+    if (['singleSelect', 'multipleSelects'].includes(field.type)) {
+      const options = field.options.choices.map(({ name }) => name).toSorted().join('/');
+      key += `:${options}`;
+    }
+    return key;
+  });
 }
 
 async function main() {

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -21,37 +21,44 @@ export async function fetchTableSchemas({ baseId, apiKey }) {
 }
 
 function getFieldKeys(table) {
-  const keys = [];
-  for (const field of table.fields) {
-    const fieldKey = `${table.name}.${field.name}.${field.type}`;
-    keys.push(fieldKey);
-  }
-  return keys;
+  return table.fields.map((field) => `${table.name}.${field.name}.${field.type}`);
 }
 
 async function main() {
   if (!isLaunchedFromCommandLine) return;
   try {
-    const apiKey = process.env.AIRTABLE_API_KEY;
-    if (!apiKey) throw new Error('Missing Airtable API key');
+    // Throw all env errors at once for faster feedback
+    const missingEnvErrors = [];
 
-    const reviewAppsBaseId = process.env.AIRTABLE_BASE;
-    if (!reviewAppsBaseId) throw new Error('Missing Review Apps base id');
+    // Jeton d'accès `read-schema-only`
+    const apiKey = process.env.AIRTABLE_READ_ONLY_API_KEY;
+    if (!apiKey) missingEnvErrors.push('🕵️ Missing AIRTABLE_READ_ONLY_API_KEY environment variable');
+
+    const reviewAppsBaseId = process.env.AIRTABLE_BASE_REVIEW_APPS;
+    if (!reviewAppsBaseId) missingEnvErrors.push('🕵️ Missing AIRTABLE_BASE_REVIEW_APPS environment variable');
 
     const integrationBaseId = process.env.AIRTABLE_BASE_INTEGRATION;
-    if (!integrationBaseId) throw new Error('Missing Integration base id');
+    if (!integrationBaseId) missingEnvErrors.push('🕵️ Missing AIRTABLE_BASE_INTEGRATION environment variable');
 
     const prodBaseId = process.env.AIRTABLE_BASE_PROD;
-    if (!prodBaseId) throw new Error('Missing Prod base id');
+    if (!prodBaseId) missingEnvErrors.push('🕵️ Missing AIRTABLE_BASE_PROD environment variable');
 
-    for (const [env, id] of [['RA', reviewAppsBaseId], ['INTEG', integrationBaseId], ['PROD', prodBaseId]]) {
+    if (missingEnvErrors.length > 0) {
+      throw new Error(missingEnvErrors.join(',\n'));
+    }
+
+    for (const [env, id] of [
+      ['REVIEW_APPS', reviewAppsBaseId],
+      ['INTEGRATION', integrationBaseId],
+      ['PRODUCTION', prodBaseId],
+    ]) {
+      console.info(`📥 Fetching schema for base '${env}' ...`);
       const reviewAppsTableSchemas = await fetchTableSchemas({ baseId: id, apiKey });
       const keys = reviewAppsTableSchemas.flatMap(getFieldKeys).sort();
 
-      const resultFileName = `COMPARE_SCRIPT_schema_${env}.json`;
+      const resultFileName = `COMPARE_SCRIPT_schema_keys_for_${env}.json`;
       await writeFile(resultFileName, JSON.stringify(keys, null, 2));
     }
-
   } catch (e) {
     console.error(e);
     process.exitCode = 1;

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -25,8 +25,9 @@ function getFieldKeys(table) {
     let key = `${table.name}.${field.name}.${field.type}`;
     if (field.type === 'formula') {
       let simplifiedFormula = field.options.formula;
-      for (const [i, fieldId] of field.options.referencedFieldIds.toSorted().entries()) {
-        simplifiedFormula = simplifiedFormula.replaceAll(fieldId, `fieldNumber${i + 1}`);
+      for (const fieldId of field.options.referencedFieldIds) {
+        const fieldName = table.fields.find((field) => field.id === fieldId).name;
+        simplifiedFormula = simplifiedFormula.replaceAll(fieldId, `\`${fieldName}\``);
       }
       key += `=\`${simplifiedFormula}\``;
     }

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -67,8 +67,8 @@ async function main() {
       ['PRODUCTION', prodBaseId],
     ]) {
       console.info(`📥 Fetching schema for base '${env}' ...`);
-      const reviewAppsTableSchemas = await fetchTableSchemas({ baseId: id, apiKey });
-      const keys = reviewAppsTableSchemas.flatMap(getFieldKeys).sort();
+      const baseTableSchemas = await fetchTableSchemas({ baseId: id, apiKey });
+      const keys = baseTableSchemas.flatMap(getFieldKeys).sort();
 
       const resultFileName = `COMPARE_SCRIPT_schema_keys_for_${env}.json`;
       await writeFile(resultFileName, JSON.stringify(keys, null, 2));

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -1,0 +1,61 @@
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import * as dotenv from 'dotenv';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+dotenv.config({ path: resolve(__dirname, '../../.env') });
+
+const __filename = fileURLToPath(import.meta.url);
+const isLaunchedFromCommandLine = process.argv[1] === __filename;
+
+export async function fetchTableSchemas({ baseId, apiKey }) {
+  const res = await fetch(`https://api.airtable.com/v0/meta/bases/${baseId}/tables`, {
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    credentials: 'include',
+  });
+  const body = await res.json();
+  return body.tables;
+}
+
+function getFieldKeys(table) {
+  const keys = [];
+  for (const field of table.fields) {
+    const fieldKey = `${table.name}.${field.name}.${field.type}`;
+    keys.push(fieldKey);
+  }
+  return keys;
+}
+
+async function main() {
+  if (!isLaunchedFromCommandLine) return;
+  try {
+    const apiKey = process.env.AIRTABLE_API_KEY;
+    if (!apiKey) throw new Error('Missing Airtable API key');
+
+    const reviewAppsBaseId = process.env.AIRTABLE_BASE;
+    if (!reviewAppsBaseId) throw new Error('Missing Review Apps base id');
+
+    const integrationBaseId = process.env.AIRTABLE_BASE_INTEGRATION;
+    if (!integrationBaseId) throw new Error('Missing Integration base id');
+
+    const prodBaseId = process.env.AIRTABLE_BASE_PROD;
+    if (!prodBaseId) throw new Error('Missing Prod base id');
+
+    for (const [env, id] of [['RA', reviewAppsBaseId], ['INTEG', integrationBaseId], ['PROD', prodBaseId]]) {
+      const reviewAppsTableSchemas = await fetchTableSchemas({ baseId: id, apiKey });
+      const keys = reviewAppsTableSchemas.flatMap(getFieldKeys).sort();
+
+      const resultFileName = `COMPARE_SCRIPT_schema_${env}.json`;
+      await writeFile(resultFileName, JSON.stringify(keys, null, 2));
+    }
+
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import * as dotenv from 'dotenv';
+import basesToCompare from './bases-to-compare.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 dotenv.config({ path: resolve(__dirname, '../../.env') });
@@ -49,24 +50,25 @@ async function main() {
     const apiKey = process.env.AIRTABLE_READ_ONLY_API_KEY;
     if (!apiKey) missingEnvErrors.push('🕵️ Missing AIRTABLE_READ_ONLY_API_KEY environment variable');
 
-    const reviewAppsBaseId = process.env.AIRTABLE_BASE_REVIEW_APPS;
-    if (!reviewAppsBaseId) missingEnvErrors.push('🕵️ Missing AIRTABLE_BASE_REVIEW_APPS environment variable');
-
-    const integrationBaseId = process.env.AIRTABLE_BASE_INTEGRATION;
-    if (!integrationBaseId) missingEnvErrors.push('🕵️ Missing AIRTABLE_BASE_INTEGRATION environment variable');
-
-    const prodBaseId = process.env.AIRTABLE_BASE_PROD;
-    if (!prodBaseId) missingEnvErrors.push('🕵️ Missing AIRTABLE_BASE_PROD environment variable');
+    const bases = [];
+    for (const baseSlug of basesToCompare) {
+      const envName = `AIRTABLE_BASE_${baseSlug}`;
+      const baseId = process.env[envName];
+      if (!baseId) missingEnvErrors.push(`🕵️ Missing ${envName} environment variable`);
+      bases.push([baseSlug, baseId]);
+    }
 
     if (missingEnvErrors.length > 0) {
       throw new Error(missingEnvErrors.join(',\n'));
     }
+    if (bases.length === 0) {
+      throw new Error('👀 No valid bases were specified in `bases-to-compare.js`');
+    }
+    if (bases.length < 2) {
+      throw new Error('🧑‍🤝‍🧑 Not enough valid bases were specified in `bases-to-compare.js`, at least 2 are required.');
+    }
 
-    for (const [env, id] of [
-      ['REVIEW_APPS', reviewAppsBaseId],
-      ['INTEGRATION', integrationBaseId],
-      ['PRODUCTION', prodBaseId],
-    ]) {
+    for (const [env, id] of bases) {
       console.info(`📥 Fetching schema for base '${env}' ...`);
       const baseTableSchemas = await fetchTableSchemas({ baseId: id, apiKey });
       const keys = baseTableSchemas.flatMap(getFieldKeys).sort();

--- a/api/scripts/compare-airtable-schemas/fetch-schemas.js
+++ b/api/scripts/compare-airtable-schemas/fetch-schemas.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import * as dotenv from 'dotenv';
+import { logger } from '../../lib/infrastructure/logger.js';
 import basesToCompare from './bases-to-compare.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -69,7 +70,7 @@ async function main() {
     }
 
     for (const [env, id] of bases) {
-      console.info(`📥 Fetching schema for base '${env}' ...`);
+      logger.info(`📥 Fetching schema for base '${env}' ...`);
       const baseTableSchemas = await fetchTableSchemas({ baseId: id, apiKey });
       const keys = baseTableSchemas.flatMap(getFieldKeys).sort();
 
@@ -77,7 +78,7 @@ async function main() {
       await writeFile(resultFileName, JSON.stringify(keys, null, 2));
     }
   } catch (e) {
-    console.error(e);
+    logger.error(e);
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## :fallen_leaf: Problème

On ne peut pas facilement savoir si les différents environnements Airtable (RA, Integ, Prod) ont les mêmes schémas de tables.

## :chestnut: Proposition

Création d'un script permettant de générer des fichiers de "diff" des schémas des différents environnements.
On peut spécifier les environnements à comparer dans le fichier `bases-to-compare.js`.
Celui-ci génère 2 types de fichiers JSON:
- Les fichiers de schémas des différentes bases `COMPARE_SCRIPT_schema_keys_for_$ENV.json`.
- Les fichiers de comparaison entre les différentes bases `COMPARE_SCRIPT_fields_in_$ENV1_but_not_in_$ENV2.json`.

En ouvrant le fichier `COMPARE_SCRIPT_fields_in_REVIEW_APPS_but_not_in_PRODUCTION.json`, on peut voir si:
- Il manque des tables dans la base PRODUCTION.
- Il manque des champs dans des tables de la base PRODUCTION.
- Des champs ont des types différents dans les tables de la base PRODUCTION. 

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
Lancer la commande `npm run airtable:compare-schemas` du sous-dossier `api`.