### PR TITLE
[TECH] Déplacer la création de l’acquis workbench dans l’API (PIX-17772) (PIX-17768)

### DIFF
--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -113,17 +113,10 @@ export class Skill {
   prepareForCreation(tube, tubeSkills, generateNewIdFnc, normalizeNonBreakingSpaceFnc) {
     this.id = generateNewIdFnc(Skill.ID_PREFIX);
     this.status = Skill.STATUSES.EN_CONSTRUCTION;
-
-    // TODO à enlever quand la création du skill workbench sera dans l’API
-    if (tube.isWorkbench) {
-      this.name = Skill.WORKBENCH_NAME;
-      this.level = null;
-    } else {
-      this.name = `${tube.name}${this.level}`;
-      this.version = tubeSkills.filter((skill) => skill.level === this.level).length + 1;
-      if (this.hint_i18n?.fr) {
-        this.hint_i18n.fr = normalizeNonBreakingSpaceFnc(this.hint_i18n.fr);
-      }
+    this.name = `${tube.name}${this.level}`;
+    this.version = tubeSkills.filter((skill) => skill.level === this.level).length + 1;
+    if (this.hint_i18n?.fr) {
+      this.hint_i18n.fr = normalizeNonBreakingSpaceFnc(this.hint_i18n.fr);
     }
   }
 

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -2,10 +2,11 @@ import * as Sentry from '@sentry/node';
 import { logger } from '../../infrastructure/logger.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { areaRepository, competenceRepository, thematicRepository, tubeRepository } from '../../infrastructure/repositories/index.js';
-import { competenceTransformer, thematicTransformer, tubeTransformer } from '../../infrastructure/transformers/index.js';
+import { areaRepository, competenceRepository, skillRepository, thematicRepository, tubeRepository } from '../../infrastructure/repositories/index.js';
+import { competenceTransformer, skillTransformer, thematicTransformer, tubeTransformer } from '../../infrastructure/transformers/index.js';
 import { BadRequestError } from '../../infrastructure/errors.js';
-import { Thematic, Tube } from '../models/index.js';
+import { Skill, Thematic, Tube } from '../models/index.js';
+import * as idGenerator from '../../infrastructure/utils/id-generator.js';
 
 export async function createCompetence(competence) {
   const [area, competences] = await Promise.all([
@@ -42,6 +43,16 @@ export async function createCompetence(competence) {
 
   const createdWorkbenchTube = await tubeRepository.create(workbenchTube);
 
+  const workbenchSkill = new Skill({
+    id: idGenerator.generateNewId('skill'),
+    name: '@workbench',
+    tubeAirtableId: createdWorkbenchTube.airtableId,
+    description: `Acquis pour l'atelier de la compétence ${createdCompetence.index} ${createdCompetence.origin}`,
+    hint_i18n: {},
+  });
+
+  const createdWorkbenchSkill = await skillRepository.create(workbenchSkill);
+
   createdCompetence.thematicIds = [createdWorkbenchThematic.id];
   createdCompetence.thematicAirtableIds = [createdWorkbenchThematic.airtableId];
   createdCompetence.tubeAirtableIds = [createdWorkbenchTube.airtableId];
@@ -62,6 +73,11 @@ export async function createCompetence(competence) {
         pixApiClient,
         model: 'tubes',
         updatedRecord: tubeTransformer.filterTubeFields(createdWorkbenchTube),
+      }),
+      updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'skills',
+        updatedRecord: skillTransformer.filterSkillFields(createdWorkbenchSkill),
       }),
     ]);
   } catch (err) {

--- a/api/lib/infrastructure/transformers/skill-transformer.js
+++ b/api/lib/infrastructure/transformers/skill-transformer.js
@@ -1,19 +1,35 @@
 import _ from 'lodash';
 
 export function filterSkillsFields(skills) {
-  const fieldsToInclude = [
-    'id',
-    'name',
-    'hint_i18n',
-    'hintStatus',
-    'tutorialIds',
-    'learningMoreTutorialIds',
-    'competenceId',
-    'pixValue',
-    'status',
-    'tubeId',
-    'version',
-    'level'
-  ];
-  return skills.map((skill) => _.pick(skill, fieldsToInclude));
+  return skills.map(filterSkillFields);
+}
+
+export function filterSkillFields({
+  id,
+  name,
+  hint_i18n,
+  hintStatus,
+  tutorialIds,
+  learningMoreTutorialIds,
+  competenceId,
+  pixValue,
+  status,
+  tubeId,
+  version,
+  level,
+}) {
+  return {
+    id,
+    name,
+    hint_i18n,
+    hintStatus,
+    tutorialIds,
+    learningMoreTutorialIds,
+    competenceId,
+    pixValue,
+    status,
+    tubeId,
+    version,
+    level,
+  };
 }

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -410,6 +410,7 @@ describe('Acceptance | Route | competences', () => {
     let airtableCreateCompetenceScope;
     let airtableCreateThematicScope;
     let airtableCreateTubeScope;
+    let airtableCreateSkillScope;
     let generateNewId;
     let pixApiCompetenceCacheScope;
     let pixApiThematicCacheScope;
@@ -474,6 +475,15 @@ describe('Acceptance | Route | competences', () => {
         index: null,
       }));
 
+      const airtableSkill = airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject({
+        id: 'skill1',
+        airtableId: 'recSkill1',
+        name: '@workbench',
+        tubeAirtableId: 'recTube1',
+        tubeId: 'tube1',
+        description: 'Acquis pour l\'atelier de la compétence 2.2 Pix',
+      }));
+
       airtableCreateCompetenceScope = nock('https://api.airtable.com')
         .post('/v0/airtableBaseValue/Competences/', {
           records: [{
@@ -517,12 +527,27 @@ describe('Acceptance | Route | competences', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [airtableTube] });
 
+      airtableCreateSkillScope = nock('https://api.airtable.com')
+        .post('/v0/airtableBaseValue/Acquis/', {
+          records: [{
+            fields: {
+              'id persistant': 'skill1',
+              Tube: ['recTube1'],
+              Description: 'Acquis pour l\'atelier de la compétence 2.2 Pix',
+            },
+          }],
+        })
+        .query({})
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: [airtableSkill] });
+
       generateNewId = vi.spyOn(idGenerator, 'generateNewId');
       generateNewId.mockImplementation((prefix) => {
         switch (prefix) {
           case 'competence': return 'competence4';
           case 'thematic': return 'thematic1';
           case 'tube': return 'tube1';
+          case 'skill': return 'skill1';
         }
       });
 
@@ -635,7 +660,7 @@ describe('Acceptance | Route | competences', () => {
       });
     });
 
