### PR TITLE
[FEATURE] Exposer toutes les missions dans la release, y compris les inactives (PIX-15478)

### DIFF
--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -37,9 +37,9 @@ export async function findAllMissions({ filter, page }) {
   };
 }
 
-export async function listActive() {
+export async function list() {
   const [missions, translations] = await Promise.all([
-    knex('missions').select('*').whereNot({ status: 'INACTIVE' }),
+    knex('missions').select('*').orderBy('id'),
     translationRepository.listByModel(model),
   ]);
 

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -1,8 +1,4 @@
-import {
-  attachmentDatasource,
-  challengeDatasource,
-  tutorialDatasource,
-} from '../datasources/airtable/index.js';
+import { attachmentDatasource, challengeDatasource, tutorialDatasource, } from '../datasources/airtable/index.js';
 import {
   areaRepository,
   challengeRepository,
@@ -16,15 +12,15 @@ import {
 import * as airtableSerializer from '../serializers/airtable-serializer.js';
 import {
   areaTransformer,
-  createChallengeTransformer,
   competenceTransformer,
-  frameworkTransformer,
-  skillTransformer,
-  tubeTransformer,
-  thematicTransformer,
-  tutorialTransformer,
-  missionTransformer,
+  createChallengeTransformer,
   fillAlternativeQualityFieldsFromMatchingProto,
+  frameworkTransformer,
+  missionTransformer,
+  skillTransformer,
+  thematicTransformer,
+  tubeTransformer,
+  tutorialTransformer,
 } from '../transformers/index.js';
 import * as tablesTranslations from '../translations/index.js';
 import { Content, Release } from '../../domain/models/release/index.js';
@@ -121,7 +117,7 @@ async function _getCurrentContent() {
     tubeRepository.list(),
     tutorialDatasource.list(),
     getStaticCourses(),
-    missionRepository.listActive(),
+    missionRepository.list(),
   ]);
   fillAlternativeQualityFieldsFromMatchingProto(challenges, skills);
   const translatedChallenges = challenges.flatMap((challenge) => [

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -197,7 +197,26 @@ async function mockCurrentContent() {
           dareChallenges: [],
           steps: [],
         },
-      }
+      },
+      {
+        id: 3,
+        name_i18n: { fr: 'Alt name' },
+        cardImageUrl: 'https://example.com/image2.png',
+        competenceId: 'competenceId',
+        thematicIds: 'thematicId,thematicId',
+        learningObjectives_i18n: { fr: 'Alt objectives' },
+        validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+        status: Mission.status.INACTIVE,
+        createdAt: new Date('2010-01-05'),
+        introductionMediaUrl: null,
+        introductionMediaType: null,
+        introductionMediaAlt_i18n: { fr: 'Message alternatif' },
+        documentationUrl: null,
+        content: {
+          dareChallenges: [],
+          steps: [],
+        },
+      },
     ]
   };
 
@@ -585,6 +604,18 @@ async function mockContentForRelease() {
       introductionMediaType: null,
       introductionMediaAlt_i18n: { fr: 'Alt Message alternatif' },
       documentationUrl: 'http://url-example.net',
+    }), new MissionForRelease({
+      id: 3,
+      name_i18n: { fr: 'Alt name' },
+      cardImageUrl: 'https://example.com/image2.png',
+      competenceId: 'competenceId',
+      learningObjectives_i18n: { fr: 'Alt objectives' },
+      validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+      status: Mission.status.INACTIVE,
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt_i18n: { fr: 'Alt Message alternatif inactive' },
+      documentationUrl: null,
     })],
   };
 
@@ -895,6 +926,7 @@ describe('Acceptance | Controller | release-controller', () => {
           thematicIds: 'thematicId,thematicId',
           learningObjectives: 'Alt objectives',
           validatedObjectives: 'Alt validated objectives',
+          introductionMediaAlt: 'Alt Message alternatif inactive',
           status: Mission.status.INACTIVE,
         });
         const server = await createServer();

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -1,18 +1,13 @@
 import { omit } from 'lodash';
-import { beforeEach, describe as context, describe, expect, expectTypeOf, it } from 'vitest';
+import { afterEach, describe, describe as context, expect, expectTypeOf, it } from 'vitest';
 import { databaseBuilder, knex } from '../../../test-helper.js';
