### PR TITLE
[TECH] Utilisation de PixTable dans la whitelist de la moulinette des URLs cassées (PIX-16641)

### DIFF
--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -24,95 +24,86 @@
     >
       <:label>URL</:label>
     </PixInput>
-    <PixButton
-      @type="submit"
-    >
-      Filtrer
-    </PixButton>
+    <PixButton @type="submit">Filtrer</PixButton>
   </PixFilterBanner>
 </form>
-<div class="panel-table-v2">
-  <table class="content-text content-text--small">
-    <colgroup class="table__column">
-      <col class="table__column--small" />
-      <col class="table__column" />
-      <col class="table__column--wide" />
-      <col class="table__column--wide" />
-      <col class="table__column--small" />
-      <col class="table__column--small" />
-    </colgroup>
-    <thead>
-    <tr>
-      <th>Nom des acquis concernés</th>
-      <th>Type de comparaison</th>
-      <th>URL</th>
-      <th>Commentaire</th>
-      <th>Créée le</th>
-      <th>Modifiée le</th>
-    </tr>
-    </thead>
-    <tbody>
-    {{#each @whitelistedUrls as |whitelistedUrl|}}
-      <tr class="tr--clickable" aria-label="URL en liste blanche">
-        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
-          {{whitelistedUrl.relatedSkillNames}}
-        </td>
-        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
+<div class="whitelisted-urls-table">
+  <PixTable
+    @caption="Liste des URLs à ne pas mettre dans les URLs cassées"
+    @condensed={{true}}
+    @data={{@whitelistedUrls}}
+    @variant="primary"
+    @onRowClick={{@goToEditWhitelistedUrl}}
+  >
+    <:columns as |whitelistedUrl context|>
+      <PixTableColumn @context={{context}} class="column--small">
+        <:header>Nom des acquis concernés</:header>
+        <:cell>{{ whitelistedUrl.relatedSkillNames }}</:cell>
+      </PixTableColumn>
+      <PixTableColumn @context={{context}}>
+        <:header>Type de comparaison</:header>
+        <:cell>
           <PixTag class="whitelisted-url-check-type-tag" @color={{this.checkTypeColor whitelistedUrl.checkType}}>
-            {{this.formatCheckType whitelistedUrl.checkType}}
+            {{ this.formatCheckType whitelistedUrl.checkType }}
           </PixTag>
-        </td>
-        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
-          {{whitelistedUrl.url}}
-        </td>
-        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
-          {{whitelistedUrl.comment}}
-        </td>
-        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
-          {{this.formatCreationString whitelistedUrl}}
-        </td>
-        <td {{on "click" (fn @goToEditWhitelistedUrl whitelistedUrl.id)}}>
-          {{this.formatUpdateString whitelistedUrl}}
-        </td>
-        <td class="actions">
-          <PixTooltip
-            @id='copy-whitelisted-url-link-tooltip'
-            @position="top"
-            @isInline={{true}}
-          >
-            <:triggerElement>
-              <PixIconButton
-                @triggerAction={{fn this.copyUrl whitelistedUrl}}
-                @iconName="copy"
-                @iconPrefix="far"
-                @ariaLabel="Copier l'URL whitelistée"
-                class="icon"
-                aria-describedby='copy-whitelisted-url-link-tooltip'
-              >
-              </PixIconButton>
-            </:triggerElement>
-            <:tooltip>Copier l’URL whitelistée</:tooltip>
-          </PixTooltip>
-          <PixTooltip
-            @id='delete-whitelisted-url-tooltip'
-            @position="top"
-            @isInline={{true}}
-          >
-            <:triggerElement>
-              <PixIconButton
-                @triggerAction={{fn this.args.onDeleteItemClicked whitelistedUrl}}
-                @iconName="delete"
-                @ariaLabel="Supprimer l'URL de la whitelist"
-                class="icon"
-                aria-describedby='delete-whitelisted-url-tooltip'
-              >
-              </PixIconButton>
-            </:triggerElement>
-            <:tooltip>Supprimer l'URL de la whitelist</:tooltip>
-        </PixTooltip>
-        </td>
-      </tr>
-    {{/each}}
-    </tbody>
-  </table>
+        </:cell>
+      </PixTableColumn>
+      <PixTableColumn @context={{context}} class="column--wide">
+        <:header>URL</:header>
+        <:cell>{{ whitelistedUrl.url }}</:cell>
+      </PixTableColumn>
+      <PixTableColumn @context={{context}} class="column--wide">
+        <:header>Commentaire</:header>
+        <:cell>{{ whitelistedUrl.comment }}</:cell>
+      </PixTableColumn>
+      <PixTableColumn @context={{context}} class="column--small">
+        <:header>Créée le</:header>
+        <:cell>{{ this.formatCreationString whitelistedUrl }}</:cell>
+      </PixTableColumn>
+      <PixTableColumn @context={{context}} class="column--small">
+        <:header>Modifiée le</:header>
+        <:cell>{{ this.formatUpdateString whitelistedUrl }}</:cell>
+      </PixTableColumn>
+      <PixTableColumn @context={{context}} class="column--small">
+        <:header>Actions</:header>
+        <:cell>
+          <div class="actions">
+            <PixTooltip
+              @id='copy-whitelisted-url-link-tooltip'
+              @position="left"
+              @isInline={{true}}
+            >
+              <:triggerElement>
+                <PixIconButton
+                  @triggerAction={{fn this.copyUrl whitelistedUrl}}
+                  @iconName="copy"
+                  @iconPrefix="far"
+                  @ariaLabel="Copier l'URL whitelistée"
+                  class="icon"
+                  aria-describedby='copy-whitelisted-url-link-tooltip'
+                />
+              </:triggerElement>
+              <:tooltip>Copier l’URL whitelistée</:tooltip>
+            </PixTooltip>
+            <PixTooltip
+              @id='delete-whitelisted-url-tooltip'
+              @position="left"
+              @isInline={{true}}
+            >
+              <:triggerElement>
+                <PixIconButton
+                  @triggerAction={{fn this.deleteWhitelistedUrl whitelistedUrl}}
+                  @iconName="delete"
+                  @ariaLabel="Supprimer l'URL de la whitelist"
+                  class="icon"
+                  aria-describedby='delete-whitelisted-url-tooltip'
+                />
+              </:triggerElement>
+              <:tooltip>Supprimer l'URL de la whitelist</:tooltip>
+            </PixTooltip>
+          </div>
+        </:cell>
+      </PixTableColumn>
+    </:columns>
+  </PixTable>
 </div>

--- a/pix-editor/app/components/whitelisted-urls/list.js
+++ b/pix-editor/app/components/whitelisted-urls/list.js
@@ -1,8 +1,10 @@
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class WhitelistedUrlList extends Component {
+  @service router;
   @tracked searchUrl;
   @tracked searchNames;
 
@@ -61,8 +63,16 @@ export default class WhitelistedUrlList extends Component {
     return formater.format(date);
   }
 
-  async copyUrl(whitelistedUrl) {
+  @action
+  async copyUrl(whitelistedUrl, event) {
+    event.stopPropagation();
     await navigator.clipboard.writeText(whitelistedUrl.url);
+  }
+
+  @action
+  async deleteWhitelistedUrl(whitelistedUrl, event) {
+    event.stopPropagation();
+    await this.args.onDeleteItemClicked(whitelistedUrl);
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -26,8 +26,8 @@ export default class WhitelistedUrlsController extends Controller {
   }
 
   @action
-  goToEditWhitelistedUrl(whitelistedUrlId) {
-    this.router.transitionTo('authenticated.whitelisted-urls.whitelisted-url.edit', whitelistedUrlId);
+  goToEditWhitelistedUrl(whitelistedUrl) {
+    this.router.transitionTo('authenticated.whitelisted-urls.whitelisted-url.edit', whitelistedUrl.id);
   }
 
   @action

--- a/pix-editor/app/styles/authenticated/whitelisted-urls/list.scss
+++ b/pix-editor/app/styles/authenticated/whitelisted-urls/list.scss
@@ -1,5 +1,7 @@
+@use 'pix-design-tokens/shadows' as *;
+
 .filter-whitelisted-url-form {
-  .card__content{
+  .card__content {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -12,13 +14,12 @@
       width: 100%;
     }
 
-    .pix-textarea{
+    .pix-textarea {
       width: 100%;
     }
-
   }
 
-  &__select{
+  &__select {
     width: 100%;
   }
 
@@ -37,5 +38,30 @@
 
   &__description {
     font-size: 0.825rem;
+  }
+}
+
+.whitelisted-urls-table {
+  .pix-table {
+    @extend %pix-shadow-sm;
+  }
+
+  .column {
+    &--small {
+      width: 8%;
+      max-width: 150px;
+    }
+
+    &--wide {
+      width: 25%;
+    }
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    height: 100%;
+    margin: auto;
   }
 }

--- a/pix-editor/app/styles/globals/table.scss
+++ b/pix-editor/app/styles/globals/table.scss
@@ -3,7 +3,7 @@
 @use 'pix-design-tokens/fonts';
 
 .table-filter-banner {
-  margin: 12px 0;
+  margin-bottom: 0.75rem;
 }
 
 .panel-table-v2 {

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -58,10 +58,7 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');
-    assert.strictEqual(
-      screen.getAllByRole('row', { name: 'URL en liste blanche' }).length,
-      3,
-    );
+    assert.strictEqual(screen.getAllByRole('row').length, 4);
     assert.dom(screen.getByText('http://pipeau-la-grenouille.fr')).exists();
     assert.dom(screen.getByText('http://chats.fr')).exists();
     assert.dom(screen.getByText('http://chiens.fr')).exists();

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
   hooks.beforeEach(async function() {
     store = this.owner.lookup('service:store');
     whitelistedUrl1 = store.createRecord('whitelisted-url', {
-      id: 1,
+      id: '1',
       url: 'https://foo.com',
       creatorName: 'Laura le chocolat',
       latestUpdatorName: 'Iris l\'anis',
@@ -31,7 +31,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
       .format(new Date('2021-01-01T09:00:00Z'))
       .replaceAll(/[A-Za-z\s]/g, '');
     whitelistedUrl2 = store.createRecord('whitelisted-url', {
-      id: 2,
+      id: '2',
       url: 'https://bar.com',
       creatorName: 'Fael le miel',
       latestUpdatorName: null,
@@ -104,10 +104,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
         name: 'Modifiée le',
       }),
     );
-    assert.strictEqual(
-      screen.getAllByRole('row', { name: 'URL en liste blanche' }).length,
-      2,
-    );
+    assert.strictEqual(screen.getAllByRole('row').length, 3);
     assert.ok(screen.getByRole('cell', { name: 'https://foo.com' }), 'https://foo.com');
     assert.ok(screen.getByRole('cell', { name: 'Strictement égale à' }), 'Strictement égale à');
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Laura' }), 'Un commentaire sur Laura');


### PR DESCRIPTION
## 🌸 Problème

Reprise de #874.

On utilise une table faite maison dans la route `authenticated.whitelisted-urls.list`.

## 🌳 Proposition

Utiliser le composant PixTable de Pix UI.

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Tests OK
- Aller sur la [page de la whitelist de la moulinette des URLs
](https://pix-lcms-review-pr922.osc-fr1.scalingo.io/whitelisted-urls)
- Vérifier que le tableau s'affiche correctement
- Vérifier que les boutons de chaque ligne fonctionnent
