### PR TITLE
[TECH] Nettoyer régulièrement le contenu de la table "releases" (PIX-18203)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -5,6 +5,7 @@ import { logger } from './lib/infrastructure/logger.js';
 import { queue as checkUrlQueue } from './lib/infrastructure/scheduled-jobs/check-urls-job.js';
 import * as releaseJob from './lib/infrastructure/scheduled-jobs/release-job.js';
 import * as exportExternalUrlListJob from './lib/infrastructure/scheduled-jobs/export-external-url-list-job.js';
+import * as cleanReleasesJob from './lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js';
 import { disconnect } from './db/knex-database-connection.js';
 import { validateEnvironmentVariables } from './lib/infrastructure/validate-environement-variables.js';
 
@@ -17,6 +18,7 @@ async function start() {
 
     releaseJob.schedule();
     exportExternalUrlListJob.schedule();
+    cleanReleasesJob.schedule();
 
     logger.info('Server running at %s', server.info.uri);
   } catch (err) {
@@ -31,6 +33,7 @@ async function exitOnSignal(signal) {
     await disconnect();
     await checkUrlQueue.close();
     await releaseJob.queue.close();
+    await cleanReleasesJob.queue.close();
     process.exit(0);
   } catch (err) {
     logger.error(err);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -99,7 +99,8 @@ export const scheduledJobs = {
   createReleaseTime: process.env.CREATE_RELEASE_TIME,
   exportExternalUrlListTime: process.env.EXPORT_EXTERNAL_URL_LIST_TIME,
   attempts: _getNumber(process.env.CREATE_RELEASE_ATTEMPTS, 4),
-  startCheckUrlJob: isFeatureEnabled(process.env.START_CHECK_URL_JOB)
+  startCheckUrlJob: isFeatureEnabled(process.env.START_CHECK_URL_JOB),
+  cleanReleasesTableTime: process.env.CLEAN_RELEASES_TABLE_TIME,
 };
 
 export const database = {

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.cjs
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.cjs
@@ -1,0 +1,4 @@
+module.exports = async function releasesTableCleaningAndRetentionJobProcessor(job) {
+  const { default: processor } = await import('./release-table-cleaning-and-retention-job.js');
+  return processor(job);
+};

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
@@ -1,0 +1,42 @@
+import './job-process.js';
+import { child } from '../logger.js';
+import { knex } from '../../../db/knex-database-connection.js';
+
+const logger = child('releases-cleaning-and-retention-job', { event: 'lcms:releases-cleaning' });
+const MONTHS_FULL_DATA = 3;
+
+export default async function releasesTableCleaningAndRetention(dependencies = { logger: logger }) {
+  const trx = await knex.transaction();
+  let rowDeletedCount = 0;
+  try {
+    const now = new Date();
+    const dailyRetentionDate = new Date(now.getFullYear(), now.getMonth() - MONTHS_FULL_DATA, now.getDate());
+    const releaseDTOs = await trx('releases').select('id','createdAt').where('createdAt', '<', dailyRetentionDate);
+    const groupedByMonth = Object.groupBy(releaseDTOs, (dto) => {
+      return dto.createdAt.getMonth().toString();
+    });
+    const releaseIdsToDelete = [];
+    for (const releasesInSameMonth of Object.values(groupedByMonth)) {
+      releaseIdsToDelete.push(
+        ...releasesInSameMonth
+          .sort(byCreatedAtAsc)
+          .slice(1)
+          .map((release) => release.id)
+      );
+    }
+    const deletedReleases = await trx('releases').whereIn('id', releaseIdsToDelete).del(['id']);
+    rowDeletedCount = deletedReleases.length;
+    dependencies.logger.info(`${rowDeletedCount} rows deleted`);
+    trx.commit();
+  } catch (err) {
+    trx.rollback();
+    dependencies.logger.error(err);
+  }
+  if (rowDeletedCount > 0) {
+    await knex.raw('VACUUM ANALYZE releases');
+  }
+}
+
+function byCreatedAtAsc(releaseA, releaseB) {
+  return releaseA.createdAt - releaseB.createdAt;
+}

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js
@@ -1,0 +1,36 @@
+import { createQueue } from './create-queue.js';
+import * as config from '../../config.js';
+import { logger } from '../logger.js';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export const queue = createQueue('release-table-cleaning-and-retention-queue');
+const cjsFile = __dirname + '/release-table-cleaning-and-retention-job-processor.cjs';
+const esmFile = __dirname + '/release-table-cleaning-and-retention-job-processor.js';
+if (process.env.NODE_ENV === 'test') {
+  import(esmFile).then((module) => {
+    queue.process(module.default);
+  });
+} else {
+  queue.process(cjsFile);
+}
+
+const releaseTableCleaningAndRetentionJobOptions = {
+  attempts: config.scheduledJobs.attempts,
+  backoff: { type: 'exponential', delay: 100 },
+  removeOnComplete: true,
+  removeOnFail: 1,
+  repeat: {
+    cron: config.scheduledJobs.cleanReleasesTableTime,
+    tz: 'Europe/Paris',
+  },
+};
+
+export function schedule() {
+  if (!config.scheduledJobs.cleanReleasesTableTime) {
+    logger.info('Scheduled releases cleaning and retention is not enabled - check `CLEAN_RELEASES_TABLE_TIME` variable');
+    return;
+  }
+  queue.add({}, releaseTableCleaningAndRetentionJobOptions);
+}

--- a/api/sample.env
+++ b/api/sample.env
@@ -395,6 +395,16 @@ CREATE_RELEASE_TIME=0 0 * * *
 # default: none
 EXPORT_EXTERNAL_URL_LIST_TIME=0 9 1 * *
 
+# Cron date/time scheduled time to handle releases cleaning and retention in PG table.
+# Europe/Paris timezone is used as reference.
+#
+# If not present, the application will not clean the table.
+#
+# presence: optional
+# type: Cron expression
+# default: none
+CLEAN_RELEASES_TABLE_TIME=3 23 5 * *
+
 # The total number of attempts to try the job until it completes.
 #
 # See https://github.com/OptimalBits/bull/blob/ad3b796d75d0a0cd8b6d71c5e756640bc8d2d992/REFERENCE.md#queueadd

--- a/api/scripts/dev/jobs/releases-table-cleaning-and-retention.js
+++ b/api/scripts/dev/jobs/releases-table-cleaning-and-retention.js
@@ -1,0 +1,20 @@
+import { Script } from '../../../lib/application/scripts/script.js';
+import { ScriptRunner } from '../../../lib/application/scripts/script-runner.js';
+import releasesTableCleaningAndRetention
+  from '../../../lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js';
+
+export class CleanReleases extends Script {
+  constructor() {
+    super({
+      description: 'Manual trigger of the job "release-table-cleaning-and-retention-job-processor.js"',
+      permanent: true,
+      options: {},
+    });
+  }
+
+  async handle({ options: _, logger }) {
+    await releasesTableCleaningAndRetention({ logger });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CleanReleases);

--- a/api/tests/integration/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor_test.js
+++ b/api/tests/integration/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor_test.js
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import releasesTableCleaningAndRetention
+  from '../../../../lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+describe('Integration | Infrastructure | scheduled-jobs | releases-table-cleaning-and-retention-job', function() {
+  let logger;
+  beforeEach(function() {
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    vi.useFakeTimers({
+      now: new Date('2021-02-15T03:04:00Z'),
+    });
+  });
+
+  afterEach(function() {
+    vi.useRealTimers();
+  });
+
+  it('keeps all releases within 3 months and first release of each month for the older ones', async function() {
+    // given
+    // releases within 3 months
+    databaseBuilder.factory.buildRelease({ id: 1, createdAt: new Date('2021-02-15T00:00:00Z'), content: {} }); // keep
+    databaseBuilder.factory.buildRelease({ id: 2, createdAt: new Date('2021-01-15T00:00:00Z'), content: {} }); // keep
+    databaseBuilder.factory.buildRelease({ id: 3, createdAt: new Date('2020-12-15T00:00:00Z'), content: {} }); // keep
+    databaseBuilder.factory.buildRelease({ id: 4, createdAt: new Date('2020-11-15T00:00:00Z'), content: {} }); // keep
+    // older releases
+    databaseBuilder.factory.buildRelease({ id: 5, createdAt: new Date('2020-11-14T00:00:00Z'), content: {} }); // del
+    databaseBuilder.factory.buildRelease({ id: 6, createdAt: new Date('2020-11-02T00:00:00Z'), content: {} }); // keep
+    databaseBuilder.factory.buildRelease({ id: 7, createdAt: new Date('2020-10-01T00:00:00Z'), content: {} }); // keep
+    databaseBuilder.factory.buildRelease({ id: 8, createdAt: new Date('2020-10-01T00:00:01Z'), content: {} }); // del
+    databaseBuilder.factory.buildRelease({ id: 9, createdAt: new Date('2020-10-10T00:00:00Z'), content: {} }); // del
+    databaseBuilder.factory.buildRelease({ id: 10, createdAt: new Date('2020-10-18T00:00:00Z'), content: {} }); // del
+    databaseBuilder.factory.buildRelease({ id: 11, createdAt: new Date('2020-10-30T00:00:00Z'), content: {} }); // del
+    await databaseBuilder.commit();
+
+    // when
+    await releasesTableCleaningAndRetention({ logger });
+
+    // then
+    const idsInDB = await knex('releases').pluck('id').orderBy('id');
+    expect(idsInDB).toStrictEqual([1, 2, 3, 4, 6, 7]);
+    expect(logger.info).toHaveBeenCalledWith('5 rows deleted');
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

On créé une release une fois par jour, à force on commence à en avoir beaucoup et ça pèse lourd dans la BDD.
On conserve les anciennes releases pour de l'archivage et pour du "super au cas où".

## ⛱️ Proposition
Il ne semble pas exister une nécessité **ultime** à conserver toutes les releases, mais pour l'histoire c'est sympa d'en garder quelques unes. Je propose, pour une date D :
- Garder toutes les releases entre D et (D - 3 mois)
- Avant ça, garder la première release de chaque mois

Mise en place d'un job planifié, je propose une exécution une fois par mois

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Créer des releases à la con sur sa BDD perso et exécuter le script pour tester
