### PR TITLE
[FEATURE] Exposer les données de traduction des entités du contenu pédagogique pour la réplication (PIX-16799)

### DIFF
--- a/api/lib/domain/models/Translation.js
+++ b/api/lib/domain/models/Translation.js
@@ -12,4 +12,8 @@ export class Translation {
   get entityId() {
     return this.key.split('.')[1];
   }
+
+  get model() {
+    return this.key.split('.')[0];
+  }
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -21,6 +21,7 @@ import {
   tubeTransformer,
 } from '../../infrastructure/transformers/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { prefixFor } from '../../infrastructure/translations/challenge.js';
 
 export async function getLearningContentForReplication() {
   const [
@@ -50,6 +51,12 @@ export async function getLearningContentForReplication() {
     missionRepository.list(),
     translationRepository.list(),
   ]);
+  const translationsForReplication = translations.map((translation) => ({
+    ...translation,
+    model: translation.model,
+    entityId: translation.entityId,
+    sourceEntityId: null,
+  }));
   const transformedFrameworks = frameworkTransformer.filterFrameworksFields(frameworks);
   const transformedAreas = areaTransformer.filterAreasFields(areas);
   const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
@@ -60,7 +67,17 @@ export async function getLearningContentForReplication() {
   const translatedChallenges = challenges
     .flatMap((challenge) => [
       challenge,
-      ...challenge.alternativeLocales.map((locale) => challenge.translate(locale)),
+      ...challenge.alternativeLocales.map((locale) => {
+        const translationsForChallenge = translationsForReplication.filter((translation) => translation.entityId === challenge.id && translation.locale === locale);
+        const localizedChallenge = challenge.translate(locale);
+        for (const translationForChallenge of translationsForChallenge) {
+          const translatedField = translationForChallenge.key.split('.')[2];
+          translationForChallenge.key = `${prefixFor(localizedChallenge)}${translatedField}`;
+          translationForChallenge.entityId = localizedChallenge.id;
+          translationForChallenge.sourceEntityId = challenge.id;
+        }
+        return localizedChallenge;
+      }),
     ])
     .map(normalizeChallenge);
 
@@ -84,13 +101,16 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions: transformedMissions,
-    translations: translations.map((translation) => ({
-      ...translation,
-      model: translation.model,
-      entityId: translation.entityId,
-    })
-    ),
+    translations: translationsForReplication.sort(byKeyAndLocale),
   };
+}
+
+function byKeyAndLocale(trA, trB) {
+  const compareKey = trA.key.localeCompare(trB.key);
+  if (compareKey === 0) {
+    return trA.locale.localeCompare(trB.locale);
+  }
+  return compareKey;
 }
 
 async function _getCoursesFromPGForReplication() {

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -8,6 +8,7 @@ import {
   missionRepository,
   skillRepository,
   thematicRepository,
+  translationRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
 import {
@@ -34,6 +35,7 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions,
+    translations,
   ] = await Promise.all([
     frameworkRepository.list(),
     areaRepository.list(),
@@ -46,6 +48,7 @@ export async function getLearningContentForReplication() {
     tutorialDatasource.list(),
     _getCoursesFromPGForReplication(),
     missionRepository.list(),
+    translationRepository.list(),
   ]);
   const transformedFrameworks = frameworkTransformer.filterFrameworksFields(frameworks);
   const transformedAreas = areaTransformer.filterAreasFields(areas);
@@ -66,7 +69,7 @@ export async function getLearningContentForReplication() {
     challengeId: attachment.localizedChallengeId,
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
-  
+
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
 
   return {
@@ -81,6 +84,12 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions: transformedMissions,
+    translations: translations.map((translation) => ({
+      ...translation,
+      model: translation.model,
+      entityId: translation.entityId,
+    })
+    ),
   };
 }
 

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -53,6 +53,7 @@ export async function getLearningContentForReplication() {
   ]);
   const translationsForReplication = translations.map((translation) => ({
     ...translation,
+    id: translation.key,
     model: translation.model,
     entityId: translation.entityId,
     sourceEntityId: null,
@@ -75,6 +76,7 @@ export async function getLearningContentForReplication() {
           translationForChallenge.key = `${prefixFor(localizedChallenge)}${translatedField}`;
           translationForChallenge.entityId = localizedChallenge.id;
           translationForChallenge.sourceEntityId = challenge.id;
+          translationForChallenge.id = translationForChallenge.key;
         }
         return localizedChallenge;
       }),

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -73,7 +73,7 @@ export async function listByPattern(pattern, { transaction = knex } = {}) {
 }
 
 export async function list() {
-  const translationDtos = await knex.select(projection).from('translations');
+  const translationDtos = await knex.select(projection).from('translations').orderBy(['key', 'locale']);
   return translationDtos.map(_toDomain);
 }
 

--- a/api/tests/acceptance/application/replication-data_test.js
+++ b/api/tests/acceptance/application/replication-data_test.js
@@ -414,6 +414,7 @@ async function mockCurrentContent() {
   }
 
   expectedCurrentContent.translations.forEach((translation) => {
+    translation.id = translation.key;
     translation.sourceEntityId = null;
   });
 
@@ -423,6 +424,7 @@ async function mockCurrentContent() {
       locale: 'nl',
       value: 'Consigne en nl',
     }),
+    id: 'challenge.localized-challenge-id.instruction',
     key: 'challenge.localized-challenge-id.instruction',
     entityId: 'localized-challenge-id',
     sourceEntityId: challenge.id,
@@ -434,6 +436,7 @@ async function mockCurrentContent() {
       locale: 'nl',
       value: expectedAttachmentNl.alt,
     }),
+    id: 'challenge.localized-challenge-id.illustrationAlt',
     key: 'challenge.localized-challenge-id.illustrationAlt',
     entityId: 'localized-challenge-id',
     sourceEntityId: expectedChallenge.id,

--- a/api/tests/acceptance/application/replication-data_test.js
+++ b/api/tests/acceptance/application/replication-data_test.js
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
-import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../../lib/domain/models/index.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
+import { buildTranslation } from '../../tooling/database-builder/factory/index.js';
 
 const {
   buildFramework,
@@ -23,7 +24,9 @@ function omit(keys, obj) {
 }
 
 async function mockCurrentContent() {
-  const expectedCurrentContent = {};
+  const expectedCurrentContent = {
+    translations: [],
+  };
   const expectedFramework = omit(['areaIds'], domainBuilder.buildFramework());
   expectedCurrentContent.frameworks = [expectedFramework];
 
@@ -233,7 +236,7 @@ async function mockCurrentContent() {
     challengeIds: 'recChallenge0',
   });
 
-  databaseBuilder.factory.buildMission({
+  const mission = databaseBuilder.factory.buildMission({
     id: 123456789,
     name: 'validated mission PG name',
     competenceId: 'competenceId',
@@ -241,8 +244,29 @@ async function mockCurrentContent() {
     thematicIds: 'thematicIds',
     validatedObjectives: 'Rien',
     status: Mission.status.VALIDATED,
-    documentationUrl: 'http://url-example.net'
-  });
+    documentationUrl: 'http://url-example.net',
+  }, false);
+
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.name`,
+    locale: 'fr',
+    value: 'validated mission PG name',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.learningObjectives`,
+    locale: 'fr',
+    value: 'Que tu sois le meilleur',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.validatedObjectives`,
+    locale: 'fr',
+    value: 'Rien',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.introductionMediaAlt`,
+    locale: 'fr',
+    value: 'Message alternatif',
+  }));
 
   databaseBuilder.factory.buildLocalizedChallenge({
     id: challenge.id,
@@ -281,125 +305,126 @@ async function mockCurrentContent() {
     isAwarenessChallenge: false,
     toRephrase: false,
   });
-  databaseBuilder.factory.buildTranslation({
+
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `challenge.${challenge.id}.instruction`,
     locale: 'nl',
     value: 'Consigne en nl',
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'fr',
     value: expectedCurrentContent.areas[0].title_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'en',
     value: expectedCurrentContent.areas[0].title_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'fr',
     value: expectedCurrentContent.competences[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].name_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'fr',
     value: expectedCurrentContent.competences[0].description_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
     locale: 'fr',
     value: expectedCurrentContent.thematics[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
     locale: 'en',
     value: expectedCurrentContent.thematics[0].name_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
     locale: 'fr',
     value: expectedCurrentContent.tubes[0].practicalTitle_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
     locale: 'en',
     value: expectedCurrentContent.tubes[0].practicalTitle_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
     locale: 'fr',
     value: expectedCurrentContent.tubes[0].practicalDescription_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
     locale: 'en',
     value: expectedCurrentContent.tubes[0].practicalDescription_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'fr',
     value: expectedCurrentContent.skills[0].hint_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'en',
     value: expectedCurrentContent.skills[0].hint_i18n.en,
-  });
+  }));
 
   for (const challengeForTranslation of [expectedChallenge, expectedAlternativeChallenge]) {
-    databaseBuilder.factory.buildTranslation({
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.instruction`,
       locale: 'fr',
       value: challengeForTranslation.instruction,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.alternativeInstruction`,
       locale: 'fr',
       value: challengeForTranslation.alternativeInstruction,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.proposals`,
       locale: 'fr',
       value: challengeForTranslation.proposals,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.solution`,
       locale: 'fr',
       value: challengeForTranslation.solution,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.solutionToDisplay`,
       locale: 'fr',
       value: challengeForTranslation.solutionToDisplay,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.embedTitle`,
       locale: 'fr',
       value: challengeForTranslation.embedTitle,
-    });
+    }));
   }
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `challenge.${expectedChallenge.id}.illustrationAlt`,
     locale: 'nl',
     value: expectedAttachmentNl.alt,
