### PR TITLE
[TECH] Proposition Archi pour injecter les usecases dynamiquement à chaque requête client

### DIFF
--- a/api/lib/application/areas.js
+++ b/api/lib/application/areas.js
@@ -2,11 +2,11 @@ import Joi from 'joi';
 import Boom from '@hapi/boom';
 import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from './security-pre-handlers.js';
-import * as usecases from '../domain/usecases/index.js';
+import { usecases } from '../domain/usecases/propal/index.js';
 import { logger } from '../infrastructure/logger.js';
 import { areaRepository } from '../infrastructure/repositories/index.js';
 import { areaSerializer } from '../infrastructure/serializers/jsonapi/index.js';
-import { Types } from './types.js';
+import * as Types from './types.js';
 
 export function register(server) {
   server.route([
@@ -54,7 +54,7 @@ export function register(server) {
           try {
             const area = await areaSerializer.deserialize(request.payload);
 
-            const createdArea = await usecases.createArea(area);
+            const createdArea = await usecases.createArea({ area });
 
             return h.response(areaSerializer.serialize(createdArea)).code(201);
           } catch (err) {

--- a/api/lib/domain/usecases/propal/create-area.js
+++ b/api/lib/domain/usecases/propal/create-area.js
@@ -1,4 +1,4 @@
-export async function createArea({ area, areaRepository, areaTransformer, pixApiClient, updatedRecordNotifier, logger, Sentry }) {
+const createArea = async function({ area, areaRepository, areaTransformer, pixApiClient, updatedRecordNotifier, logger, Sentry }) {
   const areas = await areaRepository.listByFrameworkId(area.frameworkId);
 
   area.code = `${(areas?.length ?? 0) + 1}`;
@@ -17,4 +17,8 @@ export async function createArea({ area, areaRepository, areaTransformer, pixApi
   }
 
   return createdArea;
-}
+};
+
+createArea.NEED_TRX = true;
+
+export { createArea };

--- a/api/lib/domain/usecases/propal/create-area.js
+++ b/api/lib/domain/usecases/propal/create-area.js
@@ -1,0 +1,20 @@
+export async function createArea({ area, areaRepository, areaTransformer, pixApiClient, updatedRecordNotifier, logger, Sentry }) {
+  const areas = await areaRepository.listByFrameworkId(area.frameworkId);
+
+  area.code = `${(areas?.length ?? 0) + 1}`;
+
+  const createdArea = await areaRepository.create(area);
+
+  try {
+    await updatedRecordNotifier.notify({
+      pixApiClient,
+      model: 'areas',
+      updatedRecord: areaTransformer.filterAreaFields(createdArea),
+    });
+  } catch (err) {
+    logger.error(err);
+    Sentry.captureException(err);
+  }
+
+  return createdArea;
+}

--- a/api/lib/domain/usecases/propal/index.js
+++ b/api/lib/domain/usecases/propal/index.js
@@ -1,0 +1,97 @@
+import { readdir } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+import _ from 'lodash';
+import * as Sentry from '@sentry/node';
+import { knex } from '../../../../db/knex-database-connection.js';
+import * as injectableRepositories from '../../../infrastructure/repositories/propal/index.js';
+import * as transformers from '../../../infrastructure/transformers/index.js';
+import { child } from '../../../infrastructure/logger.js';
+import * as updatedRecordNotifier from '../../../infrastructure/event-notifier/updated-record-notifier.js';
+import * as pixApiClient from '../../../infrastructure/pix-api-client.js';
+
+const path = dirname(fileURLToPath(import.meta.url));
+const usecasesWithoutInjectedDependencies = {
+  ...(await importNamedExportsFromDirectory({ path: join(path, './'), ignoredFileNames: ['index.js'] })),
+};
+
+const usecases = {};
+for (const [usecaseName, usecaseFnc] of Object.entries(usecasesWithoutInjectedDependencies)) {
+  usecases[usecaseName] = (params) => {
+    return knex.transaction((trx) => {
+      const deps = buildDependencies(usecaseName, trx);
+      const injectedUsecase =  _.partial(injectDefaults, deps, usecaseFnc)();
+      return injectedUsecase(params);
+    });
+  };
+}
+
+export { usecases };
+
+function buildDependencies(usecaseName, trx) {
+  const staticDependencies = {
+    ...transformers,
+    pixApiClient,
+    updatedRecordNotifier,
+    Sentry,
+  };
+  const dynamicDependencies = buildDynamicDependencies(usecaseName, trx);
+  return {
+    ...staticDependencies,
+    ...dynamicDependencies,
+  };
+}
+
+function buildDynamicDependencies(usecaseName, trx) {
+  const repositories = buildRepositoryDependencies(trx);
+  const logger = child(`usecase:${usecaseName}`, { event: usecaseName });
+  return {
+    ...repositories,
+    logger,
+  };
+}
+
+function buildRepositoryDependencies(trx) {
+  const instanciatedRepositories = {};
+  for (const [repoClassName, repoClassConstructor] of Object.entries(injectableRepositories)) {
+    // Comme ça, ça ressemble à l'argument nommé dans les usecases, c'est-à-dire la version avec la première lettre en minuscule
+    instanciatedRepositories[repoClassName.charAt(0).toLowerCase() + repoClassName.slice(1)] = new repoClassConstructor({ knexTransaction: trx });
+  }
+  return instanciatedRepositories;
+}
+
+export async function importNamedExportsFromDirectory({ path, ignoredFileNames = [] }) {
+  const imports = {};
+  const exportsLocations = {};
+  const files = await readdir(path, { withFileTypes: true });
+
+  for (const file of files) {
+    if (file.isDirectory()) {
+      continue;
+    }
+
+    if (!file.name.endsWith('.js') || ignoredFileNames.includes(file.name)) {
+      continue;
+    }
+
+    const fileURL = pathToFileURL(join(path, file.name));
+    const module = await import(fileURL);
+    const namedExports = Object.entries(module);
+
+    for (const [exportName, exportedValue] of namedExports) {
+      if (exportName === 'default') {
+        continue;
+      }
+      if (imports[exportName]) {
+        throw new Error(`Duplicate export name ${exportName} : ${exportsLocations[exportName]} and ${file.name}`);
+      }
+      imports[exportName] = exportedValue;
+      exportsLocations[exportName] = file.name;
+    }
+  }
+  return imports;
+}
+
+function injectDefaults(defaults, targetFn) {
+  return (args) => targetFn(Object.assign(Object.create(defaults), args));
+}

--- a/api/lib/domain/usecases/propal/index.js
+++ b/api/lib/domain/usecases/propal/index.js
@@ -18,11 +18,17 @@ const usecasesWithoutInjectedDependencies = {
 const usecases = {};
 for (const [usecaseName, usecaseFnc] of Object.entries(usecasesWithoutInjectedDependencies)) {
   usecases[usecaseName] = (params) => {
-    return knex.transaction((trx) => {
-      const deps = buildDependencies(usecaseName, trx);
+    if (usecaseFnc.NEED_TRX) {
+      return knex.transaction((trx) => {
+        const deps = buildDependencies(usecaseName, trx);
+        const injectedUsecase =  _.partial(injectDefaults, deps, usecaseFnc)();
+        return injectedUsecase(params);
+      });
+    } else {
+      const deps = buildDependencies(usecaseName, null);
       const injectedUsecase =  _.partial(injectDefaults, deps, usecaseFnc)();
       return injectedUsecase(params);
-    });
+    }
   };
 }
 

--- a/api/lib/domain/usecases/propal/mock-usecase-for-testing-purposes.js
+++ b/api/lib/domain/usecases/propal/mock-usecase-for-testing-purposes.js
@@ -1,0 +1,8 @@
+export async function mockUsecaseForTestingPurposes({ someArg1, areaRepository, translationRepository, someArg2, logger, someArg3 }) {
+  return {
+    res: someArg1 + someArg2 + someArg3,
+    areaRepository,
+    translationRepository,
+    logger,
+  };
+}

--- a/api/lib/domain/usecases/propal/mock-usecase-for-testing-purposes.js
+++ b/api/lib/domain/usecases/propal/mock-usecase-for-testing-purposes.js
@@ -1,8 +1,0 @@
-export async function mockUsecaseForTestingPurposes({ someArg1, areaRepository, translationRepository, someArg2, logger, someArg3 }) {
-  return {
-    res: someArg1 + someArg2 + someArg3,
-    areaRepository,
-    translationRepository,
-    logger,
-  };
-}

--- a/api/lib/domain/usecases/propal/mock-usecase-with-trx.js
+++ b/api/lib/domain/usecases/propal/mock-usecase-with-trx.js
@@ -1,0 +1,17 @@
+const mockUsecaseWithTrx = async function({ someArg1, mockRepositoryA, mockRepositoryB, someArg2, logger, someArg3, shouldThrow }) {
+  await mockRepositoryA.insertSomeValue();
+  if (shouldThrow) {
+    throw new Error('throwing');
+  }
+  await mockRepositoryB.insertSomeValue();
+  return {
+    res: someArg1 + someArg2 + someArg3,
+    mockRepositoryA,
+    mockRepositoryB,
+    logger,
+  };
+};
+
+mockUsecaseWithTrx.NEED_TRX = true;
+
+export { mockUsecaseWithTrx };

--- a/api/lib/domain/usecases/propal/mock-usecase-without-trx.js
+++ b/api/lib/domain/usecases/propal/mock-usecase-without-trx.js
@@ -1,0 +1,17 @@
+const mockUsecaseWithoutTrx = async function({ someArg1, mockRepositoryA, mockRepositoryB, someArg2, logger, someArg3, shouldThrow }) {
+  await mockRepositoryA.insertSomeValue();
+  if (shouldThrow) {
+    throw new Error('throwing');
+  }
+  await mockRepositoryB.insertSomeValue();
+  return {
+    res: someArg1 + someArg2 + someArg3,
+    mockRepositoryA,
+    mockRepositoryB,
+    logger,
+  };
+};
+
+mockUsecaseWithoutTrx.NEED_TRX = false;
+
+export { mockUsecaseWithoutTrx };

--- a/api/lib/infrastructure/repositories/propal/AreaRepository.js
+++ b/api/lib/infrastructure/repositories/propal/AreaRepository.js
@@ -1,0 +1,62 @@
+import _ from 'lodash';
+import { areaDatasource } from '../../datasources/airtable/index.js';
+import * as areaTranslations from '../../translations/area.js';
+import { Area } from '../../../domain/models/index.js';
+import * as idGenerator from '../../utils/id-generator.js';
+import { KnexRepository } from './KnexRepository.js';
+import { TranslationRepository } from './TranslationRepository.js';
+
+export class AreaRepository extends KnexRepository {
+  static model = 'area';
+
+  constructor({ knexTransaction } = {}) {
+    super({ knexTransaction });
+    this.translationRepository = new TranslationRepository({ knexTransaction: this.dbConn });
+  }
+
+  async create(area) {
+    area.id = idGenerator.generateNewId('area');
+    const translations = areaTranslations.extractFromDomainObject(area);
+    const createdAreaDto = await areaDatasource.create(area);
+    await this.translationRepository.save({ translations });
+
+    return toDomain(createdAreaDto, translations);
+  }
+
+  async list() {
+    const [datasourceAreas, translations] = await Promise.all([
+      areaDatasource.list(),
+      this.translationRepository.listByModel(AreaRepository.model),
+    ]);
+    return toDomainList(datasourceAreas, translations);
+  }
+
+  async listByFrameworkId(frameworkId) {
+    const [datasourceAreas, translations] = await Promise.all([
+      areaDatasource.listByFrameworkId(frameworkId),
+      this.translationRepository.listByModel(AreaRepository.model),
+    ]);
+    return toDomainList(datasourceAreas, translations);
+  }
+
+  async getByAirtableId(areaAirtableId) {
+    const areaDTO = await areaDatasource.find(areaAirtableId);
+    if (!areaDTO) return null;
+    const translations = await this.translationRepository.listByEntity(AreaRepository.model, areaDTO.id);
+    return toDomain(areaDTO, translations);
+  }
+}
+
+function toDomain(datasourceArea, translations = []) {
+  return new Area({
+    ...datasourceArea,
+    ...areaTranslations.toDomain(translations, datasourceArea),
+  });
+}
+
+function toDomainList(datasourceAreas, translations) {
+  const translationsByAreaId = _.groupBy(translations, 'entityId');
+  return datasourceAreas.map(
+    (datasourceArea) => toDomain(datasourceArea, translationsByAreaId[datasourceArea.id]),
+  );
+}

--- a/api/lib/infrastructure/repositories/propal/KnexRepository.js
+++ b/api/lib/infrastructure/repositories/propal/KnexRepository.js
@@ -1,0 +1,7 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+
+export class KnexRepository {
+  constructor({ knexTransaction } = {}) {
+    this.dbConn = knexTransaction || knex;
+  }
+}

--- a/api/lib/infrastructure/repositories/propal/MockRepositoryA.js
+++ b/api/lib/infrastructure/repositories/propal/MockRepositoryA.js
@@ -1,0 +1,19 @@
+import { KnexRepository } from './KnexRepository.js';
+import { MockRepositoryB } from './MockRepositoryB.js';
+
+export class MockRepositoryA extends KnexRepository {
+  static model = 'area';
+
+  constructor({ knexTransaction } = {}) {
+    super({ knexTransaction });
+    this.mockRepositoryB = new MockRepositoryB({ knexTransaction: this.dbConn });
+  }
+
+  async insertSomeValue() {
+    await this.dbConn('users').insert({
+      name: 'name in MockRepositoryA',
+      trigram: 'MRA',
+      apiKey: 'a0657a1d-41d4-4367-9cff-ae24257803db',
+      access: 'admin', }).returning('*');
+  }
+}

--- a/api/lib/infrastructure/repositories/propal/MockRepositoryB.js
+++ b/api/lib/infrastructure/repositories/propal/MockRepositoryB.js
@@ -1,0 +1,11 @@
+import { KnexRepository } from './KnexRepository.js';
+
+export class MockRepositoryB extends KnexRepository {
+  async insertSomeValue() {
+    await this.dbConn('users').insert({
+      name: 'name in MockRepositoryB',
+      trigram: 'MRB',
+      apiKey: '12b833c7-5c9e-4803-9e63-4ac38dec91ba',
+      access: 'admin', }).returning('*');
+  }
+}

--- a/api/lib/infrastructure/repositories/propal/TranslationRepository.js
+++ b/api/lib/infrastructure/repositories/propal/TranslationRepository.js
@@ -1,0 +1,136 @@
+import _ from 'lodash';
+import { translationDatasource } from '../../datasources/airtable/index.js';
+import { Translation } from '../../../domain/models/index.js';
+import { KnexRepository } from './KnexRepository.js';
+
+const projection = ['key', 'locale', 'value'];
+
+export class TranslationRepository extends KnexRepository {
+  static doesTableExistInAirtable;
+  static doesTableExistInAirtablePromise;
+
+  async save({ translations, shouldDuplicateToAirtable = true }) {
+    if (translations.length === 0) return [];
+
+    await this.dbConn('translations')
+      .insert(translations)
+      .onConflict(['key', 'locale'])
+      .merge();
+
+    if (!shouldDuplicateToAirtable) return;
+
+    if (TranslationRepository.doesTableExistInAirtable == null && TranslationRepository.doesTableExistInAirtablePromise == null) {
+      await this.checkIfTableExistInAirtable();
+    }
+
+    if (TranslationRepository.doesTableExistInAirtable) {
+      await translationDatasource.upsert(translations);
+    }
+  }
+
+  /**
+   * @deprecated use one of {@link listByModel}, {@link listByEntity} or {@link listByEntities}
+   */
+  async listByPrefix(prefix) {
+    const translationDtos = await this.dbConn
+      .select(projection)
+      .from('translations')
+      .whereLike('key', `${prefix}%`);
+    return translationDtos.map(_toDomain);
+  }
+
+  async listByModel(model) {
+    const translationDtos = await this.dbConn
+      .select(projection)
+      .from('translations')
+      .where('model', model);
+    return translationDtos.map(_toDomain);
+  }
+
+  async listByEntity(model, entityId) {
+    const translationDtos = await this.dbConn
+      .select(projection)
+      .from('translations')
+      .where('model', model)
+      .andWhere('entityId', entityId);
+    return translationDtos.map(_toDomain);
+  }
+
+  async listByEntities(model, entityIds) {
+    const translationDtos = await this.dbConn
+      .select(projection)
+      .from('translations')
+      .where('model', model)
+      .andWhere('entityId', 'in', entityIds);
+    return translationDtos.map(_toDomain);
+  }
+
+  async listByPattern(pattern) {
+    const translationDtos = await this.dbConn
+      .select(projection)
+      .from('translations')
+      .whereLike('key', `${pattern}`);
+    return translationDtos.map(_toDomain);
+  }
+
+  async list() {
+    const translationDtos = await this.dbConn.select(projection).from('translations').orderBy(['key', 'locale']);
+    return translationDtos.map(_toDomain);
+  }
+
+  async search({ entity, fields, search, limit }) {
+    const query = this.dbConn('translations')
+      .pluck('key')
+      .whereILike('value', `%${escapeWildcardCharacters(search)}%`)
+      .andWhere(function() {
+        for (const field of fields) {
+          this.orWhereLike('key', `${entity}.%.${field}`);
+        }
+      })
+      .orderBy('key');
+
+    if (limit) query.limit(limit);
+
+    const keys = await query;
+
+    return _.sortedUniq(keys.map((key) => {
+      return key.split('.')[1];
+    }));
+  }
+
+  async checkIfTableExistInAirtable() {
+    TranslationRepository.doesTableExistInAirtablePromise = translationDatasource.exists();
+    TranslationRepository.doesTableExistInAirtable = await TranslationRepository.doesTableExistInAirtablePromise;
+  }
+
+  async deleteByKeyPrefixAndLocales({ prefix, locales }) {
+    await this.dbConn('translations')
+      .delete()
+      .whereLike('key', `${prefix}%`)
+      .whereIn('locale', locales);
+
+    if (TranslationRepository.doesTableExistInAirtable == null && TranslationRepository.doesTableExistInAirtablePromise == null) {
+      await this.checkIfTableExistInAirtable();
+    }
+
+    if (TranslationRepository.doesTableExistInAirtable) {
+      const records = await translationDatasource.filter({
+        filter: {
+          formula: `AND(REGEX_MATCH(key, '^${prefix.replace(/(\.)/g, '\\$1')}'), OR(${locales.map((locale) => `locale = '${locale}'`).join(', ')}))`,
+        },
+      });
+      if (records.length === 0) return;
+      const recordIds = records.map(({ airtableId }) => airtableId);
+      await translationDatasource.delete(recordIds);
+    }
+  }
+}
+
+function escapeWildcardCharacters(s) {
+  return s.replace(/(%|_)/g, '\\$1');
+}
+
+function _toDomain(dto) {
+  return new Translation(dto);
+}
+

--- a/api/lib/infrastructure/repositories/propal/index.js
+++ b/api/lib/infrastructure/repositories/propal/index.js
@@ -1,7 +1,13 @@
 import { AreaRepository } from './AreaRepository.js';
 import { TranslationRepository } from './TranslationRepository.js';
+// for testing purposes
+import { MockRepositoryA } from './MockRepositoryA.js';
+import { MockRepositoryB } from './MockRepositoryB.js';
 
 export {
   AreaRepository,
   TranslationRepository,
+  // for testing purposes
+  MockRepositoryA,
+  MockRepositoryB,
 };

--- a/api/lib/infrastructure/repositories/propal/index.js
+++ b/api/lib/infrastructure/repositories/propal/index.js
@@ -1,0 +1,7 @@
+import { AreaRepository } from './AreaRepository.js';
+import { TranslationRepository } from './TranslationRepository.js';
+
+export {
+  AreaRepository,
+  TranslationRepository,
+};

--- a/api/tests/integration/infrastructure/repositories/propal/AreaRepository_test.js
+++ b/api/tests/integration/infrastructure/repositories/propal/AreaRepository_test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../../test-helper.js';
+import { Area } from '../../../../../lib/domain/models/index.js';
+import { AreaRepository } from '../../../../../lib/infrastructure/repositories/propal/index.js';
+
+describe('Integration | Repository | AreaRepository', () => {
+  let areaRepository;
+  beforeEach(function() {
+    areaRepository = new AreaRepository();
+  });
+
+  describe('#list', () => {
+    it('should return the list of all areas', async () => {
+      // given
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Domaines' }).returns([
+        airtableBuilder.factory.buildArea({
+          id: 'areaId1',
+          airtableId: 'recAreaId1',
+          code: '1',
+          color: Area.COLORS.BUTTERFLY_BUSH,
+          competenceAirtableIds: ['competenceAirtableId11', 'competenceAirtableId12'],
+          competenceIds: ['competenceId11', 'competenceId12'],
+          frameworkId: 'frameworkId1',
+        }),
+        airtableBuilder.factory.buildArea({
+          id: 'areaId2',
+          airtableId: 'recAreaId2',
+          code: '2',
+          color: Area.COLORS.WILD_STRAWBERRY,
+          competenceAirtableIds: ['competenceAirtableId21', 'competenceAirtableId22'],
+          competenceIds: ['competenceId21', 'competenceId22'],
+          frameworkId: 'frameworkId1',
+        }),
+      ]).activate().nockScope;
+
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId1.title',
+        locale: 'fr',
+        value: 'Premier domaine',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId1.title',
+        locale: 'en',
+        value: 'First area',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId2.title',
+        locale: 'fr',
+        value: 'Second domaine',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'area.areaId2.title',
+        locale: 'en',
+        value: 'Second area',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const areas = await areaRepository.list();
+
+      // then
+      expect(areas).toEqual([
+        domainBuilder.buildArea({
+          id: 'areaId1',
+          airtableId: 'recAreaId1',
+          code: '1',
+          color: Area.COLORS.BUTTERFLY_BUSH,
+          competenceAirtableIds: ['competenceAirtableId11', 'competenceAirtableId12'],
+          competenceIds: ['competenceId11', 'competenceId12'],
+          frameworkId: 'frameworkId1',
+          title_i18n: {
+            fr: 'Premier domaine',
+            en: 'First area',
+          },
+        }),
+        domainBuilder.buildArea({
+          id: 'areaId2',
+          airtableId: 'recAreaId2',
+          code: '2',
+          color: Area.COLORS.WILD_STRAWBERRY,
+          competenceAirtableIds: ['competenceAirtableId21', 'competenceAirtableId22'],
+          competenceIds: ['competenceId21', 'competenceId22'],
+          frameworkId: 'frameworkId1',
+          title_i18n: {
+            fr: 'Second domaine',
+            en: 'Second area',
+          },
+        }),
+      ]);
+
+      airtableScope.done();
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/propal/TranslationRepository_test.js
+++ b/api/tests/integration/infrastructure/repositories/propal/TranslationRepository_test.js
@@ -1,0 +1,677 @@
+import { afterEach, beforeEach, describe, describe as context, expect, it } from 'vitest';
+import nock from 'nock';
+import { databaseBuilder, domainBuilder, knex } from '../../../../test-helper.js';
+import { TranslationRepository } from '../../../../../lib/infrastructure/repositories/propal/index.js';
+
+describe('Integration | Repository | TranslationRepository', function() {
+  let translationRepository;
+  beforeEach(function() {
+    translationRepository = new TranslationRepository();
+  });
+
+  afterEach(async function() {
+    await knex('translations').delete();
+  });
+
+  context('#save', function() {
+    it('should create or update translations', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id.key1',
+        locale: 'fr',
+        value: 'key1 fr'
+      });
+      await databaseBuilder.commit();
+
+      const translations = [
+        {
+          key: 'entity.id.key1',
+          locale: 'fr',
+          value: 'key1 fr'
+        },
+        {
+          key: 'entity.id.key2',
+          locale: 'fr',
+          value: 'key2 fr'
+        }
+      ];
+
+      // when
+      await translationRepository.save({ translations });
+
+      // then
+      await expect(knex('translations').select('key', 'locale', 'value').orderBy('key')).resolves.to.deep.equal(translations);
+    });
+
+    context('when Airtable has a translations table', () => {
+      beforeEach(async function() {
+        await _setDoesTableExistInAirtable(true, translationRepository);
+      });
+
+      afterEach(async function() {
+        await _setDoesTableExistInAirtable(false, translationRepository);
+      });
+
+      it('should save translations to airtable', async function() {
+        // given
+        nock('https://api.airtable.com')
+          .patch('/v0/airtableBaseValue/translations/?', {
+            records: [
+              {
+                fields: {
+                  key: 'entity.recordid.key',
+                  locale: 'fr',
+                  value: 'translationValue'
+                }
+              }
+            ],
+            performUpsert: {
+              fieldsToMergeOn: [
+                'key',
+                'locale'
+              ]
+            }
+          })
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, { records: [] });
+
+        // when
+        await translationRepository.save({ translations: [{ key: 'entity.recordid.key', locale: 'fr', value: 'translationValue' }] });
+
+        // then
+        expect(nock.isDone()).to.be.true;
+      });
+    });
+  });
+
+  context('#deleteByKeyPrefixAndLocales', function() {
+    it('should delete translations having key prefix and locales', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'some.prefix.key',
+        locale: 'fr',
+        value: 'Bonjour, la mif'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'some.prefix.key',
+        locale: 'en',
+        value: 'Hello, the mif'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'some.prefix.key',
+        locale: 'nl-be',
+        value: 'Hallo, het mif'
+      });
+      await databaseBuilder.commit();
+
+      const prefixToDelete = 'some.prefix.';
+      const locales = ['fr', 'en'];
+
+      // when
+      await translationRepository.deleteByKeyPrefixAndLocales({ prefix: prefixToDelete, locales });
+
+      // then
+      expect(await knex('translations').select('key', 'locale', 'value')).to.deep.equal([
+        {
+          key: 'some.prefix.key',
+          locale: 'nl-be',
+          value: 'Hallo, het mif'
+        },
+      ]);
+    });
+
+    context('when Airtable has a translations table', () => {
+      beforeEach(async function() {
+        await _setDoesTableExistInAirtable(true, translationRepository);
+      });
+
+      afterEach(async function() {
+        await _setDoesTableExistInAirtable(false, translationRepository);
+      });
+
+      it('should delete keys in Airtable', async () => {
+        // given
+        nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/translations')
+          .query({
+            fields: {
+              '': [
+                'key',
+                'locale',
+                'value',
+              ],
+            },
+            filterByFormula: 'AND(REGEX_MATCH(key, \'^some\\.prefix\\.\'), OR(locale = \'fr\', locale = \'en\'))',
+          })
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, {
+            records: [
+              {
+                id: 'recTranslation1',
+                fields: {
+                  key: 'some.prefix.key',
+                  locale: 'fr',
+                  value: 'Bonjour, la mif',
+                },
+              },
+              {
+                id: 'recTranslation2',
+                fields: {
+                  key: 'some.prefix.key',
+                  locale: 'en',
+                  value: 'Hello, the mif',
+                },
+              },
+            ]
+          });
+
+        nock('https://api.airtable.com')
+          .delete('/v0/airtableBaseValue/translations')
+          .query({
+            records: {
+              '': ['recTranslation1', 'recTranslation2'],
+            }
+          })
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, {
+            records: [
+              { id: 'recTranslation1', deleted: true },
+              { id: 'recTranslation2', deleted: true },
+            ],
+          });
+
+        const prefixToDelete = 'some.prefix.';
+        const locales = ['fr', 'en'];
+
+        // when
+        await translationRepository.deleteByKeyPrefixAndLocales({ prefix: prefixToDelete, locales });
+
+        expect(nock.isDone()).toBe(true);
+      });
+    });
+  });
+
+  context('#search', function() {
+    it('should search for fields in entities', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key',
+        locale: 'fr',
+        value: 'coco'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key2',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await translationRepository.search({
+        entity: 'entity',
+        fields: ['key'],
+        search: 'coucou'
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1']);
+    });
+
+    it('should return distinct entity ids', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key2',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await translationRepository.search({
+        entity: 'entity',
+        fields: ['key', 'key2'],
+        search: 'coucou'
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1']);
+    });
+
+    it('should return entity ids sorted alphabetically', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await translationRepository.search({
+        entity: 'entity',
+        fields: ['key'],
+        search: 'coucou'
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1', 'entityId2']);
+    });
+
+    it('should return a limited number of ids', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await translationRepository.search({
+        entity: 'entity',
+        fields: ['key'],
+        search: 'coucou',
+        limit: 1,
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1']);
+    });
+
+    it('should perform a case-insensitive search', async function() {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId1.key',
+        locale: 'fr',
+        value: 'Coucou'
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.entityId2.key',
+        locale: 'fr',
+        value: 'coucou'
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const entityIds = await translationRepository.search({
+        entity: 'entity',
+        fields: ['key'],
+        search: 'coucou',
+        limit: 2,
+      });
+
+      // then
+      expect(entityIds).to.deep.equal(['entityId1', 'entityId2']);
+    });
+
+    describe('when search string contains wildcard characters', () => {
+
+      beforeEach(async () => {
+        databaseBuilder.factory.buildTranslation({
+          key: 'entity.entityId1.key',
+          locale: 'fr',
+          value: 'aaa N_n aaa',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'entity.entityId2.key',
+          locale: 'fr',
+          value: 'On est sur de nous à 80% à peu près',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'entity.entityId3.key',
+          locale: 'fr',
+          value: 'aaa Non aaa',
+        });
+        await databaseBuilder.commit();
+      });
+
+      it('should escape % character', async () => {
+        // given
+        const searchString = '%';
+
+        // when
+        const entityIds = await translationRepository.search({
+          entity: 'entity',
+          fields: ['key'],
+          search: searchString,
+        });
+
+        // then
+        expect(entityIds).to.deep.equal(['entityId2']);
+      });
+
+      it('should escape _ character', async () => {
+        // given
+        const searchString = 'N_n';
+
+        // when
+        const entityIds = await translationRepository.search({
+          entity: 'entity',
+          fields: ['key'],
+          search: searchString,
+        });
+
+        // then
+        expect(entityIds).to.deep.equal(['entityId1']);
+      });
+    });
+  });
+
+  context('#list', () => {
+    it('should list translations ordered by key and locale', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'fr',
+        value: 'field1 id1 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field1',
+        locale:  'fr',
+        value: 'field1 id2 en FR',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id2.field2',
+        locale:  'en',
+        value: 'field2 id2 en EN',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity.id1.field1',
+        locale:  'en',
+        value: 'field1 id1 en EN',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations = await translationRepository.list();
+
+      // then
+      expect(translations).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'en',
+          value: 'field1 id1 en EN',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id1.field1',
+          locale:  'fr',
+          value: 'field1 id1 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field1',
+          locale:  'fr',
+          value: 'field1 id2 en FR',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity.id2.field2',
+          locale:  'en',
+          value: 'field2 id2 en EN',
+        }),
+      ]);
+    });
+  });
+
+  context('#listByModel', () => {
+    it('should list translations matching first portion of key', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id1.field1',
+        locale:  'fr',
+        value: 'aaa',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id1.field2',
+        locale:  'fr',
+        value: 'bbb',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id2.field1',
+        locale:  'fr',
+        value: 'ccc',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id2.field1',
+        locale:  'en',
+        value: 'ddd',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity2.id1.field1',
+        locale:  'fr',
+        value: 'eee',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations1 = await translationRepository.listByModel('entity1');
+      const translations2 = await translationRepository.listByModel('entity2');
+
+      // then
+      expect(translations1).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity1.id1.field1',
+          locale:  'fr',
+          value: 'aaa',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id1.field2',
+          locale:  'fr',
+          value: 'bbb',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id2.field1',
+          locale:  'fr',
+          value: 'ccc',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id2.field1',
+          locale:  'en',
+          value: 'ddd',
+        }),
+      ]);
+      expect(translations2).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity2.id1.field1',
+          locale:  'fr',
+          value: 'eee',
+        }),
+      ]);
+    });
+  });
+
+  context('#listByEntity', () => {
+    it('should list translations matching first and second portion of key', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id1.field1',
+        locale:  'fr',
+        value: 'aaa',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id1.field2',
+        locale:  'fr',
+        value: 'bbb',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id2.field1',
+        locale:  'fr',
+        value: 'ccc',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id2.field1',
+        locale:  'en',
+        value: 'ddd',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity2.id1.field1',
+        locale:  'fr',
+        value: 'eee',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations1 = await translationRepository.listByEntity('entity1', 'id1');
+      const translations2 = await translationRepository.listByEntity('entity1', 'id2');
+      const translations3 = await translationRepository.listByEntity('entity2', 'id1');
+
+      // then
+      expect(translations1).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity1.id1.field1',
+          locale:  'fr',
+          value: 'aaa',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id1.field2',
+          locale:  'fr',
+          value: 'bbb',
+        }),
+      ]);
+      expect(translations2).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity1.id2.field1',
+          locale:  'fr',
+          value: 'ccc',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id2.field1',
+          locale:  'en',
+          value: 'ddd',
+        }),
+      ]);
+      expect(translations3).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity2.id1.field1',
+          locale:  'fr',
+          value: 'eee',
+        }),
+      ]);
+    });
+  });
+
+  context('#listByEntities', () => {
+    it('should list translations matching first and second portion of key', async () => {
+      // given
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id1.field1',
+        locale:  'fr',
+        value: 'aaa',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id1.field2',
+        locale:  'fr',
+        value: 'bbb',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id2.field1',
+        locale:  'fr',
+        value: 'ccc',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id2.field1',
+        locale:  'en',
+        value: 'ddd',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id3.field1',
+        locale:  'fr',
+        value: 'eee',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity1.id3.field2',
+        locale:  'fr',
+        value: 'fff',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'entity2.id1.field1',
+        locale:  'fr',
+        value: 'ggg',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const translations = await translationRepository.listByEntities('entity1', ['id2', 'id3']);
+
+      // then
+      expect(translations).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: 'entity1.id2.field1',
+          locale:  'fr',
+          value: 'ccc',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id2.field1',
+          locale:  'en',
+          value: 'ddd',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id3.field1',
+          locale:  'fr',
+          value: 'eee',
+        }),
+        domainBuilder.buildTranslation({
+          key: 'entity1.id3.field2',
+          locale:  'fr',
+          value: 'fff',
+        }),
+      ]);
+    });
+  });
+});
+
+async function _setDoesTableExistInAirtable(value, translationRepository) {
+  if (value) {
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/translations')
+      .query({
+        fields: {
+          '': [
+            'key',
+            'locale',
+            'value',
+          ],
+        },
+        sort: [{ field: 'key_locale', direction: 'asc' }],
+        maxRecords: 1,
+      })
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .reply(200, { records: [] });
+  } else {
+    nock('https://api.airtable.com')
+      .get('/v0/airtableBaseValue/translations')
+      .query({
+        fields: {
+          '': [
+            'key',
+            'locale',
+            'value',
+          ],
+        },
+        sort: [{ field: 'key_locale', direction: 'asc' }],
+        maxRecords: 1,
+      })
+      .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+      .reply(404);
+  }
+
+  await translationRepository.checkIfTableExistInAirtable();
+}

