### PR TITLE
[BUGFIX] Le traitement des URLs à ignorer ne marche pas bien lorsque les casses dans les URLs sont différentes (PIX-17398)

### DIFF
--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -105,8 +105,28 @@ export class WhitelistedUrl {
   }
 
   matches(url) {
-    if (this.checkType === WhitelistedUrl.CHECK_TYPES.EXACT_MATCH) return url === this.url;
-    if (this.checkType === WhitelistedUrl.CHECK_TYPES.STARTS_WITH) return url.startsWith(this.url);
+    const urlToCompare = new URL(url);
+    const urlFromWhitelist = new URL(this.url);
+
+    const urlToCompare_origin = urlToCompare.origin;
+    const urlFromWhitelist_origin = urlFromWhitelist.origin;
+
+    const urlToCompare_wholePath = urlToCompare.href.replace(urlToCompare_origin, '');
+    const urlFromWhitelist_wholePath = urlFromWhitelist.href.replace(urlFromWhitelist_origin, '');
+
+    if (this.checkType === WhitelistedUrl.CHECK_TYPES.EXACT_MATCH) {
+      const originIsMatching = urlToCompare_origin.localeCompare(urlFromWhitelist_origin, undefined, { sensitivity: 'base' }) === 0;
+      const wholePathIsMatching = urlToCompare_wholePath.localeCompare(urlFromWhitelist_wholePath, undefined, { sensitivity: 'case' }) === 0;
+
+      return originIsMatching && wholePathIsMatching;
+    }
+
+    if (this.checkType === WhitelistedUrl.CHECK_TYPES.STARTS_WITH) {
+      const originIsMatching = urlToCompare_origin.startsWith(urlFromWhitelist_origin);
+      const wholePathIsMatching = urlToCompare_wholePath.startsWith(urlFromWhitelist_wholePath);
+
+      return originIsMatching && wholePathIsMatching;
+    }
     return false;
   }
 }

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -773,11 +773,11 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         expect(isMatching).to.be.true;
       });
 
-      it('should not match when url is not the same case-wise', function() {
+      it('should not match when url is not the same case-wise after the domain part', function() {
         // given
-        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const url = 'httpS://mOn-Bidet_orangE.cOm/tokEn=COuCOu';
         const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
-          url: 'https://MON-Bidet_orange.com/token=COUCOU',
+          url: 'https://mon-bidet_orange.com/token=coucou',
           checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
         });
 
@@ -786,6 +786,21 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
         // then
         expect(isMatching).to.be.false;
+      });
+
+      it('should match when url is not the same case-wise before the domain part', function() {
+        // given
+        const url = 'httpS://mOn-Bidet_orangE.cOm/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://mon-bidet_orange.com/token=COUCOU',
+          checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.matches(url);
+
+        // then
+        expect(isMatching).to.be.true;
       });
 
       it('should not match when url is just partially the same', function() {
@@ -818,8 +833,9 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         expect(isMatching).to.be.false;
       });
     });
+
     describe('starts_with', function() {
-      it('should match when url is starts exactly with the same as the whitelisted', function() {
+      it('should match when url starts exactly with the same as the whitelisted', function() {
         // given
         const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
         const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
@@ -833,6 +849,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         // then
         expect(isMatching).to.be.true;
       });
+
       it('should match when url is exactly the same', function() {
         // given
         const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
@@ -848,11 +865,26 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         expect(isMatching).to.be.true;
       });
 
-      it('should not match when url does not start the same case-wise', function() {
+      it('should match when url starts the same case-wise before the domain part', function() {
         // given
         const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
         const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
-          url: 'https://MON-Bidet_orange.com/to',
+          url: 'https://MON-Bidet_orange.C',
+          checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
+        });
+
+        // when
+        const isMatching = whitelistedUrl.matches(url);
+
+        // then
+        expect(isMatching).to.be.true;
+      });
+
+      it('should not match when url does not start the same case-wise after the domain part', function() {
+        // given
+        const url = 'https://mOn-Bidet_orange.com/token=COUCOU';
+        const whitelistedUrl = domainBuilder.buildWhitelistedUrl({
+          url: 'https://MON-Bidet_orange.com/toKe',
           checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
         });
 


### PR DESCRIPTION
## 🌸 Problème

Certaines URLs dans la liste des URLs à ne pas analyser dans la moulinette ne semblent pas fonctionner.

## 🌳 Proposition

C'est un problème de casse. Dans une URL, on trouve grossièrement deux parties. Exemple: https://www.coucou.com?query=param#hash

- La partie `origin` : https://www.coucou.com
- Le reste : ?query=param#hash

La partie `origin` est insensible à la casse, le reste est sensible à la casse.
Il faut donc, pour déterminer si une URL est à exclure, comparer la partie `origin` de façon insensible à la casse, et le reste de façon sensible à la casse.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Ajouter une URL à ignorer et dans des épreuves validées avec des casses différentes pour faire ses tests.
Prévoir de faire une release à chaque fois avant exécution du petit script pour lancer une moulinette à la main
