### PR TITLE
[BUGFIX] Corriger l'affichage des drapeaux des tutoriels (PIX-18325)

### DIFF
--- a/pix-editor/app/components/field/tutorials.gjs
+++ b/pix-editor/app/components/field/tutorials.gjs
@@ -167,7 +167,7 @@ export default class Tutorials extends Component {
                   <div>Durée : {{tutorial.duration}}</div>
                   <div>Source : {{tutorial.source}}
                     <div class="ui right floated favorite">
-                      <span class="flag" aria-label={{tutorial.language}}>{{flagForLanguage tutorial.language}}</span>
+                      <span class="flag" aria-label={{tutorial.language}}>{{flagForLanguage tutorial.normalizedLanguage}}</span>
                       {{#if tutorial.crush}}
                         <PixIcon @name="favorite" @plainIcon={{true}} />
                       {{/if}}

--- a/pix-editor/app/components/field/tutorials.gjs
+++ b/pix-editor/app/components/field/tutorials.gjs
@@ -8,6 +8,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import { not } from 'ember-truth-helpers';
+import flagForLanguage from 'pixeditor/helpers/flag-for-language';
 
 import PopInTutorialComponent from '../pop-in/tutorial';
 import SelectSearch from './select-search';
@@ -166,6 +167,7 @@ export default class Tutorials extends Component {
                   <div>Durée : {{tutorial.duration}}</div>
                   <div>Source : {{tutorial.source}}
                     <div class="ui right floated favorite">
+                      <span class="flag" aria-label={{tutorial.language}}>{{flagForLanguage tutorial.language}}</span>
                       {{#if tutorial.crush}}
                         <PixIcon @name="favorite" @plainIcon={{true}} />
                       {{/if}}

--- a/pix-editor/app/components/form/tutorial.js
+++ b/pix-editor/app/components/form/tutorial.js
@@ -20,7 +20,7 @@ export default class TutorialForm extends Component {
   }
 
   get tutorialLanguage() {
-    return this.config.tutorialLocaleToLanguageMap[this.args.tutorial.language];
+    return this.config.tutorialLocaleToLanguageMap[this.args.tutorial.normalizedLanguage];
   }
 
   get tutorialLanguageOptions() {

--- a/pix-editor/app/helpers/flag-for-language.js
+++ b/pix-editor/app/helpers/flag-for-language.js
@@ -4,7 +4,6 @@ const flagsForLanguages = {
   fr: '🇫🇷',
   'fr-fr': '🇫🇷',
   en: '🇬🇧',
-  'en-us': ' 🇺🇸',
   es: '🇪🇸',
   nl: '🇳🇱',
 };

--- a/pix-editor/app/helpers/flag-for-language.js
+++ b/pix-editor/app/helpers/flag-for-language.js
@@ -4,6 +4,7 @@ const flagsForLanguages = {
   fr: '🇫🇷',
   'fr-fr': '🇫🇷',
   en: '🇬🇧',
+  'en-us': ' 🇺🇸',
   es: '🇪🇸',
   nl: '🇳🇱',
 };

--- a/pix-editor/app/models/tutorial.js
+++ b/pix-editor/app/models/tutorial.js
@@ -18,4 +18,9 @@ export default class TutorialModel extends Model {
     const tags = this.hasMany('tags').value() || [];
     return tags.map((tag) => tag.title).join(' | ');
   }
+
+  get normalizedLanguage() {
+    // Il y a au moins 1 tuto avec une langue null😢
+    return this.language?.split('-')?.[0];
+  }
 }

--- a/pix-editor/app/styles/components/field/tutorials.scss
+++ b/pix-editor/app/styles/components/field/tutorials.scss
@@ -19,8 +19,18 @@
     }
   }
 
-  .favorite svg {
-    fill: var(--pix-error-500);
+  .favorite {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    .flag {
+      font-size: 1.3rem;
+    }
+
+    svg {
+      fill: var(--pix-error-500);
+    }
   }
 }
 


### PR DESCRIPTION
## 🔆 Problème

Les drapeaux de pays correspondant à la langue des tutoriels ne s'affichent plus dans la liste des tutoriels d'un acquis.
Cette fonctionnalité a été perdue au passage du formulaire en `.gjs`.

## ⛱️ Proposition

Afficher ces drapeaux.

## 🌊 Remarques

Au passage, on corrige l'affichage de la langue sélectionnée dans le formulaire d'édition d'un acquis.

## 🏄 Pour tester

### Les drapeaux : 
- Se rendre sur la page de modification d'un acquis.
- **Si cette acquis possède déjà des tutoriels**, constater que des drapeaux de pays (🇫🇷, ...) s'affichent en bas à droite de leur carte.
- **Sinon**, rechercher un tutoriel et en ajouter un.
- Vérifier que ces drapeaux correspondent à la langue renseignée du tutoriel.

### Les options du sélecteur de langue :
- Ajouter les tutoriels "tuto en-us" et "Les moteurs de recherche". Ces tutoriels ont des valeurs de langue "dépréciées".
- Sur la même page, entrer dans la pop-in de modification d'un de ces tutoriels.
- Constater que la langue est bien sélectionnée (Anglais et Français respectivement).
