### PR TITLE
[TECH] Retirer les mots "whiteliste/whitelistée" des messages renvoyés par l'API pour parler des URLs à ne pas analyser (PIX-17462)

### DIFF
--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -34,7 +34,7 @@ export async function register(server) {
           const whitelistedUrlId = request.params.whitelistedUrlId;
           const whitelistedUrlToDelete = await whitelistedUrlRepository.find(whitelistedUrlId);
           if (!whitelistedUrlToDelete) {
-            throw new NotFoundWhitelistedUrlError(`L'URL whitelistée d'id ${whitelistedUrlId} n'existe pas`);
+            throw new NotFoundWhitelistedUrlError(`L'URL d'id ${whitelistedUrlId} n'existe pas`);
           }
           whitelistedUrlToDelete.canDelete(authenticatedUser);
           whitelistedUrlToDelete.delete(authenticatedUser);
@@ -88,7 +88,7 @@ export async function register(server) {
           };
           const whitelistedUrlToUpdate = await whitelistedUrlRepository.find(whitelistedUrlId);
           if (!whitelistedUrlToUpdate) {
-            throw new NotFoundWhitelistedUrlError(`L'URL whitelistée d'id ${whitelistedUrlId} n'existe pas`);
+            throw new NotFoundWhitelistedUrlError(`L'URL d'id ${whitelistedUrlId} n'existe pas`);
           }
           const existingWhitelistedUrls = await whitelistedUrlRepository.list();
           whitelistedUrlToUpdate.canUpdate(updateCommand, authenticatedUser, existingWhitelistedUrls);

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -45,12 +45,12 @@ export class WhitelistedUrl {
 
   static canCreate(creationCommand, user, existingWhitelistedUrls) {
     const activeExistingWhitelistedUrls = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive);
-    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour créer une URL whitelistée');
+    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour ajouter une URL à ne pas analyser');
     if (!isUrlValid(creationCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
     if (!isRelatedSkillNamesValid(creationCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
     if (!isCommentValid(creationCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
     if (!isCheckTypeValid(creationCommand.checkType)) throw new CommandWhitelistedUrlError({ message: `Type de check invalide. Valeurs parmi : ${Object.values(WhitelistedUrl.CHECK_TYPES).join(', ')}`, attribute: 'checkType' });
-    if (!isUrlUnique(creationCommand.url, activeExistingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
+    if (!isUrlUnique(creationCommand.url, activeExistingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà dans la liste');
   }
 
   static create(creationCommand, user) {
@@ -71,8 +71,8 @@ export class WhitelistedUrl {
   }
 
   canDelete(user) {
-    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour supprimer cette URL whitelistée');
-    if (this.deletedAt) throw new CommandWhitelistedUrlConflictError('L\'URL whitelistée a déjà été supprimée');
+    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour supprimer cette URL');
+    if (this.deletedAt) throw new CommandWhitelistedUrlConflictError('L\'URL a déjà été supprimée');
   }
 
   delete(user) {
@@ -85,13 +85,13 @@ export class WhitelistedUrl {
 
   canUpdate(updateCommand, user, existingWhitelistedUrls) {
     const activeOtherExistingWhitelistedUrls = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive && whitelistedUrl.id !== this.id);
-    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour mettre à jour cette URL whitelistée');
-    if (this.deletedAt) throw new NotFoundWhitelistedUrlError('L\'URL whitelistée n\'existe pas');
+    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour mettre à jour cette URL');
+    if (this.deletedAt) throw new NotFoundWhitelistedUrlError('L\'URL n\'existe pas');
     if (!isUrlValid(updateCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
     if (!isRelatedSkillNamesValid(updateCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
     if (!isCommentValid(updateCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
     if (!isCheckTypeValid(updateCommand.checkType)) throw new CommandWhitelistedUrlError({ message: `Type de check invalide. Valeurs parmi : ${Object.values(WhitelistedUrl.CHECK_TYPES).join(', ')}`, attribute: 'checkType' });
-    if (!isUrlUnique(updateCommand.url, activeOtherExistingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà whitelistée');
+    if (!isUrlUnique(updateCommand.url, activeOtherExistingWhitelistedUrls)) throw new CommandWhitelistedUrlConflictError('URL déjà dans la liste');
   }
 
   update(updateCommand, user) {

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -237,7 +237,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
           {
             status: '404',
             title: 'Not Found',
-            detail: 'L\'URL whitelistée d\'id 777 n\'existe pas',
+            detail: 'L\'URL d\'id 777 n\'existe pas',
           },
         ],
       });
@@ -258,7 +258,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
           {
             status: '409',
             title: 'Conflict',
-            detail: 'L\'URL whitelistée a déjà été supprimée',
+            detail: 'L\'URL a déjà été supprimée',
           },
         ],
       });

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -82,7 +82,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new CommandWhitelistedUrlForbiddenError(
-            'L\'utilisateur n\'a pas les droits pour supprimer cette URL whitelistée'
+            'L\'utilisateur n\'a pas les droits pour supprimer cette URL'
           ));
         }
       });
@@ -101,7 +101,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new CommandWhitelistedUrlConflictError(
-            'L\'URL whitelistée a déjà été supprimée'
+            'L\'URL a déjà été supprimée'
           ));
         }
       });
@@ -199,7 +199,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new CommandWhitelistedUrlForbiddenError(
-            'L\'utilisateur n\'a pas les droits pour créer une URL whitelistée'
+            'L\'utilisateur n\'a pas les droits pour ajouter une URL à ne pas analyser'
           ));
         }
       });
@@ -373,7 +373,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new CommandWhitelistedUrlConflictError(
-            'URL déjà whitelistée'
+            'URL déjà dans la liste'
           ));
         }
       });
@@ -484,7 +484,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new CommandWhitelistedUrlForbiddenError(
-            'L\'utilisateur n\'a pas les droits pour mettre à jour cette URL whitelistée'
+            'L\'utilisateur n\'a pas les droits pour mettre à jour cette URL'
           ));
         }
       });
@@ -680,7 +680,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new CommandWhitelistedUrlConflictError(
-            'URL déjà whitelistée'
+            'URL déjà dans la liste'
           ));
         }
       });
@@ -705,7 +705,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
           expect(false, 'Should have thrown').to.be.true;
         } catch (err) {
           expect(err).toStrictEqual(new NotFoundWhitelistedUrlError(
-            'L\'URL whitelistée n\'existe pas'
+            'L\'URL n\'existe pas'
           ));
         }
       });


### PR DESCRIPTION
## 🌸 Problème
Première passe faite côté front, il manque les messages d'erreurs renvoyés par le back.

## 🌳 Proposition

Virer les mots whiteliste/whitelistée etc...

## 🐝 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🤧 Pour tester
faire une erreur sur les urls à ne pas analyser et voir que le message du back n'a pas les mots interdits
