### PR TITLE
[TECH] Revert: Nettoyage des jobs Bulls

### DIFF
--- a/api/lib/infrastructure/scheduled-jobs/create-queue.js
+++ b/api/lib/infrastructure/scheduled-jobs/create-queue.js
@@ -22,33 +22,8 @@ export function createQueue(queueName) {
   queue.on('paused', () => queueMessage(queueName, 'The queue has been paused'));
   queue.on('resumed', () => queueMessage(queueName, 'The queue has been resumed'));
   queue.on('cleaned', () => queueMessage(queueName, 'The queue has been cleaned'));
-  queue.on('drained', async function() {
-    queueMessage(queueName, 'The queue has been drained');
-    await cleanQueue(queues.find((queue) => queue.name === queueName));
-  });
+  queue.on('drained', () => queueMessage(queueName, 'The queue has been drained'));
   queue.on('removed', () => queueMessage(queueName, 'A job has been removed'));
   queues.push(queue);
   return queue;
-}
-
-async function cleanQueue(queue) {
-  if (!queue.childPool) {
-    logger.info(`No childPool to clean up for queue '${queue.name}'`);
-    return;
-  }
-
-  const freeProcesses = queue.childPool?.getAllFree();
-  if (!freeProcesses || freeProcesses.length === 0) {
-    logger.info(`No free process to clean up in childPool for queue '${queue.name}'`);
-    return;
-  }
-
-  logger.info(`About to kill ${freeProcesses.length} free Bull processes to free memory in queue '${queue.name}'...`);
-  for (const freeProcess of freeProcesses) {
-    try {
-      await queue.childPool.kill(freeProcess, 'SIGTERM');
-    } catch (error) {
-      logger.error(`Error while killing free bull process in queue '${queue.name}'`, error);
-    }
-  }
 }


### PR DESCRIPTION
## 🔆 Problème

Depuis le 11 avril, soit juste après la v3.192.0, on s’est mis à créer des releases en double toutes les nuits.
Il est probable que cela vienne de la PR #906, même si cela est dur à vérifier.

## ⛱️ Proposition

Annuler les modifications de la PR #906, afin de vérifier que c’est bien ça qui pose problème.
Ensuite on avisera.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A