### PR TITLE
[BUGFIX] Les ids donnés à la volée lors de la création des données de réplication pour les traductions n'étaient pas uniques + rétablissement du code lié à l'ajout des traductions dans la répli

### DIFF
--- a/api/lib/domain/models/Translation.js
+++ b/api/lib/domain/models/Translation.js
@@ -12,4 +12,8 @@ export class Translation {
   get entityId() {
     return this.key.split('.')[1];
   }
+
+  get model() {
+    return this.key.split('.')[0];
+  }
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -8,6 +8,7 @@ import {
   missionRepository,
   skillRepository,
   thematicRepository,
+  translationRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
 import {
@@ -20,6 +21,7 @@ import {
   tubeTransformer,
 } from '../../infrastructure/transformers/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { prefixFor } from '../../infrastructure/translations/challenge.js';
 
 export async function getLearningContentForReplication() {
   const [
@@ -34,6 +36,7 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions,
+    translations,
   ] = await Promise.all([
     frameworkRepository.list(),
     areaRepository.list(),
@@ -46,7 +49,15 @@ export async function getLearningContentForReplication() {
     tutorialDatasource.list(),
     _getCoursesFromPGForReplication(),
     missionRepository.list(),
+    translationRepository.list(),
   ]);
+  const translationsForReplication = translations.map((translation) => ({
+    ...translation,
+    id: translation.key,
+    model: translation.model,
+    entityId: translation.entityId,
+    sourceEntityId: null,
+  }));
   const transformedFrameworks = frameworkTransformer.filterFrameworksFields(frameworks);
   const transformedAreas = areaTransformer.filterAreasFields(areas);
   const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
@@ -57,7 +68,18 @@ export async function getLearningContentForReplication() {
   const translatedChallenges = challenges
     .flatMap((challenge) => [
       challenge,
-      ...challenge.alternativeLocales.map((locale) => challenge.translate(locale)),
+      ...challenge.alternativeLocales.map((locale) => {
+        const translationsForChallenge = translationsForReplication.filter((translation) => translation.entityId === challenge.id && translation.locale === locale);
+        const localizedChallenge = challenge.translate(locale);
+        for (const translationForChallenge of translationsForChallenge) {
+          const translatedField = translationForChallenge.key.split('.')[2];
+          translationForChallenge.key = `${prefixFor(localizedChallenge)}${translatedField}`;
+          translationForChallenge.entityId = localizedChallenge.id;
+          translationForChallenge.sourceEntityId = challenge.id;
+          translationForChallenge.id = translationForChallenge.key;
+        }
+        return localizedChallenge;
+      }),
     ])
     .map(normalizeChallenge);
 
@@ -66,7 +88,7 @@ export async function getLearningContentForReplication() {
     challengeId: attachment.localizedChallengeId,
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
-  
+
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
 
   return {
@@ -81,7 +103,16 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions: transformedMissions,
+    translations: translationsForReplication.sort(byKeyAndLocale),
   };
+}
+
+function byKeyAndLocale(trA, trB) {
+  const compareKey = trA.key.localeCompare(trB.key);
+  if (compareKey === 0) {
+    return trA.locale.localeCompare(trB.locale);
+  }
+  return compareKey;
 }
 
 async function _getCoursesFromPGForReplication() {

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -51,9 +51,9 @@ export async function getLearningContentForReplication() {
     missionRepository.list(),
     translationRepository.list(),
   ]);
-  const translationsForReplication = translations.map((translation) => ({
+  const translationsForReplication = translations.map((translation, index) => ({
     ...translation,
-    id: translation.key,
+    id: index + 1,
     model: translation.model,
     entityId: translation.entityId,
     sourceEntityId: null,

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -73,7 +73,7 @@ export async function listByPattern(pattern, { transaction = knex } = {}) {
 }
 
 export async function list() {
-  const translationDtos = await knex.select(projection).from('translations');
+  const translationDtos = await knex.select(projection).from('translations').orderBy(['key', 'locale']);
   return translationDtos.map(_toDomain);
 }
 

--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -19,7 +19,17 @@ export function promiseStreamer(promise, writableStream = getWritableStream()) {
     writableStream.write('\n');
   }, 1000);
   promise.then((data) => {
-    writableStream.write(JSON.stringify(data));
+    clearInterval(timer);
+    writableStream.write('{');
+    const keys = Object.keys(data);
+    while (keys.length > 0) {
+      const key = keys.shift();
+      writableStream.write('"' + key + '":' + JSON.stringify(data[key]));
+      if (keys.length !== 0) {
+        writableStream.write(',');
+      }
+    }
+    writableStream.write('}');
   }).catch((error) => {
     logger.error(error);
     Sentry.captureException(error);

--- a/api/tests/acceptance/application/replication-data_test.js
+++ b/api/tests/acceptance/application/replication-data_test.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
-import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../../lib/domain/models/index.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
 
 const {
   buildFramework,
@@ -23,7 +23,9 @@ function omit(keys, obj) {
 }
 
 async function mockCurrentContent() {
-  const expectedCurrentContent = {};
+  const expectedCurrentContent = {
+    translations: [],
+  };
   const expectedFramework = omit(['areaIds'], domainBuilder.buildFramework());
   expectedCurrentContent.frameworks = [expectedFramework];
 
@@ -68,7 +70,7 @@ async function mockCurrentContent() {
     accessibility2: Challenge.ACCESSIBILITY2.OK,
   });
   const alternativeChallenge = domainBuilder.buildChallenge({
-    id: 'challenge-id_alt',
+    id: 'challenge-id-alt',
     version: 1,
     genealogy: Challenge.GENEALOGIES.DECLINAISON,
     accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -233,7 +235,7 @@ async function mockCurrentContent() {
     challengeIds: 'recChallenge0',
   });
 
-  databaseBuilder.factory.buildMission({
+  const mission = databaseBuilder.factory.buildMission({
     id: 123456789,
     name: 'validated mission PG name',
     competenceId: 'competenceId',
@@ -241,8 +243,29 @@ async function mockCurrentContent() {
     thematicIds: 'thematicIds',
     validatedObjectives: 'Rien',
     status: Mission.status.VALIDATED,
-    documentationUrl: 'http://url-example.net'
-  });
+    documentationUrl: 'http://url-example.net',
+  }, false);
+
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.name`,
+    locale: 'fr',
+    value: 'validated mission PG name',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.learningObjectives`,
+    locale: 'fr',
+    value: 'Que tu sois le meilleur',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.validatedObjectives`,
+    locale: 'fr',
+    value: 'Rien',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.introductionMediaAlt`,
+    locale: 'fr',
+    value: 'Message alternatif',
+  }));
 
   databaseBuilder.factory.buildLocalizedChallenge({
     id: challenge.id,
@@ -281,124 +304,150 @@ async function mockCurrentContent() {
     isAwarenessChallenge: false,
     toRephrase: false,
   });
-  databaseBuilder.factory.buildTranslation({
-    key: `challenge.${challenge.id}.instruction`,
-    locale: 'nl',
-    value: 'Consigne en nl',
-  });
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'fr',
     value: expectedCurrentContent.areas[0].title_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'en',
     value: expectedCurrentContent.areas[0].title_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'fr',
     value: expectedCurrentContent.competences[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].name_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'fr',
     value: expectedCurrentContent.competences[0].description_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
     locale: 'fr',
     value: expectedCurrentContent.thematics[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
     locale: 'en',
     value: expectedCurrentContent.thematics[0].name_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
     locale: 'fr',
     value: expectedCurrentContent.tubes[0].practicalTitle_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
     locale: 'en',
     value: expectedCurrentContent.tubes[0].practicalTitle_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
     locale: 'fr',
     value: expectedCurrentContent.tubes[0].practicalDescription_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
     locale: 'en',
     value: expectedCurrentContent.tubes[0].practicalDescription_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'fr',
     value: expectedCurrentContent.skills[0].hint_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'en',
     value: expectedCurrentContent.skills[0].hint_i18n.en,
-  });
+  }));
 
   for (const challengeForTranslation of [expectedChallenge, expectedAlternativeChallenge]) {
-    databaseBuilder.factory.buildTranslation({
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.instruction`,
       locale: 'fr',
       value: challengeForTranslation.instruction,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.alternativeInstruction`,
       locale: 'fr',
       value: challengeForTranslation.alternativeInstruction,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.proposals`,
       locale: 'fr',
       value: challengeForTranslation.proposals,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.solution`,
       locale: 'fr',
       value: challengeForTranslation.solution,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.solutionToDisplay`,
       locale: 'fr',
       value: challengeForTranslation.solutionToDisplay,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.embedTitle`,
       locale: 'fr',
       value: challengeForTranslation.embedTitle,
-    });
+    }));
   }
 
-  databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedChallenge.id}.illustrationAlt`,
-    locale: 'nl',
-    value: expectedAttachmentNl.alt,
+  expectedCurrentContent.translations.forEach((translation) => {
+    translation.id = translation.key;
+    translation.sourceEntityId = null;
+  });
+
+  expectedCurrentContent.translations.push({
+    ...databaseBuilder.factory.buildTranslation({
+      key: `challenge.${challenge.id}.instruction`,
+      locale: 'nl',
+      value: 'Consigne en nl',
+    }),
+    id: 'challenge.localized-challenge-id.instruction',
+    key: 'challenge.localized-challenge-id.instruction',
+    entityId: 'localized-challenge-id',
+    sourceEntityId: challenge.id,
+  });
+
+  expectedCurrentContent.translations.push({
+    ...databaseBuilder.factory.buildTranslation({
+      key: `challenge.${expectedChallenge.id}.illustrationAlt`,
+      locale: 'nl',
+      value: expectedAttachmentNl.alt,
+    }),
+    id: 'challenge.localized-challenge-id.illustrationAlt',
+    key: 'challenge.localized-challenge-id.illustrationAlt',
+    entityId: 'localized-challenge-id',
+    sourceEntityId: expectedChallenge.id,
+  });
+
+  expectedCurrentContent.translations = expectedCurrentContent.translations.sort((trA, trB) => {
+    const compareKey = trA.key.localeCompare(trB.key);
+    if (compareKey === 0) {
+      return trA.locale.localeCompare(trB.locale);
+    }
+    return compareKey;
   });
 
   await databaseBuilder.commit();
@@ -430,7 +479,7 @@ describe('Acceptance | Controller | replication-data-controller', () => {
       const response = await server.inject(currentContentOptions);
 
       // then
-      expect(JSON.parse(response.result)).toStrictEqual(expectedCurrentContent);
+      expect(JSON.parse(response.result).translations).toStrictEqual(expectedCurrentContent.translations);
     });
   });
 });

--- a/api/tests/acceptance/application/replication-data_test.js
+++ b/api/tests/acceptance/application/replication-data_test.js
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
+import _ from 'lodash';
 
 const {
   buildFramework,
@@ -414,7 +415,6 @@ async function mockCurrentContent() {
   }
 
   expectedCurrentContent.translations.forEach((translation) => {
-    translation.id = translation.key;
     translation.sourceEntityId = null;
   });
 
@@ -424,7 +424,6 @@ async function mockCurrentContent() {
       locale: 'nl',
       value: 'Consigne en nl',
     }),
-    id: 'challenge.localized-challenge-id.instruction',
     key: 'challenge.localized-challenge-id.instruction',
     entityId: 'localized-challenge-id',
     sourceEntityId: challenge.id,
@@ -436,7 +435,6 @@ async function mockCurrentContent() {
       locale: 'nl',
       value: expectedAttachmentNl.alt,
     }),
-    id: 'challenge.localized-challenge-id.illustrationAlt',
     key: 'challenge.localized-challenge-id.illustrationAlt',
     entityId: 'localized-challenge-id',
     sourceEntityId: expectedChallenge.id,
@@ -479,7 +477,11 @@ describe('Acceptance | Controller | replication-data-controller', () => {
       const response = await server.inject(currentContentOptions);
 
       // then
-      expect(JSON.parse(response.result).translations).toStrictEqual(expectedCurrentContent.translations);
+      const result = JSON.parse(response.result);
+      const resultWithoutTranslations = _.omit(result, 'translations');
+      const expectedCurrentContentWithoutTranslations = _.omit(result, 'translations');
+      expect(resultWithoutTranslations).toStrictEqual(expectedCurrentContentWithoutTranslations);
+      expect(result.translations).toMatchObject(expectedCurrentContent.translations);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it } from 'vitest';
 import nock from 'nock';
-import { knex, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as translationRepository from '../../../../lib/infrastructure/repositories/translation-repository.js';
 
 describe('Integration | Repository | translation-repository', function() {
@@ -370,6 +370,60 @@ describe('Integration | Repository | translation-repository', function() {
         // then
         expect(entityIds).to.deep.equal(['entityId1']);
       });
+    });
+  });
+
+  context('#list', () => {
+    it('should list translations ordered by key and locale', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'fr',
+        value: 'field1 id1 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field1',
+        locale:  'fr',
+        value: 'field1 id2 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field2',
+        locale:  'en',
+        value: 'field2 id2 en EN',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'en',
+        value: 'field1 id1 en EN',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations = await translationRepository.list();
+
+      // then
+      expect(translations).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'en',
+          value: 'field1 id1 en EN',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'fr',
+          value: 'field1 id1 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field1',
+          locale:  'fr',
+          value: 'field1 id2 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field2',
+          locale:  'en',
+          value: 'field2 id2 en EN',
+        }),
+      ]);
     });
   });
 

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -17,30 +17,31 @@ export function buildMission({
   documentationUrl = null,
 
   createdAt = new Date('2010-01-04'),
-} = {}) {
+} = {}, shouldBuildTranslations = true) {
 
   const values = { id, cardImageUrl, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, documentationUrl };
-
-  buildTranslation({
-    key: `mission.${id}.name`,
-    locale: 'fr',
-    value: name,
-  });
-  buildTranslation({
-    key: `mission.${id}.learningObjectives`,
-    locale: 'fr',
-    value: learningObjectives,
-  });
-  buildTranslation({
-    key: `mission.${id}.validatedObjectives`,
-    locale: 'fr',
-    value: validatedObjectives,
-  });
-  buildTranslation({
-    key: `mission.${id}.introductionMediaAlt`,
-    locale: 'fr',
-    value: introductionMediaAlt,
-  });
+  if (shouldBuildTranslations) {
+    buildTranslation({
+      key: `mission.${id}.name`,
+      locale: 'fr',
+      value: name,
+    });
+    buildTranslation({
+      key: `mission.${id}.learningObjectives`,
+      locale: 'fr',
+      value: learningObjectives,
+    });
+    buildTranslation({
+      key: `mission.${id}.validatedObjectives`,
+      locale: 'fr',
+      value: validatedObjectives,
+    });
+    buildTranslation({
+      key: `mission.${id}.introductionMediaAlt`,
+      locale: 'fr',
+      value: introductionMediaAlt,
+    });
+  }
 
   return databaseBuffer.pushInsertable({
     tableName: 'missions',

--- a/api/tests/tooling/database-builder/factory/build-translation.js
+++ b/api/tests/tooling/database-builder/factory/build-translation.js
@@ -1,9 +1,15 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildTranslation({ key, locale, value } = {}) {
-  return databaseBuffer.pushInsertable({
+  const translation = databaseBuffer.pushInsertable({
     tableName: 'translations',
     autoId: false,
     values: { key, locale, value },
   });
+
+  return {
+    ...translation,
+    model: key.split('.')[0],
+    entityId: key.split('.')[1]
+  };
 }

--- a/api/tests/unit/domain/models/Translation_test.js
+++ b/api/tests/unit/domain/models/Translation_test.js
@@ -16,4 +16,19 @@ describe('Unit | Domain | Translation', function() {
       expect(entityId).to.equal('idDuChallenge');
     });
   });
+
+  context('get model', function() {
+    it('should return the expected model', function() {
+      // given
+      const translation = domainBuilder.buildTranslation({
+        key: 'challenge.idDuChallenge.champ',
+      });
+
+      // when
+      const model = translation.model;
+
+      // then
+      expect(model).to.equal('challenge');
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
         version: 2,
         level: 1,
         challengeIds: ['challId1', 'challId2'],
-        createdAt: new Date(),
+        createdAt: new Date('2023-10-23T18:06:00Z'),
       });
 
       const attributes = {
@@ -116,7 +116,7 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
         version: 2,
         level: 1,
         challengeIds: ['challId1', 'challId2'],
-        createdAt: new Date(),
+        createdAt: new Date('2023-10-23T18:06:00Z'),
       });
 
       const attributes = {
@@ -131,7 +131,7 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
         'status': Skill.STATUSES.ACTIF,
         'version': 2,
         'level': 1,
-        'created-at': new Date(),
+        'created-at': new Date('2023-10-23T18:06:00Z'),
       };
 
       const payload = {


### PR DESCRIPTION
## 🌸 Problème
La key n'est pas unique, on met un id auto incrémenté

## 🌳 Proposition
Mettre un ID unique + revert du stream découpé + ajout des trads dans la répli

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
