### PR TITLE
[TECH] Clarifier la construction des projections de réplication et de release du modèle Framework

### DIFF
--- a/api/lib/domain/models/replication/FrameworkForReplication.js
+++ b/api/lib/domain/models/replication/FrameworkForReplication.js
@@ -1,0 +1,9 @@
+export class FrameworkForReplication {
+  constructor({
+    id,
+    name,
+  }) {
+    this.id = id;
+    this.name = name;
+  }
+}

--- a/api/lib/domain/models/replication/index.js
+++ b/api/lib/domain/models/replication/index.js
@@ -1,1 +1,3 @@
+export * from './FrameworkForReplication.js';
 export * from './SkillForReplication.js';
+

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -14,21 +14,39 @@ import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import { child } from '../../infrastructure/logger.js';
 import * as Sentry from '@sentry/node';
 
+/**
+ * @typedef {import('../../../lib/domain/models').Attachment} Attachment
+ * @typedef {import('../../../lib/domain/models').Tube} Tube
+ * @typedef {import('../../../lib/domain/models').Tutorial} Tutorial
+ **/
+
 const logger = child('updatePixApiReleaseCacheService', { event: 'lcms:patch-release' });
 
-export async function onAttachmentCreated({ attachment }) {
-  await onAttachmentCreatedOrDeleted({ attachment });
+/**
+ * @param {Attachment} attachment
+ */
+export async function onAttachmentCreated(attachment) {
+  await onAttachmentCreatedOrDeleted(attachment);
 }
 
-export async function onAttachmentUpdated({ attachment: _ }) {
+/**
+ * @param {Attachment} _
+ */
+export async function onAttachmentUpdated(_) {
   // do nothing cause fields allowed to be updated in attachment are not exposed in release
 }
 
-export async function onAttachmentDeleted({ attachment }) {
-  await onAttachmentCreatedOrDeleted({ attachment });
+/**
+ * @param {Attachment} attachment
+ */
+export async function onAttachmentDeleted(attachment) {
+  await onAttachmentCreatedOrDeleted(attachment);
 }
 
-async function onAttachmentCreatedOrDeleted({ attachment }) {
+/**
+ * @param {Attachment} attachment
+ */
+async function onAttachmentCreatedOrDeleted(attachment) {
   if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
   try {
     const localizedChallengeId = attachment.challengeId ?? attachment.localizedChallengeId;
@@ -49,15 +67,24 @@ async function onAttachmentCreatedOrDeleted({ attachment }) {
   }
 }
 
-export async function onTutorialCreated({ tutorial }) {
-  await onTutorialCreatedOrUpdated({ tutorial });
+/**
+ * @param {Tutorial} tutorial
+ */
+export async function onTutorialCreated(tutorial) {
+  await onTutorialCreatedOrUpdated(tutorial);
 }
 
-export async function onTutorialUpdated({ tutorial }) {
-  await onTutorialCreatedOrUpdated({ tutorial });
+/**
+ * @param {Tutorial} tutorial
+ */
+export async function onTutorialUpdated(tutorial) {
+  await onTutorialCreatedOrUpdated(tutorial);
 }
 
-async function onTutorialCreatedOrUpdated({ tutorial }) {
+/**
+ * @param {Tutorial} tutorial
+ */
+async function onTutorialCreatedOrUpdated(tutorial) {
   if (pixApiClient.isPixApiCachePatchingEnabled()) {
     try {
       const [tutorialForRelease] = tutorialTransformer.filterTutorialsFields([tutorial]);
@@ -74,8 +101,8 @@ async function onTutorialCreatedOrUpdated({ tutorial }) {
 }
 
 /**
- * @param {import('../models'.Tube)} tube
- * @param {string} thematicAirtableId
+ * @param {Tube} tube
+ * @param {string} thematicId
  */
 export async function onTubeCreated(tube, thematicId) {
   if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
@@ -92,7 +119,7 @@ export async function onTubeCreated(tube, thematicId) {
 }
 
 /**
- * @param {import('../models'.Tube} tube
+ * @param {Tube} tube
  */
 export async function onTubeUpdated(tube) {
   if (!pixApiClient.isPixApiCachePatchingEnabled()) return;

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -1,5 +1,6 @@
 import {
   createChallengeTransformer,
+  frameworkTransformer,
   tubeTransformer,
   tutorialTransformer,
 } from '../../infrastructure/transformers/index.js';
@@ -16,6 +17,7 @@ import * as Sentry from '@sentry/node';
 
 /**
  * @typedef {import('../../../lib/domain/models').Attachment} Attachment
+ * @typedef {import('../../../lib/domain/models').Framework} Framework
  * @typedef {import('../../../lib/domain/models').Tube} Tube
  * @typedef {import('../../../lib/domain/models').Tutorial} Tutorial
  **/
@@ -64,6 +66,24 @@ async function onAttachmentCreatedOrDeleted(attachment) {
   } catch (err) {
     logger.error(err);
     Sentry.captureException(err);
+  }
+}
+
+/**
+ * @param {Framework} framework
+ */
+export async function onFrameworkCreated(framework) {
+  if (pixApiClient.isPixApiCachePatchingEnabled()) {
+    try {
+      await updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'frameworks',
+        updatedRecord: frameworkTransformer.forRelease(framework),
+      });
+    } catch (err) {
+      logger.error(err);
+      Sentry.captureException(err);
+    }
   }
 }
 

--- a/api/lib/domain/usecases/create-attachment.js
+++ b/api/lib/domain/usecases/create-attachment.js
@@ -15,6 +15,6 @@ export async function createAttachment({
     localizedChallengeId: attachmentCreationCommand.localizedChallengeId ?? attachmentCreationCommand.challengeId,
   });
   const createdAttachment = await attachmentRepository.create(attachmentToCreate);
-  await updatePixApiReleaseCache.onAttachmentCreated({ attachment: createdAttachment });
+  await updatePixApiReleaseCache.onAttachmentCreated(createdAttachment);
   return createdAttachment;
 }

--- a/api/lib/domain/usecases/create-framework.js
+++ b/api/lib/domain/usecases/create-framework.js
@@ -1,23 +1,8 @@
-import * as Sentry from '@sentry/node';
-import { logger } from '../../infrastructure/logger.js';
-import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
-import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { frameworkTransformer } from '../../infrastructure/transformers/index.js';
 import { frameworkRepository } from '../../infrastructure/repositories/index.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 export async function createFramework(framework) {
   const createdFramework = await frameworkRepository.create(framework);
-
-  try {
-    await updatedRecordNotifier.notify({
-      pixApiClient,
-      model: 'frameworks',
-      updatedRecord: frameworkTransformer.filterFrameworkFields(createdFramework),
-    });
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-  }
-
+  await updatePixApiReleaseCache.onFrameworkCreated(createdFramework);
   return createdFramework;
 }

--- a/api/lib/domain/usecases/create-tutorial.js
+++ b/api/lib/domain/usecases/create-tutorial.js
@@ -2,6 +2,6 @@ import * as updatePixApiReleaseCache from '../services/update-pix-api-release-ca
 
 export async function createTutorial(tutorial, dependencies = { tutorialRepository }) {
   const createdTutorial = await dependencies.tutorialRepository.create(tutorial);
-  await updatePixApiReleaseCache.onTutorialCreated({ tutorial: createdTutorial });
+  await updatePixApiReleaseCache.onTutorialCreated(createdTutorial);
   return createdTutorial;
 }

--- a/api/lib/domain/usecases/delete-attachment.js
+++ b/api/lib/domain/usecases/delete-attachment.js
@@ -9,5 +9,5 @@ export async function deleteAttachment({
   if (!attachmentToDelete)
     throw new NotFoundError(`Attachment d'id ${attachmentId} n'existe pas`);
   await attachmentRepository.remove(attachmentId);
-  await updatePixApiReleaseCache.onAttachmentDeleted({ attachment: attachmentToDelete });
+  await updatePixApiReleaseCache.onAttachmentDeleted(attachmentToDelete);
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -74,7 +74,6 @@ export async function getLearningContentForReplication() {
     entityId: translation.entityId,
     sourceEntityId: null,
   }));
-  const transformedFrameworks = frameworkTransformer.filterFrameworksFields(frameworks);
   const transformedAreas = areaTransformer.filterAreasFields(areas);
   const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
@@ -122,7 +121,7 @@ export async function getLearningContentForReplication() {
 
   await setImmediatePromise();
   return {
-    frameworks: transformedFrameworks,
+    frameworks: frameworkTransformer.forReplication(frameworks),
     areas: transformedAreas,
     competences: transformedCompetences,
     thematics: transformedThematics,

--- a/api/lib/domain/usecases/update-attachment.js
+++ b/api/lib/domain/usecases/update-attachment.js
@@ -10,6 +10,6 @@ export async function updateAttachment({
     throw new NotFoundError(`Attachment d'id ${attachmentUpdateCommand.id} n'existe pas`);
   attachment.update(attachmentUpdateCommand);
   const updatedAttachment = await attachmentRepository.update(attachment);
-  await updatePixApiReleaseCache.onAttachmentUpdated({ attachment: updatedAttachment });
+  await updatePixApiReleaseCache.onAttachmentUpdated(updatedAttachment);
   return updatedAttachment;
 }

--- a/api/lib/domain/usecases/update-tutorial.js
+++ b/api/lib/domain/usecases/update-tutorial.js
@@ -8,6 +8,6 @@ export async function updateTutorial(tutorialData, dependencies = { tutorialRepo
   }
   tutorial.update(tutorialData);
   const updatedTutorial = await dependencies.tutorialRepository.update(tutorial);
-  await updatePixApiReleaseCache.onTutorialUpdated({ tutorial: updatedTutorial });
+  await updatePixApiReleaseCache.onTutorialUpdated(updatedTutorial);
   return updatedTutorial;
 }

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -109,7 +109,6 @@ async function _getCurrentContent() {
   const transformedChallenges = translatedChallenges.map(transformChallenge);
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
-  const transformedFrameworks = frameworkTransformer.filterFrameworksFields(frameworks);
   const transformedAreas = areaTransformer.filterAreasFields(areas);
 
   const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);
@@ -117,7 +116,7 @@ async function _getCurrentContent() {
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
 
   return {
-    frameworks: transformedFrameworks,
+    frameworks: frameworkTransformer.forRelease(frameworks),
     areas: transformedAreas,
     competences: filteredCompetences,
     thematics: transformedThematics,

--- a/api/lib/infrastructure/transformers/framework-transformer.js
+++ b/api/lib/infrastructure/transformers/framework-transformer.js
@@ -28,11 +28,3 @@ export function forReplication(frameworks) {
   }
   return new FrameworkForReplication(frameworks);
 }
-
-export function filterFrameworkFields({ id, name }) {
-  return { id, name };
-}
-
-export function filterFrameworksFields(frameworks) {
-  return frameworks.map(filterFrameworkFields);
-}

--- a/api/lib/infrastructure/transformers/framework-transformer.js
+++ b/api/lib/infrastructure/transformers/framework-transformer.js
@@ -1,3 +1,34 @@
+import { FrameworkForRelease } from '../../domain/models/release/index.js';
+import { FrameworkForReplication } from '../../domain/models/replication/index.js';
+
+/**
+ * @typedef {import('../../../lib/domain/models').Framework} Framework
+ * @typedef {import('../../../lib/domain/models/release').FrameworkForRelease} FrameworkForRelease
+ * @typedef {import('../../../lib/domain/models/replication').FrameworkForReplication} FrameworkForReplication
+ */
+
+/**
+ * @param {Framework|Framework[]} frameworks
+ * @returns {FrameworkForRelease|FrameworkForRelease[]}
+ */
+export function forRelease(frameworks) {
+  if (Array.isArray(frameworks)) {
+    return frameworks.map((framework) => new FrameworkForRelease(framework));
+  }
+  return new FrameworkForRelease(frameworks);
+}
+
+/**
+ @param {Framework|Framework[]} frameworks
+ @returns {FrameworkForReplication|FrameworkForReplication[]}
+ */
+export function forReplication(frameworks) {
+  if (Array.isArray(frameworks)) {
+    return frameworks.map((framework) => new FrameworkForReplication(framework));
+  }
+  return new FrameworkForReplication(frameworks);
+}
+
 export function filterFrameworkFields({ id, name }) {
   return { id, name };
 }

--- a/api/tests/acceptance/application/frameworks_test.js
+++ b/api/tests/acceptance/application/frameworks_test.js
@@ -1,21 +1,23 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
-import {
-  airtableBuilder,
-  databaseBuilder,
-  domainBuilder,
-  generateAuthorizationHeader,
-} from '../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import { frameworkDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
+import * as config from '../../../lib/config.js';
 
 describe('Acceptance | Route | frameworks', () => {
+  let editorUser, adminUser, originalPixApiUrlValue;
 
-  let editorUser, adminUser;
   beforeEach(async function() {
+    originalPixApiUrlValue = config.pixApi.baseUrl;
+    delete config.pixApi.baseUrl;
     editorUser = databaseBuilder.factory.buildEditorUser();
     adminUser = databaseBuilder.factory.buildAdminUser();
     await databaseBuilder.commit();
+  });
+
+  afterEach(function() {
+    config.pixApi.baseUrl = originalPixApiUrlValue;
   });
 
   describe('GET /frameworks', () => {
@@ -208,19 +210,6 @@ describe('Acceptance | Route | frameworks', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: [airtableFramework] });
 
-      const pixApiToken = 'secret';
-      nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
-        .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-        .reply(200, { 'access_token': pixApiToken });
-      const pixApiCacheScope = nock('https://api.test.pix.fr')
-        .patch('/api/cache/frameworks/framework4', {
-          id: 'framework4',
-          name: 'Prix',
-        })
-        .matchHeader('Authorization', `Bearer ${pixApiToken}`)
-        .reply(200);
-
       const server = await createServer();
 
       // when
@@ -240,7 +229,6 @@ describe('Acceptance | Route | frameworks', () => {
 
       // then
       expect(response.statusCode).toBe(201);
-
       expect(response.result).toEqual({
         data: {
           type: 'frameworks',
@@ -255,9 +243,7 @@ describe('Acceptance | Route | frameworks', () => {
           },
         },
       });
-
       expect(airtableFrameworksScope.isDone()).toBe(true);
-      expect(pixApiCacheScope.isDone()).toBe(true);
     });
   });
 });

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -3,7 +3,7 @@ import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationH
 import { createServer } from '../../../server.js';
 import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
 import _ from 'lodash';
-import { SkillForReplication } from '../../../lib/domain/models/replication/index.js';
+import { FrameworkForReplication, SkillForReplication } from '../../../lib/domain/models/replication/index.js';
 
 const {
   buildFramework,
@@ -64,7 +64,7 @@ async function mockCurrentContent() {
   const expectedCurrentContent = {
     translations: [],
   };
-  const expectedFramework = omit(['areaIds'], domainBuilder.buildFramework());
+  const expectedFramework = omit(['areaIds'], new FrameworkForReplication(domainBuilder.buildFramework()));
   expectedCurrentContent.frameworks = [expectedFramework];
 
   const area = domainBuilder.buildArea();

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -112,7 +112,7 @@ describe('Integration | Service | update pix api release cache', function() {
             .reply(200);
 
           // when
-          await updatePixApiReleaseCache.onAttachmentCreated({ attachment: new Attachment({ challengeId: 'challengeIdA', localizedChallengeId: null }) });
+          await updatePixApiReleaseCache.onAttachmentCreated(new Attachment({ challengeId: 'challengeIdA', localizedChallengeId: null }));
 
           // then
           expect(airtableGetChallengeScope.isDone()).to.be.true;
@@ -209,7 +209,7 @@ describe('Integration | Service | update pix api release cache', function() {
             .reply(200);
 
           // when
-          await updatePixApiReleaseCache.onAttachmentCreated({ attachment: new Attachment({ challengeId: null, localizedChallengeId: 'challengeIdA_ES' }) });
+          await updatePixApiReleaseCache.onAttachmentCreated(new Attachment({ challengeId: null, localizedChallengeId: 'challengeIdA_ES' }));
 
           // then
           expect(airtableGetChallengeScope.isDone()).to.be.true;
@@ -226,7 +226,7 @@ describe('Integration | Service | update pix api release cache', function() {
         config.pixApi.baseUrl = undefined;
 
         // when
-        await updatePixApiReleaseCache.onAttachmentCreated({ attachment: new Attachment({ challengeId: 'challengeIdA' }) });
+        await updatePixApiReleaseCache.onAttachmentCreated(new Attachment({ challengeId: 'challengeIdA' }));
 
         // then
         expect(notifyStub).not.toHaveBeenCalled();
@@ -327,7 +327,7 @@ describe('Integration | Service | update pix api release cache', function() {
             .reply(200);
 
           // when
-          await updatePixApiReleaseCache.onAttachmentDeleted({ attachment: new Attachment({ challengeId: 'challengeIdA', localizedChallengeId: null }) });
+          await updatePixApiReleaseCache.onAttachmentDeleted(new Attachment({ challengeId: 'challengeIdA', localizedChallengeId: null }));
 
           // then
           expect(airtableGetChallengeScope.isDone()).to.be.true;
@@ -424,7 +424,7 @@ describe('Integration | Service | update pix api release cache', function() {
             .reply(200);
 
           // when
-          await updatePixApiReleaseCache.onAttachmentDeleted({ attachment: new Attachment({ challengeId: null, localizedChallengeId: 'challengeIdA_ES' }) });
+          await updatePixApiReleaseCache.onAttachmentDeleted(new Attachment({ challengeId: null, localizedChallengeId: 'challengeIdA_ES' }));
 
           // then
           expect(airtableGetChallengeScope.isDone()).to.be.true;
@@ -441,7 +441,7 @@ describe('Integration | Service | update pix api release cache', function() {
         config.pixApi.baseUrl = undefined;
 
         // when
-        await updatePixApiReleaseCache.onAttachmentDeleted({ attachment: new Attachment({ challengeId: 'challengeIdA' }) });
+        await updatePixApiReleaseCache.onAttachmentDeleted(new Attachment({ challengeId: 'challengeIdA' }));
 
         // then
         expect(notifyStub).not.toHaveBeenCalled();
@@ -457,7 +457,7 @@ describe('Integration | Service | update pix api release cache', function() {
         config.pixApi.baseUrl = 'https://some-api-base-url.fr';
 
         // when
-        await updatePixApiReleaseCache.onAttachmentUpdated({ attachment: new Attachment({ challengeId: 'challengeIdA' }) });
+        await updatePixApiReleaseCache.onAttachmentUpdated(new Attachment({ challengeId: 'challengeIdA' }));
 
         // then
         expect(notifyStub).toHaveBeenCalledTimes(0);
@@ -470,7 +470,7 @@ describe('Integration | Service | update pix api release cache', function() {
         config.pixApi.baseUrl = undefined;
 
         // when
-        await updatePixApiReleaseCache.onAttachmentUpdated({ attachment: new Attachment({ challengeId: 'challengeIdA' }) });
+        await updatePixApiReleaseCache.onAttachmentUpdated(new Attachment({ challengeId: 'challengeIdA' }));
 
         // then
         expect(notifyStub).toHaveBeenCalledTimes(0);
@@ -526,7 +526,7 @@ describe('Integration | Service | update pix api release cache', function() {
           .reply(200);
 
         // when
-        await updatePixApiReleaseCache.onTutorialCreated({ tutorial });
+        await updatePixApiReleaseCache.onTutorialCreated(tutorial);
 
         // then
         expect(pixApiCacheScope.isDone()).to.be.true;
@@ -545,7 +545,7 @@ describe('Integration | Service | update pix api release cache', function() {
         const spy = vi.spyOn(updatedRecordNotifier, 'notify');
 
         // when
-        await updatePixApiReleaseCache.onTutorialCreated({ tutorial });
+        await updatePixApiReleaseCache.onTutorialCreated(tutorial);
 
         // then
         expect(spy).toHaveBeenCalledTimes(0);
@@ -601,7 +601,7 @@ describe('Integration | Service | update pix api release cache', function() {
           .reply(200);
 
         // when
-        await updatePixApiReleaseCache.onTutorialUpdated({ tutorial });
+        await updatePixApiReleaseCache.onTutorialUpdated(tutorial);
 
         // then
         expect(pixApiCacheScope.isDone()).to.be.true;
@@ -617,7 +617,7 @@ describe('Integration | Service | update pix api release cache', function() {
 
       it('should not patch anything', async function() {
         // when
-        await updatePixApiReleaseCache.onTutorialUpdated({ tutorial });
+        await updatePixApiReleaseCache.onTutorialUpdated(tutorial);
 
         // then
         expect(notifyStub).not.toHaveBeenCalled();

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
-import { Attachment, Challenge, Tutorial } from '../../../../lib/domain/models/index.js';
+import { Attachment, Challenge, Framework, Tutorial } from '../../../../lib/domain/models/index.js';
 import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import * as config from '../../../../lib/config.js';
@@ -474,6 +474,67 @@ describe('Integration | Service | update pix api release cache', function() {
 
         // then
         expect(notifyStub).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('#onFrameworkCreated', function() {
+    let framework;
+
+    beforeEach(function() {
+      framework = new Framework({
+        id: 'frameworkABC123',
+        name: 'Nom de mon framework',
+        areaIds: ['areaId1', 'areaId2'],
+      });
+    });
+
+    context('when patchingPixApi is enabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        config.pixApi.baseUrl = 'https://some-api-base-url.fr';
+      });
+
+      it('should patch the tutorial', async function() {
+        // given
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { 'access_token': pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch('/api/cache/frameworks/frameworkABC123', {
+            id: 'frameworkABC123',
+            name: 'Nom de mon framework',
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onFrameworkCreated(framework);
+
+        // then
+        expect(pixApiCacheScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when patchingPixApi is disabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        delete config.pixApi.baseUrl;
+      });
+
+      it('should not patch anything', async function() {
+        // given
+        const spy = vi.spyOn(updatedRecordNotifier, 'notify');
+
+        // when
+        await updatePixApiReleaseCache.onFrameworkCreated(framework);
+
+        // then
+        expect(spy).toHaveBeenCalledTimes(0);
       });
     });
   });

--- a/api/tests/unit/infrastructure/transformers/framework-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/framework-transformer_test.js
@@ -1,0 +1,114 @@
+import { describe, describe as context, expect, it } from 'vitest';
+import { forRelease, forReplication } from '../../../../lib/infrastructure/transformers/framework-transformer.js';
+import { Framework } from '../../../../lib/domain/models/index.js';
+import { FrameworkForRelease } from '../../../../lib/domain/models/release/index.js';
+import { FrameworkForReplication } from '../../../../lib/domain/models/replication/index.js';
+
+describe('Unit | Infrastructure | framework-transformer', function() {
+
+  describe('#forRelease', function() {
+    context('when providing a single Framework', function() {
+      it('should transform it into a single FrameworkForRelease', function() {
+        // given
+        const framework = new Framework({
+          id: 'frameworkABC123',
+          name: 'Nom de mon framework',
+          areaIds: ['areaId1', 'areaId2'],
+        });
+
+        // when
+        const actualFrameworkForRelease = forRelease(framework);
+
+        // then
+        expect(actualFrameworkForRelease).toStrictEqual(new FrameworkForRelease({
+          id: 'frameworkABC123',
+          name: 'Nom de mon framework',
+        }));
+      });
+    });
+
+    context('when providing several Frameworks', function() {
+      it('should transform them into a several FrameworksForRelease', function() {
+        // given
+        const frameworkA = new Framework({
+          id: 'frameworkABC123',
+          name: 'Nom de mon framework A',
+          areaIds: ['areaId1', 'areaId2'],
+        });
+        const frameworkB = new Framework({
+          id: 'frameworkDEF456',
+          name: 'Nom de mon framework B',
+          areaIds: ['areaId3', 'areaId4'],
+        });
+
+        // when
+        const actualFrameworksForRelease = forRelease([frameworkA, frameworkB]);
+
+        // then
+        expect(actualFrameworksForRelease).toStrictEqual([
+          new FrameworkForRelease({
+            id: 'frameworkABC123',
+            name: 'Nom de mon framework A',
+          }),
+          new FrameworkForRelease({
+            id: 'frameworkDEF456',
+            name: 'Nom de mon framework B',
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#forReplication', function() {
+    context('when providing a single Framework', function() {
+      it('should transform it into a single FrameworkForReplication', function() {
+        // given
+        const framework = new Framework({
+          id: 'frameworkABC123',
+          name: 'Nom de mon framework',
+          areaIds: ['areaId1', 'areaId2'],
+        });
+
+        // when
+        const actualFrameworkForReplication = forReplication(framework);
+
+        // then
+        expect(actualFrameworkForReplication).toStrictEqual(new FrameworkForReplication({
+          id: 'frameworkABC123',
+          name: 'Nom de mon framework',
+        }));
+      });
+    });
+
+    context('when providing several Frameworks', function() {
+      it('should transform them into a several FrameworksForReplication', function() {
+        // given
+        const frameworkA = new Framework({
+          id: 'frameworkABC123',
+          name: 'Nom de mon framework A',
+          areaIds: ['areaId1', 'areaId2'],
+        });
+        const frameworkB = new Framework({
+          id: 'frameworkDEF456',
+          name: 'Nom de mon framework B',
+          areaIds: ['areaId3', 'areaId4'],
+        });
+
+        // when
+        const actualFrameworksForReplication = forReplication([frameworkA, frameworkB]);
+
+        // then
+        expect(actualFrameworksForReplication).toStrictEqual([
+          new FrameworkForReplication({
+            id: 'frameworkABC123',
+            name: 'Nom de mon framework A',
+          }),
+          new FrameworkForReplication({
+            id: 'frameworkDEF456',
+            name: 'Nom de mon framework B',
+          }),
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Je trouve que c'est un peu le bazar la logique autour de 
- Construction de réplication
- Construction de release
- Patch vers l'API (pour la recette)

## ⛱️ Réflexion

### Constats
- En principe, la logique de construction des données pour la release ET pour le patch vers l'API devrait être **la même**. Aujourd'hui ce n'est pas le cas
- Côté réplication, il y a beaucoup de copie de code pour faire comme la release. Il pourrait être intéressant quand même de bien séparer les deux, même si dans les faits beaucoup de données se ressemblent (mais pas toute).

### Proposition
Modifier tous les `***-transformer.js` pour qu'ils exportent exactement deux fonctions : `forRelease()` et `forReplication()`. On aura un endroit centralisé et immédiat pour comprendre les données de chaque export.
En toute logique, il faut aussi appeler `forRelease()` lors du patch vers l'API pour la recette

Cette PR propose de commencer par l'entité Framework

## 🌊 Remarques

Je me tape un délire, je poursuis la JSDoc entamée par Nico sur le fichier de service du patch vers l'API, je veux voir si c'est cool

## 🏄 Pour tester

ISO release, répli, patch
