### PR TITLE
[BUMP] caniuse-lite

### DIFF
--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -13694,7 +13694,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001686",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 🌸 Problème

Le build affiche un warning `Browserslist: browsers data (caniuse-lite) is 6 months old.`.

## 🌳 Proposition

Mettre à jour caniuse-lite.

## 🐝 Remarques

N/A

## 🤧 Pour tester

Vérifier que l’appli fonctionne.