### PR TITLE
[FEATURE] Double lecture des domaines (PIX-19656)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/framework-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/framework-datasource.js
@@ -18,8 +18,8 @@ export const frameworkDatasource = datasource.extend({
     return {
       id: airtableRecord.id,
       name: airtableRecord.get('Nom'),
-      areaAirtableIds: airtableRecord.get('Domaines (identifiants)'),
-      areaIds: airtableRecord.get('Domaines (identifiants) (id persistant)'),
+      areaAirtableIds: airtableRecord.get('Domaines (identifiants)') ?? [],
+      areaIds: airtableRecord.get('Domaines (identifiants) (id persistant)') ?? [],
     };
   },
 

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -6,6 +6,7 @@ import * as areaTranslations from '../translations/area.js';
 import { Area } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { areArrayEquals, compareDtos, compareDtosLists } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'areas';
 const model = 'area';
@@ -34,26 +35,54 @@ export async function create(area) {
 }
 
 export async function list() {
-  const [datasourceAreas, translations] = await Promise.all([
+  const [airtableDtos, pgDtos, translations] = await Promise.all([
     areaDatasource.list(),
+    selectAreas().orderBy('code'),
     translationRepository.listByModel(model),
   ]);
-  return toDomainList(datasourceAreas, translations);
+
+  compareDtosLists(airtableDtos, pgDtos, compareAreaDtos);
+
+  return toDomainList(airtableDtos, translations);
 }
 
 export async function listByFrameworkId(frameworkId) {
-  const [datasourceAreas, translations] = await Promise.all([
+  const [airtableDtos, pgDtos, translations] = await Promise.all([
     areaDatasource.listByFrameworkId(frameworkId),
+    selectAreas().where('frameworkId', frameworkId).orderBy('code'),
     translationRepository.listByModel(model),
   ]);
-  return toDomainList(datasourceAreas, translations);
+
+  compareDtosLists(airtableDtos, pgDtos, compareAreaDtos);
+
+  return toDomainList(airtableDtos, translations);
 }
 
 export async function getByAirtableId(areaAirtableId) {
-  const areaDTO = await areaDatasource.find(areaAirtableId);
-  if (!areaDTO) return null;
-  const translations = await translationRepository.listByEntity(model, areaDTO.id);
-  return toDomain(areaDTO, translations);
+  const airtableDto = await areaDatasource.find(areaAirtableId);
+  if (!airtableDto) return null;
+
+  const [pgDto, translations] = await Promise.all([
+    selectAreas().where('id', airtableDto.id).first(),
+    translationRepository.listByEntity(model, airtableDto.id),
+  ]);
+
+  compareDtos(airtableDto, pgDto, compareAreaDtos);
+
+  return toDomain(airtableDto, translations);
+}
+
+function selectAreas(knexConn = knex) {
+  return knexConn.select(
+    '*',
+    knexConn.raw(
+      'coalesce((??), \'[]\') as "competenceIds"',
+      knexConn
+        .select(knexConn.raw('json_agg(??)', knexConn.ref('competences.id')))
+        .from('competences')
+        .where('competences.areaId', '=', knexConn.ref(`${TABLE_NAME}.id`)),
+    ),
+  ).from(TABLE_NAME);
 }
 
 function toDomainList(datasourceAreas, translations) {
@@ -68,4 +97,14 @@ export function toDomain(datasourceArea, translations = []) {
     ...datasourceArea,
     ...areaTranslations.toDomain(translations, datasourceArea),
   });
+}
+
+function compareAreaDtos(airtableDto, pgDto) {
+  const diff = [];
+  if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.code !== pgDto.code) diff.push(`airtable code "${airtableDto.code}" != postgres code "${pgDto.code}"`);
+  if (airtableDto.color !== pgDto.color) diff.push(`airtable color "${airtableDto.color}" != postgres color "${pgDto.color}"`);
+  if (airtableDto.frameworkId !== pgDto.frameworkId) diff.push(`airtable frameworkId "${airtableDto.frameworkId}" != postgres frameworkId "${pgDto.frameworkId}"`);
+  if (!areArrayEquals(airtableDto.competenceIds, pgDto.competenceIds)) diff.push(`airtable competenceIds "${airtableDto.competenceIds}" != postgres competenceIds "${pgDto.competenceIds}"`);
+  return diff;
 }

--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -10,11 +10,13 @@ export async function list() {
     frameworkDatasource.list(),
     knex.select(
       '*',
-      knex
-        .select(knex.raw('json_agg(??)', knex.ref('areas.id')))
-        .from('areas')
-        .where('areas.frameworkId', '=', knex.ref('frameworks.id'))
-        .as('areaIds'),
+      knex.raw(
+        'coalesce((??), \'[]\') as "areaIds"',
+        knex
+          .select(knex.raw('json_agg(??)', knex.ref('areas.id')))
+          .from('areas')
+          .where('areas.frameworkId', '=', knex.ref(`${TABLE_NAME}.id`)),
+      ),
     ).from(TABLE_NAME).orderBy('createdAt'),
   ]);
 

--- a/api/lib/infrastructure/repositories/migration-from-airtable.js
+++ b/api/lib/infrastructure/repositories/migration-from-airtable.js
@@ -23,7 +23,9 @@ export function compareDtosLists(airtableDtos, pgDtos, compareFunc) {
     }
     return;
   }
-  airtableDtos.forEach((airtableDto, i) => compareDtos(airtableDto, pgDtos[i], compareFunc));
+  const sortedAirtableDtos = airtableDtos.toSorted(byId);
+  const sortedPgDtos = pgDtos.toSorted(byId);
+  sortedAirtableDtos.forEach((airtableDto, i) => compareDtos(airtableDto, sortedPgDtos[i], compareFunc));
 }
 
 export function compareDtos(airtableDto, pgDto, compareFunc) {
@@ -43,4 +45,8 @@ export function areArrayEquals(array1, array2) {
   if (array1.length !== array2.length) return false;
   const sortedArray2 = array2.toSorted();
   return array1.toSorted().every((value, i) => value === sortedArray2[i]);
+}
+
+function byId(dto1, dto2) {
+  return dto1.id < dto2.id ? -1 : +1;
 }

--- a/api/tests/acceptance/application/areas_test.js
+++ b/api/tests/acceptance/application/areas_test.js
@@ -79,6 +79,22 @@ describe('Acceptance | Route | areas', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records: airtableAreas });
 
