### PR TITLE
[TECH] Déplacer la création de la thématique workbench dans l’API (PIX-17770)

### DIFF
--- a/api/lib/application/competences/competences.js
+++ b/api/lib/application/competences/competences.js
@@ -6,7 +6,7 @@ import * as usecases from '../../domain/usecases/index.js';
 import { logger } from '../../infrastructure/logger.js';
 import { competenceSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import { competenceRepository } from '../../infrastructure/repositories/index.js';
-import { Types } from '../types.js';
+import * as Types from '../types.js';
 import { NotFoundError } from '../../infrastructure/errors.js';
 
 export async function register(server) {

--- a/api/lib/domain/models/Thematic.js
+++ b/api/lib/domain/models/Thematic.js
@@ -5,6 +5,7 @@ export class Thematic {
     index,
     airtableId,
     competenceId,
+    competenceAirtableId,
     tubeIds,
   }) {
     this.id = id;
@@ -12,6 +13,7 @@ export class Thematic {
     this.index = index;
     this.airtableId = airtableId;
     this.competenceId = competenceId;
+    this.competenceAirtableId = competenceAirtableId;
     this.tubeIds = tubeIds;
   }
 }

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -3,7 +3,7 @@ import { logger } from '../../infrastructure/logger.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import { areaRepository, competenceRepository, thematicRepository } from '../../infrastructure/repositories/index.js';
-import { competenceTransformer } from '../../infrastructure/transformers/index.js';
+import { competenceTransformer, thematicTransformer } from '../../infrastructure/transformers/index.js';
 import { BadRequestError } from '../../infrastructure/errors.js';
 import { Thematic } from '../models/Thematic.js';
 
@@ -34,11 +34,18 @@ export async function createCompetence(competence) {
   createdCompetence.thematicAirtableIds = [createdWorkbenchThematic.airtableId];
 
   try {
-    await updatedRecordNotifier.notify({
-      pixApiClient,
-      model: 'competences',
-      updatedRecord: competenceTransformer.filterCompetenceFields(createdCompetence),
-    });
+    await Promise.all([
+      updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'competences',
+        updatedRecord: competenceTransformer.filterCompetenceFields(createdCompetence),
+      }),
+      updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'thematics',
+        updatedRecord: thematicTransformer.filterThematicFields(createdWorkbenchThematic),
+      }),
+    ]);
   } catch (err) {
     logger.error(err);
     Sentry.captureException(err);

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -2,9 +2,10 @@ import * as Sentry from '@sentry/node';
 import { logger } from '../../infrastructure/logger.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { areaRepository, competenceRepository } from '../../infrastructure/repositories/index.js';
+import { areaRepository, competenceRepository, thematicRepository } from '../../infrastructure/repositories/index.js';
 import { competenceTransformer } from '../../infrastructure/transformers/index.js';
 import { BadRequestError } from '../../infrastructure/errors.js';
+import { Thematic } from '../models/Thematic.js';
 
 export async function createCompetence(competence) {
   const [area, competences] = await Promise.all([
@@ -16,9 +17,21 @@ export async function createCompetence(competence) {
     throw new BadRequestError('unknown area');
   }
 
-  competence.index = `${area.code}.${(competences?.length ?? 0) + 1}`;
+  const indexInArea = (competences?.length ?? 0) + 1;
+  competence.index = `${area.code}.${indexInArea}`;
 
   const createdCompetence = await competenceRepository.create(competence);
+
+  const workbenchThematic = new Thematic({
+    name_i18n: { fr:`workbench_${area.code}_${indexInArea}` },
+    competenceAirtableId: createdCompetence.airtableId,
+    index: 0,
+  });
+
+  const createdWorkbenchThematic = await thematicRepository.create(workbenchThematic);
+
+  createdCompetence.thematicIds = [createdWorkbenchThematic.id];
+  createdCompetence.thematicAirtableIds = [createdWorkbenchThematic.airtableId];
 
   try {
     await updatedRecordNotifier.notify({

--- a/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/thematic-datasource.js
@@ -11,6 +11,7 @@ export const thematicDatasource = datasource.extend({
 
   usedFields: [
     'id persistant',
+    'Competence',
     'Competence (id persistant)',
     'Tubes (id persistant)',
     'Index',
@@ -21,8 +22,19 @@ export const thematicDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.id,
       competenceId: airtableRecord.get('Competence (id persistant)')[0],
+      competenceAirtableId: airtableRecord.get('Competence')[0],
       tubeIds: airtableRecord.get('Tubes (id persistant)') ?? [],
       index: airtableRecord.get('Index'),
+    };
+  },
+
+  toAirTableObject(model) {
+    return {
+      fields: {
+        'id persistant': model.id,
+        Competence: [model.competenceAirtableId],
+        Index: model.index,
+      },
     };
   },
 

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -3,6 +3,7 @@ import { thematicDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as thematicTranslations from '../translations/thematic.js';
 import { Thematic } from '../../domain/models/index.js';
+import * as idGenerator from '../utils/id-generator.js';
 
 const model = 'thematic';
 
@@ -27,6 +28,14 @@ export async function listByCompetenceId(competenceId) {
   if (!datasourceThematics) return [];
   const translations = await translationRepository.listByEntities(model, datasourceThematics.map(({ id }) => id));
   return toDomainList(datasourceThematics, translations);
+}
+
+export async function create(thematic) {
+  thematic.id = idGenerator.generateNewId('thematic');
+  const createdThematicDTO = await thematicDatasource.create(thematic);
+  const translations = thematicTranslations.extractFromDomainObject(thematic);
+  await translationRepository.save({ translations });
+  return toDomain(createdThematicDTO, translations);
 }
 
 function toDomainList(datasourceThematics, translations) {

--- a/api/lib/infrastructure/transformers/thematic-transformer.js
+++ b/api/lib/infrastructure/transformers/thematic-transformer.js
@@ -1,13 +1,7 @@
-import _ from 'lodash';
-
 export function filterThematicsFields(thematics) {
-  const fieldsToInclude = [
-    'id',
-    'name_i18n',
-    'index',
-    'competenceId',
-    'tubeIds',
-  ];
+  return thematics.map(filterThematicFields);
+}
 
-  return thematics.map((thematic) => _.pick(thematic, fieldsToInclude));
+export function filterThematicFields({ id, name_i18n, index, competenceId, tubeIds }) {
+  return { id,name_i18n,index, competenceId,tubeIds };
 }

--- a/api/lib/infrastructure/translations/thematic.js
+++ b/api/lib/infrastructure/translations/thematic.js
@@ -30,6 +30,7 @@ const thematicTranslationUtils = buildTranslationsUtils({ locales, fields, local
 
 export const {
   extractFromProxyObject,
+  extractFromDomainObject,
   airtableObjectToProxyObject,
   extractFromReleaseObject,
   proxyObjectToAirtableObject,

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -593,7 +593,7 @@ describe('Acceptance | Route | competences', () => {
       });
     });
 
-    it.fails('should respond with status 201 and created competence', async () => {
+    it('should respond with status 201 and created competence', async () => {
       // given
       const server = await createServer();
 

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -410,7 +410,8 @@ describe('Acceptance | Route | competences', () => {
     let airtableCreateCompetenceScope;
     let airtableCreateThematicScope;
     let generateNewId;
-    let pixApiCacheScope;
+    let pixApiCompetenceCacheScope;
+    let pixApiThematicCacheScope;
 
     beforeEach(async () => {
       const airtableArea = airtableBuilder.factory.buildArea(domainBuilder.buildAreaDatasourceObject({
@@ -504,8 +505,10 @@ describe('Acceptance | Route | competences', () => {
       nock('https://api.test.pix.fr')
         .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-        .reply(200, { 'access_token': pixApiToken });
-      pixApiCacheScope = nock('https://api.test.pix.fr')
+        .reply(200, { 'access_token': pixApiToken })
+        .persist();
+
+      pixApiCompetenceCacheScope = nock('https://api.test.pix.fr')
         .patch('/api/cache/competences/competence4', {
           id: 'competence4',
           index: '2.2',
@@ -521,6 +524,20 @@ describe('Acceptance | Route | competences', () => {
             fr: 'C’est la quatrième',
             en: 'It’s the fourth one'
           }
+        })
+        .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+        .reply(200);
+
+      pixApiThematicCacheScope = nock('https://api.test.pix.fr')
+        .patch('/api/cache/thematics/thematic1', {
+          id: 'thematic1',
+          name_i18n: {
+            fr: 'workbench_2_2',
+            en: null,
+          },
+          index: 0,
+          competenceId: 'competence4',
+          tubeIds: [],
         })
         .matchHeader('Authorization', `Bearer ${pixApiToken}`)
         .reply(200);
@@ -672,7 +689,8 @@ describe('Acceptance | Route | competences', () => {
       expect(airtableCompetencesScope.isDone()).toBe(true);
       expect(airtableCreateCompetenceScope.isDone()).toBe(true);
       expect(airtableCreateThematicScope.isDone()).toBe(true);
-      expect(pixApiCacheScope.isDone()).toBe(true);
+      expect(pixApiCompetenceCacheScope.isDone()).toBe(true);
+      expect(pixApiThematicCacheScope.isDone()).toBe(true);
     });
   });
 

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -405,7 +405,12 @@ describe('Acceptance | Route | competences', () => {
   });
 
   describe('POST /competences', async () => {
-    let airtableAreaScope, airtableCompetencesScope, airtableCreateCompetenceScope, generateNewId, pixApiCacheScope;
+    let airtableAreaScope;
+    let airtableCompetencesScope;
+    let airtableCreateCompetenceScope;
+    let airtableCreateThematicScope;
+    let generateNewId;
+    let pixApiCacheScope;
 
     beforeEach(async () => {
       const airtableArea = airtableBuilder.factory.buildArea(domainBuilder.buildAreaDatasourceObject({
@@ -451,6 +456,14 @@ describe('Acceptance | Route | competences', () => {
         skillIds: null,
       }));
 
+      const airtableThematic = airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({
+        id: 'thematic1',
+        airtableId: 'recThematic1',
+        index: 0,
+        competenceId: 'competence4',
+        tubeIds: [],
+      }));
+
       airtableCreateCompetenceScope = nock('https://api.airtable.com')
         .post('/v0/airtableBaseValue/Competences/', {
           records: [{
@@ -465,7 +478,27 @@ describe('Acceptance | Route | competences', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [airtableCompetence] });
 
-      generateNewId = vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce('competence4');
+      airtableCreateThematicScope = nock('https://api.airtable.com')
+        .post('/v0/airtableBaseValue/Thematiques/', {
+          records: [{
+            fields: {
+              'id persistant': 'thematic1',
+              Competence: ['recCompetence4'],
+              Index: 0,
+            },
+          }],
+        })
+        .query({})
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: [airtableThematic] });
+
+      generateNewId = vi.spyOn(idGenerator, 'generateNewId');
+      generateNewId.mockImplementation((prefix) => {
+        switch (prefix) {
+          case 'competence': return 'competence4';
+          case 'thematic': return 'thematic1';
+        }
+      });
 
       const pixApiToken = 'secret';
       nock('https://api.test.pix.fr')
@@ -478,7 +511,7 @@ describe('Acceptance | Route | competences', () => {
           index: '2.2',
           areaId: 'area2',
           skillIds: [],
-          thematicIds: [],
+          thematicIds: ['thematic1'],
           origin: 'Pix',
           name_i18n: {
             fr: 'Quatrième compétence',
@@ -560,7 +593,7 @@ describe('Acceptance | Route | competences', () => {
       });
     });
 
-    it('should respond with status 201 and created competence', async () => {
+    it.fails('should respond with status 201 and created competence', async () => {
       // given
       const server = await createServer();
 
@@ -614,7 +647,9 @@ describe('Acceptance | Route | competences', () => {
               },
             },
             'raw-themes': {
-              data: [],
+              data: [
+                { id: 'recThematic1', type: 'themes' },
+              ],
             },
             'raw-tubes': {
               data: [],
@@ -630,11 +665,13 @@ describe('Acceptance | Route | competences', () => {
         { key: 'competence.competence4.description', locale: 'fr', value: 'C’est la quatrième' },
         { key: 'competence.competence4.name', locale: 'en', value: 'Fourth competence' },
         { key: 'competence.competence4.name', locale: 'fr', value: 'Quatrième compétence' },
+        { key: 'thematic.thematic1.name', locale: 'fr', value: 'workbench_2_2' },
       ]);
 
       expect(airtableAreaScope.isDone()).toBe(true);
       expect(airtableCompetencesScope.isDone()).toBe(true);
       expect(airtableCreateCompetenceScope.isDone()).toBe(true);
+      expect(airtableCreateThematicScope.isDone()).toBe(true);
       expect(pixApiCacheScope.isDone()).toBe(true);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
-import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
-import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
-import { stringValue } from '../../../../lib/infrastructure/airtable.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
 
 describe('Integration | Repository | thematic-repository', () => {
 
@@ -13,18 +14,21 @@ describe('Integration | Repository | thematic-repository', () => {
         airtableBuilder.factory.buildThematic({
           id: 'thematic1',
           competenceId: 'competenceId1',
+          competenceAirtableId: 'recCompetenceId1',
           index: '1',
           tubeIds: ['tubeId1', 'tubeId2'],
         }),
         airtableBuilder.factory.buildThematic({
           id: 'thematic2',
           competenceId: 'competenceId2',
+          competenceAirtableId: 'recCompetenceId2',
           index: '2',
           tubeIds: ['tubeId3', 'tubeId4'],
         }),
         airtableBuilder.factory.buildThematic({
           id: 'thematic3',
           competenceId: 'competenceId2',
+          competenceAirtableId: 'recCompetenceId2',
           index: '3',
           tubeIds: null,
         }),
@@ -72,6 +76,7 @@ describe('Integration | Repository | thematic-repository', () => {
           id: 'thematic1',
           airtableId: 'thematic1',
           competenceId: 'competenceId1',
+          competenceAirtableId: 'recCompetenceId1',
           index: '1',
           tubeIds: ['tubeId1', 'tubeId2'],
           name_i18n: {
@@ -83,6 +88,7 @@ describe('Integration | Repository | thematic-repository', () => {
           id: 'thematic2',
           airtableId: 'thematic2',
           competenceId: 'competenceId2',
+          competenceAirtableId: 'recCompetenceId2',
           index: '2',
           tubeIds: ['tubeId3', 'tubeId4'],
           name_i18n: {
@@ -94,6 +100,7 @@ describe('Integration | Repository | thematic-repository', () => {
           id: 'thematic3',
           airtableId: 'thematic3',
           competenceId: 'competenceId2',
+          competenceAirtableId: 'recCompetenceId2',
           index: '3',
           tubeIds: [],
           name_i18n: {
@@ -124,14 +131,15 @@ describe('Integration | Repository | thematic-repository', () => {
       });
 
       await databaseBuilder.commit();
-      vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
+      vi.spyOn(airtable, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Thematiques') expect.unreachable('Airtable tableName should be Tubes');
-        if (options?.filterByFormula !==  `{Competence (id persistant)} = ${stringValue(competenceId)}`) expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !==  `{Competence (id persistant)} = ${airtable.stringValue(competenceId)}`) expect.unreachable('Wrong filterByFormula');
         return [{
           id: 'recAirtableThematic1',
           fields: {
             'id persistant': thematicId,
             'Competence (id persistant)': [competenceId],
+            'Competence': ['recCompetenceId1'],
             'Tubes (id persistant)': ['tubeId1', 'tubeId2'],
             'Index': 1,
           },
@@ -152,6 +160,7 @@ describe('Integration | Repository | thematic-repository', () => {
             en: 'Thematic 1 name',
           },
           competenceId: 'competenceId1',
+          competenceAirtableId: 'recCompetenceId1',
           tubeIds: ['tubeId1', 'tubeId2'],
           index: 1,
         })
@@ -180,6 +189,53 @@ describe('Integration | Repository | thematic-repository', () => {
 
       expect(result.map((thematic) => thematic.id)).toEqual([thematic2.id, thematic3.id]);
       airtableScope.done();
+    });
+  });
+
+  describe('#create', () => {
+    afterEach(() => {
+      return knex('translations').truncate();
+    });
+
+    it('should save new thematic to Airtable and translations to DB', async () => {
+      // given
+      const thematicId = 'thematic45267428';
+      vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce(thematicId);
+      const thematic = domainBuilder.buildThematic({
+        airtableId: null,
+        id: null,
+      });
+      const airtableThematic = airtableBuilder.factory.buildThematic({
+        ...thematic,
+        airtableId: 'recThematic1',
+        id: thematicId,
+      });
+      const createRecordSpy = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
+        new Airtable.Record('Thematiques', airtableThematic.id, airtableThematic),
+      );
+
+      // when
+      const createdThematic = await thematicRepository.create(thematic);
+
+      // then
+      expect(createdThematic).toStrictEqual(domainBuilder.buildThematic({
+        ...thematic,
+        airtableId: 'recThematic1',
+      }));
+      expect(createRecordSpy).toHaveBeenCalledWith(
+        'Thematiques',
+        {
+          fields: {
+            'id persistant': thematicId,
+            Competence: [thematic.competenceAirtableId],
+            Index: thematic.index,
+          },
+        },
+      );
+      await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toEqual([
+        { key: `thematic.${thematicId}.name`, locale: 'en', value: thematic.name_i18n.en },
+        { key: `thematic.${thematicId}.name`, locale: 'fr', value: thematic.name_i18n.fr },
+      ]);
     });
   });
 });

--- a/api/tests/tooling/airtable-builder/factory/build-thematic.js
+++ b/api/tests/tooling/airtable-builder/factory/build-thematic.js
@@ -3,6 +3,7 @@ export function buildThematic(
     id,
     airtableId = id,
     competenceId,
+    competenceAirtableId,
     tubeIds,
     index,
   } = {}) {
@@ -11,6 +12,7 @@ export function buildThematic(
     'fields': {
       'id persistant': id,
       'Competence (id persistant)': [competenceId],
+      'Competence': [competenceAirtableId],
       'Tubes (id persistant)': tubeIds,
       'Index': index
     },

--- a/api/tests/tooling/domain-builder/factory/build-thematic.js
+++ b/api/tests/tooling/domain-builder/factory/build-thematic.js
@@ -8,6 +8,7 @@ export function buildThematic({
     en: 'Thematic\'s name',
   },
   competenceId = 'recCompetence0',
+  competenceAirtableId = 'recAirtableCompetence0',
   tubeIds = ['recTube0'],
   index = 0,
 } = {}) {
@@ -16,6 +17,7 @@ export function buildThematic({
     name_i18n,
     airtableId,
     competenceId,
+    competenceAirtableId,
     tubeIds,
     index,
   });

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-thematic-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-thematic-datasource-object.js
@@ -3,6 +3,7 @@ export function buildThematicDatasourceObject(
     id = 'recFvllz2Ckz',
     airtableId,
     competenceId = 'recCompetence0',
+    competenceAirtableId = 'recAirtableCompetence0',
     tubeIds = ['recTube0'],
     index = 0
   } = {}) {
@@ -10,6 +11,7 @@ export function buildThematicDatasourceObject(
     id,
     airtableId: airtableId ?? id,
     competenceId,
+    competenceAirtableId,
     tubeIds,
     index,
   };

--- a/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-thematic.js
@@ -6,6 +6,7 @@ export function buildThematic(
       en: nameEnUs,
     } = {},
     competenceId,
+    competenceAirtableId,
     tubeIds,
     index,
   } = {}) {
@@ -16,6 +17,7 @@ export function buildThematic(
       'Nom': name,
       'Titre en-us': nameEnUs,
       'Competence (id persistant)': [competenceId],
+      'Competence': [competenceAirtableId],
       'Tubes (id persistant)': tubeIds,
       'Index': index
     },

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -2,21 +2,22 @@ import { describe, it, vi, expect, beforeEach } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 
 import { createCompetence } from '../../../../lib/domain/usecases/create-competence.js';
-import { areaRepository, competenceRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import { areaRepository, competenceRepository, thematicRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import { competenceTransformer } from '../../../../lib/infrastructure/transformers/index.js';
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
+import { Thematic } from '../../../../lib/domain/models/Thematic.js';
 
 describe('Unit | Domain | Usecases | create competence', function() {
 
-  const createdCompetence = Symbol('createdCompetence');
   const transformedCompetence = Symbol('transformedCompetence');
 
   beforeEach(() => {
     vi.spyOn(areaRepository, 'getByAirtableId');
     vi.spyOn(competenceRepository, 'listByAreaAirtableId');
     vi.spyOn(competenceRepository, 'create');
+    vi.spyOn(thematicRepository, 'create');
     vi.spyOn(competenceTransformer, 'filterCompetenceFields');
     vi.spyOn(updatedRecordNotifier, 'notify');
   });
@@ -60,12 +61,23 @@ describe('Unit | Domain | Usecases | create competence', function() {
         domainBuilder.buildCompetence(),
         domainBuilder.buildCompetence(),
       ]);
+      const createdThematic = domainBuilder.buildThematic();
+      const createdCompetence = domainBuilder.buildCompetence({
+        areaAirtableId,
+        thematicIds: [],
+        thematicAirtableIds: [],
+      });
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
+      thematicRepository.create.mockResolvedValueOnce(createdThematic);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       updatedRecordNotifier.notify.mockResolvedValueOnce();
 
       const competence = domainBuilder.buildCompetence({
+        id: null,
+        airtableId: null,
         areaAirtableId,
+        thematicIds: [],
+        thematicAirtableIds: [],
       });
 
       // when
@@ -75,10 +87,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(competence.index).toBe('24.6');
 
       expect(result).toBe(createdCompetence);
+      expect(result).toHaveProperty('thematicIds', [createdThematic.id]);
+      expect(result).toHaveProperty('thematicAirtableIds', [createdThematic.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.create).toHaveBeenCalledWith(competence);
+      expect(thematicRepository.create).toHaveBeenCalledWith(new Thematic({
+        name_i18n: { fr: 'workbench_24_6' },
+        index: 0,
+        competenceAirtableId: createdCompetence.airtableId,
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
@@ -97,11 +116,18 @@ describe('Unit | Domain | Usecases | create competence', function() {
         code: '24'
       }));
       competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
+      const createdCompetence = domainBuilder.buildCompetence({
+        areaAirtableId,
+      });
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
+      const createdThematic = domainBuilder.buildThematic();
+      thematicRepository.create.mockResolvedValueOnce(createdThematic);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       updatedRecordNotifier.notify.mockResolvedValueOnce();
 
       const competence = domainBuilder.buildCompetence({
+        id: null,
+        airtableId: null,
         areaAirtableId,
       });
 
@@ -112,10 +138,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(competence.index).toBe('24.1');
 
       expect(result).toBe(createdCompetence);
+      expect(result).toHaveProperty('thematicIds', [createdThematic.id]);
+      expect(result).toHaveProperty('thematicAirtableIds', [createdThematic.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.create).toHaveBeenCalledWith(competence);
+      expect(thematicRepository.create).toHaveBeenCalledWith(new Thematic({
+        name_i18n: { fr: 'workbench_24_1' },
+        index: 0,
+        competenceAirtableId: createdCompetence.airtableId,
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
@@ -134,11 +167,18 @@ describe('Unit | Domain | Usecases | create competence', function() {
         code: '24'
       }));
       competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
+      const createdCompetence = domainBuilder.buildCompetence({
+        areaAirtableId,
+      });
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
+      const createdThematic = domainBuilder.buildThematic();
+      thematicRepository.create.mockResolvedValueOnce(createdThematic);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       updatedRecordNotifier.notify.mockRejectedValueOnce(new Error());
 
       const competence = domainBuilder.buildCompetence({
+        id: null,
+        airtableId: null,
         areaAirtableId,
       });
 
@@ -149,10 +189,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(competence.index).toBe('24.1');
 
       expect(result).toBe(createdCompetence);
+      expect(result).toHaveProperty('thematicIds', [createdThematic.id]);
+      expect(result).toHaveProperty('thematicAirtableIds', [createdThematic.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.create).toHaveBeenCalledWith(competence);
+      expect(thematicRepository.create).toHaveBeenCalledWith(new Thematic({
+        name_i18n: { fr: 'workbench_24_1' },
+        index: 0,
+        competenceAirtableId: createdCompetence.airtableId,
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -5,13 +5,14 @@ import { createCompetence } from '../../../../lib/domain/usecases/create-compete
 import { areaRepository, competenceRepository, thematicRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
-import { competenceTransformer } from '../../../../lib/infrastructure/transformers/index.js';
+import { competenceTransformer, thematicTransformer } from '../../../../lib/infrastructure/transformers/index.js';
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
 import { Thematic } from '../../../../lib/domain/models/Thematic.js';
 
 describe('Unit | Domain | Usecases | create competence', function() {
 
   const transformedCompetence = Symbol('transformedCompetence');
+  const transformedThematic = Symbol('transformedThematic');
 
   beforeEach(() => {
     vi.spyOn(areaRepository, 'getByAirtableId');
@@ -19,6 +20,7 @@ describe('Unit | Domain | Usecases | create competence', function() {
     vi.spyOn(competenceRepository, 'create');
     vi.spyOn(thematicRepository, 'create');
     vi.spyOn(competenceTransformer, 'filterCompetenceFields');
+    vi.spyOn(thematicTransformer, 'filterThematicFields');
     vi.spyOn(updatedRecordNotifier, 'notify');
   });
 
@@ -69,8 +71,9 @@ describe('Unit | Domain | Usecases | create competence', function() {
       });
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
+      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
-      updatedRecordNotifier.notify.mockResolvedValueOnce();
+      updatedRecordNotifier.notify.mockResolvedValue();
 
       const competence = domainBuilder.buildCompetence({
         id: null,
@@ -99,6 +102,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
         competenceAirtableId: createdCompetence.airtableId,
       }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
+      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'thematics',
+        pixApiClient,
+        updatedRecord: transformedThematic,
+      });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
         pixApiClient,
@@ -122,8 +131,9 @@ describe('Unit | Domain | Usecases | create competence', function() {
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       const createdThematic = domainBuilder.buildThematic();
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
+      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
-      updatedRecordNotifier.notify.mockResolvedValueOnce();
+      updatedRecordNotifier.notify.mockResolvedValue();
 
       const competence = domainBuilder.buildCompetence({
         id: null,
@@ -150,6 +160,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
         competenceAirtableId: createdCompetence.airtableId,
       }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
+      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'thematics',
+        pixApiClient,
+        updatedRecord: transformedThematic,
+      });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
         pixApiClient,
@@ -173,8 +189,9 @@ describe('Unit | Domain | Usecases | create competence', function() {
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       const createdThematic = domainBuilder.buildThematic();
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
+      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
-      updatedRecordNotifier.notify.mockRejectedValueOnce(new Error());
+      updatedRecordNotifier.notify.mockRejectedValue(new Error());
 
       const competence = domainBuilder.buildCompetence({
         id: null,
@@ -201,6 +218,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
         competenceAirtableId: createdCompetence.airtableId,
       }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
+      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'thematics',
+        pixApiClient,
+        updatedRecord: transformedThematic,
+      });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
         pixApiClient,

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -51,25 +51,9 @@ export default class CompetenceManagementNewController extends Controller {
   }
 
   async _createWorkbench(frameworkName) {
-    const theme = await this._createThemeWorkbench(this.competence, frameworkName);
-    const tube = await this._createTubeWorkbench(theme, this.competence, frameworkName);
+    const themes = await this.competence.rawThemes;
+    const tube = await this._createTubeWorkbench(themes[0], this.competence, frameworkName);
     await this._createSkillWorkbench(tube, frameworkName);
-  }
-
-  async _createThemeWorkbench(competence, frameworkName) {
-    const themeWorkbenchName = this._getThemeWorkbenchName(this.competence.code, frameworkName);
-    const workbenchTheme = this.store.createRecord('theme', {
-      name: themeWorkbenchName,
-      competence,
-      index: 0,
-      pixId: this.idGenerator.newId('thematic'),
-    });
-    return await workbenchTheme.save();
-  }
-
-  _getThemeWorkbenchName(competenceCode, frameworkName) {
-    const code = competenceCode.replace('.', '_');
-    return `workbench_${frameworkName}_${code}`;
   }
 
   async _createTubeWorkbench(theme, competence, frameworkName) {

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -81,8 +81,16 @@ function routes() {
 
     competence.pixId = newId('competence');
     competence.code = `${area.code}.${areaCompetences.length + 1}`;
+    const createdCompetence = schema.competences.create(competence);
+    const createdThematic = schema.themes.create({
+      pixId: newId('thematic'),
+      name: `workbench_${area.code}_${areaCompetences.length + 1}`,
+      index: 0,
+      competence: createdCompetence,
+    });
+    competence.rawThemes = [createdThematic];
 
-    return this.serialize(schema.competences.create(competence));
+    return schema.competences.create(competence);
   });
 
   this.get('/airtable/content/Thematiques/:id', (schema, request) => {

--- a/pix-editor/tests/acceptance/competence-management/new-test.js
+++ b/pix-editor/tests/acceptance/competence-management/new-test.js
@@ -47,11 +47,9 @@ module('Acceptance | competence-management/new', function(hooks) {
     // then
     const area = await store.peekRecord('area', 'recArea1');
     const newCompetence = area.competencesArray.find((competence) => competence.title === newCompetenceTitle);
-    const workbenchTheme = newCompetence.hasMany('rawThemes').value().find((theme) => theme.name === 'workbench_Pix+_1_2');
-    const workbenchTube = workbenchTheme.hasMany('rawTubes').value().find((tube) => tube.name === '@workbench');
+    const workbenchTube = newCompetence.hasMany('rawTubes').value().find((tube) => tube.name === '@workbench');
     const workbenchSkill = workbenchTube.hasMany('rawSkills').value().find((skill) => skill.name === '@workbench');
     assert.ok(newCompetence);
-    assert.ok(workbenchTheme);
     assert.ok(workbenchTube);
     assert.ok(workbenchSkill);
     assert.dom(findAll('[data-test-main-message]')[0]).hasText('Compétence créée');

--- a/pix-editor/tests/unit/controllers/competence-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/new-test.js
@@ -26,6 +26,7 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     };
     competence = {
       code: '1.1',
+      rawThemes: ['theme'],
     };
     controller.model = {
       area,
@@ -70,6 +71,9 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       const expectedCompetence = {
         area,
         code: '1.1',
+        rawThemes: [
+          'theme',
+        ],
         save: saveStub,
       };
       // when
@@ -114,19 +118,11 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       newId = idGeneratorStub;
     }
     this.owner.register('service:idGenerator', IdGenerator);
-    const saveStub = sinon.stub()
-      .onFirstCall().resolves('theme')
-      .onSecondCall().resolves('tube');
+    const saveStub = sinon.stub().onFirstCall().resolves('tube');
     const model = { save: saveStub };
     const createRecordStub = sinon.stub().returns(model);
     controller.store.createRecord = createRecordStub;
 
-    const expectedTheme = {
-      name: 'workbench_Pix+_1_1',
-      competence,
-      index: 0,
-      pixId: 'recId',
-    };
     const expectedTube = {
       name: '@workbench',
       theme: 'theme',
@@ -144,8 +140,7 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     await controller._createWorkbench('Pix+');
 
     // then
-    assert.deepEqual(createRecordStub.getCall(0).args, ['theme', expectedTheme]);
-    assert.deepEqual(createRecordStub.getCall(1).args, ['tube', expectedTube]);
-    assert.deepEqual(createRecordStub.getCall(2).args, ['skill', expectedSkill]);
+    assert.deepEqual(createRecordStub.getCall(0).args, ['tube', expectedTube]);
+    assert.deepEqual(createRecordStub.getCall(1).args, ['skill', expectedSkill]);
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Lors de la création d’une nouvelle compétence, les entités qui composent le workbench (thématique, tube et acquis) sont créées par le front.

On veut déplacer la création de ces entités dans l’API, dans le endpoint de création de compétence.

## 🌳 Proposition

Déplacer la création de la thématique workbench dans l’API.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Créer une compétence et vérifier que toutes les entités du workbench (thématique, tube et acquis) ont été créés correctement.