### PR TITLE
[BUGFIX] Navigation de qualité à épreuves (PIX-15748)

### DIFF
--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -26,7 +26,7 @@ export default class ChallengeRoute extends Route {
       const tube = await skill.tube;
       const competence = await tube.competence;
       if (challenge.get('isPrototype') && localizedChallenge.isPrimaryChallenge) {
-        return this.router.transitionTo('authenticated.competence.prototypes.single', competence, challenge);
+        return this.router.transitionTo('authenticated.competence.prototypes.single', competence, challenge.get('id'));
       } else if (challenge.get('isPrototype')) {
         return this.router.transitionTo('authenticated.competence.prototypes.localized', competence, challenge.get('id'), localizedChallenge.get('id'));
       } else if (localizedChallenge.isPrimaryChallenge) {

--- a/pix-editor/app/routes/authenticated/competence/prototypes.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes.js
@@ -12,7 +12,7 @@ export default class PrototypesRoute extends Route {
   refreshing = false;
 
   beforeModel(transition) {
-    if (transition.to.queryParams.view === 'draft') {
+    if (!['production', 'workbench', 'workbench-list'].includes(transition.to.queryParams.view)) {
       this.router.replaceWith({
         queryParams: {
           view: 'production',

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -1,4 +1,5 @@
-import { click, currentURL, fillIn, find, visit, waitUntil } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, fillIn, find, waitUntil } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
@@ -57,6 +58,7 @@ module('Acceptance | Search', function(hooks) {
   test('search a challenge by rec id', async function(assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1?view=production';
+
     // when
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
@@ -65,7 +67,6 @@ module('Acceptance | Search', function(hooks) {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
     await click(find('[data-test-sidebar-search] li'));
-
     // then
     assert.strictEqual(currentURL(), expectedUrl);
   });
@@ -88,7 +89,7 @@ module('Acceptance | Search', function(hooks) {
 
   test('search a challenge by localized challenge id', async function(assert) {
     // given
-    const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/challengeLocalizedChallenge1';
+    const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/challengeLocalizedChallenge1?view=production';
     // when
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
@@ -96,6 +97,7 @@ module('Acceptance | Search', function(hooks) {
     await waitUntil(function() {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
+
     await click(find('[data-test-sidebar-search] li'));
 
     // then


### PR DESCRIPTION
## :christmas_tree: Problème

Impossible de revenir de la vue épreuves depuis la vue qualité.

## :gift: Proposition

Vérifier la valeur du queryParam view avant d’accéder à la vue épreuves.

## :socks: Remarques

N/A

## :santa: Pour tester

Aller sur la vue qualité et essayer de revenir sur la vue épreuves.