### PR TITLE
[TECH] Écrire les compétences dans la base postgres (PIX-19655)

### DIFF
--- a/api/db/migrations/20250923084603_create-competences-table.js
+++ b/api/db/migrations/20250923084603_create-competences-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'competences';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.string('id').notNullable().primary();
+    table.string('index').notNullable();
+    table.string('areaId').notNullable().references('areas.id');
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/areas.js
+++ b/api/db/seeds/data/areas.js
@@ -51,3 +51,20 @@ export async function persistAreas({ items, airtableClient, logger }) {
     item.airtableId = records.shift().id;
   });
 }
+
+export async function copyAreasFromAirtable({ airtableClient, databaseBuilder, logger }) {
+  const airtableAreas = await airtableClient.table('Domaines').select({ fields: ['id persistant', 'Code', 'Couleur', 'Referentiel'] }).all();
+
+  logger.info(`Copying ${airtableAreas.length} areas from airtable...`);
+
+  airtableAreas.forEach((record) => {
+    databaseBuilder.factory.buildArea({
+      id: record.get('id persistant'),
+      code: record.get('Code'),
+      color: record.get('Couleur'),
+      frameworkId: record.get('Referentiel')[0],
+      createdAt: record._rawJson.createdTime,
+      updatedAt: new Date(),
+    });
+  });
+}

--- a/api/db/seeds/data/competences.js
+++ b/api/db/seeds/data/competences.js
@@ -55,3 +55,19 @@ export async function persistCompetences({ items, airtableClient, logger }) {
     item.origin = record.fields['Origine2'];
   });
 }
+
+export async function copyCompetencesFromAirtable({ airtableClient, databaseBuilder, logger }) {
+  const airtableCompetences = await  airtableClient.table('Competences').select({ fields: ['id persistant', 'Sous-domaine', 'Domaine (id persistant)'] }).all();
+
+  logger.info(`Copying ${airtableCompetences.length} competences from airtable...`);
+
+  airtableCompetences.forEach((record) => {
+    databaseBuilder.factory.buildCompetence({
+      id: record.get('id persistant'),
+      index: record.get('Sous-domaine'),
+      areaId: record.get('Domaine (id persistant)')[0],
+      createdAt: record._rawJson.createdTime,
+      updatedAt: new Date(),
+    });
+  });
+}

--- a/api/db/seeds/data/competences.js
+++ b/api/db/seeds/data/competences.js
@@ -30,21 +30,18 @@ export function buildCompetence({ indexCompetence, areaItem, databaseBuilder, lo
     name: competenceName,
     description: competenceDescription,
   };
+  databaseBuilder.factory.buildCompetence(competenceItem);
   locales.forEach((locale) => {
-    databaseBuilder.factory.buildTranslation(
-      {
-        locale,
-        key: `competence.${competenceItem.id}.name`,
-        value: `${competenceItem.name} ${locale}`,
-      }
-    );
-    databaseBuilder.factory.buildTranslation(
-      {
-        locale,
-        key: `competence.${competenceItem.id}.description`,
-        value: `${competenceItem.description} ${locale}`,
-      }
-    );
+    databaseBuilder.factory.buildTranslation({
+      locale,
+      key: `competence.${competenceItem.id}.name`,
+      value: `${competenceItem.name} ${locale}`,
+    });
+    databaseBuilder.factory.buildTranslation({
+      locale,
+      key: `competence.${competenceItem.id}.description`,
+      value: `${competenceItem.description} ${locale}`,
+    });
   });
   return competenceItem;
 }

--- a/api/db/seeds/data/frameworks.js
+++ b/api/db/seeds/data/frameworks.js
@@ -41,3 +41,18 @@ export async function persistFrameworks({ items, airtableClient, databaseBuilder
     item.id = airtableId;
   });
 }
+
+export async function copyFrameworksFromAirtable({ airtableClient, databaseBuilder, logger }) {
+  const airtableFrameworks = await airtableClient.table('Referentiel').select({ fields: ['Nom'] }).all();
+
+  logger.info(`Copying ${airtableFrameworks.length} frameworks from airtable...`);
+
+  airtableFrameworks.forEach((record) => {
+    databaseBuilder.factory.buildFramework({
+      id: record.id,
+      name: record.get('Nom'),
+      createdAt: record._rawJson.createdTime,
+      updatedAt: new Date(),
+    });
+  });
+}

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -3,10 +3,10 @@ import { canSeedOrEmptyAirtableBase } from '../../lib/infrastructure/airtable.js
 import Airtable from 'airtable';
 import { airtable, airtableSeedsConfig } from '../../lib/config.js';
 import { logger } from '../../lib/infrastructure/logger.js';
