### PR TITLE
[TECH] S'assurer que le stream est toujours fonctionnel avant d'écrire dedans

### DIFF
--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -33,10 +33,14 @@ export function promiseStreamer(promise, writableStream = getWritableStream()) {
   }).catch((error) => {
     logger.error(error);
     Sentry.captureException(error);
-    writableStream.write('error');
+    if (!writableStream.closed) {
+      writableStream.write('error');
+    }
   }).finally(() => {
     clearInterval(timer);
-    writableStream.end();
+    if (!writableStream.closed) {
+      writableStream.end();
+    }
   });
   return writableStream;
 }


### PR DESCRIPTION
## 🌸 Problème
On essaye d'écrire dans le stream dans le catch et/ou le finally, mais en fait on sait pas à ce stade là si le stream est prêt à recevoir du flux (parce qu'il s'est cassé entre temps ?...)

## 🌳 Proposition

Vérifier que le stream n'est pas fermé avant de tenter d'écrire dedans.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
