### PR TITLE
[TECH] Exposer les traductions dans les données de réplication et résoudre les problèmes techniques

### DIFF
--- a/api/lib/application/releases.js
+++ b/api/lib/application/releases.js
@@ -4,6 +4,7 @@ import { releaseRepository } from '../infrastructure/repositories/index.js';
 import { queue as createReleaseQueue } from '../infrastructure/scheduled-jobs/release-job.js';
 import { promiseStreamer } from '../infrastructure/utils/promise-streamer.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
+import { SCOPES } from '../infrastructure/logger.js';
 
 const releaseIdType = Joi.number().greater(-2147483648).less(2147483647).required();
 
@@ -14,7 +15,10 @@ export async function register(server) {
       path: '/api/current-content',
       config: {
         handler: function() {
-          return promiseStreamer(releaseRepository.getCurrentContent());
+          return promiseStreamer({
+            promise: releaseRepository.getCurrentContent(),
+            loggingScope: SCOPES.RELEASE,
+          });
         },
       },
     },
@@ -31,7 +35,10 @@ export async function register(server) {
             const releaseId = await job.finished();
             return releaseRepository.getRelease(releaseId);
           };
-          return promiseStreamer(promise());
+          return promiseStreamer({
+            promise: promise(),
+            loggingScope: SCOPES.RELEASE,
+          });
         },
       },
     },

--- a/api/lib/application/replication-data.js
+++ b/api/lib/application/replication-data.js
@@ -1,5 +1,6 @@
 import { promiseStreamer } from '../infrastructure/utils/promise-streamer.js';
 import { getLearningContentForReplication } from '../domain/usecases/get-learning-content-for-replication.js';
