### PR TITLE
[FEATURE] Retirer toute mention du terme whitelist (PIX-17449)

### DIFF
--- a/pix-editor/app/components/form/whitelisted-url.hbs
+++ b/pix-editor/app/components/form/whitelisted-url.hbs
@@ -22,7 +22,7 @@
         placeholder="https://example.org"
         {{on "input" this.updateUrl}}
       >
-        <:label>URL à whitelister</:label>
+        <:label>URL à ne pas analyser</:label>
       </PixInput>
     </div>
   </Card>

--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -78,12 +78,12 @@
                   @triggerAction={{fn this.copyUrl whitelistedUrl}}
                   @iconName="copy"
                   @iconPrefix="far"
-                  @ariaLabel="Copier l'URL whitelistée"
+                  @ariaLabel="Copier l'URL"
                   class="icon"
                   aria-describedby='copy-whitelisted-url-link-tooltip'
                 />
               </:triggerElement>
-              <:tooltip>Copier l’URL whitelistée</:tooltip>
+              <:tooltip>Copier l’URL</:tooltip>
             </PixTooltip>
             <PixTooltip
               @id='delete-whitelisted-url-tooltip'
@@ -94,12 +94,12 @@
                 <PixIconButton
                   @triggerAction={{fn this.deleteWhitelistedUrl whitelistedUrl}}
                   @iconName="delete"
-                  @ariaLabel="Supprimer l'URL de la whitelist"
+                  @ariaLabel="Supprimer l'URL"
                   class="icon"
                   aria-describedby='delete-whitelisted-url-tooltip'
                 />
               </:triggerElement>
