### PR TITLE
[FEATURE] Cacher les champs timer, focus et shuffled pour les déclinaisons (PIX-18221)

### DIFF
--- a/pix-editor/app/components/form/challenge.hbs
+++ b/pix-editor/app/components/form/challenge.hbs
@@ -43,14 +43,14 @@
         data-test-no-validation-needed-checkbox={{@challenge.id}}
       />
     </div>
-  {{/if}}
-  {{#if this.typeIsQCUOrQCM}}
-    <Field::Checkbox
-      @label="Afficher aléatoirement l'ordre des propositions"
-      @checked={{@challenge.shuffled}}
-      @disabled={{not @edition}}
-      data-test-checkbox-shuffle
-    />
+    {{#if this.typeIsQCUOrQCM}}
+      <Field::Checkbox
+        @label="Afficher aléatoirement l'ordre des propositions"
+        @checked={{@challenge.shuffled}}
+        @disabled={{not @edition}}
+        data-test-checkbox-shuffle
+      />
+    {{/if}}
   {{/if}}
   {{#if (and this.typeIsQROCOrQROCMInd (not this.isAutoReply))}}
     <PixSelect
@@ -232,8 +232,6 @@
     >
       <:label>Type pédagogie</:label>
     </PixSelect>
-  {{/if}}
-  {{#if @challenge.isPrototype}}
     <PixSelect
       @options={{this.options.declinable}}
       @onChange={{fn (mut @challenge.declinable)}}
@@ -243,25 +241,23 @@
     >
       <:label>Déclinable</:label>
     </PixSelect>
-  {{/if}}
-  <div class="field {{if @edition '' 'disabled'}}">
-    <Field::Checkbox
-      @label="Timer"
-      @checked={{@challenge.timerOn}}
-      @disabled={{not @edition}}
-    />
-    {{#if @challenge.timer}}
-      <Field::Input @value={{@challenge.timer}} @edition={{@edition}} />
-    {{/if}}
-  </div>
-  <div class="field {{if @edition '' 'disabled'}}">
-    <Field::Checkbox
-      @label="Focus"
-      @checked={{@challenge.focusable}}
-      @disabled={{not @edition}}
-    />
-  </div>
-  {{#if @challenge.isPrototype}}
+    <div class="field {{if @edition '' 'disabled'}}">
+      <Field::Checkbox
+        @label="Timer"
+        @checked={{@challenge.timerOn}}
+        @disabled={{not @edition}}
+      />
+      {{#if @challenge.timer}}
+        <Field::Input @value={{@challenge.timer}} @edition={{@edition}} />
+      {{/if}}
+    </div>
+    <div class="field {{if @edition '' 'disabled'}}">
+      <Field::Checkbox
+        @label="Focus"
+        @checked={{@challenge.focusable}}
+        @disabled={{not @edition}}
+      />
+    </div>
     <Field::Quality @edition={{@edition}} @challenge={{@challenge}} />
   {{/if}}
   <div class="field {{if @edition '' 'disabled'}}">


### PR DESCRIPTION
## 🔆 Problème

Les champs timer et focus doivent avoir la même pour un proto et toutes ses déclis.

## ⛱️ Proposition

Ne pas faire apparaître ces champs lors de la visu/édition d’une décli.

## 🌊 Remarques

N/A

## 🏄 Pour tester

Aller sur une décli et vérifier que les champs sont absents.