### PR TITLE
[TECH] Clarifier la construction des projections de réplication et de release du modèle Area

### DIFF
--- a/api/lib/domain/models/replication/AreaForReplication.js
+++ b/api/lib/domain/models/replication/AreaForReplication.js
@@ -1,0 +1,19 @@
+export class AreaForReplication {
+  constructor({
+    id,
+    code,
+    title_i18n,
+    name,
+    competenceIds,
+    color,
+    frameworkId,
+  }) {
+    this.id = id;
+    this.code = code;
+    this.title_i18n = title_i18n;
+    this.competenceIds = competenceIds;
+    this.name = name;
+    this.color = color;
+    this.frameworkId = frameworkId;
+  }
+}

--- a/api/lib/domain/models/replication/index.js
+++ b/api/lib/domain/models/replication/index.js
@@ -1,3 +1,4 @@
+export * from './AreaForReplication.js';
 export * from './FrameworkForReplication.js';
 export * from './SkillForReplication.js';
 

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -1,4 +1,5 @@
 import {
+  areaTransformer,
   createChallengeTransformer,
   frameworkTransformer,
   tubeTransformer,
@@ -16,6 +17,7 @@ import { child } from '../../infrastructure/logger.js';
 import * as Sentry from '@sentry/node';
 
 /**
+ * @typedef {import('../../../lib/domain/models').Area} Area
  * @typedef {import('../../../lib/domain/models').Attachment} Attachment
  * @typedef {import('../../../lib/domain/models').Framework} Framework
  * @typedef {import('../../../lib/domain/models').Tube} Tube
@@ -79,6 +81,24 @@ export async function onFrameworkCreated(framework) {
         pixApiClient,
         model: 'frameworks',
         updatedRecord: frameworkTransformer.forRelease(framework),
+      });
+    } catch (err) {
+      logger.error(err);
+      Sentry.captureException(err);
+    }
+  }
+}
+
+/**
+ * @param {Area} area
+ */
+export async function onAreaCreated(area) {
+  if (pixApiClient.isPixApiCachePatchingEnabled()) {
+    try {
+      await updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'areas',
+        updatedRecord: areaTransformer.forRelease(area),
       });
     } catch (err) {
       logger.error(err);

--- a/api/lib/domain/usecases/create-area.js
+++ b/api/lib/domain/usecases/create-area.js
@@ -1,9 +1,5 @@
-import * as Sentry from '@sentry/node';
-import { logger } from '../../infrastructure/logger.js';
-import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
-import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { areaTransformer } from '../../infrastructure/transformers/index.js';
 import { areaRepository } from '../../infrastructure/repositories/index.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 export async function createArea(area) {
   const areas = await areaRepository.listByFrameworkId(area.frameworkId);
@@ -11,17 +7,6 @@ export async function createArea(area) {
   area.code = `${(areas?.length ?? 0) + 1}`;
 
   const createdArea = await areaRepository.create(area);
-
-  try {
-    await updatedRecordNotifier.notify({
-      pixApiClient,
-      model: 'areas',
-      updatedRecord: areaTransformer.filterAreaFields(createdArea),
-    });
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-  }
-
+  await updatePixApiReleaseCache.onAreaCreated(createdArea);
   return createdArea;
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -74,7 +74,6 @@ export async function getLearningContentForReplication() {
     entityId: translation.entityId,
     sourceEntityId: null,
   }));
-  const transformedAreas = areaTransformer.filterAreasFields(areas);
   const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
@@ -123,7 +122,7 @@ export async function getLearningContentForReplication() {
   await setImmediatePromise();
   return {
     frameworks: frameworkTransformer.forReplication(frameworks),
-    areas: transformedAreas,
+    areas: areaTransformer.forReplication(areas),
     competences: transformedCompetences,
     thematics: transformedThematics,
     tubes: transformedTubes,

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -109,7 +109,6 @@ async function _getCurrentContent() {
   const transformedChallenges = translatedChallenges.map(transformChallenge);
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
-  const transformedAreas = areaTransformer.filterAreasFields(areas);
 
   const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);
   const filteredTutorials = tutorialTransformer.filterTutorialsFields(tutorials);
@@ -117,7 +116,7 @@ async function _getCurrentContent() {
 
   return {
     frameworks: frameworkTransformer.forRelease(frameworks),
-    areas: transformedAreas,
+    areas: areaTransformer.forRelease(areas),
     competences: filteredCompetences,
     thematics: transformedThematics,
     tubes: transformedTubes,

--- a/api/lib/infrastructure/transformers/area-transformer.js
+++ b/api/lib/infrastructure/transformers/area-transformer.js
@@ -28,27 +28,3 @@ export function forReplication(areas) {
   }
   return new AreaForReplication(areas);
 }
-
-export function filterAreaFields({
-  id,
-  code,
-  title_i18n,
-  name,
-  competenceIds,
-  color,
-  frameworkId,
-}) {
-  return {
-    id,
-    code,
-    title_i18n,
-    name,
-    competenceIds,
-    color,
-    frameworkId,
-  };
-}
-
-export function filterAreasFields(frameworks) {
-  return frameworks.map(filterAreaFields);
-}

--- a/api/lib/infrastructure/transformers/area-transformer.js
+++ b/api/lib/infrastructure/transformers/area-transformer.js
@@ -1,3 +1,34 @@
+import { AreaForRelease } from '../../domain/models/release/index.js';
+import { AreaForReplication } from '../../domain/models/replication/index.js';
+
+/**
+ * @typedef {import('../../../lib/domain/models').Area} Area
+ * @typedef {import('../../../lib/domain/models/release').AreaForRelease} AreaForRelease
+ * @typedef {import('../../../lib/domain/models/replication').AreaForReplication} AreaForReplication
+ */
+
+/**
+ * @param {Area|Area[]} areas
+ * @returns {AreaForRelease|AreaForRelease[]}
+ */
+export function forRelease(areas) {
+  if (Array.isArray(areas)) {
+    return areas.map((area) => new AreaForRelease(area));
+  }
+  return new AreaForRelease(areas);
+}
+
+/**
+ @param {Area|Area[]} areas
+ @returns {AreaForReplication|AreaForReplication[]}
+ */
+export function forReplication(areas) {
+  if (Array.isArray(areas)) {
+    return areas.map((area) => new AreaForReplication(area));
+  }
+  return new AreaForReplication(areas);
+}
+
 export function filterAreaFields({
   id,
   code,

--- a/api/tests/acceptance/application/areas_test.js
+++ b/api/tests/acceptance/application/areas_test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
 import {
   airtableBuilder,
@@ -10,14 +10,21 @@ import {
 import { createServer } from '../../../server.js';
 import { areaDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import * as idGenerator from '../../../lib/infrastructure/utils/id-generator.js';
+import * as config from '../../../lib/config.js';
 
 describe('Acceptance | Route | areas', () => {
+  let editorUser, adminUser, originalPixApiUrlValue;
 
-  let editorUser, adminUser;
   beforeEach(async function() {
+    originalPixApiUrlValue = config.pixApi.baseUrl;
+    delete config.pixApi.baseUrl;
     editorUser = databaseBuilder.factory.buildEditorUser();
     adminUser = databaseBuilder.factory.buildAdminUser();
     await databaseBuilder.commit();
+  });
+
+  afterEach(function() {
+    config.pixApi.baseUrl = originalPixApiUrlValue;
   });
 
   describe('GET /areas', async () => {
@@ -332,27 +339,6 @@ describe('Acceptance | Route | areas', () => {
 
       const generateNewId = vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce('area5');
 
-      const pixApiToken = 'secret';
-      nock('https://api.test.pix.fr')
-        .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
-        .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-        .reply(200, { 'access_token': pixApiToken });
-      const pixApiCacheScope = nock('https://api.test.pix.fr')
-        .patch('/api/cache/areas/area5', {
-          id: 'area5',
-          code: '2',
-          title_i18n: {
-            fr: 'Cinquième domaine',
-            en: 'Fifth domain',
-          },
-          name: '2. Cinquième domaine',
-          frameworkId: 'framework2',
-          competenceIds: [],
-          color: null,
-        })
-        .matchHeader('Authorization', `Bearer ${pixApiToken}`)
-        .reply(200);
-
       const server = await createServer();
 
       // when
@@ -416,7 +402,6 @@ describe('Acceptance | Route | areas', () => {
 
       expect(airtableGetAreasScope.isDone()).toBe(true);
       expect(airtablePostAreaScope.isDone()).toBe(true);
-      expect(pixApiCacheScope.isDone()).toBe(true);
     });
   });
 });

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -3,7 +3,11 @@ import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationH
 import { createServer } from '../../../server.js';
 import { Attachment, Challenge, LocalizedChallenge, Mission } from '../../../lib/domain/models/index.js';
 import _ from 'lodash';
-import { FrameworkForReplication, SkillForReplication } from '../../../lib/domain/models/replication/index.js';
+import {
+  AreaForReplication,
+  FrameworkForReplication,
+  SkillForReplication
+} from '../../../lib/domain/models/replication/index.js';
 
 const {
   buildFramework,
@@ -44,6 +48,8 @@ describe('Acceptance | Controller | replication-data-controller', () => {
       const result = JSON.parse(response.result);
       const resultWithoutTranslations = _.omit(result, 'translations');
       const expectedCurrentContentWithoutTranslations = _.omit(expectedCurrentContent, 'translations');
+      expect(resultWithoutTranslations.frameworks).toStrictEqual(expectedCurrentContentWithoutTranslations.frameworks);
+      expect(resultWithoutTranslations.areas).toStrictEqual(expectedCurrentContentWithoutTranslations.areas);
       expect(resultWithoutTranslations).toStrictEqual(expectedCurrentContentWithoutTranslations);
       expect(result.translations).toMatchObject(expectedCurrentContent.translations.map((translation) => ({
         ...translation,
@@ -64,12 +70,12 @@ async function mockCurrentContent() {
   const expectedCurrentContent = {
     translations: [],
   };
-  const expectedFramework = omit(['areaIds'], new FrameworkForReplication(domainBuilder.buildFramework()));
-  expectedCurrentContent.frameworks = [expectedFramework];
+  const expectedFramework = new FrameworkForReplication(domainBuilder.buildFramework());
+  expectedCurrentContent.frameworks = [{ ...expectedFramework }];
 
   const area = domainBuilder.buildArea();
-  const expectedArea = omit(['airtableId', 'competenceAirtableIds'], { name: area.name, ...area });
-  expectedCurrentContent.areas = [expectedArea];
+  const expectedArea = new AreaForReplication({ name: area.name, ...area });
+  expectedCurrentContent.areas = [{ ...expectedArea }];
 
   const expectedCompetence = omit(['airtableId', 'thematicAirtableIds', 'tubeAirtableIds', 'areaAirtableId'], domainBuilder.buildCompetence({
     name_i18n: {

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
-import { Attachment, Challenge, Framework, Tutorial } from '../../../../lib/domain/models/index.js';
+import { Area, Attachment, Challenge, Framework, Tutorial } from '../../../../lib/domain/models/index.js';
 import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import * as config from '../../../../lib/config.js';
@@ -532,6 +532,77 @@ describe('Integration | Service | update pix api release cache', function() {
 
         // when
         await updatePixApiReleaseCache.onFrameworkCreated(framework);
+
+        // then
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('#onAreaCreated', function() {
+    let area;
+
+    beforeEach(function() {
+      area = new Area({
+        id: 'areaId',
+        airtableId: 'recAreaId',
+        code: '1',
+        title_i18n: { fr: 'title fr areaId', en: 'title en areaId' },
+        competenceIds: ['competenceId1', 'competenceId2'],
+        competenceAirtableIds: ['recCompetenceId1', 'recCompetenceId2'],
+        color: Area.COLORS.CERULEAN,
+        frameworkId: 'frameworkId',
+      });
+    });
+
+    context('when patchingPixApi is enabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        config.pixApi.baseUrl = 'https://some-api-base-url.fr';
+      });
+
+      it('should patch the tutorial', async function() {
+        // given
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { 'access_token': pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch('/api/cache/areas/areaId', {
+            id: 'areaId',
+            code: '1',
+            name: '1. title fr areaId',
+            title_i18n: { fr: 'title fr areaId', en: 'title en areaId' },
+            competenceIds: ['competenceId1', 'competenceId2'],
+            color: Area.COLORS.CERULEAN,
+            frameworkId: 'frameworkId',
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onAreaCreated(area);
+
+        // then
+        expect(pixApiCacheScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when patchingPixApi is disabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        delete config.pixApi.baseUrl;
+      });
+
+      it('should not patch anything', async function() {
+        // given
+        const spy = vi.spyOn(updatedRecordNotifier, 'notify');
+
+        // when
+        await updatePixApiReleaseCache.onAreaCreated(area);
 
         // then
         expect(spy).toHaveBeenCalledTimes(0);

--- a/api/tests/unit/infrastructure/transformers/area-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/area-transformer_test.js
@@ -1,0 +1,174 @@
+import { describe, describe as context, expect, it } from 'vitest';
+import { forRelease, forReplication } from '../../../../lib/infrastructure/transformers/area-transformer.js';
+import { Area } from '../../../../lib/domain/models/index.js';
+import { AreaForRelease } from '../../../../lib/domain/models/release/index.js';
+import { AreaForReplication } from '../../../../lib/domain/models/replication/index.js';
+
+describe('Unit | Infrastructure | area-transformer', function() {
+
+  describe('#forRelease', function() {
+    context('when providing a single Area', function() {
+      it('should transform it into a single AreaForRelease', function() {
+        // given
+        const area = new Area({
+          id: 'areaId',
+          airtableId: 'recAreaId',
+          code: '1',
+          title_i18n: { fr: 'title fr areaId', en: 'title en areaId' },
+          competenceIds: ['competenceId1', 'competenceId2'],
+          competenceAirtableIds: ['recCompetenceId1', 'recCompetenceId2'],
+          color: Area.COLORS.CERULEAN,
+          frameworkId: 'frameworkId',
+        });
+
+        // when
+        const actualAreaForRelease = forRelease(area);
+
+        // then
+        expect(actualAreaForRelease).toStrictEqual(new AreaForRelease({
+          id: 'areaId',
+          code: '1',
+          name: '1. title fr areaId',
+          title_i18n: { fr: 'title fr areaId', en: 'title en areaId' },
+          competenceIds: ['competenceId1', 'competenceId2'],
+          color: Area.COLORS.CERULEAN,
+          frameworkId: 'frameworkId',
+        }));
+      });
+    });
+
+    context('when providing several Areas', function() {
+      it('should transform them into a several AreasForRelease', function() {
+        // given
+        const areaA = new Area({
+          id: 'areaIdA',
+          airtableId: 'recAreaIdA',
+          code: '1',
+          title_i18n: { fr: 'title fr areaIdA', en: 'title en areaIdA' },
+          competenceIds: ['competenceId1', 'competenceId2'],
+          competenceAirtableIds: ['recCompetenceId1', 'recCompetenceId2'],
+          color: Area.COLORS.CERULEAN,
+          frameworkId: 'frameworkId',
+        });
+        const areaB = new Area({
+          id: 'areaIdB',
+          airtableId: 'recAreaIdB',
+          code: '2',
+          title_i18n: { fr: 'title fr areaIdB', en: 'title en areaIdB' },
+          competenceIds: ['competenceId3', 'competenceId4'],
+          competenceAirtableIds: ['recCompetenceId3', 'recCompetenceId4'],
+          color: Area.COLORS.BUTTERFLY_BUSH,
+          frameworkId: 'frameworkId',
+        });
+
+        // when
+        const actualAreasForRelease = forRelease([areaA, areaB]);
+
+        // then
+        expect(actualAreasForRelease).toStrictEqual([
+          new AreaForRelease({
+            id: 'areaIdA',
+            code: '1',
+            name: '1. title fr areaIdA',
+            title_i18n: { fr: 'title fr areaIdA', en: 'title en areaIdA' },
+            competenceIds: ['competenceId1', 'competenceId2'],
+            color: Area.COLORS.CERULEAN,
+            frameworkId: 'frameworkId',
+          }),
+          new AreaForRelease({
+            id: 'areaIdB',
+            code: '2',
+            name: '2. title fr areaIdB',
+            title_i18n: { fr: 'title fr areaIdB', en: 'title en areaIdB' },
+            competenceIds: ['competenceId3', 'competenceId4'],
+            color: Area.COLORS.BUTTERFLY_BUSH,
+            frameworkId: 'frameworkId',
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#forReplication', function() {
+    context('when providing a single Area', function() {
+      it('should transform it into a single AreaForReplication', function() {
+        // given
+        const area = new Area({
+          id: 'areaId',
+          airtableId: 'recAreaId',
+          code: '1',
+          title_i18n: { fr: 'title fr areaId', en: 'title en areaId' },
+          competenceIds: ['competenceId1', 'competenceId2'],
+          competenceAirtableIds: ['recCompetenceId1', 'recCompetenceId2'],
+          color: Area.COLORS.CERULEAN,
+          frameworkId: 'frameworkId',
+        });
+
+        // when
+        const actualAreaForReplication = forReplication(area);
+
+        // then
+        expect(actualAreaForReplication).toStrictEqual(new AreaForReplication({
+          id: 'areaId',
+          code: '1',
+          name: '1. title fr areaId',
+          title_i18n: { fr: 'title fr areaId', en: 'title en areaId' },
+          competenceIds: ['competenceId1', 'competenceId2'],
+          color: Area.COLORS.CERULEAN,
+          frameworkId: 'frameworkId',
+        }));
+      });
+    });
+
+    context('when providing several Areas', function() {
+      it('should transform them into a several AreasForReplication', function() {
+        // given
+        const areaA = new Area({
+          id: 'areaIdA',
+          airtableId: 'recAreaIdA',
+          code: '1',
+          title_i18n: { fr: 'title fr areaIdA', en: 'title en areaIdA' },
+          competenceIds: ['competenceId1', 'competenceId2'],
+          competenceAirtableIds: ['recCompetenceId1', 'recCompetenceId2'],
+          color: Area.COLORS.CERULEAN,
+          frameworkId: 'frameworkId',
+        });
+        const areaB = new Area({
+          id: 'areaIdB',
+          airtableId: 'recAreaIdB',
+          code: '2',
+          title_i18n: { fr: 'title fr areaIdB', en: 'title en areaIdB' },
+          competenceIds: ['competenceId3', 'competenceId4'],
+          competenceAirtableIds: ['recCompetenceId3', 'recCompetenceId4'],
+          color: Area.COLORS.BUTTERFLY_BUSH,
+          frameworkId: 'frameworkId',
+        });
+
+        // when
+        const actualAreasForReplication = forReplication([areaA, areaB]);
+
+        // then
+        expect(actualAreasForReplication).toStrictEqual([
+          new AreaForReplication({
+            id: 'areaIdA',
+            code: '1',
+            name: '1. title fr areaIdA',
+            title_i18n: { fr: 'title fr areaIdA', en: 'title en areaIdA' },
+            competenceIds: ['competenceId1', 'competenceId2'],
+            color: Area.COLORS.CERULEAN,
+            frameworkId: 'frameworkId',
+          }),
+          new AreaForReplication({
+            id: 'areaIdB',
+            code: '2',
+            name: '2. title fr areaIdB',
+            title_i18n: { fr: 'title fr areaIdB', en: 'title en areaIdB' },
+            competenceIds: ['competenceId3', 'competenceId4'],
+            color: Area.COLORS.BUTTERFLY_BUSH,
+            frameworkId: 'frameworkId',
+          }),
+        ]);
+      });
+    });
+  });
+});

--- a/pix-editor/app/styles/components/sidebar/navigation.scss
+++ b/pix-editor/app/styles/components/sidebar/navigation.scss
@@ -1,5 +1,5 @@
 .select-framework {
-  padding: 0 5px;
+  padding: 0 5px 8px 5px;
   width: 100%;
 
   .pix-select-button {


### PR DESCRIPTION
## 🔆 Problème

Je trouve que c'est un peu le bazar la logique autour de 
- Construction de réplication
- Construction de release
- Patch vers l'API (pour la recette)


## ⛱️ Réflexion

### Constats
- En principe, la logique de construction des données pour la release ET pour le patch vers l'API devrait être **la même**. Aujourd'hui ce n'est pas le cas
- Côté réplication, il y a beaucoup de copie de code pour faire comme la release. Il pourrait être intéressant quand même de bien séparer les deux, même si dans les faits beaucoup de données se ressemblent (mais pas toute).

### Proposition
Modifier tous les `***-transformer.js` pour qu'ils exportent exactement deux fonctions : `forRelease()` et `forReplication()`. On aura un endroit centralisé et immédiat pour comprendre les données de chaque export.
En toute logique, il faut aussi appeler `forRelease()` lors du patch vers l'API pour la recette

Cette PR est dédiée aux Areas

## 🌊 Remarques

PRs du passé :
- Frameworks : https://github.com/1024pix/pix-editor/pull/1042

## 🏄 Pour tester

ISO release, répli, patch
