### PR TITLE
[FEATURE] Importer les clef de traduction depuis les nouveaux projets Phrase séparés par domaine (PIX-16834).

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -86,20 +86,22 @@ export async function register(server) {
     },
     {
       method: 'GET',
-      path: '/api/challenges/{id}/translations/{locale}',
+      path: '/api/challenges/{id}/translations/{locale}/area-code/{areaCode}',
       config: {
         auth: false,
         validate: {
           params: Joi.object({
             id: challengeIdType,
             locale: Joi.string().min(2).max(5),
+            areaCode: Joi.number(),
           }),
         },
         handler: async function(request, h) {
           const challengeId = request.params.id;
           const locale = request.params.locale;
+          const areaCode = request.params.areaCode;
 
-          const translationsUrl = await getPhraseTranslationsURL({ challengeId, locale });
+          const translationsUrl = await getPhraseTranslationsURL({ challengeId, locale, areaCode });
 
           return h.redirect(translationsUrl);
         },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -120,6 +120,7 @@ export const exportExternalUrlsJob = {
 };
 
 export const phrase = {
+  enableDownloadByArea: isFeatureEnabled(process.env.ENABLE_DOWNLOAD_BY_AREA),
   apiKey: process.env.PHRASE_API_KEY,
   projectId: process.env.PHRASE_PROJECT_ID,
   projects: [

--- a/api/lib/domain/usecases/download-translation-from-phrase.js
+++ b/api/lib/domain/usecases/download-translation-from-phrase.js
@@ -6,36 +6,72 @@ import { Readable } from 'node:stream';
 
 export async function downloadTranslationFromPhrase(phraseApi = { Configuration, LocalesApi }) {
 
-  const { apiKey, projectId } = config.phrase;
+  const { apiKey, projectId, enableDownloadByArea, projects } = config.phrase;
 
-  if (!apiKey || !projectId) {
-    logger.info('Phrase API Key or Project Id is not defined. Skipping download translations.');
-    return;
-  }
-
-  const configuration = new phraseApi.Configuration({
-    fetchApi: fetch,
-    apiKey: `token ${apiKey}`,
-  });
-
-  try {
-    const localesApi = new phraseApi.LocalesApi(configuration);
-
-    const phraseLocales = await localesApi.localesList({ projectId });
-
-    for (const phraseLocale of phraseLocales) {
-      if (phraseLocale._default) continue;
-
-      const csvFile = await localesApi.localeDownload({
-        projectId,
-        id: phraseLocale.id,
-        fileFormat: 'csv',
-      });
-      await importTranslations(Readable.fromWeb(csvFile.stream()));
+  if (enableDownloadByArea) {
+    const projectsByArea = projects.filter((project) => !Number.isNaN(parseInt(project.areaCode)));
+    if (!apiKey || !projectsByArea.length) {
+      logger.info('Phrase API Key or Projects is empty or doesn\'t contain areaCode. Skipping download translations.');
+      return;
     }
-  } catch (e) {
-    const text = await e.text?.() ?? e;
-    logger.error(`Error while downloading translations: ${text}`);
-    throw new Error('Download error', { cause: e });
+    const configuration = new phraseApi.Configuration({
+      fetchApi: fetch,
+      apiKey: `token ${apiKey}`,
+    });
+
+    for (const { projectId } of projectsByArea) {
+      try {
+        const localesApi = new phraseApi.LocalesApi(configuration);
+
+        const phraseLocales = await localesApi.localesList({ projectId });
+
+        for (const phraseLocale of phraseLocales) {
+          if (phraseLocale._default) continue;
+
+          const csvFile = await localesApi.localeDownload({
+            projectId,
+            id: phraseLocale.id,
+            fileFormat: 'csv',
+          });
+          await importTranslations(Readable.fromWeb(csvFile.stream()));
+        }
+      } catch (e) {
+        const text = await e.text?.() ?? e;
+        logger.error(`Error while downloading translations: ${text}`);
+        throw new Error('Download error', { cause: e });
+      }
+    }
+
+  } else {
+    if (!apiKey || !projectId) {
+      logger.info('Phrase API Key or Project Id is not defined. Skipping download translations.');
+      return;
+    }
+
+    const configuration = new phraseApi.Configuration({
+      fetchApi: fetch,
+      apiKey: `token ${apiKey}`,
+    });
+
+    try {
+      const localesApi = new phraseApi.LocalesApi(configuration);
+
+      const phraseLocales = await localesApi.localesList({ projectId });
+
+      for (const phraseLocale of phraseLocales) {
+        if (phraseLocale._default) continue;
+
+        const csvFile = await localesApi.localeDownload({
+          projectId,
+          id: phraseLocale.id,
+          fileFormat: 'csv',
+        });
+        await importTranslations(Readable.fromWeb(csvFile.stream()));
+      }
+    } catch (e) {
+      const text = await e.text?.() ?? e;
+      logger.error(`Error while downloading translations: ${text}`);
+      throw new Error('Download error', { cause: e });
+    }
   }
 }

--- a/api/lib/domain/usecases/get-phrase-translations-url.js
+++ b/api/lib/domain/usecases/get-phrase-translations-url.js
@@ -2,8 +2,9 @@ import { AccountsApi, Configuration, LocalesApi } from 'phrase-js';
 import * as config from '../../config.js';
 import { logger } from '../../infrastructure/logger.js';
 
-export async function getPhraseTranslationsURL({ challengeId, locale }, phrase = { AccountsApi, Configuration, LocalesApi }) {
+export async function getPhraseTranslationsURL({ challengeId, locale, areaCode }, phrase = { AccountsApi, Configuration, LocalesApi }) {
   try {
+    const enableDownloadByArea = config.phrase.enableDownloadByArea;
     const configuration = new phrase.Configuration({
       apiKey: `token ${config.phrase.apiKey}`,
       fetchApi: fetch,
@@ -12,15 +13,18 @@ export async function getPhraseTranslationsURL({ challengeId, locale }, phrase =
     const accounts = await new phrase.AccountsApi(configuration).accountsList({ page: 1 });
 
     const accountId = accounts.find(({ name }) => name === 'Pix')?.id;
+    const projectId = enableDownloadByArea
+      ? config.phrase.projects.find((project) => project.areaCode === areaCode).projectId
+      : config.phrase.projectId;
 
     const locales = await new phrase.LocalesApi(configuration).localesList({
-      projectId: config.phrase.projectId,
+      projectId,
     });
 
     const defaultLocaleId = locales.find(({ _default }) => _default)?.id;
     const targetLocaleId = locales.find(({ code }) => code === locale)?.id;
 
-    const url = new URL(config.phrase.projectId, `https://app.phrase.com/editor/v4/accounts/${accountId}/projects/`);
+    const url = new URL(projectId, `https://app.phrase.com/editor/v4/accounts/${accountId}/projects/`);
     url.searchParams.set('search', `keyNameQuery:challenge.${challengeId}`);
     url.searchParams.set('locales', `'${defaultLocaleId}','${targetLocaleId}'`);
 

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -988,10 +988,11 @@ describe('Acceptance | Controller | challenges-controller', () => {
     });
   });
 
-  describe('GET /challenges/:id/translations/:locale', () => {
+  describe('GET /challenges/:id/translations/:locale/area-code/:code', () => {
 
-    it('should redirect Phrase translations page', async () => {
+    it('should redirect Phrase translations page when enableDownloadByArea is false', async () => {
       // given
+      vi.spyOn(config.phrase, 'enableDownloadByArea', 'get').mockReturnValue(false);
       const challengeId = 'challenge123';
       const locale = 'nl';
 
@@ -1048,7 +1049,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       // when
       const response = await server.inject({
         method: 'GET',
-        url: `/api/challenges/${challengeId}/translations/${locale}`,
+        url: `/api/challenges/${challengeId}/translations/${locale}/area-code/2`,
       });
 
       // then
@@ -1058,6 +1059,83 @@ describe('Acceptance | Controller | challenges-controller', () => {
       expect(phraseAccountsApiScope.isDone()).toBe(true);
       expect(phraseLocalesApiScope.isDone()).toBe(true);
     });
+
+    it('should redirect to the phrase project corresponding to area code enableDownloadByArea is true',async () => {
+      // given
+      vi.spyOn(config.phrase, 'enableDownloadByArea', 'get').mockReturnValue(true);
+      vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([
+        { areaCode: 1, projectId: 'PHRASE_PROJECT_ID_AREA_1' },
+        { areaCode: 2, projectId: 'PHRASE_PROJECT_ID_AREA_2' },
+        { projectId: 'OLD_PHRASE_PROJECT_ID' }
+      ]);
+      const challengeId = 'challenge123';
+      const locale = 'nl';
+
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeId,
+        challengeId,
+        locale: 'fr',
+      });
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: 'challenge123_nl',
+        challengeId,
+        locale,
+      });
+
+      await databaseBuilder.commit();
+
+      const phraseAccountsApiScope = nock('https://api.phrase.com')
+        .get('/v2/accounts')
+        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+        .query({ page:1 })
+        .reply(200, [
+          {
+            id: 'pixAccountId',
+            name: 'Pix',
+          },
+        ]);
+
+      const phraseLocalesApiScope = nock('https://api.phrase.com')
+        .get('/v2/projects/PHRASE_PROJECT_ID_AREA_2/locales')
+        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+        .reply(200, [
+          {
+            id: 'frLocaleId',
+            name: 'fr',
+            code: 'fr',
+            default: true,
+          },
+          {
+            id: 'enLocaleId',
+            name: 'en',
+            code: 'en',
+            default: false,
+          },
+          {
+            id: 'nlLocaleId',
+            name: 'nl',
+            code: 'nl',
+            default: false,
+          },
+        ]);
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/challenges/${challengeId}/translations/${locale}/area-code/2`,
+      });
+
+      // then
+      expect(response.statusCode).toBe(302);
+      expect(response.headers.location).toBe(`https://app.phrase.com/editor/v4/accounts/pixAccountId/projects/PHRASE_PROJECT_ID_AREA_2?search=keyNameQuery%3Achallenge.${challengeId}&locales=%27frLocaleId%27%2C%27nlLocaleId%27`);
+
+      expect(phraseAccountsApiScope.isDone()).toBe(true);
+      expect(phraseLocalesApiScope.isDone()).toBe(true);
+
+    });
+
   });
 
   describe('POST /challenges', () => {

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseString as parseCSVString } from 'fast-csv';
 import _ from 'lodash';
 import { Buffer } from 'node:buffer';
@@ -8,11 +8,11 @@ import { databaseBuilder, generateAuthorizationHeader, knex, streamToPromiseArra
 import { createServer } from '../../../server';
 import { ChallengeForRelease, SkillForRelease } from '../../../lib/domain/models/release/index.js';
 import { Area, LocalizedChallenge } from '../../../lib/domain/models/index.js';
+import * as config from '../../../lib/config.js';
 
 import * as scheduleDeleteUnmentionedKeysAfterUploadJob from '../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 
 describe('Acceptance | Controller | phrase-controller', () => {
-
   describe('POST /phrase/upload', () => {
 
     it('should upload the translations to phrase', async () => {
@@ -401,83 +401,250 @@ describe('Acceptance | Controller | phrase-controller', () => {
   });
 
   describe('POST /phrase/download', () => {
-    it('should download the translations from phrase', async () => {
-      const user = databaseBuilder.factory.buildAdminUser();
-      await databaseBuilder.commit();
+    describe('disableDownloadByArea', () => {
+      beforeEach(()=> {
+        vi.spyOn(config.phrase, 'enableDownloadByArea', 'get').mockReturnValue(false);
+        vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([{ projectId: '🍓_DES_🪵_PAS_UTILISÉ' }]);
+      });
 
-      const phraseAPILocales = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales')
-        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
-        .reply(200, [
-          {
-            id: 'frLocaleId',
-            name: 'fr',
-            code: 'fr',
-            default: true,
+      it('should download the translations from phrase', async () => {
+        const user = databaseBuilder.factory.buildAdminUser();
+        await databaseBuilder.commit();
+
+        const phraseAPILocales = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales')
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, [
+            {
+              id: 'frLocaleId',
+              name: 'fr',
+              code: 'fr',
+              default: true,
+            },
+            {
+              id: 'enLocaleId',
+              name: 'en',
+              code: 'en',
+              default: false,
+            },
+            {
+              id: 'nlLocaleId',
+              name: 'nl',
+              code: 'nl',
+              default: false,
+            },
+          ]);
+
+        const phraseAPIDownloadEn = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales/enLocaleId/download')
+          .query({ file_format: 'csv' })
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, 'key_name,en,comment', { 'Content-type': 'text/csv' });
+
+        const phraseAPIDownloadNl = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales/nlLocaleId/download')
+          .query({ file_format: 'csv' })
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, 'key_name,nl,comment\narea.recnrCmBiPXGbgIyQ.title,Environnement numérique,\nchallenge.challenge1nwE8BcKcmiNvR.instruction,"Quelle technologie sans fil est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n","Prévisualisation FR: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/api/challenges/challenge1nwE8BcKcmiNvR/preview, Pix Editor: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/challenge/challenge1nwE8BcKcmiNvR"\n', { 'Content-type': 'text/csv' });
+
+        const server = await createServer();
+        const postPhraseDownloadOptions = {
+          method: 'POST',
+          url: '/api/phrase/download',
+          headers: {
+            ...generateAuthorizationHeader(user)
           },
+        };
+
+        // When
+        const response = await server.inject(postPhraseDownloadOptions);
+
+        // Then
+        expect(response.statusCode).to.equal(204);
+        expect(phraseAPILocales.isDone()).to.be.true;
+        expect(phraseAPIDownloadEn.isDone()).to.be.true;
+        expect(phraseAPIDownloadNl.isDone()).to.be.true;
+        expect(knex('translations').select('key', 'locale', 'value').orderBy('key')).resolves.to.deep.equal([
+          { key: 'area.recnrCmBiPXGbgIyQ.title', locale: 'nl', value: 'Environnement numérique' },
           {
-            id: 'enLocaleId',
-            name: 'en',
-            code: 'en',
-            default: false,
-          },
-          {
-            id: 'nlLocaleId',
-            name: 'nl',
-            code: 'nl',
-            default: false,
+            key: 'challenge.challenge1nwE8BcKcmiNvR.instruction',
+            locale: 'nl',
+            value: 'Quelle technologie sans fil est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n'
           },
         ]);
+        expect(knex('localized_challenges').select().orderBy('id')).resolves.toEqual([{
+          id: expect.stringMatching(/^challenge.*$/),
+          challengeId: 'challenge1nwE8BcKcmiNvR',
+          locale: 'nl',
+          geography: null,
+          embedUrl: null,
+          urlsToConsult: null,
+          status: ChallengeForRelease.STATUSES.PROPOSE,
+          requireGafamWebsiteAccess: false,
+          isIncompatibleIpadCertif: false,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+          isAwarenessChallenge: false,
+          toRephrase: false,
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
+        }]);
+      });
+    });
 
-      const phraseAPIDownloadEn = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales/enLocaleId/download')
-        .query({ file_format: 'csv' })
-        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
-        .reply(200, 'key_name,en,comment', { 'Content-type': 'text/csv' });
+    describe('enableDownloadByArea', () => {
+      beforeEach(()=> {
+        vi.spyOn(config.phrase, 'enableDownloadByArea', 'get').mockReturnValue(true);
+        vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([
+          { projectId: 'MY_AREA_1_PROJECT_ID', areaCode: 1 },
+          { projectId: 'MY_AREA_2_PROJECT_ID', areaCode: 2 },
+        ]);
+      });
 
-      const phraseAPIDownloadNl = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_PHRASE_PROJECT_ID/locales/nlLocaleId/download')
-        .query({ file_format: 'csv' })
-        .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
-        .reply(200, 'key_name,nl,comment\narea.recnrCmBiPXGbgIyQ.title,Environnement numérique,\nchallenge.challenge1nwE8BcKcmiNvR.instruction,"Quelle technologie sans fil est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n","Prévisualisation FR: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/api/challenges/challenge1nwE8BcKcmiNvR/preview, Pix Editor: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/challenge/challenge1nwE8BcKcmiNvR"\n', { 'Content-type': 'text/csv' });
+      it('should download the translations from phrase', async () => {
+        const user = databaseBuilder.factory.buildAdminUser();
+        await databaseBuilder.commit();
 
-      const server = await createServer();
-      const postPhraseDownloadOptions = {
-        method: 'POST',
-        url: '/api/phrase/download',
-        headers: {
-          ...generateAuthorizationHeader(user)
-        },
-      };
+        const phraseAPIAreaOneLocales = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales')
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, [
+            {
+              id: 'frLocaleId',
+              name: 'fr',
+              code: 'fr',
+              default: true,
+            },
+            {
+              id: 'enLocaleId',
+              name: 'en',
+              code: 'en',
+              default: false,
+            },
+            {
+              id: 'nlLocaleId',
+              name: 'nl',
+              code: 'nl',
+              default: false,
+            },
+          ]);
 
-      // When
-      const response = await server.inject(postPhraseDownloadOptions);
+        const phraseAPIAreaOneDownloadEn = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales/enLocaleId/download')
+          .query({ file_format: 'csv' })
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, 'key_name,en,comment', { 'Content-type': 'text/csv' });
 
-      // Then
-      expect(response.statusCode).to.equal(204);
-      expect(phraseAPILocales.isDone()).to.be.true;
-      expect(phraseAPIDownloadEn.isDone()).to.be.true;
-      expect(phraseAPIDownloadNl.isDone()).to.be.true;
-      expect(knex('translations').select('key', 'locale', 'value').orderBy('key')).resolves.to.deep.equal([
-        { key: 'area.recnrCmBiPXGbgIyQ.title', locale: 'nl', value: 'Environnement numérique' },
-        { key: 'challenge.challenge1nwE8BcKcmiNvR.instruction', locale: 'nl', value: 'Quelle technologie sans fil est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n' },
-      ]);
-      expect(knex('localized_challenges').select().orderBy('id')).resolves.toEqual([{
-        id: expect.stringMatching(/^challenge.*$/),
-        challengeId: 'challenge1nwE8BcKcmiNvR',
-        locale: 'nl',
-        geography: null,
-        embedUrl: null,
-        urlsToConsult: null,
-        status: ChallengeForRelease.STATUSES.PROPOSE,
-        requireGafamWebsiteAccess: false,
-        isIncompatibleIpadCertif: false,
-        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
-        isAwarenessChallenge: false,
-        toRephrase: false,
-        hasEmbedInternalValidation: false,
-        noValidationNeeded: false,
-      }]);
+        const phraseAPIAreaOneDownloadNl = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales/nlLocaleId/download')
+          .query({ file_format: 'csv' })
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, 'key_name,nl,comment\narea.recnrCmBiPXGbgIyQ.title,Environnement numérique,\nchallenge.challenge1nwE8BcKcmiNvR.instruction,"Quelle technologie sans fil est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n","Prévisualisation FR: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/api/challenges/challenge1nwE8BcKcmiNvR/preview, Pix Editor: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/challenge/challenge1nwE8BcKcmiNvR"\n', { 'Content-type': 'text/csv' });
+
+        const phraseAPIAreaTwoLocales = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales')
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, [
+            {
+              id: 'frLocaleId',
+              name: 'fr',
+              code: 'fr',
+              default: true,
+            },
+            {
+              id: 'enLocaleId',
+              name: 'en',
+              code: 'en',
+              default: false,
+            },
+            {
+              id: 'nlLocaleId',
+              name: 'nl',
+              code: 'nl',
+              default: false,
+            },
+          ]);
+
+        const phraseAPIAreaTwoDownloadEn = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales/enLocaleId/download')
+          .query({ file_format: 'csv' })
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, 'key_name,en,comment', { 'Content-type': 'text/csv' });
+
+        const phraseAPIAreaTwoDownloadNl = nock('https://api.phrase.com')
+          .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales/nlLocaleId/download')
+          .query({ file_format: 'csv' })
+          .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
+          .reply(200, 'key_name,nl,comment\narea.recDesCodesLaAreaDeux.title,Environnement digital,\nchallenge.challengeDeLAreaDeux.instruction,"Quelle technologie filaire est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n","Prévisualisation FR: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/api/challenges/challenge1nwE8BcKcmiNvR/preview, Pix Editor: http://pix-lcms-review-pr556.osc-fr1.scalingo.io/challenge/challenge1nwE8BcKcmiNvR"\n', { 'Content-type': 'text/csv' });
+
+        const server = await createServer();
+        const postPhraseDownloadOptions = {
+          method: 'POST',
+          url: '/api/phrase/download',
+          headers: {
+            ...generateAuthorizationHeader(user)
+          },
+        };
+
+        // When
+        const response = await server.inject(postPhraseDownloadOptions);
+
+        // Then
+        expect(response.statusCode).to.equal(204);
+        expect(phraseAPIAreaOneLocales.isDone()).to.be.true;
+        expect(phraseAPIAreaOneDownloadEn.isDone()).to.be.true;
+        expect(phraseAPIAreaOneDownloadNl.isDone()).to.be.true;
+        expect(phraseAPIAreaTwoLocales.isDone()).to.be.true;
+        expect(phraseAPIAreaTwoDownloadEn.isDone()).to.be.true;
+        expect(phraseAPIAreaTwoDownloadNl.isDone()).to.be.true;
+        expect(knex('translations').select('key', 'locale', 'value').orderBy('key', 'asc')).resolves.to.deep.equal([
+          { key: 'area.recDesCodesLaAreaDeux.title', locale: 'nl', value: 'Environnement digital' },
+          { key: 'area.recnrCmBiPXGbgIyQ.title', locale: 'nl', value: 'Environnement numérique' },
+          {
+            key: 'challenge.challenge1nwE8BcKcmiNvR.instruction',
+            locale: 'nl',
+            value: 'Quelle technologie sans fil est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n'
+          },
+          {
+            key: 'challenge.challengeDeLAreaDeux.instruction',
+            locale: 'nl',
+            value: 'Quelle technologie filaire est utilisée pour un kit mains-libres permettant de téléphoner en voiture ?\n'
+          },
+        ]);
+        expect(knex('localized_challenges').select().orderBy('challengeId', 'asc')).resolves.toEqual([
+          {
+            id: expect.stringMatching(/^challenge.*$/),
+            challengeId: 'challenge1nwE8BcKcmiNvR',
+            locale: 'nl',
+            geography: null,
+            embedUrl: null,
+            urlsToConsult: null,
+            status: ChallengeForRelease.STATUSES.PROPOSE,
+            requireGafamWebsiteAccess: false,
+            isIncompatibleIpadCertif: false,
+            deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+            isAwarenessChallenge: false,
+            toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
+          },
+          {
+            id: expect.stringMatching(/^challenge.*$/),
+            challengeId: 'challengeDeLAreaDeux',
+            locale: 'nl',
+            geography: null,
+            embedUrl: null,
+            urlsToConsult: null,
+            status: ChallengeForRelease.STATUSES.PROPOSE,
+            requireGafamWebsiteAccess: false,
+            isIncompatibleIpadCertif: false,
+            deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+            isAwarenessChallenge: false,
+            toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
+          },
+        ]);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/download-translation-from-phrase_test.js
+++ b/api/tests/unit/domain/usecases/download-translation-from-phrase_test.js
@@ -1,46 +1,112 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadTranslationFromPhrase } from '../../../../lib/domain/usecases';
 import * as config from '../../../../lib/config.js';
 
 describe('Unit | Domain | Usecases | download-translation-from-phrase', () => {
-  it('should not download from Phrase when apiKey is not set', async () => {
-    // given
-    vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
+  describe('disableDownloadByArea',  () => {
+    beforeEach(()=> {
+      vi.spyOn(config.phrase, 'enableDownloadByArea', 'get').mockReturnValue(false);
+    });
 
-    const ConfigurationStub = vi.fn();
+    it('should not download from Phrase when apiKey is not set', async () => {
+      // given
+      vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
 
-    // when
-    await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+      const ConfigurationStub = vi.fn();
 
-    // then
-    expect(ConfigurationStub).not.toHaveBeenCalled();
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+
+      // then
+      expect(ConfigurationStub).not.toHaveBeenCalled();
+    });
+
+    it('should not download from Phrase when projectId is not set', async () => {
+      // given
+      vi.spyOn(config.phrase, 'projectId', 'get').mockReturnValue(undefined);
+
+      const ConfigurationStub = vi.fn();
+
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+
+      // then
+      expect(ConfigurationStub).not.toHaveBeenCalled();
+    });
+
+    it('should download from Phrase when config is set', async () => {
+      // given
+      const ConfigurationStub = class {};
+      const localesListStub = vi.fn().mockResolvedValue([]);
+      const LocalesApiStub = class {
+        localesList() { return localesListStub(); }
+      };
+
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub });
+
+      // then
+      expect(localesListStub).toHaveBeenCalled();
+    });
   });
+  describe('enableDownloadByArea', () => {
+    beforeEach(()=> {
+      vi.spyOn(config.phrase, 'enableDownloadByArea', 'get').mockReturnValue(true);
+    });
 
-  it('should not download from Phrase when projectId is not set', async () => {
-    // given
-    vi.spyOn(config.phrase, 'projectId', 'get').mockReturnValue(undefined);
+    it('should download from Phrase when config is set', async () => {
+      // given
+      vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([{ projectId: 'PHRASE_AREA_ONE_PROJECT', areaCode: 1 }, { projectId : 'PHRASE_AREA_TWO_PROJECT', areaCode: 2 }]);
+      const ConfigurationStub = class {};
+      const localesListStub = vi.fn().mockResolvedValue([]);
+      const LocalesApiStub = class {
+        localesList() { return localesListStub(); }
+      };
 
-    const ConfigurationStub = vi.fn();
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub });
 
-    // when
-    await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+      // then
+      expect(localesListStub).toHaveBeenCalledTimes(2);
+    });
 
-    // then
-    expect(ConfigurationStub).not.toHaveBeenCalled();
-  });
+    it('should not download from Phrase when apiKey is not set', async () => {
+      // given
+      vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
 
-  it('should download from Phrase when config is set', async () => {
-    // given
-    const ConfigurationStub = class {};
-    const localesListStub = vi.fn().mockResolvedValue([]);
-    const LocalesApiStub = class {
-      localesList() { return localesListStub(); }
-    };
+      const ConfigurationStub = vi.fn();
 
-    // when
-    await downloadTranslationFromPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub });
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
 
-    // then
-    expect(localesListStub).toHaveBeenCalled();
+      // then
+      expect(ConfigurationStub).not.toHaveBeenCalled();
+    });
+
+    it('should not download from Phrase when projects don\'t have areaCode', async () => {
+      // given
+      vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([{ projectId: 'PIX_🍓_REFERENTIEL_❤️' }]);
+
+      const ConfigurationStub = vi.fn();
+
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+
+      // then
+      expect(ConfigurationStub).not.toHaveBeenCalled();
+    });
+
+    it('should not download from Phrase when projects is empty', async () => {
+      // given
+      vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([]);
+
+      const ConfigurationStub = vi.fn();
+
+      // when
+      await downloadTranslationFromPhrase({ Configuration: ConfigurationStub });
+
+      // then
+      expect(ConfigurationStub).not.toHaveBeenCalled();
+    });
   });
 });

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -45,7 +45,7 @@ export default class LocalizedChallengesProduction extends Component {
         instruction: localizedChallengeForLocale?.instruction ?? challenge.instruction,
         primaryUpdatedAt: challenge.updatedAt,
         primaryAuthor: challenge.author,
-        translationsUrl: isPrimaryInLocale ? null : `/api/challenges/${challenge.id}/translations/${this.args.locale}`,
+        translationsUrl: isPrimaryInLocale ? null : `/api/challenges/${challenge.id}/translations/${this.args.locale}/area-code/${this.args.areaCode}`,
         primaryStatusColor: this.getPrimaryStatusColor(challenge.status),
         primaryStatusText: this.getPrimaryStatusText(challenge.status),
         localizedStatusColor: this.getLocalizedStatusColor(localizedStatus),

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -42,12 +42,16 @@ export default class LocalizedController extends Controller {
     return this.model.localizedChallenge;
   }
 
+  get competence() {
+    return this.model.competence;
+  }
+
   get previewUrl() {
     return new URL(`${this.challenge.preview}?locale=${this.localizedChallenge.locale}`, window.location).href;
   }
 
   get translationsUrl() {
-    return new URL(`${this.localizedChallenge.translations}`, window.location).href;
+    return new URL(`${this.localizedChallenge.translations}/area-code/${this.competence.areaCode}`, window.location).href;
   }
 
   get challengeRoute() {

--- a/pix-editor/app/models/competence.js
+++ b/pix-editor/app/models/competence.js
@@ -49,6 +49,10 @@ export default class CompetenceModel extends Model {
       .sortBy('index');
   }
 
+  get areaCode() {
+    return this.code.split('.')[0];
+  }
+
   get sortedTubes() {
     return this.tubes.sortBy('index');
   }

--- a/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
@@ -6,8 +6,9 @@ export default class LocalizedPrototypeRoute extends Route {
 
   async model({ localized_challenge_id }) {
     const localizedChallenge = await this.store.findRecord('localized_challenge', localized_challenge_id);
+    const competence = this.modelFor('authenticated.competence');
     const challenge = await localizedChallenge.challenge;
-    return { localizedChallenge, challenge };
+    return { localizedChallenge, challenge, competence };
   }
 
   async afterModel(model) {

--- a/pix-editor/app/routes/authenticated/v2.js
+++ b/pix-editor/app/routes/authenticated/v2.js
@@ -14,6 +14,7 @@ export default class V2Route extends Route {
 
   async model(params) {
     const competence = await this.store.findRecord('competence', params.competence_id);
+
     return {
       competence,
       locale: params.locale,

--- a/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
@@ -16,14 +16,21 @@ export default class LocalizedChallengesRoute extends Route {
   }
 
   async model(params) {
-    const { competence_id: competenceId } = this.paramsFor('authenticated.v2');
+    const { locale, competence } = this.modelFor('authenticated.v2');
     const { overview } = this.paramsFor('authenticated.v2.competence-overview');
-    const { locale } = this.paramsFor('authenticated.v2');
     const { skill_id } = params;
     const skill = await this.store.findRecord('skill', skill_id);
     const challenges = await skill.challengesProduction;
     const localizedChallenges = await skill.localizedChallengesProduction;
 
-    return { challenges, skill, localizedChallenges, locale, competenceId, overview };
+    return {
+      challenges,
+      skill,
+      localizedChallenges,
+      locale,
+      areaCode: competence.areaCode,
+      competenceId: competence.id,
+      overview,
+    };
   }
 }

--- a/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.hbs
+++ b/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.hbs
@@ -2,7 +2,8 @@
   @skill={{this.model.skill}}
   @challenges={{this.model.challenges}}
   @localizedChallenges={{this.model.localizedChallenges}}
-  @locale={{this.model.locale}}
   @overview={{this.model.overview}}
   @competenceId={{this.model.competenceId}}
+  @locale={{this.model.locale}}
+  @areaCode={{this.model.areaCode}}
 />

--- a/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
@@ -28,7 +28,7 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     const skill = this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'], level: 1 });
     const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
     const thematic = this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
-    const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
+    const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', code: '1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
       thematicOverviews: [{
@@ -63,7 +63,7 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     await click(versionEn);
 
     const embedUrlInput = await screen.getByRole('textbox', { name: 'Embed URL :' });
-    assert.deepEqual(embedUrlInput.value, 'https://my-embed.com/en.html');
+    assert.strictEqual(embedUrlInput.value, 'https://my-embed.com/en.html');
 
     const previewLink = await screen.findByText('Prévisualiser');
     assert.ok(previewLink.getAttribute('href').endsWith('/preview?locale=en'), 'href ends with /preview?locale=en');
@@ -72,7 +72,7 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     assert.dom(header).hasText(/Pas en prod/);
 
     const translationsLink = await screen.findByText('Traductions');
-    assert.ok(translationsLink.getAttribute('href').endsWith('/translations/en'), 'href ends with /translations/en');
+    assert.ok(translationsLink.getAttribute('href').endsWith('/translations/en/area-code/1'), 'href ends with /translations/en/area-code/1');
   });
 
   test('it should go back to the original challenge', async function(assert) {

--- a/pix-editor/tests/acceptance/localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/localized-challenge-test.js
@@ -131,7 +131,7 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       const competence = this.server.create('competence', {
         id: 'recCompetence1.1',
         title: 'Nom de compétence',
-        code: 1,
+        code: '1.1',
         pixId: 'pixId recCompetence1.1',
         rawThemeIds: ['recTheme1'],
         rawTubeIds: ['recTube1'],
@@ -169,7 +169,7 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       // when
       const screen = await visit('/');
       await clickByText('Nom du domaine');
-      await clickByText('1 Nom de compétence');
+      await clickByText('1.1 Nom de compétence');
       await clickByText('@acquis2');
       await clickByText('Déclinaisons >>');
       await clickByText('Instruction de la déclinaison');
@@ -180,4 +180,3 @@ module('Acceptance | Localized-Challenge', function(hooks) {
     });
   });
 });
-

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -166,13 +166,16 @@ module('Integration | Component | challenges-production | localized-challenges-p
       localizedDecliObsoleteNl,
     ];
     const locale = 'nl';
+    const areaCode = '1';
 
     screen = await render(<template>
 <LocalizedChallengesProduction
   @skill={{skill}}
   @challenges={{challenges}}
   @localizedChallenges={{localizedChallenges}}
-  @locale={{locale}} />
+  @locale={{locale}}
+  @areaCode={{areaCode}}
+/>
 </template>);
   });
 
@@ -180,7 +183,6 @@ module('Integration | Component | challenges-production | localized-challenges-p
     test('should display all expected info for a given challenge', async function(assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
-      const translationLink = screen.getByLabelText('traduction de l\'épreuve de version Proto');
       const prototype = validatedChallenges[1];
 
       assert.dom(prototype).includesText('Proto');
@@ -189,7 +191,6 @@ module('Integration | Component | challenges-production | localized-challenges-p
       assert.dom(prototype).includesText('ELLE');
       assert.dom(prototype).includesText('validé');
       assert.dom(prototype).includesText('En prod');
-      assert.ok(translationLink.href.endsWith('/api/challenges/challengeProtoValide/translations/nl'));
     });
     module('it should display actions', function() {
       test('when have translation for current locale', async function(assert) {
@@ -201,8 +202,10 @@ module('Integration | Component | challenges-production | localized-challenges-p
         assert.dom(screen.getByRole('list', { name: 'traduction' })).exists();
         const primaryPreview = screen.getByRole('link', { name: 'Prévisualiser l\'épreuve challengeProtoValide' });
         const localizedPreview = screen.getByRole('link', { name: 'Prévisualiser l\'épreuve challengeProtoValideeNl' });
+        const localizedTranslationLink = screen.getByRole('link', { name: 'traduction de l\'épreuve de version 1' });
         assert.ok(primaryPreview.href.endsWith('api/urlto/challengeProtoValide'));
         assert.ok(localizedPreview.href.endsWith('api/urlto/challengeProtoValide?locale=nl'));
+        assert.ok(localizedTranslationLink.href.endsWith('api/challenges/challengeDecliArchivee/translations/nl/area-code/1'));
         assert.dom(screen.getByRole('button', { name: 'Copier le lien de l\'épreuve challengeProtoValideeNl' })).exists();
       });
 

--- a/pix-editor/tests/unit/models/competence-test.js
+++ b/pix-editor/tests/unit/models/competence-test.js
@@ -46,4 +46,16 @@ module('Unit | Model | competence', function(hooks) {
       assert.deepEqual(competence.productionTubes, [liveTube]);
     });
   });
+
+  module('#getAreaCode', function() {
+    test('should return area code', function(assert) {
+      const store = this.owner.lookup('service:store');
+
+      const competence = store.createRecord('competence', {
+        code: '2.4',
+      });
+
+      assert.strictEqual(competence.areaCode, '2');
+    });
+  });
 });


### PR DESCRIPTION
## :pancakes: Problème

Notre projet Phrase est devenu trop gros ce qui nous oblige à séparer nos clef de traduction par domaine dans des projet Phrase distinct .

## :bacon: Proposition

Permettre la récupération des clefs de traductions depuis plusieurs projets Phrase

## 🧃 Remarques

Nous avons ajouté une nouvelle variable d’environnement afin d'activer ou désactiver cette nouvelle feature

## :yum: Pour tester

Nous ne possédons pas de projet phrase pour les review app, nous testerons cela sur l’intégration.
Vérifier que les testes passent 
