### PR TITLE
[TECH] Clarifier la construction des projections de réplication et de release du modèle Thematic

### DIFF
--- a/api/lib/domain/models/replication/ThematicForReplication.js
+++ b/api/lib/domain/models/replication/ThematicForReplication.js
@@ -1,0 +1,15 @@
+export class ThematicForReplication {
+  constructor({
+    id,
+    name_i18n,
+    index,
+    competenceId,
+    tubeIds,
+  }) {
+    this.id = id;
+    this.name_i18n = name_i18n;
+    this.index = index;
+    this.competenceId = competenceId;
+    this.tubeIds = tubeIds;
+  }
+}

--- a/api/lib/domain/models/replication/index.js
+++ b/api/lib/domain/models/replication/index.js
@@ -2,4 +2,4 @@ export * from './AreaForReplication.js';
 export * from './CompetenceForReplication.js';
 export * from './FrameworkForReplication.js';
 export * from './SkillForReplication.js';
-
+export * from './ThematicForReplication.js';

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -3,6 +3,7 @@ import {
   competenceTransformer,
   createChallengeTransformer,
   frameworkTransformer,
+  thematicTransformer,
   tubeTransformer,
   tutorialTransformer,
 } from '../../infrastructure/transformers/index.js';
@@ -22,6 +23,7 @@ import * as Sentry from '@sentry/node';
  * @typedef {import('../../../lib/domain/models').Attachment} Attachment
  * @typedef {import('../../../lib/domain/models').Competence} Competence
  * @typedef {import('../../../lib/domain/models').Framework} Framework
+ * @typedef {import('../../../lib/domain/models').Thematic} Thematic
  * @typedef {import('../../../lib/domain/models').Tube} Tube
  * @typedef {import('../../../lib/domain/models').Tutorial} Tutorial
  **/
