### PR TITLE
[FEATURE] Devant certains caractères spéciaux, ne pas remplacer le vide par une espace fine insécable (PIX-17603)

### DIFF
--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -1,6 +1,5 @@
 export function normalizeNonBreakingSpace(str) {
   return str
-    .replaceAll(/ ?([€$%])/g, ' $1')
     .replaceAll(/ ?(°C)/g, ' $1')
-    .replaceAll(/ ([;?!])/g, ' $1');
+    .replaceAll(/ ([;?!€$%])/g, ' $1');
 }

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -4,12 +4,12 @@ import { normalizeNonBreakingSpace } from '../../../../lib/infrastructure/utils/
 describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
   it('should replace spaces by non breaking spaces if are before `;`, `?` or `!`', () => {
     // given
-    const string = 'Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16€, 16$, 16%, 16°C';
+    const string = 'Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16°C';
 
     // when
     const result = normalizeNonBreakingSpace(string);
 
     // then
-    expect(result).toBe('Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16 €, 16 $, 16 %, 16 °C');
+    expect(result).toBe('Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16 °C');
   });
 });


### PR DESCRIPTION
## 🌸 Problème
Devant `€$%` ça peut possiblement être des urls, donc on veut pas remplacer `5$` mais juste `5 $` (Avec une espace forcément)

## 🌳 Proposition
Modifier la regex en conséquence.

## 🐝 Remarques
RAS

## 🤧 Pour tester
Tests au vert. 