### PR TITLE
[BUGFIX] Problème d'actualisation du label framework dans la sidebar (PIX-12884)

### DIFF
--- a/pix-editor/app/components/sidebar/navigation.js
+++ b/pix-editor/app/components/sidebar/navigation.js
@@ -14,7 +14,6 @@ export default class SidebarNavigationComponent extends Component {
   @service router;
   @service store;
 
-  @tracked _selectedFramework;
   @tracked newFramework;
   @tracked displayNewFrameworkPopIn;
 
@@ -67,7 +66,6 @@ export default class SidebarNavigationComponent extends Component {
       return;
     }
     this.currentData.setFramework(item.data);
-    this._selectedFramework = item;
   }
 
   @action

--- a/pix-editor/app/components/sidebar/navigation.js
+++ b/pix-editor/app/components/sidebar/navigation.js
@@ -31,9 +31,6 @@ export default class SidebarNavigationComponent extends Component {
   }
 
   get selectedFramework() {
-    if (this._selectedFramework) {
-      return this._selectedFramework;
-    }
     return this.frameworkList.find((item) => {
       if (this.currentData.getFramework()) {
         return item.label === this.currentData.getFramework().name;

--- a/pix-editor/tests/unit/component/sidebar/navigation-test.js
+++ b/pix-editor/tests/unit/component/sidebar/navigation-test.js
@@ -89,10 +89,6 @@ module('unit | Component | sidebar/navigation', function(hooks) {
       assert.ok(loaderStartStub.calledOnce);
       assert.ok(loaderStopStub.calledOnce);
       assert.ok(setFrameworkStub.calledWith(framework));
-      assert.deepEqual(component._selectedFramework, {
-        label: 'pix +',
-        data: framework,
-      });
       assert.ok(notifyMessageStub.calledWith('Référentiel créé'));
       assert.notOk(component.displayNewFrameworkPopIn);
       assert.ok(transitionToStub.calledWith('authenticated'));


### PR DESCRIPTION
## 🌸 Problème

Le nom du framework ne se réactualise pas correctement après une recherche

## 🌳 Proposition

Retirer la confidtion dans le code qui pose ce problème

## 🐝 Remarques
RAS
## 🤧 Pour tester

1. Selectionner un framework
2. Rechercher un acquis qui n'est pas de ce framework
3. Après chargement vérifier que le label du framwork est bien recharger avec la bonne liste de domaine
