### PR TITLE
[BUGFIX] Les parenthèses n'étaient pas bien prises en compte lors de l'identification des URLs dans les champs d'épreuve pour la moulinette et pour l'export des urls externes (PIX-15983)

### DIFF
--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -6,14 +6,6 @@ import { CookieJar } from 'tough-cookie';
 import { wrapper } from 'axios-cookiejar-support';
 import axios from 'axios';
 
-/* Given the following text: Coucou (https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
-  - With "parens" at false, it extracts the url until the first closing bracket : https://fr.wikipedia.org/wiki/(14234
-  - With "parens" at true, it extracts the url until the last closing bracket, that does not belong to the url: https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
-
-  So we leave the mode that extracts the closest to what we want (which is "parens" at true) and we do some calculation to remove
-  last bracket if it does not belong to the url
- */
-
 const GENERIC_URL_REGEX_IN_TEXT = new RegExp(urlRegex({ strict: true, parens: true, returnString: true }), 'i');
 
 export function findUrlsInMarkdown(value) {
@@ -102,17 +94,17 @@ export function getOrigin(url) {
 }
 
 /* Given the following text: Coucou (https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
-  - With "parens" at false, it extracts the url until the first closing bracket : https://fr.wikipedia.org/wiki/(14234
-  - With "parens" at true, it extracts the url until the last closing bracket, that does not belong to the url: https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
+  - With "parens" at false, it extracts the url until the first closing parenthesis : https://fr.wikipedia.org/wiki/(14234
+  - With "parens" at true, it extracts the url until the last closing parenthesis, that does not belong to the url: https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
 
   So we leave the mode that extracts the closest to what we want (which is "parens" at true) and we do some calculation to remove
-  the last bracket if it does not belong to the url
+  the last parenthesis if it does not belong to the url
   To do so, given an extracted url if :
-    The url ends with a closing bracket
+    The url ends with a closing parenthesis
   AND
-    The character before the url is an opened bracket
+    The character before the url is an opened parenthesis
   THEN
-    We can remove the last closing bracket in the url
+    We can remove the last closing parenthesis in the url
  */
 export function findUrlsInText(inputText) {
   let textToParse = inputText;

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -6,6 +6,8 @@ import { CookieJar } from 'tough-cookie';
 import { wrapper } from 'axios-cookiejar-support';
 import axios from 'axios';
 
+const GENERIC_URL_REGEX_IN_TEXT = urlRegex({ strict: true, parens: true });
+
 export function findUrlsInMarkdown(value) {
   const safeValue = value || '';
   const converter = new showdown.Converter();
@@ -92,7 +94,7 @@ export function getOrigin(url) {
 }
 
 export function findUrlsInText(inputText) {
-  const urls = inputText.match(urlRegex({ strict: true }));
+  const urls = inputText.match(GENERIC_URL_REGEX_IN_TEXT);
   if (!urls) {
     return [];
   }

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -14,7 +14,7 @@ import axios from 'axios';
   last bracket if it does not belong to the url
  */
 
-const GENERIC_URL_REGEX_IN_TEXT = urlRegex({ strict: true, parens: true, returnString: true });
+const GENERIC_URL_REGEX_IN_TEXT = new RegExp(urlRegex({ strict: true, parens: true, returnString: true }), 'i');
 
 export function findUrlsInMarkdown(value) {
   const safeValue = value || '';

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -6,7 +6,7 @@ import { CookieJar } from 'tough-cookie';
 import { wrapper } from 'axios-cookiejar-support';
 import axios from 'axios';
 
-const GENERIC_URL_REGEX_IN_TEXT = urlRegex({ strict: true, parens: true });
+const GENERIC_URL_REGEX_IN_TEXT = urlRegex({ strict: true, parens: true, returnString: true });
 
 export function findUrlsInMarkdown(value) {
   const safeValue = value || '';
@@ -94,7 +94,23 @@ export function getOrigin(url) {
 }
 
 export function findUrlsInText(inputText) {
-  const urls = inputText.match(GENERIC_URL_REGEX_IN_TEXT);
+  let textToParse = inputText;
+  let hasUrlsLeft = true;
+  const urls = [];
+  do {
+    const result = textToParse.match(GENERIC_URL_REGEX_IN_TEXT);
+    if (!result) {
+      hasUrlsLeft = false;
+    } else {
+      let url = result[0];
+      const characterBeforeUrl = textToParse.charAt(result.index - 1);
+      if (characterBeforeUrl === '(' && url.slice(-1) === ')') {
+        url = url.slice(0, -1);
+      }
+      urls.push(url);
+      textToParse = textToParse.slice(result.index + url.length);
+    }
+  } while (hasUrlsLeft);
   if (!urls) {
     return [];
   }

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -6,6 +6,14 @@ import { CookieJar } from 'tough-cookie';
 import { wrapper } from 'axios-cookiejar-support';
 import axios from 'axios';
 
+/* Given the following text: Coucou (https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
+  - With "parens" at false, it extracts the url until the first closing bracket : https://fr.wikipedia.org/wiki/(14234
+  - With "parens" at true, it extracts the url until the last closing bracket, that does not belong to the url: https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
+
+  So we leave the mode that extracts the closest to what we want (which is "parens" at true) and we do some calculation to remove
+  last bracket if it does not belong to the url
+ */
+
 const GENERIC_URL_REGEX_IN_TEXT = urlRegex({ strict: true, parens: true, returnString: true });
 
 export function findUrlsInMarkdown(value) {
@@ -93,6 +101,19 @@ export function getOrigin(url) {
   return new URL(url).origin;
 }
 
+/* Given the following text: Coucou (https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
+  - With "parens" at false, it extracts the url until the first closing bracket : https://fr.wikipedia.org/wiki/(14234
+  - With "parens" at true, it extracts the url until the last closing bracket, that does not belong to the url: https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
+
+  So we leave the mode that extracts the closest to what we want (which is "parens" at true) and we do some calculation to remove
+  the last bracket if it does not belong to the url
+  To do so, given an extracted url if :
+    The url ends with a closing bracket
+  AND
+    The character before the url is an opened bracket
+  THEN
+    We can remove the last closing bracket in the url
+ */
 export function findUrlsInText(inputText) {
   let textToParse = inputText;
   let hasUrlsLeft = true;

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -84,6 +84,7 @@ soin:
 - (https://solution_example.net/123)_fin_deuxparentheses())
 - (https://solution_example.net/123)_fin_parentheseouvrante()
 - (https://solution_example.net/123)_fin_parenthesefermante))
+solutionA to display https://solutionToDisplay_example.org/
 `;
 
       const result = UrlUtils.findUrlsInText(inputString);
@@ -100,6 +101,7 @@ soin:
         'https://solution_example.net/123)_fin_deuxparentheses()',
         'https://solution_example.net/123)_fin_parentheseouvrante(',
         'https://solution_example.net/123)_fin_parenthesefermante)',
+        'https://solutionToDisplay_example.org/',
       ]);
     });
 

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -69,7 +69,7 @@ describe('Unit | Utils | URL Utils', function() {
   });
 
   describe('#findUrlsInText', () => {
-    it('should find multiple url', function() {
+    it('should find multiple urls', function() {
       const inputString = `lien:
 - "https://pas_local.org/super_nom_wow.pdf"
 - "http://local_youyou.org/el_-_deuxième_super_truc.html"
@@ -77,7 +77,14 @@ describe('Unit | Utils | URL Utils', function() {
 - "http://local_youyou.org/autre_dossier/el_-_deuxième_super_truc.txt"
 - "www.local_youyou.org/text.txt"
 soin:
-- 20 ans`;
+- 20 ans
+- (https://solution_example.net/(123)_deuxparentheses)
+- (https://solution_example.net/(123_parentheseouvrante)
+- (https://solution_example.net/123)_parenthesefermante)
+- (https://solution_example.net/123)_fin_deuxparentheses())
+- (https://solution_example.net/123)_fin_parentheseouvrante()
+- (https://solution_example.net/123)_fin_parenthesefermante))
+`;
 
       const result = UrlUtils.findUrlsInText(inputString);
 
@@ -86,7 +93,13 @@ soin:
         'http://local_youyou.org/el_-_deuxième_super_truc.html',
         'http://local_youyou.test.org/el_-_deuxième_super_truc',
         'http://local_youyou.org/autre_dossier/el_-_deuxième_super_truc.txt',
-        'https://www.local_youyou.org/text.txt'
+        'https://www.local_youyou.org/text.txt',
+        'https://solution_example.net/(123)_deuxparentheses',
+        'https://solution_example.net/(123_parentheseouvrante',
+        'https://solution_example.net/123)_parenthesefermante',
+        'https://solution_example.net/123)_fin_deuxparentheses()',
+        'https://solution_example.net/123)_fin_parentheseouvrante(',
+        'https://solution_example.net/123)_fin_parenthesefermante)',
       ]);
     });
 


### PR DESCRIPTION
## 🌸 Problème
Pour le texte : "voir le lien entre parenthèses (https://fr.wikipedia.org/wiki/(14234)_Davidhoover)"
Le parser n'extrait que :  https://fr.wikipedia.org/wiki/(14234

## 🌳 Proposition
C'est la lib qu'on utilise qui fait comme ça par défaut https://github.com/spamscanner/url-regex-safe.
En ajoutant l'option `parens: true` on arrivait à ceci :
Pour le texte  "en français (https://fr.wikipedia.org/wiki/(14234)_Davidhoover)."
On extrait https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
La parenth

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
