### PR TITLE
[TECH] Remplacer le loader de la V2 par le nouveau loader

### DIFF
--- a/pix-editor/app/templates/authenticated/v2/loading.hbs
+++ b/pix-editor/app/templates/authenticated/v2/loading.hbs
@@ -1,3 +1,3 @@
 <div class="ui page dimmer inverted active">
-  <div class="ui loader"></div>
+  <Loader />
 </div>


### PR DESCRIPTION
## :fallen_leaf: Problème
La V2 n'utilise pas le bon loader.

## :chestnut: Proposition
Utiliser le nouveau composant `<Loader />`

## :jack_o_lantern: Remarques
RAS

## :wood: Pour tester
- Aller sur [la V2
](https://pix-lcms-review-pr829.osc-fr1.scalingo.io/v2/competences/recsvLz0W2ShyfD63/challenges-production)
- Constater que le nouveau loader s'affiche.
- Changer de langue.
- Constater que le nouveau loader s'affiche.
