### PR TITLE
[BUGFIX] Erreur à l'interprétation d'une URL entourée de guillemets avec espaces insécables (PIX-18420)

### DIFF
--- a/api/lib/infrastructure/utils/url-utils.js
+++ b/api/lib/infrastructure/utils/url-utils.js
@@ -9,7 +9,8 @@ import axios from 'axios';
 const GENERIC_URL_REGEX_IN_TEXT = new RegExp(urlRegex({ strict: true, parens: true, returnString: true }), 'i');
 
 export function findUrlsInMarkdown(value) {
-  const safeValue = value || '';
+  let safeValue = value ?? '';
+  safeValue = safeValue.replace(/\u00a0/g, ' ');
   const converter = new showdown.Converter();
   const html = converter.makeHtml(safeValue);
   return findUrlsInText(html);

--- a/api/tests/unit/infrastructure/utils/url-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/url-utils_test.js
@@ -5,7 +5,7 @@ describe('Unit | Utils | URL Utils', function() {
   describe('#findUrlsInMarkdown', function() {
     it('should return URLs in markdown text', function() {
       // given
-      const markdownText = 'instructions [link](https://example.net/) further instructions [https://other_example.net?mode=a&lang=fr](https://other_example.net?mode=a&lang=fr) <a href="https://from_link_example.net?mode=a&lang=en">ici</a>';
+      const markdownText = 'instructions [link](https://example.net/) further instructions [https://other_example.net?mode=a&lang=fr](https://other_example.net?mode=a&lang=fr) <a href="https://from_link_example.net?mode=a&lang=en">ici</a> « https://thirdexample.com/ »';
 
       // when
       const urls = UrlUtils.findUrlsInMarkdown(markdownText);
@@ -14,7 +14,8 @@ describe('Unit | Utils | URL Utils', function() {
       expect(urls).toStrictEqual([
         'https://example.net/',
         'https://other_example.net?mode=a&lang=fr',
-        'https://from_link_example.net?mode=a&lang=en'
+        'https://from_link_example.net?mode=a&lang=en',
+        'https://thirdexample.com/',
       ]);
     });
 


### PR DESCRIPTION
## 🔆 Problème

Les espaces insécables posent problème dans la recherche des URLs cassées.

## ⛱️ Proposition

Supprimer les espaces insécables avant de rechercher les URLs cassées.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Lancer une release pour déclencher la vérification des URLs cassées.
Vérifier sur Drive dans le fichier "DEV_Moulinette URLs cassées" que l’URL entre guillemet dans [cette épreuve](https://pix-lcms-review-pr1110.osc-fr1.scalingo.io/competence/recQE2U97ZMfFZRPl/prototypes/rec16EaDoCrTYiQjh?view=production) ne remonte pas avec un `&nbsp;` à la fin.