### PR TITLE
[FEATURE] Permettre de récupérer les traductions Phrase depuis la V2 (PIX-14858)

### DIFF
--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -10,10 +10,23 @@ import { eq } from 'ember-truth-helpers';
 import CompetenceOverviewSkill from './competence-overview-skill';
 
 export default class CompetenceOverview extends Component {
+  @service phrase;
   @service router;
+  @service notifications;
   @service multipanelManager;
 
   @tracked selectedSkillId = null;
+
+  @action
+  async fetchTranslations() {
+    try {
+      await this.phrase.download();
+      this.notifications.success('Téléchargement des traductions depuis Phrase effectué.');
+      await this.refresh();
+    } catch {
+      this.notifications.error('Erreur lors du téléchargement des traductions.');
+    }
+  }
 
   @action
   async refresh() {
@@ -38,16 +51,30 @@ export default class CompetenceOverview extends Component {
               </LinkTo>
             </li>
           </ul>
-          <PixButton
-            class="competence-overview-actions__refresh"
-            @iconBefore="refresh"
-            @size="small"
-            @isBorderVisible={{true}}
-            @variant="secondary"
-            @triggerAction={{this.refresh}}
-          >
-            Actualiser
-          </PixButton>
+          <div class="competence-overview-actions__buttons">
+            {{#if @locale}}
+              <PixButton
+                class="competence-overview-actions__fetch"
+                @size="small"
+                @isBorderVisible={{true}}
+                @variant="secondary"
+                @loadingColor="grey"
+                @triggerAction={{this.fetchTranslations}}
+              >
+                Récupérer les traductions
+              </PixButton>
+            {{/if}}
+            <PixButton
+              class="competence-overview-actions__refresh"
+              @iconBefore="refresh"
+              @size="small"
+              @isBorderVisible={{true}}
+              @variant="secondary"
+              @triggerAction={{this.refresh}}
+            >
+              Actualiser
+            </PixButton>
+          </div>
         </div>
         <div class="competence-overview-grid">
         {{#each @competenceOverview.thematicOverviews as |thematicOverview|}}
@@ -59,7 +86,7 @@ export default class CompetenceOverview extends Component {
               {{#each tubeOverview.skillOverviews as |skillOverview|}}
                 <CompetenceOverviewSkill
                   @skillOverview={{skillOverview}}
-                  @locale={{this.args.locale}}
+                  @locale={{@locale}}
                   class="skill"
                   @onSkillClicked={{this.updateSelectedSkillId}}
                   @isActive={{eq skillOverview.id this.selectedSkillId}}
@@ -93,4 +120,3 @@ export default class CompetenceOverview extends Component {
     </div>
   </template>
 }
-

--- a/pix-editor/app/styles/components/competence-overview.scss
+++ b/pix-editor/app/styles/components/competence-overview.scss
@@ -48,7 +48,13 @@
       }
     }
   }
-  &__refresh {
+
+  &__buttons {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+  }
+
+  &__refresh, &__fetch {
     margin: .5rem 0;
   }
 }

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -472,6 +472,10 @@ function routes() {
       updatedAt: new Date().toISOString(),
     });
   });
+
+  this.post('/phrase/download', function() {
+    return { ok: 'cool' };
+  });
 }
 
 function _serializeModel(instance, modelName) {

--- a/pix-editor/tests/acceptance/synchronize_translations_test.js
+++ b/pix-editor/tests/acceptance/synchronize_translations_test.js
@@ -1,5 +1,5 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
@@ -23,6 +23,7 @@ module('Acceptance | Synchronize Translations', function(hooks) {
 
     // then
     assert.strictEqual(currentURL(), '/synchronize-translations');
-    assert.dom(screen.getByText('Récupérer les traductions depuis Phrase')).exists();
+    await click(screen.getByRole('button', { name: 'Récupérer les traductions depuis Phrase' }));
+    assert.dom(await screen.findByText('Téléchargement des traductions depuis Phrase effectué.')).exists();
   });
 });

--- a/pix-editor/tests/acceptance/v2/competence-overview/fetch-translations_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/fetch-translations_test.js
@@ -1,0 +1,106 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import Challenge from 'pixeditor/models/challenge';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../../setup-application-rendering';
+
+module('Acceptance | fetch-translations', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  const skillId = 'skill1', skillName = '@tube1', prototypeId = 'prototype1';
+
+  hooks.beforeEach(function() {
+    window.localStorage.setItem('v2', 'true');
+    this.owner.lookup('service:store');
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    this.server.create('competence', {
+      id: 'recCompetence1',
+      code: '1.1',
+      title: 'ma compétence',
+      pixId: 'competence1',
+    });
+    this.server.create('competence-overview', {
+      id: 'competence1:challenges-production',
+      name: '1.1 ma compétence',
+      airtableId: 'recCompetence1',
+      thematicOverviews: [{
+        id: 'thematic1',
+        name: 'thematic name',
+        tubeOverviews: [{
+          id: 'tube1',
+          name: '@tube',
+          skillOverviews: [{
+            id: skillId,
+            name: skillName,
+            prototypeId,
+            isPrototypeDeclinable: true,
+            proposedChallengesCount: 1,
+            validatedChallengesCount: 1,
+            airtableId: skillId,
+          }, null, null, null, null, null, null],
+        }],
+      }],
+    });
+    this.server.create('competence-overview', {
+      id: 'competence1:challenges-production:nl',
+      name: '1.1 ma compétence',
+      airtableId: 'recCompetence1',
+      thematicOverviews: [{
+        id: 'thematic1',
+        name: 'thematic name',
+        tubeOverviews: [{
+          id: 'tube1',
+          name: '@tube',
+          skillOverviews: [{
+            id: skillId,
+            name: skillName,
+            prototypeId,
+            isPrototypeDeclinable: true,
+            proposedChallengesCount: 0,
+            validatedChallengesCount: 1,
+          }, null, null, null, null, null, null],
+        }],
+      }],
+    });
+    const skill = this.server.create('skill', {
+      id: skillId,
+      name: skillName,
+      pixId: skillId,
+    });
+    const challengeProduction = this.server.create('challenge', {
+      id: 'challengeIdProto',
+      genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+      status: Challenge.STATUSES.VALIDE,
+      instruction: 'Coucou maman',
+      locales: ['fr'],
+    });
+    skill.update({ challengesProduction: [challengeProduction] });
+
+    return authenticateSession();
+  });
+
+  module('when not filtering by language', function() {
+    test('should not display fetch translations button', async function(assert) {
+      await visit('/v2/competences/recCompetence1/challenges-production');
+      assert.dom('.competence-overview-actions__fetch').isNotVisible();
+    });
+  });
+
+  module('when filtering by language', function() {
+    test('should display fetch translations button', async function(assert) {
+      await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
+      assert.dom('.competence-overview-actions__fetch').isVisible();
+    });
+
+    test('fetch button should work', async function(assert) {
+      const screen = await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
+      await click(screen.getByRole('button', { name: 'Récupérer les traductions' }));
+      assert.dom(await screen.findByText('Téléchargement des traductions depuis Phrase effectué.')).exists();
+    });
+  });
+});


### PR DESCRIPTION
## :pancakes: Problème

On ne peut pas récupérer les traductions directement depuis la page des épreuves traduites en V2. 
On est actuellement obligés d'ouvrir la barre latérale, cliquer sur "Récupérer les traductions" puis "Récupérer les traductions depuis Phrase" 😮‍💨.

## :bacon: Proposition

Ajout d'un bouton "Récupérer les traductions" au dessus de la grille des acquis dans la V2. Ce bouton s'affiche seulement si une locale est sélectionnée.

## 🧃 Remarques

- On rafraîchit les données de la grille après la synchronisation, mais à cause d'une limitation d'Ember, l'état `loading` du bouton se termine avant ce rafraîchissement 🤷.

## :yum: Pour tester

- Se rendre sur la grille des acquis (production) en V2.
- Constater que le bouton n'est pas visible.
- Ajouter un filtre sur la langue (autre que "Langue source")
- Constater que le bouton est visible.
- Cliquer sur le bouton.
- Constater qu'un message de succès apparaît ✅.
