### PR TITLE
[BUGFIX] Création d’un proto depuis la vue workbench (PIX-15405)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence.js
+++ b/pix-editor/app/controllers/authenticated/competence.js
@@ -147,7 +147,7 @@ export default class CompetenceController extends Controller {
 
   @action
   newPrototype() {
-    this.router.transitionTo('authenticated.competence.prototypes.new', this.competence);
+    this.router.transitionTo('authenticated.competence.prototypes.new', this.competence, { queryParams: { view: 'workbench-list' } });
   }
 
   @action


### PR DESCRIPTION
## :fallen_leaf: Problème
Quand on créé un proto dans la vue workbench d’une compétence, dans la liste des protos on obtient le nouveau proto mais aussi une ligne vide.

## :chestnut: Proposition
Empêcher le model de la route de création de proto d’être appeler 2 fois.

## :jack_o_lantern: Remarques
N/A

## :wood: Pour tester
Créer un nouveau proto depuis la vue workbench.