### PR TITLE
 [BUGFIX] Problème visuel lorsque la V2 est choisit mais que la route n'existe pas (PIX-17282) 2e :)

### DIFF
--- a/pix-editor/app/controllers/authenticated.js
+++ b/pix-editor/app/controllers/authenticated.js
@@ -60,7 +60,7 @@ export default class ApplicationController extends Controller {
     return (this.router.currentRouteName === 'authenticated.index');
   }
 
-  get isV2() {
+  get shouldApplyV2Styles() {
     return this.versionManager.getV2() && this.router.currentRouteName.includes('v2');
   }
 

--- a/pix-editor/app/controllers/authenticated.js
+++ b/pix-editor/app/controllers/authenticated.js
@@ -61,7 +61,7 @@ export default class ApplicationController extends Controller {
   }
 
   get isV2() {
-    return this.versionManager.getV2();
+    return this.versionManager.getV2() && this.router.currentRouteName.includes('v2');
   }
 
   showMessage(content, positive) {

--- a/pix-editor/app/templates/authenticated.hbs
+++ b/pix-editor/app/templates/authenticated.hbs
@@ -11,7 +11,7 @@
       </button>
       {{!-- template-lint-enable --}}
     </div>
-    <div class="{{if this.isV2 "v2-main" "main"}}" {{on "click" this.closeMenu}}>
+    <div class="{{if this.shouldApplyV2Styles "v2-main" "main"}}" {{on "click" this.closeMenu}}>
       {{#if this.isIndex}}
         <div class="main-left">
           <main class="elephant ui attached"></main>


### PR DESCRIPTION
## 🔆 Problème

Lorsque l'on choisit la version 2 , et que certaines routes ne sont pas encore construite dans cette version, on se retrouve avec du css de la V2 pour de la V1

![image](https://github.com/user-attachments/assets/7081feda-5f73-45c5-812b-56c09bc1c7c2)


## ⛱️ Proposition

Ajouter un check sur l'url pour vérifier que l'on est sur une route V2

## 🌊 Remarques

Il y a peut être une meilleur solution ^^

## 🏄 Pour tester

1. cocher la V2
2. Aller sur un proto
3. Cliquer sur Déclinaison
4. Observer un agenssement comme ci-dessous

![image](https://github.com/user-attachments/assets/984ee90e-166e-427b-8e8c-bc9a7aadf23a)