### PR TITLE
[BUGFIX] Script de détection des incohérences au sein d'une grappe d'épreuves ne marche pas lorsque l'attribut "contextualizedFields" est null

### DIFF
--- a/api/scripts/scan-challenges-for-discrepancies-between-prototypes-and-alternatives.js
+++ b/api/scripts/scan-challenges-for-discrepancies-between-prototypes-and-alternatives.js
@@ -26,7 +26,7 @@ export class ScanChallengesForDiscrepanciesBetweenPrototypesAndAlternatives exte
       for (const alternative of alternativesForProto) {
         for (const commonField of Challenge.PROTO_FIELDS) {
           if (commonField === 'contextualizedFields') {
-            if (JSON.stringify(alternative[commonField].sort()) !== JSON.stringify(prototype[commonField].sort())) {
+            if (JSON.stringify(alternative[commonField]?.sort() ?? '') !== JSON.stringify(prototype[commonField]?.sort() ?? '')) {
               logger.error(`Proto: ${prototype.id} | Alternative: ${alternative.id} : different value for field "${commonField}"`);
             }
           } else {


### PR DESCRIPTION
## 🔆 Problème

🔫 

## ⛱️ Proposition
 🕵🏿 

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