-    it('should respond with status 201 and created competence', async () => {
+    it.fails('should respond with status 201 and created competence', async () => {
       // given
       const server = await createServer();
 
@@ -705,6 +730,7 @@ describe('Acceptance | Route | competences', () => {
       expect(generateNewId).toHaveBeenCalledWith('competence');
       expect(generateNewId).toHaveBeenCalledWith('thematic');
       expect(generateNewId).toHaveBeenCalledWith('tube');
+      expect(generateNewId).toHaveBeenCalledWith('skill');
 
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: 'competence.competence4.description', locale: 'en', value: 'It’s the fourth one' },
@@ -720,6 +746,7 @@ describe('Acceptance | Route | competences', () => {
       expect(airtableCreateCompetenceScope.isDone()).toBe(true);
       expect(airtableCreateThematicScope.isDone()).toBe(true);
       expect(airtableCreateTubeScope.isDone()).toBe(true);
+      expect(airtableCreateSkillScope.isDone()).toBe(true);
       expect(pixApiCompetenceCacheScope.isDone()).toBe(true);
       expect(pixApiThematicCacheScope.isDone()).toBe(true);
     });

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -660,7 +660,7 @@ describe('Acceptance | Route | competences', () => {
       });
     });
 
-    it.fails('should respond with status 201 and created competence', async () => {
+    it('should respond with status 201 and created competence', async () => {
       // given
       const server = await createServer();
 

--- a/api/tests/unit/domain/models/Skill_test.js
+++ b/api/tests/unit/domain/models/Skill_test.js
@@ -472,35 +472,6 @@ describe('Unit | Domain | Skill', () => {
         });
       });
     });
-
-    context('when tube is @workbench', () => {
-
-      it('should set name to tube’s name and version to null', () => {
-      // given
-        const skill = domainBuilder.buildSkill({
-          name: null,
-          level: 0,
-          status: null,
-          version: null,
-        });
-
-        const tube = domainBuilder.buildTube({
-          name: '@workbench',
-        });
-
-        const tubeSkills = [];
-
-        // when
-        skill.prepareForCreation(tube, tubeSkills, generateNewIdFnc, normalizeNonBreakingSpaceFnc);
-
-        // then
-        expect(skill).toHaveProperty('id', createdSkillId);
-        expect(skill).toHaveProperty('name', '@workbench');
-        expect(skill).toHaveProperty('level', null);
-        expect(skill).toHaveProperty('status', Skill.STATUSES.EN_CONSTRUCTION);
-        expect(skill).toHaveProperty('version', null);
-      });
-    });
   });
 
   describe('#update', () => {

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -2,18 +2,20 @@ import { describe, it, vi, expect, beforeEach } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 
 import { createCompetence } from '../../../../lib/domain/usecases/create-competence.js';
-import { areaRepository, competenceRepository, thematicRepository, tubeRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import { areaRepository, competenceRepository, skillRepository, thematicRepository, tubeRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
-import { competenceTransformer, thematicTransformer, tubeTransformer } from '../../../../lib/infrastructure/transformers/index.js';
+import { competenceTransformer, skillTransformer, thematicTransformer, tubeTransformer } from '../../../../lib/infrastructure/transformers/index.js';
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
-import { Thematic, Tube } from '../../../../lib/domain/models/index.js';
+import { Skill, Thematic, Tube } from '../../../../lib/domain/models/index.js';
+import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
 
 describe('Unit | Domain | Usecases | create competence', function() {
 
   const transformedCompetence = Symbol('transformedCompetence');
   const transformedThematic = Symbol('transformedThematic');
   const transformedTube = Symbol('transformedTube');
+  const transformedSkill = Symbol('transformedSkill');
 
   beforeEach(() => {
     vi.spyOn(areaRepository, 'getByAirtableId');
@@ -21,10 +23,13 @@ describe('Unit | Domain | Usecases | create competence', function() {
     vi.spyOn(competenceRepository, 'create');
     vi.spyOn(thematicRepository, 'create');
     vi.spyOn(tubeRepository, 'create');
+    vi.spyOn(skillRepository, 'create');
     vi.spyOn(competenceTransformer, 'filterCompetenceFields');
     vi.spyOn(thematicTransformer, 'filterThematicFields');
     vi.spyOn(tubeTransformer, 'filterTubeFields');
+    vi.spyOn(skillTransformer, 'filterSkillFields');
     vi.spyOn(updatedRecordNotifier, 'notify');
+    vi.spyOn(idGenerator, 'generateNewId');
   });
 
   describe('when area id is unknown', () => {
@@ -76,13 +81,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
       });
       const createdThematic = domainBuilder.buildThematic();
       const createdTube = domainBuilder.buildTube();
+      const createdSkill = domainBuilder.buildSkill();
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
+      skillRepository.create.mockResolvedValueOnce(createdSkill);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.filterTubeFields.mockReturnValueOnce(transformedTube);
+      skillTransformer.filterSkillFields.mockReturnValueOnce(transformedSkill);
       updatedRecordNotifier.notify.mockResolvedValue();
+      idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
         id: null,
@@ -121,9 +130,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
         },
         practicalDescription_i18n: {},
       }));
+      expect(skillRepository.create).toHaveBeenCalledWith(new Skill({
+        id: 'skill1',
+        name: '@workbench',
+        description: 'Acquis pour l\'atelier de la compétence 24.6 Fmk',
+        tubeAirtableId: createdTube.airtableId,
+        hint_i18n: {},
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.filterTubeFields).toHaveBeenCalledWith(createdTube);
+      expect(skillTransformer.filterSkillFields).toHaveBeenCalledWith(createdSkill);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
         pixApiClient,
@@ -139,6 +156,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
         pixApiClient,
         updatedRecord: transformedTube,
       });
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'skills',
+        pixApiClient,
+        updatedRecord: transformedSkill,
+      });
+      expect(idGenerator.generateNewId).toHaveBeenCalledWith('skill');
     });
   });
 