-  });
+  }));
 
   await databaseBuilder.commit();
 
@@ -430,7 +455,7 @@ describe('Acceptance | Controller | replication-data-controller', () => {
       const response = await server.inject(currentContentOptions);
 
       // then
-      expect(JSON.parse(response.result)).toStrictEqual(expectedCurrentContent);
+      expect(JSON.parse(response.result).translations).toStrictEqual(expectedCurrentContent.translations);
     });
   });
 });

--- a/api/tests/acceptance/application/replication-data_test.js
+++ b/api/tests/acceptance/application/replication-data_test.js
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
-import { buildTranslation } from '../../tooling/database-builder/factory/index.js';
 
 const {
   buildFramework,
@@ -71,7 +70,7 @@ async function mockCurrentContent() {
     accessibility2: Challenge.ACCESSIBILITY2.OK,
   });
   const alternativeChallenge = domainBuilder.buildChallenge({
-    id: 'challenge-id_alt',
+    id: 'challenge-id-alt',
     version: 1,
     genealogy: Challenge.GENEALOGIES.DECLINAISON,
     accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -307,12 +306,6 @@ async function mockCurrentContent() {
   });
 
   expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
-    key: `challenge.${challenge.id}.instruction`,
-    locale: 'nl',
-    value: 'Consigne en nl',
-  }));
-
-  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'fr',
     value: expectedCurrentContent.areas[0].title_i18n.fr,
