### PR TITLE
[FEATURE] Écriture des thématiques dans Postgres (PIX-19727)

### DIFF
--- a/api/db/migrations/20250926135220_create-thematics-table.js
+++ b/api/db/migrations/20250926135220_create-thematics-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'thematics';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.string('id').notNullable().primary();
+    table.integer('index').nullable();
+    table.string('competenceId').notNullable().references('competences.id');
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/thematics.js
+++ b/api/db/seeds/data/thematics.js
@@ -36,8 +36,10 @@ export function buildThematic({ indexThematic, competenceItem, databaseBuilder, 
     id: thematicId,
     index: isWorkbench ? 0 : indexThematic,
     competenceAirtableId: competenceItem.airtableId,
+    competenceId: competenceItem.id,
     name: thematicName,
   };
+  databaseBuilder.factory.buildThematic(thematicItem);
   locales.forEach((locale) => {
     databaseBuilder.factory.buildTranslation(
       {
@@ -66,4 +68,20 @@ function toAirtableObject(item) {
       Competence: [item.competenceAirtableId],
     }
   };
+}
+
+export async function copyThematicsFromAirtable({ airtableClient, databaseBuilder, logger }) {
+  const airtableThematics = await  airtableClient.table('Thematiques').select({ fields: ['id persistant', 'Index', 'Competence (id persistant)'] }).all();
+
+  logger.info(`Copying ${airtableThematics.length} thematics from airtable...`);
+
+  airtableThematics.forEach((record) => {
+    databaseBuilder.factory.buildThematic({
+      id: record.get('id persistant'),
+      index: record.get('Index'),
+      competenceId: record.get('Competence (id persistant)')[0],
+      createdAt: record._rawJson.createdTime,
+      updatedAt: new Date(),
+    });
+  });
 }

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -9,7 +9,7 @@ import { buildCompetencesFromConfig, copyCompetencesFromAirtable } from './data/
 import { buildFrameworksFromConfig, copyFrameworksFromAirtable } from './data/frameworks.js';
 import { buildPix1D } from './data/pix-1d.js';
 import { buildSkillsFromConfig } from './data/skills.js';
-import { buildThematicsFromConfig } from './data/thematics.js';
+import { buildThematicsFromConfig, copyThematicsFromAirtable } from './data/thematics.js';
 import { buildTubesFromConfig } from './data/tubes.js';
 import { staticCoursesBuilder } from './data/static-courses.js';
 import { whitelistedUrlsBuilder } from './data/whitelisted-urls.js';
@@ -71,6 +71,7 @@ export async function seed(knex) {
     await copyFrameworksFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyAreasFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyCompetencesFromAirtable({ airtableClient, databaseBuilder, logger });
+    await copyThematicsFromAirtable({ airtableClient, databaseBuilder, logger });
 
     const translations = await translationsBuilder(databaseBuilder);
     await localizedChallengesBuilder(databaseBuilder, translations);

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -7,6 +7,7 @@ import * as idGenerator from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 const model = 'thematic';
+const TABLE_NAME = 'thematics';
 
 export async function list() {
   const [datasourceThematics, translations] = await Promise.all([
@@ -54,17 +55,31 @@ export async function listByCompetenceAirtableId(competenceAirtableId) {
 }
 
 export async function create(thematic) {
-  thematic.id = idGenerator.generateNewId('thematic');
-  const createdThematicDTO = await thematicDatasource.create(thematic);
-  const translations = thematicTranslations.extractFromDomainObject(thematic);
-  await translationRepository.save({ translations });
-  return toDomain(createdThematicDTO, translations);
+  return knex.transaction(async (trx) => {
+    thematic.id = idGenerator.generateNewId('thematic');
+
+    const createdThematicDTO = await thematicDatasource.create(thematic);
+
+    const translations = thematicTranslations.extractFromDomainObject(thematic);
+
+    await Promise.all([
+      trx.insert({
+        id: thematic.id,
+        index: thematic.index,
+        competenceId: createdThematicDTO.competenceId,
+      }).into(TABLE_NAME),
+      translationRepository.save({ translations, transaction: trx })
+    ]);
+
+    return toDomain(createdThematicDTO, translations);
+  });
 }
 
 export async function update(thematic) {
   return knex.transaction(async (transaction) => {
     const updatedThematicDto = await thematicDatasource.update(thematic);
     const translations = thematicTranslations.extractFromDomainObject(thematic);
+    await transaction(TABLE_NAME).update({ index: thematic.index, updatedAt: transaction.fn.now() }).where('id', thematic.id);
     await translationRepository.deleteByKeyPrefixAndLocales({
       prefix: `${thematicTranslations.prefix}${thematic.id}.`,
       locales: ['fr', 'en'],

--- a/api/scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg.js
@@ -1,0 +1,46 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { ScriptRunner } from '../../lib/application/scripts/script-runner.js';
+import { Script } from '../../lib/application/scripts/script.js';
+import * as airtable from '../../lib/infrastructure/airtable.js';
+
+export class CopyThematicsFromAirtableToPg extends Script {
+
+  constructor() {
+    super({
+      description: 'Copie des thématiques de Airtable vers Postgres',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist insert/updates made during the script.',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const airtableThematics = await airtable.findRecords('Thematiques', {
+      fields: ['id persistant', 'Index', 'Competence (id persistant)'],
+    });
+    logger.info({ count: airtableThematics.length }, 'Loaded thematics from airtable');
+
+    const thematics = airtableThematics.map((record) => ({
+      id: record.get('id persistant'),
+      index: record.get('Index'),
+      competenceId: record.get('Competence (id persistant)')[0],
+      createdAt: record._rawJson.createdTime,
+      updatedAt: knex.fn.now(),
+    }));
+
+    if (options.dryRun) return;
+
+    await knex.insert(thematics).into('thematics').onConflict('id').merge();
+    logger.info({ count: thematics.length }, 'Inserted thematics into postgres');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CopyThematicsFromAirtableToPg);

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -606,8 +606,9 @@ describe('Acceptance | Route | competences', () => {
     });
 
     afterEach(async () => {
-      await knex('competences').truncate();
-      await knex('translations').truncate();
+      await knex('thematics').delete();
+      await knex('competences').delete();
+      await knex('translations').delete();
     });
 
     describe('when payload is NOT valid', () => {
@@ -748,6 +749,10 @@ describe('Acceptance | Route | competences', () => {
       await expect(knex.select('*').from('competences').orderBy('index')).resolves.toStrictEqual([
         { id: 'competence3', index: '2.1', areaId: 'area2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
         { id: 'competence4', index: '2.2', areaId: 'area2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
+
+      await expect(knex.select('*').from('thematics')).resolves.toStrictEqual([
+        { id: 'thematic1', index: 0, competenceId: 'competence4', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
       ]);
 
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([

--- a/api/tests/acceptance/application/thematics_test.js
+++ b/api/tests/acceptance/application/thematics_test.js
@@ -447,6 +447,13 @@ describe('Application | Route | Thematics', () => {
     context('success', function() {
 
       beforeEach(async () => {
+        databaseBuilder.factory.buildFramework({ id:'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id:'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id:'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id:'thematic1', index: 0, competenceId: 'competence1' });
+        databaseBuilder.factory.buildThematic({ id:'thematic2', index: 1, competenceId: 'competence1' });
+        await databaseBuilder.commit();
+
         const airtableThematics = [
           airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({
             id: 'thematic1',
@@ -501,7 +508,8 @@ describe('Application | Route | Thematics', () => {
       });
 
       afterEach(async () => {
-        await knex('translations').truncate();
+        await knex('thematics').delete();
+        await knex('translations').delete();
       });
 
       it('should respond with status 201 and created thematic', async () => {
@@ -563,6 +571,12 @@ describe('Application | Route | Thematics', () => {
 
         expect(airtableCreateThematicScope.isDone()).toBe(true);
         expect(airtableThematicsScope.isDone()).toBe(true);
+
+        await expect(knex.select('*').from('thematics').orderBy('index')).resolves.toStrictEqual([
+          { id: 'thematic1', index: 0, competenceId: 'competence1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { id: 'thematic2', index: 1, competenceId: 'competence1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { id: 'thematic3', index: 2, competenceId: 'competence1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        ]);
 
         await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
           { key: 'thematic.thematic3.name', locale: 'en', value: 'Third thematic' },
@@ -729,6 +743,11 @@ describe('Application | Route | Thematics', () => {
 
     context('success', function() {
       beforeEach(async () => {
+        databaseBuilder.factory.buildFramework({ id:'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id:'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id:'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', index: 1, competenceId: 'competence1', createdAt: '2025-09-29T13:20:25Z' });
+
         const airtableThematic = airtableBuilder.factory.buildThematic(domainBuilder.buildThematicDatasourceObject({
           id: 'thematic1',
           airtableId: 'recThematic1',
@@ -854,6 +873,10 @@ describe('Application | Route | Thematics', () => {
 
         expect(airtableUpdateThematicScope.isDone()).toBe(true);
         expect(airtableThematicScope.isDone()).toBe(true);
+
+        await expect(knex.select('*').from('thematics')).resolves.toStrictEqual([
+          { id: 'thematic1', index: 2, competenceId: 'competence1', createdAt: new Date('2025-09-29T13:20:25Z'), updatedAt: expect.any(Date) },
+        ]);
 
         await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
           { key: 'thematic.thematic1.name', locale: 'en', value: '1st thematic' },

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -6,6 +6,9 @@ import * as airtable from '../../../../lib/infrastructure/airtable.js';
 import * as idGenerator from '../../../../lib/infrastructure/utils/id-generator.js';
 import { thematicDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 
+const TABLE_NAME = 'thematics';
+const AIRTABLE_NAME = 'Thematiques';
+
 describe('Integration | Repository | thematic-repository', () => {
 
   describe('#list', () => {
@@ -253,36 +256,58 @@ describe('Integration | Repository | thematic-repository', () => {
 
   describe('#create', () => {
     afterEach(() => {
+      return knex('thematics').truncate();
       return knex('translations').truncate();
     });
 
     it('should save new thematic to Airtable and translations to DB', async () => {
       // given
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      await databaseBuilder.commit();
+
       const thematicId = 'thematic45267428';
       vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce(thematicId);
       const thematic = domainBuilder.buildThematic({
         airtableId: null,
         id: null,
+        competenceId: null,
+        tubeAirtableIds: null,
+        tubeIds: null,
       });
       const airtableThematic = airtableBuilder.factory.buildThematic({
         ...thematic,
         airtableId: 'recThematic1',
         id: thematicId,
+        competenceId: 'competence1',
       });
       const createRecordSpy = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
-        new Airtable.Record('Thematiques', airtableThematic.id, airtableThematic),
+        new Airtable.Record(AIRTABLE_NAME, airtableThematic.id, airtableThematic),
       );
 
       // when
       const createdThematic = await thematicRepository.create(thematic);
 
       // then
+      await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([
+        {
+          id: thematicId,
+          index: thematic.index,
+          competenceId: 'competence1',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
       expect(createdThematic).toStrictEqual(domainBuilder.buildThematic({
         ...thematic,
+        competenceId: 'competence1',
         airtableId: 'recThematic1',
+        tubeAirtableIds: [],
+        tubeIds: [],
       }));
       expect(createRecordSpy).toHaveBeenCalledWith(
-        'Thematiques',
+        AIRTABLE_NAME,
         {
           fields: {
             'id persistant': thematicId,
@@ -403,6 +428,12 @@ describe('Integration | Repository | thematic-repository', () => {
   describe('#update', () => {
     it('should save thematic to Airtable and translations to DB', async () => {
       // given
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', index: 1, competenceId: 'competence1', createdAt: '2025-09-26T14:26:10Z' });
+      await databaseBuilder.commit();
+
       const thematicUpdates = {
         airtableId: 'recThematic1',
         id: 'thematic1',
@@ -436,6 +467,16 @@ describe('Integration | Repository | thematic-repository', () => {
       const updatedThematic = await thematicRepository.update(thematic);
 
       // then
+      await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([
+        {
+          id: 'thematic1',
+          index: 2,
+          competenceId: 'competence1',
+          createdAt: new Date('2025-09-26T14:26:10Z'),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
       expect(updatedThematic).toStrictEqual(domainBuilder.buildThematic(expectedThematic));
       expect(updateRecordSpy).toHaveBeenCalledWith(
         'Thematiques',

--- a/api/tests/integration/scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg_test.js
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { CopyThematicsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg.js';
+import { logger } from '../../../../lib/infrastructure/logger.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+
+const TABLE_NAME = 'thematics';
+const AIRTABLE_NAME = 'Thematiques';
+
+describe('Integration | Scripts | CopyThematicsFromAirtableToPg', () => {
+  /** @type {CopyThematicsFromAirtableToPg} */
+  let script;
+
+  beforeEach(() => {
+    script = new CopyThematicsFromAirtableToPg();
+  });
+
+  describe('#handle', () => {
+    afterEach(async () => {
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('reads thematics from airtable and saves these to postgres', async () => {
+      // given
+      const options = { dryRun: false };
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+          fields: {
+            'id persistant': 'thematic123',
+            'Index': 0,
+            'Competence (id persistant)': ['competence123'],
+          },
+          createdTime: '2025-09-29T00:00:00Z',
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+          fields: {
+            'id persistant': 'thematic456',
+            'Index': 1,
+            'Competence (id persistant)': ['competence123'],
+          },
+          createdTime: '2025-09-29T13:58:00Z',
+        }),
+      ]);
+
+      databaseBuilder.factory.buildFramework({
+        id: 'recFmk123',
+        name: 'Un référentiel',
+      });
+      databaseBuilder.factory.buildArea({
+        id: 'area123',
+        code: '1',
+        frameworkId: 'recFmk123',
+      });
+      databaseBuilder.factory.buildCompetence({
+        id: 'competence123',
+        index: '1.1',
+        areaId: 'area123',
+      });
+      databaseBuilder.factory.buildThematic({
+        id: 'thematic123',
+        index: 666,
+        competenceId: 'competence123',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Index', 'Competence (id persistant)'] });
+
+      await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+        {
+          id: 'thematic123',
+          index: 0,
+          competenceId: 'competence123',
+          createdAt: new Date('2025-09-29T00:00:00Z'),
+          updatedAt: expect.any(Date),
+        },
+        {
+          id: 'thematic456',
+          index: 1,
+          competenceId: 'competence123',
+          createdAt: new Date('2025-09-29T13:58:00Z'),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+    });
+
+    describe('when dryRun is true', () => {
+      it('reads thematics from airtable and stops', async () => {
+        // given
+        const options = { dryRun: true };
+
+        const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+          new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+            fields: {
+              'id persistant': 'thematic123',
+              'Index': 0,
+              'Competence (id persistant)': ['competence123'],
+            },
+            createdTime: '2025-09-29T00:00:00Z',
+          }),
+          new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+            fields: {
+              'id persistant': 'thematic456',
+              'Index': 1,
+              'Competence (id persistant)': ['competence123'],
+            },
+            createdTime: '2025-09-29T13:58:00Z',
+          }),
+        ]);
+
+        databaseBuilder.factory.buildFramework({
+          id: 'recFmk123',
+          name: 'Un référentiel',
+        });
+        databaseBuilder.factory.buildArea({
+          id: 'area123',
+          code: '1',
+          frameworkId: 'recFmk123',
+        });
+        databaseBuilder.factory.buildCompetence({
+          id: 'competence123',
+          index: '1.1',
+          areaId: 'area123',
+        });
+        databaseBuilder.factory.buildThematic({
+          id: 'thematic123',
+          index: 666,
+          competenceId: 'competence123',
+          createdAt: '2025-09-29T00:00:00Z',
+          updatedAt: '2025-09-29T10:00:00Z',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Index', 'Competence (id persistant)'] });
+
+        await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([
+          {
+            id: 'thematic123',
+            index: 666,
+            competenceId: 'competence123',
+            createdAt: new Date('2025-09-29T00:00:00Z'),
+            updatedAt: new Date('2025-09-29T10:00:00Z'),
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-thematic.js
+++ b/api/tests/tooling/database-builder/factory/build-thematic.js
@@ -1,0 +1,9 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildThematic({ id, index, competenceId, createdAt, updatedAt } = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'thematics',
+    autoId: false,
+    values: { id, index, competenceId, createdAt, updatedAt },
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -8,6 +8,7 @@ export * from './build-release.js';
 export * from './build-skill.js';
 export * from './build-static-course.js';
 export * from './build-static-course-tag.js';
+export * from './build-thematic.js';
 export * from './build-translation.js';
 export * from './build-user.js';
 export * from './build-whitelisted-url.js';


### PR DESCRIPTION
## 🔆 Problème

On souhaite sortir d’Airtable.

## ⛱️ Proposition

 - Création de la table thematics dans postgres
 - Écriture des thématiques en double dans Airtable et postgres
 - Création d’un script de migration des thématiques existantes (réexécutable)
 - Écriture des thématiques dans postgres dans les seeds

## 🌊 Remarques

N/A

## 🏄 Pour tester

Le script de migration a été exécuté sur la RA.

Vérifier que les thématiques sont bien dans Postgres avec les bonnes données.

Créer une compétence et vérifier que sa thématique workbench est bien dans Postgres.
Créer une thématique et vérifier qu’elle est bien dans Postgres.
Réordonner des thématiques et vérifier que l’index est bien mis à jour dans Postgres.