### PR TITLE
[TECH] Ajouter des pièces jointes aux seeds

### DIFF
--- a/api/db/seeds/data/attachments.js
+++ b/api/db/seeds/data/attachments.js
@@ -1,0 +1,43 @@
+import { cycle, saveInAirtable } from './utils.js';
+import { attachmentDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
+
+const iterForData = cycle([
+  { filename: 'SEEDS_poireau.png', mimeType: 'image/png', size: 7155, urlForTypeIllustration: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385540690/SEEDS_poireau.png', urlForTypeAttachment: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385541460/UHQVGOKEDI.png' },
+  { filename: 'SEEDS_olive.png', mimeType: 'image/png', size: 2189, urlForTypeIllustration: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385614972/SEEDS_olive.png', urlForTypeAttachment: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385615325/GHJYVAKPZU.png' },
+  { filename: 'SEEDS_brocoli.jpeg', mimeType: 'image/jpeg', size: 4498, urlForTypeIllustration: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385881871/SEEDS_brocoli.jpeg', urlForTypeAttachment: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385882781/KVSUGQBUQQ.jpeg' },
+  { filename: 'SEEDS_carotte.png', mimeType: 'image/png', size: 3470, urlForTypeIllustration: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385957127/SEEDS_carotte.png', urlForTypeAttachment: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747385957448/NCGRJRKLVF.png' },
+  { filename: 'SEEDS_cerise.png', mimeType: 'image/png', size: 3869, urlForTypeIllustration: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747386024743/SEEDS_cerise.png', urlForTypeAttachment: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-lcms-attachments-review/1747386025148/RRXILBIXHL.png' },
+]);
+
+export function buildAttachment({ challengeId, localizedChallengeId, type, databaseBuilder, locale }) {
+  databaseBuilder.factory.buildTranslation({
+    key: `challenge.${challengeId}.illustrationAlt`,
+    locale: locale,
+    value: `value ${locale} for illustrationAlt`,
+  });
+  const attachmentData = iterForData.next().value;
+  return {
+    filename: attachmentData.filename,
+    mimeType: attachmentData.mimeType,
+    size: attachmentData.size,
+    type,
+    url: type === 'illustration' ? attachmentData.urlForTypeIllustration : attachmentData.urlForTypeAttachment,
+    challengeId,
+    localizedChallengeId,
+  };
+}
+
+export async function persistAttachments({ items, airtableClient, logger, databaseBuilder }) {
+  const airtableItems = items.map((item) => attachmentDatasource.toAirTableObject({
+    ...item,
+    challengeId: item.challengeAirtableId,
+  }));
+  const records = await saveInAirtable({ tableName: 'Attachments', data: airtableItems, logger, airtableClient });
+  items.forEach((item) => {
+    item.airtableId = records.shift().id;
+  });
+  items.map((item) => databaseBuilder.factory.buildLocalizedChallengeAttachment({
+    localizedChallengeId: item.localizedChallengeId,
+    attachmentId: item.airtableId,
+  }));
+}

--- a/api/db/seeds/data/challenges.js
+++ b/api/db/seeds/data/challenges.js
@@ -50,17 +50,22 @@ export async function buildChallengesFromConfig({
     const shouldAddAttachment = tubeIndex % 4 === 0;
     const typeForAttachment = iterFor['attachmentType'].next().value;
     let challenges;
+    let autoReply = false;
+    const type = iterFor.type.next().value;
+    if (type === Challenge.TYPES.QROC) {
+      autoReply = iterFor.autoReply.next().value;
+    }
     if (skillItem.status === 'en construction') {
-      challenges = buildChallengesForEnConstructionSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForEnConstructionSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     if (skillItem.status === 'actif') {
-      challenges = buildChallengesForActiveSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForActiveSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     if (skillItem.status === 'archivé') {
-      challenges = buildChallengesForArchivedSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForArchivedSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     if (skillItem.status === 'périmé') {
-      challenges = buildChallengesForObsoleteSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForObsoleteSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     challengeItems.push(...challenges);
     skillItem.challenges.push(...challenges);
@@ -70,7 +75,7 @@ export async function buildChallengesFromConfig({
   await persistAttachments({ items: allAttachments, airtableClient, logger, databaseBuilder });
 }
 
-export function buildChallenge({ indexChallenge, skillItem, status, isProto, protoVersion, decliVersion, shouldAddAttachment = false, typeForAttachment, databaseBuilder, locales }) {
+export function buildChallenge({ indexChallenge, skillItem, status, isProto, protoVersion, decliVersion, type = Challenge.TYPES.QCM, autoReply = false, shouldAddAttachment = false, typeForAttachment, databaseBuilder, locales }) {
   const partId = skillItem.id.split('skill')[1];
   const challengeId = `challenge${partId}Ch${indexChallenge}`;
   const attachments = [];
@@ -78,7 +83,7 @@ export function buildChallenge({ indexChallenge, skillItem, status, isProto, pro
     attachments.push(buildAttachment({ challengeId, localizedChallengeId: challengeId, type: typeForAttachment, databaseBuilder, locale: locales[0] }));
   }
   const challengeItem = {
-    ...generateBaseChallengeData(status),
+    ...generateBaseChallengeData(status, autoReply),
     id: challengeId,
     status: status,
     skills: [skillItem.airtableId],
@@ -87,6 +92,8 @@ export function buildChallenge({ indexChallenge, skillItem, status, isProto, pro
     genealogy: isProto ? Challenge.GENEALOGIES.PROTOTYPE : Challenge.GENEALOGIES.DECLINAISON,
     version: protoVersion,
     alternativeVersion: decliVersion,
+    type,
+    autoReply,
   };
   addPrimaryLocalizedChallenge(challengeItem, databaseBuilder);
   if (status !== Challenge.STATUSES.PROPOSE && locales.length > 1) {
@@ -113,39 +120,39 @@ export async function persistChallenges({ items, airtableClient, logger }) {
   });
 }
 
-function buildChallengesForEnConstructionSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
+function buildChallengesForEnConstructionSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: true, protoVersion: skillItem.version, decliVersion: null, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function buildChallengesForActiveSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
+function buildChallengesForActiveSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.VALIDE, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.VALIDE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 3, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 3, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.VALIDE, isProto: true, protoVersion: skillItem.version, decliVersion: null, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.VALIDE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 3, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 3, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function buildChallengesForArchivedSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
+function buildChallengesForArchivedSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: true, protoVersion: skillItem.version, decliVersion: null, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function buildChallengesForObsoleteSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
+function buildChallengesForObsoleteSkill(skillItem, type, autoReply, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PERIME, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PERIME, isProto: true, protoVersion: skillItem.version, decliVersion: null, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 1, type, autoReply, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function generateBaseChallengeData(status) {
+function generateBaseChallengeData(status, autoReply) {
   let updatedAt, validatedAt, archivedAt, madeObsoleteAt, createdAt;
   if (status === Challenge.STATUSES.PROPOSE) {
     createdAt = new Date('2024-01-01');
@@ -175,16 +182,11 @@ function generateBaseChallengeData(status) {
     archivedAt = null;
     madeObsoleteAt = new Date('2021-05-05');
   }
-  let autoReply = false;
-  const type = iterFor.type.next().value;
   let embedUrl, embedHeight, embedTitle;
-  if (type === Challenge.TYPES.QROC) {
-    autoReply = iterFor.autoReply.next().value;
-    if (autoReply) {
-      embedUrl = 'https://some-embed-url.com';
-      embedTitle = 'some embed title';
-      embedHeight = 400;
-    }
+  if (autoReply) {
+    embedUrl = 'https://some-embed-url.com';
+    embedTitle = 'some embed title';
+    embedHeight = 400;
   }
   return {
     accessibility1: iterFor.accessibility1.next().value,
@@ -210,7 +212,6 @@ function generateBaseChallengeData(status) {
     embedHeight,
     embedTitle,
     embedUrl,
-    type,
     createdAt,
     updatedAt,
     validatedAt,

--- a/api/db/seeds/data/challenges.js
+++ b/api/db/seeds/data/challenges.js
@@ -175,12 +175,23 @@ function generateBaseChallengeData(status) {
     archivedAt = null;
     madeObsoleteAt = new Date('2021-05-05');
   }
+  let autoReply = false;
+  const type = iterFor.type.next().value;
+  let embedUrl, embedHeight, embedTitle;
+  if (type === Challenge.TYPES.QROC) {
+    autoReply = iterFor.autoReply.next().value;
+    if (autoReply) {
+      embedUrl = 'https://some-embed-url.com';
+      embedTitle = 'some embed title';
+      embedHeight = 400;
+    }
+  }
   return {
     accessibility1: iterFor.accessibility1.next().value,
     accessibility2: iterFor.accessibility2.next().value,
     alpha: iterFor.alpha.next().value,
     author: ['DEV'],
-    autoReply: iterFor.autoReply.next().value,
+    autoReply,
     contextualizedFields: [iterFor.contextualizedFields.next().value, iterFor.contextualizedFields.next().value],
     declinable: iterFor.declinable.next().value,
     delta: iterFor.delta.next().value,
@@ -196,7 +207,10 @@ function generateBaseChallengeData(status) {
     t2Status: iterFor.t2Status.next().value,
     t3Status: iterFor.t3Status.next().value,
     timer: iterFor.timer.next().value,
-    type: iterFor.type.next().value,
+    embedHeight,
+    embedTitle,
+    embedUrl,
+    type,
     createdAt,
     updatedAt,
     validatedAt,
@@ -211,6 +225,7 @@ function addPrimaryLocalizedChallenge(challengeData, databaseBuilder) {
     challengeId: challengeData.id,
     locale: challengeData.locales[0],
     status: null,
+    embedUrl: challengeData.embedUrl,
     ...generateBaseLocalizedChallengeData(),
   });
   for (const translatableField of fields.filter((field) => field !== 'illustrationAlt')) {

--- a/api/db/seeds/data/challenges.js
+++ b/api/db/seeds/data/challenges.js
@@ -2,6 +2,7 @@ import { cycle, saveInAirtable, } from './utils.js';
 import { Challenge, LocalizedChallenge } from '../../../lib/domain/models/index.js';
 import { fields } from '../../../lib/infrastructure/translations/challenge.js';
 import { challengeDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
+import { buildAttachment, persistAttachments } from './attachments.js';
 
 const ignoreEmptyValues = (val) => Boolean(val);
 
@@ -29,6 +30,7 @@ const iterFor = {
   'isIncompatibleIpadCertif': cycle([true, false]),
   'requireGafamWebsiteAccess': cycle([true, false]),
   'contextualizedFields': cycle(Object.values(Challenge.CONTEXTUALIZED_FIELDS).filter(ignoreEmptyValues)),
+  'attachmentType': cycle(['attachment', 'illustration']),
 };
 
 let iterLocale;
@@ -41,30 +43,40 @@ export async function buildChallengesFromConfig({
 }) {
   iterLocale = cycle(learningContentConfig.locales.slice(1));
   const challengeItems = [];
-  const allSkills = learningContentData.flatMap((framework) => framework.areas.flatMap((area) => area.competences).flatMap((competence) => competence.thematics.flatMap((thematic) => thematic.tubes.flatMap((tube) => tube.skills))));
+  const allTubes = learningContentData.flatMap((framework) => framework.areas.flatMap((area) => area.competences).flatMap((competence) => competence.thematics.flatMap((thematic) => thematic.tubes)));
+  const allSkills = allTubes.flatMap((tube) => tube.skills);
   for (const skillItem of allSkills) {
+    const tubeIndex = allTubes.findIndex(({ airtableId }) => skillItem.tubeAirtableId === airtableId);
+    const shouldAddAttachment = tubeIndex % 4 === 0;
+    const typeForAttachment = iterFor['attachmentType'].next().value;
     let challenges;
     if (skillItem.status === 'en construction') {
-      challenges = buildChallengesForEnConstructionSkill(skillItem, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForEnConstructionSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     if (skillItem.status === 'actif') {
-      challenges = buildChallengesForActiveSkill(skillItem, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForActiveSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     if (skillItem.status === 'archivé') {
-      challenges = buildChallengesForArchivedSkill(skillItem, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForArchivedSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     if (skillItem.status === 'périmé') {
-      challenges = buildChallengesForObsoleteSkill(skillItem, learningContentConfig.locales, databaseBuilder);
+      challenges = buildChallengesForObsoleteSkill(skillItem, shouldAddAttachment, typeForAttachment, learningContentConfig.locales, databaseBuilder);
     }
     challengeItems.push(...challenges);
     skillItem.challenges.push(...challenges);
   }
   await persistChallenges({ items: challengeItems, airtableClient, logger });
+  const allAttachments = challengeItems.flatMap((challengeItem) => challengeItem.attachments);
+  await persistAttachments({ items: allAttachments, airtableClient, logger, databaseBuilder });
 }
 
-export function buildChallenge({ indexChallenge, skillItem, status, isProto, protoVersion, decliVersion, databaseBuilder, locales }) {
+export function buildChallenge({ indexChallenge, skillItem, status, isProto, protoVersion, decliVersion, shouldAddAttachment = false, typeForAttachment, databaseBuilder, locales }) {
   const partId = skillItem.id.split('skill')[1];
   const challengeId = `challenge${partId}Ch${indexChallenge}`;
+  const attachments = [];
+  if (shouldAddAttachment) {
+    attachments.push(buildAttachment({ challengeId, localizedChallengeId: challengeId, type: typeForAttachment, databaseBuilder, locale: locales[0] }));
+  }
   const challengeItem = {
     ...generateBaseChallengeData(status),
     id: challengeId,
@@ -80,11 +92,12 @@ export function buildChallenge({ indexChallenge, skillItem, status, isProto, pro
   if (status !== Challenge.STATUSES.PROPOSE && locales.length > 1) {
     const translatedLocales = [iterLocale.next().value, iterLocale.next().value];
     const statusForTranslation1 = status === Challenge.STATUSES.VALIDE ? LocalizedChallenge.STATUSES.PLAY : LocalizedChallenge.STATUSES.PAUSE;
-    addTranslationFor(challengeItem, translatedLocales[0], statusForTranslation1, databaseBuilder);
+    addTranslationFor(challengeItem, translatedLocales[0], statusForTranslation1, databaseBuilder, shouldAddAttachment, typeForAttachment, attachments);
     if (translatedLocales[0] !== translatedLocales[1]) {
-      addTranslationFor(challengeItem, translatedLocales[1], LocalizedChallenge.STATUSES.PAUSE, databaseBuilder);
+      addTranslationFor(challengeItem, translatedLocales[1], LocalizedChallenge.STATUSES.PAUSE, databaseBuilder, shouldAddAttachment, typeForAttachment, attachments);
     }
   }
+  challengeItem.attachments = attachments;
   return challengeItem;
 }
 
@@ -92,39 +105,43 @@ export async function persistChallenges({ items, airtableClient, logger }) {
   const airtableItems = items.map(challengeDatasource.toAirTableObject);
   const records = await saveInAirtable({ tableName: 'Epreuves', data: airtableItems, logger, airtableClient });
   items.forEach((item) => {
-    item.airtableId = records.shift().id;
+    const airtableId = records.shift().id;
+    item.airtableId = airtableId;
+    item.attachments.forEach((att) => {
+      att.challengeAirtableId = airtableId;
+    });
   });
 }
 
-function buildChallengesForEnConstructionSkill(skillItem, locales, databaseBuilder) {
+function buildChallengesForEnConstructionSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: true, protoVersion: skillItem.version, decliVersion: null, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PROPOSE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function buildChallengesForActiveSkill(skillItem, locales, databaseBuilder) {
+function buildChallengesForActiveSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.VALIDE, isProto: true, protoVersion: skillItem.version, decliVersion: null, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.VALIDE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 3, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 3, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.VALIDE, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.VALIDE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 3, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 3, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function buildChallengesForArchivedSkill(skillItem, locales, databaseBuilder) {
+function buildChallengesForArchivedSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: true, protoVersion: skillItem.version, decliVersion: null, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.ARCHIVE, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 2, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 2, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
-function buildChallengesForObsoleteSkill(skillItem, locales, databaseBuilder) {
+function buildChallengesForObsoleteSkill(skillItem, shouldAddAttachment, typeForAttachment, locales, databaseBuilder) {
   const challenges = [];
-  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PERIME, isProto: true, protoVersion: skillItem.version, decliVersion: null, databaseBuilder, locales }));
-  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 1, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 0, skillItem, status: Challenge.STATUSES.PERIME, isProto: true, protoVersion: skillItem.version, decliVersion: null, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
+  challenges.push(buildChallenge({ indexChallenge: 1, skillItem, status: Challenge.STATUSES.PERIME, isProto: false, protoVersion: skillItem.version, decliVersion: 1, shouldAddAttachment, typeForAttachment, databaseBuilder, locales }));
   return challenges;
 }
 
@@ -196,7 +213,7 @@ function addPrimaryLocalizedChallenge(challengeData, databaseBuilder) {
     status: null,
     ...generateBaseLocalizedChallengeData(),
   });
-  for (const translatableField of fields) {
+  for (const translatableField of fields.filter((field) => field !== 'illustrationAlt')) {
     databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeData.id}.${translatableField}`,
       locale: challengeData.locales[0],
@@ -205,15 +222,19 @@ function addPrimaryLocalizedChallenge(challengeData, databaseBuilder) {
   }
 }
 
-function addTranslationFor(challengeData, locale, status, databaseBuilder) {
+function addTranslationFor(challengeData, locale, status, databaseBuilder, shouldAddAttachment, typeForAttachment, attachments) {
+  const localizedChallengeId = `${challengeData.id}${locale.toUpperCase()}`;
+  if (shouldAddAttachment) {
+    attachments.push(buildAttachment({ challengeId: challengeData.id, localizedChallengeId, type: typeForAttachment, databaseBuilder, locale }));
+  }
   databaseBuilder.factory.buildLocalizedChallenge({
-    id: `${challengeData.id}${locale.toUpperCase()}`,
+    id: localizedChallengeId,
     challengeId: challengeData.id,
     locale: locale,
     status,
     ...generateBaseLocalizedChallengeData(),
   });
-  for (const translatableField of fields) {
+  for (const translatableField of fields.filter((field) => field !== 'illustrationAlt')) {
     databaseBuilder.factory.buildTranslation({
       key: `challenge.${challengeData.id}.${translatableField}`,
       locale: locale,

--- a/api/db/seeds/data/challenges.js
+++ b/api/db/seeds/data/challenges.js
@@ -14,7 +14,7 @@ const iterFor = {
   'pedagogy': cycle(Object.values(Challenge.PEDAGOGIES).filter(ignoreEmptyValues)),
   'responsive': cycle(Object.values(Challenge.RESPONSIVES).filter(ignoreEmptyValues)),
   'spoil': cycle(Object.values(Challenge.SPOILS).filter(ignoreEmptyValues)),
-  'type': cycle(Object.values(Challenge.TYPES).filter(ignoreEmptyValues)),
+  'type': cycle(Object.values(Challenge.TYPES).filter(ignoreEmptyValues).filter((type) => ![Challenge.TYPES.QROCM, Challenge.TYPES.QMAIL].includes(type))),
   'deafAndHardOfHearing': cycle(Object.values(LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES).filter(ignoreEmptyValues)),
   'alpha': cycle([...Array(5).keys(), null]),
   'delta': cycle([...Array(5).keys(), null]),

--- a/api/db/seeds/data/challenges.js
+++ b/api/db/seeds/data/challenges.js
@@ -222,19 +222,29 @@ function generateBaseChallengeData(status, autoReply) {
 
 function addPrimaryLocalizedChallenge(challengeData, databaseBuilder) {
   databaseBuilder.factory.buildLocalizedChallenge({
+    ...generateBaseLocalizedChallengeData(),
     id: challengeData.id,
     challengeId: challengeData.id,
     locale: challengeData.locales[0],
     status: null,
     embedUrl: challengeData.embedUrl,
-    ...generateBaseLocalizedChallengeData(),
   });
   for (const translatableField of fields.filter((field) => field !== 'illustrationAlt')) {
-    databaseBuilder.factory.buildTranslation({
-      key: `challenge.${challengeData.id}.${translatableField}`,
-      locale: challengeData.locales[0],
-      value: `value ${challengeData.locales[0]} for ${translatableField}`,
-    });
+    if (translatableField === 'embedTitle') {
+      if (challengeData.embedTitle) {
+        databaseBuilder.factory.buildTranslation({
+          key: `challenge.${challengeData.id}.${translatableField}`,
+          locale: challengeData.locales[0],
+          value: `${challengeData.embedTitle}_${challengeData.locales[0]}`,
+        });
+      }
+    } else {
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeData.id}.${translatableField}`,
+        locale: challengeData.locales[0],
+        value: `value ${challengeData.locales[0]} for ${translatableField}`,
+      });
+    }
   }
 }
 
@@ -244,18 +254,28 @@ function addTranslationFor(challengeData, locale, status, databaseBuilder, shoul
     attachments.push(buildAttachment({ challengeId: challengeData.id, localizedChallengeId, type: typeForAttachment, databaseBuilder, locale }));
   }
   databaseBuilder.factory.buildLocalizedChallenge({
+    ...generateBaseLocalizedChallengeData(),
     id: localizedChallengeId,
     challengeId: challengeData.id,
     locale: locale,
     status,
-    ...generateBaseLocalizedChallengeData(),
   });
   for (const translatableField of fields.filter((field) => field !== 'illustrationAlt')) {
-    databaseBuilder.factory.buildTranslation({
-      key: `challenge.${challengeData.id}.${translatableField}`,
-      locale: locale,
-      value: `value ${locale} for ${translatableField}`,
-    });
+    if (translatableField === 'embedTitle') {
+      if (challengeData.embedTitle) {
+        databaseBuilder.factory.buildTranslation({
+          key: `challenge.${challengeData.id}.${translatableField}`,
+          locale: locale,
+          value: `${challengeData.embedTitle}_${locale}`,
+        });
+      }
+    } else {
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeData.id}.${translatableField}`,
+        locale: locale,
+        value: `value ${locale} for ${translatableField}`,
+      });
+    }
   }
 }
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -197,3 +197,6 @@ if (process.env.NODE_ENV === 'test') {
   phrase.projectId = 'MY_PHRASE_PROJECT_ID';
   phrase.projects = [{ projectId: 'MY_PHRASE_PROJECT_ID' }];
 }
+
+// amandeNoix3
+// amandeCajou1


### PR DESCRIPTION
## 🌸 Problème

Pas de PJ dans les seeds

## 🌳 Proposition

Ajout de PJ (panachage type illustration/attachment) à tout un groupe d'épreuve du même acquis tous les 4 sujets

## 🐝 Remarques
Je corrige au passage quelques pétouilles :
- Autoreply et les attributs d'embed toujours vide SAUF une fois sur deux sur les types QROC, on va avoir un embed à valid auto
- Faire en sorte que toutes les épreuves d'une même grappe de proto soient du même type
- Ne pas faire d'épreuve type QROCM ou QMAIL

## 🤧 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
