### PR TITLE
[TECH] Gérer le traitement du header conditionnel "if-modified-since" dans le endpoint GET /releases/latest pour ne renvoyer la dernière release que si elle est plus récente que la date transmise

### DIFF
--- a/api/lib/application/releases.js
+++ b/api/lib/application/releases.js
@@ -46,9 +46,16 @@ export async function register(server) {
       method: 'GET',
       path: '/api/releases/latest',
       config: {
-        handler: async function() {
-          const release = await releaseRepository.getLatestRelease();
-          return JSON.stringify(release);
+        handler: async function(request, h) {
+          const ifModifiedSinceDate = request.headers?.['if-modified-since'] ? new Date(request.headers['if-modified-since']) : null;
+          const latestReleaseDate = await releaseRepository.getLatestReleaseDate();
+          if (!ifModifiedSinceDate || latestReleaseDate.getTime() > ifModifiedSinceDate.getTime()) {
+            const release = await releaseRepository.getLatestRelease();
+            return JSON.stringify(release);
+          }
+
+          return h.response()
+            .header('Last-Modified', latestReleaseDate.toUTCString());
         },
       },
     },

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -48,6 +48,15 @@ export async function getLatestRelease() {
   return _toDomain(release[0]);
 }
 
+export async function getLatestReleaseDate() {
+  const [createdAt] = await knex('releases')
+    .pluck('createdAt')
+    .orderBy('createdAt', 'desc')
+    .limit(1);
+
+  return createdAt;
+}
+
 export async function getRelease(id) {
   const release = await knex('releases')
     .select('id', 'content', 'createdAt')

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -830,12 +830,11 @@ describe('Acceptance | Controller | release-controller', () => {
   });
 
   describe('GET /releases/latest - Returns latest release', () => {
+    let user;
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+    });
     context('nominal case', () => {
-      let user;
-      beforeEach(async function() {
-        user = databaseBuilder.factory.buildAdminUser();
-      });
-
       it('should return latest release of learning content', async () => {
         // Given
         const expectedLatestRelease = databaseBuilder.factory.buildRelease({
@@ -850,7 +849,7 @@ describe('Acceptance | Controller | release-controller', () => {
             tubes: [],
             tutorials: [],
             missions: [],
-          }
+          },
         });
         const expectedContent = {
           areas: [],
@@ -873,6 +872,79 @@ describe('Acceptance | Controller | release-controller', () => {
           method: 'GET',
           url: '/api/releases/latest',
           headers: generateAuthorizationHeader(user),
+        });
+
+        // Then
+        const latestRelease = JSON.parse(response.result);
+        expect(latestRelease.content).to.deep.equal(expectedContent);
+        expect(latestRelease.id).to.deep.equal(expectedLatestRelease.id);
+        expect(latestRelease.date).to.deep.equal(expectedLatestRelease.date);
+      });
+    });
+
+    context('with if-modified-since header', function() {
+      it('should return a 304 when no latest release exist after given if-modified-since date', async function() {
+        // given
+        const server = await createServer();
+        const latestReleaseDate = new Date('2023-01-01T00:00:00Z');
+        databaseBuilder.factory.buildRelease({ createdAt: latestReleaseDate, content: '{"value":"coucouLatest"}' });
+        databaseBuilder.factory.buildRelease({ createdAt: new Date('2021-01-01'), content: '{"value":"coucouOld"}' });
+        databaseBuilder.factory.buildRelease({ createdAt: new Date('2020-01-01'), content: '{"value":"coucouSuperOld"}' });
+        await databaseBuilder.commit();
+
+        // when
+        const headers = generateAuthorizationHeader(user);
+        headers['If-Modified-Since'] = latestReleaseDate.toUTCString();
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/releases/latest',
+          headers,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(304);
+        expect(response.result).to.be.null;
+      });
+      it('should return the latest release if the release is newer than given if-modified-since date', async function() {
+        // Given
+        const expectedLatestRelease = databaseBuilder.factory.buildRelease({
+          content: {
+            areas: [],
+            challenges: [],
+            competences: [],
+            courses: [],
+            frameworks: [],
+            skills: [],
+            thematics: [],
+            tubes: [],
+            tutorials: [],
+            missions: [],
+          },
+          createdAt: new Date('2023-01-01T00:00:01Z'),
+        });
+        const expectedContent = {
+          areas: [],
+          challenges: [],
+          competences: [],
+          courses: [],
+          frameworks: [],
+          skills: [],
+          thematics: [],
+          tubes: [],
+          tutorials: [],
+          missions: [],
+        };
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // When
+        const headers = generateAuthorizationHeader(user);
+        headers['If-Modified-Since'] = new Date('2023-01-01T00:00:00Z').toUTCString();
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/releases/latest',
+          headers,
         });
 
         // Then

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -4,18 +4,18 @@ import {
   create,
   getCurrentContent,
   getLatestRelease,
+  getLatestReleaseDate,
   getRelease
 } from '../../../../lib/infrastructure/repositories/release-repository.js';
 import { Area, Attachment, Challenge, LocalizedChallenge, Mission } from '../../../../lib/domain/models/index.js';
 import { ChallengeForRelease, SkillForRelease, TutorialForRelease } from '../../../../lib/domain/models/release/index.js';
 
 describe('Integration | Repository | release-repository', function() {
+  afterEach(function() {
+    return knex('releases').delete();
+  });
+
   describe('#create', function() {
-
-    afterEach(function() {
-      return knex('releases').delete();
-    });
-
     it('should save current content as a new release', async function() {
       // Given
       const currentContent = { some: 'property' };
@@ -96,6 +96,31 @@ describe('Integration | Repository | release-repository', function() {
         content: expectedContent
       });
       expect(latestRelease).toEqualInstance(expectedRelease);
+    });
+  });
+
+  describe('#getLatestReleaseDate', function() {
+    it('should return the date of the latest release', async function() {
+      // Given
+      databaseBuilder.factory.buildRelease({
+        createdAt: new Date('2022-01-01'),
+        content: '{}',
+      });
+      const latestReleaseDate = databaseBuilder.factory.buildRelease({
+        createdAt: new Date('2023-01-01'),
+        content: '{}',
+      }).createdAt;
+      databaseBuilder.factory.buildRelease({
+        createdAt: new Date('2021-01-01'),
+        content: '{}',
+      });
+      await databaseBuilder.commit();
+
+      // When
+      const actualLatestReleaseDate = await getLatestReleaseDate();
+
+      // Then
+      expect(actualLatestReleaseDate).to.deep.equal(latestReleaseDate);
     });
   });
 


### PR DESCRIPTION
## 🌸 Problème

Dans la journée plein de dévs rejouent les seeds sur le projet Pix et passent par nina.
Le truc c'est que Nina doit à chaque fois récupérer la release, obfusquer et renvoyer. Or dans la journée il est rare qu'une nouvelle release soit créée.

## 🌳 Proposition

On pourrait, côté Nina, conserver la release obfusquée tant que celle-ci est bien la plus récente. Pour cela, on ajoute la possibilité de passer le header condition "if-modified-since" dans le endpoint GET /releases/latest et ainsi obtenir un code 304 dans le cas où, pour la date transmise, il n'existe pas de nouvelle release postérieure.

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
