### PR TITLE
[BUGFIX] Échec de la création du workbench acquis lors de la création d’une compétence (PIX-17777)

### DIFF
--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -112,9 +112,16 @@ export class Skill {
 
   prepareForCreation(tube, tubeSkills, generateNewIdFnc) {
     this.id = generateNewIdFnc(Skill.ID_PREFIX);
-    this.name = `${tube.name}${this.level}`;
     this.status = Skill.STATUSES.EN_CONSTRUCTION;
-    this.version = tubeSkills.filter((skill) => skill.level === this.level).length + 1;
+
+    // TODO à enlever quand la création du skill workbench sera dans l’API
+    if (tube.isWorkbench) {
+      this.name = Skill.WORKBENCH_NAME;
+      this.level = null;
+    } else {
+      this.name = `${tube.name}${this.level}`;
+      this.version = tubeSkills.filter((skill) => skill.level === this.level).length + 1;
+    }
   }
 
   cloneSkillAndChallenges({ tubeDestination, level, skillChallenges, tubeSkills, attachments, generateNewIdFnc }) {

--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -16,4 +16,12 @@ export class Tube {
     this.index = index;
     this.competenceId = competenceId;
   }
+
+  static get WORKBENCH_NAME() {
+    return '@workbench';
+  }
+
+  get isWorkbench() {
+    return this.name === Tube.WORKBENCH_NAME;
+  }
 }

--- a/api/tests/unit/domain/models/Skill_test.js
+++ b/api/tests/unit/domain/models/Skill_test.js
@@ -436,8 +436,38 @@ describe('Unit | Domain | Skill', () => {
       // then
       expect(skill).toHaveProperty('id', createdSkillId);
       expect(skill).toHaveProperty('name', '@test6');
+      expect(skill).toHaveProperty('level', 6);
       expect(skill).toHaveProperty('status', Skill.STATUSES.EN_CONSTRUCTION);
       expect(skill).toHaveProperty('version', 2);
+    });
+
+    describe('when tube is @workbench', () => {
+
+      it('should set name to tube’s name and version to null', () => {
+      // given
+        const skill = domainBuilder.buildSkill({
+          name: null,
+          level: 0,
+          status: null,
+          version: null,
+        });
+
+        const tube = domainBuilder.buildTube({
+          name: '@workbench',
+        });
+
+        const tubeSkills = [];
+
+        // when
+        skill.prepareForCreation(tube, tubeSkills, generateNewIdFnc);
+
+        // then
+        expect(skill).toHaveProperty('id', createdSkillId);
+        expect(skill).toHaveProperty('name', '@workbench');
+        expect(skill).toHaveProperty('level', null);
+        expect(skill).toHaveProperty('status', Skill.STATUSES.EN_CONSTRUCTION);
+        expect(skill).toHaveProperty('version', null);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/Tube_test.js
+++ b/api/tests/unit/domain/models/Tube_test.js
@@ -1,0 +1,32 @@
+import {  describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Domain | Tube', () => {
+  describe('#get isWorkbench', () => {
+    it('is true when name is @workbench', () => {
+      // given
+      const tube  = domainBuilder.buildTube({
+        name: '@workbench',
+      });
+
+      // when
+      const { isWorkbench } = tube;
+
+      // then
+      expect(isWorkbench).toBe(true);
+    });
+
+    it('is false when name os @workbench', () => {
+      // given
+      const tube  = domainBuilder.buildTube({
+        name: '@test',
+      });
+
+      // when
+      const { isWorkbench } = tube;
+
+      // then
+      expect(isWorkbench).toBe(false);
+    });
+  });
+});

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -87,10 +87,9 @@ export default class CompetenceManagementNewController extends Controller {
   async _createSkillWorkbench(tube, frameworkName) {
     const description = `Acquis pour l'atelier de la compétence ${this.competence.code} ${frameworkName}`;
     const skillWorkbench = this.store.createRecord('skill', {
-      name: '@workbench',
+      level: 0,
       description,
       tube,
-      pixId: this.idGenerator.newId('skill'),
     });
     return await skillWorkbench.save();
   }

--- a/pix-editor/app/controllers/authenticated/competence/skills/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/new.js
@@ -10,11 +10,7 @@ export default class NewController extends Skill {
   defaultSaveSkillChangelog = 'Création de l\'acquis';
 
   get skill() {
-    return this.model.skill;
-  }
-
-  get tube() {
-    return this.model.tube;
+    return this.model;
   }
 
   @service changelogEntry;
@@ -33,13 +29,9 @@ export default class NewController extends Skill {
   @action
   async save() {
     this.loader.start();
-    const skill = this.skill;
-    const tube = this.tube;
     try {
-      skill.tube = tube;
-      skill.version = tube.getNextSkillVersion(skill.level);
-      await skill.save();
-      await this._handleSkillChangelog(skill, this.defaultSaveSkillChangelog, this.changelogEntry.createAction);
+      await this.skill.save();
+      await this._handleSkillChangelog(this.skill, this.defaultSaveSkillChangelog, this.changelogEntry.createAction);
       this.edition = false;
       this.loader.stop();
       this.notify.message('Acquis créé');

--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -6,7 +6,7 @@ export default class SkillModel extends Model {
 
   _pinnedRelationships = {};
 
-  @attr('string', { readOnly: true }) name;
+  @attr name;
   @attr clue;
   @attr clueEn;
   @attr clueStatus;
@@ -17,7 +17,7 @@ export default class SkillModel extends Model {
   @attr status;
   @attr pixId;
   @attr i18n;
-  @attr('number') version;
+  @attr version;
 
   @belongsTo('tube', { async: true, inverse: 'rawSkills' }) tube;
 

--- a/pix-editor/app/models/tube.js
+++ b/pix-editor/app/models/tube.js
@@ -91,11 +91,6 @@ export default class TubeModel extends Model {
     return this.productionSkillCount > 0;
   }
 
-  getNextSkillVersion(level) {
-    const skills = this.filledSkills[level - 1];
-    return skills.length;
-  }
-
   _getFilledOrderedVersions(skills) {
     const filledSkills = this._getFilledSkillGroupByLevel(skills);
     return filledSkills.map((filledSkill) => {

--- a/pix-editor/app/routes/authenticated/competence/skills/new.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/new.js
@@ -6,20 +6,18 @@ export default class NewRoute extends SingleRoute {
   templateName = 'authenticated/competence/skills/single';
   @service store;
 
-  model() {
-    return {
-      skill: this.store.createRecord('skill', { status: 'en construction' }),
-    };
-  }
-
-  async afterModel(model) {
-    const params = this.paramsFor(this.routeName);
+  async model(params) {
     const tube = await this.store.findRecord('tube', params.tube_id);
     const level = parseInt(params.level);
-    model.skill.name = tube.name + level;
-    model.skill.level = level;
-    model.tube = tube;
-    return tube;
+    return this.store.createRecord('skill', {
+      name: `${tube.name}${level}`,
+      level,
+      status: 'en construction',
+      tube,
+    });
+  }
+
+  async afterModel() {
   }
 
   setupController(controller) {

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -141,7 +141,20 @@ function routes() {
 
   this.get('/skills/:id');
 
-  this.post('/skills');
+  this.post('/skills', (schema, request) => {
+    const skillPayload = JSON.parse(request.requestBody);
+    const tube = schema.tubes.find(skillPayload.data.relationships.tube.data.id);
+    const createdSkill = schema.skills.create({
+      ...skillPayload.data.attributes,
+      id: 'newSkillId',
+      pixId: 'newPixId',
+      status: 'en construction',
+      tubeId: skillPayload.data.relationships.tube.data.id,
+      name: tube.name === '@workbench' ? '@workbench' : `${tube.name}${skillPayload.data.attributes.level}`,
+      level: tube.name === '@workbench' ? undefined : skillPayload.data.attributes.level,
+    });
+    return createdSkill;
+  });
 
   this.post('/skills/clone', function(schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;

--- a/pix-editor/tests/unit/controllers/competence-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/new-test.js
@@ -135,10 +135,9 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       pixId: 'recId',
     };
     const expectedSkill = {
-      name: '@workbench',
       tube: 'tube',
       description: 'Acquis pour l\'atelier de la compétence 1.1 Pix+',
-      pixId: 'recId',
+      level: 0,
     };
 
     // when

--- a/pix-editor/tests/unit/models/tube-test.js
+++ b/pix-editor/tests/unit/models/tube-test.js
@@ -149,15 +149,6 @@ module('Unit | Model | tube', function(hooks) {
     });
   });
 
-  test('it should get a next skill version', async function(assert) {
-
-    // when
-    const nextSkillVersion = tube.getNextSkillVersion(skillRecord2.level);
-
-    // then
-    assert.strictEqual(nextSkillVersion, 2);
-  });
-
   module('#productionSkills', function() {
     test('returns validated skills in the tube', function(assert) {
       assert.strictEqual(tube.productionSkillCount, 3);


### PR DESCRIPTION
## 🌸 Problème

La création de l’acquis échoue sur une 400 bad request.

## 🌳 Proposition

Corriger la payload de request pour qu’elle soit conforme à ce qui est attendu.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Créer une compétence et vérifier que le workbench se créé comme attendu.
Créer un acquis et vérifier qu’il se créer comme attendu.