### PR TITLE
[BUGFIX] Corriger le déplacement d'un sujet (PIX-18209).

### DIFF
--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -43,13 +43,16 @@ export class Tube {
 
   /**
    * @param {Tube} updates
+   * @param {import('./Thematic.js').Thematic} thematic
    */
-  update(updates) {
+  update(updates, thematic) {
     this.name = updates.name;
     this.index = updates.index;
     this.practicalTitle_i18n.fr = updates.practicalTitle_i18n.fr;
     this.practicalTitle_i18n.en = updates.practicalTitle_i18n.en;
     this.practicalDescription_i18n.fr = updates.practicalDescription_i18n.fr;
     this.practicalDescription_i18n.en = updates.practicalDescription_i18n.en;
+    this.thematicAirtableId = thematic.airtableId;
+    this.competenceAirtableId = thematic.competenceAirtableId;
   }
 }

--- a/api/lib/domain/usecases/update-tube.js
+++ b/api/lib/domain/usecases/update-tube.js
@@ -1,16 +1,15 @@
-import { tubeRepository } from '../../infrastructure/repositories/index.js';
+import { tubeRepository, thematicRepository } from '../../infrastructure/repositories/index.js';
 import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 import { NotFoundError } from '../errors.js';
 
-export async function updateTube(tubeAirtableId, tubeUpdates, dependencies = { tubeRepository, updatePixApiReleaseCache }) {
+export async function updateTube(tubeAirtableId, tubeUpdates, dependencies = { tubeRepository, thematicRepository, updatePixApiReleaseCache }) {
   const tube = await dependencies.tubeRepository.getByAirtableId(tubeAirtableId);
   if (!tube) throw new NotFoundError('unknown tube id');
-
-  tube.update(tubeUpdates);
+  const thematic = await dependencies.thematicRepository.getByAirtableId(tubeUpdates.thematicAirtableId);
+  tube.update(tubeUpdates, thematic);
 
   const updatedTube = await dependencies.tubeRepository.update(tube);
 
   await dependencies.updatePixApiReleaseCache.onTubeUpdated(updatedTube);
-
   return updatedTube;
 }

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -19,9 +19,7 @@ export async function list() {
 export async function getByAirtableId(airtableId) {
   const datasourceThematic = await thematicDatasource.find(airtableId);
   if (!datasourceThematic) return null;
-
   const translations = await translationRepository.listByEntity(model, datasourceThematic.id);
-
   return toDomain(datasourceThematic, translations);
 }
 

--- a/api/tests/acceptance/application/tubes_test.js
+++ b/api/tests/acceptance/application/tubes_test.js
@@ -3,7 +3,7 @@ import nock from 'nock';
 
 import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, knex } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
-import { tubeDatasource } from '../../../lib/infrastructure/datasources/airtable/tube-datasource.js';
+import { tubeDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import * as idGenerator from '../../../lib/infrastructure/utils/id-generator.js';
 
 describe('Application | Route | Tubes', () => {
@@ -769,9 +769,18 @@ describe('Application | Route | Tubes', () => {
           airtableId: 'recTube1',
           name: '@test',
           index: 1,
-          competenceAirtableId: 'recCompetence1',
-          thematicAirtableId: 'recThematic1',
+          competenceAirtableId: 'recCompetence0',
+          thematicAirtableId: 'recThematic0',
           skillAirtableIds: ['recSkill1', 'recSkill2'],
+        }));
+        const airtableThematic = airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({
+          id: 'thematic1',
+          airtableId: 'recThematic1',
+          competenceId: 'recCompetence1',
+          competenceAirtableId: 'recCompetence1',
+          tubeIds: ['tubeId0'],
+          tubeAirtableIds: ['recTube0'],
+          index: 0
         }));
 
         airtableTubeScope = nock('https://api.airtable.com')
@@ -780,10 +789,18 @@ describe('Application | Route | Tubes', () => {
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .reply(200, airtableTube);
 
+        airtableTubeScope = nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/Thematiques/recThematic1')
+          .query({})
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, airtableThematic);
+
         databaseBuilder.factory.buildTranslation({ key: 'tube.tube1.practicalTitle', locale: 'fr', value: 'Titre du tube' });
         databaseBuilder.factory.buildTranslation({ key: 'tube.tube1.practicalTitle', locale: 'en', value: 'Tube’s title' });
         databaseBuilder.factory.buildTranslation({ key: 'tube.tube1.practicalDescription', locale: 'fr', value: 'Description du tube' });
         databaseBuilder.factory.buildTranslation({ key: 'tube.tube1.practicalDescription', locale: 'en', value: 'Tube’s description' });
+
+        databaseBuilder.factory.buildTranslation({ key: 'thematic.thematic1.name', locale: 'fr', value: 'Nom de la thématique' });
 
         await databaseBuilder.commit();
 
@@ -839,12 +856,6 @@ describe('Application | Route | Tubes', () => {
                 'practical-description-en': 'Tube’s description after',
               },
               relationships: {
-                'competence': {
-                  data: {
-                    type: 'competences',
-                    id: 'recCompetence1',
-                  },
-                },
                 'theme': {
                   data: {
                     type: 'themes',
@@ -917,6 +928,7 @@ describe('Application | Route | Tubes', () => {
         expect(airtableTubeScope.isDone()).toBe(true);
 
         await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
+          { key: 'thematic.thematic1.name', locale: 'fr', value: 'Nom de la thématique' },
           { key: 'tube.tube1.practicalDescription', locale: 'en', value: 'Tube’s description after' },
           { key: 'tube.tube1.practicalDescription', locale: 'fr', value: 'Description tube après' },
           { key: 'tube.tube1.practicalTitle', locale: 'en', value: 'Tube’s title after' },

--- a/api/tests/unit/domain/models/Tube_test.js
+++ b/api/tests/unit/domain/models/Tube_test.js
@@ -82,8 +82,18 @@ describe('Unit | Domain | Tube', () => {
         },
       });
 
+      const thematicDestination = domainBuilder.buildThematicDatasourceObject({
+        id: 'thematic1',
+        airtableId: 'recThematic1',
+        competenceId: 'recCompetence1',
+        competenceAirtableId: 'recCompetence1',
+        tubeIds: ['tubeId0'],
+        tubeAirtableIds: ['recTube0'],
+        index: 0
+      });
+
       // when
-      tube.update(tubeUpdates);
+      tube.update(tubeUpdates, thematicDestination);
 
       // then
       expect(tube).toHaveProperty('name', '@pouet');
@@ -92,6 +102,9 @@ describe('Unit | Domain | Tube', () => {
       expect(tube).toHaveProperty('practicalTitle_i18n.en', 'Title after');
       expect(tube).toHaveProperty('practicalDescription_i18n.fr', 'Description après');
       expect(tube).toHaveProperty('practicalDescription_i18n.en', 'Description after');
+
+      expect(tube).toHaveProperty('thematicAirtableId', 'recThematic1');
+      expect(tube).toHaveProperty('competenceAirtableId', 'recCompetence1');
     });
   });
 });

--- a/api/tests/unit/domain/usecases/update-tube_test.js
+++ b/api/tests/unit/domain/usecases/update-tube_test.js
@@ -7,14 +7,23 @@ describe('Unit | Domain | Use Cases | update-tube', () => {
 
   const updatedTube = Symbol('updatedTube');
   const tubeUpdates = Symbol('tubeUpdates');
+  const thematicDestination = {
+    thematicAirtableId: 'thematicAirtableId',
+    competenceAirtableId: 'competenceAirtableId'
+  };
 
-  let tubeRepository, tube, updateStub, updatePixApiReleaseCache;
+  let tubeRepository, thematicRepository, tube, updateStub, updatePixApiReleaseCache;
 
   beforeEach(() => {
     tubeRepository = {
       getByAirtableId: vi.fn(),
       update: vi.fn(),
     };
+
+    thematicRepository = {
+      getByAirtableId: vi.fn().mockReturnValueOnce(thematicDestination)
+    };
+
     updatePixApiReleaseCache = {
       onTubeUpdated: vi.fn().mockResolvedValueOnce(),
     };
@@ -27,10 +36,11 @@ describe('Unit | Domain | Use Cases | update-tube', () => {
     tubeRepository.update.mockResolvedValueOnce(updatedTube);
   });
 
-  it('updates thematic and saves it', async () => {
+  it('updates tube and saves it', async () => {
     // when
     const result = updateTube('recTube1', tubeUpdates, {
       tubeRepository,
+      thematicRepository,
       updatePixApiReleaseCache,
     });
 
@@ -38,12 +48,12 @@ describe('Unit | Domain | Use Cases | update-tube', () => {
     await expect(result).resolves.toBe(updatedTube);
 
     expect(tubeRepository.getByAirtableId).toHaveBeenCalledWith('recTube1');
-    expect(updateStub).toHaveBeenCalledWith(tubeUpdates);
+    expect(updateStub).toHaveBeenCalledWith(tubeUpdates, thematicDestination);
     expect(tubeRepository.update).toHaveBeenCalledWith(tube);
     expect(updatePixApiReleaseCache.onTubeUpdated).toHaveBeenCalledWith(updatedTube);
   });
 
-  describe('when thematic is not found', () => {
+  describe('when tube is not found', () => {
     it('throws a NotFoundError', async () => {
       // given
       tubeRepository.getByAirtableId.mockReset().mockResolvedValueOnce(null);

--- a/pix-editor/app/controllers/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/single.js
@@ -128,7 +128,7 @@ export default class SingleController extends Controller {
       .then(() => {
         this.loader.stop();
         this.notify.message('Tube mis à jour');
-        this.router.transitionTo('authenticated.competence.tubes.single', newCompetence, tube);
+        this.router.transitionTo('authenticated.competence.skills', newCompetence.id);
       })
       .catch((error) => {
         console.error(error);

--- a/pix-editor/app/routes/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/tubes/single.js
@@ -11,10 +11,6 @@ export default class SingleRoute extends Route {
     return this.store.findRecord('tube', params.tube_id);
   }
 
-  afterModel(model) {
-    this.currentData.setPrototype(model);
-  }
-
   setupController(controller) {
     super.setupController(...arguments);
     controller.edition = false;

--- a/pix-editor/tests/unit/controllers/competence/tubes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/tubes/single-test.js
@@ -179,7 +179,7 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
       assert.ok(saveStub.calledOnce);
       assert.ok(loaderStopStub.calledOnce);
       assert.ok(notifyMessageStub.calledWith('Tube mis à jour'));
-      assert.ok(transitionToRouteStub.calledWith('authenticated.competence.tubes.single', newCompetence, controller.model));
+      assert.ok(transitionToRouteStub.calledWith('authenticated.competence.skills', newCompetence.id));
       assert.deepEqual(competence, newCompetence);
       assert.deepEqual(theme, newTheme);
     });


### PR DESCRIPTION
## 🔆 Problème

Lors de la mise à jour d'un sujet, sa thématique ne l'était pas ce qui rendait le déplacement d'un sujet impossible. 

## ⛱️ Proposition

Corriger la mise à jour d'un sujet en assurant la relation avec la compétence et la thématique de destination.

## 🌊 Remarques

Nous redirigeons maintenant vers la route `competence/skills` une fois qu'un sujet est déplacé, car la route de modification d'un sujet est sœur de la route `competence/skills` ce qui entraîne un bug au niveau du chargement de la grille des acquis.

Un bug persiste lors du rafraîchissement de la page `competence/tube`, la grille des acquis n'est pas chargée.

## 🏄 Pour tester

Déplacer un sujet de thématique.
Déplacer un sujet de compétence.
