### PR TITLE
[TECH] Écrire les frameworks dans la base postgres (PIX-19507)

### DIFF
--- a/api/db/migrations/20250902095942_adds-frameworks-table.js
+++ b/api/db/migrations/20250902095942_adds-frameworks-table.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'frameworks';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.string('id').notNullable().primary();
+    table.string('name').notNullable();
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/frameworks.js
+++ b/api/db/seeds/data/frameworks.js
@@ -1,14 +1,14 @@
 import { frameworkDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import { saveInAirtable } from './utils.js';
 
-export async function buildFrameworksFromConfig({ airtableClient, databaseBuilder: _, logger, learningContentConfig }) {
+export async function buildFrameworksFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig }) {
   const frameworkItems = [];
   for (let i = 0; i < learningContentConfig.cntFrameworks; ++i) {
     const name = i === 0 ? 'Pix' : `RéfComplémentaire_${i}`;
     frameworkItems.push(buildFramework({ name }));
   }
 
-  await persistFrameworks({ items: frameworkItems, airtableClient, logger });
+  await persistFrameworks({ items: frameworkItems, airtableClient, databaseBuilder, logger });
   return frameworkItems.map((frameworkItem) => {
     return {
       ...frameworkItem,
@@ -23,9 +23,18 @@ export function buildFramework({ name }) {
   };
 }
 
-export async function persistFrameworks({ items, airtableClient, logger }) {
+export async function persistFrameworks({ items, airtableClient, databaseBuilder, logger }) {
   const airtableItems = items.map(frameworkDatasource.toAirTableObject);
   const records = await saveInAirtable({ tableName: 'Referentiel', data: airtableItems, logger, airtableClient });
+
+  records.forEach((record) => {
+    databaseBuilder.factory.buildFramework({
+      id: record.id,
+      name: record.get('Nom'),
+      createdAt: record.get('Date'),
+    });
+  });
+
   items.forEach((item) => {
     const airtableId = records.shift().id;
     item.airtableId = airtableId;

--- a/api/db/seeds/data/pix-1d.js
+++ b/api/db/seeds/data/pix-1d.js
@@ -10,7 +10,7 @@ import { buildChallenge, persistChallenges } from './challenges.js';
 export async function buildPix1D({ airtableClient, databaseBuilder, logger, locales, indexFramework }) {
   logger.info('About to create whole framework Pix 1D...');
   const pix1DFrameworkItem = buildFramework({ name: 'Pix 1D' });
-  await persistFrameworks({ items: [pix1DFrameworkItem], airtableClient, logger });
+  await persistFrameworks({ items: [pix1DFrameworkItem], airtableClient, databaseBuilder, logger });
 
   const areaItem1 = buildArea({ indexFramework, indexArea: 0, frameworkItem: pix1DFrameworkItem, databaseBuilder, locales });
   const areaItem2 = buildArea({ indexFramework, indexArea: 1, frameworkItem: pix1DFrameworkItem, databaseBuilder, locales });

--- a/api/db/seeds/data/utils.js
+++ b/api/db/seeds/data/utils.js
@@ -21,6 +21,7 @@ export async function saveInAirtable({ tableName, data, logger, airtableClient }
     progression = progression + chunk.length;
     logProgression(progression, data.length);
   }
+  process.stdout.cursorTo(0);
   logger.info('Done !');
   return records;
 }

--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -1,13 +1,25 @@
 import { Framework } from '../../domain/models/index.js';
 import { frameworkDatasource } from '../datasources/airtable/index.js';
+import { knex } from '../../../db/knex-database-connection.js';
+
+const TABLE_NAME = 'frameworks';
 
 export async function list() {
   const frameworkDtos = await frameworkDatasource.list();
   return frameworkDtos.map(toDomain);
 }
 
+/**
+ * @param {Framework} framework
+ */
 export async function create(framework) {
   const createdFrameworkDto = await frameworkDatasource.create(framework);
+
+  await knex.insert({
+    id: createdFrameworkDto.id,
+    name: framework.name,
+  }).into(TABLE_NAME);
+
   return toDomain(createdFrameworkDto);
 }
 

--- a/api/scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg.js
@@ -1,0 +1,45 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { ScriptRunner } from '../../lib/application/scripts/script-runner.js';
+import { Script } from '../../lib/application/scripts/script.js';
+import * as airtable from '../../lib/infrastructure/airtable.js';
+
+export class CopyFrameworksFromAirtableToPg extends Script {
+
+  constructor() {
+    super({
+      description: 'Copie des référentiels de Airtable vers Postgres',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist insert/updates made during the script.',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const airtableFrameworks = await airtable.findRecords('Referentiel', {
+      fields: ['Nom'],
+    });
+    logger.info({ count: airtableFrameworks.length }, 'Loaded frameworks from airtable');
+
+    const frameworks = airtableFrameworks.map((record) => ({
+      id: record.id,
+      name: record.get('Nom'),
+      createdAt: record._rawJson.createdTime,
+      updatedAt: knex.fn.now(),
+    }));
+
+    if (options.dryRun) return;
+
+    await knex.insert(frameworks).into('frameworks').onConflict('id').merge();
+    logger.info({ count: frameworks.length }, 'Inserted frameworks into postgres');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CopyFrameworksFromAirtableToPg);

--- a/api/tests/acceptance/application/frameworks_test.js
+++ b/api/tests/acceptance/application/frameworks_test.js
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
-import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, } from '../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader, knex, } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import { frameworkDatasource } from '../../../lib/infrastructure/datasources/airtable/index.js';
 import * as config from '../../../lib/config.js';
+
+const TABLE_NAME = 'frameworks';
 
 describe('Acceptance | Route | frameworks', () => {
   let editorUser, adminUser, originalPixApiUrlValue;
@@ -140,6 +142,10 @@ describe('Acceptance | Route | frameworks', () => {
   });
 
   describe('POST /frameworks', () => {
+    beforeEach(async () => {
+      await knex.delete().from(TABLE_NAME);
+    });
+
     describe('when user is NOT admin', () => {
       it('should respond with status 403', async () => {
         // given
@@ -244,6 +250,14 @@ describe('Acceptance | Route | frameworks', () => {
         },
       });
       expect(airtableFrameworksScope.isDone()).toBe(true);
+      await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([
+        {
+          id: 'framework4',
+          name: 'Prix',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/framework-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/framework-repository_test.js
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { create } from '../../../../lib/infrastructure/repositories/framework-repository.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { knex } from '../../../test-helper.js';
+import { Framework } from '../../../../lib/domain/models/Framework.js';
+
+const TABLE_NAME = 'frameworks';
+const AIRTABLE_NAME = 'Referentiel';
+
+describe('Integration | Infrastructure | Repositories | Framework', () => {
+  describe('#create', () => {
+    afterEach(async () => {
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('inserts framework in Airtable and Postgres', async () => {
+      // given
+      const id = 'rec123Abc456Def';
+      const name = 'Nouveau référentiel';
+
+      const createRecord = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
+        new Airtable.Record(AIRTABLE_NAME, id, {
+          fields: {
+            Nom: name,
+            'Domaines (identifiants)': [],
+          },
+        }),
+      );
+
+      const framework = new Framework({ name });
+
+      // when
+      const createdFramework = await create(framework);
+
+      // then
+      expect(createdFramework).toStrictEqual(new Framework({
+        id,
+        name,
+        areaIds: [],
+      }));
+
+      expect(createRecord).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, {
+        fields: {
+          Nom: name,
+        },
+      });
+
+      await expect(knex.select('*').from('frameworks')).resolves.toStrictEqual([
+        {
+          id,
+          name,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/integration/scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg_test.js
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { CopyFrameworksFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg.js';
+import { logger } from '../../../../lib/infrastructure/logger.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+const TABLE_NAME = 'frameworks';
+const AIRTABLE_NAME = 'Referentiel';
+
+describe('Integration | Scripts | CopyFrameworksFromAirtableToPg', () => {
+  /** @type {CopyFrameworksFromAirtableToPg} */
+  let script;
+
+  beforeEach(() => {
+    script = new CopyFrameworksFromAirtableToPg();
+  });
+
+  describe('#handle', () => {
+    afterEach(async () => {
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('reads frameworks from airtable and saves these to postgres', async () => {
+      // given
+      const options = { dryRun: false };
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'rec123Abc', {
+          fields: {
+            Nom: 'Pix',
+          },
+          createdTime: '2025-09-02T04:30:00Z',
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'rec456Def', {
+          fields: {
+            Nom: 'Nouveau',
+          },
+          createdTime: '2025-09-02T13:58:00Z',
+        }),
+      ]);
+
+      databaseBuilder.factory.buildFramework({
+        id: 'rec123Abc',
+        name: 'Oux',
+        createdAt: '2025-09-02T00:00:00Z',
+        updatedAt: '2025-09-02T10:00:00Z',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['Nom'] });
+
+      await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+        {
+          id: 'rec123Abc',
+          name: 'Pix',
+          createdAt: new Date('2025-09-02T04:30:00Z'),
+          updatedAt: expect.any(Date),
+        },
+        {
+          id: 'rec456Def',
+          name: 'Nouveau',
+          createdAt: new Date('2025-09-02T13:58:00Z'),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+    });
+
+    describe('when dryRun is true', () => {
+      it('reads frameworks from airtable and stops', async () => {
+        // given
+        const options = { dryRun: true };
+
+        const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+          new Airtable.Record(AIRTABLE_NAME, 'rec123Abc', {
+            fields: {
+              Nom: 'Pix',
+            },
+            createdTime: '2025-09-02T04:30:00Z',
+          }),
+          new Airtable.Record(AIRTABLE_NAME, 'rec456Def', {
+            fields: {
+              Nom: 'Nouveau',
+            },
+            createdTime: '2025-09-02T13:58:00Z',
+          }),
+        ]);
+
+        databaseBuilder.factory.buildFramework({
+          id: 'rec123Abc',
+          name: 'Oux',
+          createdAt: '2025-09-02T00:00:00Z',
+          updatedAt: '2025-09-02T10:00:00Z',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['Nom'] });
+
+        await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([
+          {
+            id: 'rec123Abc',
+            name: 'Oux',
+            createdAt: new Date('2025-09-02T00:00:00Z'),
+            updatedAt: new Date('2025-09-02T10:00:00Z'),
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-framework.js
+++ b/api/tests/tooling/database-builder/factory/build-framework.js
@@ -1,0 +1,9 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildFramework({ id, name, createdAt, updatedAt } = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'frameworks',
+    autoId: false,
+    values: { id, name, createdAt, updatedAt },
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -1,3 +1,4 @@
+export * from './build-framework.js';
 export * from './build-localized-challenge.js';
 export * from './build-localized-challenge-attachment.js';
 export * from './build-mission.js';


### PR DESCRIPTION
## 🔆 Problème

On souhaite sortir d’Airtable.

## ⛱️ Proposition

 - Création de la table frameworks dans postgres
 - Écriture des frameworks en double dans Airtable et postgres
 - Création d’un script de migration des frameworks existants (réexécutable)
 - Écriture des frameworks dans postgres dans les seeds

## 🌊 Remarques

N/A

## 🏄 Pour tester

Le script de migration a été exécuté sur la RA.

Vérifier que les frameworks sont bien dans Postgres avec les bonnes données.

Créer un framework et vérifier qu’il est bien dans Postgres.