### PR TITLE
[FEATURE] Envoyer les clés `fr` dans les nouveaux projets Phrase séparés par domaine (PIX-16832)

### DIFF
--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -23,7 +23,8 @@ export async function register(server) {
         handler: async function(request, h) {
           const stream = new PassThrough();
           const baseUrl = config.lcms.baseUrl;
-          await exportTranslations(stream, request.query, { releaseRepository, localizedChallengeRepository, baseUrl });
+          const release = await releaseRepository.getLatestRelease();
+          await exportTranslations(stream, request.query, { localizedChallengeRepository, release, baseUrl });
           return h.response(stream).header('Content-type', 'text/csv');
         }
       },

--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -7,6 +7,7 @@ import { logger } from '../infrastructure/logger.js';
 import { releaseRepository, localizedChallengeRepository } from '../infrastructure/repositories/index.js';
 import * as config from '../config.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
+import Joi from 'joi';
 
 export async function register(server) {
   server.route([
@@ -14,10 +15,15 @@ export async function register(server) {
       method: 'GET',
       path: '/api/translations.csv',
       config: {
+        validate:{
+          query:  Joi.object({
+            areaCode: Joi.number()
+          })
+        },
         handler: async function(request, h) {
           const stream = new PassThrough();
           const baseUrl = config.lcms.baseUrl;
-          await exportTranslations(stream, { releaseRepository, localizedChallengeRepository, baseUrl });
+          await exportTranslations(stream, request.query, { releaseRepository, localizedChallengeRepository, baseUrl });
           return h.response(stream).header('Content-type', 'text/csv');
         }
       },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -122,6 +122,14 @@ export const exportExternalUrlsJob = {
 export const phrase = {
   apiKey: process.env.PHRASE_API_KEY,
   projectId: process.env.PHRASE_PROJECT_ID,
+  projects: [
+    { projectId: process.env.PHRASE_PROJECT_ID },
+    { areaCode: 1, projectId: process.env.PHRASE_PIX_FIRST_AREA_PROJECT_ID },
+    { areaCode: 2, projectId: process.env.PHRASE_PIX_SECOND_AREA_PROJECT_ID },
+    { areaCode: 3, projectId: process.env.PHRASE_PIX_THIRD_AREA_PROJECT_ID },
+    { areaCode: 4, projectId: process.env.PHRASE_PIX_FOURTH_AREA_PROJECT_ID },
+    { areaCode: 5, projectId: process.env.PHRASE_PIX_FIFTH_AREA_PROJECT_ID },
+  ].filter(({ projectId }) => projectId),
 };
 
 export const importTranslationsFileMaxSize = process.env.IMPORT_TRANSLATIONS_FILE_MAX_SIZE || 2097152;
@@ -169,4 +177,5 @@ if (process.env.NODE_ENV === 'test') {
 
   phrase.apiKey = 'MY_PHRASE_ACCESS_TOKEN';
   phrase.projectId = 'MY_PHRASE_PROJECT_ID';
+  phrase.projects = [{ projectId: 'MY_PHRASE_PROJECT_ID' }];
 }

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -10,11 +10,10 @@ import * as tubeTranslations from '../../infrastructure/translations/tube.js';
 import { mergeStreams } from '../../infrastructure/utils/merge-stream.js';
 import { logger } from '../../infrastructure/logger.js';
 
-export async function exportTranslations(stream, dependencies) {
+export async function exportTranslations(stream, { areaCode }, dependencies) {
   const release = await dependencies.releaseRepository.getLatestRelease();
   const rawLocalizedChallenges = await dependencies.localizedChallengeRepository.list();
   const localizedChallenges = _.groupBy(rawLocalizedChallenges, 'challengeId');
-
   const releaseContent = Object.fromEntries(
     Object.entries(release.content)
       .map(([collection, entities]) => [
@@ -47,6 +46,7 @@ export async function exportTranslations(stream, dependencies) {
   const csvLinesStream = translationsStreams
     .filter(({ translation }) => translation.locale === localeToExtract)
     .filter(keepPixFramework)
+    .filter(keepSpecifiedArea(areaCode))
     .map(translationAndTagsToCSVLine);
 
   pipeline(
@@ -58,6 +58,13 @@ export async function exportTranslations(stream, dependencies) {
       logger.error({ error }, 'Error while exporting translations from release');
     },
   );
+}
+
+function keepSpecifiedArea(areaCode) {
+  return ({ tags }) => {
+    if (!areaCode) return true;
+    return tags.includes(`Pix-${areaCode}`);
+  };
 }
 
 function createTranslationsStream(entities, extractMetadataFn, releaseContent, typeTag, extractTranslationsFn) {

--- a/api/lib/domain/usecases/export-translations.js
+++ b/api/lib/domain/usecases/export-translations.js
@@ -11,7 +11,7 @@ import { mergeStreams } from '../../infrastructure/utils/merge-stream.js';
 import { logger } from '../../infrastructure/logger.js';
 
 export async function exportTranslations(stream, { areaCode }, dependencies) {
-  const release = await dependencies.releaseRepository.getLatestRelease();
+  const release = dependencies.release;
   const rawLocalizedChallenges = await dependencies.localizedChallengeRepository.list();
   const localizedChallenges = _.groupBy(rawLocalizedChallenges, 'challengeId');
   const releaseContent = Object.fromEntries(

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -17,9 +17,11 @@ export async function uploadTranslationToPhrase(phraseApi = { Configuration, Loc
     return;
   }
 
+  const release = await releaseRepository.getLatestRelease();
+
   for (const { projectId, areaCode } of projects) {
     const stream = new PassThrough();
-    await exportTranslations(stream, { areaCode }, { releaseRepository, localizedChallengeRepository, baseUrl });
+    await exportTranslations(stream, { areaCode }, { release, localizedChallengeRepository, baseUrl });
     const csvFile = new File([await streamToPromise(stream)], 'translations.csv');
 
     const configuration = new phraseApi.Configuration({

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -9,53 +9,55 @@ import { schedule as scheduleDeleteUnmentionedKeysAfterUploadJob } from '../../i
 
 export async function uploadTranslationToPhrase(phraseApi = { Configuration, LocalesApi, UploadsApi }) {
 
-  const { apiKey, projectId } = config.phrase;
+  const { apiKey, projects } = config.phrase;
+  const baseUrl = config.lcms.baseUrl;
 
-  if (!apiKey || !projectId) {
+  if (!apiKey || !projects.length) {
     logger.info('Phrase API Key or Project Id is not defined. Skipping upload translations.');
     return;
   }
 
-  const baseUrl = config.lcms.baseUrl;
-  const stream = new PassThrough();
-  await exportTranslations(stream, { releaseRepository, localizedChallengeRepository, baseUrl });
-  const csvFile = new File([await streamToPromise(stream)], 'translations.csv');
+  for (const { projectId, areaCode } of projects) {
+    const stream = new PassThrough();
+    await exportTranslations(stream, { areaCode }, { releaseRepository, localizedChallengeRepository, baseUrl });
+    const csvFile = new File([await streamToPromise(stream)], 'translations.csv');
 
-  const configuration = new phraseApi.Configuration({
-    fetchApi: fetch,
-    apiKey: `token ${config.phrase.apiKey}`,
-  });
-
-  try {
-    const locales = await new phraseApi.LocalesApi(configuration).localesList({
-      projectId: config.phrase.projectId,
+    const configuration = new phraseApi.Configuration({
+      fetchApi: fetch,
+      apiKey: `token ${apiKey}`,
     });
 
-    const defaultLocaleId = locales.find((locale) => locale._default)?.id;
+    try {
+      const locales = await new phraseApi.LocalesApi(configuration).localesList({
+        projectId,
+      });
 
-    const upload = await new phraseApi.UploadsApi(configuration).uploadCreate({
-      projectId: config.phrase.projectId,
-      localeId: defaultLocaleId,
-      file: csvFile,
-      fileFormat: 'csv',
-      updateDescriptions: true,
-      updateTranslations: true,
-      skipUploadTags: true,
-      localeMapping: {
-        fr: 2,
-      },
-      formatOptions: {
-        key_index: 1,
-        tag_column: 3,
-        comment_index: 4,
-        header_content_row: true,
-      }
-    });
+      const defaultLocaleId = locales.find((locale) => locale._default)?.id;
 
-    await scheduleDeleteUnmentionedKeysAfterUploadJob({ uploadId: upload.id });
-  } catch (e) {
-    const text = await e.text?.() ?? e;
-    logger.error(`Phrase error while uploading translations: ${text}`);
-    throw new Error('Phrase error', { cause: e });
+      const upload = await new phraseApi.UploadsApi(configuration).uploadCreate({
+        projectId,
+        localeId: defaultLocaleId,
+        file: csvFile,
+        fileFormat: 'csv',
+        updateDescriptions: true,
+        updateTranslations: true,
+        skipUploadTags: true,
+        localeMapping: {
+          fr: 2,
+        },
+        formatOptions: {
+          key_index: 1,
+          tag_column: 3,
+          comment_index: 4,
+          header_content_row: true,
+        }
+      });
+
+      await scheduleDeleteUnmentionedKeysAfterUploadJob({ uploadId: upload.id });
+    } catch (e) {
+      const text = await e.text?.() ?? e;
+      logger.error(`Phrase error while uploading translations: ${text}`);
+      throw new Error('Phrase error', { cause: e });
+    }
   }
 }

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, beforeEach } from 'vitest';
 import FormData from 'form-data';
 import { parseString as parseCSVString } from 'fast-csv';
 import _ from 'lodash';
@@ -9,244 +9,247 @@ import { Area } from '../../../lib/domain/models/index.js';
 
 describe('Acceptance | Controller | translations-controller', () => {
 
-  describe('GET /translations.csv - export only french translations with validated challenges of core framework in CSV file', () => {
+  describe('GET /translations.csv', () => {
+    let releaseContent;
+    let user;
 
-    it('should return a csv file', async () => {
-      // Given
-      const user = databaseBuilder.factory.buildAdminUser();
-      const releaseContent = {
-        frameworks: [{
-          id: 'recFramework0',
-          name: 'Pix'
-        }, {
-          id: 'recFramework1',
-          name: 'Pix+'
-        }],
-        areas: [{
-          id: 'recArea0',
-          name: '1. Titre du Domaine - fr',
-          code: '1',
-          title_i18n: {
-            fr: 'Titre du Domaine - fr',
-            en: 'Titre du Domaine - en',
-          },
-          competenceIds: ['recCompetence0'],
-          color: Area.COLORS.JAFFA,
-          frameworkId: 'recFramework0',
+    beforeEach(() => {
+      user = databaseBuilder.factory.buildAdminUser();
+
+      const frameworks = [{
+        id: 'recFramework0',
+        name: 'Pix'
+      }, {
+        id: 'recFramework1',
+        name: 'Pix+'
+      }];
+
+      const areas = [{
+        id: 'recArea0',
+        name: '1. Titre du Domaine - fr',
+        code: '1',
+        title_i18n: {
+          fr: 'Titre du Domaine - fr',
+          en: 'Titre du Domaine - en',
         },
-        {
-          id: 'recArea1',
-          name: '1. Titre du Domaine Pix+ - fr',
-          code: '1',
-          title_i18n: {
-            fr: 'Titre du Domaine Pix+ - fr',
-            en: 'Titre du Domaine Pix+ - en',
-          },
-          competenceIds: ['recCompetence1'],
-          color: Area.COLORS.JAFFA,
-          frameworkId: 'recFramework1',
-        }],
-        competences: [{
-          id: 'recCompetence0',
-          index: '1.1',
-          name_i18n: {
-            fr: 'Nom de la Compétence - fr',
-            en: 'Nom de la Compétence - en',
-          },
-          areaId: 'recArea0',
-          origin: 'Pix',
-          skillIds: ['recSkill0'],
-          thematicIds: ['recThematic0'],
-          description_i18n: {
-            fr: 'Description de la compétence - fr',
-            en: 'Description de la compétence - en',
-          }
+        competenceIds: ['recCompetence0'],
+        color: Area.COLORS.JAFFA,
+        frameworkId: 'recFramework0',
+      },
+      {
+        id: 'recArea1',
+        name: '1. Titre du Domaine Pix+ - fr',
+        code: '1',
+        title_i18n: {
+          fr: 'Titre du Domaine Pix+ - fr',
+          en: 'Titre du Domaine Pix+ - en',
         },
-        {
-          id: 'recCompetence1',
-          index: '1.1',
-          name_i18n: {
-            fr: 'Nom de la Compétence - fr',
-            en: 'Nom de la Compétence - en',
-          },
-          areaId: 'recArea1',
-          origin: 'Pix+',
-          skillIds: [],
-          thematicIds: [],
-          description_i18n: {
-            fr: 'Description de la compétence - fr',
-            en: 'Description de la compétence - en',
-          }
-        }],
-        thematics: [{
-          id: 'recThematic0',
-          name_i18n: {
-            fr: 'Nom',
-            en: 'name',
-          },
-          competenceId: 'recCompetence0',
-          tubeIds: ['recTube0'],
-          index: 0
-        }],
-        tubes: [{
-          id: 'recTube0',
-          name: '@acquis',
-          practicalTitle_i18n: {
-            fr: 'Titre pratique du Tube - fr',
-            en: 'Titre pratique du Tube - en',
-          },
-          practicalDescription_i18n: {
-            fr: 'Description pratique du Tube - fr',
-            en: 'Description pratique du Tube - en',
-          },
-          competenceId: 'recCompetence0',
-          thematicId: 'recThematic0',
-          skillIds: ['recSkill0'],
-          isMobileCompliant: true,
-          isTabletCompliant: false,
-        },{
-          id: 'recTube1',
-          name: '@tube',
-          practicalTitle_i18n: {
-            fr: 'Titre pratique du Tube 1 - fr',
-            en: 'Titre pratique du Tube 1 - en',
-          },
-          practicalDescription_i18n: {
-            fr: 'Description pratique du Tube 1 - fr',
-            en: 'Description pratique du Tube 1 - en',
-          },
-          competenceId: 'recCompetence0',
-          thematicId: 'recThematic0',
-          skillIds: ['recSkill1'],
-          isMobileCompliant: true,
-          isTabletCompliant: false,
-        }],
-        skills: [{
-          id: 'recSkill0',
-          name: '@acquis1',
-          hint_i18n: {
-            fr: 'Indice - fr',
-            en: 'Indice - en',
-          },
-          hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
-          tutorialIds: ['recTutorial0'],
-          learningMoreTutorialIds: ['recTutorial1'],
-          pixValue: 8,
-          competenceId: 'recCompetence0',
-          status: SkillForRelease.STATUSES.ACTIF,
-          tubeId: 'recTube0',
-          version: 1,
-          level: 1,
-        }, {
-          id: 'recSkill1',
-          name: '@tube1',
-          hint_i18n: {
-            fr: 'Indice 1 - fr',
-            en: 'Indice 1 - en',
-          },
-          hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
-          tutorialIds: [],
-          learningMoreTutorialIds: [],
-          pixValue: 8,
-          competenceId: 'recCompetence0',
-          status: SkillForRelease.STATUSES.ARCHIVE,
-          tubeId: 'recTube1',
-          version: 1,
-          level: 1,
-        }],
-        challenges: [{
-          id: 'recChallenge0',
-          instruction: 'Consigne du Challenge',
-          proposals: 'Propositions du Challenge',
-          type: ChallengeForRelease.TYPES.QCM,
-          solution: 'Bonnes réponses du Challenge',
-          solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
-          t1Status: false,
-          t2Status: true,
-          t3Status: false,
-          status: ChallengeForRelease.STATUSES.VALIDE,
-          skillId: 'recSkill0',
-          embedUrl: 'Embed URL',
-          embedTitle: 'Embed title',
-          embedHeight: 'Embed height',
-          timer: 12,
-          illustrationUrl: 'url de l‘illustration',
-          attachments: ['url de la pièce jointe'],
-          competenceId: 'recCompetence0',
-          illustrationAlt: 'Texte alternatif illustration',
-          format: ChallengeForRelease.FORMATS.MOTS,
-          autoReply: false,
-          locales: ['fr'],
-          alternativeInstruction: 'Consigne alternative',
-          focusable: false,
-          delta: 0.5,
-          alpha: 0.9,
-          responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
-          genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+        competenceIds: ['recCompetence1'],
+        color: Area.COLORS.JAFFA,
+        frameworkId: 'recFramework1',
+      }];
+
+      const competences = [{
+        id: 'recCompetence0',
+        index: '1.1',
+        name_i18n: {
+          fr: 'Nom de la Compétence - fr',
+          en: 'Nom de la Compétence - en',
         },
-        {
-          id: 'recChallenge1',
-          instruction: 'Consigne du Challenge',
-          proposals: 'Propositions du Challenge',
-          type: ChallengeForRelease.TYPES.QCM,
-          solution: 'Bonnes réponses du Challenge',
-          solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
-          t1Status: false,
-          t2Status: true,
-          t3Status: false,
-          status: ChallengeForRelease.STATUSES.VALIDE,
-          skillId: 'recSkill0',
-          embedUrl: 'Embed URL',
-          embedTitle: 'Embed title',
-          embedHeight: 'Embed height',
-          timer: 12,
-          illustrationUrl: 'url de l‘illustration',
-          attachments: ['url de la pièce jointe'],
-          competenceId: 'recCompetence0',
-          illustrationAlt: 'Texte alternatif illustration',
-          format: ChallengeForRelease.FORMATS.MOTS,
-          autoReply: false,
-          locales: ['en'],
-          alternativeInstruction: 'Consigne alternative',
-          focusable: false,
-          delta: 0.5,
-          alpha: 0.9,
-          responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
-          genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
-        },{
-          id: 'recChallenge2',
-          instruction: 'Consigne du Challenge',
-          proposals: 'Propositions du Challenge',
-          type: ChallengeForRelease.TYPES.QCM,
-          solution: 'Bonnes réponses du Challenge',
-          solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
-          t1Status: false,
-          t2Status: true,
-          t3Status: false,
-          status: ChallengeForRelease.STATUSES.PROPOSE,
-          skillId: 'recSkill0',
-          embedUrl: 'Embed URL',
-          embedTitle: 'Embed title',
-          embedHeight: 'Embed height',
-          timer: 12,
-          illustrationUrl: 'url de l‘illustration',
-          attachments: ['url de la pièce jointe'],
-          competenceId: 'recCompetence0',
-          illustrationAlt: 'Texte alternatif illustration',
-          format: ChallengeForRelease.FORMATS.MOTS,
-          autoReply: false,
-          locales: ['fr'],
-          alternativeInstruction: 'Consigne alternative',
-          focusable: false,
-          delta: 0.5,
-          alpha: 0.9,
-          responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
-          genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
-        }],
-      };
-      databaseBuilder.factory.buildRelease({
-        content: releaseContent
-      });
+        areaId: 'recArea0',
+        origin: 'Pix',
+        skillIds: ['recSkill0'],
+        thematicIds: ['recThematic0'],
+        description_i18n: {
+          fr: 'Description de la compétence - fr',
+          en: 'Description de la compétence - en',
+        }
+      },
+      {
+        id: 'recCompetence1',
+        index: '1.1',
+        name_i18n: {
+          fr: 'Nom de la Compétence - fr',
+          en: 'Nom de la Compétence - en',
+        },
+        areaId: 'recArea1',
+        origin: 'Pix+',
+        skillIds: [],
+        thematicIds: [],
+        description_i18n: {
+          fr: 'Description de la compétence - fr',
+          en: 'Description de la compétence - en',
+        }
+      }];
+
+      const thematics = [{
+        id: 'recThematic0',
+        name_i18n: {
+          fr: 'Nom',
+          en: 'name',
+        },
+        competenceId: 'recCompetence0',
+        tubeIds: ['recTube0'],
+        index: 0
+      }];
+
+      const tubes = [{
+        id: 'recTube0',
+        name: '@acquis',
+        practicalTitle_i18n: {
+          fr: 'Titre pratique du Tube - fr',
+          en: 'Titre pratique du Tube - en',
+        },
+        practicalDescription_i18n: {
+          fr: 'Description pratique du Tube - fr',
+          en: 'Description pratique du Tube - en',
+        },
+        competenceId: 'recCompetence0',
+        thematicId: 'recThematic0',
+        skillIds: ['recSkill0'],
+        isMobileCompliant: true,
+        isTabletCompliant: false,
+      }, {
+        id: 'recTube1',
+        name: '@tube',
+        practicalTitle_i18n: {
+          fr: 'Titre pratique du Tube 1 - fr',
+          en: 'Titre pratique du Tube 1 - en',
+        },
+        practicalDescription_i18n: {
+          fr: 'Description pratique du Tube 1 - fr',
+          en: 'Description pratique du Tube 1 - en',
+        },
+        competenceId: 'recCompetence0',
+        thematicId: 'recThematic0',
+        skillIds: ['recSkill1'],
+        isMobileCompliant: true,
+        isTabletCompliant: false,
+      }];
+
+      const skills = [{
+        id: 'recSkill0',
+        name: '@acquis1',
+        hint_i18n: {
+          fr: 'Indice - fr',
+          en: 'Indice - en',
+        },
+        hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
+        tutorialIds: ['recTutorial0'],
+        learningMoreTutorialIds: ['recTutorial1'],
+        pixValue: 8,
+        competenceId: 'recCompetence0',
+        status: SkillForRelease.STATUSES.ACTIF,
+        tubeId: 'recTube0',
+        version: 1,
+        level: 1,
+      }, {
+        id: 'recSkill1',
+        name: '@tube1',
+        hint_i18n: {
+          fr: 'Indice 1 - fr',
+          en: 'Indice 1 - en',
+        },
+        hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
+        tutorialIds: [],
+        learningMoreTutorialIds: [],
+        pixValue: 8,
+        competenceId: 'recCompetence0',
+        status: SkillForRelease.STATUSES.ARCHIVE,
+        tubeId: 'recTube1',
+        version: 1,
+        level: 1,
+      }];
+
+      const challenges = [{
+        id: 'recChallenge0',
+        instruction: 'Consigne du Challenge',
+        proposals: 'Propositions du Challenge',
+        type: ChallengeForRelease.TYPES.QCM,
+        solution: 'Bonnes réponses du Challenge',
+        solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+        t1Status: false,
+        t2Status: true,
+        t3Status: false,
+        status: ChallengeForRelease.STATUSES.VALIDE,
+        skillId: 'recSkill0',
+        embedUrl: 'Embed URL',
+        embedTitle: 'Embed title',
+        embedHeight: 'Embed height',
+        timer: 12,
+        illustrationUrl: 'url de l‘illustration',
+        attachments: ['url de la pièce jointe'],
+        competenceId: 'recCompetence0',
+        illustrationAlt: 'Texte alternatif illustration',
+        format: ChallengeForRelease.FORMATS.MOTS,
+        autoReply: false,
+        locales: ['fr'],
+        alternativeInstruction: 'Consigne alternative',
+        focusable: false,
+        delta: 0.5,
+        alpha: 0.9,
+        responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
+        genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      },
+      {
+        id: 'recChallenge1',
+        instruction: 'Consigne du Challenge',
+        proposals: 'Propositions du Challenge',
+        type: ChallengeForRelease.TYPES.QCM,
+        solution: 'Bonnes réponses du Challenge',
+        solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+        t1Status: false,
+        t2Status: true,
+        t3Status: false,
+        status: ChallengeForRelease.STATUSES.VALIDE,
+        skillId: 'recSkill0',
+        embedUrl: 'Embed URL',
+        embedTitle: 'Embed title',
+        embedHeight: 'Embed height',
+        timer: 12,
+        illustrationUrl: 'url de l‘illustration',
+        attachments: ['url de la pièce jointe'],
+        competenceId: 'recCompetence0',
+        illustrationAlt: 'Texte alternatif illustration',
+        format: ChallengeForRelease.FORMATS.MOTS,
+        autoReply: false,
+        locales: ['en'],
+        alternativeInstruction: 'Consigne alternative',
+        focusable: false,
+        delta: 0.5,
+        alpha: 0.9,
+        responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
+        genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      },{
+        id: 'recChallenge2',
+        instruction: 'Consigne du Challenge',
+        proposals: 'Propositions du Challenge',
+        type: ChallengeForRelease.TYPES.QCM,
+        solution: 'Bonnes réponses du Challenge',
+        solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+        t1Status: false,
+        t2Status: true,
+        t3Status: false,
+        status: ChallengeForRelease.STATUSES.PROPOSE,
+        skillId: 'recSkill0',
+        embedUrl: 'Embed URL',
+        embedTitle: 'Embed title',
+        embedHeight: 'Embed height',
+        timer: 12,
+        illustrationUrl: 'url de l‘illustration',
+        attachments: ['url de la pièce jointe'],
+        competenceId: 'recCompetence0',
+        illustrationAlt: 'Texte alternatif illustration',
+        format: ChallengeForRelease.FORMATS.MOTS,
+        autoReply: false,
+        locales: ['fr'],
+        alternativeInstruction: 'Consigne alternative',
+        focusable: false,
+        delta: 0.5,
+        alpha: 0.9,
+        responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
+        genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      }];
 
       databaseBuilder.factory.buildLocalizedChallenge({
         challengeId: 'recChallenge0',
@@ -267,6 +270,15 @@ describe('Acceptance | Controller | translations-controller', () => {
         challengeId: 'recChallenge2',
         id: 'recChallenge2',
         locale: 'fr',
+      });
+
+      releaseContent = { frameworks, areas, competences, thematics,tubes, skills, challenges };
+    });
+
+    it('should return a csv file - export only french translations with validated challenges of core framework in CSV file', async () => {
+      // Given
+      databaseBuilder.factory.buildRelease({
+        content: releaseContent
       });
 
       await databaseBuilder.commit();
@@ -376,127 +388,340 @@ describe('Acceptance | Controller | translations-controller', () => {
       ]);
     });
 
-    it('should still export csv file even when a challenge has no skill', async () => {
+    it('should return a csv for single area', async () => {
       // Given
-      const user = databaseBuilder.factory.buildAdminUser();
-      const releaseContent = {
-        frameworks: [{
-          id: 'recFramework0',
-          name: 'Pix'
-        }],
-        areas: [{
-          id: 'recArea0',
-          name: '1. Titre du Domaine - fr',
-          code: '1',
-          title_i18n: {
-            fr: 'Titre du Domaine - fr',
-            en: 'Titre du Domaine - en',
-          },
-          competenceIds: ['recCompetence0'],
-          color: Area.COLORS.JAFFA,
-          frameworkId: 'recFramework0',
-        }],
-        competences: [{
-          id: 'recCompetence0',
-          index: '1.1',
-          name_i18n: {
-            fr: 'Nom de la Compétence - fr',
-            en: 'Nom de la Compétence - en',
-          },
-          areaId: 'recArea0',
-          origin: 'Pix',
-          skillIds: ['recSkill0'],
-          thematicIds: ['recThematic0'],
-          description_i18n: {
-            fr: 'Description de la compétence - fr',
-            en: 'Description de la compétence - en',
-          }
-        }],
-        thematics: [{
-          id: 'recThematic0',
-          name_i18n: {
-            fr: 'Nom',
-            en: 'name',
-          },
-          competenceId: 'recCompetence0',
-          tubeIds: ['recTube0'],
-          index: 0
-        }],
-        tubes: [{
-          id: 'recTube0',
-          name: '@acquis',
-          title: 'Titre du Tube',
-          description: 'Description du Tube',
-          practicalTitle_i18n: {
-            fr: 'Titre pratique du Tube - fr',
-            en: 'Titre pratique du Tube - en',
-          },
-          practicalDescription_i18n: {
-            fr: 'Description pratique du Tube - fr',
-            en: 'Description pratique du Tube - en',
-          },
-          competenceId: 'recCompetence0',
-          thematicId: 'recThematic0',
-          skillIds: ['recSkill0'],
-          isMobileCompliant: true,
-          isTabletCompliant: false,
-        }],
-        skills: [{
-          id: 'recSkill0',
-          name: '@acquis1',
-          hint_i18n: {
-            fr: 'Indice - fr',
-            en: 'Indice - en',
-          },
-          hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
-          tutorialIds: ['recTutorial0'],
-          learningMoreTutorialIds: ['recTutorial1'],
-          pixValue: 8,
-          competenceId: 'recCompetence0',
-          status: SkillForRelease.STATUSES.ACTIF,
-          tubeId: 'recTube0',
-          version: 1,
-          level: 1,
-        }],
-        challenges: [{
-          id: 'recChallenge0',
-          instruction: 'Consigne du Challenge',
-          proposals: 'Propositions du Challenge',
-          type: ChallengeForRelease.TYPES.QCM,
-          solution: 'Bonnes réponses du Challenge',
-          solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
-          t1Status: false,
-          t2Status: true,
-          t3Status: false,
-          status: ChallengeForRelease.STATUSES.VALIDE,
-          skillId: 'inconnu',
-          embedUrl: 'Embed URL',
-          embedTitle: 'Embed title',
-          embedHeight: 'Embed height',
-          timer: 12,
-          illustrationUrl: 'url de l‘illustration',
-          attachments: ['url de la pièce jointe'],
-          competenceId: 'recCompetence0',
-          illustrationAlt: 'Texte alternatif illustration',
-          format: ChallengeForRelease.FORMATS.MOTS,
-          autoReply: false,
-          locales: ['fr'],
-          alternativeInstruction: 'Consigne alternative',
-          focusable: false,
-          delta: 0.5,
-          alpha: 0.9,
-          responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
-          genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
-        }],
-      };
+      releaseContent.areas.push({
+        id: 'recArea2',
+        name: '2. Titre du Domaine - fr',
+        code: '2',
+        title_i18n: {
+          fr: 'Titre du Domaine - fr',
+          en: 'Titre du Domaine - en',
+        },
+        competenceIds: ['recCompetence2'],
+        color: Area.COLORS.JAFFA,
+        frameworkId: 'recFramework0',
+      });
+
+      releaseContent.competences.push({
+        id: 'recCompetence2',
+        index: '2.1',
+        name_i18n: {
+          fr: 'Nom de la Compétence - fr',
+          en: 'Nom de la Compétence - en',
+        },
+        areaId: 'recArea2',
+        origin: 'Pix',
+        skillIds: ['recSkill2'],
+        thematicIds: ['recThematic1'],
+        description_i18n: {
+          fr: 'Description de la compétence - fr',
+          en: 'Description de la compétence - en',
+        }
+      });
+
+      releaseContent.thematics.push({
+        id: 'recThematic1',
+        name_i18n: {
+          fr: 'Nom',
+          en: 'name',
+        },
+        competenceId: 'recCompetence2',
+        tubeIds: ['recTube2'],
+        index: 1,
+      });
+
+      releaseContent.tubes.push({
+        id: 'recTube2',
+        name: '@tube',
+        practicalTitle_i18n: {
+          fr: 'Titre pratique du Tube 1 - fr',
+          en: 'Titre pratique du Tube 1 - en',
+        },
+        practicalDescription_i18n: {
+          fr: 'Description pratique du Tube 1 - fr',
+          en: 'Description pratique du Tube 1 - en',
+        },
+        competenceId: 'recCompetence2',
+        thematicId: 'recThematic1',
+        skillIds: ['recSkill2'],
+        isMobileCompliant: true,
+        isTabletCompliant: false,
+      });
+
+      releaseContent.skills.push({
+        id: 'recSkill2',
+        name: '@acquis1',
+        hint_i18n: {
+          fr: 'Indice - fr',
+          en: 'Indice - en',
+        },
+        hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
+        tutorialIds: ['recTutorial0'],
+        learningMoreTutorialIds: ['recTutorial1'],
+        pixValue: 8,
+        competenceId: 'recCompetence2',
+        status: SkillForRelease.STATUSES.ACTIF,
+        tubeId: 'recTube2',
+        version: 1,
+        level: 1,
+      });
+
+      releaseContent.challenges.push({
+        id: 'recChallenge3',
+        instruction: 'Consigne du Challenge',
+        proposals: 'Propositions du Challenge',
+        type: ChallengeForRelease.TYPES.QCM,
+        solution: 'Bonnes réponses du Challenge',
+        solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+        t1Status: false,
+        t2Status: true,
+        t3Status: false,
+        status: ChallengeForRelease.STATUSES.VALIDE,
+        skillId: 'recSkill2',
+        embedUrl: 'Embed URL',
+        embedTitle: 'Embed title',
+        embedHeight: 'Embed height',
+        timer: 12,
+        illustrationUrl: 'url de l‘illustration',
+        attachments: ['url de la pièce jointe'],
+        competenceId: 'recCompetence2',
+        illustrationAlt: 'Texte alternatif illustration',
+        format: ChallengeForRelease.FORMATS.MOTS,
+        autoReply: false,
+        locales: ['fr'],
+        alternativeInstruction: 'Consigne alternative',
+        focusable: false,
+        delta: 0.5,
+        alpha: 0.9,
+        responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
+        genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      });
+
+      databaseBuilder.factory.buildLocalizedChallenge({
+        challengeId: 'recChallenge3',
+        id: 'recChallenge3',
+        locale: 'fr',
+      });
+
       databaseBuilder.factory.buildRelease({
         content: releaseContent
       });
 
-      databaseBuilder.factory.buildLocalizedChallenge({
-        challengeId: 'recChallenge0',
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+      const getTranslationsOptions = {
+        method: 'GET',
+        url: '/api/translations.csv?areaCode=1',
+        headers: generateAuthorizationHeader(user),
+      };
+
+      // When
+      const response = await server.inject(getTranslationsOptions);
+
+      // Then
+      expect(response.statusCode).to.equal(200);
+      expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
+
+      const [headers, ...data] = await streamToPromiseArray(parseCSVString(response.payload));
+
+      expect(headers).to.deep.equal(['key', 'fr', 'tags', 'description']);
+      expect(_.orderBy(data, '0')).to.deep.equal([
+        [
+          'area.recArea0.title',
+          'Titre du Domaine - fr',
+          'domaine,Pix-1,Pix',
+          ''
+        ],
+        [
+          'challenge.recChallenge0.alternativeInstruction',
+          'Consigne alternative',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'challenge.recChallenge0.embedTitle',
+          'Embed title',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'challenge.recChallenge0.illustrationAlt',
+          'Texte alternatif illustration',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'challenge.recChallenge0.instruction',
+          'Consigne du Challenge',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'challenge.recChallenge0.proposals',
+          'Propositions du Challenge',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'challenge.recChallenge0.solution',
+          'Bonnes réponses du Challenge',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'challenge.recChallenge0.solutionToDisplay',
+          'Bonnes réponses du Challenge à afficher',
+          'epreuve,Pix-1-1.1-acquis-acquis1-valide,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          'Prévisualisation FR: http://test.site/api/challenges/recChallenge0/preview\nPrévisualisation NL: http://test.site/api/challenges/recChallenge0/preview?locale=nl\nPix Editor: http://test.site/challenge/recChallenge0'
+        ],
+        [
+          'competence.recCompetence0.description',
+          'Description de la compétence - fr',
+          'competence,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+        [
+          'competence.recCompetence0.name',
+          'Nom de la Compétence - fr',
+          'competence,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+        [
+          'skill.recSkill0.hint',
+          'Indice - fr',
+          'acquis,Pix-1-1.1-acquis-acquis1,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+        [
+          'thematic.recThematic0.name',
+          'Nom',
+          'thematique,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+        [
+          'tube.recTube0.practicalDescription',
+          'Description pratique du Tube - fr',
+          'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+        [
+          'tube.recTube0.practicalTitle',
+          'Titre pratique du Tube - fr',
+          'sujet,Pix-1-1.1-acquis,Pix-1-1.1,Pix-1,Pix',
+          ''
+        ],
+      ]);
+    });
+
+    it('should still export csv file even when a challenge has no skill', async () => {
+      // Given
+
+      releaseContent.frameworks = [{
+        id: 'recFramework0',
+        name: 'Pix'
+      }];
+      releaseContent.areas = [{
+        id: 'recArea0',
+        name: '1. Titre du Domaine - fr',
+        code: '1',
+        title_i18n: {
+          fr: 'Titre du Domaine - fr',
+          en: 'Titre du Domaine - en',
+        },
+        competenceIds: ['recCompetence0'],
+        color: Area.COLORS.JAFFA,
+        frameworkId: 'recFramework0',
+      }];
+
+      releaseContent.competences = [{
+        id: 'recCompetence0',
+        index: '1.1',
+        name_i18n: {
+          fr: 'Nom de la Compétence - fr',
+          en: 'Nom de la Compétence - en',
+        },
+        areaId: 'recArea0',
+        origin: 'Pix',
+        skillIds: ['recSkill0'],
+        thematicIds: ['recThematic0'],
+        description_i18n: {
+          fr: 'Description de la compétence - fr',
+          en: 'Description de la compétence - en',
+        }
+      }];
+      releaseContent.tubes = [{
+        id: 'recTube0',
+        name: '@acquis',
+        title: 'Titre du Tube',
+        description: 'Description du Tube',
+        practicalTitle_i18n: {
+          fr: 'Titre pratique du Tube - fr',
+          en: 'Titre pratique du Tube - en',
+        },
+        practicalDescription_i18n: {
+          fr: 'Description pratique du Tube - fr',
+          en: 'Description pratique du Tube - en',
+        },
+        competenceId: 'recCompetence0',
+        thematicId: 'recThematic0',
+        skillIds: ['recSkill0'],
+        isMobileCompliant: true,
+        isTabletCompliant: false,
+      }];
+
+      releaseContent.skills = [{
+        id: 'recSkill0',
+        name: '@acquis1',
+        hint_i18n: {
+          fr: 'Indice - fr',
+          en: 'Indice - en',
+        },
+        hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
+        tutorialIds: ['recTutorial0'],
+        learningMoreTutorialIds: ['recTutorial1'],
+        pixValue: 8,
+        competenceId: 'recCompetence0',
+        status: SkillForRelease.STATUSES.ACTIF,
+        tubeId: 'recTube0',
+        version: 1,
+        level: 1,
+      }];
+
+      releaseContent.challenges =  [{
         id: 'recChallenge0',
-        locale: 'fr',
+        instruction: 'Consigne du Challenge',
+        proposals: 'Propositions du Challenge',
+        type: ChallengeForRelease.TYPES.QCM,
+        solution: 'Bonnes réponses du Challenge',
+        solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+        t1Status: false,
+        t2Status: true,
+        t3Status: false,
+        status: ChallengeForRelease.STATUSES.VALIDE,
+        skillId: 'inconnu',
+        embedUrl: 'Embed URL',
+        embedTitle: 'Embed title',
+        embedHeight: 'Embed height',
+        timer: 12,
+        illustrationUrl: 'url de l‘illustration',
+        attachments: ['url de la pièce jointe'],
+        competenceId: 'recCompetence0',
+        illustrationAlt: 'Texte alternatif illustration',
+        format: ChallengeForRelease.FORMATS.MOTS,
+        autoReply: false,
+        locales: ['fr'],
+        alternativeInstruction: 'Consigne alternative',
+        focusable: false,
+        delta: 0.5,
+        alpha: 0.9,
+        responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
+        genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+      }];
+
+      databaseBuilder.factory.buildRelease({
+        content: releaseContent
       });
 
       await databaseBuilder.commit();
@@ -531,56 +756,55 @@ describe('Acceptance | Controller | translations-controller', () => {
     describe('when an error occurs during streaming', () => {
       it('should manage unexpected errors', async () => {
         // Given
-        const user = databaseBuilder.factory.buildAdminUser();
-        const releaseContent = {
-          skills: [{
-            id: 'recSkill0',
-            name: '@acquis1',
-            hint_i18n: {
-              fr: 'Indice - fr',
-              en: 'Indice - en',
-            },
-            hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
-            tutorialIds: ['recTutorial0'],
-            learningMoreTutorialIds: ['recTutorial1'],
-            pixValue: 8,
-            competenceId: 'recCompetence0',
-            status: SkillForRelease.STATUSES.ACTIF,
-            tubeId: 'recTube0',
-            version: 1,
-            level: 1,
-          }],
-          challenges: [{
-            id: 'recChallenge0',
-            instruction: 'Consigne du Challenge',
-            proposals: 'Propositions du Challenge',
-            type: ChallengeForRelease.TYPES.QCM,
-            solution: 'Bonnes réponses du Challenge',
-            solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
-            t1Status: false,
-            t2Status: true,
-            t3Status: false,
-            status: ChallengeForRelease.STATUSES.VALIDE,
-            skillId: 'recSkill0',
-            embedUrl: 'Embed URL',
-            embedTitle: 'Embed title',
-            embedHeight: 'Embed height',
-            timer: 12,
-            illustrationUrl: 'url de l‘illustration',
-            attachments: ['url de la pièce jointe'],
-            competenceId: 'recCompetence0',
-            illustrationAlt: 'Texte alternatif illustration',
-            format: ChallengeForRelease.FORMATS.MOTS,
-            autoReply: false,
-            locales: ['fr'],
-            alternativeInstruction: 'Consigne alternative',
-            focusable: false,
-            delta: 0.5,
-            alpha: 0.9,
-            responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
-            genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
-          }],
-        };
+        releaseContent = {};
+        releaseContent.skills  = [{
+          id: 'recSkill0',
+          name: '@acquis1',
+          hint_i18n: {
+            fr: 'Indice - fr',
+            en: 'Indice - en',
+          },
+          hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
+          tutorialIds: ['recTutorial0'],
+          learningMoreTutorialIds: ['recTutorial1'],
+          pixValue: 8,
+          competenceId: 'recCompetence0',
+          status: SkillForRelease.STATUSES.ACTIF,
+          tubeId: 'recTube0',
+          version: 1,
+          level: 1,
+        }];
+        releaseContent.challenges = [{
+          id: 'recChallenge0',
+          instruction: 'Consigne du Challenge',
+          proposals: 'Propositions du Challenge',
+          type: ChallengeForRelease.TYPES.QCM,
+          solution: 'Bonnes réponses du Challenge',
+          solutionToDisplay: 'Bonnes réponses du Challenge à afficher',
+          t1Status: false,
+          t2Status: true,
+          t3Status: false,
+          status: ChallengeForRelease.STATUSES.VALIDE,
+          skillId: 'recSkill0',
+          embedUrl: 'Embed URL',
+          embedTitle: 'Embed title',
+          embedHeight: 'Embed height',
+          timer: 12,
+          illustrationUrl: 'url de l‘illustration',
+          attachments: ['url de la pièce jointe'],
+          competenceId: 'recCompetence0',
+          illustrationAlt: 'Texte alternatif illustration',
+          format: ChallengeForRelease.FORMATS.MOTS,
+          autoReply: false,
+          locales: ['fr'],
+          alternativeInstruction: 'Consigne alternative',
+          focusable: false,
+          delta: 0.5,
+          alpha: 0.9,
+          responsive: ChallengeForRelease.RESPONSIVES.SMARTPHONE,
+          genealogy: ChallengeForRelease.GENEALOGIES.PROTOTYPE,
+        }];
+
         databaseBuilder.factory.buildRelease({
           content: releaseContent
         });
@@ -602,7 +826,6 @@ describe('Acceptance | Controller | translations-controller', () => {
       });
     });
   });
-
   describe('PATCH /translations.csv - import translations from a CSV file', () => {
 
     afterEach(async () => {

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { uploadTranslationToPhrase } from '../../../../lib/domain/usecases/index.js';
+import { localizedChallengeRepository, releaseRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import * as exportTranslationsUseCase from '../../../../lib/domain/usecases/export-translations.js';
 import * as deleteUnmentionedKeysAfterUploadJob from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 import * as config from '../../../../lib/config.js';
@@ -7,6 +8,7 @@ import * as config from '../../../../lib/config.js';
 describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
   it('should upload to Phrase', async () => {
     // given
+    const release = Symbol('release');
     const ConfigurationStub = class {};
     const localesListStub = vi.fn().mockResolvedValue([
       { id: 'frLocaleId', code: 'fr', name: 'fr', _default: true },
@@ -18,14 +20,28 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     const UploadsApiStub = class {
       uploadCreate() { return uploadCreateStub(); }
     };
-    vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+    const exportTranslationsStub = vi.spyOn(exportTranslationsUseCase, 'exportTranslations')
+      .mockImplementation((stream) => stream.end());
     vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
+
+    const releaseStub = vi.spyOn(releaseRepository, 'getLatestRelease').mockResolvedValue(release);
 
     // when
     await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
 
     // then
-    expect(uploadCreateStub).toHaveBeenCalled();
+    expect(releaseStub).toHaveBeenCalledTimes(1);
+    expect(exportTranslationsStub).toHaveBeenCalledTimes(1);
+    expect(exportTranslationsStub).toHaveBeenCalledWith(
+      expect.anything(),
+      { areaCode: undefined },
+      {
+        baseUrl: 'http://test.site',
+        localizedChallengeRepository,
+        release
+      }
+    );
+    expect(uploadCreateStub).toHaveBeenCalledTimes(1);
   });
 
   it('should schedule deletion of unmentioned keys', async () => {
@@ -53,6 +69,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
 
   it('should multi upload to Phrase when the are several projectIds', async () => {
     // given
+    const release = Symbol('release');
     const ConfigurationStub = class {};
     vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([
       { projectId: 'mon-projet-1' },
@@ -77,8 +94,10 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
       uploadCreate(...args) { return uploadCreateStub(...args); }
     };
 
-    vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+    const exportTranslationsStub = vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
     vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
+
+    const releaseStub = vi.spyOn(releaseRepository, 'getLatestRelease').mockResolvedValue(release);
 
     // when
     await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
@@ -100,6 +119,26 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
         header_content_row: true,
       }
     };
+    expect(releaseStub).toHaveBeenCalledTimes(1);
+    expect(exportTranslationsStub).toHaveBeenCalledTimes(2);
+    expect(exportTranslationsStub).toHaveBeenCalledWith(
+      expect.anything(),
+      { areaCode: undefined },
+      {
+        baseUrl: 'http://test.site',
+        localizedChallengeRepository,
+        release
+      }
+    );
+    expect(exportTranslationsStub).toHaveBeenCalledWith(
+      expect.anything(),
+      { areaCode: '4' },
+      {
+        baseUrl: 'http://test.site',
+        localizedChallengeRepository,
+        release
+      }
+    );
     expect(uploadCreateStub).toHaveBeenCalledTimes(2);
     expect(uploadCreateStub).toHaveBeenNthCalledWith(1, { projectId: 'mon-projet-1', localeId: 'frLocaleId-1', ...expectedData });
     expect(uploadCreateStub).toHaveBeenNthCalledWith(2, { projectId: 'mon-projet-2', localeId: 'frLocaleId-2', ...expectedData });

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -19,6 +19,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
       uploadCreate() { return uploadCreateStub(); }
     };
     vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+    vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
 
     // when
     await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
@@ -50,6 +51,98 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });
   });
 
+  it('should multi upload to Phrase when the are several projectIds', async () => {
+    // given
+    const ConfigurationStub = class {};
+    vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([
+      { projectId: 'mon-projet-1' },
+      { projectId: 'mon-projet-2', areaCode: '4' },
+    ]);
+    const localesListStub = vi.fn()
+      .mockResolvedValueOnce([
+        { id: 'frLocaleId-1', code: 'fr', name: 'fr', _default: true },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'frLocaleId-2', code: 'fr', name: 'fr', _default: true },
+      ]);
+
+    const LocalesApiStub = class {
+      localesList() { return localesListStub(); }
+    };
+    const uploadCreateStub = vi.fn()
+      .mockResolvedValue({ id: 'upload-id-1' })
+      .mockResolvedValue({ id: 'upload-id-2' });
+
+    const UploadsApiStub = class {
+      uploadCreate(...args) { return uploadCreateStub(...args); }
+    };
+
+    vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+    vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
+
+    // when
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
+
+    // then
+    const expectedData = {
+      file: expect.anything(),
+      fileFormat: 'csv',
+      updateDescriptions: true,
+      updateTranslations: true,
+      skipUploadTags: true,
+      localeMapping: {
+        fr: 2,
+      },
+      formatOptions: {
+        key_index: 1,
+        tag_column: 3,
+        comment_index: 4,
+        header_content_row: true,
+      }
+    };
+    expect(uploadCreateStub).toHaveBeenCalledTimes(2);
+    expect(uploadCreateStub).toHaveBeenNthCalledWith(1, { projectId: 'mon-projet-1', localeId: 'frLocaleId-1', ...expectedData });
+    expect(uploadCreateStub).toHaveBeenNthCalledWith(2, { projectId: 'mon-projet-2', localeId: 'frLocaleId-2', ...expectedData });
+  });
+
+  it('should schedule multiple deletions of unmentioned keys when the are several projectIds', async () => {
+    // given
+    const ConfigurationStub = class {};
+    vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([
+      { projectId: 'mon-projet-1' },
+      { projectId: 'mon-projet-2', areaCode: '4' },
+    ]);
+    const localesListStub = vi.fn()
+      .mockResolvedValueOnce([
+        { id: 'frLocaleId-1', code: 'fr', name: 'fr', _default: true },
+      ])
+      .mockResolvedValueOnce([
+        { id: 'frLocaleId-2', code: 'fr', name: 'fr', _default: true },
+      ]);
+
+    const LocalesApiStub = class {
+      localesList() { return localesListStub(); }
+    };
+    const uploadCreateStub = vi.fn()
+      .mockResolvedValueOnce({ id: 'upload-id-1' })
+      .mockResolvedValueOnce({ id: 'upload-id-2' });
+
+    const UploadsApiStub = class {
+      uploadCreate(...args) { return uploadCreateStub(...args); }
+    };
+
+    vi.spyOn(exportTranslationsUseCase, 'exportTranslations').mockImplementation((stream) => stream.end());
+    const deleteUnmentionedKeysJobStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
+
+    // when
+    await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
+
+    // then
+    expect(deleteUnmentionedKeysJobStub).toHaveBeenCalledTimes(2);
+    expect(deleteUnmentionedKeysJobStub).toHaveBeenNthCalledWith(1, { uploadId: 'upload-id-1' });
+    expect(deleteUnmentionedKeysJobStub).toHaveBeenNthCalledWith(2, { uploadId: 'upload-id-2' });
+  });
+
   it('should not upload to Phrase when apiKey is not set', async () => {
     // given
     vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
@@ -65,7 +158,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
 
   it('should not upload to Phrase when projectId is not set', async () => {
     // given
-    vi.spyOn(config.phrase, 'projectId', 'get').mockReturnValue(undefined);
+    vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([]);
 
     const ConfigurationStub = vi.fn();
 


### PR DESCRIPTION
## :pancakes: Problème

On envoie actuellement toutes les clés de traduction `fr` dans un seul projet Phrase.
Cela pose problème car nous avons dépassé 10000 clés dans ce projet, qui est une limite de Phrase pour le job `deleteUnmentionnedKeys`.

## :bacon: Proposition

Séparer le projet (référentiel Pix) par domaine.
Ajouter une clé de configuration `config.phrase.projects` qui représente une liste de projets Phrase.

## 🧃 Remarques

Faire attention à l'utilisation de RAM de l'application 🕵️

## :yum: Pour tester

- Essayer de récupérer le fichier csv contenant seulement les clés d'un domaine(GET /api/translations.csv?areaCode=1)
- Lancer manuellement le job `uploadTranslationToPhrase` et vérifier que les clés aient bien été ajoutées aux projets Phrase.