+      databaseBuilder.factory.buildFramework({ id: 'framework1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence2', index: '1.2', areaId: 'area1' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'framework1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence3', index: '2.1', areaId: 'area2' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence4', index: '2.2', areaId: 'area2' });
+      databaseBuilder.factory.buildArea({ id: 'area3', code: '3', frameworkId: 'framework1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence5', index: '3.1', areaId: 'area3' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence6', index: '3.2', areaId: 'area3' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence7', index: '3.3', areaId: 'area3' });
+      databaseBuilder.factory.buildFramework({ id: 'framework2', name: 'Fmk 2' });
+      databaseBuilder.factory.buildArea({ id: 'area4', code: '1', frameworkId: 'framework2' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence8', index: '1.1', areaId: 'area4' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence9', index: '1.2', areaId: 'area4' });
+
       databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'Premier domaine' });
       databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'en', value: 'First domain' });
       databaseBuilder.factory.buildTranslation({ key: 'area.area2.title', locale: 'fr', value: 'Deuxième domaine' });
@@ -301,30 +317,51 @@ describe('Acceptance | Route | areas', () => {
         id: 'framework1',
         name: 'Ref 1',
       });
+      databaseBuilder.factory.buildArea({
+        id: 'area1',
+        code: '1',
+        frameworkId: 'framework1',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area2',
+        code: '2',
+        frameworkId: 'framework1',
+      });
       databaseBuilder.factory.buildFramework({
         id: 'framework2',
         name: 'Ref 2',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area4',
+        code: '1',
+        frameworkId: 'framework2',
       });
       await databaseBuilder.commit();
 
       const airtableAreas = [
         airtableBuilder.factory.buildArea(domainBuilder.buildAreaDatasourceObject({
           id: 'area1',
-          airtableId: 'recArea2',
+          airtableId: 'recArea1',
           code: '1',
+          color: null,
           frameworkId: 'framework1',
+          competenceIds: null,
         })),
         airtableBuilder.factory.buildArea(domainBuilder.buildAreaDatasourceObject({
           id: 'area4',
           airtableId: 'recArea4',
           code: '1',
+          color: null,
           frameworkId: 'framework2',
+          competenceIds: null,
         })),
         airtableBuilder.factory.buildArea(domainBuilder.buildAreaDatasourceObject({
           id: 'area2',
           airtableId: 'recArea2',
           code: '2',
+          color: null,
           frameworkId: 'framework1',
+          competenceIds: null,
         })),
       ];
 

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -422,6 +422,10 @@ describe('Acceptance | Route | competences', () => {
         id: 'area2',
         airtableId: 'recArea2',
         code: '2',
+        color: null,
+        competenceIds: ['competence3'],
+        competenceAirtableIds: ['recCompetence3'],
+        frameworkId: 'recFmk1',
       }));
 
       airtableAreaScope = nock('https://api.airtable.com')
