### PR TITLE
[BUGFIX] Le bouton de fermeture de la liste des localized challenges ne fonctionnait pas (PIX-16453)

### DIFF
--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -122,7 +122,7 @@ export default class LocalizedChallengesProduction extends Component {
   }
 
 <template>
-    <ChallengesProductionHeader @skill={{@skill}} />
+    <ChallengesProductionHeader @skill={{@skill}} @overview={{@overview}} @competenceId={{@competenceId}} />
     <section class="challenges-production">
       <div class="challenges-production-table">
         <PixTable @condensed={{true}} @data={{this.localizedChallengeDataItems}} @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}}>

--- a/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
@@ -16,12 +16,14 @@ export default class LocalizedChallengesRoute extends Route {
   }
 
   async model(params) {
+    const { competence_id: competenceId } = this.paramsFor('authenticated.v2');
+    const { overview } = this.paramsFor('authenticated.v2.competence-overview');
     const { locale } = this.paramsFor('authenticated.v2');
     const { skill_id } = params;
     const skill = await this.store.findRecord('skill', skill_id);
     const challenges = await skill.challengesProduction;
     const localizedChallenges = await skill.localizedChallengesProduction;
 
-    return { challenges, skill, localizedChallenges, locale };
+    return { challenges, skill, localizedChallenges, locale, competenceId, overview };
   }
 }

--- a/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.hbs
+++ b/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.hbs
@@ -3,4 +3,6 @@
   @challenges={{this.model.challenges}}
   @localizedChallenges={{this.model.localizedChallenges}}
   @locale={{this.model.locale}}
+  @overview={{this.model.overview}}
+  @competenceId={{this.model.competenceId}}
 />


### PR DESCRIPTION
## :pancakes: Problème
Le bouton de fermeture de la liste des localized challenges ne marche pas.

## :bacon: Proposition
Transmettre les infos manquantes au component pour que le bouton fonctionne.

## 🧃 Remarques
RAS

## :yum: Pour tester
Aller sur la v2, choisissez une langue, cliquez sur une case d'acquis et voyez s'afficher la liste des challenges de la langue choisie. Fermer ce panneau-là et constater que ça fonctionne 🎉 
