### PR TITLE
[TECH] Centraliser la gestion d'erreurs imprévues côté API dans le pre-response-utils

### DIFF
--- a/api/lib/application/areas.js
+++ b/api/lib/application/areas.js
@@ -1,9 +1,6 @@
 import Joi from 'joi';
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import * as usecases from '../domain/usecases/index.js';
-import { logger } from '../infrastructure/logger.js';
 import { areaRepository } from '../infrastructure/repositories/index.js';
 import { areaSerializer } from '../infrastructure/serializers/jsonapi/index.js';
 import * as Types from './types.js';
@@ -15,14 +12,8 @@ export function register(server) {
       path: '/api/areas',
       config: {
         handler: async function() {
-          try {
-            const areas = await areaRepository.list();
-            return areaSerializer.serialize(areas);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const areas = await areaRepository.list();
+          return areaSerializer.serialize(areas);
         },
       },
     },
@@ -51,17 +42,11 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const area = await areaSerializer.deserialize(request.payload);
+          const area = await areaSerializer.deserialize(request.payload);
 
-            const createdArea = await usecases.createArea(area);
+          const createdArea = await usecases.createArea(area);
 
-            return h.response(areaSerializer.serialize(createdArea)).code(201);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          return h.response(areaSerializer.serialize(createdArea)).code(201);
         },
       },
     },

--- a/api/lib/application/attachments.js
+++ b/api/lib/application/attachments.js
@@ -1,9 +1,6 @@
 import Joi from 'joi';
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import * as usecases from '../domain/usecases/index.js';
-import { logger } from '../infrastructure/logger.js';
 import * as Types from './types.js';
 import * as attachmentSerializer from '../infrastructure/serializers/jsonapi/attachment-serializer.js';
 import * as attachmentRepository from '../infrastructure/repositories/attachment-repository.js';
@@ -50,20 +47,14 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const attachmentCreationCommand = attachmentSerializer.deserializeCreationCommand(request.payload);
-            const createdAttachment = await usecases.createAttachment({
-              attachmentCreationCommand,
-              attachmentRepository,
-              localizedChallengeRepository,
-              updatePixApiReleaseCache,
-            });
-            return h.response(attachmentSerializer.serialize(createdAttachment)).code(201);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const attachmentCreationCommand = attachmentSerializer.deserializeCreationCommand(request.payload);
+          const createdAttachment = await usecases.createAttachment({
+            attachmentCreationCommand,
+            attachmentRepository,
+            localizedChallengeRepository,
+            updatePixApiReleaseCache,
+          });
+          return h.response(attachmentSerializer.serialize(createdAttachment)).code(201);
         },
       },
     },
@@ -109,19 +100,13 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const attachmentUpdateCommand = attachmentSerializer.deserializeUpdateCommand(request.payload);
-            const updatedAttachment = await usecases.updateAttachment({
-              attachmentUpdateCommand,
-              attachmentRepository,
-              updatePixApiReleaseCache,
-            });
-            return h.response(attachmentSerializer.serialize(updatedAttachment)).code(200);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const attachmentUpdateCommand = attachmentSerializer.deserializeUpdateCommand(request.payload);
+          const updatedAttachment = await usecases.updateAttachment({
+            attachmentUpdateCommand,
+            attachmentRepository,
+            updatePixApiReleaseCache,
+          });
+          return h.response(attachmentSerializer.serialize(updatedAttachment)).code(200);
         },
       },
     },
@@ -140,19 +125,13 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const attachmentId = request.params.attachmentId;
-            await usecases.deleteAttachment({
-              attachmentId,
-              attachmentRepository,
-              updatePixApiReleaseCache,
-            });
-            return h.response().code(204);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const attachmentId = request.params.attachmentId;
+          await usecases.deleteAttachment({
+            attachmentId,
+            attachmentRepository,
+            updatePixApiReleaseCache,
+          });
+          return h.response().code(204);
         },
       },
     },
@@ -166,15 +145,9 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const id = request.params.attachmentId;
-            const attachment = await usecases.findAttachment({ id, attachmentRepository });
-            return h.response(attachmentSerializer.serialize(attachment));
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const id = request.params.attachmentId;
+          const attachment = await usecases.findAttachment({ id, attachmentRepository });
+          return h.response(attachmentSerializer.serialize(attachment));
         },
       },
     },