@@ -133,6 +135,38 @@ async function onCompetenceCreatedOrUpdated(competence) {
         pixApiClient,
         model: 'competences',
         updatedRecord: competenceTransformer.forRelease(competence),
+      });
+    } catch (err) {
+      logger.error(err);
+      Sentry.captureException(err);
+    }
+  }
+}
+
+/**
+ * @param {Thematic} thematic
+ */
+export async function onThematicCreated(thematic) {
+  await onThematicCreatedOrUpdated(thematic);
+}
+
+/**
+ @param {Thematic} thematic
+ */
+export async function onThematicUpdated(thematic) {
+  await onThematicCreatedOrUpdated(thematic);
+}
+
+/**
+ * @param {Thematic} thematic
+ */
+async function onThematicCreatedOrUpdated(thematic) {
+  if (pixApiClient.isPixApiCachePatchingEnabled()) {
+    try {
+      await updatedRecordNotifier.notify({
+        pixApiClient,
+        model: 'thematics',
+        updatedRecord: thematicTransformer.forRelease(thematic),
       });
     } catch (err) {
       logger.error(err);

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -9,11 +9,7 @@ import {
   thematicRepository,
   tubeRepository
 } from '../../infrastructure/repositories/index.js';
-import {
-  skillTransformer,
-  thematicTransformer,
-  tubeTransformer
-} from '../../infrastructure/transformers/index.js';
+import { skillTransformer, tubeTransformer } from '../../infrastructure/transformers/index.js';
 import { BadRequestError } from '../../infrastructure/errors.js';
 import { Skill, Thematic, Tube } from '../models/index.js';
 import * as idGenerator from '../../infrastructure/utils/id-generator.js';
@@ -77,11 +73,7 @@ export async function createCompetence(competence) {
   try {
     await Promise.all([
       updatePixApiReleaseCache.onCompetenceCreated(createdCompetence),
-      updatedRecordNotifier.notify({
-        pixApiClient,
-        model: 'thematics',
-        updatedRecord: thematicTransformer.filterThematicFields(createdWorkbenchThematic),
-      }),
+      updatePixApiReleaseCache.onThematicCreated(createdWorkbenchThematic),
       updatedRecordNotifier.notify({
         pixApiClient,
         model: 'tubes',

--- a/api/lib/domain/usecases/create-thematic.js
+++ b/api/lib/domain/usecases/create-thematic.js
@@ -1,27 +1,12 @@
 import { thematicRepository } from '../../infrastructure/repositories/index.js';
-import { thematicTransformer } from '../../infrastructure/transformers/index.js';
-import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
-import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { logger } from '../../infrastructure/logger.js';
-import * as Sentry from '@sentry/node';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
-export async function createThematic(thematic, dependencies = { thematicRepository, thematicTransformer, updatedRecordNotifier, pixApiClient }) {
+export async function createThematic(thematic, dependencies = { thematicRepository }) {
   const competenceThematics = await dependencies.thematicRepository.listByCompetenceAirtableId(thematic.competenceAirtableId);
 
   thematic.prepareForCreation(competenceThematics);
 
   const createdThematic = await dependencies.thematicRepository.create(thematic);
-
-  try {
-    await dependencies.updatedRecordNotifier.notify({
-      model: 'thematics',
-      updatedRecord: dependencies.thematicTransformer.filterThematicFields(createdThematic),
-      pixApiClient: dependencies.pixApiClient,
-    });
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-  }
-
+  await updatePixApiReleaseCache.onThematicCreated(createdThematic);
   return createdThematic;
 }

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -74,7 +74,6 @@ export async function getLearningContentForReplication() {
     entityId: translation.entityId,
     sourceEntityId: null,
   }));
-  const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
 
   const translationsGroupedByEntityId = Object.groupBy(translationsForReplication, (translation) => translation.entityId);
@@ -123,7 +122,7 @@ export async function getLearningContentForReplication() {
     frameworks: frameworkTransformer.forReplication(frameworks),
     areas: areaTransformer.forReplication(areas),
     competences: competenceTransformer.forReplication(competences),
-    thematics: transformedThematics,
+    thematics: thematicTransformer.forReplication(thematics),
     tubes: transformedTubes,
     skills: skillTransformer.forReplication(skills),
     challenges: allTranslatedChallenges,

--- a/api/lib/domain/usecases/update-thematic.js
+++ b/api/lib/domain/usecases/update-thematic.js
@@ -1,12 +1,8 @@
 import { thematicRepository } from '../../infrastructure/repositories/index.js';
-import { thematicTransformer } from '../../infrastructure/transformers/index.js';
-import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
-import * as pixApiClient from '../../infrastructure/pix-api-client.js';
-import { logger } from '../../infrastructure/logger.js';
-import * as Sentry from '@sentry/node';
 import { NotFoundError } from '../errors.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
-export async function updateThematic(thematicAirtableId, thematicUpdates, dependencies = { thematicRepository, thematicTransformer, updatedRecordNotifier, pixApiClient }) {
+export async function updateThematic(thematicAirtableId, thematicUpdates, dependencies = { thematicRepository }) {
   const thematic = await dependencies.thematicRepository.getByAirtableId(thematicAirtableId);
 
   if (!thematic) {
@@ -14,19 +10,8 @@ export async function updateThematic(thematicAirtableId, thematicUpdates, depend
   }
 
   thematic.update(thematicUpdates);
-
   const updatedThematic = await dependencies.thematicRepository.update(thematic);
 
-  try {
-    await dependencies.updatedRecordNotifier.notify({
-      model: 'thematics',
-      updatedRecord: dependencies.thematicTransformer.filterThematicFields(updatedThematic),
-      pixApiClient: dependencies.pixApiClient,
-    });
-  } catch (err) {
-    logger.error(err);
-    Sentry.captureException(err);
-  }
-
+  await updatePixApiReleaseCache.onThematicUpdated(updatedThematic);
   return updatedThematic;
 }

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -108,7 +108,6 @@ async function _getCurrentContent() {
   const transformChallenge = createChallengeTransformer({ attachments });
   const transformedChallenges = translatedChallenges.map(transformChallenge);
   const transformedTubes = tubeTransformer.transformTubes(tubes, thematics, challenges);
-  const transformedThematics = thematicTransformer.filterThematicsFields(thematics);
 
   const filteredTutorials = tutorialTransformer.filterTutorialsFields(tutorials);
   const transformedMissions = missionTransformer.transform({ missions, challenges, tubes, thematics, skills });
@@ -117,7 +116,7 @@ async function _getCurrentContent() {
     frameworks: frameworkTransformer.forRelease(frameworks),
     areas: areaTransformer.forRelease(areas),
     competences: competenceTransformer.forRelease(competences),
-    thematics: transformedThematics,
+    thematics: thematicTransformer.forRelease(thematics),
     tubes: transformedTubes,
     skills: skillTransformer.forRelease(skills),
     challenges: transformedChallenges,

--- a/api/lib/infrastructure/transformers/thematic-transformer.js
+++ b/api/lib/infrastructure/transformers/thematic-transformer.js
@@ -28,11 +28,3 @@ export function forReplication(thematics) {
   }
   return new ThematicForReplication(thematics);
 }
-
-export function filterThematicsFields(thematics) {
-  return thematics.map(filterThematicFields);
-}
-
-export function filterThematicFields({ id, name_i18n, index, competenceId, tubeIds }) {
-  return { id,name_i18n,index, competenceId,tubeIds };
-}

--- a/api/lib/infrastructure/transformers/thematic-transformer.js
+++ b/api/lib/infrastructure/transformers/thematic-transformer.js
@@ -1,3 +1,34 @@
+import { ThematicForRelease } from '../../domain/models/release/index.js';
+import { ThematicForReplication } from '../../domain/models/replication/index.js';
+
+/**
+ * @typedef {import('../../../lib/domain/models').Thematic} Thematic
+ * @typedef {import('../../../lib/domain/models/release').ThematicForRelease} ThematicForRelease
+ * @typedef {import('../../../lib/domain/models/replication').ThematicForReplication} ThematicForReplication
+ */
+
+/**
+ * @param {Thematic|Thematic[]} thematics
+ * @returns {ThematicForRelease|ThematicForRelease[]}
+ */
+export function forRelease(thematics) {
+  if (Array.isArray(thematics)) {
+    return thematics.map((thematic) => new ThematicForRelease(thematic));
+  }
+  return new ThematicForRelease(thematics);
+}
+
+/**
+ @param {Thematic|Thematic[]} thematics
+ @returns {ThematicForReplication|ThematicForReplication[]}
+ */
+export function forReplication(thematics) {
+  if (Array.isArray(thematics)) {
+    return thematics.map((thematic) => new ThematicForReplication(thematic));
+  }
+  return new ThematicForReplication(thematics);
+}
+
 export function filterThematicsFields(thematics) {
   return thematics.map(filterThematicFields);
 }

--- a/api/tests/acceptance/application/thematics_test.js
+++ b/api/tests/acceptance/application/thematics_test.js
@@ -5,14 +5,21 @@ import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationH
 import { createServer } from '../../../server.js';
 import { thematicDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import * as idGenerator from '../../../lib/infrastructure/utils/id-generator.js';
+import * as config from '../../../lib/config.js';
 
 describe('Application | Route | Thematics', () => {
-  let editorUser, readonlyUser;
+  let editorUser, readonlyUser, originalPixApiUrlValue;
 
   beforeEach(async function() {
+    originalPixApiUrlValue = config.pixApi.baseUrl;
+    delete config.pixApi.baseUrl;
     editorUser = databaseBuilder.factory.buildEditorUser();
     readonlyUser = databaseBuilder.factory.buildReadonlyUser();
     await databaseBuilder.commit();
+  });
+
+  afterEach(function() {
+    config.pixApi.baseUrl = originalPixApiUrlValue;
   });
 
   describe('GET /api/thematics/{thematicAirtableId}', () => {
@@ -361,7 +368,7 @@ describe('Application | Route | Thematics', () => {
   });
 
   describe('POST /api/thematics', async () => {
-    let airtableCreateThematicScope, airtableThematicsScope, pixApiCacheScope;
+    let airtableCreateThematicScope, airtableThematicsScope;
 
     context('when user has not the right to do the operation', function() {
       it('should respond with status 403', async function() {
@@ -491,25 +498,6 @@ describe('Application | Route | Thematics', () => {
           .reply(200, { records: [createdAirtableThematic] });
 
         vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce('thematic3');
-
-        const pixApiToken = 'secret';
-        nock('https://api.test.pix.fr')
-          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
-          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-          .reply(200, { 'access_token': pixApiToken });
-        pixApiCacheScope = nock('https://api.test.pix.fr')
-          .patch('/api/cache/thematics/thematic3', {
-            id: createdAirtableThematic.fields['id persistant'],
-            name_i18n: {
-              fr: 'Troisième thématique',
-              en: 'Third thematic',
-            },
-            index: 2,
-            competenceId: 'competence1',
-            tubeIds: [],
-          })
-          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
-          .reply(200);
       });
 
       afterEach(async () => {
@@ -575,7 +563,6 @@ describe('Application | Route | Thematics', () => {
 
         expect(airtableCreateThematicScope.isDone()).toBe(true);
         expect(airtableThematicsScope.isDone()).toBe(true);
-        expect(pixApiCacheScope.isDone()).toBe(true);
 
         await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
           { key: 'thematic.thematic3.name', locale: 'en', value: 'Third thematic' },
@@ -586,7 +573,7 @@ describe('Application | Route | Thematics', () => {
   });
 
   describe('PATCH /api/thematics/{thematicAirtableId}', async () => {
-    let airtableUpdateThematicScope, airtableThematicScope, pixApiCacheScope;
+    let airtableUpdateThematicScope, airtableThematicScope;
 
     context('when user has not the right to do the operation', function() {
       it('should respond with status 403', async function() {
@@ -785,25 +772,6 @@ describe('Application | Route | Thematics', () => {
           .query({})
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .reply(200, { records: [updatedAirtableThematic] });
-
-        const pixApiToken = 'secret';
-        nock('https://api.test.pix.fr')
-          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
-          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
-          .reply(200, { 'access_token': pixApiToken });
-        pixApiCacheScope = nock('https://api.test.pix.fr')
-          .patch('/api/cache/thematics/thematic1', {
-            id: 'thematic1',
-            name_i18n: {
-              fr: '1ère thématique',
-              en: '1st thematic',
-            },
-            index: 2,
-            competenceId: 'competence1',
-            tubeIds: ['tube1', 'tube2'],
-          })
-          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
-          .reply(200);
       });
 
       it('should respond with status 201 and created thematic', async () => {
@@ -886,7 +854,6 @@ describe('Application | Route | Thematics', () => {
 
         expect(airtableUpdateThematicScope.isDone()).toBe(true);
         expect(airtableThematicScope.isDone()).toBe(true);
-        expect(pixApiCacheScope.isDone()).toBe(true);
 
         await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
           { key: 'thematic.thematic1.name', locale: 'en', value: '1st thematic' },

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
-import { Area, Attachment, Challenge, Competence, Framework, Tutorial } from '../../../../lib/domain/models/index.js';
+import {
+  Area,
+  Attachment,
+  Challenge,
+  Competence,
+  Framework,
+  Thematic,
+  Tutorial
+} from '../../../../lib/domain/models/index.js';
 import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import * as config from '../../../../lib/config.js';
@@ -755,6 +763,144 @@ describe('Integration | Service | update pix api release cache', function() {
 
         // when
         await updatePixApiReleaseCache.onCompetenceUpdated(competence);
+
+        // then
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('#onThematicCreated', function() {
+    let thematic;
+
+    beforeEach(function() {
+      thematic = new Thematic({
+        id: 'thematicId',
+        airtableId: 'recThematicId',
+        name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+        index: 1,
+        competenceId: 'competenceId',
+        competenceAirtableId: 'recCompetenceId',
+        tubeIds: ['tubeId1', 'tubeId2'],
+        tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+      });
+    });
+
+    context('when patchingPixApi is enabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        config.pixApi.baseUrl = 'https://some-api-base-url.fr';
+      });
+
+      it('should patch the tutorial', async function() {
+        // given
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { 'access_token': pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch('/api/cache/thematics/thematicId', {
+            id: 'thematicId',
+            name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+            index: 1,
+            competenceId: 'competenceId',
+            tubeIds: ['tubeId1', 'tubeId2'],
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onThematicCreated(thematic);
+
+        // then
+        expect(pixApiCacheScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when patchingPixApi is disabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        delete config.pixApi.baseUrl;
+      });
+
+      it('should not patch anything', async function() {
+        // given
+        const spy = vi.spyOn(updatedRecordNotifier, 'notify');
+
+        // when
+        await updatePixApiReleaseCache.onThematicCreated(thematic);
+
+        // then
+        expect(spy).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe('#onThematicUpdated', function() {
+    let thematic;
+
+    beforeEach(function() {
+      thematic = new Thematic({
+        id: 'thematicId',
+        airtableId: 'recThematicId',
+        name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+        index: 1,
+        competenceId: 'competenceId',
+        competenceAirtableId: 'recCompetenceId',
+        tubeIds: ['tubeId1', 'tubeId2'],
+        tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+      });
+    });
+
+    context('when patchingPixApi is enabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        config.pixApi.baseUrl = 'https://some-api-base-url.fr';
+      });
+
+      it('should patch the tutorial', async function() {
+        // given
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { 'access_token': pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch('/api/cache/thematics/thematicId', {
+            id: 'thematicId',
+            name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+            index: 1,
+            competenceId: 'competenceId',
+            tubeIds: ['tubeId1', 'tubeId2'],
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onThematicUpdated(thematic);
+
+        // then
+        expect(pixApiCacheScope.isDone()).to.be.true;
+      });
+    });
+
+    context('when patchingPixApi is disabled', function() {
+
+      beforeEach(function() {
+        originalPixApiUrlValue = config.pixApi.baseUrl;
+        delete config.pixApi.baseUrl;
+      });
+
+      it('should not patch anything', async function() {
+        // given
+        const spy = vi.spyOn(updatedRecordNotifier, 'notify');
+
+        // when
+        await updatePixApiReleaseCache.onThematicUpdated(thematic);
 
         // then
         expect(spy).toHaveBeenCalledTimes(0);

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -11,11 +11,7 @@ import {
 } from '../../../../lib/infrastructure/repositories/index.js';
 import { BadRequestError } from '../../../../lib/infrastructure/errors.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
-import {
-  skillTransformer,
-  thematicTransformer,
-  tubeTransformer
-} from '../../../../lib/infrastructure/transformers/index.js';
+import { skillTransformer, tubeTransformer } from '../../../../lib/infrastructure/transformers/index.js';
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
 import { Skill, Thematic, Tube } from '../../../../lib/domain/models/index.js';
 import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
@@ -23,7 +19,6 @@ import * as updatePixApiReleaseCache from '../../../../lib/domain/services/updat
 
 describe('Unit | Domain | Usecases | create competence', function() {
 
-  const transformedThematic = Symbol('transformedThematic');
   const transformedTube = Symbol('transformedTube');
   const skillForRelease = Symbol('skillForRelease');
 
@@ -34,12 +29,12 @@ describe('Unit | Domain | Usecases | create competence', function() {
     vi.spyOn(thematicRepository, 'create');
     vi.spyOn(tubeRepository, 'create');
     vi.spyOn(skillRepository, 'create');
-    vi.spyOn(thematicTransformer, 'filterThematicFields');
     vi.spyOn(tubeTransformer, 'transformTube');
     vi.spyOn(skillTransformer, 'forRelease');
     vi.spyOn(updatedRecordNotifier, 'notify');
     vi.spyOn(idGenerator, 'generateNewId');
     vi.spyOn(updatePixApiReleaseCache, 'onCompetenceCreated');
+    vi.spyOn(updatePixApiReleaseCache, 'onThematicCreated');
   });
 
   describe('when area id is unknown', () => {
@@ -96,11 +91,11 @@ describe('Unit | Domain | Usecases | create competence', function() {
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
       skillRepository.create.mockResolvedValueOnce(createdSkill);
-      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.transformTube.mockReturnValueOnce(transformedTube);
       skillTransformer.forRelease.mockReturnValueOnce(skillForRelease);
       updatedRecordNotifier.notify.mockResolvedValue();
       updatePixApiReleaseCache.onCompetenceCreated.mockResolvedValue();
+      updatePixApiReleaseCache.onThematicCreated.mockResolvedValue();
       idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
@@ -147,15 +142,10 @@ describe('Unit | Domain | Usecases | create competence', function() {
         tubeAirtableId: createdTube.airtableId,
         hint_i18n: {},
       }));
-      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.transformTube).toHaveBeenCalledWith(createdTube, createdThematic.id);
       expect(skillTransformer.forRelease).toHaveBeenCalledWith(createdSkill);
       expect(updatePixApiReleaseCache.onCompetenceCreated).toHaveBeenCalledWith(createdCompetence);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'thematics',
-        pixApiClient,
-        updatedRecord: transformedThematic,
-      });
+      updatePixApiReleaseCache.onThematicCreated.mockResolvedValue(createdThematic);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'tubes',
         pixApiClient,
@@ -194,11 +184,11 @@ describe('Unit | Domain | Usecases | create competence', function() {
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
       skillRepository.create.mockResolvedValueOnce(createdSkill);
-      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.transformTube.mockReturnValueOnce(transformedTube);
       skillTransformer.forRelease.mockReturnValueOnce(skillForRelease);
       updatedRecordNotifier.notify.mockResolvedValue();
       updatePixApiReleaseCache.onCompetenceCreated.mockResolvedValue();
+      updatePixApiReleaseCache.onThematicCreated.mockResolvedValue();
       idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
@@ -245,15 +235,10 @@ describe('Unit | Domain | Usecases | create competence', function() {
         tubeAirtableId: createdTube.airtableId,
         hint_i18n: {},
       }));
-      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
       expect(tubeTransformer.transformTube).toHaveBeenCalledWith(createdTube, createdThematic.id);
       expect(skillTransformer.forRelease).toHaveBeenCalledWith(createdSkill);
       expect(updatePixApiReleaseCache.onCompetenceCreated).toHaveBeenCalledWith(createdCompetence);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'thematics',
-        pixApiClient,
-        updatedRecord: transformedThematic,
-      });
+      expect(updatePixApiReleaseCache.onThematicCreated).toHaveBeenCalledWith(createdThematic);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'tubes',
         pixApiClient,
@@ -291,11 +276,11 @@ describe('Unit | Domain | Usecases | create competence', function() {
       thematicRepository.create.mockResolvedValueOnce(createdThematic);
       tubeRepository.create.mockResolvedValueOnce(createdTube);
       skillRepository.create.mockResolvedValueOnce(createdSkill);
-      thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
       tubeTransformer.transformTube.mockReturnValueOnce(transformedTube);
       skillTransformer.forRelease.mockReturnValueOnce(skillForRelease);
       updatedRecordNotifier.notify.mockRejectedValue(new Error());
       updatePixApiReleaseCache.onCompetenceCreated.mockResolvedValue();
+      updatePixApiReleaseCache.onThematicCreated.mockResolvedValue();
       idGenerator.generateNewId.mockReturnValueOnce('skill1');
 
       const competence = domainBuilder.buildCompetence({
@@ -342,15 +327,9 @@ describe('Unit | Domain | Usecases | create competence', function() {
         tubeAirtableId: createdTube.airtableId,
         hint_i18n: {},
       }));
-      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
-      expect(tubeTransformer.transformTube).toHaveBeenCalledWith(createdTube, createdThematic.id);
       expect(skillTransformer.forRelease).toHaveBeenCalledWith(createdSkill);
       expect(updatePixApiReleaseCache.onCompetenceCreated).toHaveBeenCalledWith(createdCompetence);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
-        model: 'thematics',
-        pixApiClient,
-        updatedRecord: transformedThematic,
-      });
+      expect(updatePixApiReleaseCache.onThematicCreated).toHaveBeenCalledWith(createdThematic);
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'tubes',
         pixApiClient,

--- a/api/tests/unit/domain/usecases/create-thematic_test.js
+++ b/api/tests/unit/domain/usecases/create-thematic_test.js
@@ -1,26 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { createThematic } from '../../../../lib/domain/usecases/index.js';
+import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 
 describe('Unit | Domain | Use Cases | create-thematic', () => {
 
-  const pixApiClient = Symbol('pixApiClient');
   const competenceThematics = Symbol('competenceThematics');
   const createdThematic = Symbol('createdThematic');
-  const transformedThematic = Symbol('transformedThematic');
-
-  let thematicRepository, thematic, prepareForCreationStub, thematicTransformer, updatedRecordNotifier;
+  let thematicRepository, thematic, prepareForCreationStub;
 
   beforeEach(() => {
+    vi.spyOn(updatePixApiReleaseCache, 'onThematicCreated');
     thematicRepository = {
       create: vi.fn(),
       listByCompetenceAirtableId: vi.fn(),
-    };
-    thematicTransformer = {
-      filterThematicFields: vi.fn(),
-    };
-    updatedRecordNotifier = {
-      notify: vi.fn(),
     };
 
     thematicRepository.listByCompetenceAirtableId.mockResolvedValueOnce(competenceThematics);
@@ -31,20 +24,15 @@ describe('Unit | Domain | Use Cases | create-thematic', () => {
     prepareForCreationStub = vi.spyOn(thematic, 'prepareForCreation');
 
     thematicRepository.create.mockResolvedValueOnce(createdThematic);
-
-    thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
   });
 
   it('prepares thematic for creation and saves it', async () => {
     // given
-    updatedRecordNotifier.notify.mockResolvedValueOnce();
+    updatePixApiReleaseCache.onThematicCreated.mockResolvedValueOnce();
 
     // when
     const result = createThematic(thematic, {
       thematicRepository,
-      thematicTransformer,
-      updatedRecordNotifier,
-      pixApiClient,
     });
 
     // then
@@ -53,31 +41,6 @@ describe('Unit | Domain | Use Cases | create-thematic', () => {
     expect(thematicRepository.listByCompetenceAirtableId).toHaveBeenCalledWith('recCompetence1');
     expect(prepareForCreationStub).toHaveBeenCalledWith(competenceThematics);
     expect(thematicRepository.create).toHaveBeenCalledWith(thematic);
-    expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
-    expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({ updatedRecord: transformedThematic , model: 'thematics', pixApiClient });
-  });
-
-  describe('when record update notify fails', () => {
-    it('does not fail', async () => {
-      // given
-      updatedRecordNotifier.notify.mockRejectedValueOnce(new Error());
-
-      // when
-      const result = createThematic(thematic, {
-        thematicRepository,
-        thematicTransformer,
-        updatedRecordNotifier,
-        pixApiClient,
-      });
-
-      // then
-      await expect(result).resolves.toBe(createdThematic);
-
-      expect(thematicRepository.listByCompetenceAirtableId).toHaveBeenCalledWith('recCompetence1');
-      expect(prepareForCreationStub).toHaveBeenCalledWith(competenceThematics);
-      expect(thematicRepository.create).toHaveBeenCalledWith(thematic);
-      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(createdThematic);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({ updatedRecord: transformedThematic , model: 'thematics', pixApiClient });
-    });
+    expect(updatePixApiReleaseCache.onThematicCreated).toHaveBeenCalledWith(createdThematic);
   });
 });

--- a/api/tests/unit/domain/usecases/update-thematic_test.js
+++ b/api/tests/unit/domain/usecases/update-thematic_test.js
@@ -2,48 +2,35 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { updateThematic } from '../../../../lib/domain/usecases/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
+import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
 
 describe('Unit | Domain | Use Cases | update-thematic', () => {
 
-  const pixApiClient = Symbol('pixApiClient');
   const updatedThematic = Symbol('updatedThematic');
-  const transformedThematic = Symbol('transformedThematic');
   const thematicUpdates = Symbol('thematicUpdates');
 
-  let thematicRepository, thematic, updateStub, thematicTransformer, updatedRecordNotifier;
+  let thematicRepository, thematic, updateStub;
 
   beforeEach(() => {
+    vi.spyOn(updatePixApiReleaseCache, 'onThematicUpdated');
     thematicRepository = {
       getByAirtableId: vi.fn(),
       update: vi.fn(),
     };
-    thematicTransformer = {
-      filterThematicFields: vi.fn(),
-    };
-    updatedRecordNotifier = {
-      notify: vi.fn(),
-    };
 
     thematic = domainBuilder.buildThematic();
     updateStub = vi.spyOn(thematic, 'update').mockReturnValueOnce();
-
     thematicRepository.getByAirtableId.mockResolvedValueOnce(thematic);
-
     thematicRepository.update.mockResolvedValueOnce(updatedThematic);
-
-    thematicTransformer.filterThematicFields.mockReturnValueOnce(transformedThematic);
   });
 
   it('updates thematic and saves it', async () => {
     // given
-    updatedRecordNotifier.notify.mockResolvedValueOnce();
+    updatePixApiReleaseCache.onThematicUpdated.mockResolvedValueOnce();
 
     // when
     const result = updateThematic('recThematic1', thematicUpdates, {
       thematicRepository,
-      thematicTransformer,
-      updatedRecordNotifier,
-      pixApiClient,
     });
 
     // then
@@ -52,8 +39,7 @@ describe('Unit | Domain | Use Cases | update-thematic', () => {
     expect(thematicRepository.getByAirtableId).toHaveBeenCalledWith('recThematic1');
     expect(updateStub).toHaveBeenCalledWith(thematicUpdates);
     expect(thematicRepository.update).toHaveBeenCalledWith(thematic);
-    expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(updatedThematic);
-    expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({ updatedRecord: transformedThematic, model: 'thematics', pixApiClient });
+    expect(updatePixApiReleaseCache.onThematicUpdated).toHaveBeenCalledWith(updatedThematic);
   });
 
   describe('when thematic is not found', () => {
@@ -69,30 +55,6 @@ describe('Unit | Domain | Use Cases | update-thematic', () => {
       // then
       await expect(result).rejects.toStrictEqual(new NotFoundError('unknown thematic id'));
       expect(thematicRepository.getByAirtableId).toHaveBeenCalledWith('recThematic1');
-    });
-  });
-
-  describe('when record update notify fails', () => {
-    it('does not fail', async () => {
-      // given
-      updatedRecordNotifier.notify.mockRejectedValueOnce(new Error());
-
-      // when
-      const result = updateThematic('recThematic1', thematicUpdates, {
-        thematicRepository,
-        thematicTransformer,
-        updatedRecordNotifier,
-        pixApiClient,
-      });
-
-      // then
-      await expect(result).resolves.toBe(updatedThematic);
-
-      expect(thematicRepository.getByAirtableId).toHaveBeenCalledWith('recThematic1');
-      expect(updateStub).toHaveBeenCalledWith(thematicUpdates);
-      expect(thematicRepository.update).toHaveBeenCalledWith(thematic);
-      expect(thematicTransformer.filterThematicFields).toHaveBeenCalledWith(updatedThematic);
-      expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({ updatedRecord: transformedThematic, model: 'thematics', pixApiClient });
     });
   });
 });

--- a/api/tests/unit/infrastructure/transformers/thematic-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/thematic-transformer_test.js
@@ -1,10 +1,5 @@
 import { describe, describe as context, expect, it } from 'vitest';
-import { domainBuilder } from '../../../test-helper.js';
-import {
-  filterThematicsFields,
-  forRelease,
-  forReplication
-} from '../../../../lib/infrastructure/transformers/thematic-transformer.js';
+import { forRelease, forReplication } from '../../../../lib/infrastructure/transformers/thematic-transformer.js';
 import { Thematic } from '../../../../lib/domain/models/index.js';
 import { ThematicForRelease } from '../../../../lib/domain/models/release/index.js';
 import { ThematicForReplication } from '../../../../lib/domain/models/replication/index.js';
@@ -163,19 +158,5 @@ describe('Unit | Infrastructure | thematic-transformer', function() {
         ]);
       });
     });
-  });
-
-  it('should only keep useful fields', function() {
-    const thematics = [domainBuilder.buildThematic()];
-
-    const filteredThematics = filterThematicsFields(thematics);
-
-    expect(filteredThematics.length).to.equal(1);
-    expect(filteredThematics[0].id).to.exist;
-    expect(filteredThematics[0].name_i18n).to.exist;
-    expect(filteredThematics[0].index).to.exist;
-    expect(filteredThematics[0].competenceId).to.exist;
-    expect(filteredThematics[0].tubeIds).to.exist;
-    expect(filteredThematics[0].airtableId).to.not.exist;
   });
 });

--- a/api/tests/unit/infrastructure/transformers/thematic-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/thematic-transformer_test.js
@@ -1,8 +1,169 @@
-import { describe, expect, it } from 'vitest';
+import { describe, describe as context, expect, it } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { filterThematicsFields } from '../../../../lib/infrastructure/transformers/thematic-transformer.js';
+import {
+  filterThematicsFields,
+  forRelease,
+  forReplication
+} from '../../../../lib/infrastructure/transformers/thematic-transformer.js';
+import { Thematic } from '../../../../lib/domain/models/index.js';
+import { ThematicForRelease } from '../../../../lib/domain/models/release/index.js';
+import { ThematicForReplication } from '../../../../lib/domain/models/replication/index.js';
 
 describe('Unit | Infrastructure | thematic-transformer', function() {
+
+  describe('#forRelease', function() {
+    context('when providing a single Thematic', function() {
+      it('should transform it into a single ThematicForRelease', function() {
+        // given
+        const thematic = new Thematic({
+          id: 'thematicId',
+          airtableId: 'recThematicId',
+          name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+          index: 1,
+          competenceId: 'competenceId',
+          competenceAirtableId: 'recCompetenceId',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+        });
+
+        // when
+        const actualThematicForRelease = forRelease(thematic);
+
+        // then
+        expect(actualThematicForRelease).toStrictEqual(new ThematicForRelease({
+          id: 'thematicId',
+          name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+          index: 1,
+          competenceId: 'competenceId',
+          tubeIds: ['tubeId1', 'tubeId2'],
+        }));
+      });
+    });
+
+    context('when providing several Thematics', function() {
+      it('should transform them into a several ThematicsForRelease', function() {
+        // given
+        const thematicA = new Thematic({
+          id: 'thematicIdA',
+          airtableId: 'recThematicIdA',
+          name_i18n: { fr: 'name fr thematicIdA', en: 'name en thematicIdA' },
+          index: 1,
+          competenceId: 'competenceId',
+          competenceAirtableId: 'recCompetenceId',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+        });
+        const thematicB = new Thematic({
+          id: 'thematicIdB',
+          airtableId: 'recThematicIdB',
+          name_i18n: { fr: 'name fr thematicIdB', en: 'name en thematicIdB' },
+          index: 2,
+          competenceId: 'competenceId',
+          competenceAirtableId: 'recCompetenceId',
+          tubeIds: ['tubeId3', 'tubeId4'],
+          tubeAirtableIds: ['recTubeId3', 'recTubeId4'],
+        });
+
+        // when
+        const actualThematicsForRelease = forRelease([thematicA, thematicB]);
+
+        // then
+        expect(actualThematicsForRelease).toStrictEqual([
+          new ThematicForRelease({
+            id: 'thematicIdA',
+            name_i18n: { fr: 'name fr thematicIdA', en: 'name en thematicIdA' },
+            index: 1,
+            competenceId: 'competenceId',
+            tubeIds: ['tubeId1', 'tubeId2'],
+          }),
+          new ThematicForRelease({
+            id: 'thematicIdB',
+            name_i18n: { fr: 'name fr thematicIdB', en: 'name en thematicIdB' },
+            index: 2,
+            competenceId: 'competenceId',
+            tubeIds: ['tubeId3', 'tubeId4'],
+          }),
+        ]);
+      });
+    });
+  });
+
+  describe('#forReplication', function() {
+    context('when providing a single Thematic', function() {
+      it('should transform it into a single ThematicForReplication', function() {
+        // given
+        const thematic = new Thematic({
+          id: 'thematicId',
+          airtableId: 'recThematicId',
+          name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+          index: 1,
+          competenceId: 'competenceId',
+          competenceAirtableId: 'recCompetenceId',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+        });
+
+        // when
+        const actualThematicForReplication = forReplication(thematic);
+
+        // then
+        expect(actualThematicForReplication).toStrictEqual(new ThematicForReplication({
+          id: 'thematicId',
+          name_i18n: { fr: 'name fr thematicId', en: 'name en thematicId' },
+          index: 1,
+          competenceId: 'competenceId',
+          tubeIds: ['tubeId1', 'tubeId2'],
+        }));
+      });
+    });
+
+    context('when providing several Thematics', function() {
+      it('should transform them into a several ThematicsForReplication', function() {
+        // given
+        const thematicA = new Thematic({
+          id: 'thematicIdA',
+          airtableId: 'recThematicIdA',
+          name_i18n: { fr: 'name fr thematicIdA', en: 'name en thematicIdA' },
+          index: 1,
+          competenceId: 'competenceId',
+          competenceAirtableId: 'recCompetenceId',
+          tubeIds: ['tubeId1', 'tubeId2'],
+          tubeAirtableIds: ['recTubeId1', 'recTubeId2'],
+        });
+        const thematicB = new Thematic({
+          id: 'thematicIdB',
+          airtableId: 'recThematicIdB',
+          name_i18n: { fr: 'name fr thematicIdB', en: 'name en thematicIdB' },
+          index: 2,
+          competenceId: 'competenceId',
+          competenceAirtableId: 'recCompetenceId',
+          tubeIds: ['tubeId3', 'tubeId4'],
+          tubeAirtableIds: ['recTubeId3', 'recTubeId4'],
+        });
+
+        // when
+        const actualThematicsForReplication = forReplication([thematicA, thematicB]);
+
+        // then
+        expect(actualThematicsForReplication).toStrictEqual([
+          new ThematicForReplication({
+            id: 'thematicIdA',
+            name_i18n: { fr: 'name fr thematicIdA', en: 'name en thematicIdA' },
+            index: 1,
+            competenceId: 'competenceId',
+            tubeIds: ['tubeId1', 'tubeId2'],
+          }),
+          new ThematicForReplication({
+            id: 'thematicIdB',
+            name_i18n: { fr: 'name fr thematicIdB', en: 'name en thematicIdB' },
+            index: 2,
+            competenceId: 'competenceId',
+            tubeIds: ['tubeId3', 'tubeId4'],
+          }),
+        ]);
+      });
+    });
+  });
 
   it('should only keep useful fields', function() {
     const thematics = [domainBuilder.buildThematic()];


### PR DESCRIPTION
## 🔆 Problème

c'est le bazar la logique autour de :
- Construction de réplication
- Construction de release
- Patch vers l'API (pour la recette)

## ⛱️ Réflexion

### Constats
- En principe, la logique de construction des données pour la release ET pour le patch vers l'API devrait être **la même**. Aujourd'hui ce n'est pas le cas
- Côté réplication, il y a beaucoup de copie de code pour faire comme la release. Il pourrait être intéressant quand même de bien séparer les deux, même si dans les faits beaucoup de données se ressemblent (mais pas toute).

### Proposition
Modifier tous les `***-transformer.js` pour qu'ils exportent exactement deux fonctions : `forRelease()` et `forReplication()`. On aura un endroit centralisé et immédiat pour comprendre les données de chaque export.
En toute logique, il faut aussi appeler `forRelease()` lors du patch vers l'API pour la recette

Cette PR fait le travail pour l'entité Thematic

## 🌊 Remarques

## 🏄 Pour tester

ISO release, répli, patch
