### PR TITLE
[BUGFIX] Fix sur la notation des couleurs rgba

### DIFF
--- a/pix-editor/.stylelintrc.json
+++ b/pix-editor/.stylelintrc.json
@@ -4,6 +4,7 @@
   ],
   "rules": {
     "alpha-value-notation": null,
+    "color-function-alias-notation": "with-alpha",
     "color-function-notation": null,
     "font-family-no-missing-generic-family-keyword": null,
     "no-descending-specificity": null,

--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -2,7 +2,7 @@
 
 // stylelint-disable color-no-hex, color-named
 .alternative {
-  color: rgb(0, 0, 0 / 0.87);
+  color: rgba(0, 0, 0, 0.87);
   font-size: 12px;
 
   .production {
@@ -98,8 +98,8 @@ img.clickable {
 }
 
 .challenge-header {
-  border-top: 1px solid rgb(34, 36, 38 / 0.15);
-  border-bottom: 1px solid rgb(34, 36, 38 / 0.15);
+  border-top: 1px solid rgba(34, 36, 38, 0.15);
+  border-bottom: 1px solid rgba(34, 36, 38, 0.15);
 
   .creation {
     font-style: italic;
@@ -201,7 +201,7 @@ img.clickable {
       padding: 0.78571429em 1em;
       overflow: scroll;
       background-color: #f9f9f9;
-      border: 1px solid rgb(34, 36, 38 / 0.15);
+      border: 1px solid rgba(34, 36, 38, 0.15);
       border-radius: 0.28571429rem;
     }
 
@@ -256,7 +256,7 @@ img.clickable {
 %challenge-menu {
   margin-top: 0;
   border: none;
-  border-left: 1px solid rgb(34, 36, 38 / 0.15);
+  border-left: 1px solid rgba(34, 36, 38, 0.15);
   box-shadow: none;
 
   div.item::before {

--- a/pix-editor/app/styles/_competence.scss
+++ b/pix-editor/app/styles/_competence.scss
@@ -55,7 +55,7 @@
     &.theme-cell {
       width: 200px;
       padding-left: 10px;
-      background: rgb(0, 0, 0 / 0.01);
+      background: rgba(0, 0, 0, 0.01);
 
       &.create-tube {
         position: relative;
@@ -81,13 +81,13 @@
       width: 160px;
       padding-left: 10px;
       font-weight: bold;
-      background: rgb(0, 0, 0 / 0.03);
-      border-left: 1px solid rgb(34, 36, 38 / 0.15);
+      background: rgba(0, 0, 0, 0.03);
+      border-left: 1px solid rgba(34, 36, 38, 0.15);
 
     }
 
     &.empty-row {
-      background: rgb(0, 0, 0 / 0.03);
+      background: rgba(0, 0, 0, 0.03);
     }
 
     &.skill-cell {
@@ -126,7 +126,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: rgb(146, 146, 55 / 0.3);
+            background: rgba(146, 146, 55, 0.3);
             content: '';
           }
         }
@@ -191,13 +191,13 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: rgb(124, 144, 167 / 0.3);
+            background: rgba(124, 144, 167, 0.3);
             content: '';
           }
         }
 
         .idea.icon {
-          text-shadow: 1px 1px 1px rgb(0, 0, 0 / 0.8);
+          text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.8);
 
           &.validated,
           &.prevalidated {

--- a/pix-editor/app/styles/_custom-tabs.scss
+++ b/pix-editor/app/styles/_custom-tabs.scss
@@ -13,7 +13,7 @@
       cursor: pointer;
 
       &.ember-tabs__tab--selected {
-        border: 1px solid rgb(212, 212, 213);
+        border: 1px solid rgba(212, 212, 213, 1);
         border-bottom-color: white;
         border-radius: 5px 5px 0 0;
       }

--- a/pix-editor/app/styles/_custom-tooltip.scss
+++ b/pix-editor/app/styles/_custom-tooltip.scss
@@ -8,7 +8,7 @@
   text-shadow: none;
   background-color: white;
   border-radius: 5px;
-  box-shadow: 1px 1px 4px rgb(0, 0, 0 / 0.5);
+  box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.5);
 
   &.large {
     width: 75vw;

--- a/pix-editor/app/styles/_global.scss
+++ b/pix-editor/app/styles/_global.scss
@@ -58,7 +58,7 @@ a, p, span, li {
 }
 
 .ui.menu.main-menu {
-  border-right: 1px solid rgb(34, 36, 38 / 0.15);
+  border-right: 1px solid rgba(34, 36, 38, 0.15);
   border-radius: 0;
 
   .ui.icon.button {
@@ -147,7 +147,7 @@ a, p, span, li {
     &.menu:not(.tabular) {
       background-color: #F9FAFB;
       border: none;
-      border-bottom: 1px solid rgb(34, 36, 38 / 0.15);
+      border-bottom: 1px solid rgba(34, 36, 38, 0.15);
     }
 
     .ui.button.item.left.first {
@@ -156,7 +156,7 @@ a, p, span, li {
 
     + .ui.attached.menu:not(.top) {
       display: flex;
-      border-top: 1px solid rgb(34, 36, 38 / 0.15);
+      border-top: 1px solid rgba(34, 36, 38, 0.15);
 
       .item.competence-info {
         flex: 1;
@@ -199,7 +199,7 @@ a, p, span, li {
   box-sizing: border-box;
   padding: 10px;
   background-color: #3498db;
-  border-bottom: 1px solid rgb(34, 36, 38 / 0.15);
+  border-bottom: 1px solid rgba(34, 36, 38, 0.15);
 
   &.lite {
     background-color: #7C0E6A;
@@ -277,7 +277,7 @@ a, p, span, li {
 
 footer.ui.attached.header {
   color: white;
-  background: rgb(52, 152, 219) !important;
+  background: rgba(52, 152, 219) !important;
 
   p {
     position: relative;
@@ -291,7 +291,7 @@ footer.ui.attached.header {
   background-color: transparent;
 
   &:hover, &:focus {
-    background-color: rgb(0, 0, 0 / 0.03);
+    background-color: rgba(0, 0, 0, 0.03);
   }
 }
 

--- a/pix-editor/app/styles/_lists.scss
+++ b/pix-editor/app/styles/_lists.scss
@@ -35,8 +35,8 @@
       padding: 10px;
       text-align: left;
       background-color: #F9FAFB;
-      border-bottom: 1px solid rgb(34, 36, 38 / 0.1);
-      border-left: 1px solid rgb(34, 36, 38 / 0.1);
+      border-bottom: 1px solid rgba(34, 36, 38, 0.1);
+      border-left: 1px solid rgba(34, 36, 38, 0.1);
 
       .et-sort-indicator {
 
@@ -60,8 +60,8 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      border-bottom: 1px solid rgb(34, 36, 38 / 0.1);
-      border-left: 1px solid rgb(34, 36, 38 / 0.1);
+      border-bottom: 1px solid rgba(34, 36, 38, 0.1);
+      border-left: 1px solid rgba(34, 36, 38, 0.1);
       cursor: pointer;
 
       &.suggested {

--- a/pix-editor/app/styles/_sidebar.scss
+++ b/pix-editor/app/styles/_sidebar.scss
@@ -42,20 +42,20 @@
           cursor: pointer;
 
           &:hover {
-            background: rgb(0, 0, 0 / 0.08);
+            background: rgba(0, 0, 0, 0.08);
           }
         }
       }
     }
 
     .a11y-accordion-panel-content {
-      background: rgb(0, 0, 0 / 0.08);
+      background: rgba(0, 0, 0, 0.08);
 
       .item {
         padding: .8rem;
 
         &:hover, &.active, &.active:hover {
-          background: rgb(0, 0, 0 / 0.08) !important;
+          background: rgba(0, 0, 0, 0.08) !important;
         }
       }
     }
@@ -71,7 +71,7 @@
     box-shadow: none;
 
     .button:hover {
-      background: rgb(255, 255, 255 / 0.1);
+      background: rgba(255, 255, 255, 0.1);
     }
 
     .icon {
@@ -111,12 +111,12 @@
 
       input {
         padding: 4px;
-        color: rgb(255, 255, 255 / 0.8);
+        color: rgba(255, 255, 255, 0.8);
         background-color: transparent;
-        border-color: rgb(255, 255, 255 / 0.7);
+        border-color: rgba(255, 255, 255, 0.7);
 
         &::placeholder {
-          color: rgb(255, 255, 255 / 0.7);
+          color: rgba(255, 255, 255, 0.7);
         }
       }
 
@@ -138,7 +138,7 @@
 
   .secondary-links {
     margin-top: 40px;
-    border-top: solid 1px rgb(255, 255, 255 / 0.08);
+    border-top: solid 1px rgba(255, 255, 255, 0.08);
 
     .secondary-links--action {
       display: flex;
@@ -147,7 +147,7 @@
     }
 
     i, a, p {
-      color: rgb(255, 255, 255 / 0.9);
+      color: rgba(255, 255, 255, 0.9);
     }
 
     a, p {
@@ -156,7 +156,7 @@
       padding: 13px 5px;
 
       &:hover {
-        background-color: rgb(255, 255, 255 / 0.08);
+        background-color: rgba(255, 255, 255, 0.08);
         cursor: pointer;
       }
 

--- a/pix-editor/app/styles/_skill.scss
+++ b/pix-editor/app/styles/_skill.scss
@@ -6,7 +6,7 @@
   .skill-mode {
     float: right;
     margin-top: 2px;
-    color: rgb(255, 255, 255 / 0.5);
+    color: rgba(255, 255, 255, 0.5);
     font-weight: normal;
     font-size: 14px;
 
@@ -90,7 +90,7 @@
 
   li {
     padding: .8em 1.14em;
-    border-bottom: solid 1px rgb(34, 36, 38 / 0.1);
+    border-bottom: solid 1px rgba(34, 36, 38, 0.1);
 
     .search-title {
       font-weight: bold;

--- a/pix-editor/app/styles/_target-profile.scss
+++ b/pix-editor/app/styles/_target-profile.scss
@@ -5,12 +5,12 @@
     align-items: center;
     float: right;
     margin-top: 2px;
-    color: rgb(255, 255, 255 / 0.5);
+    color: rgba(255, 255, 255, 0.5);
     font-weight: normal;
     font-size: 14px;
 
     &.active {
-      color: rgb(255, 255, 255 / 0.9);
+      color: rgba(255, 255, 255, 0.9);
     }
 
     .ui.toggle.checkbox {
@@ -67,7 +67,7 @@
 
     .competence-info {
       .ui.basic.button {
-        border: 1px solid rgb(255, 255, 255 / 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.6);
         border-radius: 50%;
         box-shadow: none;
 
@@ -112,7 +112,7 @@
       display: flex;
 
       &:hover {
-        background: rgb(50, 170, 220 / 0.1);
+        background: rgba(50, 170, 220, 0.1);
         cursor: pointer;
       }
 
@@ -155,7 +155,7 @@
           height: 100%;
 
           &.active {
-            background-color: rgb(87, 200, 130 / 0.3);
+            background-color: rgba(87, 200, 130, 0.3);
           }
 
           &__color-red {
@@ -169,7 +169,7 @@
         padding: 10px 50px 10px 5px;
 
         &.active {
-          background-color: rgb(87, 200, 130 / 0.3);
+          background-color: rgba(87, 200, 130, 0.3);
         }
       }
 
@@ -181,13 +181,13 @@
         .practicalTitle-profile {
 
           &.active {
-            background-color: rgb(63, 123, 196 / 0.3);
+            background-color: rgba(63, 123, 196, 0.3);
           }
         }
 
         .practicalDescription-profile {
           &.active {
-            background-color: rgb(63, 123, 196 / 0.3);
+            background-color: rgba(63, 123, 196, 0.3);
           }
         }
       }
@@ -220,7 +220,7 @@
       cursor: pointer;
 
       &.selected {
-        background-color: rgb(87, 200, 130 / 0.5);
+        background-color: rgba(87, 200, 130, 0.5);
       }
 
       &.disabled {
@@ -234,7 +234,7 @@
     .levels {
       .level {
         &.selected {
-          background-color: rgb(63, 123, 196 / 0.3);
+          background-color: rgba(63, 123, 196, 0.3);
         }
       }
     }

--- a/pix-editor/app/styles/components/card.scss
+++ b/pix-editor/app/styles/components/card.scss
@@ -2,7 +2,7 @@
 @use 'pix-design-tokens/fonts';
 
 .card {
-  box-shadow: 5px 4px 10px 2px rgb(0 0 0 / 10%);
+  box-shadow: 5px 4px 10px 2px rgba(0, 0, 0, 10%);
   border-radius: 8px;
   background: var(--pix-neutral-0);
   border: 1.2px colors.$pix-neutral-35 solid;
@@ -37,7 +37,7 @@
   &-footer {
     display: flex;
     justify-content: center;
-    border-top: 1px solid rgb(0 0 0 / 12.5%);
+    border-top: 1px solid rgba(0, 0, 0, 12.5%);
 
     &:last-child {
       border-radius: 0 0 calc(0.25rem - 1px) calc(0.25rem - 1px);
@@ -47,6 +47,6 @@
   .card-footer,
   .card-header {
     padding: 0.75rem 1.25rem;
-    background-color: rgb(0 0 0 / 3%);
+    background-color: rgba(0, 0, 0, 3%);
   }
 }

--- a/pix-editor/app/styles/components/challenge-view-header.scss
+++ b/pix-editor/app/styles/components/challenge-view-header.scss
@@ -76,7 +76,7 @@
     color: var(--pix-neutral-0);
 
     &:hover {
-      background-color: rgb(var(--pix-neutral-500-inline) / 0.5);
+      background-color: rgba(var(--pix-neutral-500-inline), 0.5);
     }
   }
 

--- a/pix-editor/app/styles/components/challenges-production-header.scss
+++ b/pix-editor/app/styles/components/challenges-production-header.scss
@@ -28,7 +28,7 @@
     color: var(--pix-neutral-0);
 
     &:hover {
-      background-color: rgb(var(--pix-neutral-500-inline) / 0.5);
+      background-color: rgbq(var(--pix-neutral-500-inline), 0.5);
     }
   }
 }

--- a/pix-editor/app/styles/components/form/tutorial.scss
+++ b/pix-editor/app/styles/components/form/tutorial.scss
@@ -35,12 +35,12 @@
 
     &:active {
       color: red;
-      background: rgb(255, 0, 0 / 0.1);
+      background: rgba(255, 0, 0, 0.1);
     }
 
     &:focus {
       color: red;
-      background: rgb(255, 0, 0 / 0.1);
+      background: rgba(255, 0, 0, 0.1);
       outline: 2px solid red;
     }
   }

--- a/pix-editor/app/styles/components/sidebar/navigation.scss
+++ b/pix-editor/app/styles/components/sidebar/navigation.scss
@@ -12,7 +12,7 @@
     }
 
     &:focus, &:focus-within {
-      outline-color: rgb(var(--pix-info-100-inline) / 0.5);
+      outline-color: rgba(var(--pix-info-100-inline), 0.5);
     }
   }
 

--- a/pix-editor/app/styles/components/sidebar/search.scss
+++ b/pix-editor/app/styles/components/sidebar/search.scss
@@ -12,7 +12,7 @@
     }
 
     &:focus, &:focus-within {
-      outline-color: rgb(var(--pix-info-100-inline) / 0.5);
+      outline-color: rgba(var(--pix-info-100-inline), 0.5);
     }
   }
 

--- a/pix-editor/app/styles/globals/table.scss
+++ b/pix-editor/app/styles/globals/table.scss
@@ -8,7 +8,7 @@
 .panel-table-v2 {
   border-radius: 4px;
   border: none;
-  box-shadow: 0 2px 5px 0 rgb(var(--pix-neutral-100-inline) / 0.05);
+  box-shadow: 0 2px 5px 0 rgba(var(--pix-neutral-100-inline), 0.05);
   background-color: var(--pix-neutral-0);
   overflow: auto;
 

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -40042,7 +40042,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.82.0",
+      "version": "1.89.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
+      "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 🔆 Problème

Suite à la mise à jour de stylelint, la notation des `rgba` est passée de `rgba(0, 0, 0, 0.2)` à `rgb(0, 0, 0 / 0.2)` pour être conforme avec les [nouvelles recos](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb).

Problème, cette notation ne passe pas le build et transforme les rgb en couleur noire. 

## ⛱️ Proposition

Bloquer la règle de stylelint en attendant une mise à jour de Sass (a priori, `2.0.0`)

## 🏄 Pour tester

- Linter OK
- Vérifier que les fonds ne s'affichent pas en noir dans la sidebar et dans l'affichage des compétences