### PR TITLE
[TECH] Afficher un avertissement quand on commit un `console.log`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,12 +19,19 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NO_COLOR='\033[0m'
 
+URI_START='\x1B]8;;'
+ALIAS_START='\x1B\\'
+ALIAS_END='\x1B]8;;'
+URI_END='\x1B\\'
+
 sniff_smell () {
   FILE=$1
   SMELL=$2
   MATCHES="$(grep --count "$SMELL" "$FILE" || true)"
   if [[ "$MATCHES" > 0 ]]; then
-    echo -e "🚨 Found ${MATCHES} ${RED}$SMELL${NO_COLOR} in file ${YELLOW}$FILE${NO_COLOR}"
+    echo -e "\
+🚨 Found ${MATCHES} ${RED}$SMELL${NO_COLOR} in file \
+${YELLOW}${URI_START}file://$(pwd)/$FILE${ALIAS_START}$FILE${ALIAS_END}${URI_END}${NO_COLOR}"
   fi
 }
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,25 +1,35 @@
 #!/usr/bin/env bash
-
 set -eo pipefail
 
-# In case filename contains spaces [https://www.baeldung.com/linux/reading-output-into-array#1-output-may-contain-spaces](https://www.baeldung.com/linux/reading-output-into-array#1-output-may-contain-spaces)
-IFS=$'\n'
+SMELLS=(
+  "console.log"
+  "console.info"
+  "console.error"
+  "console.warn"
+  "{{ log"
+  "{{log"
+  ".skip("
+  ".only("
+  "this.pauseTest()"
+)
 
 CHANGED_FILES=($(git diff --name-only --cached --diff-filter=ACMR))
 
-SECRET=postgres://postgres:J9FUMSBhei8oU@db.dbhostprovider.com:5434/thedb
-
 RED='\033[0;31m'
-GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 NO_COLOR='\033[0m'
 
-for file in "${CHANGED_FILES[@]}"
-do
-  echo -e "Inspecting file : ${GREEN} ${file} ${NO_COLOR}"
-  MATCHES="$(grep --count "$SECRET" "${file}" || true)"
-  if [[ "$MATCHES" > 0 ]]
-    then
-      echo -e "Oops, we found the secret ${RED} ${SECRET} ${NO_COLOR} in file ${file} ! "
-      exit 255
+sniff_smell () {
+  FILE=$1
+  SMELL=$2
+  MATCHES="$(grep --count "$SMELL" "$FILE" || true)"
+  if [[ "$MATCHES" > 0 ]]; then
+    echo -e "🚨 Found ${MATCHES} ${RED}$SMELL${NO_COLOR} in file ${YELLOW}$FILE${NO_COLOR}"
   fi
+}
+
+for file in "${CHANGED_FILES[@]}"; do
+  for smell in "${SMELLS[@]}"; do
+    sniff_smell $file "$smell"
+  done
 done


### PR DESCRIPTION
## 🌸 Problème

On commit trop souvent des `console.log` sans faire exprès.

## 🌳 Proposition

Modification du hook de pre-commit git déjà existant (mais pas utilisé ?) pour détecter des codes smells simples.
- _L'objectif **n'est pas** de recréer ESLint, ou de lancer celui-ci._
- L'exécution du hook doit être instantanée.
- Le hook ne doit pas forcer l'utilisateur à supprimer les code smells détectés, il sert **uniquement** à l'avertir.

![image](https://github.com/user-attachments/assets/2459276f-8b33-4f4d-806c-ead3a403b400)


## 🐝 Remarques

J'ai sûrement oublié des choses dans la liste `SMELLS`, n'hésitez pas à en rajouter quand vous en trouvez.

## 🤧 Pour tester

- Lancer la commande `echo "console.log('hehehe');" > patate.js` à la racine du projet, qui va créer un fichier `patate.js`
- Essayer de commit ce fichier
- Constater que le hook n'a pas empêché la création du commit
- Constater que le hook a affiché l'avertissement suivant : `🚨 Found 1 console.log in file patate.js`