### PR TITLE
[BUGFIX] Affichage erroné de l'état des traductions dans la v2 (PIX-16456)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/skill-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/skill-serializer.js
@@ -11,6 +11,7 @@ const serializer = new Serializer('skill', {
     'clueStatus',
     'challenges',
     'challengesProduction',
+    'localizedChallengesProduction',
     'createdAt',
     'description',
     'descriptionStatus',
@@ -48,6 +49,7 @@ const serializer = new Serializer('skill', {
       i18n: internationalisation,
       challenges: challengeIds?.map((id) => ({ id })),
       challengesProduction: {},
+      localizedChallengesProduction: {},
       tutoSolution: tutorialAirtableIds?.map((id) => ({ id })),
       tutoMore: learningMoreTutorialAirtableIds?.map((id) => ({ id })),
       tube: tubeAirtableId && { id: tubeAirtableId },
@@ -62,6 +64,15 @@ const serializer = new Serializer('skill', {
     relationshipLinks: {
       related(skill) {
         return `/api/skills/${skill.pixId}/challenges-production`;
+      },
+    },
+  },
+  localizedChallengesProduction: {
+    ref: 'id',
+    ignoreRelationshipData: true,
+    relationshipLinks: {
+      related(skill) {
+        return `/api/skills/${skill.pixId}/localized-challenges-production`;
       },
     },
   },

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -569,6 +569,11 @@ describe('Application | Route | Skills', () => {
                     related: '/api/skills/skill1/challenges-production',
                   },
                 },
+                'localized-challenges-production': {
+                  links: {
+                    related: '/api/skills/skill1/localized-challenges-production',
+                  },
+                },
               }
             },
             {
@@ -634,6 +639,11 @@ describe('Application | Route | Skills', () => {
                 'challenges-production': {
                   links: {
                     related: '/api/skills/skill2/challenges-production',
+                  },
+                },
+                'localized-challenges-production': {
+                  links: {
+                    related: '/api/skills/skill2/localized-challenges-production',
                   },
                 },
               }
@@ -787,6 +797,11 @@ describe('Application | Route | Skills', () => {
                     related: '/api/skills/skill1/challenges-production',
                   },
                 },
+                'localized-challenges-production': {
+                  links: {
+                    related: '/api/skills/skill1/localized-challenges-production',
+                  },
+                },
               }
             },
             {
@@ -852,6 +867,11 @@ describe('Application | Route | Skills', () => {
                 'challenges-production': {
                   links: {
                     related: '/api/skills/skill2/challenges-production',
+                  },
+                },
+                'localized-challenges-production': {
+                  links: {
+                    related: '/api/skills/skill2/localized-challenges-production',
                   },
                 },
               }
@@ -1006,6 +1026,11 @@ describe('Application | Route | Skills', () => {
                     related: '/api/skills/skill1/challenges-production',
                   },
                 },
+                'localized-challenges-production': {
+                  links: {
+                    related: '/api/skills/skill1/localized-challenges-production',
+                  },
+                },
               }
             },
             {
@@ -1071,6 +1096,11 @@ describe('Application | Route | Skills', () => {
                 'challenges-production': {
                   links: {
                     related: '/api/skills/skill2/challenges-production',
+                  },
+                },
+                'localized-challenges-production': {
+                  links: {
+                    related: '/api/skills/skill2/localized-challenges-production',
                   },
                 },
               }
@@ -1196,6 +1226,11 @@ describe('Application | Route | Skills', () => {
               'challenges-production': {
                 links: {
                   related: '/api/skills/skill1/challenges-production',
+                },
+              },
+              'localized-challenges-production': {
+                links: {
+                  related: '/api/skills/skill1/localized-challenges-production',
                 },
               },
             }
@@ -1447,6 +1482,11 @@ describe('Application | Route | Skills', () => {
             'challenges-production': {
               links: {
                 related: '/api/skills/nouvelAcquis/challenges-production',
+              },
+            },
+            'localized-challenges-production': {
+              links: {
+                related: '/api/skills/nouvelAcquis/localized-challenges-production',
               },
             },
           }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
@@ -179,6 +179,11 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
                 'related': '/api/skills/skillId/challenges-production',
               },
             },
+            'localized-challenges-production': {
+              'links': {
+                'related': '/api/skills/skillId/localized-challenges-production',
+              },
+            },
           }
         }
       };

--- a/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
@@ -63,6 +63,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
             isPrototypeDeclinable: true,
             proposedChallengesCount: 0,
             validatedChallengesCount: 1,
+            airtableId: skillId,
           }, null, null, null, null, null, null],
         }],
       }],
@@ -79,7 +80,15 @@ module('Acceptance | competences | challenge-production', function(hooks) {
       instruction: 'Coucou maman',
       locales: ['fr'],
     });
-    skill.update({ challengesProduction: [challengeProduction] });
+
+    const localizedChallengeProduction = this.server.create('localized-challenge', {
+      id: 'localizedChallengeIdProto',
+      locale: 'nl',
+      status: Challenge.STATUSES.VALIDE,
+      instruction: 'hallo mama',
+      challenge: challengeProduction,
+    });
+    skill.update({ challengesProduction: [challengeProduction], localizedChallengesProduction: [localizedChallengeProduction] });
 
     return authenticateSession();
   });
@@ -111,6 +120,17 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     assert.dom(screen.getByText('Coucou maman'));
     assert.strictEqual(currentURL(), `/v2/competences/recCompetence1/challenges-production/skills/${skillId}/challenges`);
   });
+
+  test('should display a localized challenge production list', async function(assert) {
+    // when
+    const screen = await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
+    await clickByText('@tube1');
+
+    // then
+    assert.dom(screen.getByText('hallo mama'));
+    assert.strictEqual(currentURL(), `/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges?locale=nl`);
+  });
+
   test('it should navigate to challenge view', async function(assert) {
     await visit('/v2/competences/recCompetence1/challenges-production');
     await clickByText('@tube1');


### PR DESCRIPTION
## 🌸 Problème

Toutes les épreuves étaient marquées comme "Pas encore traduit" ou "Source dans la langue", alors même qu'il existe des traductions pour certaines de ces épreuves.

## 🌳 Proposition

Lors du refacto de la récupération des acquis (proxy airtable nanananère), on a oublié de reporter dans le json-api sérialisé d'un acquis le lien vers les `localized-challenges-production`.

## 🐝 Remarques

Ember ne mouftait pas, mais bon.
Parfois c'est pratique quand il est tolérant sur l'absence/présence des attributs dans le payload, et parfois pas.

## 🤧 Pour tester

Sélectionner un acquis pour lequel on sait qu'il y a des trads. Cliquer dessus pour afficher la liste des épreuves (en choisissant la langue souhaitée) et constater que les statuts des trads sont cohérents
