### PR TITLE
[TECH] Empêcher les tests flaky liés à l'affichage de plusieurs PixSelect

### DIFF
--- a/pix-editor/tests/acceptance/competence/skills/single-test.js
+++ b/pix-editor/tests/acceptance/competence/skills/single-test.js
@@ -4,6 +4,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 
+import { waitForSelectToBeClosed } from '../../../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
 module('Acceptance | skill | single', function(hooks) {
@@ -144,7 +145,6 @@ module('Acceptance | skill | single', function(hooks) {
       skill1.update({ challengeIds: [...skill1.challengeIds, challengeProto.id] });
       const skillDescription = 'Nouvelle description';
       // when
-      const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
       const screen = await visit(`/competence/${competence1.id}/skills/${skill1.id}`);
       await clickByText('Modifier');
@@ -156,17 +156,19 @@ module('Acceptance | skill | single', function(hooks) {
       await clickByText('Incompatible iPad certif');
       await clickByText('Sourds et malentendants');
       await click(await screen.findByRole('option', { name: 'RAS' }));
-      await delay(100);
+      await waitForSelectToBeClosed(screen);
       await clickByText('Non voyant');
       await click(await screen.findByRole('option', { name: 'OK' }));
-      await delay(100);
+      await waitForSelectToBeClosed(screen);
       await clickByText('Daltonien');
       await click(await screen.findByRole('option', { name: 'KO' }));
-      await delay(100);
+      await waitForSelectToBeClosed(screen);
       await clickByText('Spoil');
       await click(await screen.findByRole('option', { name: 'Facilement Sp' }));
+      await waitForSelectToBeClosed(screen);
       await clickByText('Responsive');
       await click(await screen.findByRole('option', { name: 'Non' }));
+      await waitForSelectToBeClosed(screen);
       const saveButton = screen.getByRole('button', { name: 'Enregistrer l\'acquis @monAcquisÀMoi' });
       await click(saveButton);
       await clickByText('Valider');

--- a/pix-editor/tests/acceptance/create-challenge-test.js
+++ b/pix-editor/tests/acceptance/create-challenge-test.js
@@ -7,6 +7,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { waitForSelectToBeClosed } from '../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../setup-application-rendering';
 
 module('Acceptance | Create-Challenge', function(hooks) {
@@ -68,7 +69,6 @@ module('Acceptance | Create-Challenge', function(hooks) {
     await clickByText('Nouveau prototype');
     await selectFiles('[data-test-file-input-illustration] input', illustrationFile);
     await selectFiles('[data-test-file-input-attachment] input', attachmentFile);
-    const delay = (ms) => new Promise((res) => setTimeout(res, ms));
     await clickByText('Épreuve de sensibilisation');
     await clickByText('Accès GAFAM requis');
     await clickByText('Formulation à revoir');
@@ -77,17 +77,19 @@ module('Acceptance | Create-Challenge', function(hooks) {
     await clickByText('Validation par l\'embed (Pix Junior)');
     await clickByText('Sourds et malentendants');
     await click(await screen.findByRole('option', { name: 'RAS' }));
-    await delay(100);
+    await waitForSelectToBeClosed(screen);
     await clickByText('Non voyant');
     await click(await screen.findByRole('option', { name: 'OK' }));
-    await delay(100);
+    await waitForSelectToBeClosed(screen);
     await clickByText('Daltonien');
     await click(await screen.findByRole('option', { name: 'KO' }));
-    await delay(100);
+    await waitForSelectToBeClosed(screen);
     await clickByText('Spoil');
     await click(await screen.findByRole('option', { name: 'Facilement Sp' }));
+    await waitForSelectToBeClosed(screen);
     await clickByText('Responsive');
     await click(await screen.findByRole('option', { name: 'Non' }));
+    await waitForSelectToBeClosed(screen);
     await click(find('[data-test-save-challenge-button]'));
 
     // then

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -4,6 +4,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 
+import { waitForSelectToBeClosed } from '../../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../../setup-application-rendering';
 
 module('Acceptance | Modify-Challenge', function(hooks) {
@@ -95,7 +96,6 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await clickByText('Modifier');
       await clickByText('Ajouter des URLs à consulter');
       await fillByLabel('URLs externes à consulter', ' https://mon-url.com \n mon-autre-url.com');
-      const delay = (ms) => new Promise((res) => setTimeout(res, ms));
       await clickByText('Épreuve de sensibilisation');
       await clickByText('Accès GAFAM requis');
       await clickByText('Formulation à revoir');
@@ -104,17 +104,19 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await clickByText('Validation par l\'embed (Pix Junior)');
       await clickByText('Sourds et malentendants');
       await click(await screen.findByRole('option', { name: 'RAS' }));
-      await delay(100);
+      await waitForSelectToBeClosed(screen);
       await clickByText('Non voyant');
       await click(await screen.findByRole('option', { name: 'OK' }));
-      await delay(100);
+      await waitForSelectToBeClosed(screen);
       await clickByText('Daltonien');
       await click(await screen.findByRole('option', { name: 'KO' }));
-      await delay(100);
+      await waitForSelectToBeClosed(screen);
       await clickByText('Spoil');
       await click(await screen.findByRole('option', { name: 'Facilement Sp' }));
+      await waitForSelectToBeClosed(screen);
       await clickByText('Responsive');
       await click(await screen.findByRole('option', { name: 'Non' }));
+      await waitForSelectToBeClosed(screen);
       await click(find('[data-test-save-challenge-button]'));
       await click(find('[data-test-confirm-log-approve]'));
 

--- a/pix-editor/tests/helpers/wait-for-select-to-be-closed.js
+++ b/pix-editor/tests/helpers/wait-for-select-to-be-closed.js
@@ -1,0 +1,7 @@
+import { waitUntil } from '@ember/test-helpers';
+
+export async function waitForSelectToBeClosed(screen, options = { timeout: 1000 }) {
+  await waitUntil(() => {
+    return screen.queryAllByRole('option').length === 0;
+  }, options);
+}


### PR DESCRIPTION
## 🌸 Problème

Dans les test, quand il y a plusieurs PixSelect sur une page et qu'on essaye d'interagir avec, les listes d'options qu'on récupère avec `screen.findByRole('option')` ne sont pas représentatives de ce qu'on voit réellement.
Les options d'un ancien PixSelect déjà fermé peuvent encore être visibles dans le DOM pendant quelques instants (sûrement lié à leur animation).

## 🌳 Proposition

Après chaque fermeture d'un PixSelect, s'assurer que toutes ses options ne soient plus visibles avant de continuer le test.

## 🐝 Remarques

Ça reste un pansement, et dans l'idéal on devrait pouvoir désactiver ce comportement du côté de pix-ui, mais c'est mieux que des tests flaky pour l'instant.

## 🤧 Pour tester

Tests OK, et espérer qu'ils le restent 👀
