### PR TITLE
[FEATURE] Renommer la page de la whitelist des URLs pour plus de clarté (PIX-17356)

### DIFF
--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -35,7 +35,7 @@
     {{#if this.mayAccessWhitelistedUrls}}
       <LinkTo class="secondary-links--action" data-test-whitelisted-urls-link @route="authenticated.whitelisted-urls" {{on "click" @close}}>
         <PixIcon @name="bookAlt" @ariaHidden={{true}}/>
-        Whitelist moulinette des URLs
+        URLs à ne pas analyser
       </LinkTo>
     {{/if}}
     <Sidebar::Export @areas={{this.areas}}/>

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/list.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <h1 class="page-title">Whitelist de la moulinette des URLs cassées</h1>
+  <h1 class="page-title">URLs à ne pas analyser dans les moulinettes</h1>
   <div class="page-actions">
     <PixTooltip
       @id='create-whitelisted-url-tooltip'

--- a/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
@@ -56,7 +56,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
   test('should create a whitelisted url', async function(assert) {
     // given
     const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('URLs à ne pas analyser');
     await clickByName('Ajouter une nouvelle URL');
 
     // when
@@ -76,7 +76,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
   test('should create a whitelisted url without comment and different check type', async function(assert) {
     // given
     const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('URLs à ne pas analyser');
     await clickByName('Ajouter une nouvelle URL');
 
     // when

--- a/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
@@ -56,7 +56,7 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
   test('should edit a whitelisted url', async function(assert) {
     // given
     const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('URLs à ne pas analyser');
     await clickByText('MIAOU');
 
     // when
@@ -75,7 +75,7 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
   test('should edit a whitelisted url\'s url', async function(assert) {
     // given
     const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('URLs à ne pas analyser');
     await clickByText('OUAF');
 
     // when

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -54,7 +54,7 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
   test('should display whitelisted urls when accessing list', async function(assert) {
     // when
     const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('URLs à ne pas analyser');
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');
@@ -67,7 +67,7 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
   test('should delete delete whitelisted url', async function(assert) {
     // when
     const screen = await visit('/');
-    await clickByName('Whitelist moulinette des URLs');
+    await clickByName('URLs à ne pas analyser');
 
     const deleteButtons = await screen.findAllByRole('button', { name: 'Supprimer l\'URL de la whitelist' });
     await click(deleteButtons[0]);


### PR DESCRIPTION
## 🌸 Problème
Puisqu'il existe deux moulinettes d'URL pour deux cas d'usage différents, le nom de notre page `Whiteliste de la moulinette des URLs` n'était pas assez clair.

## 🌳 Proposition
Changer son titre dans le menu en `URLs à ne pas analyser`
et dans la page même en `URLs à ne pas analyser dans les moulinettes`

## 🐝 Remarques
RAS

## 🤧 Pour tester
* Aller sur Pix-Editor, voir le menu et constater que le titre du menu concerné a bien changé en `URLs à ne pas analyser`
* Idem en allant sur la page en question avec `URLs à ne pas analyser dans les moulinettes`
* Tests au vert.