### PR TITLE
[BUGFIX] Ajouter l'id de l'attachment pour la réplication (PIX-18403)

### DIFF
--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -109,6 +109,7 @@ export async function getLearningContentForReplication() {
   }
 
   const translatedAttachments = attachments.map((attachment) => ({
+    id: attachment.id,
     type: attachment.type,
     url: attachment.url,
     size: attachment.size,

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -206,8 +206,8 @@ async function mockCurrentContent() {
     localizedChallengeId: 'localized-challenge-id',
   };
   expectedCurrentContent.attachments = [
-    omit(['airtableChallengeId', 'mimeType', 'localizedChallengeId', 'id'], { ...domainBuilder.buildAttachment(expectedAttachment),  alt: null, }),
-    omit(['airtableChallengeId', 'mimeType', 'localizedChallengeId', 'id'], {
+    omit(['airtableChallengeId', 'mimeType', 'localizedChallengeId'], { ...domainBuilder.buildAttachment(expectedAttachment),  alt: null, }),
+    omit(['airtableChallengeId', 'mimeType', 'localizedChallengeId'], {
       ...domainBuilder.buildAttachment({ ...expectedAttachmentNl, challengeId: challengeNl.id }),
       alt: 'alt_nl'
     }),


### PR DESCRIPTION
## 🔆 Problème
La répli ne se lance pas parce qu'elle attends un id pour l'attachment.

## ⛱️ Proposition
On n'omet pas l'id de l'attachment pour la répli

## 🌊 Remarques
RAS

## 🏄 Pour tester
Tests au vert
