### PR TITLE
[FEATURE] Modifier le terme "Type" en "Modalité" dans les formulaires et dans la vue atelier de l'atelier sur PixEditor (PIX-17961)

### DIFF
--- a/pix-editor/app/components/challenge-view/challenge-view.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view.gjs
@@ -66,7 +66,7 @@ export default class ChallengeViewProduction extends Component {
         @value={{@challenge.type}}
         @isDisabled={{true}}
       >
-        <:label>Type</:label>
+        <:label>Modalité</:label>
       </PixSelect>
 
       {{#if @challenge.isTextBased}}

--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -33,7 +33,7 @@
       @isDisabled={{not @edition}}
       @hideDefaultOption={{true}}
     >
-      <:label>Type</:label>
+      <:label>Modalité</:label>
     </PixSelect>
     <div class="field">
       <Field::Checkbox

--- a/pix-editor/app/components/list/workbench.js
+++ b/pix-editor/app/components/list/workbench.js
@@ -16,7 +16,7 @@ export default class CompetencesList extends SortedList {
     name: 'Consigne',
     valuePath: 'instruction',
   }, {
-    name: 'Type',
+    name: 'Modalité',
     valuePath: 'type',
     maxWidth: 150,
   }, {
@@ -33,13 +33,13 @@ export default class CompetencesList extends SortedList {
     'status': 'string',
   };
 
+  get current() {
+    return this.currentData.getPrototype();
+  }
+
   @action
   selectRow(row) {
     this.router.transitionTo(this.args.link, this.args.competenceModel, row);
-  }
-
-  get current() {
-    return this.currentData.getPrototype();
   }
 
 }

--- a/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
@@ -71,7 +71,7 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
     // then
     assert.dom(screen.getByLabelText('Consigne')).hasText('instructions');
     assert.dom(screen.getByLabelText('Alternative textuelle')).hasText('alternativeInstruction');
-    assert.dom(screen.getByLabelText('Type')).hasText('QROC');
+    assert.dom(screen.getByLabelText('Modalité')).hasText('QROC');
     assert.dom(screen.getByLabelText('Format')).hasValue('format');
     assert.dom(screen.getByLabelText('Propositions')).hasText('suggestion');
     assert.dom(screen.getByLabelText('Réponses')).hasText('answers');

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -59,7 +59,7 @@ module('Integration | Component | challenge-form', function(hooks) {
 
     // When
     screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}} @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
-    await click(screen.getByRole('button', { name: 'Type' }));
+    await click(screen.getByRole('button', { name: 'Modalité' }));
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'QCM' }));
 
@@ -87,7 +87,7 @@ module('Integration | Component | challenge-form', function(hooks) {
 
     // When
     screen = await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @edition={{true}}  @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
-    await click(screen.getByRole('button', { name: 'Type' }));
+    await click(screen.getByRole('button', { name: 'Modalité' }));
     await screen.findByRole('listbox');
     await click(screen.getByRole('option', { name: 'QCM' }));
 


### PR DESCRIPTION
## 🔆 Problème
On souhaite renommer "Type" en "Modalité"

## ⛱️ Proposition
Renommage côté front

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester
formulaire v1 et v2 + atelier de l'atelier
