### PR TITLE
[FEATURE] Ne pas tenir compte des URLs à ne pas analyser dans l'export des URLs externes (PIX-17260)

### DIFF
--- a/api/lib/domain/usecases/export-external-urls-from-release.js
+++ b/api/lib/domain/usecases/export-external-urls-from-release.js
@@ -1,11 +1,14 @@
 import _ from 'lodash';
 
-export async function exportExternalUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, UrlUtils }) {
+export async function exportExternalUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository, UrlUtils }) {
   const release = await releaseRepository.getLatestRelease();
   const { operativeChallenges } = release;
   const localizedChallengesById = _.keyBy(await localizedChallengeRepository.list(), 'id');
   const urlsFromChallenges = findUrlsFromChallenges(operativeChallenges, localizedChallengesById, release, UrlUtils);
-  const dataToUpload = urlsFromChallenges.map(({ origin, url, locales, status, tube }) =>
+  const whitelistedUrls = await whitelistedUrlRepository.list();
+  const activeWhitelistedUrls = whitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive);
+  const finalUrlList = urlsFromChallenges.filter(({ url }) => !activeWhitelistedUrls.some((whitelistedUrl) => whitelistedUrl.matches(url)));
+  const dataToUpload = finalUrlList.map(({ origin, url, locales, status, tube }) =>
     [origin, tube, url, locales.join(';'), status]);
   await urlRepository.exportExternalUrls(dataToUpload);
 }

--- a/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-processor.js
@@ -1,8 +1,13 @@
 import './job-process.js';
 import { exportExternalUrlsFromRelease } from '../../domain/usecases/index.js';
-import { localizedChallengeRepository, releaseRepository, urlRepository } from '../repositories/index.js';
+import {
+  localizedChallengeRepository,
+  releaseRepository,
+  urlRepository,
+  whitelistedUrlRepository
+} from '../repositories/index.js';
 import * as UrlUtils from '../utils/url-utils.js';
 
 export default function exportExternalUrlsJobProcessor() {
-  return exportExternalUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, UrlUtils });
+  return exportExternalUrlsFromRelease({ releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository, UrlUtils });
 }

--- a/api/tests/unit/domain/usecases/export-external-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/export-external-urls-from-release_test.js
@@ -3,10 +3,11 @@ import { domainBuilder } from '../../../test-helper.js';
 import { ChallengeForRelease } from '../../../../lib/domain/models/release/index.js';
 import { exportExternalUrlsFromRelease } from '../../../../lib/domain/usecases/index.js';
 import * as UrlUtils from '../../../../lib/infrastructure/utils/url-utils.js';
+import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Usecases | Export external urls from release', function() {
   describe('#exportExternalUrlsFromRelease', function() {
-    let releaseRepository, urlRepository, localizedChallengeRepository;
+    let releaseRepository, urlRepository, localizedChallengeRepository, whitelistedUrlRepository;
 
     beforeEach(function() {
       const pixCompetence = domainBuilder.buildCompetenceForRelease({
@@ -68,7 +69,7 @@ describe('Unit | Domain | Usecases | Export external urls from release', functio
       });
       const pixChallenge3Skill2 = domainBuilder.buildChallengeForRelease({
         id: 'challenge3',
-        instruction: 'instructions',
+        instruction: 'instructions https://ignore-me.us',
         skillId: 'skill2',
         status: ChallengeForRelease.STATUSES.VALIDE,
         locales: ['en'],
@@ -105,6 +106,12 @@ describe('Unit | Domain | Usecases | Export external urls from release', functio
         domainBuilder.buildLocalizedChallenge({ id: 'challenge5', challengeId: 'challenge5', urlsToConsult: null }),
       ];
       localizedChallengeRepository = { list: vi.fn().mockResolvedValue(localizedChallenges) };
+      const whitelistedUrls = [
+        domainBuilder.buildWhitelistedUrl({ url: 'https://ignorez-moi.fr', checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH, deletedAt: null }),
+        domainBuilder.buildWhitelistedUrl({ url: 'https://ignore-me.us', checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH, deletedAt: null }),
+        domainBuilder.buildWhitelistedUrl({ url: 'https://example.net/', checkType: WhitelistedUrl.CHECK_TYPES.EXACT_MATCH, deletedAt: new Date('2020-01-01') }),
+      ];
+      whitelistedUrlRepository = { list: vi.fn().mockResolvedValue(whitelistedUrls) };
       urlRepository = {
         exportExternalUrls: vi.fn(),
       };
@@ -112,7 +119,7 @@ describe('Unit | Domain | Usecases | Export external urls from release', functio
 
     it('should export external URLs for operative challenges (and also get urls from primary localized challenge)', async function() {
       // when
-      await exportExternalUrlsFromRelease({ releaseRepository, urlRepository, UrlUtils, localizedChallengeRepository });
+      await exportExternalUrlsFromRelease({ releaseRepository, urlRepository, UrlUtils, localizedChallengeRepository, whitelistedUrlRepository });
 
       // then
       expect(urlRepository.exportExternalUrls).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 🌸 Problème

Jusqu'à présent, on exportait toutes les URLs vers la sheet des urls externes.
Idéalement il faudrait ne pas remonter celles qui sont dans la whiteliste

## 🌳 Proposition
Ne pas remonter les urls présentes dans la liste des urls à ne pas analyser (aka whitelist)

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

Ajouter une url dans la whitelist
ajouter cette url dans une instruction d'épreuve en prod
faire une release
lancer l'export
vérifier que l'url n'y est pas