-import { buildAreasFromConfig } from './data/areas.js';
+import { buildAreasFromConfig, copyAreasFromAirtable } from './data/areas.js';
 import { buildChallengesFromConfig } from './data/challenges.js';
-import { buildCompetencesFromConfig } from './data/competences.js';
-import { buildFrameworksFromConfig } from './data/frameworks.js';
+import { buildCompetencesFromConfig, copyCompetencesFromAirtable } from './data/competences.js';
+import { buildFrameworksFromConfig, copyFrameworksFromAirtable } from './data/frameworks.js';
 import { buildPix1D } from './data/pix-1d.js';
 import { buildSkillsFromConfig } from './data/skills.js';
 import { buildThematicsFromConfig } from './data/thematics.js';
@@ -68,6 +68,10 @@ export async function seed(knex) {
     const tagItems = await buildTags({ airtableClient, logger });
     await buildTutorials({ airtableClient, logger, locales: learningContentConfig.locales, tagItems });
   } else {
+    await copyFrameworksFromAirtable({ airtableClient, databaseBuilder, logger });
+    await copyAreasFromAirtable({ airtableClient, databaseBuilder, logger });
+    await copyCompetencesFromAirtable({ airtableClient, databaseBuilder, logger });
+
     const translations = await translationsBuilder(databaseBuilder);
     await localizedChallengesBuilder(databaseBuilder, translations);
     await localizedChallengesAttachmentsBuilder(databaseBuilder);

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -5,8 +5,10 @@ import * as translationRepository from './translation-repository.js';
 import * as competenceTranslations from '../translations/competence.js';
 import { Competence } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
+import { knex } from '../../../db/knex-database-connection.js';
 
 const model = 'competence';
+const TABLE_NAME = 'competences';
 
 export async function list() {
   const [datasourceCompetences, translations] = await Promise.all([
@@ -52,6 +54,12 @@ export async function create(competence) {
   const translations = competenceTranslations.extractFromDomainObject(competence);
 
   const createdCompetenceDto = await competenceDatasource.create(competence);
+
+  await knex.insert({
+    id: competence.id,
+    index: competence.index,
+    areaId: createdCompetenceDto.areaId,
+  }).into(TABLE_NAME);
 
   await translationRepository.save({ translations });
 

--- a/api/scripts/migration-from-airtable/copy-competences-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-competences-from-airtable-to-pg.js
@@ -1,0 +1,46 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { ScriptRunner } from '../../lib/application/scripts/script-runner.js';
+import { Script } from '../../lib/application/scripts/script.js';
+import * as airtable from '../../lib/infrastructure/airtable.js';
+
+export class CopyCompetencesFromAirtableToPg extends Script {
+
+  constructor() {
+    super({
+      description: 'Copie des compétences de Airtable vers Postgres',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist insert/updates made during the script.',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const airtableCompetences = await airtable.findRecords('Competences', {
+      fields: ['id persistant', 'Sous-domaine', 'Domaine (id persistant)'],
+    });
+    logger.info({ count: airtableCompetences.length }, 'Loaded competences from airtable');
+
+    const competences = airtableCompetences.map((record) => ({
+      id: record.get('id persistant'),
+      index: record.get('Sous-domaine'),
+      areaId: record.get('Domaine (id persistant)')[0],
+      createdAt: record._rawJson.createdTime,
+      updatedAt: knex.fn.now(),
+    }));
+
+    if (options.dryRun) return;
+
+    await knex.insert(competences).into('competences').onConflict('id').merge();
+    logger.info({ count: competences.length }, 'Inserted competences into postgres');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CopyCompetencesFromAirtableToPg);

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -430,6 +430,9 @@ describe('Acceptance | Route | competences', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, airtableArea);
 
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk1' });
+
       const airtableCompetences = [
         airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
           id: 'competence3',
@@ -593,9 +596,12 @@ describe('Acceptance | Route | competences', () => {
         })
         .matchHeader('Authorization', `Bearer ${pixApiToken}`)
         .reply(200);
+
+      await databaseBuilder.commit();
     });
 
     afterEach(async () => {
+      await knex('competences').truncate();
       await knex('translations').truncate();
     });
 
@@ -733,6 +739,10 @@ describe('Acceptance | Route | competences', () => {
       expect(generateNewId).toHaveBeenCalledWith('thematic');
       expect(generateNewId).toHaveBeenCalledWith('tube');
       expect(generateNewId).toHaveBeenCalledWith('skill');
+
+      await expect(knex.select('*').from('competences')).resolves.toStrictEqual([
+        { id: 'competence4', index: '2.2', areaId: 'area2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
 
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: 'competence.competence4.description', locale: 'en', value: 'It’s the fourth one' },

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper';
 import * as competenceRepository from '../../../../lib/infrastructure/repositories/competence-repository.js';
+import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { Competence } from '../../../../lib/domain/models/index.js';
+
+const TABLE_NAME = 'competences';
+const AIRTABLE_NAME = 'Competences';
 
 describe('Integration | Repository | competence-repository', () => {
 
@@ -231,6 +239,109 @@ describe('Integration | Repository | competence-repository', () => {
       // then
       expect(competence).toStrictEqual(null);
       airtableScope.done();
+    });
+  });
+
+  describe('#create', () => {
+    afterEach(async () => {
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('inserts competence in airtable and postgres w/ its translations', async () => {
+      // given
+      const airtableId = 'rec123Abc';
+      const id = 'competence123Abc';
+      const index = '2';
+      const nameFr = 'Nouvelle compétence';
+      const nameEn = 'New competence';
+      const descriptionFr = 'Description nouvelle compétence';
+      const descriptionEn = 'New competence description';
+      const frameworkId = 'recFmk123';
+      const frameworkName = 'Un référentiel';
+      const areaId = 'recArea123';
+      const areaAirtableId = 'rec456Def';
+
+      const generateNewId = vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce(id);
+
+      const createRecord = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
+        new Airtable.Record(AIRTABLE_NAME, airtableId, {
+          fields: {
+            'id persistant': id,
+            'Sous-domaine': index,
+            Domaine: [areaAirtableId],
+            'Domaine (id persistant)': [areaId],
+            Origine2: [frameworkName],
+          },
+        }),
+      );
+
+      databaseBuilder.factory.buildFramework({
+        id: frameworkId,
+        name: frameworkName,
+      });
+      databaseBuilder.factory.buildArea({
+        id: areaId,
+        code: '1',
+        frameworkId,
+      });
+      await databaseBuilder.commit();
+
+      const competence = new Competence({
+        index,
+        name_i18n: {
+          fr: nameFr,
+          en: nameEn,
+        },
+        description_i18n: {
+          fr: descriptionFr,
+          en: descriptionEn,
+        },
+        areaAirtableId,
+      });
+
+      // when
+      const createdCompetence = await competenceRepository.create(competence);
+
+      // then
+      expect(createdCompetence).toStrictEqual(new Competence({
+        airtableId,
+        id,
+        index,
+        name_i18n: {
+          fr: nameFr,
+          en: nameEn,
+        },
+        description_i18n: {
+          fr: descriptionFr,
+          en: descriptionEn,
+        },
+        areaId,
+        areaAirtableId,
+        origin: frameworkName,
+        skillIds: [],
+        thematicAirtableIds: [],
+        thematicIds: [],
+        tubeAirtableIds: [],
+      }));
+
+      expect(generateNewId).toHaveBeenCalledExactlyOnceWith('competence');
+      expect(createRecord).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, {
+        fields: {
+          'id persistant': id,
+          'Sous-domaine': index,
+          Domaine: [areaAirtableId],
+        },
+      });
+
+      await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([
+        {
+          id,
+          index,
+          areaId,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
     });
   });
 });

--- a/api/tests/integration/scripts/migration-from-airtable/copy-competences-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-competences-from-airtable-to-pg_test.js
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { CopyCompetencesFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-competences-from-airtable-to-pg.js';
+import { logger } from '../../../../lib/infrastructure/logger.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+const TABLE_NAME = 'competences';
+const AIRTABLE_NAME = 'Competences';
+
+describe('Integration | Scripts | CopyCompetencesFromAirtableToPg', () => {
+  /** @type {CopyCompetencesFromAirtableToPg} */
+  let script;
+
+  beforeEach(() => {
+    script = new CopyCompetencesFromAirtableToPg();
+  });
+
+  describe('#handle', () => {
+    afterEach(async () => {
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('reads competences from airtable and saves these to postgres', async () => {
+      // given
+      const options = { dryRun: false };
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+          fields: {
+            'id persistant': 'competence123',
+            'Sous-domaine': '1',
+            'Domaine (id persistant)': ['area456'],
+          },
+          createdTime: '2025-09-23T00:00:00Z',
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+          fields: {
+            'id persistant': 'competence456',
+            'Sous-domaine': '2',
+            'Domaine (id persistant)': ['area456'],
+          },
+          createdTime: '2025-09-23T13:58:00Z',
+        }),
+      ]);
+
+      databaseBuilder.factory.buildFramework({
+        id: 'recFmk123',
+        name: 'Un référentiel',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area123',
+        code: '1',
+        frameworkId: 'recFmk123',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area456',
+        code: '2',
+        frameworkId: 'recFmk123',
+      });
+      databaseBuilder.factory.buildCompetence({
+        id: 'competence123',
+        index: '3',
+        areaId: 'area123',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Sous-domaine', 'Domaine (id persistant)'] });
+
+      await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+        {
+          id: 'competence123',
+          index: '1',
+          areaId: 'area456',
+          createdAt: new Date('2025-09-23T00:00:00Z'),
+          updatedAt: expect.any(Date),
+        },
+        {
+          id: 'competence456',
+          index: '2',
+          areaId: 'area456',
+          createdAt: new Date('2025-09-23T13:58:00Z'),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+    });
+
+    describe('when dryRun is true', () => {
+      it('reads areas from airtable and stops', async () => {
+        // given
+        const options = { dryRun: true };
+
+        const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+          new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+            fields: {
+              'id persistant': 'competence123',
+              'Sous-domaine': '1',
+              'Domaine (id persistant)': ['area456'],
+            },
+            createdTime: '2025-09-23T00:00:00Z',
+          }),
+          new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+            fields: {
+              'id persistant': 'competence456',
+              'Sous-domaine': '2',
+              'Domaine (id persistant)': ['area456'],
+            },
+            createdTime: '2025-09-23T13:58:00Z',
+          }),
+        ]);
+
+        databaseBuilder.factory.buildFramework({
+          id: 'recFmk123',
+          name: 'Un référentiel',
+        });
+        databaseBuilder.factory.buildArea({
+          id: 'area123',
+          code: '1',
+          frameworkId: 'recFmk123',
+        });
+        databaseBuilder.factory.buildArea({
+          id: 'area456',
+          code: '2',
+          frameworkId: 'recFmk123',
+        });
+        databaseBuilder.factory.buildCompetence({
+          id: 'competence123',
+          index: '3',
+          areaId: 'area123',
+          createdAt: '2025-09-23T00:00:00Z',
+          updatedAt: '2025-09-23T10:00:00Z',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Sous-domaine', 'Domaine (id persistant)'] });
+
+        await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+          {
+            id: 'competence123',
+            index: '3',
+            areaId: 'area123',
+            createdAt: new Date('2025-09-23T00:00:00Z'),
+            updatedAt: new Date('2025-09-23T10:00:00Z'),
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-competence.js
+++ b/api/tests/tooling/database-builder/factory/build-competence.js
@@ -1,0 +1,9 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildCompetence({ id, index, areaId, createdAt, updatedAt } = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'competences',
+    autoId: false,
+    values: { id, index, areaId, createdAt, updatedAt },
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -1,4 +1,5 @@
 export * from './build-area.js';
+export * from './build-competence.js';
 export * from './build-framework.js';
 export * from './build-localized-challenge.js';
 export * from './build-localized-challenge-attachment.js';


### PR DESCRIPTION
## 🔆 Problème

On souhaite sortir d’Airtable.

## ⛱️ Proposition

 - Création de la table competences dans postgres
 - Écriture des compétences en double dans Airtable et postgres
 - Création d’un script de migration des compétences existantes (réexécutable)
 - Écriture des compétences dans postgres dans les seeds

## 🌊 Remarques

N/A

## 🏄 Pour tester

Le script de migration a été exécuté sur la RA.

Vérifier que les compétences sont bien dans Postgres avec les bonnes données.

Créer une compétence et vérifier qu’elle est bien dans Postgres.