### PR TITLE
[TECH] Remplacer ember-select par PixSelect dans l'édition d'un challenge (PIX-17925)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -138,7 +138,7 @@ export function deserialize(challengeBody) {
         challengeId: challengeObject.id,
         locale: Challenge.getPrimaryLocale(challengeObject.locales),
         embedUrl: challengeObject.embedUrl,
-        geography: challengeObject.geography || 'AA',
+        geography: challengeObject.geography,
         urlsToConsult: challengeObject.urlsToConsult,
         requireGafamWebsiteAccess: challengeObject.requireGafamWebsiteAccess,
         isIncompatibleIpadCertif: challengeObject.isIncompatibleIpadCertif,

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -53,15 +53,15 @@
     />
   {{/if}}
   {{#if (and this.typeIsQROCOrQROCMInd (not this.isAutoReply))}}
-    <Field::Select
-      @title="Format QROC"
-      @value={{@challenge.format}}
-      @defaultText="Mots"
+    <PixSelect
       @options={{this.options.format}}
-      @edition={{@edition}}
-      @setValue={{fn (mut @challenge.format)}}
-      data-test-format-field
-    />
+      @onChange={{fn (mut @challenge.format)}}
+      @value={{this.challengeFormatValue}}
+      @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
+    >
+      <:label>Format QROC</:label>
+    </PixSelect>
   {{/if}}
   {{#unless this.isAutoReply}}
     <Field::Mde
@@ -223,22 +223,26 @@
         />
       </div>
     </div>
-    <Field::Select
-      @title="Type pédagogie"
-      @value={{@challenge.pedagogy}}
+    <PixSelect
       @options={{this.options.pedagogy}}
-      @edition={{@edition}}
-      @setValue={{fn (mut @challenge.pedagogy)}}
-    />
+      @onChange={{fn (mut @challenge.pedagogy)}}
+      @value={{@challenge.pedagogy}}
+      @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
+    >
+      <:label>Type pédagogie</:label>
+    </PixSelect>
   {{/if}}
   {{#if @challenge.isPrototype}}
-    <Field::Select
-      @title="Déclinable"
-      @value={{@challenge.declinable}}
+    <PixSelect
       @options={{this.options.declinable}}
-      @edition={{@edition}}
-      @setValue={{fn (mut @challenge.declinable)}}
-    />
+      @onChange={{fn (mut @challenge.declinable)}}
+      @value={{@challenge.declinable}}
+      @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
+    >
+      <:label>Déclinable</:label>
+    </PixSelect>
   {{/if}}
   <div class="field {{if @edition '' 'disabled'}}">
     <Field::Checkbox
@@ -289,14 +293,15 @@
     </div>
     {{#if @challenge.isPrototype}}
       <div class="field">
-        <Field::Select
-          @title="Champs contextualisés"
-          @value={{this.contextualizedFields}}
-          @edition={{@edition}}
-          @multiple={{true}}
+        <PixMultiSelect
+          @placeholder="Champs contextualisés"
+          @onChange={{this.setContextualizedFields}}
+          @emptyMessage="Aucun champ sélectionné"
+          @values={{this.contextualizedFields}}
           @options={{this.options.contextualizedFields}}
-          @setValue={{this.setContextualizedFields}}
-        />
+        >
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
       </div>
     {{/if}}
   </div>

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -268,14 +268,16 @@
     <label>Internationalisation</label>
     <div class="two fields">
       <div class="field">
-        <Field::Select
-          @title="Langue(s)"
-          @value={{this.languages}}
-          @edition={{@edition}}
-          @multiple={{true}}
-          @options={{this.options.locales}}
-          @setValue={{this.setLocales}}
-        />
+        <PixMultiSelect
+          @placeholder="Choisir une ou plusieurs langues"
+          @onChange={{this.setLocales}}
+          @emptyMessage="Aucune langue sélectionnée"
+          @values={{this.languages}}
+          @options={{this.languageOptions}}
+        >
+          <:label>Langue(s)</:label>
+          <:default as |option|>{{option.label}}</:default>
+        </PixMultiSelect>
       </div>
       <div class="field">
         <PixSelect
@@ -297,9 +299,10 @@
           @placeholder="Champs contextualisés"
           @onChange={{this.setContextualizedFields}}
           @emptyMessage="Aucun champ sélectionné"
-          @values={{this.contextualizedFields}}
+          @values={{this.args.challenge.contextualizedFields}}
           @options={{this.options.contextualizedFields}}
         >
+          <:label>Champs contextualisés</:label>
           <:default as |option|>{{option.label}}</:default>
         </PixMultiSelect>
       </div>

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -274,6 +274,7 @@
           @emptyMessage="Aucune langue sélectionnée"
           @values={{this.languages}}
           @options={{this.languageOptions}}
+          @isDisabled={{not @edition}}
         >
           <:label>Langue(s)</:label>
           <:default as |option|>{{option.label}}</:default>
@@ -301,6 +302,7 @@
           @emptyMessage="Aucun champ sélectionné"
           @values={{this.args.challenge.contextualizedFields}}
           @options={{this.options.contextualizedFields}}
+          @isDisabled={{not @edition}}
         >
           <:label>Champs contextualisés</:label>
           <:default as |option|>{{option.label}}</:default>

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -26,14 +26,15 @@
     />
   </Field::ToggleField>
   {{#if @challenge.isPrototype}}
-    <Field::Select
-      @title="Type"
-      @value={{this.challengeTypeValue}}
+    <PixSelect
       @options={{this.options.types}}
-      @edition={{@edition}}
-      @setValue={{this.setChallengeType}}
-      data-test-select-type
-    />
+      @onChange={{this.setChallengeType}}
+      @value={{this.challengeTypeValue}}
+      @isDisabled={{not @edition}}
+      @hideDefaultOption={{true}}
+    >
+      <:label>Type</:label>
+    </PixSelect>
     <div class="field">
       <Field::Checkbox
         @label="Sans validation (Pix Junior)"

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -144,11 +144,9 @@ export default class ChallengeForm extends Component {
   }
 
   get languages() {
-    return this.options.locales.filter((locale)=> this.args.challenge.locales.includes(locale.value));
-  }
+    const languageValueList = this.languageOptions.map(({ value }) => value);
 
-  get contextualizedFields() {
-    return this.options.contextualizedFields.filter(({ value }) => this.args.challenge.contextualizedFields?.includes(value));
+    return languageValueList.filter((locale) => this.args.challenge.locales.includes(locale));
   }
 
   get displayUrlsToConsult() {
@@ -209,11 +207,11 @@ export default class ChallengeForm extends Component {
 
   @action
   setLocales(selectedOptions) {
-    this.args.challenge.locales = selectedOptions.map(({ value }) => value);
+    this.args.challenge.locales = selectedOptions.map((value) => value);
   }
 
   @action
   setContextualizedFields(selectedOptions) {
-    this.args.challenge.contextualizedFields = selectedOptions.map(({ value }) => value);
+    this.args.challenge.contextualizedFields = selectedOptions.map((value) => value);
   }
 }

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -119,7 +119,12 @@ export default class ChallengeForm extends Component {
 
   get challengeTypeValue() {
     const actualType = this.args.challenge.autoReply ? 'autoReply' : this.args.challenge.type;
-    return this.options.types.find((type)=> type.value === actualType);
+
+    if (!actualType) {
+      return null;
+    }
+
+    return this.options.types.find((type)=> type.value === actualType).value;
   }
 
   get challengeGeographyValue() {
@@ -141,7 +146,7 @@ export default class ChallengeForm extends Component {
   shouldDisplayQualitySection = (challenge) => challenge.isDraft && challenge.isPrototype;
 
   @action
-  setChallengeType({ value }) {
+  setChallengeType(value) {
     this.args.challenge.type = value;
     this.args.challenge.autoReply = false;
     this.args.challenge.format = null;

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -18,9 +18,9 @@ export default class ChallengeForm extends Component {
       { value: 'QROCM-dep', label: 'QROCM-dep' },
       { value: 'autoReply', label: 'Embed-auto' },
     ],
-    'pedagogy': ['e-preuve', 'q-savoir', 'q-situation'],
-    'declinable': ['', 'facilement', 'difficilement', 'permutation', 'non'],
-    'format': ['petit', 'mots', 'phrase', 'paragraphe', 'nombre'],
+    'pedagogy': [{ label: 'e-preuve', value: 'e-preuve' }, { label: 'q-savoir', value: 'q-savoir' }, { label: 'q-situation', value: 'q-situation' }],
+    'declinable': [{ label: 'facilement', value: 'facilement' }, { label: 'difficilement', value: 'difficilement' }, { label: 'permutation', value: 'permutation' }, { label: 'non', value: 'non' }],
+    'format': [{ label: 'petit', value: 'petit' }, { label: 'mots', value: 'mots' }, { label: 'phrase', value: 'phrase' }, { label: 'paragraphe', value: 'paragraphe' }, { label: 'nombre', value: 'nombre' }],
     'accessibility1': ['RAS', 'OK', 'Acquis Non Pertinent', 'KO', 'A tester'],
     'accessibility2': ['RAS', 'OK', 'KO'],
     'responsive': ['Tablette', 'Smartphone', 'Tablette/Smartphone', 'Non'],
@@ -52,6 +52,10 @@ export default class ChallengeForm extends Component {
       };
       this.languageOptions.push(option);
     }
+  }
+
+  get geographyOptionList() {
+    return this.options.geography.map((g) => ({ label: g, value: g }));
   }
 
   get helpSuggestions() {
@@ -125,6 +129,14 @@ export default class ChallengeForm extends Component {
     }
 
     return this.options.types.find((type)=> type.value === actualType).value;
+  }
+
+  get challengeFormatValue() {
+    if (!this.args.challenge.format) {
+      return 'mots';
+    }
+
+    return this.options.format.find((format)=> format.value === this.args.challenge.format).value;
   }
 
   get challengeGeographyValue() {

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -42,6 +42,7 @@
 @use 'components/login-form';
 @use 'components/field';
 @use 'components/field/quality';
+@use 'components/form/challenge';
 @use 'components/field/toggle-field';
 @use 'components/form/challenge';
 @use 'components/dropdown-menu';

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -42,7 +42,6 @@
 @use 'components/login-form';
 @use 'components/field';
 @use 'components/field/quality';
-@use 'components/form/challenge';
 @use 'components/field/toggle-field';
 @use 'components/form/challenge';
 @use 'components/dropdown-menu';

--- a/pix-editor/app/styles/components/form/challenge.scss
+++ b/pix-editor/app/styles/components/form/challenge.scss
@@ -2,4 +2,7 @@
   .pix-multi-select  {
     width: 100%;
   }
+  .pix-select-button {
+    margin-bottom: var(--pix-spacing-3x);
+  }
 }

--- a/pix-editor/app/styles/components/form/challenge.scss
+++ b/pix-editor/app/styles/components/form/challenge.scss
@@ -1,5 +1,7 @@
 .challenge-form {
-  .pix-multi-select, .pix-select, .pix-select__dropdown  {
+  .pix-select,
+  .pix-select__dropdown,
+  .pix-multi-select {
     width: 100%;
   }
   .pix-select-button {

--- a/pix-editor/app/styles/components/form/challenge.scss
+++ b/pix-editor/app/styles/components/form/challenge.scss
@@ -1,5 +1,5 @@
 .challenge-form {
-  .pix-multi-select  {
+  .pix-multi-select, .pix-select, .pix-select__dropdown  {
     width: 100%;
   }
   .pix-select-button {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -130,6 +130,7 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.6.13"
+    "@floating-ui/dom": "^1.6.13",
+    "countries-list": "^3.1.1"
   }
 }

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -1,6 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
-import { click, find, findAll, settled } from '@ember/test-helpers';
+import { click, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 
@@ -8,6 +8,7 @@ import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
 module('Integration | Component | challenge-form', function(hooks) {
   setupIntlRenderingTest(hooks);
+  let screen;
 
   test('it should display expected fields if challenge type is `QROC`', async function(assert) {
     // Given
@@ -50,16 +51,17 @@ module('Integration | Component | challenge-form', function(hooks) {
     const challengeData = store.createRecord('challenge', {
       id: 'recChallenge0',
       genealogy: 'Prototype 1',
+      type: 'QCU',
     });
     this.set('countries', countries);
     this.set('challengeData', challengeData);
     this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}} @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
-
-    await click(find('[data-test-select-type] .ember-basic-dropdown-trigger'));
-    await click(findAll('.ember-power-select-option')[1]);
+    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}} @checkEmbedURL={{this.checkEmbedURL}}/>`);
+    await click(screen.getByRole('button', { name: 'Type' }));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'QCM' }));
 
     // Then
     assert.dom('[data-test-checkbox-shuffle]').exists();
@@ -77,16 +79,17 @@ module('Integration | Component | challenge-form', function(hooks) {
     const challengeData = store.createRecord('challenge', {
       id: 'recChallenge0',
       genealogy: 'Prototype 1',
+      type: 'QCM',
     });
     this.set('countries', countries);
     this.set('challengeData', challengeData);
     this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}  @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
-
-    await click(find('[data-test-select-type] .ember-basic-dropdown-trigger'));
-    await click(findAll('.ember-power-select-option')[0]);
+    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}  @checkEmbedURL={{this.checkEmbedURL}}/>`);
+    await click(screen.getByRole('button', { name: 'Type' }));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'QCM' }));
 
     // Then
     assert.dom('[data-test-checkbox-shuffle]').exists();

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -47,16 +47,18 @@ module('Integration | Component | challenge-form', function(hooks) {
   test('it should display autochecked checkbox if challenge type is `QCM`', async function(assert) {
     // Given
     const store = this.owner.lookup('service:store');
+    const countries = [{ FR: 'France' }];
     const challengeData = store.createRecord('challenge', {
       id: 'recChallenge0',
       genealogy: 'Prototype 1',
       type: 'QCU',
     });
+    this.set('countries', countries);
     this.set('challengeData', challengeData);
     this.set('checkEmbedURL', () => {});
 
     // When
-    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}} @checkEmbedURL={{this.checkEmbedURL}}/>`);
+    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}} @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
     await click(screen.getByRole('button', { name: 'Type' }));
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'QCM' }));
@@ -84,7 +86,7 @@ module('Integration | Component | challenge-form', function(hooks) {
     this.set('checkEmbedURL', () => {});
 
     // When
-    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}  @checkEmbedURL={{this.checkEmbedURL}}/>`);
+    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}  @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
     await click(screen.getByRole('button', { name: 'Type' }));
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'QCM' }));

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -19,12 +19,12 @@ module('Integration | Component | challenge-form', function(hooks) {
     this.set('checkEmbedURL', () => {});
 
     // When
-    await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
+    screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
 
     // Then
-    ['data-test-format-field', 'data-test-tolerence-fields', 'data-test-suggestion-field'].forEach((field) => {
-      assert.dom(`[${field}]`).exists();
-    });
+    assert.dom(screen.getByLabelText('Format QROC')).exists();
+    assert.dom('[data-test-tolerence-fields]').exists();
+    assert.dom('[data-test-suggestion-field]').exists();
   });
 
   test('it should hide useless fields if challenge autoReply is `true`', async function(assert) {
@@ -46,14 +46,12 @@ module('Integration | Component | challenge-form', function(hooks) {
 
   test('it should display autochecked checkbox if challenge type is `QCM`', async function(assert) {
     // Given
-    const countries = [{ FR: 'France' }];
     const store = this.owner.lookup('service:store');
     const challengeData = store.createRecord('challenge', {
       id: 'recChallenge0',
       genealogy: 'Prototype 1',
       type: 'QCU',
     });
-    this.set('countries', countries);
     this.set('challengeData', challengeData);
     this.set('checkEmbedURL', () => {});
 

--- a/pix-editor/tests/unit/component/form/challenge-test.js
+++ b/pix-editor/tests/unit/component/form/challenge-test.js
@@ -15,11 +15,7 @@ module('unit | Component | form/challenge', function(hooks) {
 
   test('it should set locales properly', async function(assert) {
     // given
-    const input = [
-      { label: 'Anglais', value: 'en' },
-      { label: 'Franco Français', value: 'fr-fr' },
-      { label: 'Francophone', value: 'fr' },
-    ];
+    const input = ['en', 'fr-fr', 'fr'];
 
     const expected = ['en', 'fr-fr', 'fr'];
 


### PR DESCRIPTION
## 🌸 Problème

Dans la continuité des travaux pour supprimer la dépendance `ember-basic-dropdown`/`ember-power-select`

## 🌳 Proposition

Remplacer les select de ce composant par des PixSelect.

## 🐝 Remarques

PixUI a été mis à jour pour intégrer le `isDisabled` des MultiSelect

## 🤧 Pour tester

- Tests OK
- Tous les select dans l'édition d'un challenge sont OK