### PR TITLE
[TECH] Monter la version de Postgres vers 15.10 sur tous les environnements de développement pour matcher avec la production (PIX-15877)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
-      - image: postgres:15.7-alpine
+      - image: postgres:15.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -47,7 +47,7 @@ executors:
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
-      - image: postgres:15.7-alpine
+      - image: postgres:15.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -61,7 +61,7 @@ executors:
         type: string
     docker:
       - image: mcr.microsoft.com/playwright:v<<parameters.playwright-version>>-focal
-      - image: postgres:15.7-alpine
+      - image: postgres:15.10-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   postgres:
-    image: postgres:15.7-alpine
+    image: postgres:15.10-alpine
     ports:
       - "5444:5432"
     environment:

--- a/scalingo.json
+++ b/scalingo.json
@@ -16,7 +16,7 @@
     {
       "plan": "postgresql:postgresql-sandbox",
       "options": {
-        "version": "15.7"
+        "version": "15.10"
       }
     },
     {


### PR DESCRIPTION
## :christmas_tree: Problème
On est désynchro avec Postgres en prod vs en dév

## :gift: Proposition
S'aligner avec la prod en mettant la 15.10

## :socks: Remarques
https://www.postgresql.org/docs/release/15.8/
https://www.postgresql.org/docs/release/15.9/
https://www.postgresql.org/docs/release/15.10/

## :santa: Pour tester
Tests au vert
