### PR TITLE
[BUGFIX] Thématiques avec `tubeIds` null dans la release (PIX-15699)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -21,7 +21,7 @@ export const thematicDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.id,
       competenceId: airtableRecord.get('Competence (id persistant)')[0],
-      tubeIds: airtableRecord.get('Tubes (id persistant)'),
+      tubeIds: airtableRecord.get('Tubes (id persistant)') ?? [],
       index: airtableRecord.get('Index'),
     };
   },

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -22,6 +22,12 @@ describe('Integration | Repository | thematic-repository', () => {
           index: '2',
           tubeIds: ['tubeId3', 'tubeId4'],
         }),
+        airtableBuilder.factory.buildThematic({
+          id: 'thematic3',
+          competenceId: 'competenceId2',
+          index: '3',
+          tubeIds: null,
+        }),
       ]).activate().nockScope;
 
       databaseBuilder.factory.buildTranslation({
@@ -43,6 +49,16 @@ describe('Integration | Repository | thematic-repository', () => {
         key: 'thematic.thematic2.name',
         locale: 'en',
         value: 'Thematic 2 name',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.thematic3.name',
+        locale: 'fr',
+        value: 'Nom thématique 3',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'thematic.thematic3.name',
+        locale: 'en',
+        value: 'Thematic 3 name',
       });
 
       await databaseBuilder.commit();
@@ -72,6 +88,17 @@ describe('Integration | Repository | thematic-repository', () => {
           name_i18n: {
             en: 'Thematic 2 name',
             fr: 'Nom thématique 2',
+          },
+        }),
+        domainBuilder.buildThematic({
+          id: 'thematic3',
+          airtableId: 'thematic3',
+          competenceId: 'competenceId2',
+          index: '3',
+          tubeIds: [],
+          name_i18n: {
+            en: 'Thematic 3 name',
+            fr: 'Nom thématique 3',
           },
         }),
       ]);


### PR DESCRIPTION
## :christmas_tree: Problème

On exporte des thématiques avec `tubeIds` null dans la release, ce n’est pas cohérent avec le reste des entités.

## :gift: Proposition

Mettre un tableau vide par défaut pour ce champ.

## :socks: Remarques

N/A

## :santa: Pour tester

Exporter la release et vérifier qu’aucune thématique n’a `tubeIds` null ou undefined.