@@ -188,15 +161,9 @@ export function register(server) {
           }).required(),
         },
         handler: async function(request, h) {
-          try {
-            const query = attachmentSerializer.deserializeQuery(request.query);
-            const attachments = await usecases.findAttachments({ query, attachmentRepository });
-            return h.response(attachmentSerializer.serialize(attachments));
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const query = attachmentSerializer.deserializeQuery(request.query);
+          const attachments = await usecases.findAttachments({ query, attachmentRepository });
+          return h.response(attachmentSerializer.serialize(attachments));
         },
       },
     },

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -1,4 +1,3 @@
-import Boom from '@hapi/boom';
 import Joi from 'joi';
 import * as Sentry from '@sentry/node';
 import { logger } from '../../infrastructure/logger.js';
@@ -16,6 +15,7 @@ import {
   updateChallenge,
 } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
+import { NotFoundError } from '../../domain/errors.js';
 
 const challengeIdType = Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+$/).required();
 
@@ -61,7 +61,7 @@ export async function register(server) {
           const params = { filter: { ids: [challengeId] } };
           const challenges = await challengeRepository.filter(params);
           if (challenges.length === 0) {
-            return Boom.notFound();
+            return new NotFoundError();
           }
           return challengeSerializer.serialize(challenges[0]);
         },

--- a/api/lib/application/competences/competences.js
+++ b/api/lib/application/competences/competences.js
@@ -1,9 +1,6 @@
 import Joi from 'joi';
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from '../security-pre-handlers.js';
 import * as usecases from '../../domain/usecases/index.js';
-import { logger } from '../../infrastructure/logger.js';
 import { competenceSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import { competenceRepository } from '../../infrastructure/repositories/index.js';
 import * as Types from '../types.js';
@@ -16,14 +13,8 @@ export async function register(server) {
       path: '/api/competences',
       config: {
         handler: async function() {
-          try {
-            const competences = await competenceRepository.list();
-            return competenceSerializer.serialize(competences);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const competences = await competenceRepository.list();
+          return competenceSerializer.serialize(competences);
         },
       },
     },
@@ -37,15 +28,9 @@ export async function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const competence = await competenceRepository.getByAirtableId(request.params.competenceAirtableId);
-            if (!competence) throw new NotFoundError('unknown competence');
-            return competenceSerializer.serialize(competence);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const competence = await competenceRepository.getByAirtableId(request.params.competenceAirtableId);
+          if (!competence) throw new NotFoundError('unknown competence');
+          return competenceSerializer.serialize(competence);
         },
       },
     },
@@ -76,15 +61,9 @@ export async function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const competence = await competenceSerializer.deserialize(request.payload);
-            const createdCompetence = await usecases.createCompetence(competence);
-            return h.response(competenceSerializer.serialize(createdCompetence)).code(201);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const competence = await competenceSerializer.deserialize(request.payload);
+          const createdCompetence = await usecases.createCompetence(competence);
+          return h.response(competenceSerializer.serialize(createdCompetence)).code(201);
         },
       },
     },
@@ -112,17 +91,11 @@ export async function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const competenceUpdates = await competenceSerializer.deserialize(request.payload);
+          const competenceUpdates = await competenceSerializer.deserialize(request.payload);
 
-            const updatedCompetence = await usecases.updateCompetence(request.params.competenceAirtableId, competenceUpdates);
+          const updatedCompetence = await usecases.updateCompetence(request.params.competenceAirtableId, competenceUpdates);
 
-            return competenceSerializer.serialize(updatedCompetence);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          return competenceSerializer.serialize(updatedCompetence);
         },
       },
     },