+import { SCOPES } from '../infrastructure/logger.js';
 
 export async function register(server) {
   server.route([
@@ -8,7 +9,10 @@ export async function register(server) {
       path: '/api/replication-data',
       config: {
         handler: async function() {
-          return promiseStreamer(getLearningContentForReplication());
+          return promiseStreamer({
+            promise: getLearningContentForReplication(),
+            loggingScope: SCOPES.REPLICATION,
+          });
         },
       },
     },

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -24,6 +24,7 @@ export const hapi = {
   options: {},
   enableRequestMonitoring: isFeatureEnabled(process.env.ENABLE_REQUEST_MONITORING),
   publicDir: 'public/',
+  shouldCompressLargeJson: isFeatureEnabled(process.env.ALLOW_COMPRESSION_ON_LARGE_JSON),
 };
 
 export const airtable = {

--- a/api/lib/domain/models/Translation.js
+++ b/api/lib/domain/models/Translation.js
@@ -12,4 +12,8 @@ export class Translation {
   get entityId() {
     return this.key.split('.')[1];
   }
+
+  get model() {
+    return this.key.split('.')[0];
+  }
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -23,6 +23,21 @@ import {
 import { knex } from '../../../db/knex-database-connection.js';
 import { prefixFor } from '../../infrastructure/translations/challenge.js';
 
+/* https://github.com/nodejs/node/issues/41821
+ Dans le cadre d'un appel API api/replication-data pour récupérer les données de la réplication, on renvoie un stream au client.
+ Pour maintenir la connexion en vie, on envoie toutes les secondes un retour chariot.
+
+ Malheureusement, ce usecase contient du code synchrone qui s'exécute dans le même tick et bloque la event-loop.
+ Ce faisant, les retours chariot cessent d'être envoyés (car le setInterval n'a pas l'opportunité d'en placer une).
+ Il y a encore de la marge d'amélioration sur l'algo, pour aller plus vite, mais on ne fait que repousser l'inévitable.
+ Il faut s'assurer que le retour chariot régulièrement envoyé continue de l'être.
+ Pour cela, il faut forcer, de temps en temps, ce usecase à rendre la main.
+ */
+const RELEASE_LOOP_EVERY_N_CHALLENGES = 5_000;
+function setImmediatePromise() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 export async function getLearningContentForReplication() {
   const [
     frameworks,
@@ -66,37 +81,42 @@ export async function getLearningContentForReplication() {
 
   const translationsGroupedByEntityId = Object.groupBy(translationsForReplication, (translation) => translation.entityId);
   fillAlternativeQualityFieldsFromMatchingProto(challenges, skills);
-  const translatedChallenges = challenges
-    .flatMap((challenge) => {
-      const translatedChallenges = challenge.alternativeLocales.map((locale) => {
-        const translationsForChallenge = translationsGroupedByEntityId[challenge.id].filter((translation) => translation.locale === locale);
-        const localizedChallenge = challenge.translate(locale);
-        for (const translationForChallenge of translationsForChallenge) {
-          const translatedField = translationForChallenge.key.split('.')[2];
-          translationForChallenge.key = `${prefixFor(localizedChallenge)}${translatedField}`;
-          translationForChallenge.entityId = localizedChallenge.id;
-          translationForChallenge.sourceEntityId = challenge.id;
-        }
-        localizedChallenge.area = localizedChallenge.geography;
-        delete localizedChallenge.localizedChallenges;
-        return localizedChallenge;
-      });
-      challenge.area = challenge.geography;
-      delete challenge.localizedChallenges;
-      return [
-        challenge,
-        ...translatedChallenges,
-      ];
+  await setImmediatePromise();
+
+  const allTranslatedChallenges = [];
+  for (let i = 0; i < challenges.length; ++i) {
+    const challenge = challenges[i];
+    if (i % RELEASE_LOOP_EVERY_N_CHALLENGES === 0) {
+      await setImmediatePromise();
+    }
+    const translatedChallenges = challenge.alternativeLocales.map((locale) => {
+      const translationsForChallenge = translationsGroupedByEntityId[challenge.id].filter((translation) => translation.locale === locale);
+      const localizedChallenge = challenge.translate(locale);
+      for (const translationForChallenge of translationsForChallenge) {
+        const translatedField = translationForChallenge.key.split('.')[2];
+        translationForChallenge.key = `${prefixFor(localizedChallenge)}${translatedField}`;
+        translationForChallenge.entityId = localizedChallenge.id;
+        translationForChallenge.sourceEntityId = challenge.id;
+      }
+      localizedChallenge.area = localizedChallenge.geography;
+      delete localizedChallenge.localizedChallenges;
+      return localizedChallenge;
     });
+    challenge.area = challenge.geography;
+    delete challenge.localizedChallenges;
+    allTranslatedChallenges.push(challenge);
+    allTranslatedChallenges.push(...translatedChallenges);
+  }
 
   const translatedAttachments = attachments.map((attachment) => ({
     ...attachment,
     challengeId: attachment.localizedChallengeId,
-    alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
+    alt: allTranslatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
 
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
 
+  await setImmediatePromise();
   return {
     frameworks: transformedFrameworks,
     areas: transformedAreas,
@@ -104,7 +124,7 @@ export async function getLearningContentForReplication() {
     thematics: transformedThematics,
     tubes: transformedTubes,
     skills,
-    challenges: translatedChallenges,
+    challenges: allTranslatedChallenges,
     attachments: translatedAttachments,
     tutorials,
     courses,

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -8,6 +8,7 @@ import {
   missionRepository,
   skillRepository,
   thematicRepository,
+  translationRepository,
   tubeRepository,
 } from '../../infrastructure/repositories/index.js';
 import {
@@ -20,6 +21,7 @@ import {
   tubeTransformer,
 } from '../../infrastructure/transformers/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { prefixFor } from '../../infrastructure/translations/challenge.js';
 
 export async function getLearningContentForReplication() {
   const [
@@ -34,6 +36,7 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions,
+    translations,
   ] = await Promise.all([
     frameworkRepository.list(),
     areaRepository.list(),
@@ -46,7 +49,15 @@ export async function getLearningContentForReplication() {
     tutorialDatasource.list(),
     _getCoursesFromPGForReplication(),
     missionRepository.list(),
+    translationRepository.list(),
   ]);
+  const translationsForReplication = translations.map((translation, index) => ({
+    ...translation,
+    id: index + 1,
+    model: translation.model,
+    entityId: translation.entityId,
+    sourceEntityId: null,
+  }));
   const transformedFrameworks = frameworkTransformer.filterFrameworksFields(frameworks);
   const transformedAreas = areaTransformer.filterAreasFields(areas);
   const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
@@ -57,7 +68,17 @@ export async function getLearningContentForReplication() {
   const translatedChallenges = challenges
     .flatMap((challenge) => [
       challenge,
-      ...challenge.alternativeLocales.map((locale) => challenge.translate(locale)),
+      ...challenge.alternativeLocales.map((locale) => {
+        const translationsForChallenge = translationsForReplication.filter((translation) => translation.entityId === challenge.id && translation.locale === locale);
+        const localizedChallenge = challenge.translate(locale);
+        for (const translationForChallenge of translationsForChallenge) {
+          const translatedField = translationForChallenge.key.split('.')[2];
+          translationForChallenge.key = `${prefixFor(localizedChallenge)}${translatedField}`;
+          translationForChallenge.entityId = localizedChallenge.id;
+          translationForChallenge.sourceEntityId = challenge.id;
+        }
+        return localizedChallenge;
+      }),
     ])
     .map(normalizeChallenge);
 
@@ -66,7 +87,7 @@ export async function getLearningContentForReplication() {
     challengeId: attachment.localizedChallengeId,
     alt: translatedChallenges.find(({ id }) => id === attachment.localizedChallengeId).illustrationAlt
   }));
-  
+
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
 
   return {
@@ -81,7 +102,16 @@ export async function getLearningContentForReplication() {
     tutorials,
     courses,
     missions: transformedMissions,
+    translations: translationsForReplication.sort(byKeyAndLocale),
   };
+}
+
+function byKeyAndLocale(trA, trB) {
+  const compareKey = trA.key.localeCompare(trB.key);
+  if (compareKey === 0) {
+    return trA.locale.localeCompare(trB.locale);
+  }
+  return compareKey;
 }
 
 async function _getCoursesFromPGForReplication() {

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -64,12 +64,12 @@ export async function getLearningContentForReplication() {
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
   const transformedTubes = tubes.map(tubeTransformer.filterTubeFields);
 
+  const translationsGroupedByEntityId = Object.groupBy(translationsForReplication, (translation) => translation.entityId);
   fillAlternativeQualityFieldsFromMatchingProto(challenges, skills);
   const translatedChallenges = challenges
-    .flatMap((challenge) => [
-      challenge,
-      ...challenge.alternativeLocales.map((locale) => {
-        const translationsForChallenge = translationsForReplication.filter((translation) => translation.entityId === challenge.id && translation.locale === locale);
+    .flatMap((challenge) => {
+      const translatedChallenges = challenge.alternativeLocales.map((locale) => {
+        const translationsForChallenge = translationsGroupedByEntityId[challenge.id].filter((translation) => translation.locale === locale);
         const localizedChallenge = challenge.translate(locale);
         for (const translationForChallenge of translationsForChallenge) {
           const translatedField = translationForChallenge.key.split('.')[2];
@@ -78,8 +78,12 @@ export async function getLearningContentForReplication() {
           translationForChallenge.sourceEntityId = challenge.id;
         }
         return localizedChallenge;
-      }),
-    ])
+      });
+      return [
+        challenge,
+        ...translatedChallenges,
+      ];
+    })
     .map(normalizeChallenge);
 
   const translatedAttachments = attachments.map((attachment) => ({

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -77,14 +77,17 @@ export async function getLearningContentForReplication() {
           translationForChallenge.entityId = localizedChallenge.id;
           translationForChallenge.sourceEntityId = challenge.id;
         }
+        localizedChallenge.area = localizedChallenge.geography;
+        delete localizedChallenge.localizedChallenges;
         return localizedChallenge;
       });
+      challenge.area = challenge.geography;
+      delete challenge.localizedChallenges;
       return [
         challenge,
         ...translatedChallenges,
       ];
-    })
-    .map(normalizeChallenge);
+    });
 
   const translatedAttachments = attachments.map((attachment) => ({
     ...attachment,
@@ -122,10 +125,4 @@ async function _getCoursesFromPGForReplication() {
   return knex('static_courses')
     .select(['id', 'name'])
     .orderBy('id');
-}
-
-function normalizeChallenge(challenge) {
-  delete challenge.localizedChallenges;
-  challenge.area = challenge.geography;
-  return challenge;
 }

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -37,5 +37,10 @@ export const logger = pino(
   config.logging.enabled ? destination : nullDestination
 );
 
+export const SCOPES = {
+  REPLICATION: 'replication',
+  RELEASE: 'release',
+};
+
 logger.debug('DEBUG logs enabled');
 logger.trace('TRACE logs enabled');

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -73,7 +73,7 @@ export async function listByPattern(pattern, { transaction = knex } = {}) {
 }
 
 export async function list() {
-  const translationDtos = await knex.select(projection).from('translations');
+  const translationDtos = await knex.select(projection).from('translations').orderBy(['key', 'locale']);
   return translationDtos.map(_toDomain);
 }
 

--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -1,4 +1,5 @@
 import { PassThrough, pipeline } from 'node:stream';
+import { child, logger as genericLogger } from '../logger.js';
 
 const NB_CHARS_PER_CHUNK = 65_536;
 
@@ -14,22 +15,52 @@ function getWritableStream() {
   return writableStream;
 }
 
-export function promiseStreamer(promise, writableStream = getWritableStream()) {
+export function promiseStreamer({
+  promise,
+  writableStream = getWritableStream(),
+  loggingScope,
+}) {
+  let logger = genericLogger;
+  if (loggingScope) {
+    logger = child('promisestream', { event: loggingScope });
+  }
   const timer = setInterval(() => {
     writableStream.write('\n');
   }, 1000);
+  writableStream.on('error', (err) => {
+    logger.error(`WritableStream error: ${err}`);
+  });
+  writableStream.on('finish', () => {
+    logger.info('WritableStream close');
+  });
+  writableStream.on('pipe', () => {
+    logger.info('WritableStream pipe');
+  });
 
+  logger.info('Gathering data...');
   promise.then((data) => {
+    logger.info('Data gathered, streaming about to begin...');
     clearInterval(timer);
     pipeline(
       chunk(data),
       writableStream,
+      (err) => {
+        if (err) {
+          logger.error(`Streaming pipeline error: ${err}`);
+          if (!writableStream.closed && !writableStream.errored) {
+            writableStream.end('error');
+          }
+        } else {
+          logger.info('Streaming pipeline done');
+        }
+      }
     );
-  }).catch(() => {
-    if (!writableStream.closed) {
-      writableStream.write('error');
-    }
+  }).catch((err) => {
     clearInterval(timer);
+    if (!writableStream.closed && !writableStream.errored) {
+      writableStream.end('error');
+    }
+    logger.error(`Error in promise : ${err}`);
   });
   return writableStream;
 }

--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -1,5 +1,6 @@
 import { PassThrough, pipeline } from 'node:stream';
 import { child, logger as genericLogger } from '../logger.js';
+import * as config from '../../config.js';
 
 const NB_CHARS_PER_CHUNK = 65_536;
 
@@ -7,11 +8,14 @@ function getWritableStream() {
   const writableStream = new PassThrough();
   writableStream.headers = {
     'content-type': 'application/json',
-
+  };
+  if (config.hapi.shouldCompressLargeJson) {
+    writableStream.headers['content-encoding'] = 'gzip';
+  } else {
     // WHY: to avoid compression because when compressing, the server buffers
     // for too long causing a response timeout.
-    'content-encoding': 'identity',
-  };
+    writableStream.headers['content-encoding'] = 'identity';
+  }
   return writableStream;
 }
 

--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -1,6 +1,6 @@
-import * as Sentry from '@sentry/node';
-import { logger } from '../logger.js';
-import { PassThrough } from 'node:stream';
+import { PassThrough, pipeline } from 'node:stream';
+
+const NB_CHARS_PER_CHUNK = 65_536;
 
 function getWritableStream() {
   const writableStream = new PassThrough();
@@ -18,15 +18,25 @@ export function promiseStreamer(promise, writableStream = getWritableStream()) {
   const timer = setInterval(() => {
     writableStream.write('\n');
   }, 1000);
+
   promise.then((data) => {
-    writableStream.write(JSON.stringify(data));
-  }).catch((error) => {
-    logger.error(error);
-    Sentry.captureException(error);
-    writableStream.write('error');
-  }).finally(() => {
     clearInterval(timer);
-    writableStream.end();
+    pipeline(
+      chunk(data),
+      writableStream,
+    );
+  }).catch(() => {
+    if (!writableStream.closed) {
+      writableStream.write('error');
+    }
+    clearInterval(timer);
   });
   return writableStream;
+}
+
+function* chunk(data) {
+  const stringifiedData = JSON.stringify(data);
+  for (let i = 0; i < stringifiedData.length; i += NB_CHARS_PER_CHUNK) {
+    yield stringifiedData.slice(i, i + NB_CHARS_PER_CHUNK);
+  }
 }

--- a/api/sample.env
+++ b/api/sample.env
@@ -594,3 +594,10 @@ EXPORT_EXTERNAL_URLS_LIST_SPREADSHEET_ID=
 # type: String
 # default: none
 # PIX_EDITOR_BASE_URL=
+
+# Enable or disable compression when returning large JSON
+#
+# presence: optional
+# type: Boolean
+# default: `undefined` (`false`)
+# ALLOW_COMPRESSION_ON_LARGE_JSON=false

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
-import { createServer } from '../../../../server.js';
-import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../../lib/domain/models/index.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, } from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
+import _ from 'lodash';
 
 const {
   buildFramework,
@@ -15,6 +16,42 @@ const {
   buildThematic,
 } = airtableBuilder.factory;
 
+describe('Acceptance | Controller | replication-data-controller', () => {
+
+  let user;
+
+  beforeEach(async function() {
+    user = databaseBuilder.factory.buildAdminUser();
+    await databaseBuilder.commit();
+  });
+
+  describe('GET /api/replication-data', function() {
+    it('should return data for replication', async function() {
+      const expectedCurrentContent = await mockCurrentContent();
+
+      const server = await createServer();
+      const currentContentOptions = {
+        method: 'GET',
+        url: '/api/replication-data',
+        headers: generateAuthorizationHeader(user),
+      };
+
+      // when
+      const response = await server.inject(currentContentOptions);
+
+      // then
+      const result = JSON.parse(response.result);
+      const resultWithoutTranslations = _.omit(result, 'translations');
+      const expectedCurrentContentWithoutTranslations = _.omit(result, 'translations');
+      expect(resultWithoutTranslations).toStrictEqual(expectedCurrentContentWithoutTranslations);
+      expect(result.translations).toMatchObject(expectedCurrentContent.translations.map((translation) => ({
+        ...translation,
+        id: expect.any(Number)
+      })));
+    });
+  });
+});
+
 function omit(keys, obj) {
   return Object.fromEntries(
     Object.entries(obj)
@@ -23,7 +60,9 @@ function omit(keys, obj) {
 }
 
 async function mockCurrentContent() {
-  const expectedCurrentContent = {};
+  const expectedCurrentContent = {
+    translations: [],
+  };
   const expectedFramework = omit(['areaIds'], domainBuilder.buildFramework());
   expectedCurrentContent.frameworks = [expectedFramework];
 
@@ -68,7 +107,7 @@ async function mockCurrentContent() {
     accessibility2: Challenge.ACCESSIBILITY2.OK,
   });
   const alternativeChallenge = domainBuilder.buildChallenge({
-    id: 'challenge-id_alt',
+    id: 'challenge-id-alt',
     version: 1,
     genealogy: Challenge.GENEALOGIES.DECLINAISON,
     accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
@@ -233,7 +272,7 @@ async function mockCurrentContent() {
     challengeIds: 'recChallenge0',
   });
 
-  databaseBuilder.factory.buildMission({
+  const mission = databaseBuilder.factory.buildMission({
     id: 123456789,
     name: 'validated mission PG name',
     competenceId: 'competenceId',
@@ -241,8 +280,29 @@ async function mockCurrentContent() {
     thematicIds: 'thematicIds',
     validatedObjectives: 'Rien',
     status: Mission.status.VALIDATED,
-    documentationUrl: 'http://url-example.net'
-  });
+    documentationUrl: 'http://url-example.net',
+  }, false);
+
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.name`,
+    locale: 'fr',
+    value: 'validated mission PG name',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.learningObjectives`,
+    locale: 'fr',
+    value: 'Que tu sois le meilleur',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.validatedObjectives`,
+    locale: 'fr',
+    value: 'Rien',
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
+    key: `mission.${mission.id}.introductionMediaAlt`,
+    locale: 'fr',
+    value: 'Message alternatif',
+  }));
 
   databaseBuilder.factory.buildLocalizedChallenge({
     id: challenge.id,
@@ -281,156 +341,150 @@ async function mockCurrentContent() {
     isAwarenessChallenge: false,
     toRephrase: false,
   });
-  databaseBuilder.factory.buildTranslation({
-    key: `challenge.${challenge.id}.instruction`,
-    locale: 'nl',
-    value: 'Consigne en nl',
-  });
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'fr',
     value: expectedCurrentContent.areas[0].title_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `area.${expectedCurrentContent.areas[0].id}.title`,
     locale: 'en',
     value: expectedCurrentContent.areas[0].title_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'fr',
     value: expectedCurrentContent.competences[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.name`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].name_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'fr',
     value: expectedCurrentContent.competences[0].description_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `competence.${expectedCurrentContent.competences[0].id}.description`,
     locale: 'en',
     value: expectedCurrentContent.competences[0].description_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
     locale: 'fr',
     value: expectedCurrentContent.thematics[0].name_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `thematic.${expectedCurrentContent.thematics[0].id}.name`,
     locale: 'en',
     value: expectedCurrentContent.thematics[0].name_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
     locale: 'fr',
     value: expectedCurrentContent.tubes[0].practicalTitle_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalTitle`,
     locale: 'en',
     value: expectedCurrentContent.tubes[0].practicalTitle_i18n.en,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
     locale: 'fr',
     value: expectedCurrentContent.tubes[0].practicalDescription_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `tube.${expectedCurrentContent.tubes[0].id}.practicalDescription`,
     locale: 'en',
     value: expectedCurrentContent.tubes[0].practicalDescription_i18n.en,
-  });
+  }));
 
-  databaseBuilder.factory.buildTranslation({
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'fr',
     value: expectedCurrentContent.skills[0].hint_i18n.fr,
-  });
-  databaseBuilder.factory.buildTranslation({
+  }));
+  expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
     key: `skill.${expectedCurrentContent.skills[0].id}.hint`,
     locale: 'en',
     value: expectedCurrentContent.skills[0].hint_i18n.en,
-  });
+  }));
 
   for (const challengeForTranslation of [expectedChallenge, expectedAlternativeChallenge]) {
-    databaseBuilder.factory.buildTranslation({
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.instruction`,
       locale: 'fr',
       value: challengeForTranslation.instruction,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.alternativeInstruction`,
       locale: 'fr',
       value: challengeForTranslation.alternativeInstruction,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.proposals`,
       locale: 'fr',
       value: challengeForTranslation.proposals,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.solution`,
       locale: 'fr',
       value: challengeForTranslation.solution,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.solutionToDisplay`,
       locale: 'fr',
       value: challengeForTranslation.solutionToDisplay,
-    });
-    databaseBuilder.factory.buildTranslation({
+    }));
+    expectedCurrentContent.translations.push(databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeForTranslation.id}.embedTitle`,
       locale: 'fr',
       value: challengeForTranslation.embedTitle,
-    });
+    }));
   }
 
-  databaseBuilder.factory.buildTranslation({
-    key: `challenge.${expectedChallenge.id}.illustrationAlt`,
-    locale: 'nl',
-    value: expectedAttachmentNl.alt,
+  expectedCurrentContent.translations.forEach((translation) => {
+    translation.sourceEntityId = null;
+  });
+
+  expectedCurrentContent.translations.push({
+    ...databaseBuilder.factory.buildTranslation({
+      key: `challenge.${challenge.id}.instruction`,
+      locale: 'nl',
+      value: 'Consigne en nl',
+    }),
+    key: 'challenge.localized-challenge-id.instruction',
+    entityId: 'localized-challenge-id',
+    sourceEntityId: challenge.id,
+  });
+
+  expectedCurrentContent.translations.push({
+    ...databaseBuilder.factory.buildTranslation({
+      key: `challenge.${expectedChallenge.id}.illustrationAlt`,
+      locale: 'nl',
+      value: expectedAttachmentNl.alt,
+    }),
+    key: 'challenge.localized-challenge-id.illustrationAlt',
+    entityId: 'localized-challenge-id',
+    sourceEntityId: expectedChallenge.id,
+  });
+
+  expectedCurrentContent.translations = expectedCurrentContent.translations.sort((trA, trB) => {
+    const compareKey = trA.key.localeCompare(trB.key);
+    if (compareKey === 0) {
+      return trA.locale.localeCompare(trB.locale);
+    }
+    return compareKey;
   });
 
   await databaseBuilder.commit();
 
   return expectedCurrentContent;
 }
-
-describe('Acceptance | Controller | replication-data-controller', () => {
-
-  let user;
-
-  beforeEach(async function() {
-    user = databaseBuilder.factory.buildAdminUser();
-    await databaseBuilder.commit();
-  });
-
-  describe('GET /api/replication-data', function() {
-    it('should return data for replication', async function() {
-      const expectedCurrentContent = await mockCurrentContent();
-
-      const server = await createServer();
-      const currentContentOptions = {
-        method: 'GET',
-        url: '/api/replication-data',
-        headers: generateAuthorizationHeader(user),
-      };
-
-      // when
-      const response = await server.inject(currentContentOptions);
-
-      // then
-      expect(JSON.parse(response.result)).toStrictEqual(expectedCurrentContent);
-    });
-  });
-});

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it } from 'vitest';
 import nock from 'nock';
-import { knex, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as translationRepository from '../../../../lib/infrastructure/repositories/translation-repository.js';
 
 describe('Integration | Repository | translation-repository', function() {
@@ -370,6 +370,60 @@ describe('Integration | Repository | translation-repository', function() {
         // then
         expect(entityIds).to.deep.equal(['entityId1']);
       });
+    });
+  });
+
+  context('#list', () => {
+    it('should list translations ordered by key and locale', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'fr',
+        value: 'field1 id1 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field1',
+        locale:  'fr',
+        value: 'field1 id2 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field2',
+        locale:  'en',
+        value: 'field2 id2 en EN',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'en',
+        value: 'field1 id1 en EN',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations = await translationRepository.list();
+
+      // then
+      expect(translations).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'en',
+          value: 'field1 id1 en EN',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'fr',
+          value: 'field1 id1 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field1',
+          locale:  'fr',
+          value: 'field1 id2 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field2',
+          locale:  'en',
+          value: 'field2 id2 en EN',
+        }),
+      ]);
     });
   });
 

--- a/api/tests/tooling/database-builder/factory/build-mission.js
+++ b/api/tests/tooling/database-builder/factory/build-mission.js
@@ -17,30 +17,31 @@ export function buildMission({
   documentationUrl = null,
 
   createdAt = new Date('2010-01-04'),
-} = {}) {
+} = {}, shouldBuildTranslations = true) {
 
   const values = { id, cardImageUrl, competenceId, thematicIds, createdAt, status, introductionMediaUrl, introductionMediaType, documentationUrl };
-
-  buildTranslation({
-    key: `mission.${id}.name`,
-    locale: 'fr',
-    value: name,
-  });
-  buildTranslation({
-    key: `mission.${id}.learningObjectives`,
-    locale: 'fr',
-    value: learningObjectives,
-  });
-  buildTranslation({
-    key: `mission.${id}.validatedObjectives`,
-    locale: 'fr',
-    value: validatedObjectives,
-  });
-  buildTranslation({
-    key: `mission.${id}.introductionMediaAlt`,
-    locale: 'fr',
-    value: introductionMediaAlt,
-  });
+  if (shouldBuildTranslations) {
+    buildTranslation({
+      key: `mission.${id}.name`,
+      locale: 'fr',
+      value: name,
+    });
+    buildTranslation({
+      key: `mission.${id}.learningObjectives`,
+      locale: 'fr',
+      value: learningObjectives,
+    });
+    buildTranslation({
+      key: `mission.${id}.validatedObjectives`,
+      locale: 'fr',
+      value: validatedObjectives,
+    });
+    buildTranslation({
+      key: `mission.${id}.introductionMediaAlt`,
+      locale: 'fr',
+      value: introductionMediaAlt,
+    });
+  }
 
   return databaseBuffer.pushInsertable({
     tableName: 'missions',

--- a/api/tests/tooling/database-builder/factory/build-translation.js
+++ b/api/tests/tooling/database-builder/factory/build-translation.js
@@ -1,9 +1,15 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildTranslation({ key, locale, value } = {}) {
-  return databaseBuffer.pushInsertable({
+  const translation = databaseBuffer.pushInsertable({
     tableName: 'translations',
     autoId: false,
     values: { key, locale, value },
   });
+
+  return {
+    ...translation,
+    model: key.split('.')[0],
+    entityId: key.split('.')[1]
+  };
 }

--- a/api/tests/unit/domain/models/Translation_test.js
+++ b/api/tests/unit/domain/models/Translation_test.js
@@ -16,4 +16,19 @@ describe('Unit | Domain | Translation', function() {
       expect(entityId).to.equal('idDuChallenge');
     });
   });
+
+  context('get model', function() {
+    it('should return the expected model', function() {
+      // given
+      const translation = domainBuilder.buildTranslation({
+        key: 'challenge.idDuChallenge.champ',
+      });
+
+      // when
+      const model = translation.model;
+
+      // then
+      expect(model).to.equal('challenge');
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/skill-serializer_test.js
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
         version: 2,
         level: 1,
         challengeIds: ['challId1', 'challId2'],
-        createdAt: new Date(),
+        createdAt: new Date('2023-10-23T18:06:00Z'),
       });
 
       const attributes = {
@@ -116,7 +116,7 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
         version: 2,
         level: 1,
         challengeIds: ['challId1', 'challId2'],
-        createdAt: new Date(),
+        createdAt: new Date('2023-10-23T18:06:00Z'),
       });
 
       const attributes = {
@@ -131,7 +131,7 @@ describe('Unit | Serializer | JSONAPI | skill-serializer', () => {
         'status': Skill.STATUSES.ACTIF,
         'version': 2,
         'level': 1,
-        'created-at': new Date(),
+        'created-at': new Date('2023-10-23T18:06:00Z'),
       };
 
       const payload = {

--- a/api/tests/unit/infrastructure/utils/promise-streamer_test.js
+++ b/api/tests/unit/infrastructure/utils/promise-streamer_test.js
@@ -12,7 +12,10 @@ describe('Unit | Infrastructure | Utils | Promise Streamer', () => {
     const streamPromise = streamToPromise(writableStream);
 
     // when
-    promiseStreamer(promise(), writableStream);
+    promiseStreamer({
+      promise: promise(),
+      writableStream,
+    });
     const result = await streamPromise;
 
     // then
@@ -26,9 +29,13 @@ describe('Unit | Infrastructure | Utils | Promise Streamer', () => {
     const streamPromise = streamToPromise(writableStream);
 
     //When
-    promiseStreamer(promise(), writableStream);
+    promiseStreamer({
+      promise: promise(),
+      writableStream,
+    });
+    const result = await streamPromise;
 
     //Then
-    expect(await streamPromise).to.match(/error$/);
+    expect(result).to.match(/error$/);
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Dans son implémentation initiale, l'exposition des traductions dans les données de réplication ne marchait pas.

## 🌳 Proposition

Nous avons rencontré et résolu plusieurs problèmes techniques. La liste des problèmes/solutions est présentée ci-dessous. Dans les faits, nous n'avons pas trouvé/résolu les problèmes dans l'ordre présenté. C'était un travail pénible sur plusieurs jours, avec une loop de feedback assez longue (on n'arrivait pas à reproduire sur les RAs, donc obligé de faire des MEPs, puis de revert tout en fin de journée pour pas casser la répli de la nuit).

### Problème 1 (résolu dans une précédente PR) : Problème de mémoire du container lié aux child-process zombies de Bull
Détaillé ici https://github.com/1024pix/pix-editor/pull/906

### Problème 2 : Problème de timeout se soldant par la fermeture de la socket côté client
Le endpoint /api/replication-data retourne un stream, dans lequel nous écrivons les données en JSON.
Comme la récupération des données, dans un premier temps, pouvait être longue, on envoyait dans un `setInterval` un retour chariot dans le stream toutes les secondes pour garder la connexion en vie.
Pourtant, depuis l'ajout des traductions dans les données, une nouvelle erreur a fait son apparition :

![epipeerror](https://github.com/user-attachments/assets/c924fd47-6c4a-4975-b519-abf2fbfbe4a9)

D'après la [documentation](https://nodejs.org/api/errors.html#common-system-errors), l'erreur **EPIPE** est : 

> EPIPE (Broken pipe): A write on a pipe, socket, or FIFO for which there is no process to read the data. Commonly encountered at the [net](https://nodejs.org/api/net.html) and [http](https://nodejs.org/api/http.html) layers, indicative that the remote side of the stream being written to has been closed.

Et pourtant, on envoie ces fichus retours chariot ! Comme l'indique la doc, c'est un problème qui se produit dans les couches `net` ou `http`. On entreprend donc, d'abord, d'ajouter `NODE_DEBUG=net,http` durant nos essais afin d'avoir plus d'informations. Le problème c'est qu'on obtenait une trop grande quantité de logs, dû au trafic normal sur LCMS (et pourtant y'a pas foule). Il s'est avéré difficile de trier le grain de l'ivraie :

![toomanylogs](https://github.com/user-attachments/assets/e9b39d83-bb7a-4382-83e4-07135291aafb)

Les captains ont activé l'env à notre demande durant une dizaine de minutes, provoquant la génération de 30 000 entrées de logs (infiniment plus que d'habitude). 
On a donc laissé tomber le debugging de cette façon, mais ça nous a permis d'attirer notre attention sur :

![gapretourchariot](https://github.com/user-attachments/assets/06c0ee72-78d0-4026-bd5a-188538b0395c)

On voit clairement qu'entre le dernier retour chariot envoyé et la destruction du `setInterval` responsable des envois réguliers du retour chariot (précédant l'envoi des données dans le stream) s'est écoulé plus d'une minute ! La socket était donc en effet bien fermé par le client pour cause d'inactivité, puisqu'à un moment donné les retour chariots n'étaient plus envoyés !
On positionne donc des loggers dans la fonction de récupération des données pour y voir plus clair :

![timeline_alog](https://github.com/user-attachments/assets/f314d8ce-42c9-45db-be70-53755e77b044)

La fonction de récupération des données de réplication est écrite selon les deux grandes parties suivantes :
- Récupération des données depuis PG et/ou Airtable dans un gros Promise.all (durant lequel les retours chariot sont bien envoyés)
- Manipulation des données pour les transformer en données pour la réplication (exécution synchrone durant laquelle aucun retour chariot n'est émis)

En regardant plus finement les logs concernant la deuxième partie, on voit qu'un traitement de manipulation de données prend à lui seul presque une minute ! On comprend/apprend donc deux choses :
1. La callback du `setInterval` n'est exécutée que lorsqu'on passe au `nextTick`. Notre problème ici est qu'on a une grosse manipulation de données synchrone qui s'effectue dans le même tick, suspendant complètement la possibilité d'envoyer des retours chariot
2. L'ajout des traductions et l'intégration de celles-ci, de façon naïve, dans les boucles de parcours a gravement ralenti la construction du résultat. Pour donner un ordre de grandeur, sur la section critique, voici le détail du avant/après en terme de tours de boucle :
```
// AVANT 
const nbEpreuves = 30_000;
const nbLocalesParEpreuve = 2; // c'est une moyenne théorique arbitraire, mais ça illustre le propos
const nbLoops = nbEpreuves * nbLocalesParEpreuve ~= 60_000

// APRES 
const nbEpreuves = 30_000;
const nbLocalesParEpreuve = 2;
const nbTraductionsEnTout = 100_000;
const nbLoops = nbEpreuves * nbLocalesParEpreuve *  nbTraductionsEnTout ~= 6_000_000_000
```
On a donc gravement ralenti l'ensemble avec une implémentation "au plus vite".

#### Solution 1
On a revu l'algo de construction des données de réplication pour éviter une forte imbrication de boucles ce qui a eu pour effet de réduire le temps d'inactivité du stream. Le risque que ça dépasse reste quand même encore présent.

#### Solution 2
L'idéal est donc de permettre à la callback du setInterval qui permet d'envoyer les retours chariot de façon continue de s'exécuter. Pour cela, il faut forcer le usecase à rendre la main sur l'event loop.
Vu une solution [ici](https://github.com/nodejs/node/issues/41821) :
```js
function setImmediatePromise() {
  return new Promise((resolve) => setImmediate(resolve));
}

for(let i = 0; i < 100_000_000_000_000; ++i) {
  if(i % 100_000 === 0) { // tous les 100 000 tours
    await setImmediatePromise();
  }
}
```

### Problème 3 : Problème de fermeture prématurée de stream à cause de paquets trop gros
Une fois le problème d'inactivité réglé, nous sommes tombés sur un nouveau problème :

![prematureclose](https://github.com/user-attachments/assets/f59f4ee8-69ee-482d-9400-7607f22b50bb)

D'après la [documentation](https://nodejs.org/api/errors.html#err_stream_premature_close), l'erreur **ERR_STREAM_PREMATURE_CLOSE** est : 

> An error returned by stream.finished() and stream.pipeline(), when a stream or a pipeline ends non gracefully with no explicit error.

Il faut reconnaître que ça ne donne pas beaucoup d'informations, mais on avait eu un instinct déjà les jours passés que peut-être que le stream n'aime pas trop quand on lui envoie un trop gros paquet d'un coup.
Dans un premier temps on a opté pour une implémentation rapide, qui consiste à construire le JSON d'un seul coup mais de l'envoyer petit à petit (caractère par caractère).
Pour cela, on décide de piper le stream d'écriture avec un stream de lecture tout simple construit grâce à la méthode utilitaire `Readable.from()` pour créer des streams de lecture à partir d'une chaîne :
```js
pipeline(
      Readable.from(JSON.stringify(data)),
      writableStream,
      (err) => {/*...*/}
);
```
Lors de l'exécution, on s'attendait à voir arriver les caractères les uns après les autres dans le terminal, mais rien à faire il y a juste interruption des retours chariot, une attente, puis une fermeture inattendue du stream.
Après moults lectures et recherches, nous tombons en fait sur cette section de la [doc](https://nodejs.org/api/stream.html#streamreadablefromiterable-options) :
> Calling Readable.from(string) or Readable.from(buffer) will not have the strings or buffers be iterated to match the other streams semantics for performance reasons.

En d'autres termes, ça continue à envoyer tout d'un coup. 

#### Solution 
Si on veut vraiment découper l'envoi, on lit qu'on peut fournir un `Iterable`. On décide donc de procéder à l'écriture d'une fonction génératrice, faisant ainsi hommage à un membre de l'équipe :
```js
function* chunk(data) {
  const stringifiedData = JSON.stringify(data);
  for (let i = 0; i < stringifiedData.length; i += NB_CHARS_PER_CHUNK) {
    yield stringifiedData.slice(i, i + NB_CHARS_PER_CHUNK);
  }
}
pipeline(
      chunk(data),
      writableStream,
      (err) => {/*...*/}
);
```
Pour déterminer la valeur de `NB_CHARS_PER_CHUNK`, on a décidé de reprendre la valeur par défaut du `HIGHWATER MARK` des [streams](https://nodejs.org/api/stream.html#streamgetdefaulthighwatermarkobjectmode) :
> Returns the default highWaterMark used by streams. Defaults to 65536 (64 KiB)


## 🐝 Remarques
On est content on a appris plein de choses, mais dans la douleur.
Le résultat de 27 patches sur LCMS quand même 😅 

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