-import {
-  findAllMissions,
-  getById,
-  listActive,
-  save,
-} from '../../../../lib/infrastructure/repositories/mission-repository.js';
+import { findAllMissions, getById, list, save, } from '../../../../lib/infrastructure/repositories/mission-repository.js';
 import { Mission } from '../../../../lib/domain/models/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | mission-repository', function() {
 
-  beforeEach(async function() {
+  afterEach(async function() {
     await knex('translations').delete();
     await knex('missions').delete();
   });
@@ -156,37 +151,54 @@ describe('Integration | Repository | mission-repository', function() {
     });
   });
 
-  describe('#listActive', function() {
-    it('should return all active missions', async function() {
+  describe('#list', function() {
+    it('should return all missions', async function() {
       databaseBuilder.factory.buildMission({
-        id: 2,
+        id: 3,
+        competenceId: 'competenceId active',
         cardImageUrl: 'https://example.com/image.png',
         name: 'Alt name',
         status: Mission.status.VALIDATED,
         learningObjectives: 'Alt objectives',
         validatedObjectives: 'Alt validated objectives',
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
+        createdAt: new Date('2020-01-01'),
       });
-
       databaseBuilder.factory.buildMission({
-        id: 3,
+        id: 2,
+        competenceId: 'competenceId inactive',
         cardImageUrl: null,
         name: 'inactive name',
         status: Mission.status.INACTIVE,
         learningObjectives: 'Alt objectives',
         validatedObjectives: 'Alt validated objectives',
-        thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
+        thematicIds: 'thematicStep1,thematicStep2',
+        createdAt: new Date('2019-01-01'),
       });
 
       await databaseBuilder.commit();
 
-      const result = await listActive();
+      const result = await list();
 
       expect(result).to.deep.equal([new Mission({
         id: 2,
+        cardImageUrl: null,
+        name_i18n: { fr: 'inactive name' },
+        competenceId: 'competenceId inactive',
+        thematicIds: 'thematicStep1,thematicStep2',
+        learningObjectives_i18n: { fr: 'Alt objectives' },
+        validatedObjectives_i18n: { fr: 'Alt validated objectives' },
+        introductionMediaUrl: null,
+        introductionMediaAlt_i18n: { fr: 'Message alternatif' },
+        introductionMediaType: null,
+        documentationUrl: null,
+        status: Mission.status.INACTIVE,
+        createdAt: new Date('2019-01-01'),
+      }),new Mission({
+        id: 3,
         cardImageUrl: 'https://example.com/image.png',
         name_i18n: { fr: 'Alt name' },
-        competenceId: 'competenceId',
+        competenceId: 'competenceId active',
         thematicIds: 'thematicStep1,thematicStep2,thematicDefi',
         learningObjectives_i18n: { fr: 'Alt objectives' },
         validatedObjectives_i18n: { fr: 'Alt validated objectives' },
@@ -195,7 +207,7 @@ describe('Integration | Repository | mission-repository', function() {
         introductionMediaType: null,
         documentationUrl: null,
         status: Mission.status.VALIDATED,
-        createdAt: new Date('2010-01-04'),
+        createdAt: new Date('2020-01-01'),
       })]);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1445,6 +1445,7 @@ function _getRichCurrentContentDTO() {
       locale: 'fr-fr',
     },
   ];
+
   const expectedMissionsDTOs = [
     {
       id: 123456789,
@@ -1459,6 +1460,25 @@ function _getRichCurrentContentDTO() {
       introductionMediaType: null,
       introductionMediaAlt_i18n: { fr: 'Message alternatif' },
       documentationUrl: 'http://url-example.net',
+      cardImageUrl: null,
+      content: {
+        dareChallenges: [],
+        steps: [],
+      },
+    },
+    {
+      id: 987654321,
+      name_i18n: { fr: 'inactive mission PG name' },
+      competenceId: 'competenceId',
+      thematicIds: 'thematicIds',
+      learningObjectives_i18n: { fr: 'Que tu sois le meilleur' },
+      validatedObjectives_i18n: { fr: 'Rien' },
+      status: Mission.status.INACTIVE,
+      createdAt: new Date('2010-01-04'),
+      introductionMediaUrl: null,
+      introductionMediaType: null,
+      introductionMediaAlt_i18n: { fr: 'Message alternatif' },
+      documentationUrl: null,
       cardImageUrl: null,
       content: {
         dareChallenges: [],


### PR DESCRIPTION
## :fallen_leaf: Problème
Le concept de la release c'est qu'on ne "supprime" rien.

## :chestnut: Proposition
Pour rester ISO avec les autres entités on expose toutes les missions dans la release et c'est à la charge de l'API Pix de filtrer les missions qui l'intéressent

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :wood: Pour tester
Vérifier que le lcms contient bien des missions dans tous les états possibles.

1. Créer une release -> celle-ci contient toutes les missions. 
2. Accéder à pix-junior -> seules les missions validées sont visibles dans la liste.
3. Ajouter la variable d'environnement FT_SHOW_EXPERIMENTAL_MISSIONS=true dans l'API et redémarrer.
Accéder à pix-junior -> seules les missions validées et expérimentales sont visibles dans la liste.