### PR TITLE
[BUMP] PixEditor : ember-intl de la version 7.0.0 vers 7.3.1 ET ember-file-upload de la version 9.0.0 vers 9.5.0 ET ember-inflector de 4.0.2 vers 4.0.3

### DIFF
--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -58,7 +58,7 @@
         "ember-eslint-parser": "^0.5.3",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^9.5.0",
-        "ember-inflector": "^4.0.2",
+        "ember-inflector": "^4.0.3",
         "ember-intl": "^7.3.1",
         "ember-lifeline": "7.0.0",
         "ember-load-initializers": "^3.0.0",
@@ -23795,6 +23795,8 @@
     },
     "node_modules/ember-inflector": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-4.0.3.tgz",
+      "integrity": "sha512-E+NnmzybMRWn1JyEfDxY7arjOTJLIcGjcXnUxizgjD4TlvO1s3O65blZt+Xq2C2AFSPeqHLC6PXd6XHYM8BxdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -57,7 +57,7 @@
         "ember-dayjs": "^0.12.1",
         "ember-eslint-parser": "^0.5.3",
         "ember-fetch": "^8.1.2",
-        "ember-file-upload": "^9.0.0",
+        "ember-file-upload": "^9.5.0",
         "ember-inflector": "^4.0.2",
         "ember-intl": "^7.3.1",
         "ember-lifeline": "7.0.0",
@@ -21787,26 +21787,26 @@
       }
     },
     "node_modules/ember-file-upload": {
-      "version": "9.1.0",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-9.5.0.tgz",
+      "integrity": "sha512-qcYAuaA4MsmGzTaGgaC/KWAPh3Gc/rwl3h9YgI8pHP2AbLSrJ3Ichi73nr71NrUerYLZ3ccmT6M0ohPKaTeXIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ember/test-waiters": "^3.0.0",
+        "@ember/test-waiters": "^3.0.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.5.0",
-        "@embroider/macros": "^1.0.0",
-        "ember-auto-import": "^2.0.0"
+        "@embroider/macros": "^1.0.0"
       },
       "engines": {
         "node": "16.* || >= 18"
       },
       "peerDependencies": {
-        "@ember/test-helpers": "^2.9.3 || ^3.0.3 || ^4.0.4",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
+        "@ember/test-helpers": "^2.9.3 || ^3.0.3 || ^4.0.4 || ^5.0.0",
+        "@glimmer/component": ">=1.1.2",
         "ember-cli-mirage": "*",
         "ember-modifier": "^3.2.7 || ^4.1.0",
         "miragejs": "*",
-        "tracked-built-ins": "^3.1.1"
+        "tracked-built-ins": ">=3.1.1"
       },
       "peerDependenciesMeta": {
         "ember-cli-mirage": {

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -59,7 +59,7 @@
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^9.0.0",
         "ember-inflector": "^4.0.2",
-        "ember-intl": "^7.0.0",
+        "ember-intl": "^7.3.1",
         "ember-lifeline": "7.0.0",
         "ember-load-initializers": "^3.0.0",
         "ember-modifier": "^4.1.0",
@@ -162,97 +162,6 @@
       },
       "engines": {
         "node": "^20 || ^22"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
-      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.1",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
-      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/icu-skeleton-parser": "1.8.14",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
-      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/intl": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.6.tgz",
-      "integrity": "sha512-tDkXnA4qpIFcDWac8CyVJq6oW8DR7W44QDUBsfXWIIJD/FYYen0QoH46W7XsVMFfPOVKkvbufjboZrrWbEfmww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.2",
-        "intl-messageformat": "10.7.16",
-        "tslib": "^2.8.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
-      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/intl-messageformat": {
-      "version": "10.7.16",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
-      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.4",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.2",
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@1024pix/stylelint-config": {
@@ -989,20 +898,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.2",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.7.tgz",
+      "integrity": "sha512-xgu/ySj2mTiUFmdE9yCMfBxLp4DHd5DwmbbD05YAuICfodYT3VvRxbrh81LGQ/8UpSdtMdfKMn3KouYDX59DGQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1010,20 +923,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.0",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
+      "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.0",
-        "@babel/generator": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.0",
-        "@babel/parser": "^7.26.0",
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.26.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.5",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.27.7",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.27.7",
+        "@babel/types": "^7.27.7",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -1058,12 +973,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.27.5",
+        "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -1096,12 +1013,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
-        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -1174,25 +1093,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.26.0",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1279,7 +1202,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1287,7 +1212,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1295,7 +1222,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1316,23 +1245,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
+      "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.27.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2613,28 +2546,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.9",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
+      "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.5",
+        "@babel/parser": "^7.27.7",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2651,12 +2588,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
+      "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6042,57 +5981,66 @@
       "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "2"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.10.15",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.6.tgz",
+      "integrity": "sha512-tDkXnA4qpIFcDWac8CyVJq6oW8DR7W44QDUBsfXWIIJD/FYYen0QoH46W7XsVMFfPOVKkvbufjboZrrWbEfmww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "intl-messageformat": "10.7.16",
+        "tslib": "^2.8.0"
       },
       "peerDependencies": {
-        "typescript": "^4.7 || 5"
+        "typescript": "^5.6.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -6100,32 +6048,14 @@
         }
       }
     },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat": {
