### PR TITLE
[TECH] Clarifier la construction des projections de réplication et de release du modèle Competence

### DIFF
--- a/api/lib/domain/models/replication/CompetenceForReplication.js
+++ b/api/lib/domain/models/replication/CompetenceForReplication.js
@@ -1,0 +1,21 @@
+export class CompetenceForReplication {
+  constructor({
+    id,
+    name_i18n,
+    index,
+    description_i18n,
+    areaId,
+    skillIds,
+    thematicIds,
+    origin,
+  }) {
+    this.id = id;
+    this.index = index;
+    this.areaId = areaId;
+    this.skillIds = skillIds;
+    this.thematicIds = thematicIds;
+    this.origin = origin;
+    this.name_i18n = name_i18n;
+    this.description_i18n = description_i18n;
+  }
+}

--- a/api/lib/domain/models/replication/index.js
+++ b/api/lib/domain/models/replication/index.js
@@ -1,4 +1,5 @@
 export * from './AreaForReplication.js';
+export * from './CompetenceForReplication.js';
 export * from './FrameworkForReplication.js';
 export * from './SkillForReplication.js';
 

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -1,5 +1,6 @@
 import {
   areaTransformer,
+  competenceTransformer,
   createChallengeTransformer,
   frameworkTransformer,
   tubeTransformer,
@@ -19,6 +20,7 @@ import * as Sentry from '@sentry/node';
 /**
  * @typedef {import('../../../lib/domain/models').Area} Area
  * @typedef {import('../../../lib/domain/models').Attachment} Attachment
+ * @typedef {import('../../../lib/domain/models').Competence} Competence
  * @typedef {import('../../../lib/domain/models').Framework} Framework
  * @typedef {import('../../../lib/domain/models').Tube} Tube
  * @typedef {import('../../../lib/domain/models').Tutorial} Tutorial
@@ -99,6 +101,38 @@ export async function onAreaCreated(area) {
         pixApiClient,
         model: 'areas',
         updatedRecord: areaTransformer.forRelease(area),
+      });
+    } catch (err) {
+      logger.error(err);
+      Sentry.captureException(err);
+    }
+  }
+}
+
+/**
+ * @param {Competence} competence
+ */
+export async function onCompetenceCreated(competence) {
+  await onCompetenceCreatedOrUpdated(competence);
+}
+
+/**
+ @param {Competence} competence
+ */
+export async function onCompetenceUpdated(competence) {
+  await onCompetenceCreatedOrUpdated(competence);
+}
+
+/**
+ * @param {Competence} competence
+ */
+async function onCompetenceCreatedOrUpdated(competence) {
+  if (pixApiClient.isPixApiCachePatchingEnabled()) {
+    try {
+      await updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'competences',
+        updatedRecord: competenceTransformer.forRelease(competence),
       });
     } catch (err) {
       logger.error(err);

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -10,7 +10,6 @@ import {
   tubeRepository
 } from '../../infrastructure/repositories/index.js';
 import {
-  competenceTransformer,
   skillTransformer,
   thematicTransformer,
   tubeTransformer
@@ -18,6 +17,7 @@ import {
 import { BadRequestError } from '../../infrastructure/errors.js';
 import { Skill, Thematic, Tube } from '../models/index.js';
 import * as idGenerator from '../../infrastructure/utils/id-generator.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 export async function createCompetence(competence) {
   const [area, competences] = await Promise.all([
@@ -76,11 +76,7 @@ export async function createCompetence(competence) {
 
   try {
     await Promise.all([
-      updatedRecordNotifier.notify({
-        pixApiClient,
-        model: 'competences',
-        updatedRecord: competenceTransformer.filterCompetenceFields(createdCompetence),
-      }),
+      updatePixApiReleaseCache.onCompetenceCreated(createdCompetence),
       updatedRecordNotifier.notify({
         pixApiClient,
         model: 'thematics',

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -74,7 +74,6 @@ export async function getLearningContentForReplication() {
     entityId: translation.entityId,
     sourceEntityId: null,
   }));
-  const transformedCompetences = competenceTransformer.filterCompetencesFields(competences);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
 
@@ -123,7 +122,7 @@ export async function getLearningContentForReplication() {
   return {
     frameworks: frameworkTransformer.forReplication(frameworks),
     areas: areaTransformer.forReplication(areas),
-    competences: transformedCompetences,
+    competences: competenceTransformer.forReplication(competences),
     thematics: transformedThematics,
     tubes: transformedTubes,
     skills: skillTransformer.forReplication(skills),

--- a/api/lib/domain/usecases/update-competence.js
+++ b/api/lib/domain/usecases/update-competence.js
@@ -1,10 +1,6 @@
-import * as Sentry from '@sentry/node';
-import { logger } from '../../infrastructure/logger.js';
-import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
-import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import { competenceRepository } from '../../infrastructure/repositories/index.js';
-import { competenceTransformer } from '../../infrastructure/transformers/index.js';
 import { NotFoundError } from '../../infrastructure/errors.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 export async function updateCompetence(competenceAirtableId, competenceUpdates) {
   const competence = await competenceRepository.getByAirtableId(competenceAirtableId);
@@ -14,17 +10,6 @@ export async function updateCompetence(competenceAirtableId, competenceUpdates) 
   competence.update(competenceUpdates);
 
   const updatedCompetence = await competenceRepository.update(competence);
-
-  try {
-    await updatedRecordNotifier.notify({
-      pixApiClient,
-      model: 'competences',
-      updatedRecord: competenceTransformer.filterCompetenceFields(updatedCompetence),
-    });
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-  }
-
+  await updatePixApiReleaseCache.onCompetenceUpdated(updatedCompetence);
   return updatedCompetence;
 }

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -110,14 +110,13 @@ async function _getCurrentContent() {
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
   const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
 
-  const filteredCompetences = competenceTransformer.filterCompetencesFields(competences);
   const filteredTutorials = tutorialTransformer.filterTutorialsFields(tutorials);
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
 
   return {
     frameworks: frameworkTransformer.forRelease(frameworks),
     areas: areaTransformer.forRelease(areas),
-    competences: filteredCompetences,
+    competences: competenceTransformer.forRelease(competences),
     thematics: transformedThematics,
     tubes: transformedTubes,
     skills: skillTransformer.forRelease(skills),

--- a/api/lib/infrastructure/transformers/competence-transformer.js
+++ b/api/lib/infrastructure/transformers/competence-transformer.js
@@ -28,29 +28,3 @@ export function forReplication(competences) {
   }
   return new CompetenceForReplication(competences);
 }
-
-export function filterCompetencesFields(competences) {
-  return competences.map(filterCompetenceFields);
-}
-
-export function filterCompetenceFields({
-  id,
-  index,
-  name_i18n,
-  description_i18n,
-  areaId,
-  skillIds,
-  thematicIds,
-  origin,
-}) {
-  return {
-    id,
-    index,
-    name_i18n,
-    description_i18n,
-    areaId,
-    skillIds,
-    thematicIds,
-    origin,
-  };
-}

--- a/api/lib/infrastructure/transformers/competence-transformer.js
+++ b/api/lib/infrastructure/transformers/competence-transformer.js
@@ -1,3 +1,34 @@
+import { CompetenceForRelease } from '../../domain/models/release/index.js';
+import { CompetenceForReplication } from '../../domain/models/replication/index.js';
+
+/**
+ * @typedef {import('../../../lib/domain/models').Competence} Competence
+ * @typedef {import('../../../lib/domain/models/release').CompetenceForRelease} CompetenceForRelease
+ * @typedef {import('../../../lib/domain/models/replication').CompetenceForReplication} CompetenceForReplication
+ */
+
+/**
+ * @param {Competence|Competence[]} competences
+ * @returns {CompetenceForRelease|CompetenceForRelease[]}
+ */
+export function forRelease(competences) {
+  if (Array.isArray(competences)) {
+    return competences.map((competence) => new CompetenceForRelease(competence));
+  }
+  return new CompetenceForRelease(competences);
+}
+
+/**
+ @param {Competence|Competence[]} competences
+ @returns {CompetenceForReplication|CompetenceForReplication[]}
+ */
+export function forReplication(competences) {
+  if (Array.isArray(competences)) {
+    return competences.map((competence) => new CompetenceForReplication(competence));
+  }
+  return new CompetenceForReplication(competences);
+}
+
 export function filterCompetencesFields(competences) {
   return competences.map(filterCompetenceFields);
 }

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
-import { Area, Attachment, Challenge, Framework, Tutorial } from '../../../../lib/domain/models/index.js';
+import { Area, Attachment, Challenge, Competence, Framework, Tutorial } from '../../../../lib/domain/models/index.js';
 import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import * as config from '../../../../lib/config.js';
@@ -603,6 +603,158 @@ describe('Integration | Service | update pix api release cache', function() {
 
         // when
         await updatePixApiReleaseCache.onAreaCreated(area);
+
+        // then
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('#onCompetenceCreated', function() {
+    let competence;
+
+    beforeEach(function() {
+      competence = new Competence({
+        id: 'competenceId',
+        airtableId: 'recCompetenceId',
+        index: 1,
+        origin: 'Pix+Fruits',
+        areaId: 'areaId',
+        areaAirtableId: 'recAreaId',
+        thematicIds: ['thematicId1', 'thematicId2'],
+        thematicAirtableIds: ['recThematicId1', 'recThematicId2'],
+        tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+        skillIds: ['skillId1', 'skillId2'],
+        name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+        description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+      });
+    });
+
+    context('when patchingPixApi is enabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        config.pixApi.baseUrl = 'https://some-api-base-url.fr';
+      });
+
+      it('should patch the tutorial', async function() {
+        // given
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { 'access_token': pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch('/api/cache/competences/competenceId', {
+            id: 'competenceId',
+            index: 1,
+            origin: 'Pix+Fruits',
+            areaId: 'areaId',
+            thematicIds: ['thematicId1', 'thematicId2'],
+            skillIds: ['skillId1', 'skillId2'],
+            name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+            description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onCompetenceCreated(competence);
+
+        // then
+        expect(pixApiCacheScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when patchingPixApi is disabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        delete config.pixApi.baseUrl;
+      });
+
+      it('should not patch anything', async function() {
+        // given
+        const spy = vi.spyOn(updatedRecordNotifier, 'notify');
+
+        // when
+        await updatePixApiReleaseCache.onCompetenceCreated(competence);
+
+        // then
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('#onCompetenceUpdated', function() {
+    let competence;
+
+    beforeEach(function() {
+      competence = new Competence({
+        id: 'competenceId',
+        airtableId: 'recCompetenceId',
+        index: 1,
+        origin: 'Pix+Fruits',
+        areaId: 'areaId',
+        areaAirtableId: 'recAreaId',
+        thematicIds: ['thematicId1', 'thematicId2'],
+        thematicAirtableIds: ['recThematicId1', 'recThematicId2'],
+        tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+        skillIds: ['skillId1', 'skillId2'],
+        name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+        description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+      });
+    });
+
+    context('when patchingPixApi is enabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        config.pixApi.baseUrl = 'https://some-api-base-url.fr';
+      });
+
+      it('should patch the tutorial', async function() {
+        // given
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { 'access_token': pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch('/api/cache/competences/competenceId', {
+            id: 'competenceId',
+            index: 1,
+            origin: 'Pix+Fruits',
+            areaId: 'areaId',
+            thematicIds: ['thematicId1', 'thematicId2'],
+            skillIds: ['skillId1', 'skillId2'],
+            name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+            description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onCompetenceUpdated(competence);
+
+        // then
+        expect(pixApiCacheScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when patchingPixApi is disabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        delete config.pixApi.baseUrl;
+      });
+
+      it('should not patch anything', async function() {
+        // given
+        const spy = vi.spyOn(updatedRecordNotifier, 'notify');
+
+        // when
+        await updatePixApiReleaseCache.onCompetenceUpdated(competence);
 
         // then
         expect(spy).toHaveBeenCalledTimes(0);

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -12,7 +12,6 @@ import {
 import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import {
-  competenceTransformer,
   skillTransformer,
   thematicTransformer,
   tubeTransformer
@@ -20,10 +19,10 @@ import {
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
 import { Skill, Thematic, Tube } from '../../../../lib/domain/models/index.js';
 import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
+import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 
 describe('Unit | Domain | Usecases | create competence', function() {
 
-  const transformedCompetence = Symbol('transformedCompetence');
   const transformedThematic = Symbol('transformedThematic');
   const transformedTube = Symbol('transformedTube');
   const skillForRelease = Symbol('skillForRelease');
@@ -35,12 +34,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
     vi.spyOn(thematicRepository, 'create');
     vi.spyOn(tubeRepository, 'create');
     vi.spyOn(skillRepository, 'create');
-    vi.spyOn(competenceTransformer, 'filterCompetenceFields');
     vi.spyOn(thematicTransformer, 'filterThematicFields');
     vi.spyOn(tubeTransformer, 'transformTube');
     vi.spyOn(skillTransformer, 'forRelease');
     vi.spyOn(updatedRecordNotifier, 'notify');
     vi.spyOn(idGenerator, 'generateNewId');
+    vi.spyOn(updatePixApiReleaseCache, 'onCompetenceCreated');
   });
 
   describe('when area id is unknown', () => {
@@ -97,11 +96,11 @@ describe('Unit | Domain | Usecases | create competence', function() {
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
       skillRepository.create.mockResolvedValueOnce(createdSkill);
-      competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.transformTube.mockReturnValueOnce(transformedTube);
       skillTransformer.forRelease.mockReturnValueOnce(skillForRelease);
       updatedRecordNotifier.notify.mockResolvedValue();
+      updatePixApiReleaseCache.onCompetenceCreated.mockResolvedValue();
       idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
@@ -148,15 +147,10 @@ describe('Unit | Domain | Usecases | create competence', function() {
         tubeAirtableId: createdTube.airtableId,
         hint_i18n: {},
       }));
-      expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.transformTube).toHaveBeenCalledWith(createdTube, createdThematic.id);
       expect(skillTransformer.forRelease).toHaveBeenCalledWith(createdSkill);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
-        pixApiClient,
-        updatedRecord: transformedCompetence,
-      });
+      expect(updatePixApiReleaseCache.onCompetenceCreated).toHaveBeenCalledWith(createdCompetence);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'thematics',
         pixApiClient,
@@ -200,11 +194,11 @@ describe('Unit | Domain | Usecases | create competence', function() {
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
       skillRepository.create.mockResolvedValueOnce(createdSkill);
-      competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.transformTube.mockReturnValueOnce(transformedTube);
       skillTransformer.forRelease.mockReturnValueOnce(skillForRelease);
       updatedRecordNotifier.notify.mockResolvedValue();
+      updatePixApiReleaseCache.onCompetenceCreated.mockResolvedValue();
       idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
@@ -251,15 +245,10 @@ describe('Unit | Domain | Usecases | create competence', function() {
         tubeAirtableId: createdTube.airtableId,
         hint_i18n: {},
       }));
-      expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.transformTube).toHaveBeenCalledWith(createdTube, createdThematic.id);
       expect(skillTransformer.forRelease).toHaveBeenCalledWith(createdSkill);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
-        pixApiClient,
-        updatedRecord: transformedCompetence,
-      });
+      expect(updatePixApiReleaseCache.onCompetenceCreated).toHaveBeenCalledWith(createdCompetence);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'thematics',
         pixApiClient,
@@ -302,11 +291,11 @@ describe('Unit | Domain | Usecases | create competence', function() {
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
       skillRepository.create.mockResolvedValueOnce(createdSkill);
-      competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
       thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.transformTube.mockReturnValueOnce(transformedTube);
       skillTransformer.forRelease.mockReturnValueOnce(skillForRelease);
       updatedRecordNotifier.notify.mockRejectedValue(new Error());
+      updatePixApiReleaseCache.onCompetenceCreated.mockResolvedValue();
       idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
@@ -353,15 +342,10 @@ describe('Unit | Domain | Usecases | create competence', function() {
         tubeAirtableId: createdTube.airtableId,
         hint_i18n: {},
       }));
-      expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(createdCompetence);
       expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.transformTube).toHaveBeenCalledWith(createdTube, createdThematic.id);
       expect(skillTransformer.forRelease).toHaveBeenCalledWith(createdSkill);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
-        pixApiClient,
-        updatedRecord: transformedCompetence,
-      });
+      expect(updatePixApiReleaseCache.onCompetenceCreated).toHaveBeenCalledWith(createdCompetence);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'thematics',
         pixApiClient,

--- a/api/tests/unit/domain/usecases/update-competence_test.js
+++ b/api/tests/unit/domain/usecases/update-competence_test.js
@@ -1,24 +1,20 @@
-import { describe, it, vi, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 
-import { updateCompetence } from '../../../../lib/domain/usecases/update-competence.js';
+import { updateCompetence } from '../../../../lib/domain/usecases/index.js';
 import { competenceRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { NotFoundError } from '../../../../lib/infrastructure/errors.js';
-import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
-import { competenceTransformer } from '../../../../lib/infrastructure/transformers/index.js';
-import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
+import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 
 describe('Unit | Domain | Usecases | update competence', function() {
 
   const competenceUpdates = Symbol('competenceUpdates');
   const updatedCompetence = Symbol('updatedCompetence');
-  const transformedCompetence = Symbol('transformedCompetence');
 
   beforeEach(() => {
     vi.spyOn(competenceRepository, 'getByAirtableId');
     vi.spyOn(competenceRepository, 'update');
-    vi.spyOn(competenceTransformer, 'filterCompetenceFields');
-    vi.spyOn(updatedRecordNotifier, 'notify');
+    vi.spyOn(updatePixApiReleaseCache, 'onCompetenceUpdated');
   });
 
   describe('when competence id is unknown', () => {
@@ -48,8 +44,7 @@ describe('Unit | Domain | Usecases | update competence', function() {
 
     competenceRepository.getByAirtableId.mockResolvedValueOnce(existingCompetence);
     competenceRepository.update.mockResolvedValueOnce(updatedCompetence);
-    competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
-    updatedRecordNotifier.notify.mockResolvedValueOnce();
+    updatePixApiReleaseCache.onCompetenceUpdated.mockResolvedValueOnce();
 
     const competenceUpdates = domainBuilder.buildCompetence();
 
@@ -62,44 +57,6 @@ describe('Unit | Domain | Usecases | update competence', function() {
     expect(competenceRepository.getByAirtableId).toHaveBeenCalledWith(competenceAirtableId);
     expect(existingCompetence.update).toHaveBeenCalledWith(competenceUpdates);
     expect(competenceRepository.update).toHaveBeenCalledWith(existingCompetence);
-    expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(updatedCompetence);
-    expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-      model: 'competences',
-      pixApiClient,
-      updatedRecord: transformedCompetence,
-    });
-  });
-
-  describe('when record notifier fails', () => {
-    it('should resolve anyway', async () =>{
-      // given
-      const competenceAirtableId = 'competenceAirtableId';
-      const existingCompetence = {
-        update: vi.fn(),
-      };
-
-      competenceRepository.getByAirtableId.mockResolvedValueOnce(existingCompetence);
-      competenceRepository.update.mockResolvedValueOnce(updatedCompetence);
-      competenceTransformer.filterCompetenceFields.mockReturnValueOnce(transformedCompetence);
-      updatedRecordNotifier.notify.mockRejectedValueOnce(new Error());
-
-      const competenceUpdates = domainBuilder.buildCompetence();
-
-      // when
-      const result = await updateCompetence(competenceAirtableId, competenceUpdates);
-
-      // then
-      expect(result).toBe(updatedCompetence);
-
-      expect(competenceRepository.getByAirtableId).toHaveBeenCalledWith(competenceAirtableId);
-      expect(existingCompetence.update).toHaveBeenCalledWith(competenceUpdates);
-      expect(competenceRepository.update).toHaveBeenCalledWith(existingCompetence);
-      expect(competenceTransformer.filterCompetenceFields).toHaveBeenCalledWith(updatedCompetence);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'competences',
-        pixApiClient,
-        updatedRecord: transformedCompetence,
-      });
-    });
+    expect(updatePixApiReleaseCache.onCompetenceUpdated).toHaveBeenCalledWith(updatedCompetence);
   });
 });

--- a/api/tests/unit/infrastructure/transformers/competence-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/competence-transformer_test.js
@@ -1,10 +1,5 @@
 import { describe, describe as context, expect, it } from 'vitest';
-import { domainBuilder } from '../../../test-helper.js';
-import {
-  filterCompetencesFields,
-  forRelease,
-  forReplication
-} from '../../../../lib/infrastructure/transformers/competence-transformer.js';
+import { forRelease, forReplication } from '../../../../lib/infrastructure/transformers/competence-transformer.js';
 import { CompetenceForReplication } from '../../../../lib/domain/models/replication/index.js';
 import { Competence } from '../../../../lib/domain/models/index.js';
 import { CompetenceForRelease } from '../../../../lib/domain/models/release/index.js';
@@ -204,13 +199,5 @@ describe('Unit | Infrastructure | competence-transformer', function() {
         ]);
       });
     });
-  });
-
-  it('should only keep useful fields', function() {
-    const airtableCompetences = [domainBuilder.buildCompetenceDatasourceObject()];
-
-    const competences = filterCompetencesFields(airtableCompetences);
-
-    expect(competences.length).to.equal(1);
   });
 });

--- a/api/tests/unit/infrastructure/transformers/competence-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/competence-transformer_test.js
@@ -1,8 +1,210 @@
-import { describe, expect, it } from 'vitest';
+import { describe, describe as context, expect, it } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { filterCompetencesFields } from '../../../../lib/infrastructure/transformers/competence-transformer.js';
+import {
+  filterCompetencesFields,
+  forRelease,
+  forReplication
+} from '../../../../lib/infrastructure/transformers/competence-transformer.js';
+import { CompetenceForReplication } from '../../../../lib/domain/models/replication/index.js';
+import { Competence } from '../../../../lib/domain/models/index.js';
+import { CompetenceForRelease } from '../../../../lib/domain/models/release/index.js';
 
 describe('Unit | Infrastructure | competence-transformer', function() {
+  describe('#forRelease', function() {
+    context('when providing a single Competence', function() {
+      it('should transform it into a single CompetenceForRelease', function() {
+      // given
+        const competence = new Competence({
+          id: 'competenceId',
+          airtableId: 'recCompetenceId',
+          index: 1,
+          origin: 'Pix+Fruits',
+          areaId: 'areaId',
+          areaAirtableId: 'recAreaId',
+          thematicIds: ['thematicId1', 'thematicId2'],
+          thematicAirtableIds: ['recThematicId1', 'recThematicId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+          skillIds: ['skillId1', 'skillId2'],
+          name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+          description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+        });
+
+        // when
+        const actualCompetenceForRelease = forRelease(competence);
+
+        // then
+        expect(actualCompetenceForRelease).toStrictEqual(new CompetenceForRelease({
+          id: 'competenceId',
+          index: 1,
+          origin: 'Pix+Fruits',
+          areaId: 'areaId',
+          thematicIds: ['thematicId1', 'thematicId2'],
+          skillIds: ['skillId1', 'skillId2'],
+          name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+          description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+        }));
+      });
+    });
+
+    context('when providing several Competences', function() {
+      it('should transform them into a several CompetencesForRelease', function() {
+      // given
+        const competenceA = new Competence({
+          id: 'competenceIdA',
+          airtableId: 'recCompetenceIdA',
+          index: 1,
+          origin: 'Pix+Fruits',
+          areaId: 'areaId',
+          areaAirtableId: 'recAreaId',
+          thematicIds: ['thematicId1', 'thematicId2'],
+          thematicAirtableIds: ['recThematicId1', 'recThematicId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+          skillIds: ['skillId1', 'skillId2'],
+          name_i18n: { fr: 'name fr competenceIdA', en: 'name en competenceIdA' },
+          description_i18n: { fr: 'description fr competenceIdA', en: 'description en competenceIdA' },
+        });
+        const competenceB = new Competence({
+          id: 'competenceIdB',
+          airtableId: 'recCompetenceIdB',
+          index: 2,
+          origin: 'Pix+Légumes',
+          areaId: 'areaId',
+          areaAirtableId: 'recAreaId',
+          thematicIds: ['thematicId3', 'thematicId4'],
+          thematicAirtableIds: ['recThematicId3', 'recThematicId4'],
+          tubeAirtableIds: ['recTubeId3', 'recTubeId4'],
+          skillIds: ['skillId3', 'skillId4'],
+          name_i18n: { fr: 'name fr competenceIdB', en: 'name en competenceIdB' },
+          description_i18n: { fr: 'description fr competenceIdB', en: 'description en competenceIdB' },
+        });
+
+        // when
+        const actualCompetencesForRelease = forRelease([competenceA, competenceB]);
+
+        // then
+        expect(actualCompetencesForRelease).toStrictEqual([
+          new CompetenceForRelease({
+            id: 'competenceIdA',
+            index: 1,
+            origin: 'Pix+Fruits',
+            areaId: 'areaId',
+            thematicIds: ['thematicId1', 'thematicId2'],
+            skillIds: ['skillId1', 'skillId2'],
+            name_i18n: { fr: 'name fr competenceIdA', en: 'name en competenceIdA' },
+            description_i18n: { fr: 'description fr competenceIdA', en: 'description en competenceIdA' },
+          }),
+          new CompetenceForRelease({
+            id: 'competenceIdB',
+            index: 2,
+            origin: 'Pix+Légumes',
+            areaId: 'areaId',
+            thematicIds: ['thematicId3', 'thematicId4'],
+            skillIds: ['skillId3', 'skillId4'],
+            name_i18n: { fr: 'name fr competenceIdB', en: 'name en competenceIdB' },
+            description_i18n: { fr: 'description fr competenceIdB', en: 'description en competenceIdB' },
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#forReplication', function() {
+    context('when providing a single Competence', function() {
+      it('should transform it into a single CompetenceForReplication', function() {
+      // given
+        const competence = new Competence({
+          id: 'competenceId',
+          airtableId: 'recCompetenceId',
+          index: 1,
+          origin: 'Pix+Fruits',
+          areaId: 'areaId',
+          areaAirtableId: 'recAreaId',
+          thematicIds: ['thematicId1', 'thematicId2'],
+          thematicAirtableIds: ['recThematicId1', 'recThematicId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+          skillIds: ['skillId1', 'skillId2'],
+          name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+          description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+        });
+
+        // when
+        const actualCompetenceForReplication = forReplication(competence);
+
+        // then
+        expect(actualCompetenceForReplication).toStrictEqual(new CompetenceForReplication({
+          id: 'competenceId',
+          index: 1,
+          origin: 'Pix+Fruits',
+          areaId: 'areaId',
+          thematicIds: ['thematicId1', 'thematicId2'],
+          skillIds: ['skillId1', 'skillId2'],
+          name_i18n: { fr: 'name fr competenceId', en: 'name en competenceId' },
+          description_i18n: { fr: 'description fr competenceId', en: 'description en competenceId' },
+        }));
+      });
+    });
+
+    context('when providing several Competences', function() {
+      it('should transform them into a several CompetencesForReplication', function() {
+      // given
+        const competenceA = new Competence({
+          id: 'competenceIdA',
+          airtableId: 'recCompetenceIdA',
+          index: 1,
+          origin: 'Pix+Fruits',
+          areaId: 'areaId',
+          areaAirtableId: 'recAreaId',
+          thematicIds: ['thematicId1', 'thematicId2'],
+          thematicAirtableIds: ['recThematicId1', 'recThematicId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+          skillIds: ['skillId1', 'skillId2'],
+          name_i18n: { fr: 'name fr competenceIdA', en: 'name en competenceIdA' },
+          description_i18n: { fr: 'description fr competenceIdA', en: 'description en competenceIdA' },
+        });
+        const competenceB = new Competence({
+          id: 'competenceIdB',
+          airtableId: 'recCompetenceIdB',
+          index: 2,
+          origin: 'Pix+Légumes',
+          areaId: 'areaId',
+          areaAirtableId: 'recAreaId',
+          thematicIds: ['thematicId3', 'thematicId4'],
+          thematicAirtableIds: ['recThematicId3', 'recThematicId4'],
+          tubeAirtableIds: ['recTubeId3', 'recTubeId4'],
+          skillIds: ['skillId3', 'skillId4'],
+          name_i18n: { fr: 'name fr competenceIdB', en: 'name en competenceIdB' },
+          description_i18n: { fr: 'description fr competenceIdB', en: 'description en competenceIdB' },
+        });
+
+        // when
+        const actualCompetencesForReplication = forReplication([competenceA, competenceB]);
+
+        // then
+        expect(actualCompetencesForReplication).toStrictEqual([
+          new CompetenceForReplication({
+            id: 'competenceIdA',
+            index: 1,
+            origin: 'Pix+Fruits',
+            areaId: 'areaId',
+            thematicIds: ['thematicId1', 'thematicId2'],
+            skillIds: ['skillId1', 'skillId2'],
+            name_i18n: { fr: 'name fr competenceIdA', en: 'name en competenceIdA' },
+            description_i18n: { fr: 'description fr competenceIdA', en: 'description en competenceIdA' },
+          }),
+          new CompetenceForReplication({
+            id: 'competenceIdB',
+            index: 2,
+            origin: 'Pix+Légumes',
+            areaId: 'areaId',
+            thematicIds: ['thematicId3', 'thematicId4'],
+            skillIds: ['skillId3', 'skillId4'],
+            name_i18n: { fr: 'name fr competenceIdB', en: 'name en competenceIdB' },
+            description_i18n: { fr: 'description fr competenceIdB', en: 'description en competenceIdB' },
+          }),
+        ]);
+      });
+    });
+  });
 
   it('should only keep useful fields', function() {
     const airtableCompetences = [domainBuilder.buildCompetenceDatasourceObject()];


### PR DESCRIPTION
## 🔆 Problème

c'est le bazar la logique autour de :
- Construction de réplication
- Construction de release
- Patch vers l'API (pour la recette)

## ⛱️ Réflexion

### Constats
- En principe, la logique de construction des données pour la release ET pour le patch vers l'API devrait être **la même**. Aujourd'hui ce n'est pas le cas
- Côté réplication, il y a beaucoup de copie de code pour faire comme la release. Il pourrait être intéressant quand même de bien séparer les deux, même si dans les faits beaucoup de données se ressemblent (mais pas toute).

### Proposition
Modifier tous les `***-transformer.js` pour qu'ils exportent exactement deux fonctions : `forRelease()` et `forReplication()`. On aura un endroit centralisé et immédiat pour comprendre les données de chaque export.
En toute logique, il faut aussi appeler `forRelease()` lors du patch vers l'API pour la recette

Cette PR fait le travail pour l'entité Competence

## 🌊 Remarques

## 🏄 Pour tester

ISO release, répli, patch