--- a/api/tests/unit/domain/usecases/propal/index_test.js
+++ b/api/tests/unit/domain/usecases/propal/index_test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { usecases } from '../../../../../lib/domain/usecases/propal/index.js';
+
+describe('Unit | Domain | Usecases | index', () => {
+  it('should have injected usecase properly', async function() {
+    const injectedUsecase = usecases.mockUsecaseForTestingPurposes;
+    const {
+      res: res1,
+      areaRepository: areaRepository1,
+      translationRepository: translationRepository1,
+      logger: logger1,
+    } = await injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100 });
+    const {
+      res: res2,
+      areaRepository: areaRepository2,
+      translationRepository: translationRepository2,
+      logger: logger2,
+    } = await injectedUsecase({ someArg1: 2, someArg2: 20, someArg3: 200 });
+
+    expect(res1, 'First instance of usecase should return the expected result').to.equal(111);
+    expect(res2, 'Second instance of usecase should return the expected result').to.equal(222);
+    expect(areaRepository1, 'Repositories should be different instances between usecases').not.toBe(areaRepository2);
+    expect(translationRepository1, 'Repositories should be different instances between usecases').not.toBe(translationRepository2);
+    expect(areaRepository1.dbConn, 'Repositories within same usecase should share the knex connection').toBe(translationRepository1.dbConn);
+    expect(areaRepository2.dbConn, 'Repositories within same usecase should share the knex connection').toBe(translationRepository2.dbConn);
+    expect(areaRepository1.dbConn, 'Same repositories in different usecase should have a different knex connection').not.toBe(areaRepository2.dbConn);
+    expect(translationRepository1.dbConn, 'Same repositories in different usecase should have a different knex connection').not.toBe(translationRepository2.dbConn);
+    expect(logger1, 'Loggers should be different').not.toBe(logger2);
+    expect(logger1.bindings(), 'Logger should have an event name related to the usecase').toStrictEqual({ event: 'mockUsecaseForTestingPurposes' });
+    expect(logger1.bindings(), 'Loggers should have the same bindings').toStrictEqual(logger2.bindings());
+  });
+});

