### PR TITLE
[BUGFIX] Utilisation de `findUrlsInMarkdown()` sur champs qui ne sont pas du markdown (PIX15982)

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -14,8 +14,8 @@ function findUrlsFromChallenges(challenges, release, localizedChallengesById, Ur
     const functions = [
       (challenge) => UrlUtils.findUrlsInMarkdown(challenge.instruction),
       (challenge) => UrlUtils.findUrlsInMarkdown(challenge.proposals),
-      (challenge) => UrlUtils.findUrlsInMarkdown(challenge.solution),
-      (challenge) => UrlUtils.findUrlsInMarkdown(challenge.solutionToDisplay),
+      (challenge) => UrlUtils.findUrlsInText(challenge.solution),
+      (challenge) => UrlUtils.findUrlsInText(challenge.solutionToDisplay),
       (challenge) => localizedChallengesById[challenge.id].urlsToConsult ?? [],
     ];
     const urls = functions

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -10,11 +10,7 @@ export function findUrlsInMarkdown(value) {
   const safeValue = value || '';
   const converter = new showdown.Converter();
   const html = converter.makeHtml(safeValue);
-  const urls = html.match(urlRegex({ strict: true }));
-  if (!urls) {
-    return [];
-  }
-  return _.uniq(urls.map(cleanUrl).map(ensureProtocol));
+  return findUrlsInText(html);
 }
 
 /**
@@ -93,4 +89,12 @@ function ensureProtocol(url) {
 
 export function getOrigin(url) {
   return new URL(url).origin;
+}
+
+export function findUrlsInText(inputText) {
+  const urls = inputText.match(urlRegex({ strict: true }));
+  if (!urls) {
+    return [];
+  }
+  return _.uniq(urls.map(cleanUrl).map(ensureProtocol));
 }

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -199,6 +199,7 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       mockedUrlUtils = {
         findUrlsInMarkdown: UrlUtils.findUrlsInMarkdown,
         analyzeIdentifiedUrls: vi.fn().mockResolvedValue('yo'),
+        findUrlsInText: UrlUtils.findUrlsInText,
       };
     });
 

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -68,6 +68,29 @@ describe('Unit | Utils | URL Utils', function() {
     });
   });
 
+  describe('#findUrlsInText', () => {
+    it('should find multiple url', function() {
+      const inputString = `lien:
+- "https://pas_local.org/super_nom_wow.pdf"
+- "http://local_youyou.org/el_-_deuxième_super_truc.html"
+- "http://local_youyou.test.org/el_-_deuxième_super_truc"
+- "http://local_youyou.org/autre_dossier/el_-_deuxième_super_truc.txt"
+- "www.local_youyou.org/text.txt"
+soin:
+- 20 ans`;
+
+      const result = UrlUtils.findUrlsInText(inputString);
+
+      expect(result).toStrictEqual([
+        'https://pas_local.org/super_nom_wow.pdf',
+        'http://local_youyou.org/el_-_deuxième_super_truc.html',
+        'http://local_youyou.test.org/el_-_deuxième_super_truc',
+        'http://local_youyou.org/autre_dossier/el_-_deuxième_super_truc.txt',
+        'https://www.local_youyou.org/text.txt'
+      ]);
+    });
+
+  });
   describe('#getOrigin', () => {
     [
       { url: 'http://pix.fr', expected: 'http://pix.fr' },


### PR DESCRIPTION
## :pancakes: Problème

Lors de l’extraction des urls de notre référentiel (dans le but de vérifier s'ils sont toujours actif), nous utilisons la méthode `findUrlsInMarkdown` sur des champs qui ne sont pas du markdown ce qui provoque des erreur. 

## :bacon: Proposition

Utiliser une méthode `findUrlsInText` pour les champs qui ne sont pas écrit en markdown.

## 🧃 Remarques
RAS

## :yum: Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
