### PR TITLE
[BUGFIX] Le bouton d'expand de la liste des localized challenges a disparu. (PIX-17146)

### DIFF
--- a/pix-editor/app/components/challenges-production/challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/challenges-production.gjs
@@ -67,7 +67,7 @@ export default class ChallengesProduction extends Component {
   }
 
   <template>
-    <ChallengesProductionHeader @skill={{@skill}} @overview={{@overview}} @competenceId={{@competenceId}} @canExpand={{@canExpand}}/>
+    <ChallengesProductionHeader @skill={{@skill}} @overview={{@overview}} @competenceId={{@competenceId}} @canExpand={{@canExpand}} />
     <section class="challenges-production {{if this.multipanelManager.tableShouldBeMinimized "challenges-production--hidden" ""}}">
       <div class="challenges-production-table">
         <PixTable @data={{this.challenges}} @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}} @condensed={{true}}>

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -122,7 +122,7 @@ export default class LocalizedChallengesProduction extends Component {
   }
 
 <template>
-    <ChallengesProductionHeader @skill={{@skill}} @overview={{@overview}} @competenceId={{@competenceId}} />
+    <ChallengesProductionHeader @skill={{@skill}} @overview={{@overview}} @competenceId={{@competenceId}} @canExpand={{@canExpand}} />
     <section class="challenges-production">
       <div class="challenges-production-table">
         <PixTable @condensed={{true}} @data={{this.localizedChallengeDataItems}} @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}}>

--- a/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.hbs
+++ b/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.hbs
@@ -6,4 +6,5 @@
   @competenceId={{this.model.competenceId}}
   @locale={{this.model.locale}}
   @areaCode={{this.model.areaCode}}
+  @canExpand={{true}}
 />


### PR DESCRIPTION
## 🌸 Problème
Le bouton d'expand de la liste des localized challenges a disparu.

## 🌳 Proposition
Ajouter la valeur @canExpand dans le header du composant concerné sur la page concernée.

## 🐝 Remarques
Ce booléen a été ajouté pour une raison qu'on ignore et il est utilisé uniquement pour la liste des challenges et des localized challenges. Si on veut toujours garder la possibilité d'expand la liste, ce booléen est peut-être inutile ?

## 🤧 Pour tester
Passer en vue v2 des épreuves, choisir une autre langue que le français, constater que le bouton d'agrandissement/rétrécissement de la liste des challenges s'affiche bien et est fonctionnel.