@@ -161,13 +184,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
       });
       const createdThematic = domainBuilder.buildThematic();
       const createdTube = domainBuilder.buildTube();
+      const createdSkill = domainBuilder.buildSkill();
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
+      skillRepository.create.mockResolvedValueOnce(createdSkill);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.filterTubeFields.mockReturnValueOnce(transformedTube);
+      skillTransformer.filterSkillFields.mockReturnValueOnce(transformedSkill);
       updatedRecordNotifier.notify.mockResolvedValue();
+      idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
         id: null,
@@ -206,9 +233,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
         },
         practicalDescription_i18n: {},
       }));
+      expect(skillRepository.create).toHaveBeenCalledWith(new Skill({
+        id: 'skill1',
+        name: '@workbench',
+        description: 'Acquis pour l\'atelier de la compétence 24.1 Fmk',
+        tubeAirtableId: createdTube.airtableId,
+        hint_i18n: {},
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.filterTubeFields).toHaveBeenCalledWith(createdTube);
+      expect(skillTransformer.filterSkillFields).toHaveBeenCalledWith(createdSkill);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
         pixApiClient,
@@ -224,6 +259,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
         pixApiClient,
         updatedRecord: transformedTube,
       });
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'skills',
+        pixApiClient,
+        updatedRecord: transformedSkill,
+      });
+      expect(idGenerator.generateNewId).toHaveBeenCalledWith('skill');
     });
   });
 
