### PR TITLE
[FEATURE] Permettre aux éditeurs de gérer la liste des URLs à ne pas analyser (PIX-18418)

### DIFF
--- a/api/lib/application/whitelisted-urls/index.js
+++ b/api/lib/application/whitelisted-urls/index.js
@@ -12,7 +12,7 @@ export async function register(server) {
       method: 'GET',
       path: '/api/whitelisted-urls',
       config: {
-        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
           const whitelistedUrls_read = await whitelistedUrlReadRepository.list();
           return h.response(whitelistedUrlSerializer.serialize(whitelistedUrls_read));
@@ -28,7 +28,7 @@ export async function register(server) {
             whitelistedUrlId: Types.whitelistedUrlId().required(),
           }),
         },
-        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
           const authenticatedUser = request.auth.credentials.user;
           const whitelistedUrlId = request.params.whitelistedUrlId;
@@ -47,7 +47,7 @@ export async function register(server) {
       method: 'POST',
       path: '/api/whitelisted-urls',
       config: {
-        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
           const authenticatedUser = request.auth.credentials.user;
           const attributes = request.payload.data.attributes;
@@ -75,7 +75,7 @@ export async function register(server) {
             whitelistUrlId: Types.whitelistedUrlId().required(),
           }),
         },
-        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
           const authenticatedUser = request.auth.credentials.user;
           const attributes = request.payload.data.attributes;

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -30,4 +30,8 @@ export class User {
   get isAdmin() {
     return this.access === User.ROLES.ADMIN;
   }
+
+  get isEditor() {
+    return this.access === User.ROLES.EDITOR || this.isAdmin;
+  }
 }

