### PR TITLE
[BUGFIX] Afficher les données qualités depuis un acquis (PIX-15771)

### DIFF
--- a/pix-editor/app/routes/authenticated/competence/skills/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single.js
@@ -10,11 +10,11 @@ export default class SingleRoute extends Route {
 
   async model(params) {
     const skill = await this.store.findRecord('skill', params.skill_id);
-    await skill.challenges;
     return skill;
   }
 
-  afterModel(model) {
+  async afterModel(model) {
+    await model.challenges;
     return model.pinRelationships();
   }
 
@@ -32,12 +32,13 @@ export default class SingleRoute extends Route {
   }
 
   @action
-  willTransition(transition) {
+  async willTransition(transition) {
     if (this.controllerFor('authenticated.competence.skills.single').edition &&
       !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else {
       const modelSkillSingle = this.controllerFor('authenticated.competence.skills.single').model;
+
       if (modelSkillSingle && modelSkillSingle.rollbackAttributes) {
         // may not exist if it was a new skill
         modelSkillSingle.rollbackAttributes();


### PR DESCRIPTION
## :pancakes: Problème

Les données de qualités se trouvent sur le prototype, cette relation est charger au niveau du model, mais lorsqu'on navigue entre les acquis on ne passe pas par le  hook model et les données qualités ne s'affichent pas.

## :bacon: Proposition
déplacer le chargement de la relation acquis épreuve au niveau du hook afterModel

## 🧃 Remarques

RAS
## :yum: Pour tester

Se rendre sur la vu acquis et naviguer entre les acquis et vérifier la présence d'informations de qualités
