### PR TITLE
[BUGFIX] Lorsque le resultat d'une recherche est long alors une barre de scroll apparait (PIX-18612)

### DIFF
--- a/pix-editor/app/styles/components/sidebar/search.scss
+++ b/pix-editor/app/styles/components/sidebar/search.scss
@@ -19,9 +19,14 @@
   .pix-select__dropdown {
     // Prevents weird layout behaviour :(
     transform: translate(0, 54px) !important;
+    min-width: auto;
   }
 
   .pix-select-list-category__option {
+    width: 100%;
+    overflow-x: hidden;
+    white-space: normal;
+
     &--selected {
       background: var(--pix-info-50);
       color: var(--pix-info-900);


### PR DESCRIPTION
## 🔆 Problème
Lorsqu'on fait une recherche d'épreuve sur l'instruction, le resultat déborde de pix-select et provoque une barre de scroll.

## ⛱️ Proposition

supprimer la propriété `min-width: fit-content` et limiter la taille des résultats de recherche.

## 🌊 Remarques
RAS

## 🏄 Pour tester

Faire une recherche avec de long résultats
