### PR TITLE
[TECH] Écriture des tutoriels dans Postgres (PIX-19960)

### DIFF
--- a/api/db/migrations/20251009145131_create-tutorials-table.js
+++ b/api/db/migrations/20251009145131_create-tutorials-table.js
@@ -1,0 +1,40 @@
+const TABLE_NAME = 'tutorials';
+const RELATIONSHIPS_TABLE_NAME = 'tutorials-tutorial_tags';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.string('id').primary().notNullable();
+    table.string('title').notNullable();
+    table.string('duration').notNullable();
+    table.string('source').notNullable();
+    table.string('format').notNullable();
+    table.string('link').notNullable();
+    table.string('license').nullable();
+    table.string('level').nullable();
+    table.boolean('crush').notNullable().defaultTo(false);
+    table.string('locale').notNullable();
+
+    table.timestamps(true, true, true);
+  });
+
+  await knex.schema.createTable(RELATIONSHIPS_TABLE_NAME, function(table) {
+    table.string('tutorialId').notNullable().references('tutorials.id');
+    table.string('tutorialTagId').notNullable().references('tutorial_tags.id');
+    table.primary(['tutorialId', 'tutorialTagId']);
+
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(RELATIONSHIPS_TABLE_NAME);
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/tutorials.js
+++ b/api/db/seeds/data/tutorials.js
@@ -10,24 +10,24 @@ const iterFor = {
 };
 let iterTags;
 let iterLocales;
-export async function buildTutorials({ airtableClient, logger, locales, tagItems }) {
+export async function buildTutorials({ airtableClient, databaseBuilder, logger, locales, tagItems }) {
   iterTags = cycle(tagItems);
   iterLocales = cycle(locales);
   const tutorialItems = [];
   let i = 0;
-  tutorialItems.push(buildTutorial({ title: 'Faire ses courses', index: i++, tagItems: [] }));
-  tutorialItems.push(buildTutorial({ title: 'Se laver les dents', index: i++, tagItems: [iterTags.next().value] }));
-  tutorialItems.push(buildTutorial({ title: 'Payer ses impôts', index: i++, tagItems: [iterTags.next().value, iterTags.next().value] }));
-  tutorialItems.push(buildTutorial({ title: 'Faire son lit', index: i++, tagItems: [] }));
-  tutorialItems.push(buildTutorial({ title: 'Saluer ses voisins', index: i++, tagItems: [iterTags.next().value] }));
+  tutorialItems.push(buildTutorial({ databaseBuilder, title: 'Faire ses courses', index: i++, tagItems: [] }));
+  tutorialItems.push(buildTutorial({ databaseBuilder, title: 'Se laver les dents', index: i++, tagItems: [iterTags.next().value] }));
+  tutorialItems.push(buildTutorial({ databaseBuilder, title: 'Payer ses impôts', index: i++, tagItems: [iterTags.next().value, iterTags.next().value] }));
+  tutorialItems.push(buildTutorial({ databaseBuilder, title: 'Faire son lit', index: i++, tagItems: [] }));
+  tutorialItems.push(buildTutorial({ databaseBuilder, title: 'Saluer ses voisins', index: i++, tagItems: [iterTags.next().value] }));
 
   await persistTutorials({ items: tutorialItems, airtableClient, logger });
   return tutorialItems;
 }
 
-export function buildTutorial({ title, index, tagItems }) {
+export function buildTutorial({ databaseBuilder, title, index, tagItems }) {
   const tutorialId = `tutorial${index}`;
-  return {
+  const tutorial = {
     id: tutorialId,
     title: `${title} - Tuto${index}`,
     duration: `0${index}:0${index}:0${index}`,
@@ -39,7 +39,10 @@ export function buildTutorial({ title, index, tagItems }) {
     crush: iterFor.crush.next().value,
     locale: iterLocales.next().value,
     tagAirtableIds: tagItems.map((tagItem) => tagItem.airtableId),
+    tagIds: tagItems.map((tagItem) => tagItem.id),
   };
+  databaseBuilder.factory.buildTutorial(tutorial);
+  return tutorial;
 }
 
 export async function persistTutorials({ items, airtableClient, logger }) {
@@ -47,5 +50,41 @@ export async function persistTutorials({ items, airtableClient, logger }) {
   const records = await saveInAirtable({ tableName: 'Tutoriels', data: airtableItems, logger, airtableClient });
   items.forEach((item) => {
     item.airtableId = records.shift().id;
+  });
+}
+
+export async function copyTutorialsFromAirtable({ airtableClient, databaseBuilder, logger }) {
+  const airtableTutorials = await  airtableClient.table('Tutoriels').select({ fields: [
+    'id persistant',
+    'Durée',
+    'Format',
+    'Lien',
+    'Source',
+    'Titre',
+    'Langue',
+    'License',
+    'niveau',
+    'CoupDeCoeur',
+    'Tags (id persistant)',
+  ] }).all();
+
+  logger.info(`Copying ${airtableTutorials.length} tutorials from airtable...`);
+
+  airtableTutorials.forEach((record) => {
+    databaseBuilder.factory.buildTutorial({
+      id: record.get('id persistant'),
+      duration: record.get('Durée'),
+      format: record.get('Format'),
+      link: record.get('Lien'),
+      source: record.get('Source'),
+      title: record.get('Titre'),
+      locale: record.get('Langue'),
+      license: record.get('License'),
+      level: record.get('niveau'),
+      crush: record.get('CoupDeCoeur') === 'YES',
+      tagIds: record.get('Tags (id persistant)'),
+      createdAt: record._rawJson.createdTime,
+      updatedAt: new Date(),
+    });
   });
 }

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -19,7 +19,7 @@ import { localizedChallengesBuilder } from './data/localized-challenges.js';
 import { translationsBuilder } from './data/translations.js';
 import { buildMissions } from './data/missions.js';
 import { buildTags, copyTutorialTagsFromAirtable } from './data/tags.js';
-import { buildTutorials } from './data/tutorials.js';
+import { buildTutorials, copyTutorialsFromAirtable } from './data/tutorials.js';
 
 export async function seed(knex) {
   const airtableClient = new Airtable({ apiKey: airtable.apiKey }).base(airtable.base);
@@ -66,7 +66,7 @@ export async function seed(knex) {
     await buildChallengesFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
     await buildPix1D({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, indexFramework: learningContentConfig.cntFrameworks });
     const tagItems = await buildTags({ airtableClient, logger, databaseBuilder });
-    await buildTutorials({ airtableClient, logger, locales: learningContentConfig.locales, tagItems });
+    await buildTutorials({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, tagItems });
   } else {
     await copyFrameworksFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyAreasFromAirtable({ airtableClient, databaseBuilder, logger });
@@ -74,6 +74,7 @@ export async function seed(knex) {
     await copyThematicsFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyTubesFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyTutorialTagsFromAirtable({ airtableClient, databaseBuilder, logger });
+    await copyTutorialsFromAirtable({ airtableClient, databaseBuilder, logger });
 
     const translations = await translationsBuilder(databaseBuilder);
     await localizedChallengesBuilder(databaseBuilder, translations);

--- a/api/lib/domain/models/Tutorial.js
+++ b/api/lib/domain/models/Tutorial.js
@@ -12,6 +12,7 @@ export class Tutorial {
     crush,
     locale,
     tagAirtableIds,
+    tagIds,
   }) {
     this.id = id;
     this.airtableId = airtableId;
@@ -25,6 +26,7 @@ export class Tutorial {
     this.crush = crush;
     this.locale = locale;
     this.tagAirtableIds = tagAirtableIds;
+    this.tagIds = tagIds;
   }
 
   static get FORMATS() {

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -19,6 +19,7 @@ export const tutorialDatasource = datasource.extend({
     'niveau',
     'CoupDeCoeur',
     'Tags',
+    'Tags (id persistant)',
     'Solution à',
     'En savoir plus',
   ],
@@ -37,6 +38,7 @@ export const tutorialDatasource = datasource.extend({
       level: airtableRecord.get('niveau'),
       crush: airtableRecord.get('CoupDeCoeur') === 'YES',
       tagAirtableIds: airtableRecord.get('Tags') ?? [],
+      tagIds: airtableRecord.get('Tags (id persistant)') ?? [],
       tutorialForSkills: airtableRecord.get('Solution à'),
       furtherInformation: airtableRecord.get('En savoir plus'),
     };
@@ -103,4 +105,3 @@ export const tutorialDatasource = datasource.extend({
     return records.map(this.fromAirTableObject);
   },
 });
-

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -1,11 +1,40 @@
 import { Tutorial } from '../../domain/models/index.js';
 import { tutorialDatasource } from '../datasources/airtable/index.js';
 import { generateNewId } from '../utils/id-generator.js';
+import { knex } from '../../../db/knex-database-connection.js';
+
+const TABLE_NAME = 'tutorials';
+const TAGS_RELATION_TABLE_NAME = 'tutorials-tutorial_tags';
 
 export async function create(tutorial) {
-  tutorial.id = generateNewId('tutorial');
-  const datasourceTutorial = await tutorialDatasource.create(tutorial);
-  return toDomain(datasourceTutorial);
+  return knex.transaction(async (transaction) => {
+    tutorial.id = generateNewId('tutorial');
+
+    const [airtableDto] = await Promise.all([
+      tutorialDatasource.create(tutorial),
+      transaction.insert({
+        id: tutorial.id,
+        title: tutorial.title,
+        duration: tutorial.duration,
+        source: tutorial.source,
+        format: tutorial.format,
+        link: tutorial.link,
+        license: tutorial.license,
+        level: tutorial.level,
+        crush: tutorial.crush,
+        locale: tutorial.locale,
+      }).into(TABLE_NAME),
+    ]);
+
+    if (airtableDto.tagIds.length !== 0) {
+      await transaction.insert(airtableDto.tagIds.map((tutorialTagId) => ({
+        tutorialId: tutorial.id,
+        tutorialTagId,
+      }))).into(TAGS_RELATION_TABLE_NAME);
+    }
+
+    return toDomain(airtableDto);
+  });
 }
 
 export async function update(tutorial) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -38,8 +38,37 @@ export async function create(tutorial) {
 }
 
 export async function update(tutorial) {
-  const datasourceTutorial = await tutorialDatasource.update(tutorial);
-  return toDomain(datasourceTutorial);
+  return knex.transaction(async (transaction) => {
+    const [airtableDto] = await Promise.all([
+      tutorialDatasource.update(tutorial),
+      transaction(TABLE_NAME).update({
+        title: tutorial.title,
+        duration: tutorial.duration,
+        source: tutorial.source,
+        format: tutorial.format,
+        link: tutorial.link,
+        license: tutorial.license,
+        level: tutorial.level,
+        crush: tutorial.crush,
+        locale: tutorial.locale,
+        updatedAt: transaction.fn.now(),
+      }).where('id', tutorial.id),
+    ]);
+
+    await transaction.delete().from(TAGS_RELATION_TABLE_NAME).where('tutorialId', tutorial.id).whereNotIn('tutorialTagId', airtableDto.tagIds);
+    if (airtableDto.tagIds.length !== 0) {
+      await transaction.insert(airtableDto.tagIds.map((tutorialTagId) => ({
+        tutorialId: tutorial.id,
+        tutorialTagId,
+        updatedAt: transaction.fn.now(),
+      })))
+        .into(TAGS_RELATION_TABLE_NAME)
+        .onConflict(['tutorialId', 'tutorialTagId'])
+        .merge();
+    }
+
+    return toDomain(airtableDto);
+  });
 }
 
 export async function getByAirtableId(tutorialId) {

--- a/api/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg.js
@@ -1,0 +1,82 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { ScriptRunner } from '../../lib/application/scripts/script-runner.js';
+import { Script } from '../../lib/application/scripts/script.js';
+import * as airtable from '../../lib/infrastructure/airtable.js';
+
+export class CopyTutorialsFromAirtableToPg extends Script {
+
+  constructor() {
+    super({
+      description: 'Copie des tutoriels de Airtable vers Postgres',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist insert/updates made during the script.',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const airtableTutorials = await airtable.findRecords('Tutoriels', {
+      fields: [
+        'id persistant',
+        'Durée',
+        'Format',
+        'Lien',
+        'Source',
+        'Titre',
+        'Langue',
+        'License',
+        'niveau',
+        'CoupDeCoeur',
+        'Tags (id persistant)',
+      ],
+    });
+    logger.info({ count: airtableTutorials.length }, 'Loaded tutorials from airtable');
+
+    const tutorials = airtableTutorials.map((record) => ({
+      id: record.get('id persistant'),
+      duration: record.get('Durée'),
+      format: record.get('Format'),
+      link: record.get('Lien'),
+      source: record.get('Source'),
+      title: record.get('Titre'),
+      locale: record.get('Langue'),
+      license: record.get('License'),
+      level: record.get('niveau'),
+      crush: record.get('CoupDeCoeur') === 'YES',
+      createdAt: record._rawJson.createdTime,
+      updatedAt: knex.fn.now(),
+    }));
+
+    const tutorialsTagsRelations = airtableTutorials.flatMap((record) => record.get('Tags (id persistant)')?.map((tutorialTagId) => ({
+      tutorialId: record.get('id persistant'),
+      tutorialTagId,
+      updatedAt: knex.fn.now(),
+    })) ?? []);
+
+    if (options.dryRun) return;
+
+    await knex.insert(tutorials).into('tutorials').onConflict('id').merge();
+    logger.info({ count: tutorials.length }, 'Inserted tutorials into postgres');
+
+    const deletedRelationsCount = await knex.delete()
+      .from('tutorials-tutorial_tags')
+      .whereNotIn(
+        knex.raw('(??, ??)', [knex.ref('tutorialId'), knex.ref('tutorialTagId')]),
+        tutorialsTagsRelations.map(({ tutorialId, tutorialTagId }) => [tutorialId, tutorialTagId]),
+      );
+    logger.info({ count: deletedRelationsCount }, 'Deleted tutorials tutorial_tags relations into postgres');
+
+    await knex.insert(tutorialsTagsRelations).into('tutorials-tutorial_tags').onConflict(['tutorialId', 'tutorialTagId']).merge();
+    logger.info({ count: tutorialsTagsRelations.length }, 'Inserted tutorials tutorial_tags relations into postgres');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CopyTutorialsFromAirtableToPg);

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
 
-import { airtableBuilder, databaseBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { airtableBuilder, databaseBuilder, generateAuthorizationHeader, knex } from '../../test-helper.js';
 import { createServer } from '../../../server.js';
 import * as idGenerator from '../../../lib/infrastructure/utils/id-generator.js';
 import { Tutorial } from '../../../lib/domain/models/index.js';
@@ -25,6 +25,11 @@ describe('Application | Route | Tutorials', () => {
 
   describe('POST /api/tutorials', async () => {
     let airtableCreateTutorialScope;
+
+    afterEach(async () => {
+      await knex.delete().from('tutorials-tutorial_tags');
+      await knex.delete().from('tutorials');
+    });
 
     context('when user has not the right to do the operation', function() {
       it('should respond with status 403', async function() {
@@ -125,6 +130,10 @@ describe('Application | Route | Tutorials', () => {
         // given
         const generateNewId = vi.spyOn(idGenerator, 'generateNewId');
         generateNewId.mockReturnValue('tutorialId1');
+        databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'title1' });
+        databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'title2' });
+        await databaseBuilder.commit();
+
         const createdAirtableTutorial = airtableBuilder.factory.buildTutorial({
           id: 'tutorialId1',
           airtableId: 'tutorialAirtableId1',
@@ -138,6 +147,7 @@ describe('Application | Route | Tutorials', () => {
           level: Tutorial.LEVELS.TWO,
           crush: true,
           tagAirtableIds: ['tagAirtableId1', 'tagAirtableId2'],
+          tagIds: ['tagId1', 'tagId2'],
         });
         airtableCreateTutorialScope = nock('https://api.airtable.com')
           .post('/v0/airtableBaseValue/Tutoriels/', {
@@ -234,6 +244,28 @@ describe('Application | Route | Tutorials', () => {
           },
         });
         expect(airtableCreateTutorialScope.isDone()).toBe(true);
+
+        await expect(knex('tutorials').select()).resolves.toStrictEqual([
+          {
+            id: 'tutorialId1',
+            title: 'mon titre',
+            duration: '12:01:02',
+            source: 'Mon grenier',
+            format: Tutorial.FORMATS.PDF,
+            link: 'https://coucou.com',
+            license: Tutorial.LICENSES.C,
+            level: Tutorial.LEVELS.TWO,
+            crush: true,
+            locale: 'fr',
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          },
+        ]);
+
+        await expect(knex('tutorials-tutorial_tags').select().orderBy('tutorialTagId')).resolves.toStrictEqual([
+          { tutorialId: 'tutorialId1', tutorialTagId: 'tagId1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tutorialId1', tutorialTagId: 'tagId2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        ]);
       });
     });
   });

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -542,6 +542,26 @@ describe('Application | Route | Tutorials', () => {
     context('success', function() {
       it('should respond with status 200 and updated tutorial', async () => {
         // given
+        databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'title1' });
+        databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'title2' });
+        databaseBuilder.factory.buildTag({ id: 'tagId3', title: 'title3' });
+
+        databaseBuilder.factory.buildTutorial({
+          id: 'tutorialId',
+          title: 'mon titre old',
+          format: Tutorial.FORMATS.FRISE,
+          duration: '06:06:06',
+          source: 'Mon grenier old',
+          link: 'https://coucou.old',
+          locale: 'nl',
+          license: Tutorial.LICENSES.YOUTUBE,
+          level: Tutorial.LEVELS.FOUR,
+          crush: false,
+          tagIds: ['tagId3']
+        });
+
+        await databaseBuilder.commit();
+
         const originalAirtableTutorial = airtableBuilder.factory.buildTutorial({
           id: 'tutorialId',
           airtableId: 'tutorialAirtableId',
@@ -574,6 +594,7 @@ describe('Application | Route | Tutorials', () => {
           level: Tutorial.LEVELS.TWO,
           crush: true,
           tagAirtableIds: ['tagAirtableId1', 'tagAirtableId2'],
+          tagIds: ['tagId1', 'tagId2'],
         });
         airtableUpdateTutorialScope = nock('https://api.airtable.com')
           .patch('/v0/airtableBaseValue/Tutoriels/', {
@@ -673,6 +694,28 @@ describe('Application | Route | Tutorials', () => {
           },
         });
         expect(airtableUpdateTutorialScope.isDone()).toBe(true);
+
+        await expect(knex.select('*').from('tutorials')).resolves.toStrictEqual([
+          {
+            id: 'tutorialId',
+            title: 'mon titre',
+            format: Tutorial.FORMATS.PDF,
+            duration: '12:01:02',
+            source: 'Mon grenier',
+            link: 'https://coucou.com',
+            locale: 'fr',
+            license: Tutorial.LICENSES.C,
+            level: Tutorial.LEVELS.TWO,
+            crush: true,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          },
+        ]);
+
+        await expect(knex('tutorials-tutorial_tags').select().orderBy('tutorialTagId')).resolves.toStrictEqual([
+          { tutorialId: 'tutorialId', tutorialTagId: 'tagId1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tutorialId', tutorialTagId: 'tagId2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        ]);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -25,6 +25,7 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
             niveau: 'niveau 1',
             CoupDeCoeur: 'YES',
             Tags: ['recTag1', 'recTag2'],
+            'Tags (id persistant)': ['tag1', 'tag2'],
             'Solution à': ['recSkill1', 'recSkill2'],
             'En savoir plus': ['recSkill1', 'recSkill3'],
           },
@@ -42,6 +43,7 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
             niveau: 'niveau 2',
             CoupDeCoeur: 'NON',
             Tags: ['recTag2', 'recTag3'],
+            'Tags (id persistant)': ['tag2', 'tag3'],
           },
         }),
       ]);
@@ -64,6 +66,7 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
           level: 'niveau 1',
           crush: true,
           tagAirtableIds: ['recTag1', 'recTag2'],
+          tagIds: ['tag1', 'tag2'],
         }),
         new Tutorial({
           airtableId: 'recTuto2',
@@ -78,6 +81,7 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
           level: 'niveau 2',
           crush: false,
           tagAirtableIds: ['recTag2', 'recTag3'],
+          tagIds: ['tag2', 'tag3'],
         }),
       ]);
 

--- a/api/tests/integration/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg_test.js
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { CopyTutorialsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg.js';
+import { logger } from '../../../../lib/infrastructure/logger.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+import { Tutorial } from '../../../../lib/domain/models/Tutorial.js';
+
+const TABLE_NAME = 'tutorials';
+const TAGS_RELATION_TABLE_NAME = 'tutorials-tutorial_tags';
+const AIRTABLE_NAME = 'Tutoriels';
+
+describe('Integration | Scripts | CopyTutorialsFromAirtableToPg', () => {
+  /** @type {CopyTutorialsFromAirtableToPg} */
+  let script;
+
+  beforeEach(() => {
+    script = new CopyTutorialsFromAirtableToPg();
+  });
+
+  describe('#handle', () => {
+    afterEach(async () => {
+      await knex.delete().from(TAGS_RELATION_TABLE_NAME);
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('reads tutorials from airtable and saves these to postgres', async () => {
+      // given
+      const options = { dryRun: false };
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+          fields: {
+            'id persistant': 'tutorial1',
+            Titre: 'mon titre 1',
+            Format: Tutorial.FORMATS.PDF,
+            Durée: '12:01:02',
+            Source: 'Mon grenier',
+            Lien: 'https://coucou.com',
+            Langue: 'fr',
+            License: Tutorial.LICENSES.C,
+            niveau: Tutorial.LEVELS.TWO,
+            CoupDeCoeur: 'YES',
+            'Tags (id persistant)': ['tag1', 'tag2'],
+          },
+          createdTime: '2025-10-10T00:00:00Z',
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+          fields: {
+            'id persistant': 'tutorial2',
+            Titre: 'mon titre 2',
+            Format: Tutorial.FORMATS.VIDEO,
+            Durée: '00:01:02',
+            Source: 'Dailymotion',
+            Lien: 'https://agaga.com',
+            Langue: 'en',
+            License: Tutorial.LICENSES.CCBYSA,
+            niveau: Tutorial.LEVELS.EIGHT,
+            CoupDeCoeur: null,
+            'Tags (id persistant)': ['tag2', 'tag3'],
+          },
+          createdTime: '2025-10-10T13:58:00Z',
+        }),
+      ]);
+
+      databaseBuilder.factory.buildTag({ id: 'tag1', title: 'Tag 1' });
+      databaseBuilder.factory.buildTag({ id: 'tag2', title: 'Tag 2' });
+      databaseBuilder.factory.buildTag({ id: 'tag3', title: 'Tag 3' });
+
+      databaseBuilder.factory.buildTutorial({
+        id: 'tutorial1',
+        title: 'mon titre 1 avant',
+        format: Tutorial.FORMATS.FRISE,
+        duration: '02:01:02',
+        source: 'Ma cave',
+        link: 'https://coucoucou.com',
+        locale: 'fr-fr',
+        license: Tutorial.LICENSES.YOUTUBE,
+        level: Tutorial.LEVELS.THREE,
+        crush: true,
+        tagIds: ['tag1', 'tag3'],
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: [
+        'id persistant',
+        'Durée',
+        'Format',
+        'Lien',
+        'Source',
+        'Titre',
+        'Langue',
+        'License',
+        'niveau',
+        'CoupDeCoeur',
+        'Tags (id persistant)',
+      ] });
+
+      await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+        {
+          id: 'tutorial1',
+          title: 'mon titre 1',
+          format: Tutorial.FORMATS.PDF,
+          duration: '12:01:02',
+          source: 'Mon grenier',
+          link: 'https://coucou.com',
+          locale: 'fr',
+          license: Tutorial.LICENSES.C,
+          level: Tutorial.LEVELS.TWO,
+          crush: true,
+          createdAt: new Date('2025-10-10T00:00:00Z'),
+          updatedAt: expect.any(Date),
+        },
+        {
+          id: 'tutorial2',
+          title: 'mon titre 2',
+          format: Tutorial.FORMATS.VIDEO,
+          duration: '00:01:02',
+          source: 'Dailymotion',
+          link: 'https://agaga.com',
+          locale: 'en',
+          license: Tutorial.LICENSES.CCBYSA,
+          level: Tutorial.LEVELS.EIGHT,
+          crush: false,
+          createdAt: new Date('2025-10-10T13:58:00Z'),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
+      await expect(knex.select('*').from(TAGS_RELATION_TABLE_NAME).orderBy(['tutorialId', 'tutorialTagId'])).resolves.toStrictEqual([
+        { tutorialId: 'tutorial1', tutorialTagId: 'tag1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { tutorialId: 'tutorial1', tutorialTagId: 'tag2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { tutorialId: 'tutorial2', tutorialTagId: 'tag2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { tutorialId: 'tutorial2', tutorialTagId: 'tag3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
+    });
+
+    describe('when dryRun is true', () => {
+      it('reads tutorials from airtable and stops', async () => {
+        // given
+        const options = { dryRun: true };
+
+        const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+          new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+            fields: {
+              'id persistant': 'tutorial1',
+              Titre: 'mon titre 1',
+              Format: Tutorial.FORMATS.PDF,
+              Durée: '12:01:02',
+              Source: 'Mon grenier',
+              Lien: 'https://coucou.com',
+              Langue: 'fr',
+              License: Tutorial.LICENSES.C,
+              niveau: Tutorial.LEVELS.TWO,
+              CoupDeCoeur: 'YES',
+              'Tags (id persistant)': ['tag1', 'tag2'],
+            },
+            createdTime: '2025-10-10T00:00:00Z',
+          }),
+          new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+            fields: {
+              'id persistant': 'tutorial2',
+              Titre: 'mon titre 2',
+              Format: Tutorial.FORMATS.VIDEO,
+              Durée: '00:01:02',
+              Source: 'Dailymotion',
+              Lien: 'https://agaga.com',
+              Langue: 'en',
+              License: Tutorial.LICENSES.CCBYSA,
+              niveau: Tutorial.LEVELS.EIGHT,
+              CoupDeCoeur: null,
+              'Tags (id persistant)': ['tag2', 'tag3'],
+            },
+            createdTime: '2025-10-10T13:58:00Z',
+          }),
+        ]);
+
+        databaseBuilder.factory.buildTag({ id: 'tag1', title: 'Tag 1' });
+        databaseBuilder.factory.buildTag({ id: 'tag2', title: 'Tag 2' });
+        databaseBuilder.factory.buildTag({ id: 'tag3', title: 'Tag 3' });
+
+        databaseBuilder.factory.buildTutorial({
+          id: 'tutorial1',
+          title: 'mon titre 1 avant',
+          format: Tutorial.FORMATS.FRISE,
+          duration: '02:01:02',
+          source: 'Ma cave',
+          link: 'https://coucoucou.com',
+          locale: 'fr-fr',
+          license: Tutorial.LICENSES.YOUTUBE,
+          level: Tutorial.LEVELS.THREE,
+          crush: true,
+          tagIds: ['tag1', 'tag3'],
+          createdAt: '2025-10-06T00:00:00Z',
+          updatedAt: '2025-10-06T10:00:00Z',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: [
+          'id persistant',
+          'Durée',
+          'Format',
+          'Lien',
+          'Source',
+          'Titre',
+          'Langue',
+          'License',
+          'niveau',
+          'CoupDeCoeur',
+          'Tags (id persistant)',
+        ] });
+
+        await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+          {
+            id: 'tutorial1',
+            title: 'mon titre 1 avant',
+            format: Tutorial.FORMATS.FRISE,
+            duration: '02:01:02',
+            source: 'Ma cave',
+            link: 'https://coucoucou.com',
+            locale: 'fr-fr',
+            license: Tutorial.LICENSES.YOUTUBE,
+            level: Tutorial.LEVELS.THREE,
+            crush: true,
+            createdAt: new Date('2025-10-06T00:00:00Z'),
+            updatedAt: new Date('2025-10-06T10:00:00Z'),
+          },
+        ]);
+
+        await expect(knex.select('*').from(TAGS_RELATION_TABLE_NAME).orderBy(['tutorialId', 'tutorialTagId'])).resolves.toStrictEqual([
+          { tutorialId: 'tutorial1', tutorialTagId: 'tag1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tutorial1', tutorialTagId: 'tag3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/airtable-builder/factory/build-tutorial.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tutorial.js
@@ -11,6 +11,7 @@ export function buildTutorial({
   level,
   crush,
   tagAirtableIds,
+  tagIds,
   tutorialForSkills,
   furtherInformation,
 } = {}) {
@@ -28,6 +29,7 @@ export function buildTutorial({
       'niveau': level,
       'CoupDeCoeur': crush ? 'YES' : null,
       'Tags': tagAirtableIds ?? [],
+      'Tags (id persistant)': tagIds ?? [],
       'Solution à': tutorialForSkills,
       'En savoir plus': furtherInformation,
     },

--- a/api/tests/tooling/database-builder/factory/build-tag.js
+++ b/api/tests/tooling/database-builder/factory/build-tag.js
@@ -1,6 +1,6 @@
 import { databaseBuffer } from '../database-buffer.js';
 
-export function buildTag({ id, title, notes , createdAt, updatedAt } = {}) {
+export function buildTag({ id, title, notes, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'tutorial_tags',
     autoId: false,

--- a/api/tests/tooling/database-builder/factory/build-tutorial.js
+++ b/api/tests/tooling/database-builder/factory/build-tutorial.js
@@ -1,0 +1,15 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildTutorial({ id, title, duration, source, format, link, license, level, crush, locale, tagIds, createdAt, updatedAt } = {}) {
+  const tutorial = databaseBuffer.pushInsertable({
+    tableName: 'tutorials',
+    autoId: false,
+    values: { id, title, duration, source, format, link, license, level, crush, locale, createdAt, updatedAt },
+  });
+  tagIds?.forEach((tutorialTagId) => databaseBuffer.pushInsertable({
+    tableName: 'tutorials-tutorial_tags',
+    autoId: false,
+    values: { tutorialId: id, tutorialTagId, createdAt, updatedAt },
+  }));
+  return { ...tutorial, tagIds };
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -11,6 +11,7 @@ export * from './build-static-course-tag.js';
 export * from './build-tag.js';
 export * from './build-thematic.js';
 export * from './build-tube.js';
+export * from './build-tutorial.js';
 export * from './build-translation.js';
 export * from './build-user.js';
 export * from './build-whitelisted-url.js';

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tutorial-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tutorial-datasource-object.js
@@ -15,10 +15,10 @@ export function buildTutorialDatasourceObject(
     level = Tutorial.LEVELS.THREE,
     crush = true,
     tagAirtableIds = ['tagAirtableId1'],
+    tagIds = ['tagId1'],
     tutorialForSkills = ['skillId1'],
     furtherInformation = ['skillId2'],
   } = {}) {
-
   return {
     id,
     airtableId,
@@ -32,6 +32,7 @@ export function buildTutorialDatasourceObject(
     level,
     crush,
     tagAirtableIds,
+    tagIds,
     tutorialForSkills,
     furtherInformation,
   };


### PR DESCRIPTION
## 🍂 Problème

On souhaite sortir d’Airtable.

## 🌰 Proposition

 - Création de la table `tutorials` et de la table `tutorials-tutorial_tags` dans postgres
 - Écriture des tutoriels en double dans Airtable et postgres
 - Création d’un script de migration des tutoriels existants (réexécutable)
 - Écriture des tutoriels dans postgres dans les seeds

## 🍁 Remarques

N/A

## 🪵 Pour tester

Vérifier que les tutoriels sont bien dans Postgres avec les bonnes données.

Créer un tutoriel avec des tags et vérifier qu’il est bien dans Postgres avec ses relations de tags.
Mettre à jour le tutoriel et ses tags et vérifier qu’il est bien mis à jour dans Postgres avec ses relations.