### PR TITLE
[BUGFIX] Les pages du générateur de profil cible et de l'atelier workbench ne sont plus accessibles (pix-17266)

### DIFF
--- a/pix-editor/app/adapters/application.js
+++ b/pix-editor/app/adapters/application.js
@@ -1,7 +1,7 @@
 import { inject as service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
-const FIND_GROUP_SIZE = 300;
+const FIND_GROUP_SIZE = 200;
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   @service session;


### PR DESCRIPTION
## 🌸 Problème

Les pages du générateur de profil cible et de l'atelier workbench ne sont plus accessibles

## 🌳 Proposition
Limiter la tailles des lots lorsqu'on requête plusieurs entité.

## 🐝 Remarques

RAS

## 🤧 Pour tester

Se rendre sur les pages et constater que l'on peut désormais y accéder
