### PR TITLE
[FEATURE] Utiliser le numéro de version de déclinaison dans le header v2 de l'affichage d'une épreuve en production (PIX-17756)

### DIFF
--- a/pix-editor/app/components/challenge-view/challenge-view-header.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view-header.gjs
@@ -51,7 +51,14 @@ export default class ChallengesViewHeader extends Component {
   <template>
     <header class="challenge-view-header">
       <div class="challenge-view-header-first">
-        <p>Épreuve {{@challenge.version}}</p>
+        <p>
+          {{#if @challenge.isPrototype}}
+            Proto
+          {{else}}
+            Déclinaison {{@challenge.alternativeVersion}}
+          {{/if}}
+          (V{{@challenge.version}})
+        </p>
         <div class="challenge-view-header__action-buttons">
           <PixIconButton
             class="challenge-view-header__button-icon"

--- a/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
@@ -232,5 +232,45 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         assert.dom(screen.getByText('Proposée')).exists();
       });
     });
+    module('when challenge is prototype', function() {
+      test('it should display wright title', async function(assert) {
+        // given
+        const challenge = challengeFromStore;
+        // when
+        screen = await render(<template>
+            <ChallengeView
+              @challenge={{challenge}}
+              @skillId="skillId"
+              @overview="overview"
+              @competenceId="competenceId"
+            />
+          </template>,
+        );
+        // then
+        assert.dom(screen.getByText('Proto (V1)')).exists();
+      });
+    });
+    module('when challenge is alternative', function() {
+      test('it should display wright title', async function(assert) {
+        // given
+        challengeFromStore.genealogy = 'Décliné 1';
+        challengeFromStore.alternativeVersion = 2;
+        const challenge = challengeFromStore;
+
+        // when
+        screen = await render(<template>
+            <ChallengeView
+              @challenge={{challenge}}
+              @skillId="skillId"
+              @overview="overview"
+              @competenceId="competenceId"
+            />
+          </template>,
+        );
+
+        // then
+        assert.dom(screen.getByText('Déclinaison 2 (V1)')).exists();
+      });
+    });
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Nous affichons le numéro de version d'épreuve lors de l'affichage d'une épreuve en production V2.
Ce n'est pas claire et nous préférons utiliser le numéro de la version de déclinaison 

## 🌳 Proposition

Remplacer le numéro de version par le numéro de version de déclinaison.

## 🐝 Remarques
J'ai laissé le numéro de version en plus, je ne sais pas si c'est super utile.

## 🤧 Pour tester
Se rendre en vu production d'une épreuve et vérifier le header.
