### PR TITLE
[TECH] Ajout d'une route permettant de télécharger un snapshot mémoire.

### DIFF
--- a/api/lib/application/heapdump.js
+++ b/api/lib/application/heapdump.js
@@ -1,0 +1,21 @@
+import * as securityPreHandlers from './security-pre-handlers.js';
+import { getHeapSnapshot } from 'node:v8';
+
+export function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/heapdump',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        handler: async function(_, h) {
+          return h.response(getHeapSnapshot())
+            .header('Content-type', 'application/json')
+            .header('Content-disposition', `attachment; filename=lcms-api-${(new Date()).toISOString()}.heapsnapshot`);
+        },
+      },
+    },
+  ]);
+}
+
+export const name = 'heapdump-api';

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -6,6 +6,7 @@ import * as configRoute from './application/config.js';
 import * as fileStorageTokenRoute from './application/file-storage-token/index.js';
 import * as frameworksRoute from './application/frameworks.js';
 import * as healthcheckRoute from './application/healthcheck/index.js';
+import * as heapdumpRoute from './application/heapdump.js';
 import * as localizedChallengesRoute from './application/localized-challenges.js';
 import * as missionsRoute from './application/missions/index.js';
 import * as phraseRoute from './application/phrase.js';
@@ -27,6 +28,7 @@ export const routes = [
   configRoute,
   fileStorageTokenRoute,
   frameworksRoute,
+  heapdumpRoute,
   healthcheckRoute,
   localizedChallengesRoute,
   missionsRoute,


### PR DESCRIPTION
## :pancakes: Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On observe, dans les environnements de production, une occupation excessive de la mémoire après avoir créé une release. On n'arrive pas à observer ce phénomène sur un environnement local.

## :bacon: Proposition

On ajoute une route `/api/heapdump` permettant à un utilisateur admin de télécharger un snapshot de la mémoire. On pourra ainsi comparer l'occupation de la mémoire avant et après la création d'une release.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🧃 Remarques

On espère pouvoir corriger cette fuite mémoire 🤞🏾 

<!-- Des infos supplémentaires, trucs et astuces ? -->

## :yum: Pour tester

Appeler la route avec
```
curl --remote-header-name --remote-name https://pix-lcms-review-pr865.osc-fr1.scalingo.io/api/heapdump -H 'Authorization: Bearer xxxx'
```
Ouvrir le fichier téléchargé (*.heapsnapshot) avec les outils de développement de Chrome.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