--- a/api/tests/unit/domain/usecases/propal/index_test.js
+++ b/api/tests/unit/domain/usecases/propal/index_test.js
@@ -1,32 +1,69 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe as context, describe, expect, it } from 'vitest';
 import { usecases } from '../../../../../lib/domain/usecases/propal/index.js';
+import { knex } from '../../../../test-helper.js';
 
 describe('Unit | Domain | Usecases | index', () => {
+  beforeEach(function() {
+    return knex('users').del();
+  });
+
   it('should have injected usecase properly', async function() {
-    const injectedUsecase = usecases.mockUsecaseForTestingPurposes;
+    const injectedUsecase = usecases.mockUsecaseWithTrx;
     const {
       res: res1,
-      areaRepository: areaRepository1,
-      translationRepository: translationRepository1,
+      mockRepositoryA: mockRepositoryA1,
+      mockRepositoryB: mockRepositoryB1,
       logger: logger1,
-    } = await injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100 });
+    } = await injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100, shouldThrow: false });
     const {
       res: res2,
-      areaRepository: areaRepository2,
-      translationRepository: translationRepository2,
+      mockRepositoryA: mockRepositoryA2,
+      mockRepositoryB: mockRepositoryB2,
       logger: logger2,
-    } = await injectedUsecase({ someArg1: 2, someArg2: 20, someArg3: 200 });
+    } = await injectedUsecase({ someArg1: 2, someArg2: 20, someArg3: 200, shouldThrow: false });
 
     expect(res1, 'First instance of usecase should return the expected result').to.equal(111);
     expect(res2, 'Second instance of usecase should return the expected result').to.equal(222);
