### PR TITLE
[TECH] Retirer la route GET /api/databases/airtable

### DIFF
--- a/api/lib/application/replication-data.js
+++ b/api/lib/application/replication-data.js
@@ -5,15 +5,6 @@ export async function register(server) {
   server.route([
     {
       method: 'GET',
-      path: '/api/databases/airtable',
-      config: {
-        handler: async function() {
-          return promiseStreamer(getLearningContentForReplication());
-        },
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/replication-data',
       config: {
         handler: async function() {


### PR DESCRIPTION
## 🌸 Problème

Il existe deux routes pour récupérer les données de réplication.
Elles font exactement la même chose.

## 🌳 Proposition

Supprimer GET /api/database/airtable pour ne garder que GET /api/replication-data

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

rien 🤷🏿 
