### PR TITLE
[FEATURE] Gérer l'ajout d'espace insécable mot, dit NBSP, dans du texte contenant des guillemets du style «» et deux-points : (PIX-17616)

### DIFF
--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -1,5 +1,7 @@
 export function normalizeNonBreakingSpace(str) {
   return str
     .replaceAll(/ ?(°C)/g, ' $1')
-    .replaceAll(/ ([;?!€$%])/g, ' $1');
+    .replaceAll(/ ([;?!€$%])/g, ' $1')
+    .replaceAll(/ ?(»)/g, ' $1')
+    .replaceAll(/(«) ?/g, '$1 ');
 }

--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -2,6 +2,7 @@ export function normalizeNonBreakingSpace(str) {
   return str
     .replaceAll(/ ?(°C)/g, ' $1')
     .replaceAll(/ ([;?!€$%])/g, ' $1')
+    .replaceAll(/ (:)/g, ' $1')
     .replaceAll(/ ?(»)/g, ' $1')
     .replaceAll(/(«) ?/g, '$1 ');
 }

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { normalizeNonBreakingSpace } from '../../../../lib/infrastructure/utils/normalize-non-breaking-space.js';
 
 describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
-  it('should replace spaces by non breaking spaces if are before `;`, `?` or `!`', () => {
+  it('should replace spaces by narrow non breaking spaces if are before `;`, `?` or `!`', () => {
     // given
     const string = 'Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16°C';
 
@@ -11,5 +11,19 @@ describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
 
     // then
     expect(result).toBe('Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16 °C');
+  });
+
+  it('should replace spaces by non breaking spaces correctly in sentences with pointing double angle quotation marks "«»"', () => {
+    // given
+    const stringNoSpacesInsideQuotationMarks = 'Descartes a dit : «Je pense, donc je suis.»';
+    const stringWithSpacesInsideQuotationMarks = 'Descartes a dit : « Je pense, donc je suis. »';
+
+    // when
+    const result1 = normalizeNonBreakingSpace(stringNoSpacesInsideQuotationMarks);
+    const result2 = normalizeNonBreakingSpace(stringWithSpacesInsideQuotationMarks);
+
+    // then
+    expect(result1).toBe('Descartes a dit : « Je pense, donc je suis. »');
+    expect(result2).toBe('Descartes a dit : « Je pense, donc je suis. »');
   });
 });

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -16,14 +16,14 @@ describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
   it('should replace spaces by non breaking spaces correctly in sentences with pointing double angle quotation marks "«»"', () => {
     // given
     const stringNoSpacesInsideQuotationMarks = 'Descartes a dit : «Je pense, donc je suis.»';
-    const stringWithSpacesInsideQuotationMarks = 'Descartes a dit : « Je pense, donc je suis. »';
+    const stringWithSpacesInsideQuotationMarks = 'Descartes a dit: « Je pense, donc je suis. »';
 
     // when
     const result1 = normalizeNonBreakingSpace(stringNoSpacesInsideQuotationMarks);
     const result2 = normalizeNonBreakingSpace(stringWithSpacesInsideQuotationMarks);
 
     // then
-    expect(result1).toBe('Descartes a dit : « Je pense, donc je suis. »');
-    expect(result2).toBe('Descartes a dit : « Je pense, donc je suis. »');
+    expect(result1).toBe('Descartes a dit : « Je pense, donc je suis. »');
+    expect(result2).toBe('Descartes a dit: « Je pense, donc je suis. »');
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Nous ne respectons pas encore toutes les règles des espaces insécables à appliquer pour l'écriture de texte en français, notamment les lignes suivantes encadrées en bleu (extrait du confluence du métier)

![image](https://github.com/user-attachments/assets/82ce3c00-3890-4287-b2df-847c833fcabe)

## 🌳 Proposition
Faire les modifs dans les champs de consigne, proposition et alternative textuelle.

Remplacer l'espace existant ou ajouter de force un espace insécable mot :
- AVANT »
- APRES «

Remplacer l'espace existant par espace insécable mot :
- AVANT :

Exemple (_ fait office d'espace insécable) :
Descartes a dit : « Je pense, donc je suis. »
devient
Descartes a dit_: «_Je pense, donc je suis._»

et (version sans espace de base)
Descartes a dit: «Je pense, donc je suis.»
devient
Descartes a dit: «_Je pense, donc je suis._»


## 🐝 Remarques
Confirmé avec le métier, l'espace entre : et « doit continuer à être un espace normal.


## 🤧 Pour tester
Modifier une consigne d'épreuve avec plusieurs variations et constater le bon positionnement d'espaces insécables mots
