### PR TITLE
[FEATURE] Enlever le bouton "Airtable" sur les tubes, acquis et épreuves (PIX-19954)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -66,11 +66,6 @@ export const lcms = {
 };
 
 export const pixEditor = {
-  airtableUrl: process.env.AIRTABLE_URL,
-  airtableBase: process.env.AIRTABLE_BASE,
-  tableChallenges: process.env.TABLE_CHALLENGES,
-  tableSkills: process.env.TABLE_SKILLS,
-  tableTubes: process.env.TABLE_TUBES,
   storagePost: process.env.STORAGE_POST,
   storageBucket: process.env.STORAGE_BUCKET,
   localeToLanguageMap: LOCALE_TO_LANGUAGE_MAP,

--- a/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/config-serializer.js
@@ -4,11 +4,6 @@ const { Serializer } = JsonapiSerializer;
 
 const serializer = new Serializer('config', {
   attributes: [
-    'airtableUrl',
-    'airtableBase',
-    'tableChallenges',
-    'tableSkills',
-    'tableTubes',
     'storagePost',
     'storageBucket',
     'localeToLanguageMap',

--- a/api/sample.env
+++ b/api/sample.env
@@ -143,45 +143,6 @@ AIRTABLE_BASE=
 # example: app5JZ0**********
 AIRTABLE_EDITOR_BASE=
 
-# Airtable url used to redirect to airtable entry
-#
-# If not present the application will not be able to link to airtable records.
-#
-# presence: required
-# type: String
-# default: none
-AIRTABLE_URL=https://airtable.com/
-
-# Airtable id of challenges table
-#
-# If not present the application will not be able to link to airtable challenges.
-#
-# presence: required
-# type: String
-# default: none
-# example: tblt90e**********
-TABLE_CHALLENGES=
-
-# Airtable id of skills table
-#
-# If not present the application will not be able to link to airtable skills.
-#
-# presence: required
-# type: String
-# default: none
-# example: tblt90e**********
-TABLE_SKILLS=
-
-# Airtable id of tubes table
-#
-# If not present the application will not be able to open airtable tubes.
-#
-# presence: required
-# type: String
-# default: none
-# example: tblt90e**********
-TABLE_TUBES=
-
 # =======
 # LOGGING
 # =======

--- a/api/tests/acceptance/application/config/config-controller_test.js
+++ b/api/tests/acceptance/application/config/config-controller_test.js
@@ -32,10 +32,6 @@ describe('Acceptance | Controller | config', () => {
       it('should return config', async () => {
         // Given
         vi.spyOn(config, 'pixEditor', 'get').mockReturnValue({
-          'airtableUrl': 'airtableUrlValue',
-          'tableChallenges': 'tableChallengesValue',
-          'tableSkills': 'tableSkillsValue',
-          'tableTubes': 'tableTubesValue',
           'storagePost': 'storagePostValue',
           'storageBucket': 'storageBucketValue',
           'localeToLanguageMap': 'localeToLanguageMap',
@@ -46,10 +42,6 @@ describe('Acceptance | Controller | config', () => {
           data: {
             type: 'configs',
             attributes: {
-              'airtable-url': 'airtableUrlValue',
-              'table-challenges': 'tableChallengesValue',
-              'table-skills': 'tableSkillsValue',
-              'table-tubes': 'tableTubesValue',
               'storage-post': 'storagePostValue',
               'storage-bucket': 'storageBucketValue',
               'locale-to-language-map': 'localeToLanguageMap',
@@ -91,4 +83,3 @@ describe('Acceptance | Controller | config', () => {
   });
 
 });
-

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -45,7 +45,6 @@ describe('Acceptance | Controller | replication-data-controller', () => {
       const response = await server.inject(currentContentOptions);
 
       // then
-      console.log('ICI', response.result);
       const result = JSON.parse(response.result);
       const resultWithoutTranslations = _.omit(result, 'translations');
       const expectedCurrentContentWithoutTranslations = _.omit(expectedCurrentContent, 'translations');

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -91,10 +91,6 @@ export default class SingleController extends Controller {
     return this.access.mayAccessLog(this.challenge);
   }
 
-  get mayAccessAirtable() {
-    return this.access.mayAccessAirtable();
-  }
-
   get mayValidate() {
     return this.access.mayValidate(this.challenge);
   }
@@ -122,10 +118,6 @@ export default class SingleController extends Controller {
     } else {
       return false;
     }
-  }
-
-  get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableChallenges}/${this.challenge.airtableId}`;
   }
 
   get lastUpdatedAtISO() {

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -45,10 +45,6 @@ export default class SingleController extends Controller {
     return this.access.mayEditSkill(this.skill);
   }
 
-  get mayAccessAirtable() {
-    return this.access.mayAccessAirtable();
-  }
-
   get mayDuplicate() {
     return this.access.mayDuplicateSkill(this.skill);
   }
@@ -64,10 +60,6 @@ export default class SingleController extends Controller {
   get previewPrototypeUrl() {
     const prototype = this.skill.productionPrototype;
     return prototype.preview;
-  }
-
-  get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableSkills}/${this.skill.id}`;
   }
 
   get defaultSaveChangelog() {

--- a/pix-editor/app/controllers/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/single.js
@@ -24,14 +24,9 @@ export default class SingleController extends Controller {
   }
 
   @service access;
-  @service config;
   @service loader;
   @service notify;
   @service router;
-
-  get mayAccessAirtable() {
-    return this.access.mayAccessAirtable();
-  }
 
   get mayEdit() {
     return this.access.mayEditSkills();
@@ -46,10 +41,6 @@ export default class SingleController extends Controller {
       return false;
     }
     return this.isEmptyMandatoryField;
-  }
-
-  get airtableUrl() {
-    return `${this.config.airtableUrl}${this.config.airtableBase}/${this.config.tableTubes}/${this.tube.id}`;
   }
 
   @action

--- a/pix-editor/app/models/config.js
+++ b/pix-editor/app/models/config.js
@@ -1,11 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class ConfigModel extends Model {
-  @attr airtableUrl;
-  @attr airtableBase;
-  @attr tableChallenges;
-  @attr tableSkills;
-  @attr tableTubes;
   @attr storagePost;
   @attr storageBucket;
   @attr localeToLanguageMap;

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -108,10 +108,6 @@ export default class AccessService extends Service {
     return level >= EDITOR || (!prototype && level === REPLICATOR);
   }
 
-  mayAccessAirtable() {
-    return this.isAdmin();
-  }
-
   mayValidate(challenge) {
     return this.isAdmin() && challenge.isDraft && !challenge.isWorkbench;
   }

--- a/pix-editor/app/services/config.js
+++ b/pix-editor/app/services/config.js
@@ -9,11 +9,6 @@ export default class ConfigService extends Service {
 
   @tracked author;
   @tracked accessLevel;
-  @tracked airtableUrl;
-  @tracked airtableBase;
-  @tracked tableChallenges;
-  @tracked tableSkills;
-  @tracked tableTubes;
   @tracked storagePost;
   @tracked storageBucket;
   @tracked localeToLanguageMap;
@@ -25,11 +20,6 @@ export default class ConfigService extends Service {
 
     this.author = currentUser.trigram;
     this.accessLevel = this.access.getLevel(currentUser.access);
-    this.airtableUrl = config.airtableUrl;
-    this.airtableBase = config.airtableBase;
-    this.tableChallenges = config.tableChallenges;
-    this.tableSkills = config.tableSkills;
-    this.tableTubes = config.tableTubes;
     this.storagePost = config.storagePost;
     this.storageBucket = config.storageBucket;
     this.localeToLanguageMap = config.localeToLanguageMap;

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.hbs
@@ -116,12 +116,6 @@
         Dupliquer
       </button>
     {{/if}}
-    {{#if this.mayAccessAirtable}}
-      <a class="ui button item" href={{this.airtableUrl}} target="_blank" rel="noopener noreferrer">
-        <i class="table icon"></i>
-        Airtable
-      </a>
-    {{/if}}
     {{#if this.mayAccessAlternatives}}
       <button class="ui button item alternatives" {{on "click" this.showAlternatives}} type="button">
         <i class="cubes icon"></i>

--- a/pix-editor/app/templates/authenticated/competence/skills/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/skills/single.hbs
@@ -84,12 +84,6 @@
           Modifier
         </button>
       {{/if}}
-      {{#if this.mayAccessAirtable}}
-        <a class="ui button item" href={{this.airtableUrl}} target="_blank"  rel="noopener noreferrer">
-          <i class="table icon"></i>
-          Airtable
-        </a>
-      {{/if}}
       {{#unless this.skill.isLive}}
         <button class="ui button item" {{on "click" this.displayChallenges}} type="button">
           <i class="archive icon"></i>
@@ -123,4 +117,3 @@
   @showModal={{this.displayConfirmLog}}
 />
 {{outlet}}
-

--- a/pix-editor/app/templates/authenticated/competence/tubes/single.hbs
+++ b/pix-editor/app/templates/authenticated/competence/tubes/single.hbs
@@ -43,12 +43,6 @@
           Modifier
         </button>
       {{/if}}
-      {{#if this.mayAccessAirtable}}
-        <a class="ui button item" href={{this.airtableUrl}} target="_blank" rel="noopener noreferrer">
-          <i class="table icon"></i>
-          Airtable
-        </a>
-      {{/if}}
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
## 🍂 Problème

On veut sortir d’Airtable.

## 🌰 Proposition

Enlever les boutons permettant de naviguer depuis PixEditor vers Airtable sur les tubes, acquis et épreuves.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Vérifier que le bouton est bien absent sur les différentes entités et qu’il n’y a pas de régressions.