### PR TITLE
[FEATURE] Ajout d'options dans le challenge pour Pix Junior

### DIFF
--- a/api/db/migrations/20250128134613_add-has-embed-internal-validation-to-challenges.js
+++ b/api/db/migrations/20250128134613_add-has-embed-internal-validation-to-challenges.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'localized_challenges';
+const COLUMN_NAME = 'hasEmbedInternalValidation';
+
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.boolean(COLUMN_NAME).defaultTo(false).notNullable();
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/api/db/migrations/20250128134614_add-no-validation-needed-to-challenges.js
+++ b/api/db/migrations/20250128134614_add-no-validation-needed-to-challenges.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'localized_challenges';
+const COLUMN_NAME = 'noValidationNeeded';
+
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.boolean(COLUMN_NAME).defaultTo(false).notNullable();
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+}

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -398,6 +398,8 @@ export class Challenge {
     this.deafAndHardOfHearing = this.#primaryLocalizedChallenge.deafAndHardOfHearing;
     this.isAwarenessChallenge = this.#primaryLocalizedChallenge.isAwarenessChallenge;
     this.toRephrase = this.#primaryLocalizedChallenge.toRephrase;
+    this.hasEmbedInternalValidation  = this.#primaryLocalizedChallenge.hasEmbedInternalValidation;
+    this.noValidationNeeded  = this.#primaryLocalizedChallenge.noValidationNeeded;
 
     this.files = this.#allFiles
       ?.filter(({ localizedChallengeId }) => localizedChallengeId === this.id)

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -141,6 +141,8 @@ export class LocalizedChallenge {
       deafAndHardOfHearing: this.deafAndHardOfHearing,
       isAwarenessChallenge: this.isAwarenessChallenge,
       toRephrase: this.toRephrase,
+      hasEmbedInternalValidation: this.hasEmbedInternalValidation,
+      noValidationNeeded: this.noValidationNeeded,
     });
     for (const attachmentId of this.fileIds) {
       const attachmentToClone = attachments.find((attachment) => attachment.id === attachmentId);

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -87,6 +87,8 @@ export class LocalizedChallenge {
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   }) {
     return new LocalizedChallenge({
       id: challengeId,
@@ -102,6 +104,8 @@ export class LocalizedChallenge {
       deafAndHardOfHearing: deafAndHardOfHearing ?? LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
       isAwarenessChallenge: isAwarenessChallenge ?? false,
       toRephrase: toRephrase ?? false,
+      hasEmbedInternalValidation: hasEmbedInternalValidation ?? false,
+      noValidationNeeded: noValidationNeeded ?? false,
     });
   }
 

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -120,6 +120,8 @@ export class LocalizedChallenge {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
       isAwarenessChallenge: false,
       toRephrase: false,
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
     });
   }
 

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -20,7 +20,8 @@ export class LocalizedChallenge {
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
-
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   } = {}) {
     this.id = id;
     this.challengeId = challengeId;
@@ -36,6 +37,8 @@ export class LocalizedChallenge {
     this.deafAndHardOfHearing = deafAndHardOfHearing;
     this.isAwarenessChallenge = isAwarenessChallenge;
     this.toRephrase = toRephrase;
+    this.hasEmbedInternalValidation = hasEmbedInternalValidation;
+    this.noValidationNeeded = noValidationNeeded;
   }
 
   static get STATUSES() {

--- a/api/lib/domain/models/release/ChallengeForRelease.js
+++ b/api/lib/domain/models/release/ChallengeForRelease.js
@@ -39,6 +39,8 @@ export class ChallengeForRelease {
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   }) {
     this.id = id;
     this.instruction = instruction;
@@ -77,6 +79,8 @@ export class ChallengeForRelease {
     this.deafAndHardOfHearing = deafAndHardOfHearing;
     this.isAwarenessChallenge = isAwarenessChallenge;
     this.toRephrase = toRephrase;
+    this.hasEmbedInternalValidation = hasEmbedInternalValidation;
+    this.noValidationNeeded = noValidationNeeded;
   }
 
   static get STATUSES() {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -128,6 +128,8 @@ export async function update(challenge, knexConn = knex) {
   primaryLocalizedChallenge.deafAndHardOfHearing = challenge.deafAndHardOfHearing;
   primaryLocalizedChallenge.isAwarenessChallenge = challenge.isAwarenessChallenge;
   primaryLocalizedChallenge.toRephrase = challenge.toRephrase;
+  primaryLocalizedChallenge.hasEmbedInternalValidation = challenge.hasEmbedInternalValidation;
+  primaryLocalizedChallenge.noValidationNeeded = challenge.noValidationNeeded;
 
   await localizedChallengeRepository.update({
     localizedChallenge: primaryLocalizedChallenge,

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -60,7 +60,22 @@ export async function getMany({ ids, transaction: knexConnection = knex }) {
 }
 
 export async function update({
-  localizedChallenge: { id, locale, embedUrl, status, fileIds, geography, urlsToConsult, requireGafamWebsiteAccess, isIncompatibleIpadCertif, deafAndHardOfHearing, isAwarenessChallenge, toRephrase },
+  localizedChallenge: {
+    id,
+    locale,
+    embedUrl,
+    status,
+    fileIds,
+    geography,
+    urlsToConsult,
+    requireGafamWebsiteAccess,
+    isIncompatibleIpadCertif,
+    deafAndHardOfHearing,
+    isAwarenessChallenge,
+    toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
+  },
   transaction: knexConnection = knex
 }) {
   const [dto] = await knexConnection('localized_challenges').where('id', id).update({
@@ -74,6 +89,8 @@ export async function update({
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   }).returning('*');
 
   if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -102,6 +102,8 @@ function _adaptModelsForDB(localizedChallenges, generateId) {
       deafAndHardOfHearing: localizedChallenge.deafAndHardOfHearing,
       isAwarenessChallenge: localizedChallenge.isAwarenessChallenge,
       toRephrase: localizedChallenge.toRephrase,
+      hasEmbedInternalValidation: localizedChallenge.hasEmbedInternalValidation,
+      noValidationNeeded: localizedChallenge.noValidationNeeded,
     };
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -54,6 +54,8 @@ const serializer = new Serializer('challenges', {
     'deafAndHardOfHearing',
     'isAwarenessChallenge',
     'toRephrase',
+    'hasEmbedInternalValidation',
+    'noValidationNeeded',
   ],
   typeForAttribute(attribute) {
     if (attribute === 'files') return 'attachments';
@@ -139,6 +141,8 @@ export function deserialize(challengeBody) {
         deafAndHardOfHearing: challengeObject.deafAndHardOfHearing,
         isAwarenessChallenge: challengeObject.isAwarenessChallenge,
         toRephrase: challengeObject.toRephrase,
+        hasEmbedInternalValidation: challengeObject.hasEmbedInternalValidation,
+        noValidationNeeded: challengeObject.noValidationNeeded,
       })];
       return err ? reject(err) : resolve(new Challenge(challengeObject));
     });

--- a/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-challenge-serializer.js
@@ -22,6 +22,8 @@ const serializer = new Serializer('localized-challenges', {
     'deafAndHardOfHearing',
     'isAwarenessChallenge',
     'toRephrase',
+    'hasEmbedInternalValidation',
+    'noValidationNeeded',
   ],
   challenge: {
     ref: 'id',

--- a/api/lib/infrastructure/transformers/challenge-transformer.js
+++ b/api/lib/infrastructure/transformers/challenge-transformer.js
@@ -41,6 +41,8 @@ function _fillAlternativeQualityFields(challenge, prototype) {
     'deafAndHardOfHearing',
     'isAwarenessChallenge',
     'toRephrase',
+    'hasEmbedInternalValidation',
+    'noValidationNeeded',
   ];
 
   for (const field of fieldsToOverride) {
@@ -87,6 +89,8 @@ function _filterChallengeFields(challenge) {
     'deafAndHardOfHearing',
     'isAwarenessChallenge',
     'toRephrase',
+    'hasEmbedInternalValidation',
+    'noValidationNeeded',
   ];
 
   return _.pick(challenge, fieldsToInclude);

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -890,6 +890,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: false,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: localizedChallengeId,
@@ -902,12 +904,14 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
 
       await databaseBuilder.commit();
     });
 
-    it.fails('should redirect to a staging Pix App preview URL', async () => {
+    it('should redirect to a staging Pix App preview URL', async () => {
       // given
       const apiToken = 'secret';
       const apiTokenScope = nock('https://api.test.pix.fr')
@@ -943,6 +947,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             isAwarenessChallenge: false,
             toRephrase: true,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: true,
           })
         .matchHeader('Authorization', `Bearer ${apiToken}`)
         .reply(200);

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -144,6 +144,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'my id_nl',
@@ -216,6 +218,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
               'is-awareness-challenge': true,
               'to-rephrase': true,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
             },
             relationships: {
               skill: {
@@ -352,6 +356,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: '2',
@@ -364,6 +370,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
         isAwarenessChallenge: true,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: '2_nl',
@@ -439,6 +447,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
               'is-awareness-challenge': true,
               'to-rephrase': true,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
             },
             relationships: {
               skill: {
@@ -514,6 +524,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
               'is-awareness-challenge': true,
               'to-rephrase': false,
+              'has-embed-internal-validation': false,
+              'no-validation-needed': false,
             },
             relationships: {
               skill: {
@@ -649,6 +661,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'localizedChallengeId2',
@@ -757,6 +771,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             skill: {
@@ -1131,6 +1147,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
               'is-awareness-challenge': true,
               'to-rephrase': true,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
             },
             relationships: {
               skill: {
@@ -1205,6 +1223,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             skill: {
@@ -1245,8 +1265,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
-          hasEmbedInternalValidation: false,
-          noValidationNeeded: false,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         }
       ]);
       const translations = await knex('translations').select('key', 'locale', 'value').orderBy('key');
@@ -1491,7 +1511,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       user = databaseBuilder.factory.buildAdminUser();
     });
 
-    it('should update a challenge', async () => {
+    it.fails('should update a challenge', async () => {
       // Given
       const challengeId = 'recChallengeId';
       const locale = 'fr';
@@ -1769,7 +1789,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       ]);
     });
 
-    it('should change challenge\'s primary locale', async () => {
+    it.fails('should change challenge\'s primary locale', async () => {
       // Given
       const challengeId = 'recChallengeId';
       const originalLocale = 'fr-fr';

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -907,7 +907,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       await databaseBuilder.commit();
     });
 
-    it('should redirect to a staging Pix App preview URL', async () => {
+    it.fails('should redirect to a staging Pix App preview URL', async () => {
       // given
       const apiToken = 'secret';
       const apiTokenScope = nock('https://api.test.pix.fr')

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1239,6 +1239,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         }
       ]);
       const translations = await knex('translations').select('key', 'locale', 'value').orderBy('key');
@@ -2001,6 +2003,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         },
       ]);
       await expect(knex('translations').orderBy('key').select('key', 'locale', 'value')).resolves.to.deep.equal([

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1511,7 +1511,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       user = databaseBuilder.factory.buildAdminUser();
     });
 
-    it.fails('should update a challenge', async () => {
+    it('should update a challenge', async () => {
       // Given
       const challengeId = 'recChallengeId';
       const locale = 'fr';
@@ -1536,6 +1536,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: 'challenge_localized_nl',
@@ -1641,6 +1643,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
               'is-awareness-challenge': false,
               'to-rephrase': false,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
             },
             relationships: {
               skill: {
@@ -1715,6 +1719,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
             'is-awareness-challenge': false,
             'to-rephrase': false,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             skill: {
@@ -1755,6 +1761,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
       expect(localizedChallenge).toHaveProperty('deafAndHardOfHearing', LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO);
       expect(localizedChallenge).toHaveProperty('isAwarenessChallenge', false);
       expect(localizedChallenge).toHaveProperty('toRephrase', false);
+      expect(localizedChallenge).toHaveProperty('hasEmbedInternalValidation', true);
+      expect(localizedChallenge).toHaveProperty('noValidationNeeded', true);
       await expect(knex('translations').orderBy('key').select('key', 'locale', 'value')).resolves.to.deep.equal([
         {
           key: 'challenge.recChallengeId.alternativeInstruction',
@@ -1789,7 +1797,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       ]);
     });
 
-    it.fails('should change challenge\'s primary locale', async () => {
+    it('should change challenge\'s primary locale', async () => {
       // Given
       const challengeId = 'recChallengeId';
       const originalLocale = 'fr-fr';
@@ -1816,6 +1824,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.instruction`,
@@ -1914,6 +1924,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
               'is-awareness-challenge': true,
               'to-rephrase': true,
+              'has-embed-internal-validation': false,
+              'no-validation-needed': false,
             },
             relationships: {
               skill: {
@@ -1988,6 +2000,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': false,
+            'no-validation-needed': false,
           },
           relationships: {
             skill: {

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -97,6 +97,8 @@ async function mockCurrentContent() {
     deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
     isAwarenessChallenge: true,
     toRephrase: true,
+    hasEmbedInternalValidation: true,
+    noValidationNeeded: true,
   };
   const expectedChallenge = {
     ...challenge,
@@ -414,7 +416,7 @@ describe('Acceptance | Controller | replication-data-controller', () => {
   });
 
   describe('GET /api/replication-data', function() {
-    it.fails('should return data for replication', async function() {
+    it('should return data for replication', async function() {
       const expectedCurrentContent = await mockCurrentContent();
 
       const server = await createServer();

--- a/api/tests/acceptance/application/databases/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/databases/replication-data-controller_test.js
@@ -414,7 +414,7 @@ describe('Acceptance | Controller | replication-data-controller', () => {
   });
 
   describe('GET /api/replication-data', function() {
-    it('should return data for replication', async function() {
+    it.fails('should return data for replication', async function() {
       const expectedCurrentContent = await mockCurrentContent();
 
       const server = await createServer();

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -371,6 +371,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
     });
 

--- a/api/tests/acceptance/application/localized-challenges_test.js
+++ b/api/tests/acceptance/application/localized-challenges_test.js
@@ -28,6 +28,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
 
       await databaseBuilder.commit();
@@ -56,6 +58,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             challenge: {
@@ -100,6 +104,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
 
       await databaseBuilder.commit();
@@ -128,6 +134,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             challenge: {
@@ -179,6 +187,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         }),
         databaseBuilder.factory.buildLocalizedChallenge({
           challengeId: 'recChallenge1',
@@ -190,6 +200,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         }),
       ];
 
@@ -220,6 +232,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
               'is-awareness-challenge': false,
               'to-rephrase': false,
+              'has-embed-internal-validation': false,
+              'no-validation-needed': false,
             },
             relationships: {
               challenge: {
@@ -249,6 +263,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
               'is-awareness-challenge': true,
               'to-rephrase': true,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
             },
             relationships: {
               challenge: {
@@ -294,6 +310,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
         status: LocalizedChallenge.STATUSES.PAUSE,
       });
 
@@ -317,6 +335,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
               'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
               'is-awareness-challenge': false,
               'to-rephrase': false,
+              'has-embed-internal-validation': false,
+              'no-validation-needed': false,
               status: LocalizedChallenge.STATUSES.PLAY,
             },
           },
@@ -344,6 +364,8 @@ describe('Acceptance | Controller | localized-challenges-controller', () => {
           'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           'is-awareness-challenge': false,
           'to-rephrase': false,
+          'has-embed-internal-validation': false,
+          'no-validation-needed': false,
         },
         relationships: {
           challenge: {

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -470,6 +470,8 @@ describe('Acceptance | Controller | phrase-controller', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       }]);
     });
   });

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -141,6 +141,8 @@ async function mockCurrentContent() {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       }
     ],
     tutorials: [{
@@ -398,6 +400,8 @@ async function mockCurrentContent() {
     deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
     isAwarenessChallenge: true,
     toRephrase: true,
+    hasEmbedInternalValidation: false,
+    noValidationNeeded: false,
   });
 
   await databaseBuilder.commit();
@@ -527,6 +531,8 @@ async function mockContentForRelease() {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge0_1',
@@ -563,6 +569,8 @@ async function mockContentForRelease() {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },],
     tutorials: [{
       id: 'recTutorial0',

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1577,6 +1577,8 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         },
         {
           id: localizedChallengeNL_challengeA.id,
@@ -1591,6 +1593,8 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
           isAwarenessChallenge: true,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         },
         {
           id: challengeB_data.id,
@@ -1605,6 +1609,8 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         },
       ]);
       const allLocalizedChallengesAttachments = await knex('localized_challenges-attachments')
@@ -1869,6 +1875,8 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         },
       ]);
       const allLocalizedChallengesAttachments = await knex('localized_challenges-attachments')

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1171,6 +1171,8 @@ describe('Integration | Repository | challenge-repository', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const localizedChallengeNL_challengeA = domainBuilder.buildLocalizedChallenge({
         id: 'localizedChallengeNL_challengeA_id',
@@ -1186,6 +1188,8 @@ describe('Integration | Repository | challenge-repository', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: true,
         toRephrase: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: false,
       });
       const challengeA_data = {
         id: 'challengeA_id',
@@ -1249,6 +1253,8 @@ describe('Integration | Repository | challenge-repository', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       const challengeB_data = {
         id: 'challengeB_id',
@@ -1577,8 +1583,8 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
-          hasEmbedInternalValidation: false,
-          noValidationNeeded: false,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         },
         {
           id: localizedChallengeNL_challengeA.id,
@@ -1593,7 +1599,7 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
           isAwarenessChallenge: true,
           toRephrase: false,
-          hasEmbedInternalValidation: false,
+          hasEmbedInternalValidation: true,
           noValidationNeeded: false,
         },
         {

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1715,6 +1715,8 @@ describe('Integration | Repository | challenge-repository', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const challengeToCreate = domainBuilder.buildChallenge({
         ...challengeToCreate_data,
@@ -1881,8 +1883,8 @@ describe('Integration | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
-          hasEmbedInternalValidation: false,
-          noValidationNeeded: false,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         },
       ]);
       const allLocalizedChallengesAttachments = await knex('localized_challenges-attachments')

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -925,7 +925,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
   });
 
   context('#update', () => {
-    it('should change localized challenge locale, embedUrl, geography and urlsToConsult', async () => {
+    it('should change many attributes', async () => {
       // given
       const id = 'localizedChallengeId';
       databaseBuilder.factory.buildLocalizedChallenge({
@@ -940,6 +940,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: true,
       });
       await databaseBuilder.commit();
 
@@ -956,6 +958,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: false,
       });
 
       // when
@@ -976,7 +980,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
-          hasEmbedInternalValidation: false,
+          hasEmbedInternalValidation: true,
           noValidationNeeded: false,
         },
       ]);
@@ -995,6 +999,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: false,
         }));
     });
 
@@ -1043,6 +1049,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         });
 
         await databaseBuilder.commit();
@@ -1060,6 +1068,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: true,
         });
 
         // when
@@ -1081,7 +1091,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
             isAwarenessChallenge: false,
             toRephrase: false,
             hasEmbedInternalValidation: false,
-            noValidationNeeded: false,
+            noValidationNeeded: true,
           },
         ]);
 
@@ -1099,6 +1109,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
             isAwarenessChallenge: false,
             toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: true,
           }));
       });
     });

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -496,6 +496,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: `${challengeId1}En`,
@@ -552,6 +554,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: `${challengeId1}Nl`,

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -152,6 +152,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         })
       ] });
 
@@ -171,8 +173,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
-        hasEmbedInternalValidation: false,
-        noValidationNeeded: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       }]);
     });
 
@@ -203,6 +205,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         });
         delete localizedChallengeToCreate.id;
         await localizedChallengeRepository.create({
@@ -226,8 +230,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
-          hasEmbedInternalValidation: false,
-          noValidationNeeded: false,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         }]);
       });
 
@@ -265,6 +269,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         });
         await databaseBuilder.commit();
 
@@ -282,6 +288,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
             isAwarenessChallenge: false,
             toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: true,
           },
           {
             challengeId: 'challengeId',
@@ -295,6 +303,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
             isAwarenessChallenge: true,
             toRephrase: false,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: false,
           }
         ] });
 
@@ -316,8 +326,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             isAwarenessChallenge: true,
             toRephrase: true,
-            hasEmbedInternalValidation: false,
-            noValidationNeeded: false,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: true,
           },
           {
             id: expect.stringMatching(/^challenge\w+$/),
@@ -332,7 +342,7 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
             isAwarenessChallenge: true,
             toRephrase: false,
-            hasEmbedInternalValidation: false,
+            hasEmbedInternalValidation: true,
             noValidationNeeded: false,
           },
         ]);

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -171,6 +171,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       }]);
     });
 
@@ -224,6 +226,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         }]);
       });
 
@@ -312,6 +316,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             isAwarenessChallenge: true,
             toRephrase: true,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
           },
           {
             id: expect.stringMatching(/^challenge\w+$/),
@@ -326,6 +332,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
             isAwarenessChallenge: true,
             toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
           },
         ]);
       });
@@ -954,6 +962,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         },
       ]);
 
@@ -1056,6 +1066,8 @@ describe('Integration | Repository | localized-challenge-repository', function()
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
             isAwarenessChallenge: false,
             toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
           },
         ]);
 

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1265,7 +1265,7 @@ function _getRichCurrentContentDTO() {
       toRephrase: true,
       hasEmbedInternalValidation: false,
       noValidationNeeded: false,
-   },
+    },
     {
       id: 'challenge121212',
       instruction: 'challenge121212 instruction en',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1222,6 +1222,8 @@ function _getRichCurrentContentDTO() {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
     },
     {
       id: 'challengeNl',
@@ -1261,7 +1263,9 @@ function _getRichCurrentContentDTO() {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,
       toRephrase: true,
-    },
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
+   },
     {
       id: 'challenge121212',
       instruction: 'challenge121212 instruction en',
@@ -1299,6 +1303,8 @@ function _getRichCurrentContentDTO() {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
     },
     {
       id: 'challenge211111',
@@ -1338,6 +1344,8 @@ function _getRichCurrentContentDTO() {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
     },
     {
       id: 'challenge211112',
@@ -1376,6 +1384,8 @@ function _getRichCurrentContentDTO() {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
     },
     {
       id: 'challenge211113',
@@ -1414,6 +1424,8 @@ function _getRichCurrentContentDTO() {
       deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: false,
+      noValidationNeeded: false,
     },
   ];
   const expectedCourseDTOs = [

--- a/api/tests/scripts/migrate-localized-challenges-geography_test.js
+++ b/api/tests/scripts/migrate-localized-challenges-geography_test.js
@@ -87,6 +87,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge1Nl',
@@ -101,6 +103,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge2',
@@ -115,6 +119,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge2Nl',
@@ -129,6 +135,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge3',
@@ -143,6 +151,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge4',
@@ -157,6 +167,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
       {
         id: 'recChallenge5',
@@ -171,6 +183,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       },
     ]);
   });

--- a/api/tests/scripts/migrate-localized-challenges-geography_test.js
+++ b/api/tests/scripts/migrate-localized-challenges-geography_test.js
@@ -20,6 +20,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
       challengeId: 'recChallenge1',
       locale: 'nl',
       status: LocalizedChallenge.STATUSES.PLAY,
+      hasEmbedInternalValidation: true,
+      noValidationNeeded: true,
     });
     databaseBuilder.factory.buildLocalizedChallenge({
       id: 'recChallenge2',
@@ -103,8 +105,8 @@ describe('Script | migrate-localized-challenges-geography', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
-        hasEmbedInternalValidation: false,
-        noValidationNeeded: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       },
       {
         id: 'recChallenge2',

--- a/api/tests/tooling/database-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-challenge.js
@@ -13,6 +13,8 @@ export function buildLocalizedChallenge({
   status = null,
   geography = null,
   urlsToConsult = null,
+  hasEmbedInternalValidation = false,
+  noValidationNeeded = false,
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'localized_challenges',
@@ -29,6 +31,8 @@ export function buildLocalizedChallenge({
       deafAndHardOfHearing,
       isAwarenessChallenge,
       toRephrase,
+      hasEmbedInternalValidation,
+      noValidationNeeded,
     },
   });
 }

--- a/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge-for-release.js
@@ -39,6 +39,8 @@ export function buildChallengeForRelease({
   deafAndHardOfHearing = LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
   isAwarenessChallenge = false,
   toRephrase = false,
+  hasEmbedInternalValidation = false,
+  noValidationNeeded = false,
 } = {}) {
 
   return new ChallengeForRelease({
@@ -79,5 +81,7 @@ export function buildChallengeForRelease({
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   });
 }

--- a/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-localized-challenge.js
@@ -32,6 +32,8 @@ export function buildLocalizedChallenge({
   deafAndHardOfHearing = LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
   isAwarenessChallenge = false,
   toRephrase = false,
+  hasEmbedInternalValidation = false,
+  noValidationNeeded = false,
 }) {
   return new LocalizedChallenge({
     id,
@@ -48,5 +50,7 @@ export function buildLocalizedChallenge({
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   });
 }

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -352,6 +352,8 @@ describe('Unit | Domain | Challenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: true,
       });
       const dutchLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: dutchChallengeId,
@@ -366,6 +368,8 @@ describe('Unit | Domain | Challenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: false,
       });
       const englishLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: englishChallengeId,
@@ -380,6 +384,8 @@ describe('Unit | Domain | Challenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: true,
         toRephrase: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const localizedChallenges = [
         frenchLocalizedChallenge,
@@ -440,6 +446,8 @@ describe('Unit | Domain | Challenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: true,
       };
 
       const expectedEnglishChallenge = {
@@ -456,6 +464,8 @@ describe('Unit | Domain | Challenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: true,
       };
 
       // when
@@ -474,6 +484,8 @@ describe('Unit | Domain | Challenge', () => {
       expect(dutchChallenge).toHaveProperty('deafAndHardOfHearing', LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK);
       expect(dutchChallenge).toHaveProperty('isAwarenessChallenge', true);
       expect(dutchChallenge).toHaveProperty('toRephrase', true);
+      expect(dutchChallenge).toHaveProperty('hasEmbedInternalValidation', false);
+      expect(dutchChallenge).toHaveProperty('noValidationNeeded', true);
 
       expect(refrenchChallenge).toEqual(challenge);
       expect(refrenchChallenge).toHaveProperty('primaryLocale', 'fr');
@@ -485,6 +497,8 @@ describe('Unit | Domain | Challenge', () => {
       expect(refrenchChallenge).toHaveProperty('deafAndHardOfHearing', LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK);
       expect(refrenchChallenge).toHaveProperty('isAwarenessChallenge', true);
       expect(refrenchChallenge).toHaveProperty('toRephrase', true);
+      expect(refrenchChallenge).toHaveProperty('hasEmbedInternalValidation', false);
+      expect(refrenchChallenge).toHaveProperty('noValidationNeeded', true);
 
       expect(englishChallenge).toEqual(expectedEnglishChallenge);
       expect(englishChallenge).toHaveProperty('primaryLocale', 'fr');
@@ -496,6 +510,8 @@ describe('Unit | Domain | Challenge', () => {
       expect(englishChallenge).toHaveProperty('deafAndHardOfHearing', LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK);
       expect(englishChallenge).toHaveProperty('isAwarenessChallenge', true);
       expect(englishChallenge).toHaveProperty('toRephrase', true);
+      expect(englishChallenge).toHaveProperty('hasEmbedInternalValidation', false);
+      expect(englishChallenge).toHaveProperty('noValidationNeeded', true);
     });
 
     [

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -596,7 +596,7 @@ describe('Unit | Domain | Challenge', () => {
   });
 
   describe('#cloneChallengeAndAttachments', ()=> {
-    it('should clone challenge', () => {
+    it.fails('should clone challenge', () => {
       // given
       const clonedChallengeId = 'clonedChallengeId';
       const competenceId = 'competenceId';
@@ -724,6 +724,8 @@ describe('Unit | Domain | Challenge', () => {
       expect(clonedChallenge.deafAndHardOfHearing).toEqual(challenge.deafAndHardOfHearing);
       expect(clonedChallenge.isAwarenessChallenge).toEqual(challenge.isAwarenessChallenge);
       expect(clonedChallenge.toRephrase).toEqual(challenge.toRephrase);
+      expect(clonedChallenge.hasEmbedInternalValidation).toEqual(challenge.hasEmbedInternalValidation);
+      expect(clonedChallenge.noValidationNeeded).toEqual(challenge.noValidationNeeded);
       expect(clonedChallenge.localizedChallenges[0]).toStrictEqual(domainBuilder.buildLocalizedChallenge({
         id: clonedChallengeId,
         challengeId: clonedChallengeId,
@@ -738,10 +740,12 @@ describe('Unit | Domain | Challenge', () => {
         deafAndHardOfHearing: challenge.localizedChallenges[0].deafAndHardOfHearing,
         isAwarenessChallenge: challenge.localizedChallenges[0].isAwarenessChallenge,
         toRephrase: challenge.localizedChallenges[0].toRephrase,
+        hasEmbedInternalValidation: challenge.localizedChallenges[0].hasEmbedInternalValidation,
+        noValidationNeeded: challenge.localizedChallenges[0].noValidationNeeded,
       }));
     });
 
-    it('should clone challenge without translations', () => {
+    it.fails('should clone challenge without translations', () => {
       // given
       const clonedChallengeId = 'clonedChallengeId';
       const clonedNLLocalizedChallengeId = 'clonedNLLocalizedChallengeId';
@@ -788,6 +792,8 @@ describe('Unit | Domain | Challenge', () => {
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             isAwarenessChallenge: true,
             toRephrase: true,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: true,
           }),
           new LocalizedChallenge({
             id: 'locNLChallengeId',
@@ -803,6 +809,8 @@ describe('Unit | Domain | Challenge', () => {
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
             isAwarenessChallenge: false,
             toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
           }),
         ],
         files: [{
@@ -848,6 +856,9 @@ describe('Unit | Domain | Challenge', () => {
       expect(clonedChallenge.deafAndHardOfHearing).toEqual(challenge.deafAndHardOfHearing);
       expect(clonedChallenge.isAwarenessChallenge).toEqual(challenge.isAwarenessChallenge);
       expect(clonedChallenge.toRephrase).toEqual(challenge.toRephrase);
+      expect(clonedChallenge.hasEmbedInternalValidation).toEqual(challenge.hasEmbedInternalValidation);
+      expect(clonedChallenge.noValidationNeeded).toEqual(challenge.noValidationNeeded);
+
       expect(clonedChallenge.files).toStrictEqual([]);
 
       expect(clonedChallenge.translations).toStrictEqual({
@@ -875,6 +886,8 @@ describe('Unit | Domain | Challenge', () => {
           deafAndHardOfHearing: challenge.localizedChallenges[0].deafAndHardOfHearing,
           isAwarenessChallenge: challenge.localizedChallenges[0].isAwarenessChallenge,
           toRephrase: challenge.localizedChallenges[0].toRephrase,
+          hasEmbedInternalValidation: challenge.localizedChallenges[0].hasEmbedInternalValidation,
+          noValidationNeeded: challenge.localizedChallenges[0].noValidationNeeded,
         }),
       ]);
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -612,7 +612,7 @@ describe('Unit | Domain | Challenge', () => {
   });
 
   describe('#cloneChallengeAndAttachments', ()=> {
-    it.fails('should clone challenge', () => {
+    it('should clone challenge', () => {
       // given
       const clonedChallengeId = 'clonedChallengeId';
       const competenceId = 'competenceId';
@@ -647,6 +647,8 @@ describe('Unit | Domain | Challenge', () => {
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             isAwarenessChallenge: true,
             toRephrase: true,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: true,
           }),
         ],
         files: [{
@@ -761,7 +763,7 @@ describe('Unit | Domain | Challenge', () => {
       }));
     });
 
-    it.fails('should clone challenge without translations', () => {
+    it('should clone challenge without translations', () => {
       // given
       const clonedChallengeId = 'clonedChallengeId';
       const clonedNLLocalizedChallengeId = 'clonedNLLocalizedChallengeId';

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -180,7 +180,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('static buildAlternativeFromTranslation', function() {
-    it.fails('should build an alternative localized challenge', function() {
+    it('should build an alternative localized challenge', function() {
       // given
       const translation = domainBuilder.buildTranslation({
         key: 'challenge.idDuChallenge.field',
@@ -205,6 +205,8 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
     });
   });

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -99,7 +99,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('static buildPrimary', function() {
-    it('should build a primary localized challenge', function() {
+    it.fails('should build a primary localized challenge', function() {
       // given
       const challengeId = 'idDuChallenge';
       const locale = 'en';
@@ -143,7 +143,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         toRephrase: true,
       });
     });
-    it('should build a primary localized challenge with default values when some not filled', function() {
+    it.fails('should build a primary localized challenge with default values when some not filled', function() {
       // given
       const challengeId = 'idDuChallenge';
       const locale = 'en';
@@ -180,7 +180,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('static buildAlternativeFromTranslation', function() {
-    it('should build an alternative localized challenge', function() {
+    it.fails('should build an alternative localized challenge', function() {
       // given
       const translation = domainBuilder.buildTranslation({
         key: 'challenge.idDuChallenge.field',
@@ -210,7 +210,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('clone', function() {
-    it('should return a cloned localized challenge and its cloned attachments', function() {
+    it.fails('should return a cloned localized challenge and its cloned attachments', function() {
       // given
       const newId = 'newChallengeId';
       const newChallengeId = 'newChallengeId';

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -212,7 +212,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('clone', function() {
-    it.fails('should return a cloned localized challenge and its cloned attachments', function() {
+    it('should return a cloned localized challenge and its cloned attachments', function() {
       // given
       const newId = 'newChallengeId';
       const newChallengeId = 'newChallengeId';
@@ -231,6 +231,8 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const attachments = [
         domainBuilder.buildAttachment({ id: 'someIrrelevantAttachment' }),
@@ -274,6 +276,8 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       expect(clonedLocalizedChallenge).toStrictEqual(expectedLocalizedChallenge);
       expect(clonedAttachments).toStrictEqual([

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -99,7 +99,7 @@ describe('Unit | Domain | LocalizedChallenge', () => {
   });
 
   describe('static buildPrimary', function() {
-    it.fails('should build a primary localized challenge', function() {
+    it('should build a primary localized challenge', function() {
       // given
       const challengeId = 'idDuChallenge';
       const locale = 'en';
@@ -111,6 +111,8 @@ describe('Unit | Domain | LocalizedChallenge', () => {
       const deafAndHardOfHearing = LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK;
       const isAwarenessChallenge = true;
       const toRephrase = true;
+      const hasEmbedInternalValidation = true;
+      const noValidationNeeded = true;
 
       // when
       const primaryLocalizedChallenge = LocalizedChallenge.buildPrimary({
@@ -124,6 +126,8 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         deafAndHardOfHearing,
         isAwarenessChallenge,
         toRephrase,
+        hasEmbedInternalValidation,
+        noValidationNeeded,
       });
 
       // then
@@ -141,9 +145,11 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
     });
-    it.fails('should build a primary localized challenge with default values when some not filled', function() {
+    it('should build a primary localized challenge with default values when some not filled', function() {
       // given
       const challengeId = 'idDuChallenge';
       const locale = 'en';
@@ -175,6 +181,8 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
     });
   });

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -106,6 +106,8 @@ describe('Unit | Domain | Usecases | import-translations', function() {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       }),
       new LocalizedChallenge({
         id: null,
@@ -121,6 +123,8 @@ describe('Unit | Domain | Usecases | import-translations', function() {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
         isAwarenessChallenge: false,
         toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       }),
     ] });
   });

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -44,6 +44,8 @@ describe('Unit | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: '1_en',
@@ -55,6 +57,8 @@ describe('Unit | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         }),
         domainBuilder.buildLocalizedChallenge({
           id: '2',
@@ -66,6 +70,8 @@ describe('Unit | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: true,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         }),
       ]);
       vi.spyOn(challengeDatasource, 'list').mockResolvedValue([{ id: 1, locales: [], geography: 'DeprecatedLand' }, { id: 2, locales: [], geography: 'DeprecatedLand' }]);
@@ -87,6 +93,8 @@ describe('Unit | Repository | challenge-repository', () => {
       expect(challenges[0].deafAndHardOfHearing).to.equal(LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK);
       expect(challenges[0].isAwarenessChallenge).to.equal(true);
       expect(challenges[0].toRephrase).to.equal(true);
+      expect(challenges[0].hasEmbedInternalValidation).to.equal(true);
+      expect(challenges[0].noValidationNeeded).to.equal(true);
 
       expect(challenges[1].instruction).to.equal('instruction 2');
       expect(challenges[1].proposals).to.equal('proposals 2');
@@ -97,6 +105,8 @@ describe('Unit | Repository | challenge-repository', () => {
       expect(challenges[1].deafAndHardOfHearing).to.equal(LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO);
       expect(challenges[1].isAwarenessChallenge).to.equal(true);
       expect(challenges[1].toRephrase).to.equal(false);
+      expect(challenges[1].hasEmbedInternalValidation).to.equal(false);
+      expect(challenges[1].noValidationNeeded).to.equal(false);
 
     });
   });
@@ -404,7 +414,7 @@ describe('Unit | Repository | challenge-repository', () => {
     });
   });
   describe('#update', () => {
-    it('should update a challenge by id', async () => {
+    it.fails('should update a challenge by id', async () => {
       // given
       const locale = 'en';
       const oldPrimaryLocale = 'fr';
@@ -425,6 +435,11 @@ describe('Unit | Repository | challenge-repository', () => {
       const newIsAwarenessChallenge = true;
       const oldToRephrase = false;
       const newToRephrase = true;
+      const oldHasEmbedInternalValidation = false;
+      const newHasEmbedInternalValidation = true;
+      const oldNoValidationNeeded = false;
+      const newNoValidationNeeded = true;
+
       const challengeId = 'challengeId';
       const challengeFromAirtable = domainBuilder.buildChallengeDatasourceObject({
         id: challengeId,
@@ -443,6 +458,8 @@ describe('Unit | Repository | challenge-repository', () => {
         deafAndHardOfHearing: oldDeafAndHardOfHearing,
         isAwarenessChallenge: oldIsAwarenessChallenge,
         toRephrase: oldToRephrase,
+        hasEmbedInternalValidation: oldHasEmbedInternalValidation,
+        noValidationNeeded: oldNoValidationNeeded,
       };
       const localizedChallengesInDb = [
         domainBuilder.buildLocalizedChallenge(localizedChallenge_originalData),
@@ -455,6 +472,8 @@ describe('Unit | Repository | challenge-repository', () => {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         }),
       ];
       const challengeToUpdate = domainBuilder.buildChallenge({
@@ -479,6 +498,8 @@ describe('Unit | Repository | challenge-repository', () => {
             deafAndHardOfHearing: newDeafAndHardOfHearing,
             isAwarenessChallenge: newIsAwarenessChallenge,
             toRephrase: newToRephrase,
+            hasEmbedInternalValidation: newHasEmbedInternalValidation,
+            noValidationNeeded: newNoValidationNeeded,
           }),
         ],
       });
@@ -507,6 +528,8 @@ describe('Unit | Repository | challenge-repository', () => {
           deafAndHardOfHearing: newDeafAndHardOfHearing,
           isAwarenessChallenge: newIsAwarenessChallenge,
           toRephrase: newToRephrase,
+          hasEmbedInternalValidation: newHasEmbedInternalValidation,
+          noValidationNeeded: newNoValidationNeeded,
         }),
         transaction: expect.anything(),
       });
@@ -549,6 +572,8 @@ describe('Unit | Repository | challenge-repository', () => {
             deafAndHardOfHearing: newDeafAndHardOfHearing,
             isAwarenessChallenge: newIsAwarenessChallenge,
             toRephrase: newToRephrase,
+            hasEmbedInternalValidation: newHasEmbedInternalValidation,
+            noValidationNeeded: newNoValidationNeeded,
           }),
           domainBuilder.buildLocalizedChallenge({
             id: 'localizedChallengeId',
@@ -559,6 +584,8 @@ describe('Unit | Repository | challenge-repository', () => {
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
             isAwarenessChallenge: false,
             toRephrase: true,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: true,
           }),
         ],
       });

--- a/api/tests/unit/infrastructure/repository/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repository/challenge-repository_test.js
@@ -414,7 +414,7 @@ describe('Unit | Repository | challenge-repository', () => {
     });
   });
   describe('#update', () => {
-    it.fails('should update a challenge by id', async () => {
+    it('should update a challenge by id', async () => {
       // given
       const locale = 'en';
       const oldPrimaryLocale = 'fr';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -5,7 +5,7 @@ import { Challenge, LocalizedChallenge } from '../../../../../lib/domain/models/
 
 describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
   describe('#serialize', () => {
-    it.fails('should serialize a Challenge', () => {
+    it('should serialize a Challenge', () => {
       // Given
       const localizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: 'recwWzTquPlvIl4So',
@@ -109,7 +109,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
   });
 
   describe('#deserialize', () => {
-    it.fails('should deserialize a Challenge', async () => {
+    it('should deserialize a Challenge', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         geography: 'MD',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -5,7 +5,7 @@ import { Challenge, LocalizedChallenge } from '../../../../../lib/domain/models/
 
 describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
   describe('#serialize', () => {
-    it('should serialize a Challenge', () => {
+    it.fails('should serialize a Challenge', () => {
       // Given
       const localizedChallenge = domainBuilder.buildLocalizedChallenge({
         id: 'recwWzTquPlvIl4So',
@@ -16,6 +16,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const challenge = domainBuilder.buildChallenge({
         id: 'recwWzTquPlvIl4So',
@@ -73,6 +75,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             skill: {
@@ -105,7 +109,7 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
   });
 
   describe('#deserialize', () => {
-    it('should deserialize a Challenge', async () => {
+    it.fails('should deserialize a Challenge', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         geography: 'MD',
@@ -116,6 +120,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const expectedDeserializedChallenge = domainBuilder.buildChallenge({ localizedChallenges: [expectedLocalizedChallenge] }, ['alpha', 'delta', 'skillId']);
       const json = {
@@ -168,6 +174,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             skill: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
@@ -9,7 +9,7 @@ import { LocalizedChallenge } from '../../../../../lib/domain/models/index.js';
 
 describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
   describe('#deserialize', () => {
-    it.fails('should deserialize a Localized Challenge', async () => {
+    it('should deserialize a Localized Challenge', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         geography: 'BZ',
@@ -30,6 +30,8 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
             'deaf-and-hard-of-hearing': expectedLocalizedChallenge.deafAndHardOfHearing,
             'is-awareness-challenge': expectedLocalizedChallenge.isAwarenessChallenge,
             'to-rephrase': expectedLocalizedChallenge.toRephrase,
+            'has-embed-internal-validation': expectedLocalizedChallenge.hasEmbedInternalValidation,
+            'no-validation-needed': expectedLocalizedChallenge.noValidationNeeded,
           },
           relationships: {
             challenge: {
@@ -49,7 +51,7 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
       expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
     });
 
-    it.fails('should deserialize a Localized Challenge with files', async () => {
+    it('should deserialize a Localized Challenge with files', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         fileIds: ['attachmentId'],
@@ -69,6 +71,8 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
             'deaf-and-hard-of-hearing': expectedLocalizedChallenge.deafAndHardOfHearing,
             'is-awareness-challenge': expectedLocalizedChallenge.isAwarenessChallenge,
             'to-rephrase': expectedLocalizedChallenge.toRephrase,
+            'has-embed-internal-validation': expectedLocalizedChallenge.hasEmbedInternalValidation,
+            'no-validation-needed': expectedLocalizedChallenge.noValidationNeeded,
           },
           relationships: {
             challenge: {
@@ -94,7 +98,7 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
       expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
     });
 
-    it.fails('should deserialize empty embed URL as null', async () => {
+    it('should deserialize empty embed URL as null', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         embedUrl: null,
@@ -113,6 +117,8 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
             'deaf-and-hard-of-hearing': expectedLocalizedChallenge.deafAndHardOfHearing,
             'is-awareness-challenge': expectedLocalizedChallenge.isAwarenessChallenge,
             'to-rephrase': expectedLocalizedChallenge.toRephrase,
+            'has-embed-internal-validation': expectedLocalizedChallenge.hasEmbedInternalValidation,
+            'no-validation-needed': expectedLocalizedChallenge.noValidationNeeded,
           },
           relationships: {
             challenge: {
@@ -149,6 +155,8 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
         deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
         isAwarenessChallenge: true,
         toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       const expectedSerializedLocalizedChallenge = {
         data: {
@@ -167,6 +175,8 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
             'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             'is-awareness-challenge': true,
             'to-rephrase': true,
+            'has-embed-internal-validation': true,
+            'no-validation-needed': true,
           },
           relationships: {
             files: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/localized-challenge-serializer_test.js
@@ -9,7 +9,7 @@ import { LocalizedChallenge } from '../../../../../lib/domain/models/index.js';
 
 describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
   describe('#deserialize', () => {
-    it('should deserialize a Localized Challenge', async () => {
+    it.fails('should deserialize a Localized Challenge', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         geography: 'BZ',
@@ -49,7 +49,7 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
       expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
     });
 
-    it('should deserialize a Localized Challenge with files', async () => {
+    it.fails('should deserialize a Localized Challenge with files', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         fileIds: ['attachmentId'],
@@ -94,7 +94,7 @@ describe('Unit | Serializer | JSONAPI | localized-challenge-serializer', () => {
       expect(localizedChallenge).to.deep.equal(expectedLocalizedChallenge);
     });
 
-    it('should deserialize empty embed URL as null', async () => {
+    it.fails('should deserialize empty embed URL as null', async () => {
       // Given
       const expectedLocalizedChallenge = domainBuilder.buildLocalizedChallenge({
         embedUrl: null,

--- a/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/challenge-transformer_test.js
@@ -34,6 +34,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
             deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
             isAwarenessChallenge: true,
             toRephrase: true,
+            hasEmbedInternalValidation: true,
+            noValidationNeeded: true,
           })
         ]
       });
@@ -277,6 +279,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         })],
         locales: ['fr', 'fr-fr'],
         files: [],
@@ -342,6 +346,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         deafAndHardOfHearing: challengeProto1Skill1.deafAndHardOfHearing,
         isAwarenessChallenge: challengeProto1Skill1.isAwarenessChallenge,
         toRephrase: challengeProto1Skill1.toRephrase,
+        hasEmbedInternalValidation: challengeProto1Skill1.hasEmbedInternalValidation,
+        noValidationNeeded: challengeProto1Skill1.noValidationNeeded,
       });
 
       expect(challengeProto2Skill1).to.deep.equal(domainBuilder.buildChallenge(challengeProto2Skill1DTO));
@@ -356,6 +362,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         deafAndHardOfHearing: challengeProto2Skill1.deafAndHardOfHearing,
         isAwarenessChallenge: challengeProto2Skill1.isAwarenessChallenge,
         toRephrase: challengeProto2Skill1.toRephrase,
+        hasEmbedInternalValidation: challengeProto2Skill1.hasEmbedInternalValidation,
+        noValidationNeeded: challengeProto2Skill1.noValidationNeeded,
       });
 
       expect(challengeProto1Skill2).to.deep.equal(domainBuilder.buildChallenge(challengeProto1Skill2DTO));
@@ -370,6 +378,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
         deafAndHardOfHearing: challengeProto1Skill2.deafAndHardOfHearing,
         isAwarenessChallenge: challengeProto1Skill2.isAwarenessChallenge,
         toRephrase: challengeProto1Skill2.toRephrase,
+        hasEmbedInternalValidation: challengeProto1Skill2.hasEmbedInternalValidation,
+        noValidationNeeded: challengeProto1Skill2.noValidationNeeded,
       });
     });
 
@@ -398,6 +408,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         })],
         locales: ['fr', 'fr-fr'],
         files: [],
@@ -426,6 +438,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         })],
         locales: ['fr', 'fr-fr'],
         files: [],
@@ -478,6 +492,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
           isAwarenessChallenge: true,
           toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
         })],
         locales: ['fr', 'fr-fr'],
         files: [],
@@ -505,6 +521,8 @@ describe('Unit | Infrastructure | Challenge Transformer', function() {
           deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
           isAwarenessChallenge: false,
           toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
         })],
         locales: ['fr', 'fr-fr'],
         files: [],
@@ -570,6 +588,8 @@ function _buildReleaseChallenge({
   deafAndHardOfHearing,
   isAwarenessChallenge,
   toRephrase,
+  hasEmbedInternalValidation,
+  noValidationNeeded,
 }) {
   const releaseChallenge = {
     id,
@@ -608,6 +628,8 @@ function _buildReleaseChallenge({
     deafAndHardOfHearing,
     isAwarenessChallenge,
     toRephrase,
+    hasEmbedInternalValidation,
+    noValidationNeeded,
   };
   if (attachments) {
     releaseChallenge.attachments = attachments;

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -34,6 +34,14 @@
       @setValue={{this.setChallengeType}}
       data-test-select-type
     />
+    <div class="field">
+      <Field::Checkbox
+        @label="Sans validation (Pix Junior)"
+        @checked={{@challenge.noValidationNeeded}}
+        @disabled={{not @edition}}
+        data-test-no-validation-needed-checkbox={{@challenge.id}}
+      />
+    </div>
   {{/if}}
   {{#if this.typeIsQCUOrQCM}}
     <Field::Checkbox
@@ -203,6 +211,16 @@
     @id="challenge-embed-title"
   />
   {{#if @challenge.isPrototype}}
+    <div class="fields--selectors">
+      <div class="field">
+        <Field::Checkbox
+          @label="Validation par l'embed (Pix Junior)"
+          @checked={{@challenge.hasEmbedInternalValidation}}
+          @disabled={{not @edition}}
+          data-test-has-embed-internal-validation-checkbox={{@challenge.id}}
+        />
+      </div>
+    </div>
     <Field::Select
       @title="Type pédagogie"
       @value={{@challenge.pedagogy}}

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -50,6 +50,8 @@ export default class ChallengeModel extends Model {
   @attr deafAndHardOfHearing;
   @attr isAwarenessChallenge;
   @attr toRephrase;
+  @attr('boolean') hasEmbedInternalValidation;
+  @attr('boolean') noValidationNeeded;
 
   @belongsTo('skill', { inverse: 'challenges', async: true }) skill;
   @hasMany('attachment', { inverse: 'challenge', async: true }) files;

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -19,6 +19,8 @@ export default class LocalizedChallengeModel extends Model {
   @attr deafAndHardOfHearing;
   @attr isAwarenessChallenge;
   @attr toRephrase;
+  @attr('boolean') hasEmbedInternalValidation;
+  @attr('boolean') noValidationNeeded;
   @attr instruction;
 
   @belongsTo('challenge', { inverse: 'localizedChallenges', async: true }) challenge;

--- a/pix-editor/mirage/factories/challenge.js
+++ b/pix-editor/mirage/factories/challenge.js
@@ -30,6 +30,8 @@ export default Factory.extend({
   locales: 'languages',
   geography: 'geography',
   autoReply: 'autoReply',
+  hasEmbedInternalValidation: false,
+  noValidationNeeded: false,
   files: null,
   updatedAt: '2021-10-02T14:00:00.000Z',
   contextualizedFields() { return ['illustration', 'instruction']; },

--- a/pix-editor/tests/acceptance/create-challenge-test.js
+++ b/pix-editor/tests/acceptance/create-challenge-test.js
@@ -73,6 +73,8 @@ module('Acceptance | Create-Challenge', function(hooks) {
     await clickByText('Accès GAFAM requis');
     await clickByText('Formulation à revoir');
     await clickByText('Incompatible iPad certif');
+    await clickByText('Sans validation (Pix Junior)');
+    await clickByText('Validation par l\'embed (Pix Junior)');
     await clickByText('Sourds et malentendants');
     await click(await screen.findByRole('option', { name: 'RAS' }));
     await delay(100);
@@ -105,6 +107,8 @@ module('Acceptance | Create-Challenge', function(hooks) {
     assert.true(screen.getByRole('checkbox', { name: 'Accès GAFAM requis' }).checked);
     assert.true(screen.getByRole('checkbox', { name: 'Formulation à revoir' }).checked);
     assert.true(screen.getByRole('checkbox', { name: 'Incompatible iPad certif' }).checked);
+    assert.true(screen.getByRole('checkbox', { name: 'Sans validation (Pix Junior)' }).checked);
+    assert.true(screen.getByRole('checkbox', { name: 'Validation par l\'embed (Pix Junior)' }).checked);
     assert.strictEqual((await screen.getByLabelText('Responsive')).childNodes[3].textContent, 'Non');
   });
 });

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -35,6 +35,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
         version: 1,
         status: 'proposé',
         instruction: 'Cliquer sur instructions du proto pour aller sur ma page principale depuis la liste des épreuves de l\'acquis',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       this.server.create('challenge', {
         id: 'recChallenge2',
@@ -98,6 +100,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await clickByText('Accès GAFAM requis');
       await clickByText('Formulation à revoir');
       await clickByText('Incompatible iPad certif');
+      await clickByText('Sans validation (Pix Junior)');
+      await clickByText('Validation par l\'embed (Pix Junior)');
       await clickByText('Sourds et malentendants');
       await click(await screen.findByRole('option', { name: 'RAS' }));
       await delay(100);
@@ -127,6 +131,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       assert.true(screen.getByRole('checkbox', { name: 'Accès GAFAM requis' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'Formulation à revoir' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'Incompatible iPad certif' }).checked);
+      assert.true(screen.getByRole('checkbox', { name: 'Sans validation (Pix Junior)' }).checked);
+      assert.true(screen.getByRole('checkbox', { name: 'Validation par l\'embed (Pix Junior)' }).checked);
     });
 
     test('can modify common attributes but not the quality attributes when challenge is an alternative', async function(assert) {
@@ -150,6 +156,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       assert.dom(find('[data-test-require-gafam-website-access-challenge-challenge-id="recChallenge2"]')).doesNotExist();
       assert.dom(find('[data-test-to-rephrase-challenge-id="recChallenge2"]')).doesNotExist();
       assert.dom(find('[data-test-is-incompatible-ipad-certif-challenge-id="recChallenge2"]')).doesNotExist();
+      assert.dom(find('[data-test-no-validation-needed-checkbox="recChallenge2"]')).doesNotExist();
+      assert.dom(find('[data-test-has-embed-internal-validation-checkbox="recChallenge2"]')).doesNotExist();
       await click(find('[data-test-save-challenge-button]'));
       await click(find('[data-test-confirm-log-approve]'));
 
@@ -175,6 +183,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
         genealogy: 'Prototype 1',
         status: 'validé',
         instruction: 'Cliquer sur instructions pour aller sur ma page principale depuis la liste des épreuves de l\'acquis',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       const skill = this.server.create('skill', { id: 'recSkill1', level: 2, name: '@trululu2', challengeIds: ['recChallenge1'], status: 'actif' });
       const tube = this.server.create('tube', { id: 'recTube1', name: '@trululu', rawSkillIds: ['recSkill1'] });
@@ -211,6 +221,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await clickByText('Modifier');
       await clickByText('Ajouter des URLs à consulter');
       await fillByLabel('URLs externes à consulter', ' https://mon-url.com \n mon-autre-url.com');
+      await clickByText('Sans validation (Pix Junior)');
+      await clickByText('Validation par l\'embed (Pix Junior)');
       assert.dom(screen.queryByText('Accès GAFAM requis')).doesNotExist();
       assert.dom(screen.queryByText('Épreuve de sensibilisation')).doesNotExist();
       assert.dom(screen.queryByText('Formulation à revoir')).doesNotExist();
@@ -274,6 +286,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
         genealogy: 'Prototype 1',
         status: 'archivé',
         instruction: 'Cliquer sur instructions pour aller sur ma page principale depuis la liste des épreuves de l\'acquis',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       const skill = this.server.create('skill', { id: 'recSkill1', level: 2, name: '@trululu2', challengeIds: ['recChallenge1'], status: 'archivé' });
       const tube = this.server.create('tube', { id: 'recTube1', name: '@trululu', rawSkillIds: ['recSkill1'] });
@@ -316,6 +330,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await clickByText('Modifier');
       await clickByText('Ajouter des URLs à consulter');
       await fillByLabel('URLs externes à consulter', ' https://mon-url.com \n mon-autre-url.com');
+      await clickByText('Sans validation (Pix Junior)');
+      await clickByText('Validation par l\'embed (Pix Junior)');
       assert.dom(screen.queryByText('Accès GAFAM requis')).doesNotExist();
       assert.dom(screen.queryByText('Épreuve de sensibilisation')).doesNotExist();
       assert.dom(screen.queryByText('Formulation à revoir')).doesNotExist();
@@ -351,6 +367,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
         genealogy: 'Prototype 1',
         status: 'périmé',
         instruction: 'Cliquer sur instructions pour aller sur ma page principale depuis la liste des épreuves de l\'acquis',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
       });
       const skill = this.server.create('skill', { id: 'recSkill1', level: 2, name: '@trululu2', challengeIds: ['recChallenge1'], status: 'archivé' });
       const tube = this.server.create('tube', { id: 'recTube1', name: '@trululu', rawSkillIds: ['recSkill1'] });

--- a/pix-editor/tests/unit/models/challenge-test.js
+++ b/pix-editor/tests/unit/models/challenge-test.js
@@ -69,6 +69,8 @@ module('Unit | Model | challenge', function(hooks) {
       deafAndHardOfHearing: 'OK',
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: true,
+      noValidationNeeded: true,
     };
     alternative = {
       id: 'pix_1',
@@ -119,6 +121,8 @@ module('Unit | Model | challenge', function(hooks) {
       deafAndHardOfHearing: 'OK',
       isAwarenessChallenge: true,
       toRephrase: true,
+      hasEmbedInternalValidation: true,
+      noValidationNeeded: true,
     };
   });
 
@@ -179,6 +183,8 @@ module('Unit | Model | challenge', function(hooks) {
       assert.strictEqual(clonedChallenge.deafAndHardOfHearing, prototype.deafAndHardOfHearing, 'champ deafAndHardOfHearing');
       assert.strictEqual(clonedChallenge.isAwarenessChallenge, prototype.isAwarenessChallenge, 'champ isAwarenessChallenge');
       assert.strictEqual(clonedChallenge.toRephrase, prototype.toRephrase, 'champ toRephrase');
+      assert.strictEqual(clonedChallenge.hasEmbedInternalValidation, prototype.hasEmbedInternalValidation, 'champ hasEmbedInternalValidation');
+      assert.strictEqual(clonedChallenge.noValidationNeeded, prototype.noValidationNeeded, 'champ noValidationNeeded');
     });
 
     test('it should duplicate challenge to create new alternative version', async function(assert) {
@@ -237,6 +243,8 @@ module('Unit | Model | challenge', function(hooks) {
       assert.strictEqual(clonedChallenge.deafAndHardOfHearing, alternative.deafAndHardOfHearing, 'champ deafAndHardOfHearing');
       assert.strictEqual(clonedChallenge.isAwarenessChallenge, alternative.isAwarenessChallenge, 'champ isAwarenessChallenge');
       assert.strictEqual(clonedChallenge.toRephrase, alternative.toRephrase, 'champ toRephrase');
+      assert.strictEqual(clonedChallenge.hasEmbedInternalValidation, alternative.hasEmbedInternalValidation, 'champ hasEmbedInternalValidation');
+      assert.strictEqual(clonedChallenge.noValidationNeeded, alternative.noValidationNeeded, 'champ noValidationNeeded');
     });
 
     test('it should clone the attachments', async function(assert) {


### PR DESCRIPTION
## :pancakes: Problème

Dans Pix Junior, les données focus et timer sont détournées de leur usage pour gérer des cas spécifiques de validation des épreuves :

- les leçons contenant uniquement des vidéos ou des fiches récapitulatives sans besoin de validation
- les épreuves embeds avec validation interne comme les gdevelop ou les embeds pixwriter de mise en forme.


## :bacon: Proposition

Ajouter 2 nouvelles boites à cocher spécifiques dans le challenge.
* "Sans validation (Pix Junior)" (`noValidationNeeded`)au dessous du type d'épreuve pour spécifier qu'aucune étape de vérification n'est attendue pour ce "challenge"
* "Avec validation interne (Pix Junior)" (`hasEmbedInternalValidation`) au niveau des embeds pour indiquer que l'embed gère lui même ses règles de validation.

## 🧃 Remarques

Ces données sont modifiables sur un prototype uniquement.

## :yum: Pour tester

Ouvrir l'écran de création d'un nouveau challenge : 
-> les boites à cocher sont présentes et non cochées
Cocher les cases, et enregistrer le challenge.
-> les boites apparaissent bien comme cochées dans la vue de consultation
Ajouter une déclinaison.
-> les boites à cocher sont absente de l'édition de la déclinaison.
Générer une release.
-> Les 2 challenges (prototype et déclinaison) ont les valeurs `noValidationNeeded` et `hasEmbedInternalValidation` à true.
Modifier le prototype. Décocher l'une des cases et générer une release.
-> Les 2 challenges (prototype et déclinaison) ont la valeur correspondant à la case décochée à false.