-      "version": "7.7.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "2"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@glimmer/compiler": {
@@ -12280,15 +12210,47 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12716,7 +12678,9 @@
       }
     },
     "node_modules/cldr-core": {
-      "version": "45.0.0",
+      "version": "47.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-47.0.0.tgz",
+      "integrity": "sha512-tdYRy66DMgpjEwVOWCTN0zhNr+zh1+d4A6MCNgJKU7voFDGsrwcWHor6jcqudHDmElCgyVNqWBKAB1JeNdSOKg==",
       "dev": true,
       "license": "Unicode-3.0"
     },
@@ -14383,6 +14347,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexify": {
@@ -24401,33 +24380,34 @@
       }
     },
     "node_modules/ember-intl": {
-      "version": "7.0.7",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-7.3.1.tgz",
+      "integrity": "sha512-jrYI7lB9fG5WOt1U9usykK+1d1UV85OGsh4nZnXlujpGGzFXL8zFSFcSbaAsAfLf1SreQ+Nzu9tjBSjtF15O+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.25.8",
-        "@formatjs/icu-messageformat-parser": "^2.7.10",
-        "@formatjs/intl": "^2.10.8",
+        "@babel/core": "^7.27.4",
+        "@formatjs/icu-messageformat-parser": "^2.11.2",
+        "@formatjs/intl": "^3.1.6",
         "broccoli-caching-writer": "^3.0.3",
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-source": "^3.0.1",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "cldr-core": "^45.0.0",
-        "ember-auto-import": "^2.8.1",
+        "cldr-core": "^47.0.0",
+        "ember-auto-import": "^2.10.0",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-typescript": "^5.3.0",
-        "eventemitter3": "^5.0.1",
         "extend": "^3.0.2",
-        "intl-messageformat": "^10.7.0",
+        "intl-messageformat": "^10.7.16",
         "js-yaml": "^4.1.0",
-        "json-stable-stringify": "^1.1.1"
+        "json-stable-stringify": "^1.3.0"
       },
       "engines": {
         "node": "18.* || >= 20"
       },
       "peerDependencies": {
-        "@ember/test-helpers": "^2.9.4 || ^3.2.0 || ^4.0.0",
+        "@ember/test-helpers": "^2.9.4 || ^3.2.0 || ^4.0.0 || ^5.0.0",
         "typescript": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -28129,23 +28109,6 @@
         "node": "^18.18.0 || >= 20.9.0"
       }
     },
-    "node_modules/ember-template-lint/node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/ember-template-lint/node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
@@ -28186,22 +28149,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/ember-template-lint/node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/ember-template-lint/node_modules/@babel/plugin-transform-typescript": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
@@ -28220,54 +28167,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-template-lint/node_modules/@babel/template": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/ember-template-lint/node_modules/@babel/traverse": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/ember-template-lint/node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/ember-template-lint/node_modules/chalk": {
@@ -28306,16 +28205,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ember-template-lint/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ember-template-lint/node_modules/locate-path": {
@@ -31622,12 +31511,11 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -31646,7 +31534,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -33409,21 +33299,42 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stdin": {
@@ -33669,12 +33580,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.1.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -34378,14 +34288,16 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.7",
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "tslib": "2"
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/invariant": {
@@ -35303,11 +35215,14 @@
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
-      "version": "1.1.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "isarray": "^2.0.5",
         "jsonify": "^0.0.1",
         "object-keys": "^1.1.1"
@@ -35993,6 +35908,16 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mathml-tag-names": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -71,7 +71,7 @@
     "ember-dayjs": "^0.12.1",
     "ember-eslint-parser": "^0.5.3",
     "ember-fetch": "^8.1.2",
-    "ember-file-upload": "^9.0.0",
+    "ember-file-upload": "^9.5.0",
     "ember-inflector": "^4.0.2",
     "ember-intl": "^7.3.1",
     "ember-lifeline": "7.0.0",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -73,7 +73,7 @@
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^9.0.0",
     "ember-inflector": "^4.0.2",
-    "ember-intl": "^7.0.0",
+    "ember-intl": "^7.3.1",
     "ember-lifeline": "7.0.0",
     "ember-load-initializers": "^3.0.0",
     "ember-modifier": "^4.1.0",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -72,7 +72,7 @@
     "ember-eslint-parser": "^0.5.3",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^9.5.0",
-    "ember-inflector": "^4.0.2",
+    "ember-inflector": "^4.0.3",
     "ember-intl": "^7.3.1",
     "ember-lifeline": "7.0.0",
     "ember-load-initializers": "^3.0.0",


### PR DESCRIPTION
## 🔆 Problème

On est à la bourre de montée de version

## ⛱️ Proposition

Monter ember-intl et ember-file-upload
A priori pas de breaking changes qui nous concernent
Montés pour débloquer la situation autour de la montée de ember/test-helper, mais d'autres packages posent problème. Au moins ceux-là ne feront plus partie du pb

## 🌊 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🏄 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
