### PR TITLE
[BUGFIX] Fix affichage des légendes des tableaux d'épreuves en V2

### DIFF
--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -98,7 +98,7 @@ export default class CompetenceOverview extends Component {
         {{/each}}
         </div>
         <div class="competence-overview-footer">
-          {{#if this.hasLocaleSelected}}
+          {{#if @locale}}
             <ul class="competence-overview-legend">
               <li>
                 <span class="circle green"></span> L'acquis possède des épreuves validées


### PR DESCRIPTION
🌸 Problème

Les légendes ne s’affichent pas sur les tableaux des épreuves de la V2

🌳 Proposition

Le getter utilisé pour récupérer la locale n’existe plus, le remplacer par la bonne valeur

🐝 Remarques

RAS

🤧 Pour tester

Vérifier que l’affichage des légendes est OK