### PR TITLE
[FEATURE] Ajout du nom du référentiel dans l'url de traduction (PIX-19899)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -89,7 +89,7 @@ export async function register(server) {
     },
     {
       method: 'GET',
-      path: '/api/challenges/{id}/translations/{locale}/area-code/{areaCode}',
+      path: '/api/challenges/{id}/translations/{locale}/framework-name/{frameworkName}/area-code/{areaCode}',
       config: {
         auth: false,
         validate: {
@@ -97,14 +97,16 @@ export async function register(server) {
             id: challengeIdType,
             locale: Joi.string().min(2),
             areaCode: Joi.number(),
+            frameworkName: Joi.string(),
           }),
         },
         handler: async function(request, h) {
           const challengeId = request.params.id;
           const locale = request.params.locale;
           const areaCode = request.params.areaCode;
+          const frameworkName = request.params.frameworkName;
 
-          const translationsUrl = await getPhraseTranslationsURL({ challengeId, locale, areaCode });
+          const translationsUrl = await getPhraseTranslationsURL({ challengeId, locale, areaCode, frameworkName });
 
           return h.redirect(translationsUrl);
         },

--- a/api/lib/domain/usecases/get-phrase-translations-url.js
+++ b/api/lib/domain/usecases/get-phrase-translations-url.js
@@ -2,7 +2,7 @@ import { AccountsApi, Configuration, LocalesApi } from 'phrase-js';
 import * as config from '../../config.js';
 import { logger } from '../../infrastructure/logger.js';
 
-export async function getPhraseTranslationsURL({ challengeId, locale, areaCode }, phrase = { AccountsApi, Configuration, LocalesApi }) {
+export async function getPhraseTranslationsURL({ challengeId, locale, areaCode, frameworkName }, phrase = { AccountsApi, Configuration, LocalesApi }) {
   try {
     const configuration = new phrase.Configuration({
       apiKey: `token ${config.phrase.apiKey}`,
@@ -12,7 +12,7 @@ export async function getPhraseTranslationsURL({ challengeId, locale, areaCode }
     const accounts = await new phrase.AccountsApi(configuration).accountsList({ page: 1 });
 
     const accountId = accounts.find(({ name }) => name === 'Pix')?.id;
-    const projectId = config.phrase.projects.find((project) => project.areaCode === areaCode).projectId;
+    const projectId = config.phrase.projects.find(byAreaCodeAndFrameworkName(areaCode, frameworkName)).projectId;
 
     const locales = await new phrase.LocalesApi(configuration).localesList({
       projectId,
@@ -31,4 +31,13 @@ export async function getPhraseTranslationsURL({ challengeId, locale, areaCode }
     logger.error(`Phrase error while listing locales: ${text}`);
     throw new Error('Phrase error', { cause: e });
   }
+}
+
+function byAreaCodeAndFrameworkName(areaCode ,frameworkName) {
+  return (project) => {
+    if (project.areaCode) {
+      return project.areaCode === areaCode && project.frameworkName === frameworkName;
+    }
+    return project.frameworkName === frameworkName;
+  };
 }

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1531,13 +1531,14 @@ describe('Acceptance | Controller | challenges-controller', () => {
     });
   });
 
-  describe('GET /challenges/:id/translations/:locale/area-code/:code', () => {
+  describe('GET /challenges/:id/translations/:locale/framework-name/:frameworkName/area-code/:code', () => {
 
     it('should redirect to the phrase project corresponding to area code', async () => {
       // given
       vi.spyOn(config.phrase, 'projects', 'get').mockReturnValue([
-        { areaCode: 1, projectId: 'PHRASE_PROJECT_ID_AREA_1' },
-        { areaCode: 2, projectId: 'PHRASE_PROJECT_ID_AREA_2' },
+        { areaCode: 2, projectId: 'PHRASE_PROJECT_ID_AREA_3', frameworkName: 'Pix+' },
+        { areaCode: 1, projectId: 'PHRASE_PROJECT_ID_AREA_1', frameworkName: 'Pix' },
+        { areaCode: 2, projectId: 'PHRASE_PROJECT_ID_AREA_2', frameworkName: 'Pix' },
       ]);
       const challengeId = 'challenge123';
       const locale = 'nl';
@@ -1595,7 +1596,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       // when
       const response = await server.inject({
         method: 'GET',
-        url: `/api/challenges/${challengeId}/translations/${locale}/area-code/2`,
+        url: `/api/challenges/${challengeId}/translations/${locale}/framework-name/Pix/area-code/2`,
       });
 
       // then

--- a/pix-editor/app/models/challenge-locale.js
+++ b/pix-editor/app/models/challenge-locale.js
@@ -56,7 +56,7 @@ export default class ChallengeLocaleModel extends Model {
   getTranslationsUrl = (competence) => {
     if (this.isPrimaryInLocale) return null;
     if (this.locale === 'fr-fr') return null;
-    return `/api/challenges/${this.challenge.id}/translations/${this.locale}/area-code/${competence.areaCode}`;
+    return `/api/challenges/${this.challenge.id}/translations/${this.locale}/framework-name/${competence.source}/area-code/${competence.areaCode}`;
   };
 
   get isTranslated() {

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -22,6 +22,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
     competence = store.createRecord('competence', {
       id: 'competenceAId',
       code: '1.1',
+      source: 'Pix',
     });
 
     // proto
@@ -284,7 +285,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
         const localizedTranslationLink = screen.getByRole('link', { name: 'traduction de l\'épreuve de version 1' });
         assert.ok(primaryPreview.href.endsWith('api/urlto/challengeProtoValide'));
         assert.ok(localizedPreview.href.endsWith('api/urlto/challengeProtoValide?locale=nl'));
-        assert.ok(localizedTranslationLink.href.endsWith('api/challenges/challengeDecliArchivee/translations/nl/area-code/1'));
+        assert.ok(localizedTranslationLink.href.endsWith('api/challenges/challengeDecliArchivee/translations/nl/framework-name/Pix/area-code/1'));
         assert.dom(screen.getByRole('button', { name: 'Copier le lien de l\'épreuve challengeProtoValideeNl' })).exists();
       });
 


### PR DESCRIPTION
## 🍂 Problème
On a besoin de distinguer les projets Phrase par Référentiel, puisqu'il faudra traduire d'autres référentiels que le cœur.

## 🌰 Proposition
Faire le nécessaire pour ajouter le nom du référentiel dans l'import et l'export des traductions ainsi que dans l'url générée pour rediriger sur Phrase, sur la bonne traduction.

## 🍁 Remarques
RAS

## 🪵 Pour tester
Aller sur une épreuve, sélectionner une langue autre que le français, et aller sur le lien Phrase. Constater que le lien termine par /framework-name/Pix/area-code/x (x étant un nombre correspondant à l'area code)