--- a/api/lib/application/competences/overviews.js
+++ b/api/lib/application/competences/overviews.js
@@ -1,7 +1,4 @@
 import Joi from 'joi';
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
-import { logger } from '../../infrastructure/logger.js';
 import {
   getCompetenceChallengesProductionOverview,
   getCompetenceChallengesWorkbenchOverview
@@ -24,17 +21,11 @@ export async function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const competenceId = request.params.competenceId;
-            const locale = request.query.locale;
+          const competenceId = request.params.competenceId;
+          const locale = request.query.locale;
 
-            const competenceOverview = await getCompetenceChallengesProductionOverview({ competenceId, locale });
-            return competenceOverviewSerializer.serialize(competenceOverview);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const competenceOverview = await getCompetenceChallengesProductionOverview({ competenceId, locale });
+          return competenceOverviewSerializer.serialize(competenceOverview);
         },
       },
     },
@@ -48,16 +39,10 @@ export async function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const competenceId = request.params.competenceId;
+          const competenceId = request.params.competenceId;
 
-            const competenceOverview = await getCompetenceChallengesWorkbenchOverview({ competenceId });
-            return competenceOverviewSerializer.serialize(competenceOverview);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const competenceOverview = await getCompetenceChallengesWorkbenchOverview({ competenceId });
+          return competenceOverviewSerializer.serialize(competenceOverview);
         },
       },
     },

--- a/api/lib/application/frameworks.js
+++ b/api/lib/application/frameworks.js
@@ -1,8 +1,5 @@
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import * as usecases from '../domain/usecases/index.js';
-import { logger } from '../infrastructure/logger.js';
 import { frameworkRepository } from '../infrastructure/repositories/index.js';
 import { frameworkSerializer } from '../infrastructure/serializers/jsonapi/index.js';
 import Joi from 'joi';
@@ -14,14 +11,8 @@ export function register(server) {
       path: '/api/frameworks',
       config: {
         handler: async function() {
-          try {
-            const frameworks = await frameworkRepository.list();
-            return frameworkSerializer.serialize(frameworks);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const frameworks = await frameworkRepository.list();
+          return frameworkSerializer.serialize(frameworks);
         },
       },
     },
@@ -41,19 +32,13 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const framework = await frameworkSerializer.deserialize(request.payload);
+          const framework = await frameworkSerializer.deserialize(request.payload);
 
-            const createdFramework = await usecases.createFramework(framework);
+          const createdFramework = await usecases.createFramework(framework);
 
-            return h
-              .response(frameworkSerializer.serialize(createdFramework))
-              .code(201);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          return h
+            .response(frameworkSerializer.serialize(createdFramework))
+            .code(201);
         },
       },
     },

--- a/api/lib/application/localized-challenges.js
+++ b/api/lib/application/localized-challenges.js
@@ -2,9 +2,8 @@ import { localizedChallengeRepository } from '../infrastructure/repositories/ind
 import { localizedChallengeSerializer } from '../infrastructure/serializers/jsonapi/index.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
-import { hasAuthenticatedUserAccess, replyForbiddenError } from './security-utils.js';
+import { hasAuthenticatedUserAccess } from './security-utils.js';
 import { modifyLocalizedChallenge } from '../domain/usecases/index.js';
