### PR TITLE
[FEAT] Le bouton de switch à la v2 ne fonctionne pas partout (PIX-16702)

### DIFF
--- a/pix-editor/app/models/competence-overview.js
+++ b/pix-editor/app/models/competence-overview.js
@@ -18,4 +18,8 @@ export default class CompetenceOverviewModel extends Model {
   get locale() {
     return this.id.split(':')[2];
   }
+
+  get competenceAirtableId() {
+    return this.airtableId;
+  }
 }

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single.js
@@ -20,18 +20,17 @@ export default class SingleRoute extends Route {
     if (!model) return;
     await model?.files;
     this.currentData.setPrototype(model);
-
     if (!this.versionManager.isV2) return;
 
     const view = transition.to.queryParams.view;
     const goingToProduction = view === 'production' || !view;
     if (!goingToProduction) return;
 
-    const { competencePixId, locale } = this.modelFor('authenticated.competence.prototypes');
+    const { competenceAirtableId, locale } = this.modelFor('authenticated.competence.prototypes');
     const skillId = skill.id;
     const overview = 'challenges-production';
 
-    this.router.transitionTo('authenticated.v2.competence-overview.challenges', competencePixId, overview, skillId, { queryParams: { locale } });
+    this.router.transitionTo('authenticated.v2.competence-overview.challenges', competenceAirtableId, overview, skillId, { queryParams: { locale } });
   }
 
   setupController(controller, model) {

--- a/pix-editor/tests/acceptance/v2/navigation-v1-v2_test.js
+++ b/pix-editor/tests/acceptance/v2/navigation-v1-v2_test.js
@@ -61,7 +61,8 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
         }],
       }],
     });
-
+    this.server.create('challenge', { id: 'prototype1', airtableId: 'airtableRecChallenge1', instruction: 'instructionsChallenge1' });
+    this.server.create('skill', { id: 'skill1', challengeIds: ['prototype1'], level: 1 });
     return authenticateSession();
   });
 
@@ -104,5 +105,14 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
 
     // then
     assert.strictEqual(currentURL(), '/v2/competences/recCompetence1/challenges-production?locale=nl');
+  });
+
+  test('should move to v2 of the selected challenge', async function(assert) {
+    // when
+    await visit('/competence/recCompetence1/prototypes/prototype1?view=production');
+    await clickByText('V2');
+
+    // then
+    assert.strictEqual(currentURL(), '/v2/competences/recCompetence1/challenges-production/skills/skill1/challenges');
   });
 });


### PR DESCRIPTION
## :pancakes: Problème
Quand on a sélectionné une épreuve, puis qu'on clique sur la v2, cela ne redirige nulle part.

## :bacon: Proposition
Rectification en envoyant l'airtableId de la compétence pour la transition de la route, et ajout d'un test.

## 🧃 Remarques
RAS

## :yum: Pour tester
Se mettre en v1, ouvrir une compétence et cliquer sur une case pour afficher sa liste d'épreuves.
Passer à la v2
Constater que maintenant, ça renvoie bien à la même page mais version 2.