### PR TITLE
[FEATURE] Ne pas afficher les liens de traduction vers Phrase quand l'épreuve est fr-fr (PIX-17041)

### DIFF
--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -30,6 +30,7 @@ export default class LocalizedChallengesProduction extends Component {
     }
     return this.args.challenges
       .filter((challenge) => !excludeStatuses.includes(challenge.status))
+      .filter((challenge) => challenge.locales.includes(this.args.locale) || challenge.locales.includes('fr'))
       .sort(byAlternativeVersion);
   }
 

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -46,7 +46,7 @@ export default class LocalizedChallengesProduction extends Component {
         instruction: localizedChallengeForLocale?.instruction ?? challenge.instruction,
         primaryUpdatedAt: challenge.updatedAt,
         primaryAuthor: challenge.author,
-        translationsUrl: isPrimaryInLocale ? null : `/api/challenges/${challenge.id}/translations/${this.args.locale}/area-code/${this.args.areaCode}`,
+        translationsUrl: this.getTranslationsUrl({ isPrimaryInLocale, challenge }),
         primaryStatusColor: this.getPrimaryStatusColor(challenge.status),
         primaryStatusText: this.getPrimaryStatusText(challenge.status),
         localizedStatusColor: this.getLocalizedStatusColor(localizedStatus),
@@ -58,6 +58,12 @@ export default class LocalizedChallengesProduction extends Component {
         isNotTranslated: !isPrimaryInLocale && localizedChallengeForLocale,
       };
     });