-import { ForbiddenError } from '../domain/errors.js';
 
 export async function register(server) {
   server.route([
@@ -38,18 +37,11 @@ export async function register(server) {
         handler: async function(request, h) {
           const { locale: _, ...localizedChallenge } = await localizedChallengeSerializer.deserialize(request.payload);
           const isAdmin = hasAuthenticatedUserAccess(request, ['admin']);
-          try {
-            const updatedLocalizedChallenge = await modifyLocalizedChallenge({
-              isAdmin,
-              localizedChallenge
-            }, { localizedChallengeRepository });
-            return h.response(localizedChallengeSerializer.serialize(updatedLocalizedChallenge));
-          } catch (error) {
-            if (error instanceof ForbiddenError) {
-              return replyForbiddenError(h, error);
-            }
-            throw error;
-          }
+          const updatedLocalizedChallenge = await modifyLocalizedChallenge({
+            isAdmin,
+            localizedChallenge
+          }, { localizedChallengeRepository });
+          return h.response(localizedChallengeSerializer.serialize(updatedLocalizedChallenge));
         },
       },
     },

--- a/api/lib/application/skills/skills.js
+++ b/api/lib/application/skills/skills.js
@@ -18,6 +18,7 @@ import {
   listSkills,
   updateSkill,
 } from '../../domain/usecases/index.js';
+import { NotFoundError, } from '../../domain/errors.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import { logger } from '../../infrastructure/logger.js';
 import {
@@ -75,80 +76,56 @@ export async function getProductionLocalizedChallenges(request, h) {
 }
 
 export async function list(req) {
-  try {
-    const params = extractParameters(req.query);
-    const skills = await listSkills(params);
-    return skillSerializer.serialize(skills);
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-    return Boom.internal(err);
-  }
+  const params = extractParameters(req.query);
+  const skills = await listSkills(params);
+  return skillSerializer.serialize(skills);
 }
 
 export async function get(req) {
-  try {
-    const skill = await skillRepository.getByAirtableId(req.params.skillAirtableId);
-    if (!skill) throw new NotFoundError('unknown skill');
-    return skillSerializer.serialize(skill);
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-    return Boom.internal(err);
-  }
+  const skill = await skillRepository.getByAirtableId(req.params.skillAirtableId);
+  if (!skill) throw new NotFoundError('unknown skill');
+  return skillSerializer.serialize(skill);
 }
 
 export async function create(req, h) {
-  try {
-    const skill = await skillSerializer.deserialize(req.payload);
-    const createdSkill = await createSkill(skill, {
-      skillRepository,
-      tubeRepository,
-      skillTransformer,
-      updatedRecordNotifier,
-      pixApiClient,
-      generateNewIdFnc: generateNewId,
-      normalizeNonBreakingSpaceFnc: normalizeNonBreakingSpace,
-    });
-    return h.response(skillSerializer.serialize(createdSkill)).code(201);
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-    return Boom.internal(err);
-  }
+  const skill = await skillSerializer.deserialize(req.payload);
+  const createdSkill = await createSkill(skill, {
+    skillRepository,
+    tubeRepository,
+    skillTransformer,
+    updatedRecordNotifier,
+    pixApiClient,
+    generateNewIdFnc: generateNewId,
+    normalizeNonBreakingSpaceFnc: normalizeNonBreakingSpace,
+  });
+  return h.response(skillSerializer.serialize(createdSkill)).code(201);
 }
 
 export async function update(req, h) {
   const { attributes, relationships } = req.payload.data;
-  try {
-    const updateSkillCommand = {
-      airtableId: req.params.skillAirtableId,
-      description: attributes['description'],
-      descriptionStatus: attributes['description-status'],
-      clue: attributes['clue'],
-      clueEn: attributes['clue-en'],
-      clueStatus: attributes['clue-status'],
-      i18n: attributes['i18n'],
-      status: attributes['status'],
-      tutoMoreAirtableIds: relationships['tuto-more'].data.map(({ id }) => id),
-      tutoSolutionAirtableIds: relationships['tuto-solution'].data.map(({ id }) => id),
-    };
-    const updatedSkill = await updateSkill(updateSkillCommand, {
-      skillRepository,
-      skillTransformer,
-      updatedRecordNotifier,
-      pixApiClient,
-      logger,
-      Sentry,
-      normalizeNonBreakingSpaceFnc: normalizeNonBreakingSpace,
-    });
+  const updateSkillCommand = {
+    airtableId: req.params.skillAirtableId,
+    description: attributes['description'],
+    descriptionStatus: attributes['description-status'],
+    clue: attributes['clue'],
+    clueEn: attributes['clue-en'],
+    clueStatus: attributes['clue-status'],
+    i18n: attributes['i18n'],
+    status: attributes['status'],
+    tutoMoreAirtableIds: relationships['tuto-more'].data.map(({ id }) => id),
+    tutoSolutionAirtableIds: relationships['tuto-solution'].data.map(({ id }) => id),
+  };
+  const updatedSkill = await updateSkill(updateSkillCommand, {
+    skillRepository,
+    skillTransformer,
+    updatedRecordNotifier,
+    pixApiClient,
+    logger,
+    Sentry,
+    normalizeNonBreakingSpaceFnc: normalizeNonBreakingSpace,
+  });
 
-    if (updatedSkill === null) return Boom.notFound();
+  if (updatedSkill === null) return Boom.notFound();
 
-    return h.response(skillSerializer.serialize(updatedSkill)).code(200);
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-    return Boom.internal(err);
-  }
+  return h.response(skillSerializer.serialize(updatedSkill)).code(200);
 }

--- a/api/lib/application/tags.js
+++ b/api/lib/application/tags.js
@@ -1,14 +1,11 @@
 import Joi from 'joi';
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from './security-pre-handlers.js';
-import { logger } from '../infrastructure/logger.js';
-import { DomainError } from '../domain/errors.js';
 import * as tagSerializer from '../infrastructure/serializers/jsonapi/tag-serializer.js';
 import { tagRepository } from '../infrastructure/repositories/index.js';
 import { createTag, searchTags } from '../domain/usecases/index.js';
 import * as Types from './types.js';
 import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
+import { NotFoundError } from '../domain/errors.js';
 
 export function register(server) {
   server.route([
@@ -33,16 +30,9 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const tag = await tagSerializer.deserialize(request.payload);
-            const createdTag = await createTag(tag, { tagRepository });
-            return h.response(tagSerializer.serialize(createdTag)).code(201);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tag = await tagSerializer.deserialize(request.payload);
+          const createdTag = await createTag(tag, { tagRepository });
+          return h.response(tagSerializer.serialize(createdTag)).code(201);
         },
       },
     },
@@ -56,15 +46,9 @@ export function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const tag = await tagRepository.getByAirtableId(request.params.tagAirtableId);
-            if (!tag) return Boom.notFound('unknown tag id');
-            return tagSerializer.serialize(tag);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tag = await tagRepository.getByAirtableId(request.params.tagAirtableId);
+          if (!tag) return new NotFoundError('unknown tag id');
+          return tagSerializer.serialize(tag);
         },
       },
     },
