### PR TITLE
[TECH] Grouper les recherches de tags par id

### DIFF
--- a/api/lib/application/tags.js
+++ b/api/lib/application/tags.js
@@ -6,7 +6,7 @@ import { logger } from '../infrastructure/logger.js';
 import { DomainError } from '../domain/errors.js';
 import * as tagSerializer from '../infrastructure/serializers/jsonapi/tag-serializer.js';
 import { tagRepository } from '../infrastructure/repositories/index.js';
-import { createTag } from '../domain/usecases/index.js';
+import { createTag, searchTags } from '../domain/usecases/index.js';
 import * as Types from './types.js';
 import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
 
@@ -75,12 +75,14 @@ export function register(server) {
         validate: {
           query: Joi.object({
             'filter[title]': Joi.string(),
-          }),
+            'filter[ids][]': [Joi.string(), Joi.array().items(Joi.string())],
+          })
+            .xor('filter[title]', 'filter[ids][]')
         },
         handler: async function(request) {
           try {
             const params = extractParameters(request.query);
-            const tags = await tagRepository.searchByTitle(params.filter.title);
+            const tags = await searchTags(params, { tagRepository });
             return tagSerializer.serialize(tags);
           } catch (err) {
             logger.error(err);

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -32,6 +32,7 @@ export * from './preview-challenge.js';
 export * from './proxy-delete-request-to-airtable.js';
 export * from './proxy-read-request-to-airtable.js';
 export * from './proxy-write-request-to-airtable.js';
+export * from './search-tags.js';
 export * from './search-tutorials.js';
 export * from './update-attachment.js';
 export * from './update-challenge.js';

--- a/api/lib/domain/usecases/search-tags.js
+++ b/api/lib/domain/usecases/search-tags.js
@@ -1,0 +1,6 @@
+export async function searchTags(params, dependencies = { tagRepository }) {
+  if (params.filter.title) {
+    return dependencies.tagRepository.searchByTitle(params.filter.title);
+  }
+  return dependencies.tagRepository.getManyByAirtableIds(params.filter.ids);
+}

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -14,6 +14,13 @@ export async function getByAirtableId(tagId) {
   return toDomain(datasourceTag);
 }
 
+export async function getManyByAirtableIds(airtableIds) {
+  if (!airtableIds?.length) return [];
+  const datasourceTags = await tagDatasource.getManyByAirtableIds(airtableIds);
+  if (!datasourceTags) return [];
+  return datasourceTags.map(toDomain);
+}
+
 export async function searchByTitle(title) {
   const datasourceTags = await tagDatasource.searchByTitle(title);
   if (!datasourceTags) return [];

--- a/api/tests/acceptance/application/tags_test.js
+++ b/api/tests/acceptance/application/tags_test.js
@@ -4,6 +4,7 @@ import nock from 'nock';
 import { airtableBuilder, databaseBuilder, generateAuthorizationHeader } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import * as idGenerator from '../../../lib/infrastructure/utils/id-generator.js';
+import { tagDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 
 describe('Application | Route | Tags', () => {
   let editorUser, readonlyUser;
@@ -303,91 +304,181 @@ describe('Application | Route | Tags', () => {
     });
 
     context('success', function() {
-      it('should respond with status 200 and related tags, limited by 4 tags and sorted by title', async () => {
-        // given
-        const airtableTags = [
-          airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', description: 'une description', title: 'france' }),
-          airtableBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' }),
-          airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'frontieRe' }),
-        ];
-        airtableSearchTagsScope = nock('https://api.airtable.com')
-          .get('/v0/airtableBaseValue/Tags')
-          .query({
-            filterByFormula: 'FIND("fr", LOWER(Nom))',
-            fields: { '': [ 'id persistant', 'Nom', 'Notes', 'Description', 'Acquis', 'Tutoriels' ] },
-            sort: [{ field: 'Nom', direction: 'asc' }],
-            maxRecords: 4,
-          })
-          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, {
-            records: airtableTags,
+      context('when searching by titles', function() {
+        it('should respond with status 200 and related tags, limited by 4 tags and sorted by title', async () => {
+          // given
+          const airtableTags = [
+            airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', description: 'une description', title: 'france' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'frontieRe' }),
+          ];
+          airtableSearchTagsScope = nock('https://api.airtable.com')
+            .get('/v0/airtableBaseValue/Tags')
+            .query({
+              filterByFormula: 'FIND("fr", LOWER(Nom))',
+              fields: { '': [ 'id persistant', 'Nom', 'Notes', 'Description', 'Acquis', 'Tutoriels' ] },
+              sort: [{ field: 'Nom', direction: 'asc' }],
+              maxRecords: 4,
+            })
+            .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+            .reply(200, {
+              records: airtableTags,
+            });
+          const server = await createServer();
+
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: '/api/tags?filter[title]=fr',
+            headers: generateAuthorizationHeader(editorUser),
           });
-        const server = await createServer();
 
-        // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/tags?filter[title]=fr',
-          headers: generateAuthorizationHeader(editorUser),
+          // then
+          expect(response.statusCode).toBe(200);
+          expect(response.result).toEqual({
+            data: [
+              {
+                type: 'tags',
+                id: 'tagAirtableId3',
+                attributes: {
+                  'pix-id': 'tagId3',
+                  'title': 'france',
+                  'notes': 'une note',
+                  'description': 'une description',
+                },
+                relationships: {
+                  skills: {
+                    data: [],
+                  },
+                  tutorials: {
+                    data: [],
+                  },
+                },
+              },
+              {
+                type: 'tags',
+                id: 'tagAirtableId4',
+                attributes: {
+                  'pix-id': 'tagId4',
+                  'title': 'freT',
+                },
+                relationships: {
+                  skills: {
+                    data: [],
+                  },
+                  tutorials: {
+                    data: [],
+                  },
+                },
+              },
+              {
+                type: 'tags',
+                id: 'tagAirtableId2',
+                attributes: {
+                  'pix-id': 'tagId2',
+                  'title': 'frontieRe',
+                },
+                relationships: {
+                  skills: {
+                    data: [],
+                  },
+                  tutorials: {
+                    data: [],
+                  },
+                },
+              },
+            ],
+          });
+          expect(airtableSearchTagsScope.isDone()).toBe(true);
         });
+      });
+      
+      context('when searching by ids', function() {
+        it('should respond with status 200 and related tags', async () => {
+          // given
+          const airtableTags = [
+            airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', description: 'une description', title: 'france' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'frontieRe' }),
+          ];
+          airtableSearchTagsScope = nock('https://api.airtable.com')
+            .get('/v0/airtableBaseValue/Tags')
+            .query({
+              filterByFormula: 'OR(RECORD_ID() = "tagId3", RECORD_ID() = "tagId4", RECORD_ID() = "tagId2")',
+              fields: { '': tagDatasource.usedFields },
+              sort: [{ field: tagDatasource.sortField, direction: 'asc' }]
+            })
+            .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+            .reply(200, {
+              records: airtableTags,
+            });
+          const server = await createServer();
 
-        // then
-        expect(response.statusCode).toBe(200);
-        expect(response.result).toEqual({
-          data: [
-            {
-              type: 'tags',
-              id: 'tagAirtableId3',
-              attributes: {
-                'pix-id': 'tagId3',
-                'title': 'france',
-                'notes': 'une note',
-                'description': 'une description',
-              },
-              relationships: {
-                skills: {
-                  data: [],
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: '/api/tags?filter[ids][]=tagId3&filter[ids][]=tagId4&filter[ids][]=tagId2',
+            headers: generateAuthorizationHeader(editorUser),
+          });
+
+          // then
+          expect(response.statusCode).toBe(200);
+          expect(response.result).toEqual({
+            data: [
+              {
+                type: 'tags',
+                id: 'tagAirtableId3',
+                attributes: {
+                  'pix-id': 'tagId3',
+                  'title': 'france',
+                  'notes': 'une note',
+                  'description': 'une description',
                 },
-                tutorials: {
-                  data: [],
-                },
-              },
-            },
-            {
-              type: 'tags',
-              id: 'tagAirtableId4',
-              attributes: {
-                'pix-id': 'tagId4',
-                'title': 'freT',
-              },
-              relationships: {
-                skills: {
-                  data: [],
-                },
-                tutorials: {
-                  data: [],
+                relationships: {
+                  skills: {
+                    data: [],
+                  },
+                  tutorials: {
+                    data: [],
+                  },
                 },
               },
-            },
-            {
-              type: 'tags',
-              id: 'tagAirtableId2',
-              attributes: {
-                'pix-id': 'tagId2',
-                'title': 'frontieRe',
-              },
-              relationships: {
-                skills: {
-                  data: [],
+              {
+                type: 'tags',
+                id: 'tagAirtableId4',
+                attributes: {
+                  'pix-id': 'tagId4',
+                  'title': 'freT',
                 },
-                tutorials: {
-                  data: [],
+                relationships: {
+                  skills: {
+                    data: [],
+                  },
+                  tutorials: {
+                    data: [],
+                  },
                 },
               },
-            },
-          ],
+              {
+                type: 'tags',
+                id: 'tagAirtableId2',
+                attributes: {
+                  'pix-id': 'tagId2',
+                  'title': 'frontieRe',
+                },
+                relationships: {
+                  skills: {
+                    data: [],
+                  },
+                  tutorials: {
+                    data: [],
+                  },
+                },
+              },
+            ],
+          });
+          expect(airtableSearchTagsScope.isDone()).toBe(true);
         });
-        expect(airtableSearchTagsScope.isDone()).toBe(true);
       });
     });
   });

--- a/pix-editor/app/adapters/tag.js
+++ b/pix-editor/app/adapters/tag.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class TagAdapter extends ApplicationAdapter {
+  coalesceFindRequests = true;
+}


### PR DESCRIPTION
## 🔆 Problème

J'ai pas groupé les appels de tags

## ⛱️ Proposition

Ajouter un filtre filter[ids][] sur la route GET /api/tags et rendre groupable le findRecord

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Ouvrir sa console du développeur et vérifier qu'on n'a plus des appels individuels successifs pour récupérer des tags (par exemple en récupérant des tutos ayant plusieurs tags)
