### PR TITLE
[BUGFIX] Des espaces insécables s'ajoutent au niveau des « » même s'il y en a déjà. (PIX-17957)

### DIFF
--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -1,9 +1,9 @@
 export function normalizeNonBreakingSpace(str) {
   if (!str) return str;
   return str
-    .replaceAll(/ ?(°C)/g, ' $1')
-    .replaceAll(/ ([;?!€$%])/g, ' $1')
-    .replaceAll(/ (:)/g, ' $1')
-    .replaceAll(/ ?(»)/g, ' $1')
-    .replaceAll(/(«) ?/g, '$1 ');
+    .replaceAll(/\p{Zs}?(°C)/gu, ' $1')
+    .replaceAll(/\p{Zs}([;?!€$%])/gu, ' $1')
+    .replaceAll(/\p{Zs}(:)/gu, ' $1')
+    .replaceAll(/\p{Zs}?(»)/gu, ' $1')
+    .replaceAll(/(«)\p{Zs}?/gu, '$1 ');
 }

--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -1,9 +1,9 @@
 export function normalizeNonBreakingSpace(str) {
   if (!str) return str;
   return str
-    .replaceAll(/\p{Zs}?(°C)/gu, ' $1')
+    .replaceAll(/\p{Zs}(°C)/gu, ' $1')
     .replaceAll(/\p{Zs}([;?!€$%])/gu, ' $1')
     .replaceAll(/\p{Zs}(:)/gu, ' $1')
-    .replaceAll(/\p{Zs}?(»)/gu, ' $1')
-    .replaceAll(/(«)\p{Zs}?/gu, '$1 ');
+    .replaceAll(/\p{Zs}(»)/gu, ' $1')
+    .replaceAll(/(«)\p{Zs}/gu, '$1 ');
 }

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -4,27 +4,30 @@ import { normalizeNonBreakingSpace } from '../../../../lib/infrastructure/utils/
 describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
   it('should replace spaces by narrow non breaking spaces if are before `;`, `?` or `!`', () => {
     // given
-    const string = 'Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16°C';
+    const stringNoSpacesToReplace = 'Est-ce ça? Oui! Non; 15€, 15$, 15%, 15°C';
+    const stringWithSpacesToReplace = 'Est-ce ça ? Oui ! Non ; 15 €, 15 $, 15 %, 15 °C';
 
     // when
-    const result = normalizeNonBreakingSpace(string);
+    const result1 = normalizeNonBreakingSpace(stringNoSpacesToReplace);
+    const result2 = normalizeNonBreakingSpace(stringWithSpacesToReplace);
 
     // then
-    expect(result).toBe('Est-ce ça ? Oui ! Non ; non! 15 €, 15 $, 15 %, 15 °C, 16 °C');
+    expect(result1).toBe('Est-ce ça? Oui! Non; 15€, 15$, 15%, 15°C');
+    expect(result2).toBe('Est-ce ça ? Oui ! Non ; 15 €, 15 $, 15 %, 15 °C');
   });
 
   it('should replace spaces by non breaking spaces correctly in sentences with pointing double angle quotation marks "«»"', () => {
     // given
-    const stringNoSpacesInsideQuotationMarks = 'Descartes a dit : «Je pense, donc je suis.»';
-    const stringWithSpacesInsideQuotationMarks = 'Descartes a dit: « Je pense, donc je suis. »';
+    const stringNoSpacesToReplace = 'Descartes a dit: «Je pense, donc je suis.»';
+    const stringWithSpacesToReplace = 'Descartes a dit : « Je pense, donc je suis. »';
 
     // when
-    const result1 = normalizeNonBreakingSpace(normalizeNonBreakingSpace(stringNoSpacesInsideQuotationMarks));
-    const result2 = normalizeNonBreakingSpace(normalizeNonBreakingSpace(stringWithSpacesInsideQuotationMarks));
+    const result1 = normalizeNonBreakingSpace(normalizeNonBreakingSpace(stringNoSpacesToReplace));
+    const result2 = normalizeNonBreakingSpace(normalizeNonBreakingSpace(stringWithSpacesToReplace));
 
     // then
-    expect(result1).toBe('Descartes a dit : « Je pense, donc je suis. »');
-    expect(result2).toBe('Descartes a dit: « Je pense, donc je suis. »');
+    expect(result1).toBe('Descartes a dit: «Je pense, donc je suis.»');
+    expect(result2).toBe('Descartes a dit : « Je pense, donc je suis. »');
   });
 
   it('should not break when passing null or empty values', () => {

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -19,8 +19,8 @@ describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
     const stringWithSpacesInsideQuotationMarks = 'Descartes a dit: « Je pense, donc je suis. »';
 
     // when
-    const result1 = normalizeNonBreakingSpace(stringNoSpacesInsideQuotationMarks);
-    const result2 = normalizeNonBreakingSpace(stringWithSpacesInsideQuotationMarks);
+    const result1 = normalizeNonBreakingSpace(normalizeNonBreakingSpace(stringNoSpacesInsideQuotationMarks));
+    const result2 = normalizeNonBreakingSpace(normalizeNonBreakingSpace(stringWithSpacesInsideQuotationMarks));
 
     // then
     expect(result1).toBe('Descartes a dit : « Je pense, donc je suis. »');


### PR DESCRIPTION
## 🌸 Problème

Des espaces insécables s'ajoutent au niveau des « » même s'il y en a déjà.

## 🌳 Proposition
Remplacer toutes les sorte d'espaces lors de la normalisation des espace

## 🐝 Remarques
RAS

## 🤧 Pour tester

Créer/modifier une épreuve, ajouter cette phrase : Descartes a dit : «Je pense, donc je suis.»
enregistrer
réenregistrer 
vérifier que les espaces n'ont pas été bloqué.
