### PR TITLE
[BUGFIX] Réparer la recherche d'un acquis (PIX-15500)

### DIFF
--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -33,7 +33,7 @@ export default class SidebarSearchComponent extends Component {
       version: skill.version,
       transition: {
         route: 'authenticated.skill',
-        model: skill.name,
+        model: skill.id,
       },
     }));
   }

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -56,7 +56,7 @@ Router.map(function() {
       this.route('new', { path: 'new/:area_id' });
       this.route('single', { path: '/:competence_id' });
     });
-    this.route('skill', { path: '/skill/:skill_name' });
+    this.route('skill', { path: '/skill/:skill_id' });
     this.route('challenge', { path: '/challenge/:challenge_id' });
     this.route('target-profile');
     this.route('statistics');

--- a/pix-editor/app/routes/authenticated/skill.js
+++ b/pix-editor/app/routes/authenticated/skill.js
@@ -6,13 +6,13 @@ export default class SkillRoute extends Route {
   @service router;
   @service store;
 
-  model(params) {
-    return this.store.query('skill', { filterByFormula: `FIND('${params.skill_name}', {Nom})`, maxRecords: 1 });
+  async model(params) {
+    return this.store.findRecord('skill', params.skill_id);
   }
 
   async afterModel(model) {
-    if (model.length > 0) {
-      const skill = model[0];
+    if (model) {
+      const skill = model;
       const tube = await skill.tube;
       const competence = await tube.competence;
       this.router.transitionTo('authenticated.competence.skills.single', competence.id, skill.id);

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { clickByText, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn, find, waitUntil } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -19,8 +19,9 @@ module('Acceptance | Search', function(hooks) {
     this.server.create('localized-challenge', { id: 'challengeChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', { id: 'challengeLocalizedChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1' });
+    this.server.create('skill', { id: 'recSkill2', name: '@skill1', challengeIds: [], status: 'archivé', version: 2 });
     const skill = this.server.create('skill', { id: 'recSkill1', name: '@skill1', challengeIds: ['recChallenge1', 'challengeChallenge1'] });
-    const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+    const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill2', 'recSkill1' ] });
     const competence = this.server.create('competence', {
       id: 'recCompetence1.1',
       pixId: 'pixId recCompetence1.1',
@@ -127,10 +128,11 @@ module('Acceptance | Search', function(hooks) {
     await visit('/');
     await click(find('[data-test-sidebar-search] .ember-basic-dropdown-trigger'));
     await fillIn('[data-test-sidebar-search] input', '@skill1');
+
     await waitUntil(function() {
       return find('[data-test-sidebar-search] li');
     }, { timeout: 1000 });
-    await click(find('[data-test-sidebar-search] li'));
+    await clickByText('@skill1 v1');
 
     // then
     assert.strictEqual(currentURL(), expectedUrl);


### PR DESCRIPTION
## :pancakes: Problème
Lors de la recherche d'un acquis  si nous sélectionnons une version d'un acquis, la recherche peux nous mener sur une autre version de cet acquis..

## :bacon: Proposition

Ne plus utiliser le nom mais l'id de l'acquis lors du résultat de notre recherche.

## 🧃 Remarques

RAS

## :yum: Pour tester

depuis l'input de recherche, recherchez `@eval6` et cliquer sur la v1 puis sur la v2 et constater que l'on est dirigé vers la bonne version d'acquis.
