### PR TITLE
[BUGFIX] Moulinette URLS : URL entre parenthèses mal identifiée si un caractère succède immédiatement la dernière parenthèse (PIX-17725)

### DIFF
--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -98,13 +98,9 @@ export function getOrigin(url) {
   - With "parens" at true, it extracts the url until the last closing parenthesis, that does not belong to the url: https://fr.wikipedia.org/wiki/(14234)_Davidhoover)
 
   So we leave the mode that extracts the closest to what we want (which is "parens" at true) and we do some calculation to remove
-  the last parenthesis if it does not belong to the url
-  To do so, given an extracted url if :
-    The url ends with a closing parenthesis
-  AND
-    The character before the url is an opened parenthesis
-  THEN
-    We can remove the last closing parenthesis in the url
+  the last parenthesis if it does not belong to the url.
+  If the character before the url is an opened parenthesis, then find the last closing parenthesis of the extracted URL
+  and remove everything after this parenthesis (parenthesis included)
  */
 export function findUrlsInText(inputText) {
   let textToParse = inputText;
@@ -117,8 +113,11 @@ export function findUrlsInText(inputText) {
     } else {
       let url = result[0];
       const characterBeforeUrl = textToParse.charAt(result.index - 1);
-      if (characterBeforeUrl === '(' && url.slice(-1) === ')') {
-        url = url.slice(0, -1);
+      if (characterBeforeUrl === '(') {
+        const indexOfLastParenthesis = url.lastIndexOf(')');
+        if (indexOfLastParenthesis) {
+          url = url.slice(0, indexOfLastParenthesis);
+        }
       }
       urls.push(url);
       textToParse = textToParse.slice(result.index + url.length);

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -84,6 +84,7 @@ soin:
 - (https://solution_example.net/123)_fin_deuxparentheses())
 - (https://solution_example.net/123)_fin_parentheseouvrante()
 - (https://solution_example.net/123)_fin_parenthesefermante))
+- (https://solution_example.net/(123)_deuxparentheses_avec_caractère_après),
 solutionA to display https://solutionToDisplay_example.org/
 `;
 
@@ -101,6 +102,7 @@ solutionA to display https://solutionToDisplay_example.org/
         'https://solution_example.net/123)_fin_deuxparentheses()',
         'https://solution_example.net/123)_fin_parentheseouvrante(',
         'https://solution_example.net/123)_fin_parenthesefermante)',
+        'https://solution_example.net/(123)_deuxparentheses_avec_caractère_après',
         'https://solutionToDisplay_example.org/',
       ]);
     });


### PR DESCRIPTION
## 🌸 Problème

De ceci : (https://austinlizentrait.bandcamp.com/track/wanderings), 
on extrait ceci : https://austinlizentrait.bandcamp.com/track/wanderings), 
or il faudrait extraire ceci : https://austinlizentrait.bandcamp.com/track/wanderings

## 🌳 Proposition
Si une parenthèse ouvrante se trouve juste avant le début de l'URL (donc l'URL se trouve dans des parenthèses) alors, de l'URL extraite, on trouve la dernière parenthèse et on la vire + tout ce qui suit

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