@@ -80,15 +64,9 @@ export function register(server) {
             .xor('filter[title]', 'filter[ids][]')
         },
         handler: async function(request) {
-          try {
-            const params = extractParameters(request.query);
-            const tags = await searchTags(params, { tagRepository });
-            return tagSerializer.serialize(tags);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const params = extractParameters(request.query);
+          const tags = await searchTags(params, { tagRepository });
+          return tagSerializer.serialize(tags);
         },
       },
     },

--- a/api/lib/application/thematics.js
+++ b/api/lib/application/thematics.js
@@ -1,14 +1,11 @@
 import Joi from 'joi';
 import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
-import { logger } from '../infrastructure/logger.js';
 import * as Types from './types.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import { thematicRepository } from '../infrastructure/repositories/index.js';
 import { thematicSerializer } from '../infrastructure/serializers/jsonapi/index.js';
 import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
 import { createThematic, listThematics, updateThematic } from '../domain/usecases/index.js';
-import { DomainError } from '../domain/errors.js';
 
 export function register(server) {
   server.route([
@@ -22,15 +19,9 @@ export function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const thematic = await thematicRepository.getByAirtableId(request.params.thematicAirtableId);
-            if (!thematic) return Boom.notFound('unknown thematic id');
-            return thematicSerializer.serialize(thematic);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const thematic = await thematicRepository.getByAirtableId(request.params.thematicAirtableId);
+          if (!thematic) return Boom.notFound('unknown thematic id');
+          return thematicSerializer.serialize(thematic);
         },
       },
     },
@@ -44,16 +35,9 @@ export function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const params = extractParameters(request.query);
-            const thematics = await listThematics(params);
-            return thematicSerializer.serialize(thematics);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const params = extractParameters(request.query);
+          const thematics = await listThematics(params);
+          return thematicSerializer.serialize(thematics);
         },
       },
     },
@@ -79,16 +63,9 @@ export function register(server) {
         },
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
-          try {
-            const thematic = await thematicSerializer.deserialize(request.payload);
-            const createdThematic = await createThematic(thematic);
-            return h.response(thematicSerializer.serialize(createdThematic)).code(201);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const thematic = await thematicSerializer.deserialize(request.payload);
+          const createdThematic = await createThematic(thematic);
+          return h.response(thematicSerializer.serialize(createdThematic)).code(201);
         },
       },
     },
