### PR TITLE
[FEATURE] Script de suppression de tutoriels (PIX-18830)

### DIFF
--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -72,7 +72,9 @@ export async function upsertRecords(tableName, records, fieldsToMergeOn) {
 
 export async function deleteRecords(tableName, recordIds) {
   logger.info({ tableName }, 'Deleting records in Airtable');
-  return _airtableClient().table(tableName).destroy(recordIds);
+  for (const chunk of chunks(recordIds, 10)) {
+    return _airtableClient().table(tableName).destroy(chunk);
+  }
 }
 
 export function stringValue(value) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -44,6 +44,18 @@ export async function searchByTagTitles(tagTitles) {
   return datasourceTutorials.map(toDomain);
 }
 
+export async function getMany(ids) {
+  const datasourceTutorials = await tutorialDatasource.filter({ filter: { ids } });
+  return datasourceTutorials.map(toDomain);
+}
+
+async function _delete(ids) {
+  const airtableIds = Object.entries(await tutorialDatasource.getAirtableIdsByIds(ids)).map(([, airtableId]) => airtableId);
+  await tutorialDatasource.delete(airtableIds);
+}
+
+export { _delete as delete };
+
 function toDomain(datasourceTutorial) {
   return new Tutorial(datasourceTutorial);
 }

--- a/api/scripts/delete-tutorials.js
+++ b/api/scripts/delete-tutorials.js
@@ -1,0 +1,48 @@
+import { tutorialRepository } from '../lib/infrastructure/repositories/index.js';
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+
+export class DeleteTutorials extends Script {
+  constructor() {
+    super({
+      description: 'Script de suppression de tutoriels',
+      permanent: true,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not perform any deletion.',
+          demandOption: true,
+          default: true,
+        },
+        id: {
+          type: 'array',
+          describe: 'Id of tutorials to delete (space separated)',
+          demandOption: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun, ids: options.id }, 'Script options');
+
+    const tutorials = await tutorialRepository.getMany(options.id);
+
+    if (tutorials.length === 0) {
+      logger.info('No tutorials were found');
+      return;
+    }
+
+    const ids = tutorials.map((tutorial) => tutorial.id);
+    logger.info({ ids }, `${tutorials.length} tutorials were found and will be deleted`);
+
+    if (options.dryRun) {
+      logger.info('Dry run, stopping before deletion');
+      return;
+    }
+
+    await tutorialRepository.delete(ids);
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, DeleteTutorials);

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -5,7 +5,7 @@ import { airtableBuilder, databaseBuilder, generateAuthorizationHeader } from '.
 import { createServer } from '../../../server.js';
 import * as idGenerator from '../../../lib/infrastructure/utils/id-generator.js';
 import { Tutorial } from '../../../lib/domain/models/index.js';
-import { tubeDatasource, tutorialDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
+import { tutorialDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import * as config from '../../../lib/config.js';
 
 describe('Application | Route | Tutorials', () => {
@@ -1050,7 +1050,7 @@ describe('Application | Route | Tutorials', () => {
             .query({
               filterByFormula: 'OR(RECORD_ID() = "tutorialId1", RECORD_ID() = "tutorialId2")',
               fields: { '': tutorialDatasource.usedFields },
-              sort: [{ field: tubeDatasource.sortField, direction: 'asc' }]
+              sort: [{ field: tutorialDatasource.sortField, direction: 'asc' }]
             })
             .matchHeader('authorization', 'Bearer airtableApiKeyValue')
             .reply(200, {

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import * as tutorialRepository from '../../../../lib/infrastructure/repositories/tutorial-repository.js';
+import { Tutorial } from '../../../../lib/domain/models/Tutorial.js';
+import { tutorialDatasource } from '../../../../lib/infrastructure/datasources/airtable/tutorial-datasource.js';
+
+const AIRTABLE_NAME = 'Tutoriels';
+
+describe('Integration | Infrastructure | Repository | Tutorial', () => {
+  describe('#getMany', () => {
+    it('returns corresponding tutorials for given ids', async () => {
+      // given
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'recTuto1', {
+          fields: {
+            'id persistant': 'tuto1',
+            Durée: 'Durée 1',
+            Format: 'Format 1',
+            Lien: 'Lien 1',
+            Source: 'Source 1',
+            Titre: 'Titre 1',
+            Langue: 'Langue 1',
+            License: 'License 1',
+            niveau: 'niveau 1',
+            CoupDeCoeur: 'YES',
+            Tags: ['recTag1', 'recTag2'],
+            'Solution à': ['recSkill1', 'recSkill2'],
+            'En savoir plus': ['recSkill1', 'recSkill3'],
+          },
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'recTuto2', {
+          fields: {
+            'id persistant': 'tuto2',
+            Durée: 'Durée 2',
+            Format: 'Format 2',
+            Lien: 'Lien 2',
+            Source: 'Source 2',
+            Titre: 'Titre 2',
+            Langue: 'Langue 2',
+            License: 'License 2',
+            niveau: 'niveau 2',
+            CoupDeCoeur: 'NON',
+            Tags: ['recTag2', 'recTag3'],
+          },
+        }),
+      ]);
+
+      // when
+      const tutorials = await tutorialRepository.getMany(['tuto1', 'tuto2']);
+
+      // then
+      expect(tutorials).toStrictEqual([
+        new Tutorial({
+          airtableId: 'recTuto1',
+          id: 'tuto1',
+          duration: 'Durée 1',
+          format: 'Format 1',
+          link: 'Lien 1',
+          source: 'Source 1',
+          title: 'Titre 1',
+          locale: 'Langue 1',
+          license: 'License 1',
+          level: 'niveau 1',
+          crush: true,
+          tagAirtableIds: ['recTag1', 'recTag2'],
+        }),
+        new Tutorial({
+          airtableId: 'recTuto2',
+          id: 'tuto2',
+          duration: 'Durée 2',
+          format: 'Format 2',
+          link: 'Lien 2',
+          source: 'Source 2',
+          title: 'Titre 2',
+          locale: 'Langue 2',
+          license: 'License 2',
+          level: 'niveau 2',
+          crush: false,
+          tagAirtableIds: ['recTag2', 'recTag3'],
+        }),
+      ]);
+
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, {
+        fields: tutorialDatasource.usedFields,
+        filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant})',
+      });
+    });
+  });
+
+  describe('#delete', () => {
+    it('deletes records corresponding to given ids', async () => {
+      // given
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'recTuto1', {
+          fields: {
+            'Record ID': 'recTuto1',
+            'id persistant': 'tuto1',
+          },
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'recTuto2', {
+          fields: {
+            'Record ID': 'recTuto2',
+            'id persistant': 'tuto2',
+          },
+        }),
+      ]);
+
+      const deleteRecords = vi.spyOn(airtable, 'deleteRecords').mockResolvedValueOnce();
+
+      // when
+      await tutorialRepository.delete(['tuto1', 'tuto2']);
+
+      // then
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, {
+        fields: ['Record ID', 'id persistant'],
+        filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant})',
+      });
+
+      expect(deleteRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, ['recTuto1', 'recTuto2']);
+    });
+  });
+});