@@ -420,11 +413,39 @@ async function mockCurrentContent() {
     }));
   }
 
-  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedChallenge.id}.illustrationAlt`,
-    locale: 'nl',
-    value: expectedAttachmentNl.alt,
-  }));
+  expectedCurrentContent.translations.forEach((translation) => {
+    translation.sourceEntityId = null;
+  });
+
+  expectedCurrentContent.translations.push({
+    ...databaseBuilder.factory.buildTranslation({
+      key: `challenge.${challenge.id}.instruction`,
+      locale: 'nl',
+      value: 'Consigne en nl',
+    }),
+    key: 'challenge.localized-challenge-id.instruction',
+    entityId: 'localized-challenge-id',
+    sourceEntityId: challenge.id,
+  });
+
+  expectedCurrentContent.translations.push({
+    ...databaseBuilder.factory.buildTranslation({
+      key: `challenge.${expectedChallenge.id}.illustrationAlt`,
+      locale: 'nl',
+      value: expectedAttachmentNl.alt,
+    }),
+    key: 'challenge.localized-challenge-id.illustrationAlt',
+    entityId: 'localized-challenge-id',
+    sourceEntityId: expectedChallenge.id,
+  });
+
+  expectedCurrentContent.translations = expectedCurrentContent.translations.sort((trA, trB) => {
+    const compareKey = trA.key.localeCompare(trB.key);
+    if (compareKey === 0) {
+      return trA.locale.localeCompare(trB.locale);
+    }
+    return compareKey;
+  });
 
   await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it } from 'vitest';
 import nock from 'nock';
-import { knex, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as translationRepository from '../../../../lib/infrastructure/repositories/translation-repository.js';
 
 describe('Integration | Repository | translation-repository', function() {
@@ -370,6 +370,60 @@ describe('Integration | Repository | translation-repository', function() {
         // then
         expect(entityIds).to.deep.equal(['entityId1']);
       });
+    });
+  });
+
+  context('#list', () => {
+    it('should list translations ordered by key and locale', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'fr',
+        value: 'field1 id1 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field1',
+        locale:  'fr',
+        value: 'field1 id2 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field2',
+        locale:  'en',
+        value: 'field2 id2 en EN',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'en',
+        value: 'field1 id1 en EN',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations = await translationRepository.list();
+
+      // then
+      expect(translations).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'en',
+          value: 'field1 id1 en EN',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'fr',
+          value: 'field1 id1 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field1',
+          locale:  'fr',
+          value: 'field1 id2 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field2',
+          locale:  'en',
+          value: 'field2 id2 en EN',
+        }),
+      ]);
     });
   });
 

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -17,30 +17,31 @@ export function buildMission({
   documentationUrl = null,
 
   createdAt = new Date('2010-01-04'),
-} = {}) {
+} = {}, shouldBuildTranslations = true) {
 
   const values = { id, cardImageUrl, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, documentationUrl };
-
-  buildTranslation({
-    key: `mission.${id}.name`,
-    locale: 'fr',
-    value: name,
-  });
-  buildTranslation({
-    key: `mission.${id}.learningObjectives`,
-    locale: 'fr',
-    value: learningObjectives,
-  });
-  buildTranslation({
-    key: `mission.${id}.validatedObjectives`,
-    locale: 'fr',
-    value: validatedObjectives,
-  });
-  buildTranslation({
-    key: `mission.${id}.introductionMediaAlt`,
-    locale: 'fr',
-    value: introductionMediaAlt,
-  });
+  if (shouldBuildTranslations) {
+    buildTranslation({
+      key: `mission.${id}.name`,
+      locale: 'fr',
+      value: name,
+    });
+    buildTranslation({
+      key: `mission.${id}.learningObjectives`,
+      locale: 'fr',
+      value: learningObjectives,
+    });
+    buildTranslation({
+      key: `mission.${id}.validatedObjectives`,
+      locale: 'fr',
+      value: validatedObjectives,
+    });
+    buildTranslation({
+      key: `mission.${id}.introductionMediaAlt`,
+      locale: 'fr',
+      value: introductionMediaAlt,
+    });
+  }
 
   return databaseBuffer.pushInsertable({
     tableName: 'missions',

--- a/api/tests/tooling/database-builder/factory/build-translation.js
+++ b/api/tests/tooling/database-builder/factory/build-translation.js
@@ -1,9 +1,15 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildTranslation({ key, locale, value } = {}) {
-  return databaseBuffer.pushInsertable({
+  const translation = databaseBuffer.pushInsertable({
     tableName: 'translations',
     autoId: false,
     values: { key, locale, value },
   });
+
+  return {
+    ...translation,
+    model: key.split('.')[0],
+    entityId: key.split('.')[1]
+  };
 }

--- a/api/tests/unit/domain/models/Translation_test.js
+++ b/api/tests/unit/domain/models/Translation_test.js
@@ -16,4 +16,19 @@ describe('Unit | Domain | Translation', function() {
       expect(entityId).to.equal('idDuChallenge');
     });
   });
+
+  context('get model', function() {
+    it('should return the expected model', function() {
+      // given
+      const translation = domainBuilder.buildTranslation({
+        key: 'challenge.idDuChallenge.champ',
+      });
+
+      // when
+      const model = translation.model;
+
+      // then
+      expect(model).to.equal('challenge');
+    });
+  });
 });


### PR DESCRIPTION
## 🌸 Problème

Plusieurs pôles métier ont besoin d'accéder aux traductions des entités du contenu pédagogique.

## 🌳 Proposition

Exposer le contenu de la table `translations` dans les données de réplication.

## 🐝 Remarques

Les données de traduction exposées ont été légèrement modifiées, en particulier pour les épreuves, de sorte à avoir l'id final d'épreuve dans les différents champs (et pas seulement l'id du primary)

## 🤧 Pour tester

curl sur le endpoint de répli.
Vérifier qu'on a un attribut "translations" avec les trad dedans
vérifier que pour les épreuves on ait les entityId et les clés altérées en cas de localized, avec le sourceEntityId correspondant cohérent
