### PR TITLE
[TECH] Double lecture des frameworks (PIX-19654)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -145,6 +145,10 @@ export const airtableSeedsConfig = {
   locales: _getStringArray(process.env.AIRTABLE_SEEDS_LOCALES, ['fr', 'en']),
 };
 
+export const migrationFromAirtable = {
+  throwOnPostgresDifference: false,
+};
+
 if (process.env.NODE_ENV === 'test') {
   port = 0;
   hapi.publicDir = 'tests/public-tests/';
@@ -189,7 +193,6 @@ if (process.env.NODE_ENV === 'test') {
   phrase.apiKey = 'MY_PHRASE_ACCESS_TOKEN';
   phrase.projectId = 'MY_PHRASE_PROJECT_ID';
   phrase.projects = [{ projectId: 'MY_PHRASE_PROJECT_ID' }];
-}
 
-// amandeNoix3
-// amandeCajou1
+  migrationFromAirtable.throwOnPostgresDifference = true;
+}

--- a/api/lib/infrastructure/datasources/airtable/framework-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/framework-datasource.js
@@ -11,13 +11,15 @@ export const frameworkDatasource = datasource.extend({
   usedFields: [
     'Nom',
     'Domaines (identifiants)',
+    'Domaines (identifiants) (id persistant)',
   ],
 
   fromAirTableObject(airtableRecord) {
     return {
       id: airtableRecord.id,
       name: airtableRecord.get('Nom'),
-      areaIds: airtableRecord.get('Domaines (identifiants)'),
+      areaAirtableIds: airtableRecord.get('Domaines (identifiants)'),
+      areaIds: airtableRecord.get('Domaines (identifiants) (id persistant)'),
     };
   },
 
@@ -29,4 +31,3 @@ export const frameworkDatasource = datasource.extend({
     };
   },
 });
-