-    expect(areaRepository1, 'Repositories should be different instances between usecases').not.toBe(areaRepository2);
-    expect(translationRepository1, 'Repositories should be different instances between usecases').not.toBe(translationRepository2);
-    expect(areaRepository1.dbConn, 'Repositories within same usecase should share the knex connection').toBe(translationRepository1.dbConn);
-    expect(areaRepository2.dbConn, 'Repositories within same usecase should share the knex connection').toBe(translationRepository2.dbConn);
-    expect(areaRepository1.dbConn, 'Same repositories in different usecase should have a different knex connection').not.toBe(areaRepository2.dbConn);
-    expect(translationRepository1.dbConn, 'Same repositories in different usecase should have a different knex connection').not.toBe(translationRepository2.dbConn);
+    expect(mockRepositoryA1, 'Repositories should be different instances between usecases').not.toBe(mockRepositoryA2);
+    expect(mockRepositoryB1, 'Repositories should be different instances between usecases').not.toBe(mockRepositoryB2);
+    expect(mockRepositoryA1.dbConn, 'Repositories within same usecase should share the knex connection').toBe(mockRepositoryB1.dbConn);
+    expect(mockRepositoryA2.dbConn, 'Repositories within same usecase should share the knex connection').toBe(mockRepositoryB2.dbConn);
+    expect(mockRepositoryA1.dbConn, 'Same repositories in different usecase should have a different knex connection').not.toBe(mockRepositoryA2.dbConn);
+    expect(mockRepositoryB1.dbConn, 'Same repositories in different usecase should have a different knex connection').not.toBe(mockRepositoryB2.dbConn);
     expect(logger1, 'Loggers should be different').not.toBe(logger2);
