### PR TITLE
[BUGFIX] Un lien de tutoriel sans protocole casse la moulinette (PIX-17825)

### DIFF
--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -36,7 +36,7 @@ function findUrlsFromChallenges(challenges, release, localizedChallengesById, Ur
   });
 }
 
-function findUrlsFromTutorials(tutorials, release) {
+function findUrlsFromTutorials(tutorials, release, UrlUtils) {
   return tutorials.map((tutorial) => {
     return {
       id: [
@@ -44,7 +44,7 @@ function findUrlsFromTutorials(tutorials, release) {
         release.findSkillNamesForTutorial(tutorial).join(' '),
         tutorial.id
       ].join(';'),
-      url: tutorial.link,
+      url: UrlUtils.findUrlsInText(tutorial.link)[0],
     };
   });
 }
@@ -69,7 +69,7 @@ async function checkAndUploadKOUrlsFromChallenges(release, { urlRepository, loca
 
 async function checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils }, whitelistedUrls) {
   const tutorials = release.content.tutorials;
-  const urlList = findUrlsFromTutorials(tutorials, release);
+  const urlList = findUrlsFromTutorials(tutorials, release, UrlUtils);
   const finalUrlList = urlList.filter(({ url }) => !whitelistedUrls.some((whitelistedUrl) => whitelistedUrl.matches(url)));
   const analyzedUrls = await UrlUtils.analyzeIdentifiedUrls(finalUrlList);
   const formattedKOTutorialUrls = keepAndFormatKOUrls(analyzedUrls);

--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -86,7 +86,7 @@ function cleanUrl(url) {
 
 function ensureProtocol(url) {
   if (/^https?:\/\//i.test(url)) return url;
-  return  url = 'https://' + url;
+  return 'https://' + url;
 }
 
 export function getOrigin(url) {

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -54,7 +54,7 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
     };
     const identifiedTutorial2 = {
       id: 'competence 4.5;@mySkill23;tutorial2',
-      url: 'https://tuto2.net/',
+      url: 'https://www.tuto2.net/',
     };
     const identifiedTutorial3 = {
       id: 'competence 1.1;@mySkill1;tutorial3',
@@ -107,7 +107,7 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       });
       const tutorials = [
         domainBuilder.buildTutorialForRelease({ id: 'tutorial1', link: 'https://tuto1.net/' }),
-        domainBuilder.buildTutorialForRelease({ id: 'tutorial2', link: 'https://tuto2.net/' }),
+        domainBuilder.buildTutorialForRelease({ id: 'tutorial2', link: 'www.tuto2.net/' }),
         domainBuilder.buildTutorialForRelease({ id: 'tutorial3', link: 'https://tuto3.net/' }),
       ];
       const pixChallenge1Skill1 = domainBuilder.buildChallengeForRelease({
@@ -398,7 +398,7 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         'competence 4.5',
         '@mySkill23',
         'tutorial2',
-        'https://tuto2.net/',
+        'https://www.tuto2.net/',
         'KO',
         'FORMAT_ERROR',
         'identifiedTutorial2 identifiedTutorial2',


### PR DESCRIPTION
## 🌸 Problème
Un lien de tutoriel sans protocole (http ou https) casse la moulinette.

## 🌳 Proposition
Faire passer les urls des tutos par le même code d'extraction / ajout de protocole que les autres champs (UrlUtils.findUrlsInText())

## 🐝 Remarques
Ce bug existe car il s'agit d'un "vieux" tuto. Entre temps, récemment, on a ajouté une PR côté front pour forcer la saisie d'un lien valide (c'est--à-dire qui passe le constructeur new URL() sans péter, et donc avec protocole)

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