@@ -245,13 +286,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
       });
       const createdThematic = domainBuilder.buildThematic();
       const createdTube = domainBuilder.buildTube();
+      const createdSkill = domainBuilder.buildSkill();
       competenceRepository.create.mockResolvedValueOnce(createdCompetence);
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
+      skillRepository.create.mockResolvedValueOnce(createdSkill);
       competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.filterTubeFields.mockReturnValueOnce(transformedTube);
+      skillTransformer.filterSkillFields.mockReturnValueOnce(transformedSkill);
       updatedRecordNotifier.notify.mockRejectedValue(new Error());
+      idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
         id: null,
@@ -290,9 +335,17 @@ describe('Unit | Domain | Usecases | create competence', function() {
         },
         practicalDescription_i18n: {},
       }));
+      expect(skillRepository.create).toHaveBeenCalledWith(new Skill({
+        id: 'skill1',
+        name: '@workbench',
+        description: 'Acquis pour l\'atelier de la compétence 24.1 Fmk',
+        tubeAirtableId: createdTube.airtableId,
+        hint_i18n: {},
+      }));
       expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.filterTubeFields).toHaveBeenCalledWith(createdTube);
+      expect(skillTransformer.filterSkillFields).toHaveBeenCalledWith(createdSkill);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'competences',
         pixApiClient,
@@ -308,6 +361,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
         pixApiClient,
         updatedRecord: transformedTube,
       });
+      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
+        model: 'skills',
+        pixApiClient,
+        updatedRecord: transformedSkill,
+      });
+      expect(idGenerator.generateNewId).toHaveBeenCalledWith('skill');
     });
   });
 });

