### PR TITLE
[BUGFIX] Le bouton de déconnexion et la version ne devraient pas se superposer aux options du menu (PIX-15505).

### DIFF
--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -1,6 +1,5 @@
 // stylelint-disable color-no-hex, color-named
 .main-sidebar {
-
   &.ui.sidebar {
     z-index: 99;
     transition: transform 0.5s, visibility 0.5s;
@@ -130,27 +129,38 @@
   }
 
   .ui.menu {
-    position: absolute;
-    bottom: 0;
+    align-items: end;
     width: 100%;
+    height:100%;
+    padding-bottom: 1rem;
     background: transparent;
     border: none;
     box-shadow: none;
+
+    .button:hover {
+      background: rgba(255,255,255,.1);
+    }
+
+    .icon {
+      margin-left: .5rem !important;
+    }
   }
 
-  .ui.vertical.inverted.menu {
+  .menu .item {
+    align-items: initial;
+    padding: 10px;
+    color: #fff;
+  }
 
-    .menu .item {
-      align-items: initial;
-      padding: 10px;
-      color: #fff;
-    }
+  .menu .item i.icon {
+    float: none;
+    margin-right: 5px;
+    font-size: 12px;
+  }
 
-    .menu .item i.icon {
-      float: none;
-      margin-right: 5px;
-      font-size: 12px;
-    }
+  &.ui.vertical.inverted.menu {
+    display: flex !important;
+    flex-direction: column;
   }
 
   .ui.search {


### PR DESCRIPTION
## :christmas_tree: Problème

Sur certain écran le bouton de déconnexion et la version se superposent aux options du menu.

## :gift: Proposition

Modifier le style pour que les éléments affichant le bouton de déconnexion et la version rentre dans le flux.

## :socks: Remarques

RAS

## :santa: Pour tester

Se rendre sur Pix-editor et vérifier que le bouton de déconnexion et la version ne devraient pas se superposer aux options du menu, même lorsqu’on zoom sur la page
