### PR TITLE
[BUGFIX] L’ordre d’affichage des thématiques n’est pas le bon (PIX-18287)

### DIFF
--- a/pix-editor/app/models/competence.js
+++ b/pix-editor/app/models/competence.js
@@ -37,7 +37,7 @@ export default class CompetenceModel extends Model {
   }
 
   get sortedThemes() {
-    return sortBy(this.themes, ['name', 'index']);
+    return sortBy(this.themes, ['index', 'name']);
   }
 
   get productionTubes() {


### PR DESCRIPTION
## 🔆 Problème

L’ordre d’affichage des thématiques n’est pas le bon.

## ⛱️ Proposition

Corriger l’ordre d’affichage.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Réordonner des thématiques et vérifier que l’ordre d’affichage est bon.