--- a/api/tests/scripts/delete-tutorials_test.js
+++ b/api/tests/scripts/delete-tutorials_test.js
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import nock from 'nock';
+
+import { airtableBuilder } from '../test-helper.js';
+import { DeleteTutorials } from '../../scripts/delete-tutorials.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+import { tutorialDatasource } from '../../lib/infrastructure/datasources/airtable/index.js';
+
+describe('Script | DeleteTutorials', () => {
+  /** @type {DeleteTutorials} */
+  let script;
+
+  beforeEach(() => {
+    script = new DeleteTutorials();
+  });
+
+  describe('#handle', () => {
+    it('deletes existing tutorials corresponding to given ids', async () => {
+      // given
+      const options = {
+        dryRun: false,
+        id: ['tuto1', 'tuto2', 'tuto3']
+      };
+
+      const records = [
+        airtableBuilder.factory.buildTutorial({
+          airtableId: 'recTuto1',
+          id: 'tuto1',
+        }),
+        airtableBuilder.factory.buildTutorial({
+          airtableId: 'recTuto3',
+          id: 'tuto3',
+        }),
+      ];
+
+      const getManyScope = nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Tutoriels')
+        .query({
+          filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant},"tuto3" = {id persistant})',
+          'fields[]': tutorialDatasource.usedFields,
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records });
+
+      const getAirtableIdsByIdsScope = nock('https://api.airtable.com')
+        .get('/v0/airtableBaseValue/Tutoriels')
+        .query({
+          filterByFormula: 'OR("tuto1" = {id persistant},"tuto3" = {id persistant})',
+          'fields[]': ['Record ID', 'id persistant'],
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: records.map((record) => ({
+          ...record,
+          fields: {
+            ...record.fields,
+            'Record ID': record.id,
+          },
+        })) });
+
+      const deleteScope = nock('https://api.airtable.com')
+        .delete('/v0/airtableBaseValue/Tutoriels')
+        .query({
+          'records[]': ['recTuto1', 'recTuto3'],
+        })
+        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+        .reply(200, { records: [
+          { deleted: true, id: 'recTuto1', },
+          { deleted: true, id: 'recTuto3', },
+        ] });
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(getManyScope.isDone()).toBe(true);
+      expect(getAirtableIdsByIdsScope.isDone()).toBe(true);
+      expect(deleteScope.isDone()).toBe(true);
+    });
+
+    describe('when dryRun option is true', () => {
+      it('stops before deletion', async () => {
+        // given
+        const options = {
+          dryRun: true,
+          id: ['tuto1', 'tuto2', 'tuto3']
+        };
+
+        const records = [
+          airtableBuilder.factory.buildTutorial({
+            airtableId: 'recTuto1',
+            id: 'tuto1',
+          }),
+          airtableBuilder.factory.buildTutorial({
+            airtableId: 'recTuto3',
+            id: 'tuto3',
+          }),
+        ];
+
+        const getManyScope = nock('https://api.airtable.com')
+          .get('/v0/airtableBaseValue/Tutoriels')
+          .query({
+            filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant},"tuto3" = {id persistant})',
+            'fields[]': tutorialDatasource.usedFields,
+          })
+          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
+          .reply(200, { records });
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(getManyScope.isDone()).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🔆 Problème

Le métier n’a pas la main pour supprimer des tutoriels.

## ⛱️ Proposition

Créer un script permettant de supprimer des tutoriels.

## 🌊 Remarques

N/A

## 🏄 Pour tester

À tester en local :
 - Seeder son environnement `npm run db:reset`
 - Rattacher des tutos existants à des acquis (au moins un parmi "Se laver les dents", "Payer ses impots" et "Faire son lit")
 - Lancer le script

En dry run :

```
cd api
node scripts/delete-tutorials.js --id tutorial1 tutorial2 tutorial3
```

Pour de vrai :

```
cd api
node scripts/delete-tutorials.js --id tutorial1 tutorial2 tutorial3 --dryRun false
```

Repasser une deuxième fois pour de vrai pour voir que le script ne fait rien.