### PR TITLE
 [FEATURE] Afficher la consigne du tableau `challenges-production` sur 2 lignes (PIX-16072)

### DIFF
--- a/pix-editor/app/components/competence-overview/challenges-production.gjs
+++ b/pix-editor/app/components/competence-overview/challenges-production.gjs
@@ -18,6 +18,7 @@ import ChallengesProductionHeader from './challenges-production-header';
 
 export default class ChallengesProduction extends Component {
   @service router;
+  @service multipanelManager;
 
   @tracked shouldDisplayObsoleteChallenges = false;
 
@@ -67,7 +68,7 @@ export default class ChallengesProduction extends Component {
 
 <template>
     <ChallengesProductionHeader @skill={{@skill}} />
-    <section class="challenges-production">
+    <section class="challenges-production {{if this.multipanelManager.tableShouldBeExpanded "challenges-production--full" ""}}">
       <div class="challenges-production-table">
         <PixTable @data={{this.challenges}} @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}}>
           <:columns as |challenge context|>

--- a/pix-editor/app/components/competence-overview/challenges-production.gjs
+++ b/pix-editor/app/components/competence-overview/challenges-production.gjs
@@ -89,7 +89,9 @@ export default class ChallengesProduction extends Component {
                 Consigne
               </:header>
               <:cell>
-                {{challenge.instruction}}
+                <div class="challenges-production-table__consigne">
+                  {{challenge.instruction}}
+                </div>
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}}>
@@ -124,13 +126,13 @@ export default class ChallengesProduction extends Component {
               </:header>
               <:cell>
                 {{#each challenge.locales as |locale|}}
-                  <p>
+                  <div class="challenges-production-table__locale">
                     {{flagForLanguage locale}} {{locale}}
-                  </p>
+                  </div>
                 {{/each}}
               </:cell>
             </PixTableColumn>
-            <PixTableColumn @context={{context}}>
+            <PixTableColumn @context={{context}} class="challenges-production-table__actions">
               <:header>
                 Actions
               </:header>

--- a/pix-editor/app/components/loader.hbs
+++ b/pix-editor/app/components/loader.hbs
@@ -1,3 +1,3 @@
 <div>
-  <img src="/assets/images/elephant_loader.gif" width="400" height="400" alt="elephant qui marche en attendant que la page se charge" />
+  <img src="/assets/images/elephant_loader.gif" width="150" height="150" alt="petit elephant qui marche en attendant que la page se charge" />
 </div>

--- a/pix-editor/app/services/multipanel-manager.js
+++ b/pix-editor/app/services/multipanel-manager.js
@@ -4,6 +4,10 @@ import { tracked } from '@glimmer/tracking';
 export default class MultipanelManager extends Service {
   @tracked gridShouldBeMinimized = false;
 
+  get tableShouldBeExpanded() {
+    return this.gridShouldBeMinimized;
+  }
+
   reset() {
     this.gridShouldBeMinimized = false;
   }

--- a/pix-editor/app/styles/components/challenges-production.scss
+++ b/pix-editor/app/styles/components/challenges-production.scss
@@ -3,6 +3,10 @@
   overflow: auto;
   height: 70%;
 
+  &--full {
+    height: auto;
+  }
+
   &-table {
     padding: var(--pix-spacing-6x) var(--pix-spacing-8x);
 

--- a/pix-editor/app/styles/components/challenges-production.scss
+++ b/pix-editor/app/styles/components/challenges-production.scss
@@ -10,13 +10,8 @@
   &-table {
     padding: var(--pix-spacing-6x) var(--pix-spacing-8x);
 
-    &__consigne {
-      max-width: 650px;
-      height: 3rem;
-      line-height: 1.5rem;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
+    &__locale {
+      text-wrap: nowrap;
     }
 
     &__display-actions {
@@ -25,7 +20,25 @@
       margin-block: var(--pix-spacing-4x);
     }
   }
+}
 
+td.challenges-production-table {
+  &__actions {
+    text-wrap: nowrap;
+  }
+
+  &__consigne {
+    max-width: 650px;
+
+    div {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+  }
 }
 
 .challenges-production-loader {


### PR DESCRIPTION
## :christmas_tree: Problème

La consigne des épreuves du tableau `challenges-production` ne s'affiche que sur une seule ligne. Sur des petits écrans, ça devient facilement illisible.

## :gift: Proposition

Afficher 2 lignes de consigne.

## :socks: Remarques

On utilise des propriétés pas hyper standardisées mais ça semble pas hyper grave.
On a corrigé des bugs d'affichage de la table au passage.
On a aussi réduit la taille du loader de l'éléphant.

## :santa: Pour tester

Ouvrir la liste des épreuves d'une acquis dans la V2.
Constater que les épreuves avec une longue consigne s'affichent sur 2 lignes.