@@ -432,6 +436,7 @@ describe('Acceptance | Route | competences', () => {
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk' });
       databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence3', index: '2.1', areaId: 'area2' });
 
       const airtableCompetences = [
         airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
@@ -740,7 +745,8 @@ describe('Acceptance | Route | competences', () => {
       expect(generateNewId).toHaveBeenCalledWith('tube');
       expect(generateNewId).toHaveBeenCalledWith('skill');
 
-      await expect(knex.select('*').from('competences')).resolves.toStrictEqual([
+      await expect(knex.select('*').from('competences').orderBy('index')).resolves.toStrictEqual([
+        { id: 'competence3', index: '2.1', areaId: 'area2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
         { id: 'competence4', index: '2.2', areaId: 'area2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
       ]);
 

--- a/api/tests/acceptance/application/frameworks_test.js
+++ b/api/tests/acceptance/application/frameworks_test.js
@@ -148,7 +148,7 @@ describe('Acceptance | Route | frameworks', () => {
             },
             relationships: {
               areas: {
-                data: null,
+                data: [],
               },
             },
           },
@@ -263,7 +263,7 @@ describe('Acceptance | Route | frameworks', () => {
           },
           relationships: {
             areas: {
-              data: null,
+              data: [],
             },
           },
         },

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -46,7 +46,7 @@ async function mockCurrentContent() {
         en: 'Nom de la Compétence - en',
         nl: 'Nom de la Compétence - nl',
       },
-      areaId: '1',
+      areaId: 'recArea0',
       origin: 'Pix',
       skillIds: ['recSkill0'],
       thematicIds: ['recThematic0'],
@@ -263,6 +263,7 @@ async function mockCurrentContent() {
 
   databaseBuilder.factory.buildFramework(expectedCurrentContent.frameworks[0]);
   databaseBuilder.factory.buildArea(expectedCurrentContent.areas[0]);
+  databaseBuilder.factory.buildCompetence(expectedCurrentContent.competences[0]);
 
   databaseBuilder.factory.buildStaticCourse({
     id: 'recCourse0',
@@ -434,7 +435,7 @@ async function mockContentForRelease() {
     competences: [{
       id: 'recCompetence0',
       index: '1.1',
-      areaId: '1',
+      areaId: 'recArea0',
       origin: 'Pix',
       skillIds: ['recSkill0'],
       thematicIds: ['recThematic0'],
@@ -676,6 +677,7 @@ async function mockContentForRelease() {
 
   databaseBuilder.factory.buildFramework(expectedCurrentContent.frameworks[0]);
   databaseBuilder.factory.buildArea(expectedCurrentContent.areas[0]);
+  databaseBuilder.factory.buildCompetence(expectedCurrentContent.competences[0]);
 
   databaseBuilder.factory.buildStaticCourse({
     id: 'recCourse0',

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -73,7 +73,7 @@ async function mockCurrentContent() {
   const expectedFramework = new FrameworkForReplication(domainBuilder.buildFramework());
   expectedCurrentContent.frameworks = [{ ...expectedFramework }];
 
-  const area = domainBuilder.buildArea({ frameworkId: expectedFramework.id });
+  const area = domainBuilder.buildArea({ frameworkId: expectedFramework.id, competenceIds: ['recCompetence1'] });
   const expectedArea = new AreaForReplication({ name: area.name, ...area });
   expectedCurrentContent.areas = [{ ...expectedArea }];
 
@@ -85,7 +85,7 @@ async function mockCurrentContent() {
     description_i18n: {
       fr: 'Description française',
       en: 'Description anglaise',
-    }
+    },
   }));
   expectedCurrentContent.competences = [expectedCompetence];
 
@@ -257,6 +257,7 @@ async function mockCurrentContent() {
 
   databaseBuilder.factory.buildFramework(expectedCurrentContent.frameworks[0]);
   databaseBuilder.factory.buildArea(expectedCurrentContent.areas[0]);
+  databaseBuilder.factory.buildCompetence(expectedCurrentContent.competences[0]);
 
   airtableBuilder.mockLists({
     frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -115,6 +115,14 @@ describe('Integration | Infrastructure | Repository | area-repository', () => {
         }),
       ]).activate().nockScope;
 
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId1', name: 'Fmk' });
+      databaseBuilder.factory.buildArea({ id: 'areaId1', code: '1', color: Area.COLORS.BUTTERFLY_BUSH, frameworkId: 'frameworkId1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competenceId11', index: '1.1', areaId: 'areaId1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competenceId12', index: '1.2', areaId: 'areaId1' });
+      databaseBuilder.factory.buildArea({ id: 'areaId2', code: '2', color: Area.COLORS.WILD_STRAWBERRY, frameworkId: 'frameworkId1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competenceId21', index: '2.1', areaId: 'areaId2' });
+      databaseBuilder.factory.buildCompetence({ id: 'competenceId22', index: '2.2', areaId: 'areaId2' });
+
       databaseBuilder.factory.buildTranslation({
         key: 'area.areaId1.title',
         locale: 'fr',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -446,6 +446,7 @@ function _mockRichAirtableContent() {
     thematicIds: ['thematic111', 'thematic112'],
     origin: 'FrameworkA',
   };
+  databaseBuilder.factory.buildCompetence(competence11);
   const airtableCompetence11 = airtableBuilder.factory.buildCompetence(competence11);
   const competence12 = {
     id: 'competence12',
@@ -455,6 +456,7 @@ function _mockRichAirtableContent() {
     thematicIds: ['thematic121'],
     origin: 'FrameworkA',
   };
+  databaseBuilder.factory.buildCompetence(competence12);
   const airtableCompetence12 = airtableBuilder.factory.buildCompetence(competence12);
   const competence21 = {
     id: 'competence21',
@@ -464,6 +466,7 @@ function _mockRichAirtableContent() {
     thematicIds: ['thematic211'],
     origin: 'FrameworkA',
   };
+  databaseBuilder.factory.buildCompetence(competence21);
   const airtableCompetence21 = airtableBuilder.factory.buildCompetence(competence21);
   const thematic111 = {
     id: 'thematic111',


### PR DESCRIPTION
## 🔆 Problème

On souhaite sortir d’Airtable.

## ⛱️ Proposition

Lire les domaines dans Airtable et dans Postgres et comparer les données :
 - en prod, faire un log niveau warning si une différence est détectée
 - em test, lever une erreur si une différence est détectée

## 🌊 Remarques

N/A

## 🏄 Pour tester

Ouvrir la RA, vérifier qu’il n’y a pas de logs de warning concernant des différences de données entre Airtable et Postgres.