--- a/api/lib/domain/models/WhitelistedUrl.js
+++ b/api/lib/domain/models/WhitelistedUrl.js
@@ -45,7 +45,7 @@ export class WhitelistedUrl {
 
   static canCreate(creationCommand, user, existingWhitelistedUrls) {
     const activeExistingWhitelistedUrls = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive);
-    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour ajouter une URL à ne pas analyser');
+    if (!user.isEditor) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour ajouter une URL à ne pas analyser');
     if (!isUrlValid(creationCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
     if (!isRelatedSkillNamesValid(creationCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });
     if (!isCommentValid(creationCommand.comment)) throw new CommandWhitelistedUrlError({ message: 'Commentaire invalide. Doit être un texte ou vide', attribute: 'comment' });
@@ -71,7 +71,7 @@ export class WhitelistedUrl {
   }
 
   canDelete(user) {
-    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour supprimer cette URL');
+    if (!user.isEditor) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour supprimer cette URL');
     if (this.deletedAt) throw new CommandWhitelistedUrlConflictError('L\'URL a déjà été supprimée');
   }
 
@@ -85,7 +85,7 @@ export class WhitelistedUrl {
 
   canUpdate(updateCommand, user, existingWhitelistedUrls) {
     const activeOtherExistingWhitelistedUrls = existingWhitelistedUrls.filter((whitelistedUrl) => whitelistedUrl.isActive && whitelistedUrl.id !== this.id);
-    if (!user.isAdmin) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour mettre à jour cette URL');
+    if (!user.isEditor) throw new CommandWhitelistedUrlForbiddenError('L\'utilisateur n\'a pas les droits pour mettre à jour cette URL');
     if (this.deletedAt) throw new NotFoundWhitelistedUrlError('L\'URL n\'existe pas');
     if (!isUrlValid(updateCommand.url)) throw new CommandWhitelistedUrlError({ message: 'URL invalide', attribute: 'url' });
     if (!isRelatedSkillNamesValid(updateCommand.relatedSkillNames)) throw new CommandWhitelistedUrlError({ message: 'Liste d\'acquis invalide. Doit être une suite d\'acquis séparés par des virgules ou vide', attribute: 'relatedSkillNames' });

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -18,13 +18,13 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
   });
 
   describe('GET /whitelisted-urls', () => {
-    let adminUser, server;
+    let editorUser, server;
     beforeEach(async function() {
-      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      editorUser = databaseBuilder.factory.buildUser({ name: 'Madame Editor', access: 'editor' });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 123,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
         deletedBy: null,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
@@ -49,9 +49,9 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 789,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
-        deletedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
+        deletedBy: editorUser.id,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
         deletedAt: new Date('2023-01-01'),
@@ -64,16 +64,16 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       server = await createServer();
     });
 
-    it('should return a 403 status code when user is not admin', async () => {
+    it('should return a 403 status code when user is not editor', async () => {
       // given
-      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      const notEditorUser = databaseBuilder.factory.buildReadonlyUser();
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
         method: 'GET',
         url: '/api/whitelisted-urls',
-        headers: generateAuthorizationHeader(notAdminUser)
+        headers: generateAuthorizationHeader(notEditorUser)
       });
 
       // Then
@@ -94,7 +94,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'GET',
         url: '/api/whitelisted-urls',
-        headers: generateAuthorizationHeader(adminUser)
+        headers: generateAuthorizationHeader(editorUser)
       });
 
       // Then
@@ -121,8 +121,8 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
             attributes: {
               'created-at': new Date('2020-01-01'),
               'updated-at':new Date('2022-02-02'),
-              'creator-name': 'Madame Admin',
-              'latest-updator-name': 'Madame Admin',
+              'creator-name': 'Madame Editor',
+              'latest-updator-name': 'Madame Editor',
               'url': 'https://www.google.com',
               'related-skill-names': '@morse2,@saumon5',
               'comment': 'Je décide de whitelister ça car mon cousin travaille chez google',
@@ -134,13 +134,13 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
     });
   });
   describe('DELETE /whitelisted-urls/{whitelistedUrlId}', () => {
-    let adminUser, server;
+    let editorUser, server;
     beforeEach(async function() {
-      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      editorUser = databaseBuilder.factory.buildUser({ name: 'Madame Editor', access: 'admin' });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 123,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
         deletedBy: null,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
@@ -165,9 +165,9 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 789,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
-        deletedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
+        deletedBy: editorUser.id,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
         deletedAt: new Date('2023-01-01'),
@@ -180,16 +180,16 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       server = await createServer();
     });
 
-    it('should return a 403 status code when user is not admin', async () => {
+    it('should return a 403 status code when user is not editor', async () => {
       // given
-      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      const notEditorUser = databaseBuilder.factory.buildReadonlyUser();
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
         method: 'DELETE',
         url: '/api/whitelisted-urls/123456',
-        headers: generateAuthorizationHeader(notAdminUser)
+        headers: generateAuthorizationHeader(notEditorUser)
       });
 
       // Then
@@ -210,7 +210,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'DELETE',
         url: '/api/whitelisted-urls/coucoumaman',
-        headers: generateAuthorizationHeader(adminUser)
+        headers: generateAuthorizationHeader(editorUser)
       });
 
       // Then
@@ -227,7 +227,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'DELETE',
         url: '/api/whitelisted-urls/777',
-        headers: generateAuthorizationHeader(adminUser)
+        headers: generateAuthorizationHeader(editorUser)
       });
 
       // Then
@@ -248,7 +248,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'DELETE',
         url: '/api/whitelisted-urls/789',
-        headers: generateAuthorizationHeader(adminUser)
+        headers: generateAuthorizationHeader(editorUser)
       });
 
       // Then
@@ -269,7 +269,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'DELETE',
         url: '/api/whitelisted-urls/123',
-        headers: generateAuthorizationHeader(adminUser)
+        headers: generateAuthorizationHeader(editorUser)
       });
 
       // Then
@@ -279,13 +279,13 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
     });
   });
   describe('POST /whitelisted-urls', () => {
-    let adminUser, server, validPayload;
+    let editorUser, server, validPayload;
     beforeEach(async function() {
-      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      editorUser = databaseBuilder.factory.buildUser({ name: 'Madame Editor', access: 'admin' });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 123,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
         deletedBy: null,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
@@ -310,9 +310,9 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 789,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
-        deletedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
+        deletedBy: editorUser.id,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
         deletedAt: new Date('2023-01-01'),
@@ -335,16 +335,16 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       };
     });
 
-    it('should return a 403 status code when user is not admin', async () => {
+    it('should return a 403 status code when user is not editor', async () => {
       // given
-      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      const notEditorUser = databaseBuilder.factory.buildReadonlyUser();
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
         method: 'POST',
         url: '/api/whitelisted-urls',
-        headers: generateAuthorizationHeader(notAdminUser),
+        headers: generateAuthorizationHeader(notEditorUser),
         payload: validPayload,
       });
 
@@ -368,7 +368,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'POST',
         url: '/api/whitelisted-urls',
-        headers: generateAuthorizationHeader(adminUser),
+        headers: generateAuthorizationHeader(editorUser),
         payload: invalidPayload,
       });
 
@@ -391,7 +391,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'POST',
         url: '/api/whitelisted-urls',
-        headers: generateAuthorizationHeader(adminUser),
+        headers: generateAuthorizationHeader(editorUser),
         payload: validPayload,
       });
 
