### PR TITLE
[BUGFIX] La release ne fonctionne pas lorsqu'il existe un tube qui n'a pas d'acquis (PIX-18375)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { datasource } from './datasource.js';
 import { findRecords, stringValue } from '../../airtable.js';
 
@@ -30,8 +29,8 @@ export const tubeDatasource = datasource.extend({
       thematicAirtableId: airtableRecord.get('Thematique')[0],
       competenceAirtableId: airtableRecord.get('Competences')[0],
       competenceId: airtableRecord.get('Competences (id persistant)')[0],
-      skillAirtableIds: airtableRecord.get('Acquis'),
-      skillIds: airtableRecord.get('Acquis (id persistant)'),
+      skillAirtableIds: airtableRecord.get('Acquis') ?? [],
+      skillIds: airtableRecord.get('Acquis (id persistant)') ?? [],
     };
   },
 

--- a/api/tests/unit/infrastructure/datasources/airtable/tube-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/tube-datasource_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { domainBuilder, airtableBuilder } from '../../../../test-helper.js';
-import { tubeDatasource } from '../../../../../lib/infrastructure/datasources/airtable/tube-datasource.js';
+import { airtableBuilder, domainBuilder } from '../../../../test-helper.js';
+import { tubeDatasource } from '../../../../../lib/infrastructure/datasources/airtable/index.js';
 import airtable from 'airtable';
 
 const { Record: AirtableRecord } = airtable;
@@ -12,6 +12,26 @@ describe('Unit | Infrastructure | Datasource | Airtable | TubeDatasource', () =>
       // given
       const expectedTube = domainBuilder.buildTubeDatasourceObject();
       const airtableTube = airtableBuilder.factory.buildTube(expectedTube);
+      const tubeRecord = new AirtableRecord('Tube', airtableTube.id, airtableTube);
+
+      // when
+      const tube = tubeDatasource.fromAirTableObject(tubeRecord);
+
+      // then
+      expect(tube).to.deep.equal(expectedTube);
+    });
+
+    it('should create a Tube from the AirtableRecord even when Tube has no skills', () => {
+      // given
+      const expectedTube = domainBuilder.buildTubeDatasourceObject({
+        skillAirtableIds: [],
+        skillIds: [],
+      });
+      const airtableTube = airtableBuilder.factory.buildTube({
+        ...expectedTube,
+        skillAirtableIds: null,
+        skillIds: null,
+      });
       const tubeRecord = new AirtableRecord('Tube', airtableTube.id, airtableTube);
 
       // when


### PR DESCRIPTION
## 🔆 Problème

Lors de la sortie du proxy des tubes, on a ajouté la liste des acquis au modèle.
Problème, c'est que malheureusement il existe dans le airtable de prod des tubes n'ayant pas d'acquis, et le code n'était pas robuste contre ce cas.

## ⛱️ Proposition

Forcer le tableau vide sur la liste des acquis lorsque le sujet n'en a pas.

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
