### PR TITLE
[TECH] Renommage de Pix1D en PixJunior dans les labels, les noms de fichiers et de variables (PIX-18419)

### DIFF
--- a/api/db/seeds/data/pix-junior.js
+++ b/api/db/seeds/data/pix-junior.js
@@ -7,13 +7,13 @@ import { buildTube, persistTubes } from './tubes.js';
 import { buildSkill, persistSkills } from './skills.js';
 import { buildChallenge, persistChallenges } from './challenges.js';
 
-export async function buildPix1D({ airtableClient, databaseBuilder, logger, locales, indexFramework }) {
-  logger.info('About to create whole framework Pix 1D...');
-  const pix1DFrameworkItem = buildFramework({ name: 'Pix 1D' });
-  await persistFrameworks({ items: [pix1DFrameworkItem], airtableClient, logger });
+export async function buildPixJunior({ airtableClient, databaseBuilder, logger, locales, indexFramework }) {
+  logger.info('About to create whole framework Pix Junior...');
+  const pixJuniorFrameworkItem = buildFramework({ name: 'Pix Junior' });
+  await persistFrameworks({ items: [pixJuniorFrameworkItem], airtableClient, logger });
 
-  const areaItem1 = buildArea({ indexFramework, indexArea: 0, frameworkItem: pix1DFrameworkItem, databaseBuilder, locales });
-  const areaItem2 = buildArea({ indexFramework, indexArea: 1, frameworkItem: pix1DFrameworkItem, databaseBuilder, locales });
+  const areaItem1 = buildArea({ indexFramework, indexArea: 0, frameworkItem: pixJuniorFrameworkItem, databaseBuilder, locales });
+  const areaItem2 = buildArea({ indexFramework, indexArea: 1, frameworkItem: pixJuniorFrameworkItem, databaseBuilder, locales });
   await persistAreas({ items: [areaItem1, areaItem2], airtableClient, logger });
 
   const competenceItems = [];

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -7,7 +7,7 @@ import { buildAreasFromConfig } from './data/areas.js';
 import { buildChallengesFromConfig } from './data/challenges.js';
 import { buildCompetencesFromConfig } from './data/competences.js';
 import { buildFrameworksFromConfig } from './data/frameworks.js';
-import { buildPix1D } from './data/pix-1d.js';
+import { buildPixJunior } from './data/pix-junior.js';
 import { buildSkillsFromConfig } from './data/skills.js';
 import { buildThematicsFromConfig } from './data/thematics.js';
 import { buildTubesFromConfig } from './data/tubes.js';
@@ -64,7 +64,7 @@ export async function seed(knex) {
     await buildTubesFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
     await buildSkillsFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
     await buildChallengesFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
-    await buildPix1D({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, indexFramework: learningContentConfig.cntFrameworks });
+    await buildPixJunior({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, indexFramework: learningContentConfig.cntFrameworks });
     const tagItems = await buildTags({ airtableClient, logger });
     await buildTutorials({ airtableClient, logger, locales: learningContentConfig.locales, tagItems });
   } else {

--- a/api/tests/integration/domain/services/mission-validator_test.js
+++ b/api/tests/integration/domain/services/mission-validator_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { describe as context } from '@vitest/runner';
-import {  Mission, Skill } from '../../../../lib/domain/models/index.js';
+import { Mission, Skill } from '../../../../lib/domain/models/index.js';
 import * as missionValidator from '../../../../lib/domain/services/mission-validator.js';
 import { InvalidMissionContentError, MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
 import { airtableBuilder } from '../../../test-helper.js';
@@ -14,7 +14,7 @@ describe('Integration | Validator | Mission', function() {
             airtableBuilder.factory.buildSkill({ id: 'skillTuto1', level: 1, tubeId: 'tubeTuto1' }),
           ],
           tubes: [
-            airtableBuilder.factory.buildTube({ id: 'tubeTuto1', name: '@Pix1D-recherche_di' }),
+            airtableBuilder.factory.buildTube({ id: 'tubeTuto1', name: '@PixJunior-recherche_di' }),
           ],
           thematics: [
             airtableBuilder.factory.buildThematic({
@@ -134,7 +134,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill1Bis],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -186,7 +186,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill1Bis],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -244,7 +244,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill1Bis, skill2],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -275,7 +275,7 @@ describe('Integration | Validator | Mission', function() {
             const warnings = await missionValidator.validate(mission);
 
             // then
-            expect(warnings).to.deep.equal(['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
+            expect(warnings).to.deep.equal(['L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
           });
         });
         context('when there is several skills with "en construction"', function() {
@@ -296,7 +296,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill2],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -329,8 +329,8 @@ describe('Integration | Validator | Mission', function() {
             // then
             expect(warnings).to.deep.equal(
               [
-                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 1.',
-                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'
+                'L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 1.',
+                'L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'
               ]);
           });
         });

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -33,7 +33,7 @@ describe('Integration | Usecases | create mission', function() {
           status: Skill.STATUSES.EN_CONSTRUCTION
         })],
       tubes: [
-        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
       ],
       thematics: [
         airtableBuilder.factory.buildThematic({
@@ -52,7 +52,7 @@ describe('Integration | Usecases | create mission', function() {
     const result = await createMission(createdMission);
 
     // then
-    expect(result.warnings).to.deep.equal(['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
+    expect(result.warnings).to.deep.equal(['L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
   });
 
   it('when mission is not valid, should throw an error', async () => {
@@ -65,7 +65,7 @@ describe('Integration | Usecases | create mission', function() {
           status: Skill.STATUSES.EN_CONSTRUCTION
         })],
       tubes: [
-        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
       ],
       thematics: [
         airtableBuilder.factory.buildThematic({

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -31,7 +31,7 @@ describe('Integration | Usecases | Update mission', function() {
           status: Skill.STATUSES.EN_CONSTRUCTION
         })],
       tubes: [
-        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+        airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
       ],
       thematics: [
         airtableBuilder.factory.buildThematic({
@@ -54,7 +54,7 @@ describe('Integration | Usecases | Update mission', function() {
     const result = await updateMission(updatedMission);
 
     // then
-    expect(result).to.deep.equal({ mission: updatedMission, warnings: ['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'] });
+    expect(result).to.deep.equal({ mission: updatedMission, warnings: ['L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'] });
   });
 
   it('when mission is not valid, should throw an error', async () => {

--- a/api/tests/unit/domain/services/mission-validator_test.js
+++ b/api/tests/unit/domain/services/mission-validator_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { describe as context } from '@vitest/runner';
-import {  Mission, Skill } from '../../../../lib/domain/models/index.js';
+import { Mission, Skill } from '../../../../lib/domain/models/index.js';
 import * as missionValidator from '../../../../lib/domain/services/mission-validator.js';
 import { InvalidMissionContentError, MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
 import { airtableBuilder } from '../../../test-helper.js';
@@ -14,7 +14,7 @@ describe('Integration | Validator | Mission', function() {
             airtableBuilder.factory.buildSkill({ id: 'skillTuto1', level: 1, tubeId: 'tubeTuto1' }),
           ],
           tubes: [
-            airtableBuilder.factory.buildTube({ id: 'tubeTuto1', name: '@Pix1D-recherche_di' }),
+            airtableBuilder.factory.buildTube({ id: 'tubeTuto1', name: '@PixJunior-recherche_di' }),
           ],
           thematics: [
             airtableBuilder.factory.buildThematic({
@@ -134,7 +134,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill1Bis],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -186,7 +186,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill1Bis],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -244,7 +244,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill1Bis, skill2],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -275,7 +275,7 @@ describe('Integration | Validator | Mission', function() {
             const warnings = await missionValidator.validate(mission);
 
             // then
-            await expect(warnings).to.deep.equal(['L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
+            await expect(warnings).to.deep.equal(['L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.']);
           });
         });
         context('when there is several skills with "en construction"', function() {
@@ -296,7 +296,7 @@ describe('Integration | Validator | Mission', function() {
             const mockedLearningContent = {
               skills: [skill1, skill2],
               tubes: [
-                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@Pix1D-recherche_di' }),
+                airtableBuilder.factory.buildTube({ id: 'tubeTuto', name: '@PixJunior-recherche_di' }),
               ],
               thematics: [
                 airtableBuilder.factory.buildThematic({
@@ -329,8 +329,8 @@ describe('Integration | Validator | Mission', function() {
             // then
             await expect(warnings).to.deep.equal(
               [
-                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 1.',
-                'L\'activité \'@Pix1D-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'
+                'L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 1.',
+                'L\'activité \'@PixJunior-recherche_di\' n\'a pas d\'acquis actif pour le niveau 2.'
               ]);
           });
         });

--- a/api/tests/unit/infrastructure/transformers/mission-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/mission-transformer_test.js
@@ -57,13 +57,13 @@ describe('Unit | Transformer | mission-transformer', function() {
       ];
       tubes = [
         new Tube({ id: 'aTubeWithoutName' }),
-        domainBuilder.buildTube({ id: 'tubeTuto1', name: '@Pix1D-recherche_di' }),
-        domainBuilder.buildTube({ id: 'tubeTraining1', name: '@Pix1D-recherche_en' }),
-        domainBuilder.buildTube({ id: 'tubeValidation1', name: '@Pix1D-recherche_va' }),
-        domainBuilder.buildTube({ id: 'tubeTuto2', name: '@Pix1D-recherche-2_di' }),
-        domainBuilder.buildTube({ id: 'tubeTraining2', name: '@Pix1D-recherche-2_en' }),
-        domainBuilder.buildTube({ id: 'tubeValidation2', name: '@Pix1D-recherche-2_va' }),
-        domainBuilder.buildTube({ id: 'tubeDare', name: '@Pix1D-recherche_de' }),
+        domainBuilder.buildTube({ id: 'tubeTuto1', name: '@PixJunior-recherche_di' }),
+        domainBuilder.buildTube({ id: 'tubeTraining1', name: '@PixJunior-recherche_en' }),
+        domainBuilder.buildTube({ id: 'tubeValidation1', name: '@PixJunior-recherche_va' }),
+        domainBuilder.buildTube({ id: 'tubeTuto2', name: '@PixJunior-recherche-2_di' }),
+        domainBuilder.buildTube({ id: 'tubeTraining2', name: '@PixJunior-recherche-2_en' }),
+        domainBuilder.buildTube({ id: 'tubeValidation2', name: '@PixJunior-recherche-2_va' }),
+        domainBuilder.buildTube({ id: 'tubeDare', name: '@PixJunior-recherche_de' }),
       ];
       thematics = [
         domainBuilder.buildThematic({

--- a/pix-editor/app/components/sidebar/main.hbs
+++ b/pix-editor/app/components/sidebar/main.hbs
@@ -18,7 +18,7 @@
     {{/if}}
     {{#if this.shouldShowMissionsLink}}
       <LinkTo @route="authenticated.missions" {{on "click" @close}}>
-        <i class="graduation cap icon"></i> Missions Pix 1D
+        <i class="graduation cap icon"></i> Missions Pix Junior
       </LinkTo>
     {{/if}}
     {{#if this.mayAccessStaticCourses}}

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -49,7 +49,7 @@ export default class SidebarMain extends Component {
   }
 
   get shouldShowMissionsLink() {
-    return this.currentData?.getFramework()?.name.toLowerCase() === FrameworkModel.pix1DFrameworkName.toLowerCase();
+    return this.currentData?.getFramework()?.name.toLowerCase() === FrameworkModel.pixJuniorFrameworkName.toLowerCase();
   }
 
   get isV2() {

--- a/pix-editor/app/models/framework.js
+++ b/pix-editor/app/models/framework.js
@@ -2,7 +2,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class FrameworkModel extends Model {
 
-  static pix1DFrameworkName = 'Pix 1D';
+  static pixJuniorFrameworkName = 'Pix Junior';
 
   @attr name;
   @hasMany('area', { async: true, inverse: 'framework' }) areas;

--- a/pix-editor/app/routes/authenticated/missions/mission/details.js
+++ b/pix-editor/app/routes/authenticated/missions/mission/details.js
@@ -7,12 +7,12 @@ export default class MissionDetailsRoute extends Route {
 
   async model() {
     const mission = this.modelFor('authenticated.missions.mission');
-    const competences = await this.currentData.getCompetencesFromPix1DFramework();
+    const competences = await this.currentData.getCompetencesFromPixJuniorFramework();
     const missionCompetence = competences.filter((competence) => competence.pixId === mission.competenceId);
     let missionThematicNames;
     if (mission.thematicIds) {
-      const pix1DThematics = await this.currentData.getThematicsFromPix1DFramework();
-      const thematicNameById = new Map(pix1DThematics.map((thematic) => [thematic.pixId, thematic.name]));
+      const pixJuniorThematics = await this.currentData.getThematicsFromPixJuniorFramework();
+      const thematicNameById = new Map(pixJuniorThematics.map((thematic) => [thematic.pixId, thematic.name]));
       const missionThematicIds = mission.thematicIds.split(',');
       missionThematicNames = missionThematicIds.map((thematicId) => thematicNameById.get(thematicId)).join(', ');
     }

--- a/pix-editor/app/routes/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/routes/authenticated/missions/mission/edit.js
@@ -14,7 +14,7 @@ export default class MissionNewRoute extends Route {
   }
 
   async model() {
-    const competences = await this.currentData.getCompetencesFromPix1DFramework();
+    const competences = await this.currentData.getCompetencesFromPixJuniorFramework();
     const mission = this.modelFor('authenticated.missions.mission');
     return {
       mission,
@@ -23,6 +23,6 @@ export default class MissionNewRoute extends Route {
   }
 
   afterModel() {
-    return this.currentData.getThematicsFromPix1DFramework();
+    return this.currentData.getThematicsFromPixJuniorFramework();
   }
 }

--- a/pix-editor/app/routes/authenticated/missions/new.js
+++ b/pix-editor/app/routes/authenticated/missions/new.js
@@ -14,7 +14,7 @@ export default class MissionNewRoute extends Route {
   }
 
   async model() {
-    const competences = await this.currentData.getCompetencesFromPix1DFramework();
+    const competences = await this.currentData.getCompetencesFromPixJuniorFramework();
     const mission = this.store.createRecord('mission');
 
     return {
@@ -24,6 +24,6 @@ export default class MissionNewRoute extends Route {
   }
 
   afterModel() {
-    return this.currentData.getThematicsFromPix1DFramework();
+    return this.currentData.getThematicsFromPixJuniorFramework();
   }
 }

--- a/pix-editor/app/services/current-data.js
+++ b/pix-editor/app/services/current-data.js
@@ -12,6 +12,10 @@ export default class CurrentDataService extends Service {
   @tracked _sources = null;
   @tracked _source = null;
 
+  get isPixFramework() {
+    return this._framework && this._framework.name === 'Pix';
+  }
+
   setFrameworks(frameworks) {
     this._frameworks = frameworks;
   }
@@ -40,10 +44,6 @@ export default class CurrentDataService extends Service {
     return this._framework;
   }
 
-  get isPixFramework() {
-    return this._framework && this._framework.name === 'Pix';
-  }
-
   getAreas(filteredBySource = true) {
     if (filteredBySource && this._framework) {
       return this._framework.sortedAreas;
@@ -59,8 +59,8 @@ export default class CurrentDataService extends Service {
     return this._prototype;
   }
 
-  async getCompetencesFromPix1DFramework() {
-    const frameworks = this.getFrameworks().filter((framework) => framework.name === FrameworkModel.pix1DFrameworkName);
+  async getCompetencesFromPixJuniorFramework() {
+    const frameworks = this.getFrameworks().filter((framework) => framework.name === FrameworkModel.pixJuniorFrameworkName);
     const getAreas = frameworks.map((framework) => framework.areas);
     const frameworkAreas = await Promise.all(getAreas);
     const getCompetences = frameworkAreas.map((areas) => areas.map((area) => area.competences)).flat();
@@ -68,8 +68,8 @@ export default class CurrentDataService extends Service {
     return areaCompetences.flatMap((competences) => [...competences]);
   }
 
-  async getThematicsFromPix1DFramework() {
-    const competences = await this.getCompetencesFromPix1DFramework();
+  async getThematicsFromPixJuniorFramework() {
+    const competences = await this.getCompetencesFromPixJuniorFramework();
     const getThemes = competences.map((competence) => competence.rawThemes);
     const themes = await Promise.all(getThemes);
     return themes.flatMap((theme) => [...theme]);

--- a/pix-editor/mirage/scenarios/default.js
+++ b/pix-editor/mirage/scenarios/default.js
@@ -16,5 +16,5 @@ export default function(server) {
   server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
   server.create('area', { id: 'recArea2', name: '2. Communication et collaboration', code: '2', competenceIds: ['recCompetence2.1'] });
   server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1', 'recArea2'] });
-  server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D' });
+  server.create('framework', { id: 'recFrameworkPixJunior', name: 'Pix Junior' });
 }

--- a/pix-editor/tests/acceptance/missions/creation-test.js
+++ b/pix-editor/tests/acceptance/missions/creation-test.js
@@ -16,7 +16,7 @@ module('Acceptance | Missions | Creation', function(hooks) {
     this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixIdRecCompetence1.1', title: 'Notre compétence', source: 'Pix+' });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
-    this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D', areaIds: ['recArea1'] });
+    this.server.create('framework', { id: 'recFrameworkPixJunior', name: 'Pix Junior', areaIds: ['recArea1'] });
     this.server.create('mission-summary', { name: 'Mission 1', competence: 'Mirage', createdAt: '2023/12/11', status: 'ACTIVE' });
     this.server.create('mission-summary', { name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
   });
@@ -33,8 +33,8 @@ module('Acceptance | Missions | Creation', function(hooks) {
       const screen = await visit('/');
       await clickByName('Sélectionner un référentiel');
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Pix 1D' }));
-      await clickByName('Missions Pix 1D');
+      await click(screen.getByRole('option', { name: 'Pix Junior' }));
+      await clickByName('Missions Pix Junior');
 
       // then
       assert.dom(screen.queryByText('Créer une nouvelle mission')).doesNotExist();
@@ -55,8 +55,8 @@ module('Acceptance | Missions | Creation', function(hooks) {
       const screen = await visit('/');
       await clickByName('Sélectionner un référentiel');
       await screen.findByRole('listbox');
-      await click(screen.getByRole('option', { name: 'Pix 1D' }));
-      await clickByName('Missions Pix 1D');
+      await click(screen.getByRole('option', { name: 'Pix Junior' }));
+      await clickByName('Missions Pix Junior');
 
       // when
       await clickByName('Créer une nouvelle mission');

--- a/pix-editor/tests/acceptance/missions/details_test.js
+++ b/pix-editor/tests/acceptance/missions/details_test.js
@@ -17,7 +17,7 @@ module('Acceptance | Missions | Details', function(hooks) {
     this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixIdRecCompetence1.1', title: 'Notre compétence' });
     this.server.create('area', { id: 'recArea1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
-    this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D', areaIds: ['recArea1'] });
+    this.server.create('framework', { id: 'recFrameworkPixJunior', name: 'Pix Junior', areaIds: ['recArea1'] });
     this.server.create('mission-summary', { id: 1, name: 'Mission 1', competence: 'Mirage', createdAt: '2023/12/11', status: 'ACTIVE' });
     this.server.create('mission', { id: 1, name: 'Mission 1', competenceId: 'pixIdRecCompetence1.1', createdAt: '2023/12/11', status: 'ACTIVE', learningObjectives: 'Tout savoir', validatedObjectives: 'Jusque là, rien', documentationUrl: 'http://url-example.net' });
     this.server.create('mission-summary', { id: 2, name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
@@ -25,7 +25,7 @@ module('Acceptance | Missions | Details', function(hooks) {
     return authenticateSession();
   });
 
-  test('it displays all Pix 1D missions', async function(assert) {
+  test('it displays all Pix Junior missions', async function(assert) {
     // when
     const screen = await visit('/missions');
     await click(screen.getAllByRole('row')[1]);

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -20,7 +20,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       code: '1',
       competenceIds: ['recCompetence1.1'],
     });
-    this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D', areaIds: ['recArea1'] });
+    this.server.create('framework', { id: 'recFrameworkPixJunior', name: 'Pix Junior', areaIds: ['recArea1'] });
     this.server.create('mission', {
       id: 2,
       name: 'Mission 1',

--- a/pix-editor/tests/acceptance/missions/list_test.js
+++ b/pix-editor/tests/acceptance/missions/list_test.js
@@ -13,7 +13,7 @@ module('Acceptance | Missions | List', function(hooks) {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
-    this.server.create('framework', { id: 'recFrameworkPix1D', name: 'Pix 1D' });
+    this.server.create('framework', { id: 'recFrameworkPixJunior', name: 'Pix Junior' });
     this.server.create('mission-summary', { name: 'Mission 1', competence: 'Mirage', createdAt: '2023/12/11', status: 'VALIDATED' });
     this.server.create('mission-summary', { name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
     this.server.create('mission-summary', { name: 'Mission 3', competence: 'Autres', createdAt: '2023/11/11', status: 'EXPERIMENTAL' });
@@ -21,13 +21,13 @@ module('Acceptance | Missions | List', function(hooks) {
     return authenticateSession();
   });
 
-  test('it displays all Pix 1D missions', async function(assert) {
+  test('it displays all Pix Junior missions', async function(assert) {
     // when
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
     await screen.findByRole('listbox');
-    await click(screen.getByRole('option', { name: 'Pix 1D' }));
-    await clickByName('Missions Pix 1D');
+    await click(screen.getByRole('option', { name: 'Pix Junior' }));
+    await clickByName('Missions Pix Junior');
 
     // then
     assert.strictEqual(currentURL(), '/missions');
@@ -40,8 +40,8 @@ module('Acceptance | Missions | List', function(hooks) {
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
     await screen.findByRole('listbox');
-    await click(screen.getByRole('option', { name: 'Pix 1D' }));
-    await clickByName('Missions Pix 1D');
+    await click(screen.getByRole('option', { name: 'Pix Junior' }));
+    await clickByName('Missions Pix Junior');
     await click(screen.getByLabelText('Statut'));
     await click(await screen.findByRole('checkbox', { name: 'Validée' }));
 
@@ -55,8 +55,8 @@ module('Acceptance | Missions | List', function(hooks) {
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
     await screen.findByRole('listbox');
-    await click(screen.getByRole('option', { name: 'Pix 1D' }));
-    await clickByName('Missions Pix 1D');
+    await click(screen.getByRole('option', { name: 'Pix Junior' }));
+    await clickByName('Missions Pix Junior');
     await click(screen.getByLabelText('Statut'));
     await click(await screen.findByRole('checkbox', { name: 'Validée' }));
     await click(await screen.findByRole('checkbox', { name: 'Expérimentale' }));

--- a/pix-editor/tests/integration/components/sidebar/main-test.js
+++ b/pix-editor/tests/integration/components/sidebar/main-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | main-sidebar', function(hooks) {
     this.set('closeMenu', function() {});
     this.owner.register('service:currentData', class MockService extends Service {
       getFramework() {
-        return { name: 'Pix 1D' };
+        return { name: 'Pix Junior' };
       }
       getAreas() {
         return [];
@@ -27,11 +27,11 @@ module('Integration | Component | main-sidebar', function(hooks) {
     assert.dom('.main-sidebar').exists();
   });
 
-  module('the pix1d framework is selected', function() {
+  module('the pixJunior framework is selected', function() {
     test('displays mission tab', async function(assert) {
       this.owner.register('service:currentData', class MockService extends Service {
         getFramework() {
-          return { name: 'Pix 1D' };
+          return { name: 'Pix Junior' };
         }
         getAreas() {
           return [];
@@ -44,12 +44,12 @@ module('Integration | Component | main-sidebar', function(hooks) {
       const screen = await render(hbs`<Sidebar::Main @openLogout={{this.openLogout}}
                                     @open={{this.menuOpen}}
                                     @close={{this.closeMenu}} />`);
-      assert.dom(screen.getByText('Missions Pix 1D')).exists();
+      assert.dom(screen.getByText('Missions Pix Junior')).exists();
     });
   });
 
-  module('the pix1d framework is not selected', function() {
-    test('does not display the Mission Pix 1D', async function(assert) {
+  module('the pixJunior framework is not selected', function() {
+    test('does not display the Mission Pix Junior', async function(assert) {
       this.owner.register('service:currentData', class MockService extends Service {
         getFramework() {
           return { name: 'Pix+ Droit' };
@@ -66,7 +66,7 @@ module('Integration | Component | main-sidebar', function(hooks) {
                                     @open={{this.menuOpen}}
                                     @close={{this.closeMenu}} />`);
 
-      assert.dom(screen.queryByText('Missions Pix 1D')).doesNotExist();
+      assert.dom(screen.queryByText('Missions Pix Junior')).doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/unit/services/current-data-test.js
+++ b/pix-editor/tests/unit/services/current-data-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Service | current-data', function(hooks) {
   setupTest(hooks);
-  let competence, service, pixFramework, pixFranceFramework, pix1dFramework, pixArea, pix1dArea, pixFranceArea, pix1dThematic, pix1dCompetence, prototype;
+  let competence, service, pixFramework, pixFranceFramework, pixJuniorFramework, pixArea, pixJuniorArea, pixFranceArea, pixJuniorThematic, pixJuniorCompetence, prototype;
 
   hooks.beforeEach(function() {
     const store = this.owner.lookup('service:store');
@@ -17,13 +17,13 @@ module('Unit | Service | current-data', function(hooks) {
       id: 'competence',
     });
 
-    pix1dThematic = store.createRecord('theme', {
+    pixJuniorThematic = store.createRecord('theme', {
       id: 'thematic',
     });
 
-    pix1dCompetence = store.createRecord('competence', {
-      id: 'pix1dCompetence',
-      rawThemes: [pix1dThematic],
+    pixJuniorCompetence = store.createRecord('competence', {
+      id: 'pixJuniorCompetence',
+      rawThemes: [pixJuniorThematic],
     });
 
     pixFranceArea = store.createRecord('area', {
@@ -36,10 +36,10 @@ module('Unit | Service | current-data', function(hooks) {
       code: '2',
     });
 
-    pix1dArea = store.createRecord('area', {
-      id: 'pix1dArea',
+    pixJuniorArea = store.createRecord('area', {
+      id: 'pixJuniorArea',
       code: '3',
-      competences: [pix1dCompetence],
+      competences: [pixJuniorCompetence],
     });
 
     pixFranceFramework = store.createRecord('framework', {
@@ -54,16 +54,16 @@ module('Unit | Service | current-data', function(hooks) {
       areas: [pixArea],
     });
 
-    pix1dFramework = store.createRecord('framework', {
-      id: 'pix1dFramework',
-      name: 'Pix 1D',
-      areas: [pix1dArea],
+    pixJuniorFramework = store.createRecord('framework', {
+      id: 'pixJuniorFramework',
+      name: 'Pix Junior',
+      areas: [pixJuniorArea],
     });
 
     service = this.owner.lookup('service:current-data');
-    service.setFrameworks([pixFramework, pixFranceFramework, pix1dFramework]);
+    service.setFrameworks([pixFramework, pixFranceFramework, pixJuniorFramework]);
     service.setFramework(pixFramework);
-    service.setAreas([pixArea, pixFranceArea, pix1dArea]);
+    service.setAreas([pixArea, pixFranceArea, pixJuniorArea]);
     service.setCompetence(competence);
     service.setPrototype(prototype);
   });
@@ -73,7 +73,7 @@ module('Unit | Service | current-data', function(hooks) {
     const frameworks = service.getFrameworks();
 
     // then
-    assert.deepEqual(frameworks, [pixFramework, pixFranceFramework, pix1dFramework]);
+    assert.deepEqual(frameworks, [pixFramework, pixFranceFramework, pixJuniorFramework]);
   });
 
   test('it should return one framework', function(assert) {
@@ -89,7 +89,7 @@ module('Unit | Service | current-data', function(hooks) {
     const areas = service.getAreas(false);
 
     // then
-    assert.deepEqual(areas, [pixArea, pixFranceArea, pix1dArea]);
+    assert.deepEqual(areas, [pixArea, pixFranceArea, pixJuniorArea]);
   });
 
   test('it should return areas of set framework when have no argument ', async function(assert) {
@@ -135,19 +135,19 @@ module('Unit | Service | current-data', function(hooks) {
     assert.notOk(isPixFrameworkResult);
   });
 
-  test('it should return competences for pix1d', async function(assert) {
+  test('it should return competences for pixJunior', async function(assert) {
     // when
-    const competencesResult = await service.getCompetencesFromPix1DFramework();
+    const competencesResult = await service.getCompetencesFromPixJuniorFramework();
 
     // then
-    assert.deepEqual(competencesResult, [pix1dCompetence]);
+    assert.deepEqual(competencesResult, [pixJuniorCompetence]);
   });
 
-  test('it should return thematics for pix1d', async function(assert) {
+  test('it should return thematics for pixJunior', async function(assert) {
     // when
-    const thematicsResult = await service.getThematicsFromPix1DFramework();
+    const thematicsResult = await service.getThematicsFromPixJuniorFramework();
 
     // then
-    assert.deepEqual(thematicsResult, [pix1dThematic]);
+    assert.deepEqual(thematicsResult, [pixJuniorThematic]);
   });
 });


### PR DESCRIPTION
## 🔆 Problème

La fiesta du renommage

## ⛱️ Proposition

Tout renommer

## 🌊 Remarques

Au fur et à mesure de l'avancée du ticket dans le flux de déploiement, il faut renommer le référentiel dans Airtable en direct.
J'invite également mes chers collègues à claquer un bon gros npm run db:reset des familles pour que leur airtable personnel soit mis à jour

BLOQUé le temps de voir si côté Pix aussi y'a des choses à faire

## 🏄 Pour tester

Non rég sur Pix 1D, euuuuuh Pix Junior pardon
