### PR TITLE
[FEATURE] Pouvoir voir clairement et proprement la liste des noms des acquis concernés dans le tableau des URLs à ne pas analyser (PIX-17354)

### DIFF
--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -36,7 +36,7 @@
     @onRowClick={{@goToEditWhitelistedUrl}}
   >
     <:columns as |whitelistedUrl context|>
-      <PixTableColumn @context={{context}} class="column--small">
+      <PixTableColumn @context={{context}} class="column--wide">
         <:header>Nom des acquis concernés</:header>
         <:cell>
           <WhitelistedUrls::RelatedSkillCell @skills={{whitelistedUrl.relatedSkillNames}} />

--- a/pix-editor/app/components/whitelisted-urls/list.hbs
+++ b/pix-editor/app/components/whitelisted-urls/list.hbs
@@ -38,7 +38,9 @@
     <:columns as |whitelistedUrl context|>
       <PixTableColumn @context={{context}} class="column--small">
         <:header>Nom des acquis concernés</:header>
-        <:cell>{{ whitelistedUrl.relatedSkillNames }}</:cell>
+        <:cell>
+          <WhitelistedUrls::RelatedSkillCell @skills={{whitelistedUrl.relatedSkillNames}} />
+        </:cell>
       </PixTableColumn>
       <PixTableColumn @context={{context}}>
         <:header>Type de comparaison</:header>

--- a/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
+++ b/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+
+export default class RelatedSkillCell extends Component {
+  get skills() {
+    if (!this.args.skills) {
+      return '';
+    }
+    const skillsArray = this.args.skills.split(',');
+    const orderedSkillsArray = skillsArray.sort((a,b) => a.localeCompare(b, undefined, { sensitivity: "case" }));
+    if (orderedSkillsArray.length === 1) {
+      return orderedSkillsArray[0];
+    }
+    const other = orderedSkillsArray.length === 2 ? 'autre' : 'autres';
+    return `${orderedSkillsArray[0]} et ${orderedSkillsArray.length - 1} ${other} acquis`
+  }
+
+  <template>
+    {{ this.skills }}
+  </template>
+}

--- a/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
+++ b/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
@@ -1,20 +1,46 @@
+import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
+import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 export default class RelatedSkillCell extends Component {
-  get skills() {
+
+  constructor(...args) {
+    super(...args);
+    this.id = 'related-skill-cell-' + guidFor(this);
+  }
+
+  get skillCellContent() {
     if (!this.args.skills) {
       return '';
     }
     const skillsArray = this.args.skills.split(',');
-    const orderedSkillsArray = skillsArray.sort((a,b) => a.localeCompare(b, undefined, { sensitivity: "case" }));
+    const orderedSkillsArray = skillsArray.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'case' }));
     if (orderedSkillsArray.length === 1) {
       return orderedSkillsArray[0];
     }
     const other = orderedSkillsArray.length === 2 ? 'autre' : 'autres';
-    return `${orderedSkillsArray[0]} et ${orderedSkillsArray.length - 1} ${other} acquis`
+    return `${orderedSkillsArray[0]} et ${orderedSkillsArray.length - 1} ${other} acquis`;
+  }
+
+  get skillTooltipContent() {
+    if (!this.args.skills) {
+      return '';
+    }
+    const skillsArray = this.args.skills.split(',');
+    return skillsArray
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'case' }))
+      .join(',');
   }
 
   <template>
-    {{ this.skills }}
+    <PixTooltip @id={{this.id}} @position="top-left">
+      <:triggerElement>
+      <span class="icon icon-info" aria-labelledby={{this.id}}>{{this.skillCellContent}}</span>
+      </:triggerElement>
+
+      <:tooltip>
+        {{this.skillTooltipContent}}
+      </:tooltip>
+    </PixTooltip>
   </template>
 }

--- a/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
+++ b/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
@@ -33,9 +33,9 @@ export default class RelatedSkillCell extends Component {
   }
 
   <template>
-    <PixTooltip @id={{this.id}} @position="top-left">
+    <PixTooltip @id={{this.id}} @position="top-right">
       <:triggerElement>
-      <span class="icon icon-info" aria-labelledby={{this.id}}>{{this.skillCellContent}}</span>
+        <span class="icon icon-info" aria-labelledby={{this.id}}>{{this.skillCellContent}}</span>
       </:triggerElement>
 
       <:tooltip>

--- a/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
@@ -69,7 +69,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
     assert.strictEqual(currentURL(), '/whitelisted-urls');
     assert.dom(screen.getByText('Test de création')).exists();
     assert.dom(screen.getByText('https://example.org')).exists();
-    assert.dom(screen.getByText('@test1,@test2')).exists();
+    assert.dom(screen.getByText('@test1 et 1 autre acquis')).exists();
     assert.strictEqual(screen.getAllByText('Strictement égale à').length, 3);
   });
 
