### PR TITLE
[TECH] Remplacer les PixTables par des PixTables condensés (PIX-16039)

### DIFF
--- a/pix-editor/app/components/competence-overview/challenges-production.gjs
+++ b/pix-editor/app/components/competence-overview/challenges-production.gjs
@@ -70,7 +70,7 @@ export default class ChallengesProduction extends Component {
     <ChallengesProductionHeader @skill={{@skill}} />
     <section class="challenges-production {{if this.multipanelManager.tableShouldBeExpanded "challenges-production--full" ""}}">
       <div class="challenges-production-table">
-        <PixTable @data={{this.challenges}} @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}}>
+        <PixTable @data={{this.challenges}} @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}} @condensed={{true}}>
           <:columns as |challenge context|>
             <PixTableColumn @context={{context}}>
               <:header>


### PR DESCRIPTION
## :pancakes: Problème
Le tableau listant les épreuves est trop grand.

## :bacon: Proposition
Condenser le tableau listant les épreuves en utilisant la propriété `@condensed={{true}}`

## 🧃 Remarques
RAS

## :yum: Pour tester

Afficher une liste d'épreuves en production en vue v2
