### PR TITLE
[BUGFIX]  Pouvoir avoir une locale en query params qui dépasse 5 caractères (PIX-19652)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -75,7 +75,7 @@ export async function register(server) {
             id: challengeIdType,
           }),
           query: Joi.object({
-            locale: Joi.string().min(2).max(5)
+            locale: Joi.string().min(2)
           }),
         },
         handler: async function(request, h) {
@@ -95,7 +95,7 @@ export async function register(server) {
         validate: {
           params: Joi.object({
             id: challengeIdType,
-            locale: Joi.string().min(2).max(5),
+            locale: Joi.string().min(2),
             areaCode: Joi.number(),
           }),
         },

--- a/api/lib/application/types.js
+++ b/api/lib/application/types.js
@@ -35,7 +35,7 @@ export function competenceRelationship({ allow = [] } = {}) {
 }
 
 export function locale() {
-  return Joi.string().pattern(/^[a-z]{2}(-[a-z]{2})?$/);
+  return Joi.string().min(2);
 }
 
 export function localizedChallengeId() {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -825,8 +825,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
 
   describe('GET /challenges/:id/preview', () => {
     const challengeId = 'challenge123';
-    const localizedChallengeId = challengeId + '_nl';
-    const locale = 'nl';
+    const localizedChallengeId = challengeId + '_es-419';
+    const locale = 'es-419';
     let airtableChallengeScope;
     let airtableAttachmentScope;
     let attachment;
@@ -851,37 +851,37 @@ describe('Acceptance | Controller | challenges-controller', () => {
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.instruction`,
         locale,
-        value: 'instruction for nl',
+        value: 'instruction for es',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.alternativeInstruction`,
         locale,
-        value: 'alternative instruction for nl',
+        value: 'alternative instruction for es',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.solution`,
         locale,
-        value: 'solution for nl',
+        value: 'solution for es',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.solutionToDisplay`,
         locale,
-        value: 'solution to display for nl',
+        value: 'solution to display for es',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.proposals`,
         locale,
-        value: 'proposals for nl',
+        value: 'proposals for es',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.embedTitle`,
         locale,
-        value: 'embed title for nl',
+        value: 'embed title for es',
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeId}.illustrationAlt`,
         locale,
-        value: 'illustration alt for nl',
+        value: 'illustration alt for es',
       });
 
       databaseBuilder.factory.buildLocalizedChallenge({
@@ -925,22 +925,22 @@ describe('Acceptance | Controller | challenges-controller', () => {
       const apiCacheScope = nock('https://api.test.pix.fr')
         .patch(`/api/cache/challenges/${localizedChallengeId}`,
           {
-            id: 'challenge123_nl',
+            id: 'challenge123_es-419',
             alpha: null,
-            alternativeInstruction: 'alternative instruction for nl',
+            alternativeInstruction: 'alternative instruction for es',
             autoReply: false,
             competenceId: null,
             delta: null,
             embedUrl: null,
-            embedTitle: 'embed title for nl',
+            embedTitle: 'embed title for es',
             format: Challenge.FORMATS.MOTS,
-            illustrationAlt: 'illustration alt for nl',
+            illustrationAlt: 'illustration alt for es',
             illustrationUrl: attachment.fields.url,
-            instruction: 'instruction for nl',
-            locales: ['nl'],
-            proposals: 'proposals for nl',
-            solution: 'solution for nl',
-            solutionToDisplay: 'solution to display for nl',
+            instruction: 'instruction for es',
+            locales: ['es-419'],
+            proposals: 'proposals for es',
+            solution: 'solution for es',
+            solutionToDisplay: 'solution to display for es',
             skillId: null,
             t1Status: false,
             t2Status: false,


### PR DESCRIPTION
## 🔆 Problème

Notre schema JOI n’accepte pas les locale de plus de 5 caractère hors nous venons d'ajouter la locale `es-419`

## ⛱️ Proposition

Supprimer la longueur maximale d'une locale en query params

## 🌊 Remarques

RAS

## 🏄 Pour tester
Se rendre sur la vue épreuves production et filtrer avec la locale d'Amérique Latine
