### PR TITLE
[FEATURE] Ajout de la locale Espagnol d'Amérique latine (PIX-19575)

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -7,6 +7,7 @@ export const LOCALE = {
   PORTUGUESE_SPOKEN: 'pt',
   SPANISH_SPOKEN: 'es',
   DUTCH_SPOKEN: 'nl',
+  URUGUAYAN_SPOKEN: 'es-419',
 };
 
 export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
@@ -18,6 +19,7 @@ export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
   [LOCALE.ITALIAN_SPOKEN]: 'Italie',
   [LOCALE.DUTCH_SPOKEN]: 'Néerlandais',
   [LOCALE.PORTUGUESE_SPOKEN]: 'Portugais',
+  [LOCALE.URUGUAYAN_SPOKEN]: 'Espagnol (Amérique latine)',
 });
 
 export const TUTORIAL_LOCALE_TO_LANGUAGE_MAP = Object.freeze({

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -196,4 +196,4 @@ function isSupportedLocale(s) {
   return SUPPORTED_LOCALES.includes(s);
 }
 
-const SUPPORTED_LOCALES = ['en', 'es', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];
+const SUPPORTED_LOCALES = ['en', 'es', 'es-419', 'fr', 'fr-BE', 'fr-FR', 'nl-BE', 'nl'];

--- a/pix-editor/app/components/competence-header.gjs
+++ b/pix-editor/app/components/competence-header.gjs
@@ -57,6 +57,10 @@ export default class CompetenceHeader extends Component {
       value: 'es',
     },
     {
+      label: 'Espagnol (Amérique latine)',
+      value: 'es-419',
+    },
+    {
       label: 'Néerlandais',
       value: 'nl',
     },

--- a/pix-editor/app/components/competence/competence-header.gjs
+++ b/pix-editor/app/components/competence/competence-header.gjs
@@ -18,28 +18,40 @@ export default class CompetenceHeader extends Component {
   },
   ];
 
-  languageOptions = [{
-    label: 'Anglais',
-    value: 'en',
-  }, {
-    label: 'Espagnol',
-    value: 'es',
-  }, {
-    label: 'Francophone',
-    value: 'fr',
-  }, {
-    label: 'Franco Français',
-    value: 'fr-fr',
-  }, {
-    label: 'Italie',
-    value: 'it',
-  }, {
-    label: 'Portugais',
-    value: 'pt',
-  }, {
-    label: 'Néerlandais',
-    value: 'nl',
-  }];
+  languageOptions = [
+    {
+      label: 'Anglais',
+      value: 'en',
+    },
+    {
+      label: 'Espagnol',
+      value: 'es',
+    },
+    {
+      label: 'Espagnol (Amérique latine)',
+      value: 'es-419',
+    },
+    {
+      label: 'Francophone',
+      value: 'fr',
+    },
+    {
+      label: 'Franco Français',
+      value: 'fr-fr',
+    },
+    {
+      label: 'Italie',
+      value: 'it',
+    },
+    {
+      label: 'Portugais',
+      value: 'pt',
+    },
+    {
+      label: 'Néerlandais',
+      value: 'nl',
+    },
+  ];
 
   get liteClass() {
     return this.config.lite ? ' lite ' : '';

--- a/pix-editor/app/helpers/convert-language-as-flag.js
+++ b/pix-editor/app/helpers/convert-language-as-flag.js
@@ -2,11 +2,13 @@ import { helper } from '@ember/component/helper';
 
 export function convertLanguageAsFlag([language]) {
   switch (language) {
-    case 'fr-fr' :
+    case 'fr-fr':
       return 'fr fr-fr';
     case 'en-us':
     case 'en':
       return 'gb uk';
+    case 'es-419':
+      return 'es';
   }
   return language;
 }

--- a/pix-editor/app/helpers/flag-for-language.js
+++ b/pix-editor/app/helpers/flag-for-language.js
@@ -5,6 +5,7 @@ const flagsForLanguages = {
   'fr-fr': '🇫🇷',
   en: '🇬🇧',
   es: '🇪🇸',
+  'es-419': '🌎',
   nl: '🇳🇱',
 };
 

--- a/pix-editor/tests/unit/helpers/convert-language-as-flag-test.js
+++ b/pix-editor/tests/unit/helpers/convert-language-as-flag-test.js
@@ -12,6 +12,7 @@ module('Unit | Helpers | convert language as flag', function() {
     { expected: 'de', language: 'de' },
     { expected: 'pt', language: 'pt' },
     { expected: 'es', language: 'es' },
+    { expected: 'es', language: 'es-419' },
   ].forEach((item) => {
     test(`it should return ${item.expected} if language is ${item.language}`, function(assert) {
       // when

--- a/pix-editor/tests/unit/helpers/flag-for-language_test.js
+++ b/pix-editor/tests/unit/helpers/flag-for-language_test.js
@@ -26,6 +26,14 @@ module('Unit | Helpers | flag for language', function() {
     assert.strictEqual(result, '🇪🇸');
   });
 
+  test('it should return the expected flag emoji for language "es-419"', function(assert) {
+    // when
+    const result = flagForLanguage(['es-419']);
+
+    // then
+    assert.strictEqual(result, '🌎');
+  });
+
   test('it should return the expected flag emoji for language "nl"', function(assert) {
     // when
     const result = flagForLanguage(['nl']);


### PR DESCRIPTION
## 🔆 Problème
Il y a besoin d'ajouter une langue (espagnol d'amérique latine) à Pix Editor

## ⛱️ Proposition
Ajouter la langue en question

## 🌊 Remarques
RAS

## 🏄 Pour tester
Voir le front et s'assurer qu'on a bien le choix de la langue `Espagnol (Amérique latine)` tant sur la v1 que sur la v2