### PR TITLE
[BUGFIX] Migration Airtable : Comparaison des champs nullables

### DIFF
--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -6,7 +6,7 @@ import * as areaTranslations from '../translations/area.js';
 import { Area } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { areArrayEquals, compareDtos, compareDtosLists } from './migration-from-airtable.js';
+import { areArrayEquals, areNullableValuesEqual, compareDtos, compareDtosLists } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'areas';
 const model = 'area';
@@ -103,7 +103,7 @@ function compareAreaDtos(airtableDto, pgDto) {
   const diff = [];
   if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
   if (airtableDto.code !== pgDto.code) diff.push(`airtable code "${airtableDto.code}" != postgres code "${pgDto.code}"`);
-  if (airtableDto.color !== pgDto.color) diff.push(`airtable color "${airtableDto.color}" != postgres color "${pgDto.color}"`);
+  if (!areNullableValuesEqual(airtableDto.color, pgDto.color)) diff.push(`airtable color "${airtableDto.color}" != postgres color "${pgDto.color}"`);
   if (airtableDto.frameworkId !== pgDto.frameworkId) diff.push(`airtable frameworkId "${airtableDto.frameworkId}" != postgres frameworkId "${pgDto.frameworkId}"`);
   if (!areArrayEquals(airtableDto.competenceIds, pgDto.competenceIds)) diff.push(`airtable competenceIds "${airtableDto.competenceIds}" != postgres competenceIds "${pgDto.competenceIds}"`);
   return diff;

--- a/api/lib/infrastructure/repositories/migration-from-airtable.js
+++ b/api/lib/infrastructure/repositories/migration-from-airtable.js
@@ -47,6 +47,11 @@ export function areArrayEquals(array1, array2) {
   return array1.toSorted().every((value, i) => value === sortedArray2[i]);
 }
 
+export function areNullableValuesEqual(value1, value2) {
+  if (value1 == null && value2 == null) return true;
+  return value1 === value2;
+}
+
 function byId(dto1, dto2) {
   return dto1.id < dto2.id ? -1 : +1;
 }


### PR DESCRIPTION
## 🔆 Problème

Les champs nullables n’ont pas la même valeur dans Airtable et Postgres.

## ⛱️ Proposition

Considérer `null` et `undefined` comme égaux.

## 🌊 Remarques

N/A

## 🏄 Pour tester

N/A