### PR TITLE
[TECH] Supprime test flacky sur la modification d'épreuve.

### DIFF
--- a/pix-editor/tests/helpers/wait-for-select-to-be-closed.js
+++ b/pix-editor/tests/helpers/wait-for-select-to-be-closed.js
@@ -1,6 +1,6 @@
 import { waitUntil } from '@ember/test-helpers';
 
-export async function waitForSelectToBeClosed(screen, options = { timeout: 1000 }) {
+export async function waitForSelectToBeClosed(screen, options = { timeout: 5000 }) {
   await waitUntil(() => {
     return screen.queryAllByRole('option').length === 0;
   }, options);


### PR DESCRIPTION
## 🔆 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Les tests relatifs à la modification d'épreuves sont aléatoires (flacky).
En regardant les échecs de ces tests sur la CI, on constate qu'on dépasse parfois le délai de 1s quand on attend que le select soit fermé.

## ⛱️ Proposition

On augmente le délai d'attente à 5s.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Lancer la CI plusieurs fois de suite et constater que tous les tests sont verts à chaque passage.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