-              <:tooltip>Supprimer l'URL de la whitelist</:tooltip>
+              <:tooltip>Supprimer l'URL</:tooltip>
             </PixTooltip>
           </div>
         </:cell>

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -45,12 +45,12 @@ export default class WhitelistedUrlsController extends Controller {
   @action
   async deleteUrl(whitelistedUrl) {
     try {
-      await this.confirm.ask('Suppression', 'Êtes-vous sûr de vouloir supprimer cette URL de la whitelist ?');
+      await this.confirm.ask('Suppression', 'Êtes-vous sûr de vouloir supprimer cette URL ? (Cette URL pourra à nouveau être analysée par les moulinettes)');
     } catch {
       return;
     }
     await whitelistedUrl.destroyRecord().catch(() => {
-      this.notifications.error('Une erreur est survenue lors de la suppression de cette URL de la whitelist.');
+      this.notifications.error('Une erreur est survenue lors de la suppression de cette URL.');
     });
   }
 }

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/new.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/new.js
@@ -12,11 +12,11 @@ export default class NewWhitelistedUrlController extends Controller {
     const whitelistedUrl = this.store.createRecord('whitelisted-url', formData);
     try {
       await whitelistedUrl.save();
-      this.notifications.success('URL ajoutée à la whitelist avec succès.');
+      this.notifications.success('URL ajoutée avec succès.');
       this.router.transitionTo('authenticated.whitelisted-urls.list');
     } catch (err) {
       whitelistedUrl.deleteRecord();
-      await this.notifications.error('Une erreur est survenue lors de l\'ajout de l\'URL à la whitelist');
+      await this.notifications.error('Une erreur est survenue lors de l\'ajout de l\'URL');
       const knownErrors = err?.errors.map((error) => error.detail).join('\n');
       const finalErrors = knownErrors ?? JSON.stringify(err);
       throw new Error(finalErrors);

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/whitelisted-url/edit.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/whitelisted-url/edit.js
@@ -15,10 +15,10 @@ export default class EditWhitelistedUrlController extends Controller {
         whitelistedUrl[property] = value;
       }
       await whitelistedUrl.save();
-      this.notifications.success('URL whitelistée modifiée avec succès.');
+      this.notifications.success('URL modifiée avec succès.');
       this.router.transitionTo('authenticated.whitelisted-urls.list');
     } catch (err) {
-      await this.notifications.error('Une erreur est survenue lors de la modification de l\'URL whitelistée.');
+      await this.notifications.error('Une erreur est survenue lors de la modification de l\'URL.');
       const knownErrors = err?.errors.map((error) => error.detail).join('\n');
       const finalErrors = knownErrors ?? JSON.stringify(err);
       throw new Error(finalErrors);

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/new.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/new.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <h1 class="page-title">Ajout d'une URL whitelistée</h1>
+  <h1 class="page-title">Ajout d'une URL à ne pas analyser dans les moulinettes</h1>
 </header>
 <main class="page-body">
   <section class="page-section">
@@ -10,7 +10,7 @@
       @initialCheckType=""
       @cancelButtonText="Annuler"
       @onFormCancelled={{this.goBackToList}}
-      @submitButtonText={{"Ajouter l'URL à la whitelist"}}
+      @submitButtonText={{"Ajouter"}}
       @onFormSubmitted={{this.createWhitelistedUrl}}
     />
   </section>

--- a/pix-editor/app/templates/authenticated/whitelisted-urls/whitelisted-url/edit.hbs
+++ b/pix-editor/app/templates/authenticated/whitelisted-urls/whitelisted-url/edit.hbs
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <h1 class="page-title">Édition d'une URL whitelistée</h1>
+  <h1 class="page-title">Édition d'une URL à ne pas analyser dans les moulinettes</h1>
 </header>
 <main class="page-body">
   <section class="page-section">
@@ -10,7 +10,7 @@
       @initialCheckType={{this.model.whitelistedUrl.checkType}}
       @cancelButtonText="Annuler"
       @onFormCancelled={{this.goBackToList}}
-      @submitButtonText={{"Modifier l'URL whitelistée"}}
+      @submitButtonText={{"Modifier"}}
       @onFormSubmitted={{this.editWhitelistedUrl}}
     />
   </section>

--- a/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
@@ -60,10 +60,10 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
     await clickByName('Ajouter une nouvelle URL');
 
     // when
-    await fillByLabel('URL à whitelister', 'https://example.org');
+    await fillByLabel('URL à ne pas analyser', 'https://example.org');
     await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
     await fillByLabel('Commentaire', 'Test de création');
-    await clickByName('Ajouter l\'URL à la whitelist');
+    await clickByName('Ajouter');
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');
@@ -82,9 +82,9 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
     // when
     await clickByName('Type de comparaison d\'URL');
     await clickByText('Commence par');
-    await fillByLabel('URL à whitelister', 'https://example.org');
+    await fillByLabel('URL à ne pas analyser', 'https://example.org');
     await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
-    await clickByName('Ajouter l\'URL à la whitelist');
+    await clickByName('Ajouter');
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');

--- a/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
@@ -62,7 +62,7 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
     // when
     await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@miaou1,@croquettes2');
     await fillByLabel('Commentaire', 'MIAOU MIAOU');
-    await clickByName('Modifier l\'URL whitelistée');
+    await clickByName('Modifier');
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');
@@ -79,8 +79,8 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
     await clickByText('OUAF');
 
     // when
-    await fillByLabel('URL à whitelister', 'https://en.wikipedia.org/wiki/Dog');
-    await clickByName('Modifier l\'URL whitelistée');
+    await fillByLabel('URL à ne pas analyser', 'https://en.wikipedia.org/wiki/Dog');
+    await clickByName('Modifier');
 
     // then
     assert.strictEqual(currentURL(), '/whitelisted-urls');

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -69,7 +69,7 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');
 
-    const deleteButtons = await screen.findAllByRole('button', { name: 'Supprimer l\'URL de la whitelist' });
+    const deleteButtons = await screen.findAllByRole('button', { name: 'Supprimer l\'URL' });
     await click(deleteButtons[0]);
     await click(await screen.findByRole('button', { name: 'Oui' }));
 

--- a/pix-editor/tests/integration/components/form/whitelisted-url-test.js
+++ b/pix-editor/tests/integration/components/form/whitelisted-url-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
 
     const onSubmit = sinon.spy(() => {});
 
-    this.set('submitButtonText', 'Ajouter l\'URL à la whitelist');
+    this.set('submitButtonText', 'Ajouter');
     this.set('createWhitelistedUrl', onSubmit);
 
     const screen = await render(
@@ -26,9 +26,9 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
         @onFormSubmitted={{this.createWhitelistedUrl}}
       />`);
 
-    await fillByLabel('URL à whitelister', 'https://example.org');
+    await fillByLabel('URL à ne pas analyser', 'https://example.org');
 
-    const submitButton = screen.getByRole('button', { name: 'Ajouter l\'URL à la whitelist' });
+    const submitButton = screen.getByRole('button', { name: 'Ajouter' });
     await click(submitButton);
     assert.ok(onSubmit.calledOnce);
     assert.deepEqual(onSubmit.args[0][0], {
@@ -57,7 +57,7 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
 
   test('should enable add url button when mandatory information has been given', async function(assert) {
 
-    this.set('submitButtonText', 'Ajouter l\'URL à la whitelist');
+    this.set('submitButtonText', 'Ajouter');
 
     const screen = await render(
       hbs`<Form::WhitelistedUrl
@@ -68,15 +68,15 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
         @submitButtonText={{this.submitButtonText}}
       />`);
 
-    await fillByLabel('URL à whitelister', 'https://example.org');
+    await fillByLabel('URL à ne pas analyser', 'https://example.org');
 
-    const button = screen.getByRole('button', { name: 'Ajouter l\'URL à la whitelist' });
+    const button = screen.getByRole('button', { name: 'Ajouter' });
     assert.dom(button).doesNotHaveAttribute('disabled');
   });
 
   test('should disable create mission button when no complete informations', async function(assert) {
 
-    this.set('submitButtonText', 'Ajouter l\'URL à la whitelist');
+    this.set('submitButtonText', 'Ajouter');
 
     const screen = await render(
       hbs`<Form::WhitelistedUrl
@@ -87,7 +87,7 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
         @submitButtonText={{this.submitButtonText}}
       />`);
 
-    const button = screen.getByRole('button', { name: 'Ajouter l\'URL à la whitelist' });
+    const button = screen.getByRole('button', { name: 'Ajouter' });
     assert.dom(button).hasAttribute('disabled');
 
     await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
@@ -105,15 +105,15 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
         @submitButtonText={{this.submitButtonText}}
       />`);
 
-    await fillByLabel('URL à whitelister', '');
+    await fillByLabel('URL à ne pas analyser', '');
     const urlErrorMandatoryField = screen.getByText('L\'URL est obligatoire');
     assert.dom(urlErrorMandatoryField).isVisible();
 
-    await fillByLabel('URL à whitelister *', 'chouchou beignets');
+    await fillByLabel('URL à ne pas analyser *', 'chouchou beignets');
     const urlErrorInvalidUrl = screen.getByText('L\'URL n\'est pas valide');
     assert.dom(urlErrorInvalidUrl).isVisible();
 
-    await fillByLabel('URL à whitelister *', 'https://example.org');
+    await fillByLabel('URL à ne pas analyser *', 'https://example.org');
     assert.dom(urlErrorInvalidUrl).isNotVisible();
     assert.dom(urlErrorMandatoryField).isNotVisible();
 


### PR DESCRIPTION
## 🌸 Problème
Le terme de `whitelist` n'est pas vraiment clair, on a préféré le changer pour "ne pas analyser"

## 🌳 Proposition
Retirer toute mention du terme whitelist

## 🐝 Remarques
Il semble qu'il y a encore mention de ce terme, quand un utilisateur qui n'a pas les droits requis tente de faire des choses dans la page concernée. (vous n'avez pas les droits pour ajouter une URL à la whiteliste) Je n'y ai pas touché mais on peut peut peut-être modifier aussi le terme à ces endroits.

## 🤧 Pour tester
* Aller sur la page URLs à ne pas analyser.
* Tester de la création, modification, suppression dedans, et constater qu'il n'est fait mention nulle part de `whitelist`
* Tests au vert
