### PR TITLE
[BUGFIX] Script de suppression de tutos: ne supprime que les 10 1ers ids (PIX-19619)

### DIFF
--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -73,7 +73,7 @@ export async function upsertRecords(tableName, records, fieldsToMergeOn) {
 export async function deleteRecords(tableName, recordIds) {
   logger.info({ tableName }, 'Deleting records in Airtable');
   for (const chunk of chunks(recordIds, 10)) {
-    return _airtableClient().table(tableName).destroy(chunk);
+    await _airtableClient().table(tableName).destroy(chunk);
   }
 }
 


### PR DESCRIPTION
## 🔆 Problème

Le script de suppression des tutos ne supprime que les dix premiers identifiants qu’il reçoit.

## ⛱️ Proposition

Corriger la suppression pour itérer sur tous les ids à supprimer.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A