### PR TITLE
[TECH] Exploration des problèmes de mémoire sur la création de release

### DIFF
--- a/api/lib/infrastructure/scheduled-jobs/create-queue.js
+++ b/api/lib/infrastructure/scheduled-jobs/create-queue.js
@@ -24,8 +24,33 @@ export function createQueue(queueName) {
   queue.on('paused', () => queueMessage(queueName, 'The queue has been paused'));
   queue.on('resumed', () => queueMessage(queueName, 'The queue has been resumed'));
   queue.on('cleaned', () => queueMessage(queueName, 'The queue has been cleaned'));
-  queue.on('drained', () => queueMessage(queueName, 'The queue has been drained'));
+  queue.on('drained', async function() {
+    queueMessage(queueName, 'The queue has been drained');
+    await cleanQueue(queues.find((queue) => queue.name === queueName));
+  });
   queue.on('removed', () => queueMessage(queueName, 'A job has been removed'));
   queues.push(queue);
   return queue;
+}
+
+async function cleanQueue(queue) {
+  if (!queue.childPool) {
+    logger.info(`No childPool to clean up for queue '${queue.name}'`);
+    return;
+  }
+
+  const freeProcesses = queue.childPool?.getAllFree();
+  if (!freeProcesses || freeProcesses.length === 0) {
+    logger.info(`No free process to clean up in childPool for queue '${queue.name}'`);
+    return;
+  }
+
+  logger.info(`About to kill ${freeProcesses.length} free Bull processes to free memory in queue '${queue.name}'...`);
+  for (const freeProcess of freeProcesses) {
+    try {
+      await queue.childPool.kill(freeProcess, 'SIGTERM');
+    } catch (error) {
+      logger.error(`Error while killing free bull process in queue '${queue.name}'`, error);
+    }
+  }
 }


### PR DESCRIPTION
## 🌸 Problème

Crash mémoire, au bout d'un moment, des containers de prod. La mémoire monte constamment sans se vider.

## 🌳 Proposition

Lorsque Bull exécute un job, le job est exécuté dans un process différent. Il lance donc un nouveau process node pour exécuter le job.
A la fin du job, Bull ne fait pas de nettoyage. Le worker du job est toujours vivant mais sans rien à faire.
Ce qui rend ce comportement problématique dans notre cas c'est que le job exécuté par le worker manipule beaucoup de données (création de release par ex) et donc utilise et ne libère jamais de la mémoire.

On propose donc de forcer le nettoyage des workers ayant fini leur tâche.
Lorsqu'une queue de job est drainée (n'a plus de jobs en attente), elle déclenche une fonction de nettoyage de son pool de workers.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Fonctionnellement, vu qu'on a mis du logger.info un peu partout on peut déjà voir que la fonction de nettoyage est bien déclenchée au vidage de la queue.
Aussi, on peut lancer de façon répétée des créations de release et constater qu'on part pas en swap, que ça se vide régulièrement
