### PR TITLE
[BUGFIX] Rediriger vers la V2 depuis `/challenge/{id}` (PIX-17244)

### DIFF
--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -5,6 +5,7 @@ export default class ChallengeRoute extends Route {
 
   @service router;
   @service store;
+  @service versionManager;
 
   async model(params) {
     try {
@@ -26,13 +27,56 @@ export default class ChallengeRoute extends Route {
       const tube = await skill.tube;
       const competence = await tube.competence;
       if (challenge.get('isPrototype') && localizedChallenge.isPrimaryChallenge) {
-        return this.router.transitionTo('authenticated.competence.prototypes.single', competence, challenge.get('id'));
+        if (this.versionManager.isV2 && challenge.get('isValidated')) {
+          return this.router.transitionTo(
+            'authenticated.v2.challenge',
+            competence.get('id'),
+            'challenges-production',
+            skill.get('id'),
+            challenge.get('id'),
+          );
+        } else {
+          return this.router.transitionTo(
+            'authenticated.competence.prototypes.single',
+            competence.get('id'),
+            challenge.get('id'),
+            { queryParams: { view: challenge.get('isValidated') ? 'production' : 'workbench' } },
+          );
+        }
       } else if (challenge.get('isPrototype')) {
-        return this.router.transitionTo('authenticated.competence.prototypes.localized', competence, challenge.get('id'), localizedChallenge.get('id'));
+        return this.router.transitionTo(
+          'authenticated.competence.prototypes.localized',
+          competence.get('id'),
+          challenge.get('id'),
+          localizedChallenge.get('id'),
+        );
       } else if (localizedChallenge.isPrimaryChallenge) {
-        return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', competence, challenge.get('relatedPrototype'), challenge);
+        const prototype = challenge.get('relatedPrototype');
+        if (this.versionManager.isV2 && prototype.get('isValidated')) {
+          return this.router.transitionTo(
+            'authenticated.v2.challenge',
+            competence.get('id'),
+            'challenges-production',
+            skill.get('id'),
+            challenge.get('id'),
+          );
+        } else {
+          return this.router.transitionTo(
+            'authenticated.competence.prototypes.single.alternatives.single',
+            competence.get('id'),
+            prototype.get('id'),
+            challenge.get('id'),
+            { queryParams: { view: prototype.get('isValidated') ? 'production' : 'workbench' } },
+          );
+        }
       } else {
-        return this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.localized', competence, challenge.get('relatedPrototype'), challenge.get('id'), localizedChallenge.get('id'));
+        return this.router.transitionTo(
+          'authenticated.competence.prototypes.single.alternatives.localized',
+          competence.get('id'),
+          challenge.get('relatedPrototype').get('id'),
+          challenge.get('id'),
+          localizedChallenge.get('id'),
+        );
       }
     } catch {
       this.router.transitionTo('authenticated');

--- a/pix-editor/tests/unit/routes/challenge-test.js
+++ b/pix-editor/tests/unit/routes/challenge-test.js
@@ -1,0 +1,357 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | challenge', function(hooks) {
+  setupTest(hooks);
+
+  let route;
+
+  const competenceId = 'competence123';
+  const skillId = 'skill123';
+  const prototypeId = 'challenge123';
+  const alternativeId = 'challenge321';
+
+  let prototype;
+  let primaryLocalizedPrototype;
+  let secondaryLocalizedPrototype;
+  let alternative;
+  let primaryLocalizedAlternative;
+  let secondaryLocalizedAlternative;
+
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated.challenge');
+
+    route.versionManager = {};
+
+    route.router = {
+      transitionTo: sinon.stub(),
+    };
+
+    const store = this.owner.lookup('service:store');
+
+    const competence = store.createRecord('competence', {
+      id: competenceId,
+    });
+    const tube = store.createRecord('tube', {
+      competence,
+    });
+    const skill = store.createRecord('skill', {
+      id: skillId,
+      tube,
+    });
+    prototype = store.createRecord('challenge', {
+      id: prototypeId,
+      skill,
+      genealogy: 'Prototype 1',
+      version: 1,
+    });
+    primaryLocalizedPrototype = store.createRecord('localized-challenge', {
+      id: prototypeId,
+      challenge: prototype,
+    });
+    secondaryLocalizedPrototype = store.createRecord('localized-challenge', {
+      id: `${prototypeId}nl`,
+      challenge: prototype,
+    });
+    alternative = store.createRecord('challenge', {
+      id: alternativeId,
+      skill,
+      genealogy: 'Décliné 1',
+      version: 1,
+    });
+    primaryLocalizedAlternative = store.createRecord('localized-challenge', {
+      id: alternativeId,
+      challenge: alternative,
+    });
+    secondaryLocalizedAlternative = store.createRecord('localized-challenge', {
+      id: `${alternativeId}nl`,
+      challenge: alternative,
+    });
+  });
+
+  module('#afterModel', function() {
+    module('when in v2', function(hooks) {
+      hooks.beforeEach(function() {
+        route.versionManager.isV2 = true;
+      });
+
+      module('when prototype is in production', function(hooks) {
+        hooks.beforeEach(function() {
+          prototype.status = 'validé';
+        });
+
+        module('when navigating to prototype’s primary', function() {
+          test('redirects to v2 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedPrototype;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.v2.challenge',
+              competenceId,
+              'challenges-production',
+              skillId,
+              prototypeId,
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to alternative’s primary', function() {
+          test('redirects to v2 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedAlternative;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.v2.challenge',
+              competenceId,
+              'challenges-production',
+              skillId,
+              alternativeId,
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to prototype’s secondary', function() {
+          test('redirects to v1 localized challenge', async function(assert) {
+            // given
+            const model = secondaryLocalizedPrototype;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.localized',
+              competenceId,
+              prototypeId,
+              secondaryLocalizedPrototype.get('id'),
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to alternative’s secondary', function() {
+          test('redirects to v1 localized challenge', async function(assert) {
+            // given
+            const model = secondaryLocalizedAlternative;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single.alternatives.localized',
+              competenceId,
+              prototypeId,
+              alternativeId,
+              secondaryLocalizedAlternative.get('id'),
+            );
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when prototype is not in production', function(hooks) {
+        hooks.beforeEach(function() {
+          prototype.status = 'périmé';
+        });
+
+        module('when navigating to prototype’s primary', function() {
+          test('redirects to v1 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedPrototype;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single',
+              competenceId,
+              prototypeId,
+              { queryParams: { view: 'workbench' } },
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to alternative’s primary', function() {
+          test('redirects to v1 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedAlternative;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single.alternatives.single',
+              competenceId,
+              prototypeId,
+              alternativeId,
+              { queryParams: { view: 'workbench' } },
+            );
+            assert.ok(true);
+          });
+        });
+      });
+    });
+
+    module('when in v1', function(hooks) {
+      hooks.beforeEach(function() {
+        route.versionManager.isV2 = false;
+      });
+
+      module('when prototype is in production', function(hooks) {
+        hooks.beforeEach(function() {
+          prototype.status = 'validé';
+        });
+
+        module('when navigating to prototype’s primary', function() {
+          test('redirects to v1 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedPrototype;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single',
+              competenceId,
+              prototypeId,
+              { queryParams: { view: 'production' } },
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to alternative’s primary', function() {
+          test('redirects to v1 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedAlternative;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single.alternatives.single',
+              competenceId,
+              prototypeId,
+              alternativeId,
+              { queryParams: { view: 'production' } },
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to prototype’s secondary', function() {
+          test('redirects to v1 localized challenge', async function(assert) {
+            // given
+            const model = secondaryLocalizedPrototype;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.localized',
+              competenceId,
+              prototypeId,
+              secondaryLocalizedPrototype.get('id'),
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to alternative’s secondary', function() {
+          test('redirects to v1 localized challenge', async function(assert) {
+            // given
+            const model = secondaryLocalizedAlternative;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single.alternatives.localized',
+              competenceId,
+              prototypeId,
+              alternativeId,
+              secondaryLocalizedAlternative.get('id'),
+            );
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when prototype is not in production', function(hooks) {
+        hooks.beforeEach(function() {
+          prototype.status = 'périmé';
+        });
+
+        module('when navigating to prototype’s primary', function() {
+          test('redirects to v1 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedPrototype;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single',
+              competenceId,
+              prototypeId,
+              { queryParams: { view: 'workbench' } },
+            );
+            assert.ok(true);
+          });
+        });
+
+        module('when navigating to alternative’s primary', function() {
+          test('redirects to v1 challenge', async function(assert) {
+            // given
+            const model = primaryLocalizedAlternative;
+
+            // when
+            await route.afterModel(model);
+
+            // then
+            sinon.assert.calledOnceWithExactly(
+              route.router.transitionTo,
+              'authenticated.competence.prototypes.single.alternatives.single',
+              competenceId,
+              prototypeId,
+              alternativeId,
+              { queryParams: { view: 'workbench' } },
+            );
+            assert.ok(true);
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🌸 Problème

La route `/challenge/{id}` de PixEditor est utilisée pour accéder à un challenge sans connaître l’URL complète (competence...).
Elle ne fonctionne pas pour la v2.

## 🌳 Proposition

Gérer la v2 lors de la redirection.

## 🐝 Remarques

Cette route est utilisée par la recherche d’épreuves.

## 🤧 Pour tester

Faire des recherches de challenge par exemple.

Les cas qui doivent atterrir en v2 :
 - proto primary en prod
 - decli primary en prod

Tout le reste doit atterrir en v1.