### PR TITLE
[BUGFIX] Le texte de l'accordéon de sélection de domaine n'est pas correctement aligné (PIX-18561)

### DIFF
--- a/pix-editor/app/styles/components/sidebar/navigation.scss
+++ b/pix-editor/app/styles/components/sidebar/navigation.scss
@@ -54,6 +54,7 @@
       flex-direction: row-reverse;
       justify-content: start;
       gap: 0.375rem;
+      text-align: start;
 
       &:hover {
         background: #3B8DCC;


### PR DESCRIPTION
## 🔆 Problème

Le texte de l'accordéon de sélection de domaine n'est pas correctement aligné. Quand le texte revient à la ligne, il est aligné au centre.

## ⛱️ Proposition

Aligner le texte à gauche, comme avant.

## 🌊 Remarques

RAS

## 🏄 Pour tester

- Trouver ou créer un domaine avec un nom qui revient à la ligne.
- Constater que le texte est aligné à gauche.