+  }
+
+  getTranslationsUrl({ isPrimaryInLocale, challenge }) {
+    if (this.args.locale === 'fr-fr') return null;
+    if (isPrimaryInLocale) return null;
+    return `/api/challenges/${challenge.id}/translations/${this.args.locale}/area-code/${this.args.areaCode}`;
   }
 
   getPrimaryStatusColor(primaryStatus) {

--- a/pix-editor/eslint.config.mjs
+++ b/pix-editor/eslint.config.mjs
@@ -73,6 +73,7 @@ export default [
       ],
 
       'qunit/require-expect': ['error', 'except-simple'],
+      'ember/template-no-let-reference': 'off',
     },
   },
   {

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -9,11 +9,11 @@ import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
 module('Integration | Component | challenges-production | localized-challenges-production', function(hooks) {
   setupIntlRenderingTest(hooks);
-  let screen, store;
+  let screen, store, skill, challenges, localizedChallenges, locale, areaCode;
 
   hooks.beforeEach(async function() {
     store = this.owner.lookup('service:store');
-    const skill = store.createRecord('skill', {
+    skill = store.createRecord('skill', {
       id: 'skillAId',
       name: '@skillA1',
       version: 3,
@@ -147,14 +147,14 @@ module('Integration | Component | challenges-production | localized-challenges-p
       status: LocalizedChallenge.STATUSES.PAUSE,
     });
 
-    const challenges = [
+    challenges = [
       challengeProtoValide,
       challengeDecliArchivee,
       challengeDecliNl,
       challengeDecliProposee,
       challengeDecliObsolete,
     ];
-    const localizedChallenges = [
+    localizedChallenges = [
       localizedProtoValideFr,
       localizedProtoValideNl,
       localizedDecliArchiveeFr,
@@ -165,26 +165,27 @@ module('Integration | Component | challenges-production | localized-challenges-p
       localizedDecliObsoleteFr,
       localizedDecliObsoleteNl,
     ];
-    const locale = 'nl';
-    const areaCode = '1';
-
-    screen = await render(<template>
-<LocalizedChallengesProduction
-  @skill={{skill}}
-  @challenges={{challenges}}
-  @localizedChallenges={{localizedChallenges}}
-  @locale={{locale}}
-  @areaCode={{areaCode}}
-/>
-</template>);
+    locale = 'nl';
+    areaCode = '1';
   });
 
-  module('list item', function() {
+  module('list item', function(hooks) {
+    hooks.beforeEach(async ()=> {
+      screen = await render(<template>
+        <LocalizedChallengesProduction
+          @skill={{skill}}
+          @challenges={{challenges}}
+          @localizedChallenges={{localizedChallenges}}
+          @locale={{locale}}
+          @areaCode={{areaCode}}
+        />
+      </template>);
+    });
+
     test('should display all expected info for a given challenge', async function(assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
       const prototype = validatedChallenges[1];
-
       assert.dom(prototype).includesText('Proto');
       assert.dom(prototype).includesText('Een super maxi lange instructie');
       assert.dom(prototype).includesText('25/12/2019');
@@ -255,8 +256,40 @@ module('Integration | Component | challenges-production | localized-challenges-p
   });
 
   module('when displaying the list', function() {
+    test('it should display only challenge who has selected locale or fr', async function(assert) {
+      // given
+      locale = 'es';
+
+      // when
+      screen = await render(<template>
+        <LocalizedChallengesProduction
+          @skill={{skill}}
+          @challenges={{challenges}}
+          @localizedChallenges={{localizedChallenges}}
+          @locale={{locale}}
+          @areaCode={{areaCode}}
+        />
+      </template>);
+
+      // then
+      const challengesList = screen.queryAllByRole('row');
+      const challengeListWithoutThead = challengesList.slice(1);
+      assert.strictEqual(challengeListWithoutThead.length, 3);
+    });
+
     module('when box to display obsolete challenges not checked', function() {
       test('should display all but obsolete', async function(assert) {
+        // when
+        screen = await render(<template>
+          <LocalizedChallengesProduction
+            @skill={{skill}}
+            @challenges={{challenges}}
+            @localizedChallenges={{localizedChallenges}}
+            @locale={{locale}}
+            @areaCode={{areaCode}}
+          />
+        </template>);
+
         // then
         const validatedChallenges = screen.queryAllByText('validé');
         const obsoleteChallenges = screen.queryAllByText('périmé');
@@ -272,6 +305,16 @@ module('Integration | Component | challenges-production | localized-challenges-p
     module('when box to display obsolete challenges checked', function() {
       test('display all challenges', async function(assert) {
         // when
+        screen = await render(<template>
+          <LocalizedChallengesProduction
+            @skill={{skill}}
+            @challenges={{challenges}}
+            @localizedChallenges={{localizedChallenges}}
+            @locale={{locale}}
+            @areaCode={{areaCode}}
+          />
+        </template>);
+
         await click(screen.getByLabelText('Afficher les épreuves périmées'));
 
         // then

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -277,6 +277,29 @@ module('Integration | Component | challenges-production | localized-challenges-p
       assert.strictEqual(challengeListWithoutThead.length, 3);
     });
 
+    module('when locale is not in phrase', function() {
+      test('when locale is not in phrase', async function(assert) {
+        // given
+        locale = 'fr-fr';
+
+        // when
+        screen = await render(<template>
+          <LocalizedChallengesProduction
+            @skill={{skill}}
+            @challenges={{challenges}}
+            @localizedChallenges={{localizedChallenges}}
+            @locale={{locale}}
+            @areaCode={{areaCode}}
+          />
+        </template>);
+
+        // then
+        const phraseLinks = screen.queryAllByRole('link', { name: /traduction de l'épreuve de version/ });
+
+        assert.strictEqual(phraseLinks.length, 0);
+      });
+    });
+
     module('when box to display obsolete challenges not checked', function() {
       test('should display all but obsolete', async function(assert) {
         // when


### PR DESCRIPTION
## 🌸 Problème
On affichait le lien vers Phrase pour des épreuves `fr-fr`, alors qu'il ne faut pas.
De plus, quand le filtre de langue était activé, on affichait aussi des versions d'épreuves qui n'étaient pas pertinentes.

## 🌳 Proposition
Filtrer les épreuves `fr-fr` pour ne pas afficher le lien vers Phrase dans ces cas-là.
Lors de l'utilisation du filtre par langue, ne remonter que les épreuves dont la langue source est égale à cette langue ou à `fr`

## 🐝 Remarques
RAS

## 🤧 Pour tester
* Se mettre en vue v2.
* Chercher une épreuve en `fr-fr`
* Vérifier que le bouton pour aller vers Phrase ne s'affiche pas sur l'épreuve en question.
* 🎉