### PR TITLE
[TECH] Déplacer la création du sujet workbench dans l’API (PIX-17771)

### DIFF
--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -6,6 +6,8 @@ export class Tube {
     practicalTitle_i18n,
     practicalDescription_i18n,
     index,
+    thematicAirtableId,
+    competenceAirtableId,
     competenceId,
   }) {
     this.id = id;
@@ -14,6 +16,8 @@ export class Tube {
     this.practicalTitle_i18n = practicalTitle_i18n;
     this.practicalDescription_i18n = practicalDescription_i18n;
     this.index = index;
+    this.thematicAirtableId = thematicAirtableId;
+    this.competenceAirtableId = competenceAirtableId;
     this.competenceId = competenceId;
   }
 

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -2,10 +2,10 @@ import * as Sentry from '@sentry/node';
 import { logger } from '../../infrastructure/logger.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { areaRepository, competenceRepository, thematicRepository } from '../../infrastructure/repositories/index.js';
-import { competenceTransformer, thematicTransformer } from '../../infrastructure/transformers/index.js';
+import { areaRepository, competenceRepository, thematicRepository, tubeRepository } from '../../infrastructure/repositories/index.js';
+import { competenceTransformer, thematicTransformer, tubeTransformer } from '../../infrastructure/transformers/index.js';
 import { BadRequestError } from '../../infrastructure/errors.js';
-import { Thematic } from '../models/Thematic.js';
+import { Thematic, Tube } from '../models/index.js';
 
 export async function createCompetence(competence) {
   const [area, competences] = await Promise.all([
@@ -30,8 +30,21 @@ export async function createCompetence(competence) {
 
   const createdWorkbenchThematic = await thematicRepository.create(workbenchThematic);
 
+  const workbenchTube = new Tube({
+    competenceAirtableId: createdCompetence.airtableId,
+    name: Tube.WORKBENCH_NAME,
+    thematicAirtableId: createdWorkbenchThematic.airtableId,
+    practicalTitle_i18n: {
+      fr: `Tube pour l'atelier de la compétence ${createdCompetence.index} ${createdCompetence.origin}`,
+    },
+    practicalDescription_i18n: {},
+  });
+
+  const createdWorkbenchTube = await tubeRepository.create(workbenchTube);
+
   createdCompetence.thematicIds = [createdWorkbenchThematic.id];
   createdCompetence.thematicAirtableIds = [createdWorkbenchThematic.airtableId];
+  createdCompetence.tubeAirtableIds = [createdWorkbenchTube.airtableId];
 
   try {
     await Promise.all([
@@ -44,6 +57,11 @@ export async function createCompetence(competence) {
         pixApiClient,
         model: 'thematics',
         updatedRecord: thematicTransformer.filterThematicFields(createdWorkbenchThematic),
+      }),
+      updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'tubes',
+        updatedRecord: tubeTransformer.filterTubeFields(createdWorkbenchTube),
       }),
     ]);
   } catch (err) {

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -13,6 +13,8 @@ export const tubeDatasource = datasource.extend({
   usedFields: [
     'id persistant',
     'Nom',
+    'Thematique',
+    'Competences',
     'Competences (id persistant)',
     'Index',
   ],
@@ -23,7 +25,9 @@ export const tubeDatasource = datasource.extend({
       airtableId: airtableRecord.id,
       name: airtableRecord.get('Nom'),
       index: airtableRecord.get('Index'),
-      competenceId: _.head(airtableRecord.get('Competences (id persistant)')),
+      thematicAirtableId: airtableRecord.get('Thematique')[0],
+      competenceAirtableId: airtableRecord.get('Competences')[0],
+      competenceId: airtableRecord.get('Competences (id persistant)')[0],
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -31,6 +31,18 @@ export const tubeDatasource = datasource.extend({
     };
   },
 
+  toAirTableObject(model) {
+    return {
+      fields: {
+        'id persistant': model.id,
+        Nom: model.name,
+        Thematique: [model.thematicAirtableId],
+        Competences: [model.competenceAirtableId],
+        Index: model.index,
+      },
+    };
+  },
+
   async listByCompetenceId(competenceId) {
     const airtableRawObjects = await findRecords(this.tableName, {
       fields: this.usedFields,

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -3,6 +3,7 @@ import { tubeDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as tubeTranslations from '../translations/tube.js';
 import { Tube } from '../../domain/models/Tube.js';
+import * as idGenerator from '../utils/id-generator.js';
 
 const model = 'tube';
 
@@ -35,6 +36,14 @@ export async function getByAirtableId(airtableId) {
   if (!datasourceTube) return null;
   const translations = await translationRepository.listByEntity(model, datasourceTube.id);
   return toDomain(datasourceTube, translations);
+}
+
+export async function create(tube) {
+  tube.id = idGenerator.generateNewId('tube');
+  const createdTubeDTO = await tubeDatasource.create(tube);
+  const translations = tubeTranslations.extractFromDomainObject(tube);
+  await translationRepository.save({ translations });
+  return toDomain(createdTubeDTO, translations);
 }
 
 function toDomainList(datasourceTubes, translations) {

--- a/api/lib/infrastructure/translations/tube.js
+++ b/api/lib/infrastructure/translations/tube.js
@@ -19,6 +19,7 @@ const tubeTranslationUtils = buildTranslationsUtils({ locales, fields, prefix, i
 export const {
   extractFromProxyObject,
   extractFromReleaseObject,
+  extractFromDomainObject,
   airtableObjectToProxyObject,
   proxyObjectToAirtableObject,
   prefixFor,

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -635,7 +635,7 @@ describe('Acceptance | Route | competences', () => {
       });
     });
 
-    it.fails('should respond with status 201 and created competence', async () => {
+    it('should respond with status 201 and created competence', async () => {
       // given
       const server = await createServer();
 

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -409,6 +409,7 @@ describe('Acceptance | Route | competences', () => {
     let airtableCompetencesScope;
     let airtableCreateCompetenceScope;
     let airtableCreateThematicScope;
+    let airtableCreateTubeScope;
     let generateNewId;
     let pixApiCompetenceCacheScope;
     let pixApiThematicCacheScope;
@@ -465,6 +466,14 @@ describe('Acceptance | Route | competences', () => {
         tubeIds: [],
       }));
 
+      const airtableTube = airtableBuilder.factory.buildTube(domainBuilder.buildTubeDatasourceObject({
+        id: 'tube1',
+        airtableId: 'recTube1',
+        name: '@workbench',
+        competenceId: 'competence4',
+        index: null,
+      }));
+
       airtableCreateCompetenceScope = nock('https://api.airtable.com')
         .post('/v0/airtableBaseValue/Competences/', {
           records: [{
@@ -493,11 +502,27 @@ describe('Acceptance | Route | competences', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [airtableThematic] });
 
+      airtableCreateTubeScope = nock('https://api.airtable.com')
+        .post('/v0/airtableBaseValue/Tubes/', {
+          records: [{
+            fields: {
+              'id persistant': 'tube1',
+              Nom: '@workbench',
+              Competences: ['recCompetence4'],
+              Thematique: ['recThematic1'],
+            },
+          }],
+        })
+        .query({})
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: [airtableTube] });
+
       generateNewId = vi.spyOn(idGenerator, 'generateNewId');
       generateNewId.mockImplementation((prefix) => {
         switch (prefix) {
           case 'competence': return 'competence4';
           case 'thematic': return 'thematic1';
+          case 'tube': return 'tube1';
         }
       });
 
@@ -610,7 +635,7 @@ describe('Acceptance | Route | competences', () => {
       });
     });
 
-    it('should respond with status 201 and created competence', async () => {
+    it.fails('should respond with status 201 and created competence', async () => {
       // given
       const server = await createServer();
 
@@ -669,13 +694,17 @@ describe('Acceptance | Route | competences', () => {
               ],
             },
             'raw-tubes': {
-              data: [],
+              data: [
+                { id: 'recTube1', type: 'tubes' },
+              ],
             },
           },
         },
       });
 
       expect(generateNewId).toHaveBeenCalledWith('competence');
+      expect(generateNewId).toHaveBeenCalledWith('thematic');
+      expect(generateNewId).toHaveBeenCalledWith('tube');
 
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: 'competence.competence4.description', locale: 'en', value: 'It’s the fourth one' },
@@ -683,12 +712,14 @@ describe('Acceptance | Route | competences', () => {
         { key: 'competence.competence4.name', locale: 'en', value: 'Fourth competence' },
         { key: 'competence.competence4.name', locale: 'fr', value: 'Quatrième compétence' },
         { key: 'thematic.thematic1.name', locale: 'fr', value: 'workbench_2_2' },
+        { key: 'tube.tube1.practicalTitle', locale: 'fr', value: 'Tube pour l\'atelier de la compétence 2.2 Pix' },
       ]);
 
       expect(airtableAreaScope.isDone()).toBe(true);
       expect(airtableCompetencesScope.isDone()).toBe(true);
       expect(airtableCreateCompetenceScope.isDone()).toBe(true);
       expect(airtableCreateThematicScope.isDone()).toBe(true);
+      expect(airtableCreateTubeScope.isDone()).toBe(true);
       expect(pixApiCompetenceCacheScope.isDone()).toBe(true);
       expect(pixApiThematicCacheScope.isDone()).toBe(true);
     });

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
 import nock from 'nock';
-import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as tubeRepository from '../../../../lib/infrastructure/repositories/tube-repository.js';
-import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
-import { stringValue } from '../../../../lib/infrastructure/airtable.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
 
 describe('Integration | Repository | tube-repository', () => {
 
@@ -172,9 +173,9 @@ describe('Integration | Repository | tube-repository', () => {
         value: 'Outils d\'accès au web from PG 1'
       });
       await databaseBuilder.commit();
-      vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
+      vi.spyOn(airtable, 'findRecords').mockImplementation((tableName, options) => {
         if (tableName !== 'Tubes') expect.unreachable('Airtable tableName should be Tubes');
-        if (options?.filterByFormula !==  `{Competences (id persistant)} = ${stringValue(tube1.competenceId)}`) expect.unreachable('Wrong filterByFormula');
+        if (options?.filterByFormula !==  `{Competences (id persistant)} = ${airtable.stringValue(tube1.competenceId)}`) expect.unreachable('Wrong filterByFormula');
         return [{
           id: 'airtableTubeId1',
           fields: {
@@ -273,6 +274,57 @@ describe('Integration | Repository | tube-repository', () => {
         // then
         expect(result).toBe(null);
       });
+    });
+  });
+
+  describe('#create', () => {
+    afterEach(() => {
+      return knex('translations').truncate();
+    });
+
+    it('should save new tube to Airtable and translations to DB', async () => {
+      // given
+      const tubeId = 'tube45267428';
+      vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce(tubeId);
+      const tube = domainBuilder.buildTube({
+        airtableId: null,
+        id: null,
+      });
+      const airtableTube = airtableBuilder.factory.buildTube({
+        ...tube,
+        airtableId: 'recTube1',
+        id: tubeId,
+      });
+      const createRecordSpy = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
+        new Airtable.Record('Tubes', airtableTube.id, airtableTube),
+      );
+
+      // when
+      const createdTube = await tubeRepository.create(tube);
+
+      // then
+      expect(createdTube).toStrictEqual(domainBuilder.buildTube({
+        ...tube,
+        airtableId: 'recTube1',
+      }));
+      expect(createRecordSpy).toHaveBeenCalledWith(
+        'Tubes',
+        {
+          fields: {
+            'id persistant': tubeId,
+            'Nom': tube.name,
+            Competences: [tube.competenceAirtableId],
+            Index: tube.index,
+            'Thematique': [tube.thematicAirtableId],
+          },
+        },
+      );
+      await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toEqual([
+        { key: `tube.${tubeId}.practicalDescription`, locale: 'en', value: tube.practicalDescription_i18n.en },
+        { key: `tube.${tubeId}.practicalDescription`, locale: 'fr', value: tube.practicalDescription_i18n.fr },
+        { key: `tube.${tubeId}.practicalTitle`, locale: 'en', value: tube.practicalTitle_i18n.en },
+        { key: `tube.${tubeId}.practicalTitle`, locale: 'fr', value: tube.practicalTitle_i18n.fr },
+      ]);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -23,7 +23,9 @@ describe('Integration | Repository | tube-repository', () => {
             fr: 'practicalDescriptionFrFr tube1',
             en: 'practicalDescriptionEnUs tube1',
           },
-          competenceId: 'competenceId'
+          thematicAirtableId: 'thematicAirtableId1',
+          competenceAirtableId: 'competenceAirtableId1',
+          competenceId: 'competenceId1',
         }),
         airtableBuilder.factory.buildTube({
           id: 'tubeId2',
@@ -37,7 +39,9 @@ describe('Integration | Repository | tube-repository', () => {
             fr: 'practicalDescriptionFrFr tube2',
             en: 'practicalDescriptionEnUs tube2',
           },
-          competenceId: 'competenceId'
+          thematicAirtableId: 'thematicAirtableId2',
+          competenceAirtableId: 'competenceAirtableId2',
+          competenceId: 'competenceId2'
         }),
       ]).activate().nockScope;
       const tube1DescriptionEn = databaseBuilder.factory.buildTranslation({
@@ -101,7 +105,9 @@ describe('Integration | Repository | tube-repository', () => {
             fr: tube1DescriptionFr.value,
             en: tube1DescriptionEn.value,
           },
-          competenceId: 'competenceId',
+          thematicAirtableId: 'thematicAirtableId1',
+          competenceAirtableId: 'competenceAirtableId1',
+          competenceId: 'competenceId1',
         }),
         domainBuilder.buildTube({
           id: 'tubeId2',
@@ -116,7 +122,9 @@ describe('Integration | Repository | tube-repository', () => {
             fr: tube2DescriptionFr.value,
             en: tube2DescriptionEn.value,
           },
-          competenceId: 'competenceId',
+          thematicAirtableId: 'thematicAirtableId2',
+          competenceAirtableId: 'competenceAirtableId2',
+          competenceId: 'competenceId2',
         }),
       ]);
 
@@ -139,6 +147,8 @@ describe('Integration | Repository | tube-repository', () => {
           fr: 'practicalDescriptionFrFr tube1',
           en: 'practicalDescriptionEnUs tube1',
         },
+        thematicAirtableId: 'thematicAirtableId1',
+        competenceAirtableId: 'competenceAirtableId1',
         competenceId: 'competenceId1',
       };
       const tube1DescriptionEn = databaseBuilder.factory.buildTranslation({
@@ -170,6 +180,8 @@ describe('Integration | Repository | tube-repository', () => {
           fields: {
             'id persistant': tube1.id,
             'Nom': tube1.name,
+            'Thematique': [tube1.thematicAirtableId],
+            'Competences': [tube1.competenceAirtableId],
             'Competences (id persistant)': [tube1.competenceId],
             'Index': tube1.index,
           },
@@ -195,6 +207,8 @@ describe('Integration | Repository | tube-repository', () => {
             fr: tube1DescriptionFr.value,
             en: tube1DescriptionEn.value,
           },
+          thematicAirtableId: 'thematicAirtableId1',
+          competenceAirtableId: 'competenceAirtableId1',
           competenceId: 'competenceId1',
         })
       ]);
@@ -211,6 +225,8 @@ describe('Integration | Repository | tube-repository', () => {
         airtableId: 'recTube1',
         name: '@test',
         index: 3,
+        thematicAirtableId: 'thematicAirtableId1',
+        competenceAirtableId: 'competenceAirtableId1',
         competenceId: 'competence1',
         practicalTitle_i18n: {
           fr: 'le titre',

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -3,6 +3,8 @@ export function buildTube({
   airtableId = id,
   name,
   index,
+  thematicAirtableId,
+  competenceAirtableId,
   competenceId,
 } = {}) {
 
@@ -12,6 +14,8 @@ export function buildTube({
       'id persistant': id,
       'Nom': name,
       'Index': index,
+      'Thematique': [thematicAirtableId],
+      'Competences': [competenceAirtableId],
       'Competences (id persistant)': [competenceId],
     },
   };

--- a/api/tests/tooling/domain-builder/factory/build-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube.js
@@ -12,6 +12,8 @@ export function buildTube({
     fr: 'Identifier un navigateur web et un moteur de recherche, connaître le fonctionnement du moteur de recherche',
     en: 'Identify a web browser and a search engine, know how the search engine works',
   },
+  thematicAirtableId = 'recAirFlqfqwl1231bd1',
+  competenceAirtableId = 'recAirsvLz0W2ShyfD63',
   competenceId = 'recsvLz0W2ShyfD63',
   index = 1,
 } = {}) {
@@ -21,6 +23,8 @@ export function buildTube({
     name,
     practicalTitle_i18n,
     practicalDescription_i18n,
+    thematicAirtableId,
+    competenceAirtableId,
     competenceId,
     index,
   });

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tube-datasource-object.js
@@ -4,6 +4,8 @@ export function buildTubeDatasourceObject(
     airtableId,
     name = '@Moteur',
     index = 1,
+    thematicAirtableId = 'recAirFlqfqwl1231bd1',
+    competenceAirtableId = 'recAirsvLz0W2ShyfD63',
     competenceId = 'recsvLz0W2ShyfD63',
   } = {}) {
   return {
@@ -11,6 +13,8 @@ export function buildTubeDatasourceObject(
     airtableId: airtableId ?? id,
     name,
     index,
+    thematicAirtableId,
+    competenceAirtableId,
     competenceId,
   };
 }

--- a/api/tests/tooling/input-output-data-builder/factory/build-tube.js
+++ b/api/tests/tooling/input-output-data-builder/factory/build-tube.js
@@ -10,6 +10,8 @@ export function buildTube({
     en: practicalDescriptionEnUs,
   } = {},
   index,
+  thematicAirtableId,
+  competenceAirtableId,
   competenceId,
 } = {}) {
   return {
@@ -22,6 +24,8 @@ export function buildTube({
       'Description pratique fr-fr': practicalDescriptionFrFr,
       'Description pratique en-us': practicalDescriptionEnUs,
       'Index': index,
+      'Thematique': [thematicAirtableId],
+      'Competences': [competenceAirtableId],
       'Competences (id persistant)': [competenceId],
     },
   };

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -2,25 +2,28 @@ import { describe, it, vi, expect, beforeEach } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 
 import { createCompetence } from '../../../../lib/domain/usecases/create-competence.js';
-import { areaRepository, competenceRepository, thematicRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import { areaRepository, competenceRepository, thematicRepository, tubeRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
-import { competenceTransformer, thematicTransformer } from '../../../../lib/infrastructure/transformers/index.js';
+import { competenceTransformer, thematicTransformer, tubeTransformer } from '../../../../lib/infrastructure/transformers/index.js';
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
-import { Thematic } from '../../../../lib/domain/models/Thematic.js';
+import { Thematic, Tube } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Usecases | create competence', function() {
 
   const transformedCompetence = Symbol('transformedCompetence');
   const transformedThematic = Symbol('transformedThematic');
+  const transformedTube = Symbol('transformedTube');
 
   beforeEach(() => {
     vi.spyOn(areaRepository, 'getByAirtableId');
     vi.spyOn(competenceRepository, 'listByAreaAirtableId');
     vi.spyOn(competenceRepository, 'create');
     vi.spyOn(thematicRepository, 'create');
+    vi.spyOn(tubeRepository, 'create');
     vi.spyOn(competenceTransformer, 'filterCompetenceFields');
     vi.spyOn(thematicTransformer, 'filterThematicFields');
+    vi.spyOn(tubeTransformer, 'filterTubeFields');
     vi.spyOn(updatedRecordNotifier, 'notify');
   });
 
@@ -54,7 +57,7 @@ describe('Unit | Domain | Usecases | create competence', function() {
       const areaAirtableId = 'areaAirtableId';
 
       areaRepository.getByAirtableId.mockResolvedValueOnce(domainBuilder.buildArea({
-        code: '24'
+        code: '24',
       }));
       competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([
         domainBuilder.buildCompetence(),
@@ -63,16 +66,22 @@ describe('Unit | Domain | Usecases | create competence', function() {
         domainBuilder.buildCompetence(),
         domainBuilder.buildCompetence(),
       ]);
-      const createdThematic = domainBuilder.buildThematic();
       const createdCompetence = domainBuilder.buildCompetence({
         areaAirtableId,
         thematicIds: [],
         thematicAirtableIds: [],
+        tubeAirtableIds: [],
+        origin: 'Fmk',
+        index: '24.6',
       });
+      const createdThematic = domainBuilder.buildThematic();
+      const createdTube = domainBuilder.buildTube();
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
-      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
+      tubeRepository.create.mockResolvedValueOnce(createdTube);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
+      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
+      tubeTransformer.filterTubeFields.mockReturnValueOnce(transformedTube);
       updatedRecordNotifier.notify.mockResolvedValue();
 
       const competence = domainBuilder.buildCompetence({
@@ -81,6 +90,7 @@ describe('Unit | Domain | Usecases | create competence', function() {
         areaAirtableId,
         thematicIds: [],
         thematicAirtableIds: [],
+        tubeAirtableIds: [],
       });
 
       // when
@@ -92,6 +102,7 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(result).toBe(createdCompetence);
       expect(result).toHaveProperty('thematicIds', [createdThematic.id]);
       expect(result).toHaveProperty('thematicAirtableIds', [createdThematic.airtableId]);
+      expect(result).toHaveProperty('tubeAirtableIds', [createdTube.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
@@ -101,17 +112,32 @@ describe('Unit | Domain | Usecases | create competence', function() {
         index: 0,
         competenceAirtableId: createdCompetence.airtableId,
       }));
+      expect(tubeRepository.create).toHaveBeenCalledWith(new Tube({
+        name: '@workbench',
+        competenceAirtableId: createdCompetence.airtableId,
+        thematicAirtableId: createdThematic.airtableId,
+        practicalTitle_i18n: {
+          fr: 'Tube pour l\'atelier de la compétence 24.6 Fmk',
+        },
+        practicalDescription_i18n: {},
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
+      expect(tubeTransformer.filterTubeFields).toHaveBeenCalledWith(createdTube);
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'competences',
+        pixApiClient,
+        updatedRecord: transformedCompetence,
+      });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'thematics',
         pixApiClient,
         updatedRecord: transformedThematic,
       });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
+        model: 'tubes',
         pixApiClient,
-        updatedRecord: transformedCompetence,
+        updatedRecord: transformedTube,
       });
     });
   });
@@ -122,23 +148,34 @@ describe('Unit | Domain | Usecases | create competence', function() {
       const areaAirtableId = 'areaAirtableId';
 
       areaRepository.getByAirtableId.mockResolvedValueOnce(domainBuilder.buildArea({
-        code: '24'
+        code: '24',
       }));
       competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
       const createdCompetence = domainBuilder.buildCompetence({
         areaAirtableId,
+        thematicIds: [],
+        thematicAirtableIds: [],
+        tubeAirtableIds: [],
+        origin: 'Fmk',
+        index: '24.1',
       });
-      competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       const createdThematic = domainBuilder.buildThematic();
+      const createdTube = domainBuilder.buildTube();
+      competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
-      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
+      tubeRepository.create.mockResolvedValueOnce(createdTube);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
+      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
+      tubeTransformer.filterTubeFields.mockReturnValueOnce(transformedTube);
       updatedRecordNotifier.notify.mockResolvedValue();
 
       const competence = domainBuilder.buildCompetence({
         id: null,
         airtableId: null,
         areaAirtableId,
+        thematicIds: [],
+        thematicAirtableIds: [],
+        tubeAirtableIds: [],
       });
 
       // when
@@ -150,6 +187,7 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(result).toBe(createdCompetence);
       expect(result).toHaveProperty('thematicIds', [createdThematic.id]);
       expect(result).toHaveProperty('thematicAirtableIds', [createdThematic.airtableId]);
+      expect(result).toHaveProperty('tubeAirtableIds', [createdTube.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
@@ -159,17 +197,32 @@ describe('Unit | Domain | Usecases | create competence', function() {
         index: 0,
         competenceAirtableId: createdCompetence.airtableId,
       }));
+      expect(tubeRepository.create).toHaveBeenCalledWith(new Tube({
+        name: '@workbench',
+        competenceAirtableId: createdCompetence.airtableId,
+        thematicAirtableId: createdThematic.airtableId,
+        practicalTitle_i18n: {
+          fr: 'Tube pour l\'atelier de la compétence 24.1 Fmk',
+        },
+        practicalDescription_i18n: {},
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
+      expect(tubeTransformer.filterTubeFields).toHaveBeenCalledWith(createdTube);
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'competences',
+        pixApiClient,
+        updatedRecord: transformedCompetence,
+      });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'thematics',
         pixApiClient,
         updatedRecord: transformedThematic,
       });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
+        model: 'tubes',
         pixApiClient,
-        updatedRecord: transformedCompetence,
+        updatedRecord: transformedTube,
       });
     });
   });
@@ -184,19 +237,29 @@ describe('Unit | Domain | Usecases | create competence', function() {
       }));
       competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
       const createdCompetence = domainBuilder.buildCompetence({
-        areaAirtableId,
+        thematicIds: [],
+        thematicAirtableIds: [],
+        tubeAirtableIds: [],
+        origin: 'Fmk',
+        index: '24.1',
       });
-      competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       const createdThematic = domainBuilder.buildThematic();
+      const createdTube = domainBuilder.buildTube();
+      competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
-      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
+      tubeRepository.create.mockResolvedValueOnce(createdTube);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
+      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
+      tubeTransformer.filterTubeFields.mockReturnValueOnce(transformedTube);
       updatedRecordNotifier.notify.mockRejectedValue(new Error());
 
       const competence = domainBuilder.buildCompetence({
         id: null,
         airtableId: null,
         areaAirtableId,
+        thematicIds: [],
+        thematicAirtableIds: [],
+        tubeAirtableIds: [],
       });
 
       // when
@@ -208,6 +271,7 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(result).toBe(createdCompetence);
       expect(result).toHaveProperty('thematicIds', [createdThematic.id]);
       expect(result).toHaveProperty('thematicAirtableIds', [createdThematic.airtableId]);
+      expect(result).toHaveProperty('tubeAirtableIds', [createdTube.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
@@ -217,17 +281,32 @@ describe('Unit | Domain | Usecases | create competence', function() {
         index: 0,
         competenceAirtableId: createdCompetence.airtableId,
       }));
+      expect(tubeRepository.create).toHaveBeenCalledWith(new Tube({
+        name: '@workbench',
+        competenceAirtableId: createdCompetence.airtableId,
+        thematicAirtableId: createdThematic.airtableId,
+        practicalTitle_i18n: {
+          fr: 'Tube pour l\'atelier de la compétence 24.1 Fmk',
+        },
+        practicalDescription_i18n: {},
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
+      expect(tubeTransformer.filterTubeFields).toHaveBeenCalledWith(createdTube);
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'competences',
+        pixApiClient,
+        updatedRecord: transformedCompetence,
+      });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'thematics',
         pixApiClient,
         updatedRecord: transformedThematic,
       });
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
+        model: 'tubes',
         pixApiClient,
-        updatedRecord: transformedCompetence,
+        updatedRecord: transformedTube,
       });
     });
   });

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -51,21 +51,8 @@ export default class CompetenceManagementNewController extends Controller {
   }
 
   async _createWorkbench(frameworkName) {
-    const themes = await this.competence.rawThemes;
-    const tube = await this._createTubeWorkbench(themes[0], this.competence, frameworkName);
+    const [tube] = await this.competence.rawTubes;
     await this._createSkillWorkbench(tube, frameworkName);
-  }
-
-  async _createTubeWorkbench(theme, competence, frameworkName) {
-    const title = `Tube pour l'atelier de la compétence ${this.competence.code} ${frameworkName}`;
-    const tubeWorkbench = this.store.createRecord('tube', {
-      name: '@workbench',
-      title,
-      theme,
-      competence,
-      pixId: this.idGenerator.newId('tube'),
-    });
-    return await tubeWorkbench.save();
   }
 
   async _createSkillWorkbench(tube, frameworkName) {

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -82,6 +82,7 @@ function routes() {
     competence.pixId = newId('competence');
     competence.code = `${area.code}.${areaCompetences.length + 1}`;
     const createdCompetence = schema.competences.create(competence);
+
     const createdThematic = schema.themes.create({
       pixId: newId('thematic'),
       name: `workbench_${area.code}_${areaCompetences.length + 1}`,
@@ -90,7 +91,17 @@ function routes() {
     });
     competence.rawThemes = [createdThematic];
 
-    return schema.competences.create(competence);
+    const createdTube = schema.tubes.create({
+      pixId: newId('tube'),
+      name: '@workbench',
+      title: 'Tube pour l’atelier',
+      competence: createdCompetence,
+      theme: createdThematic,
+    });
+
+    createdCompetence.rawTubes = [createdTube];
+
+    return createdCompetence;
   });
 
   this.get('/airtable/content/Thematiques/:id', (schema, request) => {

--- a/pix-editor/tests/acceptance/competence-management/new-test.js
+++ b/pix-editor/tests/acceptance/competence-management/new-test.js
@@ -50,7 +50,6 @@ module('Acceptance | competence-management/new', function(hooks) {
     const workbenchTube = newCompetence.hasMany('rawTubes').value().find((tube) => tube.name === '@workbench');
     const workbenchSkill = workbenchTube.hasMany('rawSkills').value().find((skill) => skill.name === '@workbench');
     assert.ok(newCompetence);
-    assert.ok(workbenchTube);
     assert.ok(workbenchSkill);
     assert.dom(findAll('[data-test-main-message]')[0]).hasText('Compétence créée');
     assert.dom(findAll('[data-test-main-message]')[1]).hasText('Atelier créé');

--- a/pix-editor/tests/unit/controllers/competence-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/new-test.js
@@ -27,6 +27,7 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     competence = {
       code: '1.1',
       rawThemes: ['theme'],
+      rawTubes: ['tube'],
     };
     controller.model = {
       area,
@@ -74,6 +75,9 @@ module('Unit | Controller | competence-management/new', function(hooks) {
         rawThemes: [
           'theme',
         ],
+        rawTubes: [
+          'tube',
+        ],
         save: saveStub,
       };
       // when
@@ -118,18 +122,11 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       newId = idGeneratorStub;
     }
     this.owner.register('service:idGenerator', IdGenerator);
-    const saveStub = sinon.stub().onFirstCall().resolves('tube');
+    const saveStub = sinon.stub().onFirstCall().resolves('skill');
     const model = { save: saveStub };
     const createRecordStub = sinon.stub().returns(model);
     controller.store.createRecord = createRecordStub;
 
-    const expectedTube = {
-      name: '@workbench',
-      theme: 'theme',
-      title: 'Tube pour l\'atelier de la compétence 1.1 Pix+',
-      competence,
-      pixId: 'recId',
-    };
     const expectedSkill = {
       tube: 'tube',
       description: 'Acquis pour l\'atelier de la compétence 1.1 Pix+',
@@ -140,7 +137,6 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     await controller._createWorkbench('Pix+');
 
     // then
-    assert.deepEqual(createRecordStub.getCall(0).args, ['tube', expectedTube]);
-    assert.deepEqual(createRecordStub.getCall(1).args, ['skill', expectedSkill]);
+    assert.deepEqual(createRecordStub.getCall(0).args, ['skill', expectedSkill]);
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Lors de la création d’une compétence, les entitiés du workbench sont créés dans le front.

## 🌳 Proposition

Déplacer la création du sujet workbench dans l’API.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Créer une compétence et vérifier que l’atelier se créé correctement.