### PR TITLE
[FEATURE] Réparer le script `delete-unmentioned-keys` (PIX-17001)

### DIFF
--- a/api/lib/domain/usecases/delete-unmentioned-keys-after-upload.js
+++ b/api/lib/domain/usecases/delete-unmentioned-keys-after-upload.js
@@ -1,16 +1,22 @@
 import { Configuration, UploadsApi, KeysApi } from 'phrase-js';
 import * as config from '../../config.js';
+import { logger } from '../../infrastructure/logger.js';
 
 export const RETRY = Symbol('retry');
 export const COMPLETED = Symbol('completed');
+export const MISSING_ARGUMENTS = Symbol('missing arguments');
 
-export async function deleteUnmentionedKeysAfterUpload(uploadId) {
-  const { apiKey, projectId } = config.phrase;
+export async function deleteUnmentionedKeysAfterUpload({ projectId, uploadId }) {
+  if (!projectId || !uploadId) {
+    logger.warn('ProjectId or UploadId is not defined !');
+    return MISSING_ARGUMENTS;
+  }
+  const { apiKey } = config.phrase;
+
   const configuration = new Configuration({
     fetchApi: fetch,
     apiKey: `token ${apiKey}`,
   });
-
   const upload = await new UploadsApi(configuration).uploadShow({ projectId, id: uploadId });
 
   if (upload.state === 'processing') {

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -55,7 +55,7 @@ export async function uploadTranslationToPhrase(phraseApi = { Configuration, Loc
         }
       });
 
-      await scheduleDeleteUnmentionedKeysAfterUploadJob({ uploadId: upload.id });
+      await scheduleDeleteUnmentionedKeysAfterUploadJob({ uploadId: upload.id, projectId });
     } catch (e) {
       const text = await e.text?.() ?? e;
       logger.error(`Phrase error while uploading translations: ${text}`);

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
@@ -3,7 +3,10 @@ import { RETRY, deleteUnmentionedKeysAfterUpload } from '../../domain/usecases/i
 import { schedule } from './delete-unmentioned-keys-after-upload-job.js';
 
 export default async function deleteUnmentionedKeysAfterUploadJobProcessor(job) {
-  const status = await deleteUnmentionedKeysAfterUpload(job.data.uploadId);
+  const status = await deleteUnmentionedKeysAfterUpload({
+    uploadId: job.data.uploadId,
+    projectId: job.data.projectId,
+  });
 
   if (status === RETRY) {
     schedule(job.data);

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js
@@ -23,6 +23,6 @@ const deleteUnmentionedKeysAfterUploadJobOptions = {
   delay: 3 * 60 * 1000
 };
 
-export function schedule({ uploadId }) {
-  return queue.add({ uploadId }, deleteUnmentionedKeysAfterUploadJobOptions);
+export function schedule({ uploadId, projectId }) {
+  return queue.add({ uploadId, projectId }, deleteUnmentionedKeysAfterUploadJobOptions);
 }

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parseString as parseCSVString } from 'fast-csv';
 import _ from 'lodash';
 import { Buffer } from 'node:buffer';
@@ -9,12 +9,15 @@ import { createServer } from '../../../server';
 import { ChallengeForRelease, SkillForRelease } from '../../../lib/domain/models/release/index.js';
 import { Area, LocalizedChallenge } from '../../../lib/domain/models/index.js';
 
+import * as scheduleDeleteUnmentionedKeysAfterUploadJob from '../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
+
 describe('Acceptance | Controller | phrase-controller', () => {
 
   describe('POST /phrase/upload', () => {
 
     it('should upload the translations to phrase', async () => {
       // Given
+      const spyScheduleDeleteUnmentionedKeysAfterUploadJob = vi.spyOn(scheduleDeleteUnmentionedKeysAfterUploadJob, 'schedule');
       const user = databaseBuilder.factory.buildAdminUser();
       const releaseContent = {
         frameworks: [{
@@ -286,7 +289,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
             matchFormDataParameter(parsedBody, 'format_options[header_content_row]', 'true');
         })
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
-        .reply(201, {});
+        .reply(201, { id: 'uplaodId' });
 
       const server = await createServer();
       const postPhraseUploadOptions = {
@@ -392,6 +395,8 @@ describe('Acceptance | Controller | phrase-controller', () => {
           ''
         ],
       ]);
+
+      expect(spyScheduleDeleteUnmentionedKeysAfterUploadJob).toHaveBeenCalledWith({ uploadId: 'uplaodId', projectId: 'MY_PHRASE_PROJECT_ID' });
     });
   });
 

--- a/api/tests/integration/domain/usecases/delete-unmentioned-keys-after-upload_test.js
+++ b/api/tests/integration/domain/usecases/delete-unmentioned-keys-after-upload_test.js
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import nock from 'nock';
-import { RETRY, COMPLETED, deleteUnmentionedKeysAfterUpload } from '../../../../lib/domain/usecases/index.js';
+import { RETRY, COMPLETED, MISSING_ARGUMENTS, deleteUnmentionedKeysAfterUpload } from '../../../../lib/domain/usecases/index.js';
 
 describe('Integration | Usecases | Delete unmentioned keys after upload', function() {
   it('should delete unmentioned keys when upload is in success', async function() {
     // given
     const phraseAPIUpload = nock('https://api.phrase.com')
-      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .get('/v2/projects/phrase-project-id/uploads/upload-id')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .reply(200,  {
         id: 'upload-id',
@@ -17,7 +17,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     const phraseAPIDelete = nock('https://api.phrase.com')
-      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .delete('/v2/projects/phrase-project-id/keys')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .query({
         q: 'unmentioned_in_upload:upload-id'
@@ -27,7 +27,10 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     // when
-    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+    const result = await deleteUnmentionedKeysAfterUpload({
+      projectId: 'phrase-project-id',
+      uploadId: 'upload-id',
+    });
 
     // then
     expect(result).to.equal(COMPLETED);
@@ -38,7 +41,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
   it('should not delete unmentioned keys when there is no unmentioned keys', async function() {
     // given
     const phraseAPIUpload = nock('https://api.phrase.com')
-      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .get('/v2/projects/phrase-project-id/uploads/upload-id')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .reply(200,  {
         id: 'upload-id',
@@ -49,7 +52,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     const phraseAPIDelete = nock('https://api.phrase.com')
-      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .delete('/v2/projects/phrase-project-id/keys')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .query({
         q: 'unmentioned_in_upload:upload-id'
@@ -59,7 +62,10 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     // when
-    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+    const result = await deleteUnmentionedKeysAfterUpload({
+      projectId: 'phrase-project-id',
+      uploadId: 'upload-id',
+    });
 
     // then
     expect(result).to.equal(COMPLETED);
@@ -70,7 +76,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
   it('should returns status retry when the upload is processing', async function() {
     // given
     const phraseAPIUpload = nock('https://api.phrase.com')
-      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .get('/v2/projects/phrase-project-id/uploads/upload-id')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .reply(200, {
         id: 'upload-id',
@@ -78,7 +84,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     const phraseAPIDelete = nock('https://api.phrase.com')
-      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .delete('/v2/projects/phrase-project-id/keys')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .query({
         q: 'unmentioned_in_upload:upload-id'
@@ -88,7 +94,10 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     // when
-    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+    const result = await deleteUnmentionedKeysAfterUpload({
+      projectId: 'phrase-project-id',
+      uploadId: 'upload-id',
+    });
 
     // then
     expect(result).to.equal(RETRY);
@@ -99,7 +108,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
   it('should returns status completed when the upload is in error', async function() {
     // given
     const phraseAPIUpload = nock('https://api.phrase.com')
-      .get('/v2/projects/MY_PHRASE_PROJECT_ID/uploads/upload-id')
+      .get('/v2/projects/phrase-project-id/uploads/upload-id')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .reply(200, {
         id: 'upload-id',
@@ -107,7 +116,7 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     const phraseAPIDelete = nock('https://api.phrase.com')
-      .delete('/v2/projects/MY_PHRASE_PROJECT_ID/keys')
+      .delete('/v2/projects/phrase-project-id/keys')
       .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
       .query({
         q: 'unmentioned_in_upload:upload-id'
@@ -117,11 +126,44 @@ describe('Integration | Usecases | Delete unmentioned keys after upload', functi
       });
 
     // when
-    const result = await deleteUnmentionedKeysAfterUpload('upload-id');
+    const result = await deleteUnmentionedKeysAfterUpload({
+      projectId: 'phrase-project-id',
+      uploadId: 'upload-id',
+    });
 
     // then
     expect(result).to.equal(COMPLETED);
     expect(phraseAPIUpload.isDone()).to.be.true;
+    expect(phraseAPIDelete.isDone()).to.be.false;
+  });
+  it('should throw error when projectId isn\'t given', async function() {
+    // given
+    const phraseAPIUpload = nock('https://api.phrase.com')
+      .get('/v2/projects/phrase-project-id/uploads/upload-id')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .reply(200, {
+        id: 'upload-id',
+        state: 'error'
+      });
+
+    const phraseAPIDelete = nock('https://api.phrase.com')
+      .delete('/v2/projects/phrase-project-id/keys')
+      .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+      .query({
+        q: 'unmentioned_in_upload:upload-id'
+      })
+      .reply(200,  {
+        records_affected: 0
+      });
+
+    // when
+    const promise = deleteUnmentionedKeysAfterUpload({
+      uploadId: 'upload-id',
+    });
+
+    // then
+    await expect(promise).resolves.to.be.equal(MISSING_ARGUMENTS);
+    expect(phraseAPIUpload.isDone()).to.be.false;
     expect(phraseAPIDelete.isDone()).to.be.false;
   });
 });

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -64,7 +64,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     await uploadTranslationToPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub, UploadsApi: UploadsApiStub });
 
     // then
-    expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });
+    expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id', projectId: 'MY_PHRASE_PROJECT_ID' });
   });
 
   it('should multi upload to Phrase when the are several projectIds', async () => {
@@ -178,8 +178,8 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
 
     // then
     expect(deleteUnmentionedKeysJobStub).toHaveBeenCalledTimes(2);
-    expect(deleteUnmentionedKeysJobStub).toHaveBeenNthCalledWith(1, { uploadId: 'upload-id-1' });
-    expect(deleteUnmentionedKeysJobStub).toHaveBeenNthCalledWith(2, { uploadId: 'upload-id-2' });
+    expect(deleteUnmentionedKeysJobStub).toHaveBeenNthCalledWith(1, { uploadId: 'upload-id-1', projectId: 'mon-projet-1' });
+    expect(deleteUnmentionedKeysJobStub).toHaveBeenNthCalledWith(2, { uploadId: 'upload-id-2', projectId: 'mon-projet-2' });
   });
 
   it('should not upload to Phrase when apiKey is not set', async () => {

--- a/api/tests/unit/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job_test.js
@@ -2,19 +2,30 @@ import { describe, expect, it, vi } from 'vitest';
 import * as deleteUnmentionedKeysAfterUploadJob from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 import deleteUnmentionedKeysAfterUploadJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js';
 import * as deleteUnmentionedKeysAfterUploadUsecase from '../../../../lib/domain/usecases/delete-unmentioned-keys-after-upload.js';
+import { queue } from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 
 describe('Unit | Infrastructure | scheduled-jobs | delete-unmentioned-keys-after-upload-job', function() {
   it('should schedule a new job when delete-unmentioned-keys-after-upload return status is `retry`', async function() {
     // given
     const deleteUnmentionedKeysAfterUploadStub = vi.spyOn(deleteUnmentionedKeysAfterUploadUsecase, 'deleteUnmentionedKeysAfterUpload').mockResolvedValue(deleteUnmentionedKeysAfterUploadUsecase.RETRY);
     const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
-
+    const queueAddStub = vi.spyOn(queue, 'add');
     // when
-    await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id' } });
+    await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id', projectId: 'phrase-project-id' } });
 
     // then
-    expect(scheduleStub).toHaveBeenCalledWith({ uploadId: 'upload-id' });
-    expect(deleteUnmentionedKeysAfterUploadStub).toHaveBeenCalledWith('upload-id');
+    expect(queueAddStub).toHaveBeenCalledWith({
+      uploadId: 'upload-id',
+      projectId: 'phrase-project-id',
+    }, expect.anything());
+    expect(scheduleStub).toHaveBeenCalledWith({
+      uploadId: 'upload-id',
+      projectId: 'phrase-project-id'
+    });
+    expect(deleteUnmentionedKeysAfterUploadStub).toHaveBeenCalledWith({
+      uploadId: 'upload-id',
+      projectId: 'phrase-project-id'
+    });
   });
 
   it('should not schedule a new job when delete-unmentioned-keys-after-upload return status is `completed`', async function() {
@@ -23,10 +34,10 @@ describe('Unit | Infrastructure | scheduled-jobs | delete-unmentioned-keys-after
     const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
 
     // when
-    await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id' } });
+    await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id', projectId: 'phrase-project-id' } });
 
     // then
     expect(scheduleStub).not.toHaveBeenCalled();
-    expect(deleteUnmentionedKeysAfterUploadStub).toHaveBeenCalledWith('upload-id');
+    expect(deleteUnmentionedKeysAfterUploadStub).toHaveBeenCalledWith({ uploadId: 'upload-id', projectId: 'phrase-project-id' });
   });
 });


### PR DESCRIPTION
## 🕵️ Problème

Nous avons oublier de mettre à jour le job `delete-unmentioned-keys` dans la PR #897.
De ce fait, ce job crash le container lors de la release.

## :bacon: Proposition

Ajout de l'argument `projectId` au job `delete-unmentioned-keys`.

## 🧃 Remarques

Surveiller la consommation de la RAM 👀

## :yum: Pour tester

- Tests OK