@@ -118,17 +95,10 @@ export function register(server) {
         },
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request) {
-          try {
-            const { thematicAirtableId } = request.params;
-            const thematicUpdates = await thematicSerializer.deserialize(request.payload);
-            const updatedThematic = await updateThematic(thematicAirtableId, thematicUpdates);
-            return thematicSerializer.serialize(updatedThematic);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const { thematicAirtableId } = request.params;
+          const thematicUpdates = await thematicSerializer.deserialize(request.payload);
+          const updatedThematic = await updateThematic(thematicAirtableId, thematicUpdates);
+          return thematicSerializer.serialize(updatedThematic);
         },
       },
     },

--- a/api/lib/application/tubes.js
+++ b/api/lib/application/tubes.js
@@ -1,7 +1,5 @@
 import Joi from 'joi';
 import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
-import { logger } from '../infrastructure/logger.js';
 import * as Types from './types.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import { tubeRepository } from '../infrastructure/repositories/index.js';
@@ -21,15 +19,9 @@ export function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const tube = await tubeRepository.getByAirtableId(request.params.tubeAirtableId);
-            if (!tube) return Boom.notFound('unknown tube id');
-            return tubeSerializer.serialize(tube);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tube = await tubeRepository.getByAirtableId(request.params.tubeAirtableId);
+          if (!tube) return Boom.notFound('unknown tube id');
+          return tubeSerializer.serialize(tube);
         },
       },
     },
@@ -43,16 +35,9 @@ export function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const params = extractParameters(request.query);
-            const tubes = await listTubes(params);
-            return tubeSerializer.serialize(tubes);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const params = extractParameters(request.query);
+          const tubes = await listTubes(params);
+          return tubeSerializer.serialize(tubes);
         },
       },
     },
@@ -81,16 +66,9 @@ export function register(server) {
         },
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
-          try {
-            const tube = await tubeSerializer.deserialize(request.payload);
-            const createdTube = await createTube(tube);
-            return h.response(tubeSerializer.serialize(createdTube)).code(201);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tube = await tubeSerializer.deserialize(request.payload);
+          const createdTube = await createTube(tube);
+          return h.response(tubeSerializer.serialize(createdTube)).code(201);
         },
       },
     },
@@ -124,16 +102,9 @@ export function register(server) {
         },
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request) {
-          try {
-            const tube = await tubeSerializer.deserialize(request.payload);
-            const updatedTube = await updateTube(request.params.tubeAirtableId, tube);
-            return tubeSerializer.serialize(updatedTube);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tube = await tubeSerializer.deserialize(request.payload);
+          const updatedTube = await updateTube(request.params.tubeAirtableId, tube);
+          return tubeSerializer.serialize(updatedTube);
         },
       },
     },

--- a/api/lib/application/tutorials.js
+++ b/api/lib/application/tutorials.js
@@ -1,9 +1,6 @@
 import Joi from 'joi';
-import Boom from '@hapi/boom';
-import * as Sentry from '@sentry/node';
 import * as securityPreHandlers from './security-pre-handlers.js';
-import { logger } from '../infrastructure/logger.js';
-import { DomainError } from '../domain/errors.js';
+import { NotFoundError } from '../domain/errors.js';
 import { tutorialRepository } from '../infrastructure/repositories/index.js';
 import { Tutorial } from '../domain/models/index.js';
 import * as Types from './types.js';
@@ -57,16 +54,9 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const tutorial = await tutorialSerializer.deserialize(request.payload);
-            const createdTutorial = await createTutorial(tutorial, { tutorialRepository });
-            return h.response(tutorialSerializer.serialize(createdTutorial)).code(201);
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tutorial = await tutorialSerializer.deserialize(request.payload);
+          const createdTutorial = await createTutorial(tutorial, { tutorialRepository });
+          return h.response(tutorialSerializer.serialize(createdTutorial)).code(201);
         },
       },
     },
@@ -80,15 +70,9 @@ export function register(server) {
           }),
         },
         handler: async function(request) {
-          try {
-            const tutorial = await tutorialRepository.getByAirtableId(request.params.tutorialAirtableId);
-            if (!tutorial) return Boom.notFound('unknown tutorial id');
-            return tutorialSerializer.serialize(tutorial);
-          } catch (err) {
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tutorial = await tutorialRepository.getByAirtableId(request.params.tutorialAirtableId);
+          if (!tutorial) return new NotFoundError('unknown tutorial id');
+          return tutorialSerializer.serialize(tutorial);
         },
       },
     },