@@ -405,8 +405,8 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
           attributes: {
             'created-at': now,
             'updated-at': now,
-            'creator-name': 'Madame Admin',
-            'latest-updator-name': 'Madame Admin',
+            'creator-name': 'Madame Editor',
+            'latest-updator-name': 'Madame Editor',
             url: 'https://super-casserole.com',
             'related-skill-names': '@feutre2,@crayon1',
             comment: 'Un super commentaire',
@@ -417,13 +417,13 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
     });
   });
   describe('PATCH /whitelisted-urls/{whitelistedUrlId}', () => {
-    let adminUser, server, validPayload;
+    let editorUser, server, validPayload;
     beforeEach(async function() {
-      adminUser = databaseBuilder.factory.buildUser({ name: 'Madame Admin', access: 'admin' });
+      editorUser = databaseBuilder.factory.buildUser({ name: 'Madame Editor', access: 'admin' });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 123,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
         deletedBy: null,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
@@ -448,9 +448,9 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       });
       databaseBuilder.factory.buildWhitelistedUrl({
         id: 789,
-        createdBy: adminUser.id,
-        latestUpdatedBy: adminUser.id,
-        deletedBy: adminUser.id,
+        createdBy: editorUser.id,
+        latestUpdatedBy: editorUser.id,
+        deletedBy: editorUser.id,
         createdAt: new Date('2020-01-01'),
         updatedAt: new Date('2022-02-02'),
         deletedAt: new Date('2023-01-01'),
@@ -473,16 +473,16 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       };
     });
 
-    it('should return a 403 status code when user is not admin', async () => {
+    it('should return a 403 status code when user is not editor', async () => {
       // given
-      const notAdminUser = databaseBuilder.factory.buildEditorUser();
+      const notEditorUser = databaseBuilder.factory.buildReadonlyUser();
       await databaseBuilder.commit();
 
       // when
       const response = await server.inject({
         method: 'PATCH',
         url: '/api/whitelisted-urls/456',
-        headers: generateAuthorizationHeader(notAdminUser),
+        headers: generateAuthorizationHeader(notEditorUser),
         payload: validPayload,
       });
 
@@ -506,7 +506,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'PATCH',
         url: '/api/whitelisted-urls/456',
-        headers: generateAuthorizationHeader(adminUser),
+        headers: generateAuthorizationHeader(editorUser),
         payload: invalidPayload,
       });
 
@@ -529,7 +529,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
       const response = await server.inject({
         method: 'PATCH',
         url: '/api/whitelisted-urls/456',
-        headers: generateAuthorizationHeader(adminUser),
+        headers: generateAuthorizationHeader(editorUser),
         payload: validPayload,
       });
 
@@ -543,7 +543,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {let now;
             'created-at': new Date('2020-12-12'),
             'updated-at': now,
             'creator-name': null,
-            'latest-updator-name': 'Madame Admin',
+            'latest-updator-name': 'Madame Editor',
             url: 'https://super-casserole.com',
             'related-skill-names': '@feutre2,@crayon1',
             comment: 'Un super commentaire',

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -31,4 +31,46 @@ describe('Unit | Domain | User', () => {
       expect(isAdmin).to.be.false;
     });
   });
+
+  describe('#get isEditor', () => {
+    it('should return true when user is editor', () => {
+      // given
+      const user = domainBuilder.buildUser({
+        access: User.ROLES.EDITOR,
+      });
+
+      // when
+      const isEditor = user.isEditor;
+
+      // then
+      expect(isEditor).to.be.true;
+    });
+
+    it('should return true when user is admin', () => {
+      // given
+      const user = domainBuilder.buildUser({
+        access: User.ROLES.ADMIN,
+      });
+
+      // when
+      const isEditor = user.isEditor;
+
+      // then
+      expect(isEditor).to.be.true;
+    });
+
+    it.each(Object.keys(User.ROLES).filter((roleKey) => ![User.ROLES.ADMIN, User.ROLES.EDITOR].includes(User.ROLES[roleKey]))
+    )('should return false when role key is %s', (roleKey) => {
+      // given
+      const user  = domainBuilder.buildUser({
+        access: User.ROLES[roleKey],
+      });
+
+      // when
+      const isEditor = user.isEditor;
+
+      // then
+      expect(isEditor).to.be.false;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/WhitelistedUrl_test.js
+++ b/api/tests/unit/domain/models/WhitelistedUrl_test.js
@@ -54,7 +54,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
     describe('can', function() {
       it('should not throw when all conditions are reunited', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
           deletedAt: null,
           deletedBy: null,
@@ -68,9 +68,9 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       });
     });
     describe('cannot', function() {
-      it('should throw a CommandWhitelistedUrlForbiddenError when user is not admin', function() {
+      it('should throw a CommandWhitelistedUrlForbiddenError when user is not editor', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
+        const user = domainBuilder.buildUser({ access: User.ROLES.READONLY });
         const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
           deletedAt: null,
           deletedBy: null,
@@ -89,7 +89,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlConflictError when whitelisted url has already been deleted', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const whitelistedUrlToDelete = domainBuilder.buildWhitelistedUrl({
           deletedAt: new Date('2021-01-01'),
           deletedBy: 456,
@@ -148,7 +148,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
     describe('can', function() {
       it('should not throw when all conditions are reunited', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const existingWhitelistedUrls = [
           domainBuilder.buildWhitelistedUrl({
             id: 123,
@@ -183,9 +183,9 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       });
     });
     describe('cannot', function() {
-      it('should throw a CommandWhitelistedUrlForbiddenError when user is not admin', function() {
+      it('should throw a CommandWhitelistedUrlForbiddenError when user is not editor', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
+        const user = domainBuilder.buildUser({ access: User.ROLES.READONLY });
         const creationCommand = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,
@@ -206,7 +206,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when url is not valid in creation command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const creationCommand1 = {
           url: null,
           checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
@@ -252,7 +252,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when relatedSkillNames is not in valid format in creation command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const creationCommand1 = {
           url: 'https://www.brioche.com',
           relatedSkillNames: 123456.12,
@@ -287,7 +287,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when comment is not in valid format in creation command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const creationCommand = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,
@@ -309,7 +309,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when checkType is not valid in creation command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const creationCommand1 = {
           url: 'https://www.brioche.com',
           checkType: 'autre_type',
@@ -356,7 +356,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlConflictError when url has already been whitelisted (case sensitive, exact match)', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrl({
           url: 'https://www.brioche.com',
         })];
@@ -383,7 +383,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
   describe('#static create', () => {
     it('should return a newly created whitelisted url', function() {
       // given
-      const user = domainBuilder.buildUser({ id: 444, access: User.ROLES.ADMIN });
+      const user = domainBuilder.buildUser({ id: 444, access: User.ROLES.EDITOR });
       const creationCommand = {
         url: 'https://www.brioche.com',
         relatedSkillNames: '@proie2,@cancre5',
@@ -415,7 +415,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
     describe('can', function() {
       it('should not throw when all conditions are reunited', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const whitelistedUrlToUpdate = domainBuilder.buildWhitelistedUrl({
           id: 123,
           url: 'https://www.url-origine.com',
@@ -464,9 +464,9 @@ describe('Unit | Domain | WhitelistedUrl', () => {
       });
     });
     describe('cannot', function() {
-      it('should throw a CommandWhitelistedUrlForbiddenError when user is not admin', function() {
+      it('should throw a CommandWhitelistedUrlForbiddenError when user is not at least editor', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
+        const user = domainBuilder.buildUser({ access: User.ROLES.READONLY });
         const updateCommand = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,
@@ -491,7 +491,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when url is not valid in update command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const updateCommand1 = {
           url: null,
           checkType: WhitelistedUrl.CHECK_TYPES.STARTS_WITH,
@@ -541,7 +541,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when relatedSkillNames is not in valid format in update command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const updateCommand1 = {
           url: 'https://www.brioche.com',
           relatedSkillNames: 123456.12,
@@ -580,7 +580,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when comment is not in valid format in update command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const updateCommand = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,
@@ -606,7 +606,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlError when checkType is not valid in update command', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const updateCommand1 = {
           url: 'https://www.brioche.com',
           checkType: 'autre_type',
@@ -657,7 +657,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a CommandWhitelistedUrlConflictError when url has already been whitelisted (case sensitive, exact match)', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const existingWhitelistedUrls = [domainBuilder.buildWhitelistedUrl({
           id: 123,
           url: 'https://www.brioche.com',
@@ -687,7 +687,7 @@ describe('Unit | Domain | WhitelistedUrl', () => {
 
       it('should throw a NotFoundWhitelistedUrlError when whitelisted url is deleted', function() {
         // given
-        const user = domainBuilder.buildUser({ access: User.ROLES.ADMIN });
+        const user = domainBuilder.buildUser({ access: User.ROLES.EDITOR });
         const updateCommand = {
           url: 'https://www.brioche.com',
           relatedSkillNames: null,

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -158,11 +158,11 @@ export default class AccessService extends Service {
   }
 
   mayAccessWhitelistedUrls() {
-    return this.isAdmin();
+    return this.isEditor();
   }
 
   mayCreateOrEditWhitelistedUrl() {
-    return this.isAdmin();
+    return this.isEditor();
   }
 
   mayCreateOrEditStaticCourse() {

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -152,9 +152,9 @@ module('Unit | Service | access', function(hooks) {
   });
 
   module('mayAccessWhitelistedUrls', function() {
-    test('it should return `false` when is not admin', function(assert) {
+    test('it should return `false` when is not editor', function(assert) {
       // given
-      _stubAccessLevel(EDITOR, this.owner);
+      _stubAccessLevel(REPLICATOR, this.owner);
 
       //when
       const accessResult = accessService.mayAccessWhitelistedUrls();
@@ -163,22 +163,22 @@ module('Unit | Service | access', function(hooks) {
       assert.notOk(accessResult);
     });
 
-    test('it should return `true` when is admin', function(assert) {
-      // given
+    test('it should return `true` when is editor or above', function(assert) {
       _stubAccessLevel(ADMIN, this.owner);
-
-      //when
-      const accessResult = accessService.mayAccessWhitelistedUrls();
+      const accessResultAsAdmin = accessService.mayAccessWhitelistedUrls();
+      _stubAccessLevel(EDITOR, this.owner);
+      const accessResultAsEditor = accessService.mayAccessWhitelistedUrls();
 
       //then
-      assert.ok(accessResult);
+      assert.ok(accessResultAsAdmin);
+      assert.ok(accessResultAsEditor);
     });
   });
 
   module('mayCreateOrEditWhitelistedUrl', function() {
-    test('it should return `false` when is not admin', function(assert) {
+    test('it should return `false` when is not editor', function(assert) {
       // given
-      _stubAccessLevel(EDITOR, this.owner);
+      _stubAccessLevel(REPLICATOR, this.owner);
 
       //when
       const accessResult = accessService.mayCreateOrEditWhitelistedUrl();
@@ -187,15 +187,15 @@ module('Unit | Service | access', function(hooks) {
       assert.notOk(accessResult);
     });
 
-    test('it should return `true` when is admin', function(assert) {
-      // given
+    test('it should return `true` when is editor or above', function(assert) {
       _stubAccessLevel(ADMIN, this.owner);
-
-      //when
-      const accessResult = accessService.mayCreateOrEditWhitelistedUrl();
+      const accessResultAsAdmin = accessService.mayCreateOrEditWhitelistedUrl();
+      _stubAccessLevel(EDITOR, this.owner);
+      const accessResultAsEditor = accessService.mayCreateOrEditWhitelistedUrl();
 
       //then
-      assert.ok(accessResult);
+      assert.ok(accessResultAsAdmin);
+      assert.ok(accessResultAsEditor);
     });
   });
 });


### PR DESCRIPTION
## 🔆 Problème
Les éditeurs ont aussi besoin de gérer la liste des URLs à ne pas analyser.

## ⛱️ Proposition
Le leur permettre

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

Tester avec un compte éditeur d'intéragir avec la liste.
Tester avec un compte de lecture seule et vérifier qu'on ne peut pas accéder la liste
