### PR TITLE
[FEATURE] Ajouter les métadonnées en bas du formulaire d'un proto en édition et consultation (PIX-17955)

### DIFF
--- a/pix-editor/app/components/challenge-view/challenge-view.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view.gjs
@@ -38,13 +38,12 @@ export default class ChallengeViewProduction extends Component {
       @challenge={{@challenge}}
       @statusColor={{this.getChallengeStatusColor @challenge.status}}
       @overview={{@overview}}
-    @competenceId={{@competenceId}}
+      @competenceId={{@competenceId}}
       @skillId={{@skillId}}
     />
 
     <div class="challenge-view">
       <PixTextarea
-        @id="instruction"
         @value={{@challenge.instruction}}
         readonly
         rows="5"
@@ -52,7 +51,6 @@ export default class ChallengeViewProduction extends Component {
         <:label>Consigne</:label>
       </PixTextarea>
       <PixTextarea
-        @id="alternativeInstruction"
         @value={{@challenge.alternativeInstruction}}
         readonly
         rows="5"
@@ -60,7 +58,6 @@ export default class ChallengeViewProduction extends Component {
         <:label>Alternative textuelle</:label>
       </PixTextarea>
       <PixSelect
-        @id="type"
         @options={{this.challengeTypeOptions}}
         @value={{@challenge.type}}
         @isDisabled={{true}}
@@ -70,7 +67,6 @@ export default class ChallengeViewProduction extends Component {
 
       {{#if @challenge.isTextBased}}
         <PixInput
-          @id="format"
           @value={{@challenge.format}}
           readonly
         >
@@ -78,7 +74,6 @@ export default class ChallengeViewProduction extends Component {
         </PixInput>
       {{/if}}
       <PixTextarea
-        @id="proposals"
         @value={{@challenge.proposals}}
         readonly
         rows="5"
@@ -86,7 +81,6 @@ export default class ChallengeViewProduction extends Component {
         <:label>Propositions</:label>
       </PixTextarea>
       <PixTextarea
-        @id="solution"
         @value={{@challenge.solution}}
         readonly
         rows="3"
@@ -97,15 +91,14 @@ export default class ChallengeViewProduction extends Component {
         <p>Illustration</p>
         <img src="{{@challenge.illustration.url}}" alt="">
         <PixInput
-          @id="illustrationAlt"
           @value={{@challenge.illustrationAlt}}
           readonly
         >
           <:label>Texte alternatif</:label>
         </PixInput>
       {{/if}}
-      <div>
-        <p>Tolérance</p>
+      <fieldset>
+        <legend>Tolérance</legend>
         <div class="challenge-view__tolerance">
           <PixCheckbox
             @checked={{@challenge.t1Status}}
@@ -126,48 +119,47 @@ export default class ChallengeViewProduction extends Component {
             <:label>T3 (distance d'édition)</:label>
           </PixCheckbox>
         </div>
-      </div>
+      </fieldset>
       <PixInput
-        @id="embedUrl"
         @value={{@challenge.embedURL}}
         readonly
       >
         <:label>Embed URL</:label>
       </PixInput>
       <PixInput
-        @id="embedHeight"
         @value={{@challenge.embedHeight}}
         readonly
       >
         <:label>Hauteur</:label>
       </PixInput>
       <PixInput
-        @id="title"
-        @value={{@challenge.title}}
+        @value={{@challenge.embedTitle}}
         readonly
       >
         <:label>Titre</:label>
       </PixInput>
       <PixInput
-        @id="pedagogy"
         @value={{@challenge.pedagogy}}
         readonly
       >
         <:label>Type pédagogie</:label>
       </PixInput>
-      <PixInput
-        @id="declinable"
-        @value={{@challenge.declinable}}
-        readonly
-      >
-        <:label>Déclinable</:label>
-      </PixInput>
-      <PixCheckbox
-        @checked={{@challenge.timer}}
-        disabled
-      >
-        <:label>Timer</:label>
-      </PixCheckbox>
+      {{#if @challenge.timer}}
+        <PixInput
+          @value={{@challenge.timer}}
+          readonly
+        >
+          <:label>Timer</:label>
+        </PixInput>
+      {{else}}
+        <PixCheckbox
+          @checked="false"
+          disabled
+        >
+          <:label>Timer</:label>
+        </PixCheckbox>
+      {{/if}}
+
       <PixCheckbox
         @checked={{@challenge.focusable}}
         disabled
@@ -178,31 +170,100 @@ export default class ChallengeViewProduction extends Component {
         <p>Internationalisation</p>
         <div class="challenge-view-internationalisation">
           <PixInput
-            @id="locales"
             @value={{@challenge.locales}}
             readonly
           >
             <:label>Langue(s)</:label>
           </PixInput>
+        </div>
+      </div>
+      <div class="challenge-view-quality">
+        <fieldset>
+          <legend>Qualité et classification</legend>
           <PixInput
-            @id="geography"
+            @value={{@challenge.spoil}}
+            readonly
+          >
+            <:label>Spoil</:label>
+          </PixInput>
+          <PixInput
+            @value={{@challenge.declinable}}
+            readonly
+          >
+            <:label>Déclinable</:label>
+          </PixInput>
+          <PixInput
+            @value={{@challenge.responsive}}
+            readonly
+          >
+            <:label>Responsive</:label>
+          </PixInput>
+          <PixInput
             @value={{@challenge.geography}}
             readonly
           >
             <:label>Géographie</:label>
           </PixInput>
-        </div>
+        </fieldset>
+        <fieldset>
+          <legend>Accessibilité</legend>
+          <PixInput
+            @value={{@challenge.accessibility1}}
+            readonly
+          >
+            <:label>Non voyant</:label>
+          </PixInput>
+          <PixInput
+            @value={{@challenge.accessibility2}}
+            readonly
+          >
+            <:label>Daltonien</:label>
+          </PixInput>
+          <PixInput
+            @value={{@challenge.deafAndHardOfHearing}}
+            readonly
+          >
+            <:label>Sourds et malentendants</:label>
+          </PixInput>
+        </fieldset>
+        <fieldset>
+          <legend>certification</legend>
+          <div class="challenge-view-quality__certification">
+            <PixCheckbox
+              @checked={{@challenge.isAwarenessChallenge}}
+              disabled
+            >
+              <:label>Épreuve de sensibilisation</:label>
+            </PixCheckbox>
+            <PixCheckbox
+              @checked={{@challenge.requireGafamWebsiteAccess}}
+              disabled
+            >
+              <:label>Accès GAFAM requis</:label>
+            </PixCheckbox>
+            <PixCheckbox
+              @checked={{@challenge.toRephrase}}
+              disabled
+            >
+              <:label>Formulation à revoir</:label>
+            </PixCheckbox>
+            <PixCheckbox
+              @checked={{@challenge.isIncompatibleIpadCertif}}
+              disabled
+            >
+              <:label>Incompatible iPad certif</:label>
+            </PixCheckbox>
+          </div>
+        </fieldset>
       </div>
 
       <PixInput
-        @id="contextualizedFields"
         @value={{@challenge.contextualizedFields}}
         readonly
       >
         <:label>Champs contextualisés</:label>
       </PixInput>
       <PixInput
-        @id="id"
         @value={{@challenge.id}}
         readonly
       >

--- a/pix-editor/app/components/challenge-view/challenge-view.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view.gjs
@@ -33,6 +33,10 @@ export default class ChallengeViewProduction extends Component {
     return 'secondary';
   }
 
+  get hasTimer() {
+    return !!this.args.challenge.timer;
+  }
+
   <template>
     <ChallengeViewHeader
       @challenge={{@challenge}}
@@ -144,22 +148,21 @@ export default class ChallengeViewProduction extends Component {
       >
         <:label>Type pédagogie</:label>
       </PixInput>
-      {{#if @challenge.timer}}
+      <PixCheckbox
+        @checked={{this.hasTimer}}
+        disabled
+      >
+        <:label>Timer</:label>
+      </PixCheckbox>
+      {{#if this.hasTimer}}
         <PixInput
+          class="sr-only-label"
           @value={{@challenge.timer}}
           readonly
         >
-          <:label>Timer</:label>
+          <:label>Durée du timer</:label>
         </PixInput>
-      {{else}}
-        <PixCheckbox
-          @checked="false"
-          disabled
-        >
-          <:label>Timer</:label>
-        </PixCheckbox>
       {{/if}}
-
       <PixCheckbox
         @checked={{@challenge.focusable}}
         disabled

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -256,7 +256,7 @@
       @disabled={{not @edition}}
     />
   </div>
-  {{#if (this.shouldDisplayQualitySection @challenge)}}
+  {{#if @challenge.isPrototype}}
     <Field::Quality @edition={{@edition}} @challenge={{@challenge}} />
   {{/if}}
   <div class="field {{if @edition '' 'disabled'}}">

--- a/pix-editor/app/styles/components/challenge-view.scss
+++ b/pix-editor/app/styles/components/challenge-view.scss
@@ -29,6 +29,34 @@
     }
   }
 
+  &-quality {
+    background: var(--pix-neutral-20);
+    border-radius: var(--pix-spacing-2x);
+    padding: var(--pix-spacing-4x);
+
+    fieldset:not(:last-child) {
+      margin-bottom: var(--pix-spacing-8x);
+    }
+
+    legend {
+      font-weight: var(--pix-font-bold);
+      color: var(--pix-neutral-500);
+      margin-bottom: var(--pix-spacing-2x);
+    }
+
+    input.pix-input__input,
+    input.pix-checkbox__input:not(:checked){
+      background: var(--pix-neutral-0);
+    }
+
+    &__certification {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: var(--pix-spacing-6x);
+    }
+  }
+
   &__tolerance {
     display: flex;
     align-items: center;

--- a/pix-editor/app/styles/components/challenge-view.scss
+++ b/pix-editor/app/styles/components/challenge-view.scss
@@ -62,4 +62,15 @@
     align-items: center;
     gap: var(--pix-spacing-6x);
   }
+
+  .pix-label:has(+ div > div > .sr-only-label) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    border: 0;
+    clip: rect(0,0,0,0);
+  }
 }

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -86,7 +86,7 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('can modify common attributes as well as quality attributes when challenge is a prototype', async function(assert) {
+    test('can modify attributes when challenge is a prototype', async function(assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -215,7 +215,7 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('can modify common attributes, but cant modify quality attributes', async function(assert) {
+    test('can modify attributes', async function(assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -225,15 +225,25 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await fillByLabel('URLs externes nécessaires à la résolution de l\'épreuve', ' https://mon-url.com \n mon-autre-url.com');
       await clickByText('Sans validation (Pix Junior)');
       await clickByText('Validation par l\'embed (Pix Junior)');
-      assert.dom(screen.queryByText('Accès GAFAM requis')).doesNotExist();
-      assert.dom(screen.queryByText('Épreuve de sensibilisation')).doesNotExist();
-      assert.dom(screen.queryByText('Formulation à revoir')).doesNotExist();
-      assert.dom(screen.queryByText('Incompatible iPad certif')).doesNotExist();
-      assert.dom(screen.queryByText('Sourds et malentendants')).doesNotExist();
-      assert.dom(screen.queryByText('Non voyant')).doesNotExist();
-      assert.dom(screen.queryByText('Daltonien')).doesNotExist();
-      assert.dom(screen.queryByText('Spoil')).doesNotExist();
-      assert.dom(screen.queryByText('Responsive')).doesNotExist();
+      await clickByText('Épreuve de sensibilisation');
+      await clickByText('Accès GAFAM requis');
+      await clickByText('Formulation à revoir');
+      await clickByText('Incompatible iPad certif');
+      await clickByText('Sourds et malentendants');
+      await click(await screen.findByRole('option', { name: 'RAS' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Non voyant');
+      await click(await screen.findByRole('option', { name: 'OK' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Daltonien');
+      await click(await screen.findByRole('option', { name: 'KO' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Spoil');
+      await click(await screen.findByRole('option', { name: 'Facilement Sp' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Responsive');
+      await click(await screen.findByRole('option', { name: 'Tablette' }));
+      await waitForSelectToBeClosed(screen);
       await click(find('[data-test-save-challenge-button]'));
       await click(find('[data-test-confirm-log-approve]'));
 
@@ -322,7 +332,7 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('can modify common attributes, but cant modify quality attributes', async function(assert) {
+    test('can modify attributes', async function(assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -334,15 +344,25 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       await fillByLabel('URLs externes nécessaires à la résolution de l\'épreuve', ' https://mon-url.com \n mon-autre-url.com');
       await clickByText('Sans validation (Pix Junior)');
       await clickByText('Validation par l\'embed (Pix Junior)');
-      assert.dom(screen.queryByText('Accès GAFAM requis')).doesNotExist();
-      assert.dom(screen.queryByText('Épreuve de sensibilisation')).doesNotExist();
-      assert.dom(screen.queryByText('Formulation à revoir')).doesNotExist();
-      assert.dom(screen.queryByText('Incompatible iPad certif')).doesNotExist();
-      assert.dom(screen.queryByText('Sourds et malentendants')).doesNotExist();
-      assert.dom(screen.queryByText('Non voyant')).doesNotExist();
-      assert.dom(screen.queryByText('Daltonien')).doesNotExist();
-      assert.dom(screen.queryByText('Spoil')).doesNotExist();
-      assert.dom(screen.queryByText('Responsive')).doesNotExist();
+      await clickByText('Épreuve de sensibilisation');
+      await clickByText('Accès GAFAM requis');
+      await clickByText('Formulation à revoir');
+      await clickByText('Incompatible iPad certif');
+      await clickByText('Sourds et malentendants');
+      await click(await screen.findByRole('option', { name: 'RAS' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Non voyant');
+      await click(await screen.findByRole('option', { name: 'OK' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Daltonien');
+      await click(await screen.findByRole('option', { name: 'KO' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Spoil');
+      await click(await screen.findByRole('option', { name: 'Facilement Sp' }));
+      await waitForSelectToBeClosed(screen);
+      await clickByText('Responsive');
+      await waitForSelectToBeClosed(screen);
+      await click(await screen.findByRole('option', { name: 'Non' }));
       await click(find('[data-test-save-challenge-button]'));
       await click(find('[data-test-confirm-log-approve]'));
 

--- a/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
@@ -15,7 +15,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
       store.createRecord('challenge', {
         id: 'challengeProtoValidee',
         instruction: 'instructions',
-        type: 'QCU',
+        alternativeInstruction: 'alternativeInstruction',
+        type: 'QROC',
         format: 'format',
         proposals: 'suggestion',
         solution: 'answers',
@@ -37,11 +38,18 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         alternativeVersion: null,
         accessibility1: 'Ok',
         accessibility2: 'Ok',
+        deafAndHardOfHearing: 'Ok',
         spoil: 'spoil',
+        focusable: false,
         responsive: 'responsive',
         locales: 'languages',
         geography: 'geography',
         files: [],
+        isAwarenessChallenge: true,
+        requireGafamWebsiteAccess: true,
+        toRephrase: false,
+        isIncompatibleIpadCertif: true,
+        contextualizedFields: 'contextualizedFields',
         updatedAt: '2021-10-02T14:00:00.000Z',
       });
 
@@ -62,6 +70,34 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
 
     // then
     assert.dom(screen.getByLabelText('Consigne')).hasText('instructions');
+    assert.dom(screen.getByLabelText('Alternative textuelle')).hasText('alternativeInstruction');
+    assert.dom(screen.getByLabelText('Type')).hasText('QROC');
+    assert.dom(screen.getByLabelText('Format')).hasValue('format');
+    assert.dom(screen.getByLabelText('Propositions')).hasText('suggestion');
+    assert.dom(screen.getByLabelText('Réponses')).hasText('answers');
+    assert.dom(screen.getByLabelText('T1 (espaces/casse/accents)')).isNotChecked();
+    assert.dom(screen.getByLabelText('T2 (ponctuation)')).isChecked();
+    assert.dom(screen.getByLabelText('T3 (distance d\'édition)')).isNotChecked();
+    assert.dom(screen.getByLabelText('Embed URL')).hasValue('https://mon-site.fr/my-link.html');
+    assert.dom(screen.getByLabelText('Hauteur')).hasValue('800');
+    assert.dom(screen.getByLabelText('Titre')).hasValue('embedTitle');
+    assert.dom(screen.getByLabelText('Type pédagogie')).hasValue('pedagogy');
+    assert.dom(screen.getByLabelText('Timer')).hasValue('10');
+    assert.dom(screen.getByLabelText('Focus')).isNotChecked();
+    assert.dom(screen.getByLabelText('Langue(s)')).hasValue('languages');
+    assert.dom(screen.getByLabelText('Spoil')).hasValue('spoil');
+    assert.dom(screen.getByLabelText('Déclinable')).hasValue('difficilement');
+    assert.dom(screen.getByLabelText('Responsive')).hasValue('responsive');
+    assert.dom(screen.getByLabelText('Géographie')).hasValue('geography');
+    assert.dom(screen.getByLabelText('Non voyant')).hasValue('Ok');
+    assert.dom(screen.getByLabelText('Daltonien')).hasValue('Ok');
+    assert.dom(screen.getByLabelText('Sourds et malentendants')).hasValue('Ok');
+    assert.dom(screen.getByLabelText('Épreuve de sensibilisation')).isChecked();
+    assert.dom(screen.getByLabelText('Accès GAFAM requis')).isChecked();
+    assert.dom(screen.getByLabelText('Formulation à revoir')).isNotChecked();
+    assert.dom(screen.getByLabelText('Incompatible iPad certif')).isChecked();
+    assert.dom(screen.getByLabelText('Champs contextualisés')).hasValue('contextualizedFields');
+    assert.dom(screen.getByLabelText('Id')).hasValue('challengeProtoValidee');
   });
 
   test('it should display actions', async function(assert) {

--- a/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
@@ -82,7 +82,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
     assert.dom(screen.getByLabelText('Hauteur')).hasValue('800');
     assert.dom(screen.getByLabelText('Titre')).hasValue('embedTitle');
     assert.dom(screen.getByLabelText('Type pédagogie')).hasValue('pedagogy');
-    assert.dom(screen.getByLabelText('Timer')).hasValue('10');
+    assert.dom(screen.getByLabelText('Timer')).isChecked();
+    assert.dom(screen.getByLabelText('Durée du timer')).hasValue('10');
     assert.dom(screen.getByLabelText('Focus')).isNotChecked();
     assert.dom(screen.getByLabelText('Langue(s)')).hasValue('languages');
     assert.dom(screen.getByLabelText('Spoil')).hasValue('spoil');


### PR DESCRIPTION
## 🌸 Problème

Nous ne permettons al modifications des meta données de qualité d'une épreuve seulement lors de sa création, et l'affichage de ces donnée une fois l'épreuve validée se fait depuis la vue acquis.

## 🌳 Proposition

Permettre la modification / affichages des meta données d'une épreuve depuis un prototype

## 🐝 Remarques

Ajout de l'affichage des méta données en v2

## 🤧 Pour tester
V1 - Se rendre sur une épreuve prototype validée / archivé et  vérifier que l'on peut les modifier / les consultées les données qualités.
V2 -  Se rendre sur une épreuve et consulter les donnée qualité
