### PR TITLE
[TECH] Migrer le composant CopyLink vers le format gjs

### DIFF
--- a/pix-editor/app/components/buttons/copy-link.gjs
+++ b/pix-editor/app/components/buttons/copy-link.gjs
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import CopyButton from "ember-cli-clipboard/components/copy-button";
 
 export default class CopyLink extends Component {
   @service notify;
@@ -14,4 +15,16 @@ export default class CopyLink extends Component {
   linkCopyError() {
     this.notify.error('Erreur lors de la copie');
   }
+
+  <template>
+    <CopyButton
+      class="ui button item"
+      @text={{@link}}
+      @onSuccess={{this.linkCopySuccess}}
+      @onError={{this.linkCopyError}}
+    >
+      <i class="linkify icon"></i>
+      Copier le lien
+    </CopyButton>
+  </template>
 }

--- a/pix-editor/app/components/buttons/copy-link.hbs
+++ b/pix-editor/app/components/buttons/copy-link.hbs
@@ -1,9 +1,0 @@
-<CopyButton
-  class="ui button item"
-  @text={{@link}}
-  @onSuccess={{this.linkCopySuccess}}
-  @onError={{this.linkCopyError}}
->
-  <i class="linkify icon"></i>
-  Copier le lien
-</CopyButton>


### PR DESCRIPTION
## 🔆 Problème

Bonjour!
Le composant CopyLink utilise le format hbs plus js.

## ⛱️ Proposition

Passer ce composant au format .gjs afin de n'avoir qu'un seul fichier.

## 🌊 Remarques

Cette petite PR fu très agréable.

## 🏄 Pour tester

- Se rendre sur une page utilisant le bouton,
- Vérifier qu'il fonctionne.