-    expect(logger1.bindings(), 'Logger should have an event name related to the usecase').toStrictEqual({ event: 'mockUsecaseForTestingPurposes' });
+    expect(logger1.bindings(), 'Logger should have an event name related to the usecase').toStrictEqual({ event: 'mockUsecaseWithTrx' });
     expect(logger1.bindings(), 'Loggers should have the same bindings').toStrictEqual(logger2.bindings());
+  });
+
+  context('when usecase requires a DB transaction (NEED_TRX at true)', function() {
+    const injectedUsecase = usecases.mockUsecaseWithTrx;
+
+    it('should do usecase and persist in DB when everything is ok', async function() {
+      await injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100, shouldThrow: false });
+      const userNamesInserted = await knex('users').pluck('name').orderBy('name', 'asc');
+      expect(userNamesInserted).toStrictEqual(['name in MockRepositoryA', 'name in MockRepositoryB']);
+    });
+
+    it('should rollback the transaction when something goes wrong', async function() {
+      await expect(injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100, shouldThrow: true })).rejects.toThrowError();
+      const userNamesInserted = await knex('users').pluck('name').orderBy('name', 'asc');
+      expect(userNamesInserted).toStrictEqual([]);
+    });
+  });
+
+  context('when usecase does not requires a DB transaction (NEED_TRX at false)', function() {
+    const injectedUsecase = usecases.mockUsecaseWithoutTrx;
+
+    it('should do usecase and persist in DB when everything is ok', async function() {
+      await injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100, shouldThrow: false });
+      const userNamesInserted = await knex('users').pluck('name').orderBy('name', 'asc');
+      expect(userNamesInserted).toStrictEqual(['name in MockRepositoryA', 'name in MockRepositoryB']);
+    });
+
+    it('should persist anything executed before the error was thrown', async function() {
+      await expect(injectedUsecase({ someArg1: 1, someArg2: 10, someArg3: 100, shouldThrow: true })).rejects.toThrowError();
+      const userNamesInserted = await knex('users').pluck('name').orderBy('name', 'asc');
+      expect(userNamesInserted).toStrictEqual(['name in MockRepositoryA']);
+    });
   });
 });


### PR DESCRIPTION
## 🌸 Problème

J'ai pas envie qu'il arrive comme sur le répo principal à se traîner une domainTransaction.
Surtout que si la sortie Airtable se poursuit, ça serait super d'avoir des usecases, qui vont faire moults manipulations SQL, que l'ensemble soit toujours transactionnel.

## 🌳 Proposition
Au démarrage du serveur, les usecases exportées sont en fait des fonctions qui, à l'exécution (donc à chaque appel), vont se réinjecter ce qu'il faut, notamment des répos qui vont porter en eux la connexion knex courante (une transaction en l'occurrence).
J'en profite aussi pour tester le fait d'injecter dans les usecases un child logger.

## 🐝 Remarques

Y'a beaucoup de diffs mais en vrai pas tant que ça.
Mon usecase spécimen est 'create-area'. 
J'ai dupliqué le usecase pour passer tout en param.
J'ai dupliqué les repositories dont j'avais besoin pour les transformer en classe (pour pouvoir faire l'injection de la trx dynamiquement).
De fait j'ai dupliqué les tests de répo. Seule différence dans le code, j'instancie un répo (vu que maintenant c'est une classe), mais tous les tests sont pareils qu'avant.

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