@@ -90,7 +90,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
     assert.strictEqual(currentURL(), '/whitelisted-urls');
     assert.dom(screen.queryByText('Test de création')).doesNotExist();
     assert.dom(screen.getByText('https://example.org')).exists();
-    assert.dom(screen.getByText('@test1,@test2')).exists();
+    assert.dom(screen.getByText('@test1 et 1 autre acquis')).exists();
     assert.strictEqual(screen.getAllByText('Commence par').length, 2);
   });
 });

--- a/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
@@ -68,7 +68,7 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
     assert.strictEqual(currentURL(), '/whitelisted-urls');
     assert.dom(screen.getByText('http://chats.fr')).exists();
     assert.dom(screen.getByText('MIAOU MIAOU')).exists();
-    assert.dom(screen.getByText('@miaou1,@croquettes2')).exists();
+    assert.dom(screen.getByText('@croquettes2 et 1 autre acquis')).exists();
     assert.strictEqual(screen.getAllByText('Strictement égale à').length, 2);
   });
 

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -110,7 +110,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Laura' }), 'Un commentaire sur Laura');
     assert.ok(screen.getByRole('cell', { name: `01/01/2020 à ${hour1_create}:00 par Laura le chocolat` }), `01/01/2020 à ${hour1_create}:00 par Laura le chocolat`);
     assert.ok(screen.getByRole('cell', { name: `01/01/2021 à ${hour1_update}:00 par Iris l'anis` }), `01/01/2021 à ${hour1_update}:00 par Iris l'anis`);
-    assert.ok(screen.getByRole('cell', { name: '@fruit4,@legume5' }), '@fruit4,@legume5');
+    assert.ok(screen.getByRole('cell', { name: '@fruit4 et 1 autre acquis' }), '@fruit4 et 1 autre acquis');
     assert.ok(screen.getByRole('cell', { name: 'https://bar.com' }), 'https://bar.com');
     assert.ok(screen.getByRole('cell', { name: 'Commence par' }), 'Commence par');
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Fael' }), 'Un commentaire sur Fael');
@@ -267,7 +267,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     await clickByText('Strictement égale à');
     await clickByText('Un commentaire sur Laura');
     await clickByText('https://foo.com');
-    await clickByText('@fruit4,@legume5');
+    await clickByText('@fruit4 et 1 autre acquis');
 
     // then
     assert.strictEqual(onEditStub.callCount, 4);

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -110,7 +110,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Laura' }), 'Un commentaire sur Laura');
     assert.ok(screen.getByRole('cell', { name: `01/01/2020 à ${hour1_create}:00 par Laura le chocolat` }), `01/01/2020 à ${hour1_create}:00 par Laura le chocolat`);
     assert.ok(screen.getByRole('cell', { name: `01/01/2021 à ${hour1_update}:00 par Iris l'anis` }), `01/01/2021 à ${hour1_update}:00 par Iris l'anis`);
-    assert.dom(screen.getByText('@fruit4 et 1 autre acquis')).exists();
+    assert.ok(screen.getByText('@fruit4 et 1 autre acquis'));
     assert.ok(screen.getByRole('cell', { name: 'https://bar.com' }), 'https://bar.com');
     assert.ok(screen.getByRole('cell', { name: 'Commence par' }), 'Commence par');
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Fael' }), 'Un commentaire sur Fael');

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -110,7 +110,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Laura' }), 'Un commentaire sur Laura');
     assert.ok(screen.getByRole('cell', { name: `01/01/2020 à ${hour1_create}:00 par Laura le chocolat` }), `01/01/2020 à ${hour1_create}:00 par Laura le chocolat`);
     assert.ok(screen.getByRole('cell', { name: `01/01/2021 à ${hour1_update}:00 par Iris l'anis` }), `01/01/2021 à ${hour1_update}:00 par Iris l'anis`);
-    assert.ok(screen.getByRole('cell', { name: '@fruit4 et 1 autre acquis' }), '@fruit4 et 1 autre acquis');
+    assert.dom(screen.getByText('@fruit4 et 1 autre acquis')).exists();
     assert.ok(screen.getByRole('cell', { name: 'https://bar.com' }), 'https://bar.com');
     assert.ok(screen.getByRole('cell', { name: 'Commence par' }), 'Commence par');
     assert.ok(screen.getByRole('cell', { name: 'Un commentaire sur Fael' }), 'Un commentaire sur Fael');

--- a/pix-editor/tests/integration/components/whitelisted-urls/related-skill-cell-test.gjs
+++ b/pix-editor/tests/integration/components/whitelisted-urls/related-skill-cell-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { triggerEvent } from '@ember/test-helpers';
 import RelatedSkillCell from 'pixeditor/components/whitelisted-urls/related-skill-cell';
 import { module, test } from 'qunit';
 
@@ -18,8 +19,7 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
 
     // then
     const content = await screen.queryAllByText(/.+/i);
