### PR TITLE
[TECH] Ajout d'un log quand aucun datasource ne correspond à l'entité à sérialiser (PIX-16611)

### DIFF
--- a/api/lib/infrastructure/serializers/airtable-serializer.js
+++ b/api/lib/infrastructure/serializers/airtable-serializer.js
@@ -1,9 +1,16 @@
 import _ from 'lodash';
 import * as datasources from '../datasources/airtable/index.js';
 import airtable from 'airtable';
+import { logger } from '../logger.js';
 
 export function serialize({ airtableObject, tableName }) {
   const datasource = _.filter(datasources, (datasource) => datasource.tableName === tableName)[0];
+  if (!datasource) {
+    logger.error(
+      { event: 'lcms:airtable-serializer' },
+      `No datasource with tableName matching '${tableName}'`
+    );
+  }
   const model = datasource.path();
   const record = new airtable.Record(model, airtableObject.fields['id persistant'], airtableObject);
   const updatedRecord = datasource.fromAirTableObject(record);


### PR DESCRIPTION
## :pancakes: Problème

@BerengereC a apercu des erreurs sur `pix-lcms-production`: 
![image](https://github.com/user-attachments/assets/54eb051a-b9b6-4e89-9e02-58c371d09f5c)

Nous aimerions en savoir plus sur ce qu'il se passe.

## :bacon: Proposition

Ajout d'un `logger.error` qui décrit le datasource recherché et les datasources réellement existants, afin de mieux comprendre d'où vient l'erreur. 

## :yum: Pour tester

- Ajouter une ligne `serialize({ tableName: 'does not exist' });` dans le fichier `/api/lib/infrastructure/serializers/airtable-serializer.js`.
- À la racine du projet, lancer la commande `node ./api/lib/infrastructure/serializers/airtable-serializer.js`.
- Constater qu'un message d'erreur explicite soit bien loggé.
- (ne pas oublier de supprimer la ligne de l'étape 1 👀)
