### PR TITLE
[TECH] Suppression de dépréciations ember.

### DIFF
--- a/pix-editor/app/app.js
+++ b/pix-editor/app/app.js
@@ -1,3 +1,5 @@
+import './deprecation-workflow';
+
 import Application from '@ember/application';
 import { init as initSentry } from '@sentry/ember';
 import loadInitializers from 'ember-load-initializers';

--- a/pix-editor/app/components/pop-in/challenge-log.js
+++ b/pix-editor/app/components/pop-in/challenge-log.js
@@ -143,7 +143,7 @@ export default class PopinChallengeLog extends Component {
     const challenge = this.args.challenge;
     if (challenge) {
       const pq = this.paginatedQuery;
-      return pq.query('changelogEntry', { filterByFormula: `AND(Record_Id = '${challenge.id}', Changelog='oui')`, sort: [{ field: 'Date', direction: 'desc' }] })
+      return pq.query('changelog-entry', { filterByFormula: `AND(Record_Id = '${challenge.id}', Changelog='oui')`, sort: [{ field: 'Date', direction: 'desc' }] })
         .then((entries) => {
           this.changelogEntries = entries;
           this.changelogLoaded = true;

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -744,7 +744,7 @@ export default class SingleController extends Controller {
     if (!changelog) {
       return;
     }
-    const entry = this.store.createRecord('changelogEntry', {
+    const entry = this.store.createRecord('changelog-entry', {
       text: changelog,
       recordId: challenge.id,
       author: this.config.author,

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -189,10 +189,10 @@ export default class SingleController extends Controller {
     const challenges = this.skill.challengesArray;
     return this.confirm.ask(this.intl.t('skill.archive.confirm.title'), this.intl.t('skill.archive.confirm.message'))
       .then(() => {
-        this._displayChangelogPopIn(this.intl.t('skill.changelog.archive'), (changelogValue)=>{
+        this._displayChangelogPopIn(this.intl.t('skill.changelog.archive'), (changelogValue) => {
           this.loader.start(this.intl.t('skill.archive.loader_start'));
           return this.skill.archive()
-            .then(()=>this._handleSkillChangelog(this.skill, changelogValue, this.changelogEntry.archiveAction))
+            .then(() => this._handleSkillChangelog(this.skill, changelogValue, this.changelogEntry.archiveAction))
             .then(() => {
               this.close();
               this.notify.message(this.intl.t('skill.archive.success'));
@@ -200,7 +200,7 @@ export default class SingleController extends Controller {
             .then(() => {
               const updateChallenges = challenges.filter((challenge) => challenge.isDraft).map((challenge) => {
                 return challenge.archive()
-                  .then(()=>this._handleChallengeChangelog(challenge, this.intl.t('skill.archive.challenge.changelog', { skillName: this.skill.name })))
+                  .then(() => this._handleChallengeChangelog(challenge, this.intl.t('skill.archive.challenge.changelog', { skillName: this.skill.name })))
                   .then(() => {
                     if (challenge.isPrototype) {
                       this.notify.message(this.intl.t('skill.archive.challenge.prototype'));
@@ -240,7 +240,7 @@ export default class SingleController extends Controller {
         this._displayChangelogPopIn(this.intl.t('skill.changelog.obsolete'), (changelogValue) => {
           this.loader.start(this.intl.t('skill.obsolete.loader_start'));
           return this.skill.obsolete()
-            .then(()=>this._handleSkillChangelog(this.skill, changelogValue, this.changelogEntry.deleteAction))
+            .then(() => this._handleSkillChangelog(this.skill, changelogValue, this.changelogEntry.deleteAction))
             .then(() => {
               this.close();
               this.notify.message(this.intl.t('skill.obsolete.success'));
@@ -248,7 +248,7 @@ export default class SingleController extends Controller {
             .then(() => {
               const updateChallenges = challenges.filter((challenge) => !challenge.isObsolete).map((challenge) => {
                 return challenge.obsolete()
-                  .then(()=>this._handleChallengeChangelog(challenge, this.intl.t('skill.obsolete.challenge.changelog', { skillName: this.skill.name })))
+                  .then(() => this._handleChallengeChangelog(challenge, this.intl.t('skill.obsolete.challenge.changelog', { skillName: this.skill.name })))
                   .then(() => {
                     if (challenge.isPrototype) {
                       this.notify.message(this.intl.t('skill.obsolete.challenge.prototype'));
@@ -309,7 +309,7 @@ export default class SingleController extends Controller {
     if (!changelogValue) {
       return;
     }
-    const entry = this.store.createRecord('changelogEntry', {
+    const entry = this.store.createRecord('changelog-entry', {
       text: changelogValue,
       recordId: skill.pixId,
       skillName: skill.name,
@@ -323,7 +323,7 @@ export default class SingleController extends Controller {
   }
 
   _handleChallengeChangelog(challenge, changelogValue) {
-    const entry = this.store.createRecord('changelogEntry', {
+    const entry = this.store.createRecord('changelog-entry', {
       text: changelogValue,
       recordId: challenge.id,
       author: this.config.author,

--- a/pix-editor/app/deprecation-workflow.js
+++ b/pix-editor/app/deprecation-workflow.js
@@ -4,10 +4,6 @@ setupDeprecationWorkflow({
   'workflow': [
     {
       'handler': 'silence',
-      'matchId': 'ember-data:deprecate-legacy-imports',
-    },
-    {
-      'handler': 'silence',
       'matchId': 'template-action',
     },
     {

--- a/pix-editor/app/deprecation-workflow.js
+++ b/pix-editor/app/deprecation-workflow.js
@@ -1,0 +1,22 @@
+import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  'workflow': [
+    {
+      'handler': 'silence',
+      'matchId': 'ember-data:deprecate-legacy-imports',
+    },
+    {
+      'handler': 'silence',
+      'matchId': 'template-action',
+    },
+    {
+      'handler': 'silence',
+      'matchId': 'ember-data:deprecate-non-strict-types',
+    },
+    {
+      'handler': 'silence',
+      'matchId': 'ember-data:deprecate-relationship-remote-update-clearing-local-state',
+    },
+  ],
+});

--- a/pix-editor/app/deprecation-workflow.js
+++ b/pix-editor/app/deprecation-workflow.js
@@ -3,16 +3,8 @@ import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 setupDeprecationWorkflow({
   'workflow': [
     {
-      'handler': 'silence',
+      'handler': 'warn', // this deprecation is only on EmberTable package
       'matchId': 'template-action',
-    },
-    {
-      'handler': 'silence',
-      'matchId': 'ember-data:deprecate-non-strict-types',
-    },
-    {
-      'handler': 'silence',
-      'matchId': 'ember-data:deprecate-relationship-remote-update-clearing-local-state',
     },
   ],
 });

--- a/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/localized.js
@@ -5,7 +5,7 @@ export default class LocalizedPrototypeRoute extends Route {
   @service store;
 
   async model({ localized_challenge_id }) {
-    const localizedChallenge = await this.store.findRecord('localized_challenge', localized_challenge_id);
+    const localizedChallenge = await this.store.findRecord('localized-challenge', localized_challenge_id);
     const competence = this.modelFor('authenticated.competence');
     const challenge = await localizedChallenge.challenge;
     return { localizedChallenge, challenge, competence };

--- a/pix-editor/app/transforms/boolean.js
+++ b/pix-editor/app/transforms/boolean.js
@@ -1,0 +1,1 @@
+export { BooleanTransform as default } from '@ember-data/serializer/transform';

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -254,7 +254,7 @@ function routes() {
     const skill = schema.skills.find(skillId);
     challenge.updatedAt = new Date();
 
-    const createdChallenge = schema.challenges.create(challenge);
+    const createdChallenge = schema.challenges.create({ ...challenge, id: challenge.data.id });
     createdChallenge.skill = skill;
 
     skill.challengeIds = [...skill.challengeIds, createdChallenge.id];

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -45,6 +45,7 @@
         "ember-cli-babel": "^8.0.0",
         "ember-cli-clipboard": "1.3",
         "ember-cli-dependency-checker": "^3.3.1",
+        "ember-cli-deprecation-workflow": "^3.3.0",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-inject-live-reload": "^2.0.2",
         "ember-cli-mirage": "^3.0.0",
@@ -21192,6 +21193,23 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ember-cli-deprecation-workflow": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-3.3.0.tgz",
+      "integrity": "sha512-AZTOv+xftPXNov+X7k/JZFMd5/Suzkuvg5Zc1W3MoJb+kjIwW/3sieBOXEbt7aMq9Px4ixb9FSrFPNlzggV4qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "ember-cli-babel": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "ember-source": ">= 4.0.0"
       }
     },
     "node_modules/ember-cli-get-component-path-option": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -60,6 +60,7 @@
     "ember-cli-babel": "^8.0.0",
     "ember-cli-clipboard": "1.3",
     "ember-cli-dependency-checker": "^3.3.1",
+    "ember-cli-deprecation-workflow": "^3.3.0",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-mirage": "^3.0.0",

--- a/pix-editor/tests/integration/components/pop-in/challenge-log-test.js
+++ b/pix-editor/tests/integration/components/pop-in/challenge-log-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | popin-challenge-log', function(hooks) {
       locales: ['Francophone', 'Franco Français'],
       instruction: 'Some instructions 1',
     };
-    this.closeAction = function() {};
+    this.closeAction = function() { };
     this.challenge = challenge;
   });
 
@@ -55,7 +55,7 @@ module('Integration | Component | popin-challenge-log', function(hooks) {
     await render(hbs`<PopIn::Challenge-log @close={{this.closeAction}} @challenge={{this.challenge}}/>`);
 
     //then
-    assert.deepEqual(paginatedQueryLoadNotesStub.getCall(1).args, ['changelogEntry', { filterByFormula: `AND(Record_Id = '${this.challenge.id}', Changelog='oui')`, sort: [{ field: 'Date', direction: 'desc' }] }]);
+    assert.deepEqual(paginatedQueryLoadNotesStub.getCall(1).args, ['changelog-entry', { filterByFormula: `AND(Record_Id = '${this.challenge.id}', Changelog='oui')`, sort: [{ field: 'Date', direction: 'desc' }] }]);
   });
 
 });

--- a/pix-editor/tests/unit/controllers/competence/skills/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/skills/single-test.js
@@ -54,7 +54,7 @@ module('Unit | Controller | competence/skills/single', function(hooks) {
     const storeResult = storeStub.createRecord.getCall(0).args;
     //stub createdAt
     storeResult[1].createdAt = date;
-    assert.deepEqual(storeStub.createRecord.getCall(0).args, ['changelogEntry', expectedChangelog]);
+    assert.deepEqual(storeStub.createRecord.getCall(0).args, ['changelog-entry', expectedChangelog]);
   });
 
   test('it should create a challenge changelogEntry', async function(assert) {
@@ -83,7 +83,7 @@ module('Unit | Controller | competence/skills/single', function(hooks) {
     const storeResult = storeStub.createRecord.getCall(0).args;
     //stub createdAt
     storeResult[1].createdAt = date;
-    assert.deepEqual(storeStub.createRecord.getCall(0).args, ['changelogEntry', expectedChangelog]);
+    assert.deepEqual(storeStub.createRecord.getCall(0).args, ['changelog-entry', expectedChangelog]);
   });
 
   test('it should clone skill with new location', async function(assert) {


### PR DESCRIPTION
## 🔆 Problème

Certains changements d'Ember v5 ne seront plus supportées en v6, il est donc nécessaire de prendre en compte les messages de dépréciations dès maintenant.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## ⛱️ Proposition

On utilise `ember-ci-deprecation-workflow` pour identifier plus facilement les différentes dépréciations avant de les traiter.
Voir la documentation : https://github.com/ember-cli/ember-cli-deprecation-workflow



<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

La dépréciation `template-action` est uniquement liée à la librairie `EmberTable`.

## 🏄 Pour tester

Une CI verte, et des tests sans avertissement.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
