### PR TITLE
[FEATURE] Transformer les espaces classiques en espaces fines insécables devant certains caractères spéciaux (PIX-17590)

### DIFF
--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -1,3 +1,6 @@
 export function normalizeNonBreakingSpace(str) {
-  return str.replaceAll(/ ([;?!])/g, ' $1');
+  return str
+    .replaceAll(/ ?([€$%])/g, ' $1')
+    .replaceAll(/ ?(°C)/g, ' $1')
+    .replaceAll(/ ([;?!])/g, ' $1');
 }

--- a/api/tests/unit/domain/usecases/create-challenge_test.js
+++ b/api/tests/unit/domain/usecases/create-challenge_test.js
@@ -23,8 +23,8 @@ describe('Unit | Domain | Usecases | create challenge', function() {
   });
 
   it.each([
-    ['fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
-    ['fr-fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
+    ['fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
+    ['fr-fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
     ['other', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
   ])('should normalize breaking space when challenge is `fr` or `fr-fr`', async (locale, expected) => {
     const challenge = domainBuilder.buildChallenge({

--- a/api/tests/unit/domain/usecases/update-challenge_test.js
+++ b/api/tests/unit/domain/usecases/update-challenge_test.js
@@ -92,8 +92,8 @@ describe('Unit | Domain | Usecases | update challenge', function() {
   });
 
   it.each([
-    ['fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
-    ['fr-fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
+    ['fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
+    ['fr-fr', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
     ['other', { instruction: 'Ça va ?', proposals:'Oui !', alternativeInstruction: 'Et donc ; voilà' }],
   ])('should normalize breaking space when challenge is `fr` or `fr-fr`', async (locale, { instruction, proposals, alternativeInstruction }) => {
     const challenge = domainBuilder.buildChallenge({

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -4,12 +4,12 @@ import { normalizeNonBreakingSpace } from '../../../../lib/infrastructure/utils/
 describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
   it('should replace spaces by non breaking spaces if are before `;`, `?` or `!`', () => {
     // given
-    const string = 'Est-ce ça ? Oui ! Non ; non!';
+    const string = 'Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16€, 16$, 16%, 16°C';
 
     // when
     const result = normalizeNonBreakingSpace(string);
 
     // then
-    expect(result).toBe('Est-ce ça ? Oui ! Non ; non!');
+    expect(result).toBe('Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16 €, 16 $, 16 %, 16 °C');
   });
 });


### PR DESCRIPTION
## 🌸 Problème
C'est compliqué de penser à rajouter des espaces insécables fines dans certains cas de création d'épreuves.

## 🌳 Proposition
Automatiser la transformation de l'espace classique en espace insécable fine devant les caractères suivants : `? ! ; $ € % °C` sur les champs `instruction, proposals et alternative textuelle` à la création et à la modification d'un challenge.

## 🐝 Remarques
Pour les caractères suivants, on a géré l'ajout d'espace insécable fine avec ou sans espace, parce que c'est pas toujours écrit avec un espace : 
`15°C ou 15 °C`
`15% ou 15 %`
`15$ ou 15 $`
`15€ ou 15 €`

## 🤧 Pour tester
Créer ou modifier une épreuve et checker dans l'inspecteur si les espaces attendues sont de type fines `&#8239;`