@@ -133,16 +117,9 @@ export function register(server) {
           }),
         },
         handler: async function(request, h) {
-          try {
-            const tutorial = await tutorialSerializer.deserialize(request.payload);
-            const updatedTutorial = await updateTutorial(tutorial, { tutorialRepository });
-            return h.response(tutorialSerializer.serialize(updatedTutorial));
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const tutorial = await tutorialSerializer.deserialize(request.payload);
+          const updatedTutorial = await updateTutorial(tutorial, { tutorialRepository });
+          return h.response(tutorialSerializer.serialize(updatedTutorial));
         },
       },
     },
@@ -160,16 +137,9 @@ export function register(server) {
             .xor('filter[title]', 'filter[source]', 'filter[tagTitles][]', 'filter[ids][]')
         },
         handler: async function(request, h) {
-          try {
-            const params = extractParameters(request.query);
-            const tutorials = await searchTutorials(params, { tutorialRepository });
-            return h.response(tutorialSerializer.serialize(tutorials));
-          } catch (err) {
-            if (err instanceof DomainError) throw err;
-            logger.error(err);
-            Sentry.captureException(err);
-            return Boom.internal(err);
-          }
+          const params = extractParameters(request.query);
+          const tutorials = await searchTutorials(params, { tutorialRepository });
+          return h.response(tutorialSerializer.serialize(tutorials));
         },
       },
     },

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -88,4 +88,10 @@ export class TagTitleAlreadyUsedError extends DomainError {
   }
 }
 
+export class CloneSkillError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}
+
 export class ForbiddenError extends DomainError {}

--- a/api/lib/domain/usecases/clone-skill.js
+++ b/api/lib/domain/usecases/clone-skill.js
@@ -1,9 +1,7 @@
-import {
-  createChallengeTransformer,
-  skillTransformer,
-} from '../../infrastructure/transformers/index.js';
+import { createChallengeTransformer, skillTransformer, } from '../../infrastructure/transformers/index.js';
 import { logger } from '../../infrastructure/logger.js';
 import * as Sentry from '@sentry/node';
+import { CloneSkillError } from '../errors.js';
 
 // TODO LIST
 // industrialiser les utils translations pour gérer les objets du domaine
