### PR TITLE
[BUGFIX] Domaine vide : Release erronée (PIX-18641)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -27,8 +27,8 @@ export const areaDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.id,
       code: airtableRecord.get('Code'),
-      competenceIds: airtableRecord.get('Competences (identifiants) (id persistant)'),
-      competenceAirtableIds: airtableRecord.get('Competences (identifiants)'),
+      competenceIds: airtableRecord.get('Competences (identifiants) (id persistant)') ?? [],
+      competenceAirtableIds: airtableRecord.get('Competences (identifiants)') ?? [],
       color: airtableRecord.get('Couleur'),
       frameworkId: airtableRecord.get('Referentiel')[0],
     };

--- a/api/tests/acceptance/application/areas_test.js
+++ b/api/tests/acceptance/application/areas_test.js
@@ -347,7 +347,7 @@ describe('Acceptance | Route | areas', () => {
           },
           name: '2. Cinquième domaine',
           frameworkId: 'framework2',
-          competenceIds: null,
+          competenceIds: [],
           color: null,
         })
         .matchHeader('Authorization', `Bearer ${pixApiToken}`)
@@ -401,7 +401,7 @@ describe('Acceptance | Route | areas', () => {
               },
             },
             competences: {
-              data: null,
+              data: [],
             },
           },
         },


### PR DESCRIPTION
## 🔆 Problème

Lorsqu’un domaine est vide, sa liste de compétences est non définie au lieu d’être un tableau vide dans la release.

## ⛱️ Proposition

Mettre un tableau vide en valeur par défaut.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A