--- a/api/tests/unit/infrastructure/transformers/skill-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/skill-transformer_test.js
@@ -1,18 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { filterSkillsFields } from '../../../../lib/infrastructure/transformers/skill-transformer.js';
+import { filterSkillFields, filterSkillsFields } from '../../../../lib/infrastructure/transformers/skill-transformer.js';
 
 describe('Unit | Infrastructure | skill-transformer', function() {
 
-  it('should only keep useful fields', function() {
-    const airtableSkills = [domainBuilder.buildSkillDatasourceObject()];
+  describe('#filterSkillFields', () => {
+    it('filters skill fields for release', () => {
+      // given
+      const skill = domainBuilder.buildSkill();
 
-    const skills = filterSkillsFields(airtableSkills);
+      // when
+      const filteredSkill = filterSkillFields(skill);
 
-    expect(skills.length).to.equal(1);
-    expect(skills[0].name).to.exist;
-    expect(skills[0].description).to.not.exist;
-    expect(skills[0].level).to.equal(5);
-    expect(skills[0].internationalisation).to.not.exist;
+      // then
+      expect(filteredSkill).toEqual(domainBuilder.buildSkillForRelease(skill));
+    });
+  });
+
+  describe('#filterSkillsFields', () => {
+    it('filters skills fields for release', function() {
+      // given
+      const skill1 = domainBuilder.buildSkill({ id: 'skill1' });
+      const skill2 = domainBuilder.buildSkill({ id: 'skill2' });
+
+      // when
+      const filteredSkills = filterSkillsFields([skill1, skill2]);
+
+      // then
+      expect(filteredSkills).toEqual([domainBuilder.buildSkillForRelease(skill1), domainBuilder.buildSkillForRelease(skill2)]);
+    });
   });
 });

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -29,12 +29,9 @@ export default class CompetenceManagementNewController extends Controller {
   async save() {
     const area = this.model.area;
     try {
-      const framework = await area.framework;
       this.loader.start();
       await this._createCompetence(area);
       this.notify.message('Compétence créée');
-      await this._createWorkbench(framework.name);
-      this.notify.message('Atelier créé');
       this.edition = false;
       this.router.transitionTo('authenticated.competence.skills', this.competence.id, { queryParams: { view: 'workbench' } });
     } catch (error) {
@@ -48,20 +45,5 @@ export default class CompetenceManagementNewController extends Controller {
   async _createCompetence(area) {
     this.competence.area = area;
     await this.competence.save();
-  }
-
-  async _createWorkbench(frameworkName) {
-    const [tube] = await this.competence.rawTubes;
-    await this._createSkillWorkbench(tube, frameworkName);
-  }
-
-  async _createSkillWorkbench(tube, frameworkName) {
-    const description = `Acquis pour l'atelier de la compétence ${this.competence.code} ${frameworkName}`;
-    const skillWorkbench = this.store.createRecord('skill', {
-      level: 0,
-      description,
-      tube,
-    });
-    return await skillWorkbench.save();
   }
 }

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -101,6 +101,12 @@ function routes() {
 
     createdCompetence.rawTubes = [createdTube];
 
+    schema.skills.create({
+      pixId: newId('skill'),
+      name: '@workbench',
+      tube: createdTube,
+    });
+
     return createdCompetence;
   });
 

--- a/pix-editor/tests/acceptance/competence-management/new-test.js
+++ b/pix-editor/tests/acceptance/competence-management/new-test.js
@@ -47,12 +47,8 @@ module('Acceptance | competence-management/new', function(hooks) {
     // then
     const area = await store.peekRecord('area', 'recArea1');
     const newCompetence = area.competencesArray.find((competence) => competence.title === newCompetenceTitle);
-    const workbenchTube = newCompetence.hasMany('rawTubes').value().find((tube) => tube.name === '@workbench');
-    const workbenchSkill = workbenchTube.hasMany('rawSkills').value().find((skill) => skill.name === '@workbench');
     assert.ok(newCompetence);
-    assert.ok(workbenchSkill);
     assert.dom(findAll('[data-test-main-message]')[0]).hasText('Compétence créée');
-    assert.dom(findAll('[data-test-main-message]')[1]).hasText('Atelier créé');
     assert.strictEqual(currentURL(), `/competence/${newCompetence.id}/skills?view=workbench`);
   });
 

--- a/pix-editor/tests/unit/controllers/competence-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/new-test.js
@@ -64,9 +64,6 @@ module('Unit | Controller | competence-management/new', function(hooks) {
 
     test('it should save competence', async function(assert) {
       // given
-      const createWorkbenchStub = sinon.stub().resolves();
-      controller._createWorkbench = createWorkbenchStub;
-
       const saveStub = sinon.stub().resolves();
       competence.save = saveStub;
       const expectedCompetence = {
@@ -90,8 +87,6 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       assert.deepEqual(controller.model.competence, expectedCompetence);
       assert.ok(loaderStopStub.calledOnce);
       assert.ok(notifyMessageStub.getCall(0).args, ['Compétence créée']);
-      assert.ok(createWorkbenchStub.calledOnce);
-      assert.ok(notifyMessageStub.getCall(0).args, ['Atelier créé']);
       assert.ok(transitionToRouteStub.calledWith('authenticated.competence.skills', controller.model.competence.id, { queryParams: { view: 'workbench' } }));
     });
 
@@ -113,30 +108,5 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       assert.ok(loaderStopStub.calledOnce);
       assert.ok(notifyErrorStub.calledWith('Erreur lors de la création de la compétence'));
     });
-  });
-
-  test('it should create workbench', async function(assert) {
-    // given
-    const idGeneratorStub = sinon.stub().returns('recId');
-    class IdGenerator extends Service {
-      newId = idGeneratorStub;
-    }
-    this.owner.register('service:idGenerator', IdGenerator);
-    const saveStub = sinon.stub().onFirstCall().resolves('skill');
-    const model = { save: saveStub };
-    const createRecordStub = sinon.stub().returns(model);
-    controller.store.createRecord = createRecordStub;
-
-    const expectedSkill = {
-      tube: 'tube',
-      description: 'Acquis pour l\'atelier de la compétence 1.1 Pix+',
-      level: 0,
-    };
-
-    // when
-    await controller._createWorkbench('Pix+');
-
-    // then
-    assert.deepEqual(createRecordStub.getCall(0).args, ['skill', expectedSkill]);
   });
 });


### PR DESCRIPTION
## 🌸 Problème

Lors de la création d’une compétence, l’acquis workbench est créé par le front.

## 🌳 Proposition

Déplacer la création de l’acquis workbench dans l’API.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Créer une nouvelle compétence, vérifier que les entités du workbench sont créées correctement.