@@ -65,18 +63,18 @@ export async function cloneSkill({
 
 async function _checkIfCloningIsPossible({ level, tubeId, skillIdToClone, tubeRepository, skillRepository }) {
   if (level < 1 || level > 7) {
-    throw new Error('Le niveau doit être compris entre 1 et 7');
+    throw new CloneSkillError('Le niveau doit être compris entre 1 et 7');
   }
   const tube = await tubeRepository.get(tubeId);
   if (!tube) {
-    throw new Error(`Le sujet d'id "${tubeId}" n'existe pas`);
+    throw new CloneSkillError(`Le sujet d'id "${tubeId}" n'existe pas`);
   }
   const skillToClone = await skillRepository.get(skillIdToClone);
   if (!skillToClone) {
-    throw new Error(`L'acquis d'id "${skillIdToClone}" n'existe pas`);
+    throw new CloneSkillError(`L'acquis d'id "${skillIdToClone}" n'existe pas`);
   }
   if (!skillToClone.isLive) {
-    throw new Error('Impossible de cloner un acquis qui ne soit ni en construction ni actif');
+    throw new CloneSkillError('Impossible de cloner un acquis qui ne soit ni en construction ni actif');
   }
   return {
     tube,

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -80,6 +80,14 @@ function _mapToInfrastructureError(error) {
     };
   }
 
+  if (error instanceof DomainErrors.CloneSkillError) {
+    const infraError = new InfraErrors.BadRequestError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
+
   const infraError = new InfraErrors.InfrastructureError(error.message);
   return {
     infraErrors: [infraError],

--- a/api/lib/infrastructure/utils/pre-response-utils.js
+++ b/api/lib/infrastructure/utils/pre-response-utils.js
@@ -2,6 +2,8 @@ import * as errorManager from './error-manager.js';
 import { DomainError } from '../../domain/errors.js';
 import { InfrastructureError } from '../errors.js';
 import * as config from '../../config.js';
+import { logger } from '../logger.js';
+import * as Sentry from '@sentry/node';
 
 export function catchDomainAndInfrastructureErrors(request, h) {
   const response = request.response;
@@ -15,6 +17,9 @@ export function catchDomainAndInfrastructureErrors(request, h) {
         !request.path.startsWith('/api')) {
       return h.file(`${config.hapi.publicDir}/pix-editor/index.html`).code(200);
     }
+    const err = response?.message ?? response;
+    logger.error(err);
+    Sentry.captureException(err);
   }
 
   return h.continue;

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -97,12 +97,12 @@ describe('Unit | Infrastructure | ErrorManager', function() {
           });
         }
         else if (domainErrorName === 'InvalidStaticCourseCreationOrUpdateError') {
-          const errorStaticCourse = new domainErrorClass();
-          errorStaticCourse.addError({ attribute: 'name', detail: 'Un texte détaillant une erreur' });
-          errorStaticCourse.addError({ attribute: 'challengeIds', detail: 'le détail d\'une autre erreur' });
-          const responseStaticCourse = send(hFake, errorStaticCourse);
-          expect(responseStaticCourse.statusCode, expectErrorMessage).toStrictEqual(422);
-          expect(responseStaticCourse.source).toStrictEqual({
+          const errorInstance = new domainErrorClass();
+          errorInstance.addError({ attribute: 'name', detail: 'Un texte détaillant une erreur' });
+          errorInstance.addError({ attribute: 'challengeIds', detail: 'le détail d\'une autre erreur' });
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(422);
+          expect(responseForError.source).toStrictEqual({
             errors: [
               {
                 status: '422',
@@ -160,10 +160,10 @@ describe('Unit | Infrastructure | ErrorManager', function() {
           });
         }
         else if (domainErrorName === 'CommandWhitelistedUrlError') {
-          const errorCommandWhitelistedUrl = new domainErrorClass({ message, attribute });
-          const responseCommandWhitelistedUrl = send(hFake, errorCommandWhitelistedUrl);
-          expect(responseCommandWhitelistedUrl.statusCode, expectErrorMessage).toStrictEqual(422);
-          expect(responseCommandWhitelistedUrl.source).toStrictEqual({
+          const errorInstance = new domainErrorClass({ message, attribute });
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(422);
+          expect(responseForError.source).toStrictEqual({
             errors: [
               {
                 status: '422',
@@ -175,15 +175,29 @@ describe('Unit | Infrastructure | ErrorManager', function() {
           });
         }
         else if (domainErrorName === 'TagTitleAlreadyUsedError') {
-          const errorTagTitleAlreadyUsed = new domainErrorClass({ title: 'Internet' });
-          const responseTagTitleAlreadyUsed = send(hFake, errorTagTitleAlreadyUsed);
-          expect(responseTagTitleAlreadyUsed.statusCode, expectErrorMessage).toStrictEqual(409);
-          expect(responseTagTitleAlreadyUsed.source).toStrictEqual({
+          const errorInstance = new domainErrorClass({ title: 'Internet' });
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(409);
+          expect(responseForError.source).toStrictEqual({
             errors: [
               {
                 status: '409',
                 title: 'Conflict',
                 detail: 'Echec de création du tag : le titre "Internet" est déjà pris"',
+              },
+            ],
+          });
+        }
+        else if (domainErrorName === 'CloneSkillError') {
+          const errorInstance = new domainErrorClass('mon message');
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(400);
+          expect(responseForError.source).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Bad Request',
+                detail: 'mon message',
               },
             ],
           });


### PR DESCRIPTION
## 🔆 Problème

Dans la couche application, on se retrouve à répéter : 
```js
try {
  // mon code
} catch(err) {
  logger.error(err);
  Sentry.captureException(err);
  return Boom.internal(err);
}
```

## ⛱️ Proposition

centraliser le fait de faire apparaître l'erreur dans le logger + l'exception Sentry dans le pre-response-utils

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
