### PR TITLE
[TECH] Autoriser les tubes sans thématique pour de la réplication du référentiel minimal

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -26,7 +26,7 @@ export const tubeDatasource = datasource.extend({
       airtableId: airtableRecord.id,
       name: airtableRecord.get('Nom'),
       index: airtableRecord.get('Index'),
-      thematicAirtableId: airtableRecord.get('Thematique')[0],
+      thematicAirtableId: airtableRecord.get('Thematique') ? airtableRecord.get('Thematique')[0] : [],
       competenceAirtableId: airtableRecord.get('Competences')[0],
       competenceId: airtableRecord.get('Competences (id persistant)')[0],
       skillAirtableIds: airtableRecord.get('Acquis') ?? [],

--- a/api/tests/unit/infrastructure/datasources/airtable/tube-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/tube-datasource_test.js
@@ -40,5 +40,22 @@ describe('Unit | Infrastructure | Datasource | Airtable | TubeDatasource', () =>
       // then
       expect(tube).to.deep.equal(expectedTube);
     });
+
+    it('should create a Tube from the AirtableRecord even when Tube has no thematic', () => {
+      // given
+      const expectedTube = domainBuilder.buildTubeDatasourceObject({
+        thematicAirtableId: [],
+      });
+      const airtableTube = airtableBuilder.factory.buildTube({
+        ...expectedTube,
+      });
+      const tubeRecord = new AirtableRecord('Tube', airtableTube.id, airtableTube);
+      tubeRecord.set('Thematique', undefined);
+      // when
+      const tube = tubeDatasource.fromAirTableObject(tubeRecord);
+
+      // then
+      expect(tube).to.deep.equal(expectedTube);
+    });
   });
 });


### PR DESCRIPTION
## 🔆 Problème
La réplication du référentiel minimal (depuis pix-datwarehouse-integration) ne fonctionne plus depuis plusieurs semaines. Il apparaît que la cause de ce problème provient de tube(s) du référentiel minimal qui ne possède(nt) pas de thématique.   

## ⛱️ Proposition
Autoriser les tubes sans thématique pour de la réplication du référentiel minimal

## 🌊 Remarques
J'ai copié les tables `translations` et `localized_challenges` du lcms minimal de production ainsi que les valeurs des clés relatives à airtable.

## 🏄 Pour tester
`curl -X GET https://pix-lcms-review-pr1089.osc-fr1.scalingo.io/api/replication-data -H "Authorization: Bearer <API_KEY>" -H "client: pix-datawarehouse-integration" -H "Accept: application/json"`
