### PR TITLE
[TECH] Dans l'endpoint /api/replication-data, envoyer les données de réplication dans le flux attribut par attribut, et non plus d'un seul bloc

### DIFF
--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -19,7 +19,17 @@ export function promiseStreamer(promise, writableStream = getWritableStream()) {
     writableStream.write('\n');
   }, 1000);
   promise.then((data) => {
-    writableStream.write(JSON.stringify(data));
+    clearInterval(timer);
+    writableStream.write('{');
+    const keys = Object.keys(data);
+    while (keys.length > 0) {
+      const key = keys.shift();
+      writableStream.write('"' + key + '":' + JSON.stringify(data[key]));
+      if (keys.length !== 0) {
+        writableStream.write(',');
+      }
+    }
+    writableStream.write('}');
   }).catch((error) => {
     logger.error(error);
     Sentry.captureException(error);


### PR DESCRIPTION
## 🌸 Problème
Le stream s'interrompt de façon un peu pas claire/mystérieuse pour nous.
Il semblerait que ce soit côté LCMS et pas réplication qui pose problème.
On suppose que le volume de data, avec l'ajout des trads, est trop important, d'autant qu'avant d'envoyer dans le stream on fait un JSON.stringify, qui de fait double l'espace occupé par les données de réplication.

## 🌳 Proposition
Ecrire la version stringifiée des données de réplication petit à petit, attribut par attribut

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
