### PR TITLE
[BUGFIX] Autoriser les noms d'acquis avec accents dans les URLs à ne pas analyser (PIX-18071)

### DIFF
--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -141,7 +141,7 @@ function isUrlValid(url) {
 }
 
 function isRelatedSkillNamesValid(relatedSkillNames) {
-  const skillsSeparatedByCommaRegex = /^(@[A-Za-z]+[0-9])(,(@[A-Za-z]+[0-9]))*/;
+  const skillsSeparatedByCommaRegex = /^(@\p{L}+[0-9])(,(@\p{L}+[0-9]))*/u;
   if (!relatedSkillNames) return true;
   return skillsSeparatedByCommaRegex.test(relatedSkillNames);
 }

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -169,7 +169,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
         };
         const creationCommand2 = {
           url: 'https://www.brioche.com',
-          relatedSkillNames: '@choix1,@creux7',
+          relatedSkillNames: '@choix1, @creux7, @étÈ2001',
           comment: 'COucou',
           checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
         };

--- a/pix-editor/app/components/form/whitelisted-url.js
+++ b/pix-editor/app/components/form/whitelisted-url.js
@@ -190,7 +190,7 @@ class RelatedSkillNamesField extends FormField {
 
     const hasAnyMalformedNames = relatedSkillNames.split(',')
       .filter((name) => name !== '')
-      .some((name) => !name.match(/^@[A-Za-z]+\d$/));
+      .some((name) => !name.match(/^@\p{L}+\d$/u));
     if (hasAnyMalformedNames) {
       this.state = FormField.STATES.ERROR;
       this.errorMessage = 'Les noms d\'acquis doivent être séparés par des virgules et ne peuvent pas être vides.';

--- a/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
@@ -61,7 +61,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
 
     // when
     await fillByLabel('URL à ne pas analyser', 'https://example.org');
-    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@test2');
+    await fillByLabel('Nom des acquis concernés, séparés par des virgules', '@test1,@tèst2');
     await fillByLabel('Commentaire', 'Test de création');
     await clickByName('Ajouter');
 


### PR DESCRIPTION
## 🌸 Problème

Le champ "Nom des acquis concernés" n'accepte pas les noms avec accents dans le formulaire de création ou de modification d'une URL à ne pas analyser dans les moulinettes.
<img width="536" alt="image" src="https://github.com/user-attachments/assets/c29109cd-9acf-4b6a-9cb5-f3bd1d566853" />


## 🌳 Proposition

Autoriser les accents.

## 🐝 Remarques

RAS

## 🤧 Pour tester

- Se rendre sur la liste des URLs à ne pas analyser.
- Créer une nouvelle URL.
- Renseigner un nom d'acquis avec un ou plusieurs accents (ex: `@pôcLLM3`).
- Constater que le champ n'affiche pas d'erreur.
- Confirmer la création.
- Constater que l'URL a bien été créée.
