### PR TITLE
[TECH] Utiliser le pixId pour la route authenticated/skill (PIX-16321)

### DIFF
--- a/pix-editor/app/components/sidebar/search.js
+++ b/pix-editor/app/components/sidebar/search.js
@@ -33,7 +33,7 @@ export default class SidebarSearchComponent extends Component {
       version: skill.version,
       transition: {
         route: 'authenticated.skill',
-        model: skill.id,
+        model: skill.pixId,
       },
     }));
   }

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -58,7 +58,7 @@ Router.map(function() {
       this.route('new', { path: 'new/:area_id' });
       this.route('single', { path: '/:competence_id' });
     });
-    this.route('skill', { path: '/skill/:skill_id' });
+    this.route('skill', { path: '/skill/:skill_pix_id' });
     this.route('challenge', { path: '/challenge/:challenge_id' });
     this.route('target-profile');
     this.route('statistics');

--- a/pix-editor/app/routes/authenticated/skill.js
+++ b/pix-editor/app/routes/authenticated/skill.js
@@ -7,12 +7,12 @@ export default class SkillRoute extends Route {
   @service store;
 
   async model(params) {
-    return this.store.findRecord('skill', params.skill_id);
+    return this.store.query('skill', { filterByFormula: `FIND('${params.skill_pix_id}', {id persistant})` });
   }
 
   async afterModel(model) {
     if (model) {
-      const skill = model;
+      const skill = model[0];
       const tube = await skill.tube;
       const competence = await tube.competence;
       this.router.transitionTo('authenticated.competence.skills.single', competence.id, skill.id);

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -137,10 +137,18 @@ function routes() {
     return _serializeModel(skill, 'skill');
   });
 
-  this.get('/airtable/content/Acquis', (schema) => {
+  this.get('/airtable/content/Acquis', (schema, request) => {
+    if (request.queryParams.filterByFormula.includes('{id persistant}')) {
+      const [, pixId] = request.queryParams.filterByFormula.match(/FIND\('([^']*)'/);
+      const skill = schema.skills.findBy({ pixId });
+      const record = _serializeModel(skill, 'skill');
+      return { records: [record] };
+    }
+
     const records = schema.skills.all().models.map((skill) => {
       return _serializeModel(skill, 'skill');
     });
+
     return { records };
   });
 

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -19,8 +19,8 @@ module('Acceptance | Search', function(hooks) {
     this.server.create('localized-challenge', { id: 'challengeChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', { id: 'challengeLocalizedChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1' });
-    this.server.create('skill', { id: 'recSkill2', name: '@skill1', challengeIds: [], status: 'archivé', version: 2 });
-    const skill = this.server.create('skill', { id: 'recSkill1', name: '@skill1', challengeIds: ['recChallenge1', 'challengeChallenge1'] });
+    this.server.create('skill', { id: 'recSkill2', name: '@skill1', challengeIds: [], status: 'archivé', version: 2, pixId: 'skill2' });
+    const skill = this.server.create('skill', { id: 'recSkill1', name: '@skill1', challengeIds: ['recChallenge1', 'challengeChallenge1'], pixId: 'skill1', version: 1 });
     const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill2', 'recSkill1' ] });
     const competence = this.server.create('competence', {
       id: 'recCompetence1.1',


### PR DESCRIPTION
## :pancakes: Problème

La route `authenticated/skill` est utilisé par des applications externes qui n'ont pas connaissance du recordId (pas présent dans la release)

## :bacon: Proposition

Utiliser le `PixId` pour récupérer l'acquis de cette route.

## 🧃 Remarques

RAS

## :yum: Pour tester
Rechercher un acquis dans le champ de recherche
