### PR TITLE
[BUGFIX] Ne pas normaliser les espace contenu dans les option d'un select (PIX-18638)

### DIFF
--- a/api/lib/infrastructure/utils/normalize-non-breaking-space.js
+++ b/api/lib/infrastructure/utils/normalize-non-breaking-space.js
@@ -1,9 +1,10 @@
 export function normalizeNonBreakingSpace(str) {
   if (!str) return str;
+
   return str
-    .replaceAll(/\p{Zs}(°C)/gu, ' $1')
-    .replaceAll(/\p{Zs}([;?!€$%])/gu, ' $1')
-    .replaceAll(/\p{Zs}(:)/gu, ' $1')
-    .replaceAll(/\p{Zs}(»)/gu, ' $1')
-    .replaceAll(/(«)\p{Zs}/gu, '$1 ');
+    .replaceAll(/(?<!options=\[[^\]]*)\p{Zs}(°C)/gu, ' $1')
+    .replaceAll(/(?<!options=\[[^\]]*)\p{Zs}([;?!€$%])/gu, ' $1')
+    .replaceAll(/(?<!options=\[[^\]]*)\p{Zs}(:)/gu, ' $1')
+    .replaceAll(/(?<!options=\[[^\]]*)\p{Zs}(»)/gu, ' $1')
+    .replaceAll(/(?<!options=\[[^\]]*)(«)\p{Zs}/gu, '$1 ');
 }

--- a/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
+++ b/api/tests/unit/infrastructure/utils/normalize-non-breaking-space_test.js
@@ -30,6 +30,18 @@ describe('Unit | infrastructure | utils | normalize-non-breaking-space', () => {
     expect(result2).toBe('Descartes a dit : « Je pense, donc je suis. »');
   });
 
+  it('should not replace space in select option', () => {
+    // given
+    const proposition = 'Action à réaliser pour la première image : ${rep1#- Sélectionner -#options=["Ajouter le texte de remplacement : « banniere-accessibilite.png »","Ajouter le texte de ? remplacement : « Logo d’un bonhomme  15 °C »"]}';
+    const expectedResult = 'Action à réaliser pour la première image : ${rep1#- Sélectionner -#options=["Ajouter le texte de remplacement : « banniere-accessibilite.png »","Ajouter le texte de ? remplacement : « Logo d’un bonhomme  15 °C »"]}';
+
+    // when
+    const result = normalizeNonBreakingSpace(normalizeNonBreakingSpace(proposition));
+
+    // then
+    expect(result).toBe(expectedResult);
+  });
+
   it('should not break when passing null or empty values', () => {
     // given
     const nullValue = null;


### PR DESCRIPTION
## 🔆 Problème
Nous normalisons les espaces contenu dans les propositions contenant un select alors que les espaces ne sont pas traiter dans le champ solution ce qui entraine des erreurs lors de la validation de l'épreuve.

## ⛱️ Proposition
Ne pas normaliser les espaces des options des selects dans les propositions. 

## 🌊 Remarques

RAS

## 🏄 Pour tester

les testes sont vert.
créer une épreuves avec un select dans la proposition et vérifier que l'on ne crée pas d'espace spéciaux dans ses options
