### PR TITLE
[BUGFIX] Moulinette des URLs KO - Ne pas tenir compte de la casse pour le début des URLs (PIX-15760)

### DIFF
--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -87,7 +87,7 @@ function cleanUrl(url) {
 }
 
 function ensureProtocol(url) {
-  if (/^https?:\/\//.test(url)) return url;
+  if (/^https?:\/\//i.test(url)) return url;
   return  url = 'https://' + url;
 }
 

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -43,7 +43,7 @@ describe('Unit | Utils | URL Utils', function() {
 
     it('should fix url by prepending protocol if missing', function() {
       // given
-      const markdownText = 'instructions [link](www.example.net/) [second link](www.example.net/?url=https://example.com/path)';
+      const markdownText = 'instructions [link](www.example.net/) [second link](www.example.net/?url=https://example.com/path) [third link](HTTPS://example.com/path) ';
 
       // when
       const urls = UrlUtils.findUrlsInMarkdown(markdownText);
@@ -52,6 +52,7 @@ describe('Unit | Utils | URL Utils', function() {
       expect(urls).toStrictEqual([
         'https://www.example.net/',
         'https://www.example.net/?url=https://example.com/path',
+        'HTTPS://example.com/path',
       ]);
     });
 


### PR DESCRIPTION
## :pancakes: Problème

Si une URL est rédigée ainsi : “Http://www.jecherchelabonneadresse123.fr/index.html”, un “https://” est automatiquement ajouté en début d’URL avant qu’elle ne soit analysée dans la moulinette des URLs KO. On se retrouve alors avec l’URL : “https://Http://www.jecherchelabonneadresse123.fr/index.html”

Il ne faudrait pas tenir compte de la casse.

## :bacon: Proposition

Ignorer la casse lors du test de présence du protocole http/https

## 🧃 Remarques

RAS

## :yum: Pour tester

Test au vert