--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -1,12 +1,32 @@
 import { Framework } from '../../domain/models/index.js';
 import { frameworkDatasource } from '../datasources/airtable/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { areArrayEquals, compareDtosLists } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'frameworks';
 
 export async function list() {
-  const frameworkDtos = await frameworkDatasource.list();
-  return frameworkDtos.map(toDomain);
+  const [airtableDtos, pgDtos] = await Promise.all([
+    frameworkDatasource.list(),
+    knex.select(
+      '*',
+      knex
+        .select(knex.raw('json_agg(??)', knex.ref('areas.id')))
+        .from('areas')
+        .where('areas.frameworkId', '=', knex.ref('frameworks.id'))
+        .as('areaIds'),
+    ).from(TABLE_NAME).orderBy('createdAt'),
+  ]);
+
+  compareDtosLists(airtableDtos, pgDtos, (airtableDto, pgDto) => {
+    const diff = [];
+    if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+    if (airtableDto.name !== pgDto.name) diff.push(`airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
+    if (!areArrayEquals(airtableDto.areaIds, pgDto.areaIds)) diff.push(`airtable areaIds "${airtableDto.areaIds}" != postgres areaIds "${pgDto.areaIds}"`);
+    return diff;
+  });
+
+  return airtableDtos.map(toDomain);
 }
 
 /**

--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -24,5 +24,8 @@ export async function create(framework) {
 }
 
 function toDomain(frameworkDto) {
-  return new Framework(frameworkDto);
+  return new Framework({
+    ...frameworkDto,
+    areaIds: frameworkDto.areaAirtableIds,
+  });
 }

--- a/api/lib/infrastructure/repositories/migration-from-airtable.js
+++ b/api/lib/infrastructure/repositories/migration-from-airtable.js
@@ -1,0 +1,46 @@
+import * as config from '../../config.js';
+import { child } from '../logger.js';
+
+const logger = child('airtable:migration', { event: 'migration-from-airtable' });
+
+/**
+ * @param {object[]} airtableDtos
+ * @param {object[]} pgDtos
+ * @param {(object, object) => string[]} compareFunc
+ */
+export function compareDtosLists(airtableDtos, pgDtos, compareFunc) {
+  if (airtableDtos.length !== pgDtos.length) {
+    logger.warn({
+      airtableCount: airtableDtos.length,
+      postgresCount: pgDtos.length,
+    }, 'difference between airtable and postgres dtos count');
+    if (config.migrationFromAirtable.throwOnPostgresDifference) {
+      console.error('difference between airtable and postgres dtos count', {
+        airtableCount: airtableDtos.length,
+        postgresCount: pgDtos.length,
+      });
+      throw new Error('difference between airtable and postgres dtos count');
+    }
+    return;
+  }
+  airtableDtos.forEach((airtableDto, i) => compareDtos(airtableDto, pgDtos[i], compareFunc));
+}
+
+export function compareDtos(airtableDto, pgDto, compareFunc) {
+  const diff = compareFunc(airtableDto, pgDto);
+  if (diff.length === 0) return;
+  logger.warn({ diff }, 'difference between airtable and postgres dtos');
+  if (config.migrationFromAirtable.throwOnPostgresDifference) {
+    console.error('difference between airtable and postgres dtos', diff);
+    throw new Error('difference between airtable and postgres dtos');
+  }
+}
+
+export function areArrayEquals(array1, array2) {
+  if (array1 == null && array2 == null) return true;
+  if (array1 == null && array2 != null) return false;
+  if (array1 != null && array2 == null) return false;
+  if (array1.length !== array2.length) return false;
+  const sortedArray2 = array2.toSorted();
+  return array1.toSorted().every((value, i) => value === sortedArray2[i]);
+}

--- a/api/tests/acceptance/application/frameworks_test.js
+++ b/api/tests/acceptance/application/frameworks_test.js
@@ -31,21 +31,25 @@ describe('Acceptance | Route | frameworks', () => {
           id: 'framework1',
           name: 'Pix',
           areaIds: ['area1', 'area2'],
+          areaAirtableIds: ['recArea1', 'recArea2'],
         })),
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework3',
           name: 'Poux',
           areaIds: ['area8', 'area7', 'area6'],
+          areaAirtableIds: ['recArea8', 'recArea7', 'recArea6'],
         })),
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework2',
           name: 'Paix',
           areaIds: ['area4', 'area3', 'area5'],
+          areaAirtableIds: ['recArea4', 'recArea3', 'recArea5'],
         })),
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework4',
           name: 'Prix',
           areaIds: null,
+          areaAirtableIds: null,
         })),
       ];
 
@@ -84,8 +88,8 @@ describe('Acceptance | Route | frameworks', () => {
             relationships: {
               areas: {
                 data: [
-                  { id: 'area1', type: 'areas' },
-                  { id: 'area2', type: 'areas' },
+                  { id: 'recArea1', type: 'areas' },
+                  { id: 'recArea2', type: 'areas' },
                 ],
               },
             },
@@ -99,9 +103,9 @@ describe('Acceptance | Route | frameworks', () => {
             relationships: {
               areas: {
                 data: [
-                  { id: 'area8', type: 'areas' },
-                  { id: 'area7', type: 'areas' },
-                  { id: 'area6', type: 'areas' },
+                  { id: 'recArea8', type: 'areas' },
+                  { id: 'recArea7', type: 'areas' },
+                  { id: 'recArea6', type: 'areas' },
                 ],
               },
             },
@@ -115,9 +119,9 @@ describe('Acceptance | Route | frameworks', () => {
             relationships: {
               areas: {
                 data: [
-                  { id: 'area4', type: 'areas' },
-                  { id: 'area3', type: 'areas' },
-                  { id: 'area5', type: 'areas' },
+                  { id: 'recArea4', type: 'areas' },
+                  { id: 'recArea3', type: 'areas' },
+                  { id: 'recArea5', type: 'areas' },
                 ],
               },
             },
@@ -202,6 +206,7 @@ describe('Acceptance | Route | frameworks', () => {
         id: 'framework4',
         name: 'Prix',
         areaIds: null,
+        areaAirtableIds: null,
       }));
 
       const airtableFrameworksScope = nock('https://api.airtable.com')

--- a/api/tests/acceptance/application/frameworks_test.js
+++ b/api/tests/acceptance/application/frameworks_test.js
@@ -26,6 +26,20 @@ describe('Acceptance | Route | frameworks', () => {
     let airtableFrameworksScope;
 
     beforeEach(async () => {
+      databaseBuilder.factory.buildFramework({ id: 'framework1', name: 'Pix', createdAt: '20250905T07:20:00Z' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'framework1' });
+      databaseBuilder.factory.buildFramework({ id: 'framework2', name: 'Paix', createdAt: '20250905T07:22:00Z' });
+      databaseBuilder.factory.buildArea({ id: 'area3', code: '3', frameworkId: 'framework2' });
+      databaseBuilder.factory.buildArea({ id: 'area4', code: '4', frameworkId: 'framework2' });
+      databaseBuilder.factory.buildArea({ id: 'area5', code: '5', frameworkId: 'framework2' });
+      databaseBuilder.factory.buildFramework({ id: 'framework3', name: 'Poux', createdAt: '20250905T07:21:00Z' });
+      databaseBuilder.factory.buildArea({ id: 'area6', code: '6', frameworkId: 'framework3' });
+      databaseBuilder.factory.buildArea({ id: 'area7', code: '7', frameworkId: 'framework3' });
+      databaseBuilder.factory.buildArea({ id: 'area8', code: '8', frameworkId: 'framework3' });
+      databaseBuilder.factory.buildFramework({ id: 'framework4', name: 'Prix', createdAt: '20250905T07:23:00Z' });
+      await databaseBuilder.commit();
+
       const airtableFrameworks = [
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework1',
@@ -36,14 +50,14 @@ describe('Acceptance | Route | frameworks', () => {
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework3',
           name: 'Poux',
-          areaIds: ['area8', 'area7', 'area6'],
-          areaAirtableIds: ['recArea8', 'recArea7', 'recArea6'],
+          areaIds: ['area6', 'area7', 'area8'],
+          areaAirtableIds: ['recArea6', 'recArea7', 'recArea8'],
         })),
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework2',
           name: 'Paix',
-          areaIds: ['area4', 'area3', 'area5'],
-          areaAirtableIds: ['recArea4', 'recArea3', 'recArea5'],
+          areaIds: ['area3', 'area4', 'area5'],
+          areaAirtableIds: ['recArea3', 'recArea4', 'recArea5'],
         })),
         airtableBuilder.factory.buildFramework(domainBuilder.buildFrameworkDatasourceObject({
           id: 'framework4',
@@ -103,9 +117,9 @@ describe('Acceptance | Route | frameworks', () => {
             relationships: {
               areas: {
                 data: [
-                  { id: 'recArea8', type: 'areas' },
-                  { id: 'recArea7', type: 'areas' },
                   { id: 'recArea6', type: 'areas' },
+                  { id: 'recArea7', type: 'areas' },
+                  { id: 'recArea8', type: 'areas' },
                 ],
               },
             },
@@ -119,8 +133,8 @@ describe('Acceptance | Route | frameworks', () => {
             relationships: {
               areas: {
                 data: [
-                  { id: 'recArea4', type: 'areas' },
                   { id: 'recArea3', type: 'areas' },
+                  { id: 'recArea4', type: 'areas' },
                   { id: 'recArea5', type: 'areas' },
                 ],
               },

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -254,12 +254,15 @@ async function mockCurrentContent() {
       files: attachments.map(({ id: fileId, localizedChallengeId }) => ({ fileId, localizedChallengeId }))
     })],
     competences: [buildCompetence(expectedCurrentContent.competences[0])],
-    frameworks: [buildFramework(expectedCurrentContent.frameworks[0])],
+    frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],
     skills: [buildSkill(expectedCurrentContent.skills[0])],
     thematics: [buildThematic({ ...expectedCurrentContent.thematics[0], airtableId: expectedCurrentContent.thematics[0].id + 'Airtable' })],
     tubes: [buildTube({ ...expectedCurrentContent.tubes[0], thematicAirtableId: expectedCurrentContent.thematics[0].id + 'Airtable' })],
     tutorials: [buildTutorial(expectedCurrentContent.tutorials[0])],
   });
+
+  databaseBuilder.factory.buildFramework(expectedCurrentContent.frameworks[0]);
+  databaseBuilder.factory.buildArea(expectedCurrentContent.areas[0]);
 
   databaseBuilder.factory.buildStaticCourse({
     id: 'recCourse0',
@@ -664,12 +667,15 @@ async function mockContentForRelease() {
       }),
     ],
     competences: [buildCompetence(expectedCurrentContent.competences[0])],
-    frameworks: [buildFramework(expectedCurrentContent.frameworks[0])],
+    frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],
     skills: [buildSkill(expectedCurrentContent.skills[0])],
     thematics: [buildThematic({ ...expectedCurrentContent.thematics[0], airtableId: expectedCurrentContent.thematics[0] + 'Airtable' })],
     tubes: [buildTube({ ...expectedCurrentContent.tubes[0], thematicAirtableId: expectedCurrentContent.thematics[0] + 'Airtable' })],
     tutorials: [buildTutorial(expectedCurrentContent.tutorials[0])],
   });
+
+  databaseBuilder.factory.buildFramework(expectedCurrentContent.frameworks[0]);
+  databaseBuilder.factory.buildArea(expectedCurrentContent.areas[0]);
 
   databaseBuilder.factory.buildStaticCourse({
     id: 'recCourse0',

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -73,7 +73,7 @@ async function mockCurrentContent() {
   const expectedFramework = new FrameworkForReplication(domainBuilder.buildFramework());
   expectedCurrentContent.frameworks = [{ ...expectedFramework }];
 
-  const area = domainBuilder.buildArea();
+  const area = domainBuilder.buildArea({ frameworkId: expectedFramework.id });
   const expectedArea = new AreaForReplication({ name: area.name, ...area });
   expectedCurrentContent.areas = [{ ...expectedArea }];
 
@@ -255,16 +255,16 @@ async function mockCurrentContent() {
     },
   ];
 
-  const airtableSkill = buildSkill(expectedCurrentContent.skills[0]);
+  databaseBuilder.factory.buildFramework(expectedCurrentContent.frameworks[0]);
+  databaseBuilder.factory.buildArea(expectedCurrentContent.areas[0]);
+
   airtableBuilder.mockLists({
-    frameworks: [buildFramework(expectedCurrentContent.frameworks[0])],
+    frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],
     areas: [buildArea(expectedCurrentContent.areas[0])],
     competences: [buildCompetence(expectedCurrentContent.competences[0])],
     thematics: [buildThematic(expectedCurrentContent.thematics[0])],
     tubes: [buildTube(expectedCurrentContent.tubes[0])],
-    skills: [{
-      ...airtableSkill,
-    }],
+    skills: [buildSkill(expectedCurrentContent.skills[0])],
     challenges: [buildChallenge({
       ...expectedChallenge,
       files: [

--- a/api/tests/integration/infrastructure/repositories/framework-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/framework-repository_test.js
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
-import { create } from '../../../../lib/infrastructure/repositories/framework-repository.js';
+import { create, list } from '../../../../lib/infrastructure/repositories/framework-repository.js';
 import * as airtable from '../../../../lib/infrastructure/airtable.js';
-import { knex } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import { Framework } from '../../../../lib/domain/models/Framework.js';
+import { frameworkDatasource } from '../../../../lib/infrastructure/datasources/airtable/framework-datasource.js';
 
 const TABLE_NAME = 'frameworks';
 const AIRTABLE_NAME = 'Referentiel';
@@ -55,6 +56,87 @@ describe('Integration | Infrastructure | Repositories | Framework', () => {
           updatedAt: expect.any(Date),
         },
       ]);
+    });
+  });
+
+  describe('#list', () => {
+    it('lists all frameworks w/ attached area ids', async () => {
+      // given
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'recFmk1', {
+          fields: {
+            Nom: 'Premier framework',
+            'Domaines (identifiants)': ['recArea1', 'recArea2'],
+            'Domaines (identifiants) (id persistant)': ['area1', 'area2'],
+          },
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'recFmk2', {
+          fields: {
+            Nom: 'Deuxième framework',
+            'Domaines (identifiants)': ['recArea3', 'recArea4', 'recArea5'],
+            'Domaines (identifiants) (id persistant)': ['area3', 'area4', 'area5'],
+          },
+        }),
+      ]);
+
+      databaseBuilder.factory.buildFramework({
+        id: 'recFmk1',
+        name: 'Premier framework',
+        createdAt: '20250904T14:37:00Z',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area1',
+        code: '1',
+        frameworkId: 'recFmk1',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area2',
+        code: '2',
+        frameworkId: 'recFmk1',
+      });
+      databaseBuilder.factory.buildFramework({
+        id: 'recFmk2',
+        name: 'Deuxième framework',
+        createdAt: '20250904T14:38:00Z',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area3',
+        code: '3',
+        frameworkId: 'recFmk2',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area4',
+        code: '4',
+        frameworkId: 'recFmk2',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area5',
+        code: '5',
+        frameworkId: 'recFmk2',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const frameworks = await list();
+
+      // then
+      expect(frameworks).toStrictEqual([
+        domainBuilder.buildFramework({
+          id: 'recFmk1',
+          name: 'Premier framework',
+          areaIds: ['recArea1', 'recArea2'],
+        }),
+        domainBuilder.buildFramework({
+          id: 'recFmk2',
+          name: 'Deuxième framework',
+          areaIds: ['recArea3', 'recArea4', 'recArea5'],
+        }),
+      ]);
+
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME,  {
+        fields: frameworkDatasource.usedFields,
+        sort: [{ direction: 'asc', field: frameworkDatasource.sortField }],
+      },);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -407,9 +407,14 @@ function buildChallengeTranslationsAndLocalizedChallenge(challenge, locale, loca
 }
 
 function _mockRichAirtableContent() {
+  databaseBuilder.factory.buildFramework({
+    id: 'frameworkA',
+    name: 'FrameworkA',
+  });
   const airtableFrameworkA = airtableBuilder.factory.buildFramework({
     id: 'frameworkA',
     name: 'FrameworkA',
+    areaIds: ['area1', 'area2'],
   });
   const area1 = {
     id: 'area1',
@@ -420,6 +425,7 @@ function _mockRichAirtableContent() {
     color: Area.COLORS.JAFFA,
     frameworkId: 'frameworkA',
   };
+  databaseBuilder.factory.buildArea(area1);
   const airtableArea1 = airtableBuilder.factory.buildArea(area1);
   const area2 = {
     id: 'area2',
@@ -430,6 +436,7 @@ function _mockRichAirtableContent() {
     color: Area.COLORS.EMERALD,
     frameworkId: 'frameworkA',
   };
+  databaseBuilder.factory.buildArea(area2);
   const airtableArea2 = airtableBuilder.factory.buildArea(area2);
   const competence11 = {
     id: 'competence11',

--- a/api/tests/tooling/airtable-builder/factory/build-framework.js
+++ b/api/tests/tooling/airtable-builder/factory/build-framework.js
@@ -1,13 +1,15 @@
 export function buildFramework({
   id,
   name,
+  areaAirtableIds,
   areaIds,
 } = {}) {
   return {
     id,
     'fields': {
       'Nom': name,
-      'Domaines (identifiants)': areaIds,
+      'Domaines (identifiants)': areaAirtableIds,
+      'Domaines (identifiants) (id persistant)': areaIds,
     },
   };
 }

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-framework-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-framework-datasource-object.js
@@ -1,11 +1,13 @@
 export function buildFrameworkDatasourceObject({
   id = 'framework123',
   name = 'Un référentiel',
+  areaAirtableIds = ['recArea456', 'recArea789'],
   areaIds = ['area456', 'area789'],
 } = {}) {
   return {
     id,
     name,
+    areaAirtableIds,
     areaIds,
   };
 }

--- a/api/tests/unit/infrastructure/datasources/airtable/framework-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/framework-datasource_test.js
@@ -11,7 +11,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | FrameworkDatasource', 
 
     it('should create a Framework from the AirtableRecord', () => {
       // given
-      const expectedFramework = domainBuilder.buildFramework();
+      const expectedFramework = domainBuilder.buildFrameworkDatasourceObject();
       const airtableFramework = airtableBuilder.factory.buildFramework(expectedFramework);
       const recordFramework = new AirtableRecord('Referentiel', airtableFramework.id, airtableFramework);
 


### PR DESCRIPTION
## 🔆 Problème

On souhaite sortir d’Airtable.

## ⛱️ Proposition

Lire les frameworks dans Airtable et dans Postgres et comparer les données :
 - en prod, faire un log niveau warning si une différence est détectée
 - em test, lever une erreur si une différence est détectée

## 🌊 Remarques

N/A

## 🏄 Pour tester

Ouvrir la RA, vérifier qu’il n’y a pas de logs de warning concernant des différences de données entre Airtable et Postgres.