-
-    assert.ok(content.length === 0);
+    assert.strictEqual(content.length, 0);
   });
 
   test('it should display a skill when there is one skill', async function(assert) {
@@ -30,9 +30,19 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
     const screen = await (render(<template>
       <RelatedSkillCell @skills={{skills}} />
     </template>));
+    const allElementsWithSkill = await screen.queryAllByText('@skill1');
+    const [
+      skillCell,
+      tooltip,
+    ] = [
+      allElementsWithSkill.find((el) => el.hasAttribute('aria-labelledby')),
+      allElementsWithSkill.find((el) => !el.hasAttribute('aria-labelledby')),
+    ];
+    await triggerEvent(skillCell, 'mouseenter');
 
     // then
-    assert.dom(screen.getByText('@skill1')).exists();
+    assert.dom(skillCell).exists();
+    assert.dom(tooltip).isVisible();
   });
 
   test('it should display the first skill (as in alphabetical order) and a singular version of appended sentence when there is a list of 2 skills', async function(assert) {
@@ -43,9 +53,13 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
     const screen = await (render(<template>
       <RelatedSkillCell @skills={{skills}} />
     </template>));
+    const skillCell = await screen.getByText('@mensonge3 et 1 autre acquis');
+    const tooltip = await screen.getByText('@mensonge3,@verite2');
+    await triggerEvent(skillCell, 'mouseenter');
 
     // then
-    assert.dom(screen.getByText('@mensonge3 et 1 autre acquis')).exists();
+    assert.dom(skillCell).exists();
+    assert.dom(tooltip).isVisible();
   });
 
   test('it should display the first skill (as in alphabetical order) and a plural version of appended sentence when there is a list of more than 2 skills', async function(assert) {
@@ -56,8 +70,14 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
     const screen = await (render(<template>
       <RelatedSkillCell @skills={{skills}} />
     </template>));
+    const skillCell = await screen.getByText('@mensonge3 et 2 autres acquis');
+    const tooltip = await screen.getByText('@mensonge3,@meOperator3,@verite2');
+    await triggerEvent(skillCell, 'mouseenter');
 
     // then
-    assert.dom(screen.getByText('@mensonge3 et 2 autres acquis')).exists();
+
+    // then
+    assert.dom(skillCell).exists();
+    assert.dom(tooltip).isVisible();
   });
 });

--- a/pix-editor/tests/integration/components/whitelisted-urls/related-skill-cell-test.gjs
+++ b/pix-editor/tests/integration/components/whitelisted-urls/related-skill-cell-test.gjs
@@ -1,0 +1,63 @@
+import { render } from '@1024pix/ember-testing-library';
+import RelatedSkillCell from 'pixeditor/components/whitelisted-urls/related-skill-cell';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | whitelisted-urls/related-skill-cell', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display an empty when there is no skill', async function(assert) {
+    // given
+    const skills = null;
+
+    // when
+    const screen = await (render(<template>
+  <RelatedSkillCell @skills={{skills}} />
+</template>));
+
+    // then
+    const content = await screen.queryAllByText(/.+/i);
+
+    assert.ok(content.length === 0);
+  });
+
+  test('it should display a skill when there is one skill', async function(assert) {
+    // given
+    const skills = '@skill1';
+
+    // when
+    const screen = await (render(<template>
+      <RelatedSkillCell @skills={{skills}} />
+    </template>));
+
+    // then
+    assert.dom(screen.getByText('@skill1')).exists();
+  });
+
+  test('it should display the first skill (as in alphabetical order) and a singular version of appended sentence when there is a list of 2 skills', async function(assert) {
+    // given
+    const skills = '@verite2,@mensonge3';
+
+    // when
+    const screen = await (render(<template>
+      <RelatedSkillCell @skills={{skills}} />
+    </template>));
+
+    // then
+    assert.dom(screen.getByText('@mensonge3 et 1 autre acquis')).exists();
+  });
+
+  test('it should display the first skill (as in alphabetical order) and a plural version of appended sentence when there is a list of more than 2 skills', async function(assert) {
+    // given
+    const skills = '@verite2,@mensonge3,@meOperator3';
+
+    // when
+    const screen = await (render(<template>
+      <RelatedSkillCell @skills={{skills}} />
+    </template>));
+
+    // then
+    assert.dom(screen.getByText('@mensonge3 et 2 autres acquis')).exists();
+  });
+});


### PR DESCRIPTION
## 🌸 Problème
Quand la liste des acquis concernés contient un grand nombre d'acquis, visuellement ça faisait n'importe quoi.

## 🌳 Proposition
Si la liste contient plus de 1 acquis, mettre une phrase custom du style :
"@noix3 et 2 autres acquis" et ajouter un tooltip au hover pour mettre la liste complète

## 🐝 Remarques
On a mis la tooltip vers la droite, car à gauche elle passait en dessous au bout d'un moment (z-index n'a pas aidé).

## 🤧 Pour tester
Aller sur la liste des urls à ne pas analyser.
Regarder le comportement de la cellule "Nom des acquis concernés" avec différentes tailles de contenu (ne pas hésiter à éditer une ligne pour faire ses tests)
