### PR TITLE
[BUGFIX] Se souvenir de l'épreuve archivée sélectionnée au passage de la section "Acquis" à "Épreuves" (PIX-15501)

### DIFF
--- a/pix-editor/app/routes/authenticated/competence/prototypes.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes.js
@@ -51,9 +51,6 @@ export default class PrototypesRoute extends Route {
   }
 
   afterModel(model, transition) {
-    // QUESTION: est-ce nécessaire ?
-    this.currentData.setPrototype(null);
-
     if (!this.versionManager.isV2) return;
     this.multipanelManager.reset();
     if (transition.to.name !== 'authenticated.competence.prototypes.index') return;

--- a/pix-editor/app/routes/authenticated/competence/skills/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single.js
@@ -15,6 +15,9 @@ export default class SingleRoute extends Route {
 
   async afterModel(model) {
     await model.challenges;
+    if (model.prototypes.length > 0) {
+      this.currentData.setPrototype(model.prototypes[0]);
+    }
     return model.pinRelationships();
   }
 
@@ -44,11 +47,8 @@ export default class SingleRoute extends Route {
         modelSkillSingle.rollbackAttributes();
       }
       if (transition.targetName === 'authenticated.competence.prototypes.index') {
-        if (this.controllerFor('authenticated.competence').view === 'workbench') {
-          return true;
-        }
         const skill = this.controllerFor('authenticated.competence.skills.single').skill;
-        const prototype = skill.productionPrototype;
+        const prototype = this.currentData.getPrototype();
         if (prototype) {
           return this.router.transitionTo('authenticated.competence.prototypes.single', prototype);
         } else {


### PR DESCRIPTION

## 🌸 Problème

Dans la section Acquis, un acquis archivé (ou proposé) sélectionné s'occulte au passage à la section "Épreuves".
Ce n'est pas le cas dans l'autre sens.
C'est le cas parce qu'on ne sait pas faire le raccord entre les deux.

## 🌳 Proposition

Utiliser le `currentData` pour se souvenir du prototype sur lequel on est.

## 🐝 Remarques

Il faudrait un test.

## 🤧 Pour tester

- Se rendre sur [un acquis archivé](https://pix-lcms-review-pr910.osc-fr1.scalingo.io/competence/recQE2U97ZMfFZRPl/skills/recG9GCCUfUjCaaSB?view=workbench)
- Passer à la section "Épreuves" (select en haut à droite)
- Constater que le bon prototype est ouvert.
- Espérer qu'il n'y ait pas de bugs bizarres liés au `currentData`.
