### PR TITLE
[TECH] Écriture des acquis dans Postgres (PIX-19729)

### DIFF
--- a/api/db/migrations/20251010123307_drop-skills-airtableid.js
+++ b/api/db/migrations/20251010123307_drop-skills-airtableid.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'skills';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn('airtableId');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down() {
+  // no rollback
+}

--- a/api/db/migrations/20251010124141_create-skills-columns.js
+++ b/api/db/migrations/20251010124141_create-skills-columns.js
@@ -1,0 +1,30 @@
+const TABLE_NAME = 'skills';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string('status').nullable();
+    table.string('hintStatus').nullable();
+    table.string('descriptionStatus').nullable();
+    table.string('description').nullable();
+    table.integer('level').nullable();
+    table.string('internationalisation').nullable();
+    table.integer('version').nullable();
+    table.string('tubeId').nullable().references('tubes.id');
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.dropColumns('status', 'hintStatus', 'descriptionStatus', 'description', 'level', 'internationalisation', 'version', 'tubeId');
+    table.dropTimestamps(true);
+  });
+}

--- a/api/db/migrations/20251013114939_create-skills-tutorials-relation-table.js
+++ b/api/db/migrations/20251013114939_create-skills-tutorials-relation-table.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'skills-tutorials';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.string('skillId').notNullable().references('skills.id');
+    table.string('tutorialId').notNullable().references('tutorials.id');
+    table.string('type').checkIn(['understanding', 'learningMore']).notNullable();
+    table.primary(['tutorialId', 'skillId', 'type']);
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/db/seeds/data/skills.js
+++ b/api/db/seeds/data/skills.js
@@ -4,8 +4,18 @@ import { Skill } from '../../../lib/domain/models/index.js';
 const ignoreEmptyValues = (val) => Boolean(val);
 
 const iterFor = {
-  'hintStatus': cycle(Object.values(Skill.HINT_STATUSES).filter(ignoreEmptyValues)),
+  hintStatus: cycle(Object.values(Skill.HINT_STATUSES).filter(ignoreEmptyValues)),
+  descriptionStatus: cycle(Object.values(Skill.DESCRIPTION_STATUSES).filter(ignoreEmptyValues)),
 };
+
+function* cycleTutorials(tutotialItems) {
+  const iter = cycle(tutotialItems);
+  while (true) {
+    yield [];
+    yield [iter.next().value];
+    yield [iter.next().value, iter.next().value];
+  }
+}
 
 export async function buildSkillsFromConfig({
   airtableClient,
@@ -13,9 +23,11 @@ export async function buildSkillsFromConfig({
   logger,
   learningContentConfig,
   learningContentData,
+  tutorialItems,
 }) {
   const skillItems = [];
   const allTubes = learningContentData.flatMap((framework) => framework.areas.flatMap((area) => area.competences).flatMap((competence) => competence.thematics.flatMap((thematic) => thematic.tubes)));
+  const tutorialsIter = cycleTutorials(tutorialItems);
   for (const tubeItem of allTubes) {
     if (tubeItem.name.includes('workbench')) {
       const workbenchSkillItem = buildSkill({ tubeItem, isWorkbench: true, databaseBuilder, locales: learningContentConfig.locales });
@@ -24,15 +36,15 @@ export async function buildSkillsFromConfig({
     } else {
       for (let i = 0; i < learningContentConfig.skillMaxLevel; ++i) {
         if (i % 2 === 0) {
-          const activeSkillV1 = buildSkill({ indexSkill: i, suffix: 'Act', tubeItem, status: 'actif', version: 1, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales });
-          const enConstructionSkillV2 = buildSkill({ indexSkill: i, suffix: 'EnCons', tubeItem, status: 'en construction', version: 2, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales });
+          const activeSkillV1 = buildSkill({ indexSkill: i, suffix: 'Act', tubeItem, status: 'actif', version: 1, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales, tutorialItems: tutorialsIter.next().value, learningMoreTutorialItems: tutorialsIter.next().value });
+          const enConstructionSkillV2 = buildSkill({ indexSkill: i, suffix: 'EnCons', tubeItem, status: 'en construction', version: 2, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales, tutorialItems: tutorialsIter.next().value, learningMoreTutorialItems: tutorialsIter.next().value });
           skillItems.push(activeSkillV1);
           skillItems.push(enConstructionSkillV2);
           tubeItem.skills.push(activeSkillV1);
           tubeItem.skills.push(enConstructionSkillV2);
         } else {
-          const obsoleteSkillV1 = buildSkill({ indexSkill: i, suffix: 'Obs', tubeItem, status: 'périmé', version: 1, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales });
-          const archivedSkillV2 = buildSkill({ indexSkill: i, suffix: 'Arch', tubeItem, status: 'archivé', version: 2, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales });
+          const obsoleteSkillV1 = buildSkill({ indexSkill: i, suffix: 'Obs', tubeItem, status: 'périmé', version: 1, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales, tutorialItems: tutorialsIter.next().value, learningMoreTutorialItems: tutorialsIter.next().value });
+          const archivedSkillV2 = buildSkill({ indexSkill: i, suffix: 'Arch', tubeItem, status: 'archivé', version: 2, isWorkbench: false, databaseBuilder, locales: learningContentConfig.locales, tutorialItems: tutorialsIter.next().value, learningMoreTutorialItems: tutorialsIter.next().value });
           skillItems.push(obsoleteSkillV1);
           skillItems.push(archivedSkillV2);
           tubeItem.skills.push(obsoleteSkillV1);
@@ -60,24 +72,33 @@ function toAirtableObject(item) {
       'Level': item.level,
       'Internationalisation': item.internationalisation,
       'Version': item.version,
+      'Comprendre': item.tutorialAirtableIds,
+      'En savoir plus': item.learningMoreTutorialAirtableIds,
     }
   };
 }
 
-export function buildSkill({ indexSkill, suffix = '', tubeItem, status, version, isWorkbench, databaseBuilder, locales }) {
+export function buildSkill({ indexSkill, suffix = '', tubeItem, status, version, isWorkbench, databaseBuilder, locales, tutorialItems, learningMoreTutorialItems }) {
   const partId = tubeItem.id.split('tube')[1];
   const skillId = `skill${partId}S${isWorkbench ? 'W' : indexSkill.toString() + suffix}`;
   const skillItem = {
     id: skillId,
     level: isWorkbench ? null : indexSkill + 1,
     hintStatus: isWorkbench ? null : iterFor.hintStatus.next().value,
-    hint: isWorkbench ? '' : `${skillId} indice`,
+    hint: isWorkbench ? null : `${skillId} indice`,
     description: isWorkbench ? 'Acquis workbench' : `${skillId} description`,
+    descriptionStatus: isWorkbench ? null : iterFor.descriptionStatus.next().value,
     status: isWorkbench ? 'en construction' : status,
     internationalisation: isWorkbench ? null : 'Monde',
     version: isWorkbench ? null : version,
     tubeAirtableId: tubeItem.airtableId,
+    tubeId: tubeItem.id,
+    tutorialAirtableIds: tutorialItems?.map(({ airtableId }) => airtableId),
+    tutorialIds: tutorialItems?.map(({ id }) => id),
+    learningMoreTutorialAirtableIds: learningMoreTutorialItems?.map(({ airtableId }) => airtableId),
+    learningMoreTutorialIds: learningMoreTutorialItems?.map(({ id }) => id),
   };
+  databaseBuilder.factory.buildSkill(skillItem);
   locales.forEach((locale) => {
     databaseBuilder.factory.buildTranslation(
       {
@@ -95,5 +116,41 @@ export async function persistSkills({ items, airtableClient, logger }) {
   const records = await saveInAirtable({ tableName: 'Acquis', data: airtableItems, logger, airtableClient });
   items.forEach((item) => {
     item.airtableId = records.shift().id;
+  });
+}
+
+export async function copySkillsFromAirtable({ airtableClient, databaseBuilder, logger }) {
+  const airtableSkills = await  airtableClient.table('Acquis').select({ fields: [
+    'id persistant',
+    'Statut de l\'indice',
+    'Comprendre (id persistant)',
+    'En savoir plus (id persistant)',
+    'Status',
+    'Tube (id persistant)',
+    'Description',
+    'Level',
+    'Internationalisation',
+    'Version',
+    'Statut de la description',
+  ] }).all();
+
+  logger.info(`Copying ${airtableSkills.length} skills from airtable...`);
+
+  airtableSkills.forEach((record) => {
+    databaseBuilder.factory.buildSkill({
+      id: record.get('id persistant'),
+      hintStatus: record.get('Statut de l\'indice'),
+      status: record.get('Status'),
+      tubeId: record.get('Tube (id persistant)')[0],
+      description: record.get('Description'),
+      level: record.get('Level'),
+      internationalisation: record.get('Internationalisation'),
+      version: record.get('Version'),
+      descriptionStatus: record.get('Statut de la description'),
+      tutorialIds: record.get('Comprendre (id persistant)'),
+      learningMoreTutorialIds: record.get('En savoir plus (id persistant)'),
+      createdAt: record._rawJson.createdTime,
+      updatedAt: new Date(),
+    });
   });
 }

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -8,7 +8,7 @@ import { buildChallengesFromConfig } from './data/challenges.js';
 import { buildCompetencesFromConfig, copyCompetencesFromAirtable } from './data/competences.js';
 import { buildFrameworksFromConfig, copyFrameworksFromAirtable } from './data/frameworks.js';
 import { buildPix1D } from './data/pix-1d.js';
-import { buildSkillsFromConfig } from './data/skills.js';
+import { buildSkillsFromConfig, copySkillsFromAirtable } from './data/skills.js';
 import { buildThematicsFromConfig, copyThematicsFromAirtable } from './data/thematics.js';
 import { buildTubesFromConfig, copyTubesFromAirtable } from './data/tubes.js';
 import { staticCoursesBuilder } from './data/static-courses.js';
@@ -62,11 +62,11 @@ export async function seed(knex) {
     await buildCompetencesFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
     await buildThematicsFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
     await buildTubesFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
-    await buildSkillsFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
+    const tagItems = await buildTags({ airtableClient, logger, databaseBuilder });
+    const tutorialItems = await buildTutorials({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, tagItems });
+    await buildSkillsFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData, tutorialItems });
     await buildChallengesFromConfig({ airtableClient, databaseBuilder, logger, learningContentConfig, learningContentData });
     await buildPix1D({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, indexFramework: learningContentConfig.cntFrameworks });
-    const tagItems = await buildTags({ airtableClient, logger, databaseBuilder });
-    await buildTutorials({ airtableClient, databaseBuilder, logger, locales: learningContentConfig.locales, tagItems });
   } else {
     await copyFrameworksFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyAreasFromAirtable({ airtableClient, databaseBuilder, logger });
@@ -75,6 +75,7 @@ export async function seed(knex) {
     await copyTubesFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyTutorialTagsFromAirtable({ airtableClient, databaseBuilder, logger });
     await copyTutorialsFromAirtable({ airtableClient, databaseBuilder, logger });
+    await copySkillsFromAirtable({ airtableClient, databaseBuilder, logger });
 
     const translations = await translationsBuilder(databaseBuilder);
     await localizedChallengesBuilder(databaseBuilder, translations);

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -43,7 +43,7 @@ export const skillDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.get('Record Id'),
       name: airtableRecord.get('Nom'),
-      hintStatus: airtableRecord.get('Statut de l\'indice') ?? '',
+      hintStatus: airtableRecord.get('Statut de l\'indice'),
       tutorialIds: airtableRecord.get('Comprendre (id persistant)') ?? [],
       tutorialAirtableIds: airtableRecord.get('Comprendre') ?? [],
       learningMoreTutorialIds: airtableRecord.get('En savoir plus (id persistant)') ?? [],

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -130,7 +130,6 @@ function toDomain(datasourceSkill, translations = [], skillDataFromPG) {
 function extractDataForPG(skill) {
   return {
     id: skill.id,
-    airtableId: skill.airtableId,
     activatedAt: skill.activatedAt,
     archivedAt: skill.archivedAt,
     obsoletedAt: skill.obsoletedAt,

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -104,16 +104,31 @@ export async function create(skill) {
 
 export async function update(skill) {
   return knex.transaction(async (transaction) => {
-    const updatedSkillDto = await skillDatasource.update(skill);
+
+    const [updatedSkillDto, [skillDataFromPG]] = await Promise.all([
+      skillDatasource.update(skill),
+      transaction(TABLE_NAME).update({
+        status: skill.status,
+        hintStatus: skill.hintStatus,
+        descriptionStatus: skill.descriptionStatus,
+        description: skill.description,
+        level: skill.level,
+        internationalisation: skill.internationalisation,
+        version: skill.version,
+        activatedAt: skill.activatedAt,
+        archivedAt: skill.archivedAt,
+        obsoletedAt: skill.obsoletedAt,
+      }).where('id', skill.id).returning(['activatedAt', 'archivedAt', 'obsoletedAt']),
+    ]);
+
     const translations = skillTranslations.extractFromDomainObject(skill);
     await translationRepository.deleteByKeyPrefixAndLocales({
       prefix: `${skillTranslations.prefix}${skill.id}.`,
       locales: ['fr', 'en'],
       transaction,
     });
-    const skillDataToSaveInPG = extractDataForPG(skill);
-    const [skillDataFromPG] = await knex(TABLE_NAME).insert(skillDataToSaveInPG).onConflict('id').merge().returning('*');
     await translationRepository.save({ translations, transaction });
+
     return toDomain(updatedSkillDto, translations, skillDataFromPG);
   });
 }
@@ -134,13 +149,4 @@ function toDomain(datasourceSkill, translations = [], skillDataFromPG) {
     archivedAt: skillDataFromPG?.archivedAt ?? null,
     obsoletedAt: skillDataFromPG?.obsoletedAt ?? null,
   });
-}
-
-function extractDataForPG(skill) {
-  return {
-    id: skill.id,
-    activatedAt: skill.activatedAt,
-    archivedAt: skill.archivedAt,
-    obsoletedAt: skill.obsoletedAt,
-  };
 }

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -4,9 +4,9 @@ import { skillDatasource } from '../datasources/airtable/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
-import { Translation } from '../../domain/models/index.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
+const TABLE_NAME = 'skills';
 const model = 'skill';
 
 export async function list() {
@@ -14,7 +14,7 @@ export async function list() {
     skillDatasource.list(),
     translationRepository.listByModel(model),
   ]);
-  const skillsDataFromPG = await knex('skills').select('*');
+  const skillsDataFromPG = await knex(TABLE_NAME).select('*');
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
@@ -24,7 +24,7 @@ export async function get(id) {
     translationRepository.listByEntity(model, id),
   ]);
   if (!skillDTO) return null;
-  const skillDataFromPG = await knex('skills').select('*').where({ id }).first();
+  const skillDataFromPG = await knex(TABLE_NAME).select('*').where({ id }).first();
   return toDomain(skillDTO, translations, skillDataFromPG);
 }
 
@@ -32,7 +32,7 @@ export async function getByAirtableId(id) {
   const datasourceSkill = await skillDatasource.find(id);
   if (!datasourceSkill) return null;
   const translations = await translationRepository.listByEntity(model, datasourceSkill.id);
-  const skillDataFromPG = await knex('skills').select('*').where({ id: datasourceSkill.id }).first();
+  const skillDataFromPG = await knex(TABLE_NAME).select('*').where({ id: datasourceSkill.id }).first();
   return toDomain(datasourceSkill, translations, skillDataFromPG);
 }
 
@@ -41,7 +41,7 @@ export async function getManyByAirtableIds(ids) {
   const datasourceSkills = await skillDatasource.getManyByAirtableIds(ids);
   if (!datasourceSkills) return [];
   const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
-  const skillsDataFromPG = await knex('skills').select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
+  const skillsDataFromPG = await knex(TABLE_NAME).select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
@@ -49,7 +49,7 @@ export async function listByTubeId(tubeId) {
   const datasourceSkills = await skillDatasource.filterByTubeId(tubeId);
   if (!datasourceSkills) return [];
   const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
-  const skillsDataFromPG = await knex('skills').select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
+  const skillsDataFromPG = await knex(TABLE_NAME).select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
@@ -57,7 +57,7 @@ export async function listActiveByCompetenceId(competenceId) {
   const datasourceSkills = await skillDatasource.listActiveByCompetenceId(competenceId);
   if (!datasourceSkills) return [];
   const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
-  const skillsDataFromPG = await knex('skills').select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
+  const skillsDataFromPG = await knex(TABLE_NAME).select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
@@ -65,7 +65,7 @@ export async function listByCompetenceId(competenceId) {
   const datasourceSkills = await skillDatasource.listByCompetenceId(competenceId);
   if (!datasourceSkills) return [];
   const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
-  const skillsDataFromPG = await knex('skills').select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
+  const skillsDataFromPG = await knex(TABLE_NAME).select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
@@ -73,24 +73,33 @@ export async function search(params) {
   const datasourceSkills = await skillDatasource.search(params);
   if (!datasourceSkills) return [];
   const translations = await translationRepository.listByEntities(model, datasourceSkills.map(({ id }) => id));
-  const skillsDataFromPG = await knex('skills').select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
+  const skillsDataFromPG = await knex(TABLE_NAME).select('*').whereIn('id', datasourceSkills.map(({ id }) => id));
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
 export async function create(skill) {
-  const createdSkillDTO = await skillDatasource.create(skill);
-  const translations = [];
-  for (const [locale, value] of Object.entries(skill.hint_i18n)) {
-    if (!value) continue;
-    translations.push(new Translation({
-      key: `${model}.${skill.id}.hint`,
-      locale,
-      value,
-    }));
-  }
-  await translationRepository.save({ translations });
-  const skillDataFromPG = await knex('skills').select('*').where({ id: createdSkillDTO.id }).first();
-  return toDomain(createdSkillDTO, translations, skillDataFromPG);
+  return knex.transaction(async (transaction) => {
+    const createdSkillDTO = await skillDatasource.create(skill);
+
+    const translations = skillTranslations.extractFromDomainObject(skill);
+
+    await Promise.all([
+      transaction.insert({
+        id: skill.id,
+        status: skill.status,
+        hintStatus: skill.hintStatus,
+        descriptionStatus: skill.descriptionStatus,
+        description: skill.description,
+        level: skill.level,
+        internationalisation: skill.internationalisation,
+        version: skill.version,
+        tubeId: createdSkillDTO.tubeId,
+      }).into(TABLE_NAME),
+      translationRepository.save({ translations, transaction }),
+    ]);
+
+    return toDomain(createdSkillDTO, translations);
+  });
 }
 
 export async function update(skill) {
@@ -103,7 +112,7 @@ export async function update(skill) {
       transaction,
     });
     const skillDataToSaveInPG = extractDataForPG(skill);
-    const [skillDataFromPG] = await knex('skills').insert(skillDataToSaveInPG).onConflict('id').merge().returning('*');
+    const [skillDataFromPG] = await knex(TABLE_NAME).insert(skillDataToSaveInPG).onConflict('id').merge().returning('*');
     await translationRepository.save({ translations, transaction });
     return toDomain(updatedSkillDto, translations, skillDataFromPG);
   });

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -140,6 +140,18 @@ export async function update(skill) {
     });
     await translationRepository.save({ translations, transaction });
 
+    const skillTutorials = [
+      ...updatedSkillDto.tutorialIds.map((tutorialId) => ({ skillId: skill.id, tutorialId, type: TUTORIAL_RELATION_TYPES.UNDERSTANDING })),
+      ...updatedSkillDto.learningMoreTutorialIds.map((tutorialId) => ({ skillId: skill.id, tutorialId, type: TUTORIAL_RELATION_TYPES.LEARNING_MORE })),
+    ];
+    await transaction.delete().from(TUTORIALS_RELATION_TABLE_NAME).whereNotIn(
+      ['skillId', 'tutorialId', 'type'],
+      skillTutorials.map(({ skillId, tutorialId, type }) => [skillId, tutorialId, type]),
+    );
+    if (skillTutorials.length > 0) {
+      await transaction.insert(skillTutorials).into(TUTORIALS_RELATION_TABLE_NAME).onConflict(['skillId', 'tutorialId', 'type']).merge({ updatedAt: transaction.fn.now() });
+    }
+
     return toDomain(updatedSkillDto, translations, skillDataFromPG);
   });
 }

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -7,6 +7,11 @@ import { Skill } from '../../domain/models/Skill.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
 const TABLE_NAME = 'skills';
+const TUTORIALS_RELATION_TABLE_NAME = 'skills-tutorials';
+const TUTORIAL_RELATION_TYPES = {
+  UNDERSTANDING: 'understanding',
+  LEARNING_MORE: 'learningMore',
+};
 const model = 'skill';
 
 export async function list() {
@@ -81,22 +86,28 @@ export async function create(skill) {
   return knex.transaction(async (transaction) => {
     const createdSkillDTO = await skillDatasource.create(skill);
 
-    const translations = skillTranslations.extractFromDomainObject(skill);
+    await transaction.insert({
+      id: skill.id,
+      status: skill.status,
+      hintStatus: skill.hintStatus,
+      descriptionStatus: skill.descriptionStatus,
+      description: skill.description,
+      level: skill.level,
+      internationalisation: skill.internationalisation,
+      version: skill.version,
+      tubeId: createdSkillDTO.tubeId,
+    }).into(TABLE_NAME);
 
-    await Promise.all([
-      transaction.insert({
-        id: skill.id,
-        status: skill.status,
-        hintStatus: skill.hintStatus,
-        descriptionStatus: skill.descriptionStatus,
-        description: skill.description,
-        level: skill.level,
-        internationalisation: skill.internationalisation,
-        version: skill.version,
-        tubeId: createdSkillDTO.tubeId,
-      }).into(TABLE_NAME),
-      translationRepository.save({ translations, transaction }),
-    ]);
+    const translations = skillTranslations.extractFromDomainObject(skill);
+    await translationRepository.save({ translations, transaction });
+
+    const skillTutorials = [
+      ...createdSkillDTO.tutorialIds.map((tutorialId) => ({ skillId: skill.id, tutorialId, type: TUTORIAL_RELATION_TYPES.UNDERSTANDING })),
+      ...createdSkillDTO.learningMoreTutorialIds.map((tutorialId) => ({ skillId: skill.id, tutorialId, type: TUTORIAL_RELATION_TYPES.LEARNING_MORE })),
+    ];
+    if (skillTutorials.length > 0) {
+      await transaction.insert(skillTutorials).into(TUTORIALS_RELATION_TABLE_NAME);
+    }
 
     return toDomain(createdSkillDTO, translations);
   });

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -64,7 +64,7 @@ export async function update(tutorial) {
       })))
         .into(TAGS_RELATION_TABLE_NAME)
         .onConflict(['tutorialId', 'tutorialTagId'])
-        .merge();
+        .merge({ updatedAt: transaction.fn.now() });
     }
 
     return toDomain(airtableDto);

--- a/api/scripts/migration-from-airtable/copy-skills-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-skills-from-airtable-to-pg.js
@@ -1,0 +1,90 @@
+import { knex } from '../../db/knex-database-connection.js';
+import { ScriptRunner } from '../../lib/application/scripts/script-runner.js';
+import { Script } from '../../lib/application/scripts/script.js';
+import * as airtable from '../../lib/infrastructure/airtable.js';
+
+export class CopySkillsFromAirtableToPg extends Script {
+
+  constructor() {
+    super({
+      description: 'Copie des acquis de Airtable vers Postgres',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist insert/updates made during the script.',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const airtableSkills = await airtable.findRecords('Acquis', {
+      fields: [
+        'id persistant',
+        'Statut de l\'indice',
+        'Comprendre (id persistant)',
+        'En savoir plus (id persistant)',
+        'Status',
+        'Tube (id persistant)',
+        'Description',
+        'Level',
+        'Internationalisation',
+        'Version',
+        'Statut de la description',
+      ],
+    });
+    logger.info({ count: airtableSkills.length }, 'Loaded skills from airtable');
+
+    const skills = airtableSkills.map((record) => ({
+      id: record.get('id persistant'),
+      hintStatus: record.get('Statut de l\'indice'),
+      status: record.get('Status'),
+      tubeId: record.get('Tube (id persistant)')[0],
+      description: record.get('Description'),
+      level: record.get('Level'),
+      internationalisation: record.get('Internationalisation'),
+      version: record.get('Version'),
+      descriptionStatus: record.get('Statut de la description'),
+      createdAt: record._rawJson.createdTime,
+      updatedAt: knex.fn.now(),
+    }));
+
+    const skillsTutorialsRelations = airtableSkills.flatMap((record) => [
+      ...(record.get('Comprendre (id persistant)')?.map((tutorialId) => ({
+        skillId: record.get('id persistant'),
+        tutorialId,
+        type: 'understanding',
+        updatedAt: knex.fn.now(),
+      })) ?? []),
+      ...(record.get('En savoir plus (id persistant)')?.map((tutorialId) => ({
+        skillId: record.get('id persistant'),
+        tutorialId,
+        type: 'learningMore',
+        updatedAt: knex.fn.now(),
+      })) ?? []),
+    ]);
+
+    if (options.dryRun) return;
+
+    await knex.insert(skills).into('skills').onConflict('id').merge();
+    logger.info({ count: skills.length }, 'Inserted skills into postgres');
+
+    const deletedRelationsCount = await knex.delete()
+      .from('skills-tutorials')
+      .whereNotIn(
+        ['skillId', 'tutorialId', 'type'],
+        skillsTutorialsRelations.map(({ skillId, tutorialId, type }) => [skillId, tutorialId, type]),
+      );
+    logger.info({ count: deletedRelationsCount }, 'Deleted skills tutorials relations into postgres');
+
+    await knex.insert(skillsTutorialsRelations).into('skills-tutorials').onConflict(['skillId', 'tutorialId', 'type']).merge({ updatedAt: knex.fn.now() });
+    logger.info({ count: skillsTutorialsRelations.length }, 'Inserted skills tutorials relations into postgres');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CopySkillsFromAirtableToPg);

--- a/api/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg.js
@@ -74,7 +74,7 @@ export class CopyTutorialsFromAirtableToPg extends Script {
       );
     logger.info({ count: deletedRelationsCount }, 'Deleted tutorials tutorial_tags relations into postgres');
 
-    await knex.insert(tutorialsTagsRelations).into('tutorials-tutorial_tags').onConflict(['tutorialId', 'tutorialTagId']).merge();
+    await knex.insert(tutorialsTagsRelations).into('tutorials-tutorial_tags').onConflict(['tutorialId', 'tutorialTagId']).merge({ updatedAt: knex.fn.now() });
     logger.info({ count: tutorialsTagsRelations.length }, 'Inserted tutorials tutorial_tags relations into postgres');
   }
 }

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -609,6 +609,7 @@ describe('Acceptance | Route | competences', () => {
     });
 
     afterEach(async () => {
+      await knex('skills').delete();
       await knex('tubes').delete();
       await knex('thematics').delete();
       await knex('competences').delete();
@@ -758,6 +759,27 @@ describe('Acceptance | Route | competences', () => {
       await expect(knex.select('*').from('thematics')).resolves.toStrictEqual([
         { id: 'thematic1', index: 0, competenceId: 'competence4', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
       ]);
+
+      await expect(knex.select('*').from('tubes')).resolves.toStrictEqual([
+        { id: 'tube1', name: '@workbench', index: null, thematicId: 'thematic1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
+
+      await expect(knex.select('*').from('skills')).resolves.toStrictEqual([{
+        id: 'skill1',
+        description: 'Acquis pour l\'atelier de la compétence 2.2 Pix',
+        descriptionStatus: null,
+        hintStatus: null,
+        internationalisation: null,
+        level: null,
+        status: null,
+        version: null,
+        tubeId: 'tube1',
+        activatedAt: null,
+        archivedAt: null,
+        obsoletedAt: null,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      }]);
 
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: 'competence.competence4.description', locale: 'en', value: 'It’s the fourth one' },

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -495,6 +495,10 @@ describe('Acceptance | Route | competences', () => {
         tubeAirtableId: 'recTube1',
         tubeId: 'tube1',
         description: 'Acquis pour l\'atelier de la compétence 2.2 Pix',
+        tutorialAirtableIds: [],
+        tutorialIds: [],
+        learningMoreTutorialAirtableIds: [],
+        learningMoreTutorialIds: [],
       }));
 
       airtableCreateCompetenceScope = nock('https://api.airtable.com')

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -986,6 +986,9 @@ describe('Application | Route | Skills', () => {
       databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
       databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
       databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto1', title: 'title tuto1', duration: 'duration tuto1', source: 'source tuto1', format: 'format tuto1', link: 'link tuto1', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto2', title: 'title tuto2', duration: 'duration tuto2', source: 'source tuto2', format: 'format tuto2', link: 'link tuto2', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto3', title: 'title tuto3', duration: 'duration tuto3', source: 'source tuto3', format: 'format tuto3', link: 'link tuto3', locale: 'fr' });
       await databaseBuilder.commit();
 
       dataToPost = {
@@ -1047,7 +1050,9 @@ describe('Application | Route | Skills', () => {
         name: '@tube1',
         hintStatus: dataToPost.hintStatus,
         tutorialAirtableIds: dataToPost.tutorialAirtableIds,
+        tutorialIds: ['tuto1', 'tuto3'],
         learningMoreTutorialAirtableIds: dataToPost.learningMoreTutorialAirtableIds,
+        learningMoreTutorialIds: ['tuto2'],
         pixValue: 3,
         status: 'en construction',
         tubeAirtableId: dataToPost.tubeAirtableId,
@@ -1110,6 +1115,7 @@ describe('Application | Route | Skills', () => {
     });
 
     afterEach(async () => {
+      await knex('skills-tutorials').delete();
       await knex('skills').delete();
       await knex('translations').delete();
     });
@@ -1256,6 +1262,12 @@ describe('Application | Route | Skills', () => {
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: 'skill.nouvelAcquis.hint', locale: 'en', value: 'L indice EN de mon nouvel acquis' },
         { key: 'skill.nouvelAcquis.hint', locale: 'fr', value: 'L indice de mon nouvel acquis' },
+      ]);
+
+      await expect(knex.select('*').from('skills-tutorials').orderBy(['type', 'tutorialId'])).resolves.toStrictEqual([
+        { type: 'learningMore', skillId: 'nouvelAcquis', tutorialId: 'tuto2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { type: 'understanding', skillId: 'nouvelAcquis', tutorialId: 'tuto1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { type: 'understanding', skillId: 'nouvelAcquis', tutorialId: 'tuto3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
       ]);
     });
   });
@@ -1512,15 +1524,28 @@ describe('Application | Route | Skills', () => {
       airtableCreateAttachmentsScope,
       pixApiCacheSkillUpdateScope,
       pixApiCacheChallengeUpdateScope,
-      dataToPost;
+      dataToPost,
+      skillToClone;
 
     beforeEach(async () => {
       // given
+      skillToClone = domainBuilder.buildSkillDatasourceObject({
+        id: 'skill1Tube1',
+        airtableId: 'recSkill1Tube1',
+        tubeId: 'tube1',
+        tubeAirtableId: 'recTube1',
+        level: 1,
+        version: 1,
+      });
+
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
       databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
       databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
       databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
       databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+      [...skillToClone.tutorialIds, ...skillToClone.learningMoreTutorialIds].forEach((id) => databaseBuilder.factory.buildTutorial({
+        id, title: `title ${id}`, duration: `duration ${id}`, source: `source ${id}`, format: `format ${id}`, link: `link ${id}`, locale: 'fr',
+      }));
 
       dataToPost = {
         level: 2,
@@ -1534,14 +1559,8 @@ describe('Application | Route | Skills', () => {
         index: 5,
         competenceId: 'recCompetence1',
       }));
-      const airtableSkillToClone = airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject({
-        id: 'skill1Tube1',
-        airtableId: 'recSkill1Tube1',
-        tubeId: 'tube1',
-        tubeAirtableId: 'recTube1',
-        level: 1,
-        version: 1,
-      }));
+
+      const airtableSkillToClone = airtableBuilder.factory.buildSkill(skillToClone);
       const airtableSkillAlreadyAtDestinationTubeLevel = airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject({
         id: 'skill2Tube1',
         airtableId: 'recSkill2Tube1',
@@ -1897,6 +1916,7 @@ describe('Application | Route | Skills', () => {
     });
 
     afterEach(async () => {
+      await knex('skills-tutorials').delete();
       await knex('skills').delete();
       await knex('translations').delete();
     });
@@ -1965,6 +1985,11 @@ describe('Application | Route | Skills', () => {
       expect(airtableCreateAttachmentsScope.isDone()).to.be.true;
       expect(pixApiCacheSkillUpdateScope.isDone()).to.be.true;
       expect(pixApiCacheChallengeUpdateScope.isDone()).to.be.true;
+
+      await expect(knex.select('*').from('skills-tutorials').orderBy(['type', 'tutorialId'])).resolves.toStrictEqual([
+        ...skillToClone.learningMoreTutorialIds.toSorted().map((tutorialId) => ({ type: 'learningMore', skillId: 'clonedAcquisId', tutorialId, createdAt: expect.any(Date), updatedAt: expect.any(Date) })),
+        ...skillToClone.tutorialIds.map((tutorialId) => ({ type: 'understanding', skillId: 'clonedAcquisId', tutorialId, createdAt: expect.any(Date), updatedAt: expect.any(Date) })),
+      ]);
     });
   });
 });

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -1345,6 +1345,9 @@ describe('Application | Route | Skills', () => {
       databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
       databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
       databaseBuilder.factory.buildTube({ id: skillDataObject.tubeId, name: '@foo', thematicId: 'thematic1' });
+      databaseBuilder.factory.buildTutorial({ id: 'tutorialIdPersistant', title: 'title tuto1', duration: 'duration tuto1', source: 'source tuto1', format: 'format tuto1', link: 'link tuto1', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tutorialLMIdPersistant', title: 'title tuto2', duration: 'duration tuto2', source: 'source tuto2', format: 'format tuto2', link: 'link tuto2', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tutorialLMNewIdPersistant', title: 'title tuto3', duration: 'duration tuto3', source: 'source tuto3', format: 'format tuto3', link: 'link tuto3', locale: 'fr' });
       databaseBuilder.factory.buildSkill(skillDataObject);
 
       databaseBuilder.factory.buildTranslation({
@@ -1361,10 +1364,6 @@ describe('Application | Route | Skills', () => {
       await databaseBuilder.commit();
     });
 
-    afterEach(function() {
-      return knex('skills').delete();
-    });
-
     it('should patch skill', async () => {
       // Given
       const skillToUpdateFromAirtableScope = nock('https://api.airtable.com')
@@ -1375,7 +1374,7 @@ describe('Application | Route | Skills', () => {
       const skillPatched = {
         ...skillDataObject,
         hintStatus: skillPayload.data.attributes['clue-status'],
-        learningMoreTutorialIds: ['tutorialLMIdPersistant', 'recNewTuto'],
+        learningMoreTutorialIds: ['tutorialLMIdPersistant', 'tutorialLMNewIdPersistant'],
         learningMoreTutorialAirtableIds: ['tutorialLMAirtableId', 'tutorialLMNewAirtableId'],
         status: skillPayload.data.attributes.status,
         description: skillPayload.data.attributes.description,
@@ -1477,7 +1476,14 @@ describe('Application | Route | Skills', () => {
         locale: 'fr',
         value: 'new clue'
       }]);
+
+      await expect(knex.select('*').from('skills-tutorials').orderBy(['type', 'tutorialId'])).resolves.toStrictEqual([
+        { type: 'learningMore', skillId: 'skillIdPersistant', tutorialId: 'tutorialLMIdPersistant', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { type: 'learningMore', skillId: 'skillIdPersistant', tutorialId: 'tutorialLMNewIdPersistant', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { type: 'understanding', skillId: 'skillIdPersistant', tutorialId: 'tutorialIdPersistant', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
     });
+
     describe('when resources doesn\'t exists', () => {
       it('Should not patch and return 404 code', async () => {
         // Given

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -981,6 +981,13 @@ describe('Application | Route | Skills', () => {
     let airtableGetTubeScope, airtableGetSkillsScope, airtableCreateSkillScope, pixApiCacheScope, dataToPost;
 
     beforeEach(async () => {
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+      await databaseBuilder.commit();
+
       dataToPost = {
         level: 1,
         description: 'La description de mon nouvel acquis',
@@ -1044,6 +1051,7 @@ describe('Application | Route | Skills', () => {
         pixValue: 3,
         status: 'en construction',
         tubeAirtableId: dataToPost.tubeAirtableId,
+        tubeId: 'tube1',
         descriptionStatus: dataToPost.descriptionStatus,
         level: 1,
         internationalisation: dataToPost.internationalisation,
@@ -1102,7 +1110,8 @@ describe('Application | Route | Skills', () => {
     });
 
     afterEach(async () => {
-      await knex('translations').truncate();
+      await knex('skills').delete();
+      await knex('translations').delete();
     });
 
     it('should respond with status 201 and created skill', async () => {
@@ -1162,10 +1171,6 @@ describe('Application | Route | Skills', () => {
       });
 
       // then
-      expect(airtableGetTubeScope.isDone()).to.be.true;
-      expect(airtableGetSkillsScope.isDone()).to.be.true;
-      expect(airtableCreateSkillScope.isDone()).to.be.true;
-      expect(pixApiCacheScope.isDone()).to.be.true;
       expect(response.statusCode).toBe(201);
       expect(response.result).toEqual({
         data: {
@@ -1224,11 +1229,34 @@ describe('Application | Route | Skills', () => {
         }
       });
 
+      expect(airtableGetTubeScope.isDone()).to.be.true;
+      expect(airtableGetSkillsScope.isDone()).to.be.true;
+      expect(airtableCreateSkillScope.isDone()).to.be.true;
+      expect(pixApiCacheScope.isDone()).to.be.true;
+
+      await expect(knex.select('*').from('skills')).resolves.toStrictEqual([
+        {
+          id: 'nouvelAcquis',
+          description: 'La description de mon nouvel acquis',
+          descriptionStatus: 'Un statut de description pour mon nouvel acquis',
+          hintStatus: 'Le statut de l indice de mon nouvel acquis',
+          internationalisation: 'Internationalisation de mon nouvel acquis',
+          level: 1,
+          status: 'en construction',
+          tubeId: 'tube1',
+          version: 2,
+          activatedAt: null,
+          archivedAt: null,
+          obsoletedAt: null,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: 'skill.nouvelAcquis.hint', locale: 'en', value: 'L indice EN de mon nouvel acquis' },
         { key: 'skill.nouvelAcquis.hint', locale: 'fr', value: 'L indice de mon nouvel acquis' },
       ]);
-
     });
   });
 
@@ -1470,6 +1498,12 @@ describe('Application | Route | Skills', () => {
 
     beforeEach(async () => {
       // given
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+
       dataToPost = {
         level: 2,
         skillIdToClone: 'skill1Tube1',
@@ -1845,7 +1879,8 @@ describe('Application | Route | Skills', () => {
     });
 
     afterEach(async () => {
-      await knex('translations').truncate();
+      await knex('skills').delete();
+      await knex('translations').delete();
     });
 
     it('should respond with status 302 with cloned skill redirection', async () => {
@@ -1870,6 +1905,36 @@ describe('Application | Route | Skills', () => {
       });
 
       // then
+      expect(response.statusCode).toBe(302);
+      expect(response.headers.location).toBe('/api/skills/recClonedSkillAirtableId');
+
+      await expect(knex.select('*').from('skills').where('id', 'clonedAcquisId').first()).resolves.toStrictEqual({
+        description: 'skill description',
+        descriptionStatus: 'Validé',
+        hintStatus: 'Validé',
+        id: 'clonedAcquisId',
+        internationalisation: 'Monde',
+        level: 2,
+        status: 'en construction',
+        tubeId: 'tube1',
+        version: 2,
+        activatedAt: null,
+        archivedAt: null,
+        obsoletedAt: null,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+
+      await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
+        { key: 'challenge.clonedChallengeId.instruction', locale: 'fr', value: 'Juste une trad ?' },
+        { key: 'challenge.validatedChallengeProto.instruction', locale: 'fr', value: 'Juste une trad ?' },
+        { key: 'challenge.validatedChallengeProto.instruction', locale: 'nl', value: 'Slechts een vertaling ?' },
+        { key: 'skill.clonedAcquisId.hint', locale: 'en', value: 'AIRTABLE IS SO FUN OMG 🥰' },
+        { key: 'skill.clonedAcquisId.hint', locale: 'fr', value: 'C\'est chaud-nen' },
+        { key: 'skill.skill1Tube1.hint', locale: 'en', value: 'AIRTABLE IS SO FUN OMG 🥰' },
+        { key: 'skill.skill1Tube1.hint', locale: 'fr', value: 'C\'est chaud-nen' },
+      ]);
+
       expect(airtableGetTubeByIdScope.isDone()).to.be.true;
       expect(airtableGetSkillByIdScope.isDone()).to.be.true;
       expect(airtableGetTubeSkillsScope.isDone()).to.be.true;
@@ -1882,18 +1947,6 @@ describe('Application | Route | Skills', () => {
       expect(airtableCreateAttachmentsScope.isDone()).to.be.true;
       expect(pixApiCacheSkillUpdateScope.isDone()).to.be.true;
       expect(pixApiCacheChallengeUpdateScope.isDone()).to.be.true;
-      expect(response.statusCode).toBe(302);
-      expect(response.headers.location).toMatch('/api/skills/');
-
-      await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
-        { key: 'challenge.clonedChallengeId.instruction', locale: 'fr', value: 'Juste une trad ?' },
-        { key: 'challenge.validatedChallengeProto.instruction', locale: 'fr', value: 'Juste une trad ?' },
-        { key: 'challenge.validatedChallengeProto.instruction', locale: 'nl', value: 'Slechts een vertaling ?' },
-        { key: 'skill.clonedAcquisId.hint', locale: 'en', value: 'AIRTABLE IS SO FUN OMG 🥰' },
-        { key: 'skill.clonedAcquisId.hint', locale: 'fr', value: 'C\'est chaud-nen' },
-        { key: 'skill.skill1Tube1.hint', locale: 'en', value: 'AIRTABLE IS SO FUN OMG 🥰' },
-        { key: 'skill.skill1Tube1.hint', locale: 'fr', value: 'C\'est chaud-nen' },
-      ]);
     });
   });
 });

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -1350,7 +1350,7 @@ describe('Application | Route | Skills', () => {
     });
 
     afterEach(function() {
-      return knex('skills').truncate();
+      return knex('skills').delete();
     });
 
     it('should patch skill', async () => {

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -1328,6 +1328,13 @@ describe('Application | Route | Skills', () => {
         },
       };
 
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: skillDataObject.tubeId, name: '@foo', thematicId: 'thematic1' });
+      databaseBuilder.factory.buildSkill(skillDataObject);
+
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',
         key: 'skill.skillIdPersistant.hint',
@@ -1353,7 +1360,7 @@ describe('Application | Route | Skills', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, airtableSkill);
 
-      const airtableSkillPatched = airtableBuilder.factory.buildSkill({
+      const skillPatched = {
         ...skillDataObject,
         hintStatus: skillPayload.data.attributes['clue-status'],
         learningMoreTutorialIds: ['tutorialLMIdPersistant', 'recNewTuto'],
@@ -1362,7 +1369,9 @@ describe('Application | Route | Skills', () => {
         description: skillPayload.data.attributes.description,
         descriptionStatus: skillPayload.data.attributes['description-status'],
         internationalisation: skillPayload.data.attributes.i18n
-      });
+      };
+
+      const airtableSkillPatched = airtableBuilder.factory.buildSkill(skillPatched);
 
       const airtablePatchScope = nock('https://api.airtable.com')
         .patch('/v0/airtableBaseValue/Acquis/?', {
@@ -1428,12 +1437,26 @@ describe('Application | Route | Skills', () => {
       expect(airtablePatchScope.isDone()).toBe(true);
       expect(pixApiCacheScope.isDone()).toBe(true);
 
-      const translations = await knex('translations').select('key', 'locale', 'value').orderBy([{
-        column: 'key',
-        order: 'asc'
-      }, { column: 'locale', order: 'asc' }]);
+      await expect(knex.select('*').from('skills')).resolves.toStrictEqual([
+        {
+          id: skillPatched.id,
+          description: skillPatched.description,
+          descriptionStatus: skillPatched.descriptionStatus,
+          hintStatus: skillPatched.hintStatus,
+          internationalisation: skillPatched.internationalisation,
+          level: skillPatched.level,
+          status: skillPatched.status,
+          tubeId: skillPatched.tubeId,
+          version: skillPatched.version,
+          activatedAt: null,
+          archivedAt: null,
+          obsoletedAt: null,
+          createdAt: new Date(skillPatched.createdAt),
+          updatedAt: expect.any(Date),
+        },
+      ]);
 
-      expect(translations).to.deep.equal([{
+      await expect(knex('translations').select('key', 'locale', 'value').orderBy(['key', 'locale'])).resolves.toStrictEqual([{
         key: 'skill.skillIdPersistant.hint',
         locale: 'en',
         value: 'new clueEn'
@@ -1463,12 +1486,7 @@ describe('Application | Route | Skills', () => {
         expect(skillToUpdateFromAirtableScope.isDone()).toBe(true);
         expect(response.statusCode).to.equal(404);
 
-        const translations = await knex('translations').select('key', 'locale', 'value').orderBy([{
-          column: 'key',
-          order: 'asc'
-        }, { column: 'locale', order: 'asc' }]);
-
-        expect(translations).to.deep.equal([{
+        await expect(knex('translations').select('key', 'locale', 'value').orderBy(['key', 'locale'])).resolves.toStrictEqual([{
           key: 'skill.skillIdPersistant.hint',
           locale: 'en',
           value: 'Toot'

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -837,16 +837,25 @@ describe('Integration | Repository | skill-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(() => {
-      return knex('translations').truncate();
+    afterEach(async () => {
+      await knex('skills').delete();
+      await knex('translations').delete();
     });
 
-    it('should save new skill to Airtable and translations to DB', async () => {
+    it('should save new skill and translations', async () => {
       // given
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+      await databaseBuilder.commit();
+
       const skill = domainBuilder.buildSkill({
         airtableId: null,
+        tubeId: null,
       });
-      const airtableSkill = airtableBuilder.factory.buildSkill({ ...skill, airtableId: 'recSkillPouet' });
+      const airtableSkill = airtableBuilder.factory.buildSkill({ ...skill, airtableId: 'recSkillPouet', tubeId: 'tube1' });
       const createRecordSpy = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
         new Airtable.Record('Acquis', airtableSkill.id, airtableSkill),
       );
@@ -858,24 +867,48 @@ describe('Integration | Repository | skill-repository', () => {
       expect(createdSkill).toStrictEqual(domainBuilder.buildSkill({
         ...skill,
         airtableId: 'recSkillPouet',
+        tubeId: 'tube1',
       }));
       expect(createRecordSpy).toHaveBeenCalledWith(
         'Acquis',
+        { fields: {
+          'id persistant': skill.id,
+          'Statut de l\'indice': skill.hintStatus,
+          'Comprendre': skill.tutorialAirtableIds,
+          'En savoir plus': skill.learningMoreTutorialAirtableIds,
+          'Status': skill.status,
+          'Tube': [skill.tubeAirtableId],
+          'Description': skill.description,
+          'Statut de la description': skill.descriptionStatus,
+          'Level': skill.level,
+          'Internationalisation': skill.internationalisation,
+          'Version': skill.version,
+        } },
+      );
+
+      await expect(knex.select('*').from('skills')).resolves.toStrictEqual([
         {
-          fields: {
-            'id persistant': skill.id,
-            'Statut de l\'indice': skill.hintStatus,
-            'Comprendre': skill.tutorialAirtableIds,
-            'En savoir plus': skill.learningMoreTutorialAirtableIds,
-            'Status': skill.status,
-            'Tube': [skill.tubeAirtableId],
-            'Description': skill.description,
-            'Statut de la description': skill.descriptionStatus,
-            'Level': skill.level,
-            'Internationalisation': skill.internationalisation,
-            'Version': skill.version,
-          },
-        });
+          id: skill.id,
+          description: skill.description,
+          descriptionStatus: skill.descriptionStatus,
+          hintStatus: skill.hintStatus,
+          internationalisation: skill.internationalisation,
+          level: skill.level,
+          status: skill.status,
+          tubeId: 'tube1',
+          version: 1,
+          activatedAt: null,
+          archivedAt: null,
+          obsoletedAt: null,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
+      await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
+        { key: `skill.${skill.id}.hint`, locale: 'en', value: skill.hint_i18n.en },
+        { key: `skill.${skill.id}.hint`, locale: 'fr', value: skill.hint_i18n.fr },
+      ]);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -777,6 +777,16 @@ describe('Integration | Repository | skill-repository', () => {
           activatedAt: new Date('2023-11-06T18:08:00Z'),
           archivedAt: new Date('2023-12-07T18:08:00Z'),
           obsoletedAt: new Date('2024-01-08T18:08:00Z'),
+          description: null,
+          descriptionStatus: null,
+          hintStatus: null,
+          internationalisation: null,
+          level: null,
+          status: null,
+          tubeId: null,
+          version: null,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
         });
       });
 
@@ -811,6 +821,16 @@ describe('Integration | Repository | skill-repository', () => {
           activatedAt: new Date('2023-11-06T18:08:00Z'),
           archivedAt: new Date('2023-12-07T18:08:00Z'),
           obsoletedAt: null,
+          description: null,
+          descriptionStatus: null,
+          hintStatus: null,
+          internationalisation: null,
+          level: null,
+          status: null,
+          tubeId: null,
+          version: null,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
         });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, describe as context, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as skillRepository from '../../../../lib/infrastructure/repositories/skill-repository.js';
@@ -650,189 +650,88 @@ describe('Integration | Repository | skill-repository', () => {
 
     afterEach(async () => {
       await knex('skills').truncate();
-      return knex('translations').truncate();
+      await knex('translations').delete();
     });
 
-    it('should update the skill', async function() {
+    it('should save skill and translations', async () => {
       // given
-      const skillToSave = domainBuilder.buildSkill({
-        id: 'skillIdPersistant',
-        airtableId: 'skillAirtableId',
-        hintStatus: Skill.HINT_STATUSES.PROPOSE,
-        tutorialAirtableIds: ['tutorialAirtableId'],
-        learningMoreTutorialAirtableIds: ['learningMoreTutorialAirtableId'],
-        status: Skill.STATUSES.ACTIF,
-        tubeAirtableId: 'tubeAirtableId',
-        description: 'ma nouvelle description',
-        level: 4,
-        internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
-        version: 2,
-        hint_i18n: { fr: 'hint fr', en: 'hint en' },
-        activatedAt: new Date('2023-11-06T18:08:00Z'),
-        archivedAt: new Date('2023-12-07T18:08:00Z'),
-        obsoletedAt: new Date('2024-01-08T18:08:00Z'),
-      });
+      const skill = domainBuilder.buildSkill();
 
-      vi.spyOn(skillDatasource, 'update')
-        .mockImplementationOnce(() => ({
-          id: skillToSave.id,
-          airtableId: skillToSave.airtableId,
-          name: 'Nom computé depuis Airtable',
-          hintStatus: skillToSave.hintStatus,
-          tutorialIds: ['tutorialIdPersistant'],
-          tutorialAirtableIds: skillToSave.tutorialAirtableIds,
-          learningMoreTutorialIds: ['learningMoreTutorialIdPersistant'],
-          learningMoreTutorialAirtableIds: skillToSave.learningMoreTutorialAirtableIds,
-          pixValue: 789,
-          competenceId: 'competenceIdPersistant',
-          status: skillToSave.status,
-          tubeId: 'tubeIdPersistant',
-          tubeAirtableId: skillToSave.tubeAirtableId,
-          description: skillToSave.description,
-          level: skillToSave.level,
-          internationalisation: skillToSave.internationalisation,
-          version: skillToSave.version,
-          createdAt: new Date('2020-01-01'),
-          descriptionStatus: skillToSave.descriptionStatus,
-          challengeIds: ['someChallengeIdPersistant'],
-        }));
-
-      // when
-      await skillRepository.update(skillToSave);
-
-      // when
-      expect(skillDatasource.update).toHaveBeenCalledTimes(1);
-      expect(skillDatasource.update).toHaveBeenNthCalledWith(1, skillToSave);
-    });
-
-    it('should handle translations correctly', async function() {
-      // given
-      const skillAlterHintFrDeleteHintEn_A = domainBuilder.buildSkill({
-        id: 'skillIdPersistantA',
-        airtableId: 'skillAirtableIdA',
-        hint_i18n: { fr: 'hint après A FR', en: '' },
-      });
-      databaseBuilder.factory.buildTranslation({
-        key: 'skill.skillIdPersistantA.hint',
-        locale: 'fr',
-        value: 'hint avant A FR',
-      });
-      databaseBuilder.factory.buildTranslation({
-        key: 'skill.skillIdPersistantA.hint',
-        locale: 'en',
-        value: 'hint avant A EN',
-      });
-      const skillAddHint_B = domainBuilder.buildSkill({
-        id: 'skillIdPersistantB',
-        airtableId: 'skillAirtableIdB',
-        hint_i18n: { fr: 'nouveau hint B FR', en: '' },
-      });
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: skill.tubeId, name: '@foo', thematicId: 'thematic1' });
+      databaseBuilder.factory.buildSkill(skill);
+      databaseBuilder.factory.buildTranslation({ key: `skill.${skill.id}.hint`, locale: 'fr', value: skill.hint_i18n.fr });
+      databaseBuilder.factory.buildTranslation({ key: `skill.${skill.id}.hint`, locale: 'en', value: skill.hint_i18n.en });
       await databaseBuilder.commit();
 
-      vi.spyOn(skillDatasource, 'update')
-        .mockImplementationOnce(() => skillAlterHintFrDeleteHintEn_A)
-        .mockImplementationOnce(() => skillAddHint_B);
+      const expectedSkill = domainBuilder.buildSkill({
+        description: 'skill description new',
+        descriptionStatus: Skill.DESCRIPTION_STATUSES.A_RETRAVAILLER,
+        hintStatus: Skill.HINT_STATUSES.A_RETRAVAILLER,
+        hint_i18n: { fr: 'nouvel indice', en: 'new hint' },
+        internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+        status: Skill.STATUSES.EN_CONSTRUCTION,
+        archivedAt: new Date('2025-10-10T15:20:23Z'),
+        activatedAt: new Date('2025-10-11T15:20:23Z'),
+        obsoletedAt: new Date('2025-10-12T15:20:23Z'),
+      });
+
+      const airtableSkill = airtableBuilder.factory.buildSkill(expectedSkill);
+      const updateRecordSpy = vi.spyOn(airtable, 'updateRecord').mockResolvedValueOnce(
+        new Airtable.Record('Acquis', airtableSkill.id, airtableSkill),
+      );
 
       // when
-      await skillRepository.update(skillAlterHintFrDeleteHintEn_A);
-      await skillRepository.update(skillAddHint_B);
+      const updatedSkill = await skillRepository.update(expectedSkill);
 
-      // when
-      const allTranslations = await knex('translations').select('key', 'locale', 'value').orderBy('key', 'locale');
-      expect(allTranslations).toEqual([
+      // then
+      expect(updatedSkill).toStrictEqual(expectedSkill);
+      expect(updateRecordSpy).toHaveBeenCalledWith(
+        'Acquis',
         {
-          key: 'skill.skillIdPersistantA.hint',
-          locale: 'fr',
-          value: skillAlterHintFrDeleteHintEn_A.hint_i18n.fr,
-        },{
-          key: 'skill.skillIdPersistantB.hint',
-          locale: 'fr',
-          value: skillAddHint_B.hint_i18n.fr,
+          id: skill.airtableId,
+          fields: {
+            'id persistant': skill.id,
+            'Statut de l\'indice': expectedSkill.hintStatus,
+            'Status': expectedSkill.status,
+            'Description': expectedSkill.description,
+            'Statut de la description': expectedSkill.descriptionStatus,
+            'Level': expectedSkill.level,
+            'Internationalisation': expectedSkill.internationalisation,
+            'Version': expectedSkill.version,
+            'Tube': [skill.tubeAirtableId],
+            'Comprendre': skill.tutorialAirtableIds,
+            'En savoir plus': skill.learningMoreTutorialAirtableIds,
+          },
+        },
+      );
+
+      await expect(knex.select('*').from('skills')).resolves.toStrictEqual([
+        {
+          id: skill.id,
+          description: expectedSkill.description,
+          descriptionStatus: expectedSkill.descriptionStatus,
+          hintStatus: expectedSkill.hintStatus,
+          internationalisation: expectedSkill.internationalisation,
+          level: expectedSkill.level,
+          status: expectedSkill.status,
+          version: expectedSkill.version,
+          tubeId: skill.tubeId,
+          activatedAt: expectedSkill.activatedAt,
+          archivedAt: expectedSkill.archivedAt,
+          obsoletedAt: expectedSkill.obsoletedAt,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
         },
       ]);
-    });
-    context('PG', function() {
-      it('should insert the row in PG if it was not in it yet', async function() {
-        // given
-        const skillToSave = domainBuilder.buildSkill({
-          id: 'skillIdPersistant',
-          airtableId: 'skillAirtableId',
-          activatedAt: new Date('2023-11-06T18:08:00Z'),
-          archivedAt: new Date('2023-12-07T18:08:00Z'),
-          obsoletedAt: new Date('2024-01-08T18:08:00Z'),
-        });
 
-        vi.spyOn(skillDatasource, 'update')
-          .mockImplementationOnce(() => ({
-            id: skillToSave.id,
-            airtableId: skillToSave.airtableId,
-          }));
-
-        // when
-        await skillRepository.update(skillToSave);
-
-        // when
-        await expect(knex('skills').select('*').where({ id: 'skillIdPersistant' }).first()).resolves.toStrictEqual({
-          id: 'skillIdPersistant',
-          activatedAt: new Date('2023-11-06T18:08:00Z'),
-          archivedAt: new Date('2023-12-07T18:08:00Z'),
-          obsoletedAt: new Date('2024-01-08T18:08:00Z'),
-          description: null,
-          descriptionStatus: null,
-          hintStatus: null,
-          internationalisation: null,
-          level: null,
-          status: null,
-          tubeId: null,
-          version: null,
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        });
-      });
-
-      it('should update the row in PG if it was already in it', async function() {
-        // given
-        const skillToSave = domainBuilder.buildSkill({
-          id: 'skillIdPersistant',
-          airtableId: 'skillAirtableId',
-          activatedAt: new Date('2023-11-06T18:08:00Z'),
-          archivedAt: new Date('2023-12-07T18:08:00Z'),
-          obsoletedAt: null,
-        });
-        databaseBuilder.factory.buildSkill({
-          id: 'skillIdPersistant',
-          activatedAt: null,
-          archivedAt: null,
-          obsoletedAt: new Date('2024-01-08T18:08:00Z'),
-        });
-        await databaseBuilder.commit();
-        vi.spyOn(skillDatasource, 'update')
-          .mockImplementationOnce(() => ({
-            id: skillToSave.id,
-            airtableId: skillToSave.airtableId,
-          }));
-
-        // when
-        await skillRepository.update(skillToSave);
-
-        // when
-        await expect(knex('skills').select('*').where({ id: 'skillIdPersistant' }).first()).resolves.toStrictEqual({
-          id: 'skillIdPersistant',
-          activatedAt: new Date('2023-11-06T18:08:00Z'),
-          archivedAt: new Date('2023-12-07T18:08:00Z'),
-          obsoletedAt: null,
-          description: null,
-          descriptionStatus: null,
-          hintStatus: null,
-          internationalisation: null,
-          level: null,
-          status: null,
-          tubeId: null,
-          version: null,
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        });
-      });
+      await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
+        { key: `skill.${skill.id}.hint`, locale: 'en', value: expectedSkill.hint_i18n.en },
+        { key: `skill.${skill.id}.hint`, locale: 'fr', value: expectedSkill.hint_i18n.fr },
+      ]);
     });
   });
 
@@ -895,8 +794,8 @@ describe('Integration | Repository | skill-repository', () => {
           internationalisation: skill.internationalisation,
           level: skill.level,
           status: skill.status,
+          version: skill.version,
           tubeId: 'tube1',
-          version: 1,
           activatedAt: null,
           archivedAt: null,
           obsoletedAt: null,

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -737,23 +737,28 @@ describe('Integration | Repository | skill-repository', () => {
 
   describe('#create', () => {
     afterEach(async () => {
+      await knex('skills-tutorials').delete();
       await knex('skills').delete();
       await knex('translations').delete();
     });
 
     it('should save new skill and translations', async () => {
       // given
+      const skill = domainBuilder.buildSkill({
+        airtableId: null,
+        tubeId: null,
+      });
+
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
       databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
       databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
       databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
       databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+      [...skill.tutorialIds, ...skill.learningMoreTutorialIds].forEach((id) => databaseBuilder.factory.buildTutorial({
+        id, title: `title ${id}`, duration: `duration ${id}`, source: `source ${id}`, format: `format ${id}`, link: `link ${id}`, locale: 'fr',
+      }));
       await databaseBuilder.commit();
 
-      const skill = domainBuilder.buildSkill({
-        airtableId: null,
-        tubeId: null,
-      });
       const airtableSkill = airtableBuilder.factory.buildSkill({ ...skill, airtableId: 'recSkillPouet', tubeId: 'tube1' });
       const createRecordSpy = vi.spyOn(airtable, 'createRecord').mockResolvedValueOnce(
         new Airtable.Record('Acquis', airtableSkill.id, airtableSkill),
@@ -807,6 +812,11 @@ describe('Integration | Repository | skill-repository', () => {
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: `skill.${skill.id}.hint`, locale: 'en', value: skill.hint_i18n.en },
         { key: `skill.${skill.id}.hint`, locale: 'fr', value: skill.hint_i18n.fr },
+      ]);
+
+      await expect(knex.select('*').from('skills-tutorials').orderBy(['type', 'tutorialId'])).resolves.toStrictEqual([
+        ...skill.learningMoreTutorialIds.toSorted().map((tutorialId) => ({ type: 'learningMore', skillId: skill.id, tutorialId, createdAt: expect.any(Date), updatedAt: expect.any(Date) })),
+        ...skill.tutorialIds.map((tutorialId) => ({ type: 'understanding', skillId: skill.id, tutorialId, createdAt: expect.any(Date), updatedAt: expect.any(Date) })),
       ]);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -61,7 +61,6 @@ describe('Integration | Repository | skill-repository', () => {
 
       databaseBuilder.factory.buildSkill({
         id: 'skill1',
-        airtableId: 'recId1',
         activatedAt: new Date('2023-11-06T18:08:00Z'),
         archivedAt: new Date('2023-12-07T18:08:00Z'),
         obsoletedAt: new Date('2024-01-08T18:08:00Z'),
@@ -773,10 +772,8 @@ describe('Integration | Repository | skill-repository', () => {
         await skillRepository.update(skillToSave);
 
         // when
-        const skillInPG = await knex('skills').select('*').where({ id: 'skillIdPersistant' }).first();
-        expect(skillInPG).toStrictEqual({
+        await expect(knex('skills').select('*').where({ id: 'skillIdPersistant' }).first()).resolves.toStrictEqual({
           id: 'skillIdPersistant',
-          airtableId: 'skillAirtableId',
           activatedAt: new Date('2023-11-06T18:08:00Z'),
           archivedAt: new Date('2023-12-07T18:08:00Z'),
           obsoletedAt: new Date('2024-01-08T18:08:00Z'),
@@ -794,7 +791,6 @@ describe('Integration | Repository | skill-repository', () => {
         });
         databaseBuilder.factory.buildSkill({
           id: 'skillIdPersistant',
-          airtableId: 'skillAirtableId',
           activatedAt: null,
           archivedAt: null,
           obsoletedAt: new Date('2024-01-08T18:08:00Z'),
@@ -810,10 +806,8 @@ describe('Integration | Repository | skill-repository', () => {
         await skillRepository.update(skillToSave);
 
         // when
-        const skillInPG = await knex('skills').select('*').where({ id: 'skillIdPersistant' }).first();
-        expect(skillInPG).toStrictEqual({
+        await expect(knex('skills').select('*').where({ id: 'skillIdPersistant' }).first()).resolves.toStrictEqual({
           id: 'skillIdPersistant',
-          airtableId: 'skillAirtableId',
           activatedAt: new Date('2023-11-06T18:08:00Z'),
           archivedAt: new Date('2023-12-07T18:08:00Z'),
           obsoletedAt: null,

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -649,7 +649,7 @@ describe('Integration | Repository | skill-repository', () => {
   describe('#update', () => {
 
     afterEach(async () => {
-      await knex('skills').truncate();
+      await knex('skills').delete();
       await knex('translations').delete();
     });
 

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -647,21 +647,24 @@ describe('Integration | Repository | skill-repository', () => {
   });
 
   describe('#update', () => {
-
-    afterEach(async () => {
-      await knex('skills').delete();
-      await knex('translations').delete();
-    });
-
     it('should save skill and translations', async () => {
       // given
-      const skill = domainBuilder.buildSkill();
+      const skill = domainBuilder.buildSkill({
+        tutorialIds: ['tuto1', 'tuto2'],
+        tutorialAirtableIds: ['recTuto1', 'recTuto2'],
+        learningMoreTutorialIds: ['tuto3'],
+        learningMoreTutorialAirtableIds: ['recTuto3'],
+      });
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
       databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
       databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
       databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
       databaseBuilder.factory.buildTube({ id: skill.tubeId, name: '@foo', thematicId: 'thematic1' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto1', title: 'title tuto1', duration: 'duration tuto1', source: 'source tuto1', format: 'format tuto1', link: 'link tuto1', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto2', title: 'title tuto2', duration: 'duration tuto2', source: 'source tuto2', format: 'format tuto2', link: 'link tuto2', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto3', title: 'title tuto3', duration: 'duration tuto3', source: 'source tuto3', format: 'format tuto3', link: 'link tuto3', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto4', title: 'title tuto4', duration: 'duration tuto4', source: 'source tuto4', format: 'format tuto4', link: 'link tuto4', locale: 'fr' });
       databaseBuilder.factory.buildSkill(skill);
       databaseBuilder.factory.buildTranslation({ key: `skill.${skill.id}.hint`, locale: 'fr', value: skill.hint_i18n.fr });
       databaseBuilder.factory.buildTranslation({ key: `skill.${skill.id}.hint`, locale: 'en', value: skill.hint_i18n.en });
@@ -677,6 +680,10 @@ describe('Integration | Repository | skill-repository', () => {
         archivedAt: new Date('2025-10-10T15:20:23Z'),
         activatedAt: new Date('2025-10-11T15:20:23Z'),
         obsoletedAt: new Date('2025-10-12T15:20:23Z'),
+        tutorialIds: ['tuto2', 'tuto4'],
+        tutorialAirtableIds: ['recTuto2', 'recTuto4'],
+        learningMoreTutorialIds: ['tuto1', 'tuto2'],
+        learningMoreTutorialAirtableIds: ['recTuto1', 'recTuto2'],
       });
 
       const airtableSkill = airtableBuilder.factory.buildSkill(expectedSkill);
@@ -703,8 +710,8 @@ describe('Integration | Repository | skill-repository', () => {
             'Internationalisation': expectedSkill.internationalisation,
             'Version': expectedSkill.version,
             'Tube': [skill.tubeAirtableId],
-            'Comprendre': skill.tutorialAirtableIds,
-            'En savoir plus': skill.learningMoreTutorialAirtableIds,
+            'Comprendre': expectedSkill.tutorialAirtableIds,
+            'En savoir plus': expectedSkill.learningMoreTutorialAirtableIds,
           },
         },
       );
@@ -731,6 +738,11 @@ describe('Integration | Repository | skill-repository', () => {
       await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([
         { key: `skill.${skill.id}.hint`, locale: 'en', value: expectedSkill.hint_i18n.en },
         { key: `skill.${skill.id}.hint`, locale: 'fr', value: expectedSkill.hint_i18n.fr },
+      ]);
+
+      await expect(knex.select('*').from('skills-tutorials').orderBy(['type', 'tutorialId'])).resolves.toStrictEqual([
+        ...expectedSkill.learningMoreTutorialIds.toSorted().map((tutorialId) => ({ type: 'learningMore', skillId: skill.id, tutorialId, createdAt: expect.any(Date), updatedAt: expect.any(Date) })),
+        ...expectedSkill.tutorialIds.toSorted().map((tutorialId) => ({ type: 'understanding', skillId: skill.id, tutorialId, createdAt: expect.any(Date), updatedAt: expect.any(Date) })),
       ]);
     });
   });

--- a/api/tests/integration/scripts/migration-from-airtable/copy-skills-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-skills-from-airtable-to-pg_test.js
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Airtable from 'airtable';
+
+import { CopySkillsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-skills-from-airtable-to-pg.js';
+import { logger } from '../../../../lib/infrastructure/logger.js';
+import * as airtable from '../../../../lib/infrastructure/airtable.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
+import { Skill } from '../../../../lib/domain/models/Skill.js';
+
+const TABLE_NAME = 'skills';
+const TUTORIALS_RELATION_TABLE_NAME = 'skills-tutorials';
+const AIRTABLE_NAME = 'Acquis';
+
+describe('Integration | Scripts | CopySkillsFromAirtableToPg', () => {
+  /** @type {CopySkillsFromAirtableToPg} */
+  let script;
+
+  beforeEach(() => {
+    script = new CopySkillsFromAirtableToPg();
+  });
+
+  describe('#handle', () => {
+    afterEach(async () => {
+      await knex.delete().from(TUTORIALS_RELATION_TABLE_NAME);
+      await knex.delete().from(TABLE_NAME);
+    });
+
+    it('reads skills from airtable and saves these to postgres', async () => {
+      // given
+      const options = { dryRun: false };
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+        new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+          fields: {
+            'id persistant': 'skill1',
+            'Statut de l\'indice': Skill.HINT_STATUSES.ARCHIVE,
+            'Comprendre (id persistant)': ['tuto1'],
+            'En savoir plus (id persistant)': ['tuto2', 'tuto3'],
+            'Status': Skill.STATUSES.ARCHIVE,
+            'Tube (id persistant)': ['tube123'],
+            'Description': 'Un premier acquis',
+            'Level': 2,
+            'Internationalisation': Skill.INTERNATIONALISATIONS.FRANCE,
+            'Version': 2,
+            'Statut de la description': Skill.DESCRIPTION_STATUSES.ARCHIVE,
+          },
+          createdTime: '2025-10-14T00:00:00Z',
+        }),
+        new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+          fields: {
+            'id persistant': 'skill2',
+            'Statut de l\'indice': Skill.HINT_STATUSES.VALIDE,
+            'Comprendre (id persistant)': ['tuto2', 'tuto4'],
+            'En savoir plus (id persistant)': ['tuto3'],
+            'Status': Skill.STATUSES.ACTIF,
+            'Tube (id persistant)': ['tube456'],
+            'Description': 'Un deuxième acquis',
+            'Level': 6,
+            'Internationalisation': Skill.INTERNATIONALISATIONS.UNION_EUROPEENNE,
+            'Version': 3,
+            'Statut de la description': Skill.DESCRIPTION_STATUSES.VALIDE,
+          },
+          createdTime: '2025-10-14T13:58:00Z',
+        }),
+      ]);
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk123', name: 'Un référentiel' });
+      databaseBuilder.factory.buildArea({ id: 'area123', code: '1', frameworkId: 'recFmk123' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence123', index: '1.1', areaId: 'area123' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic123', index: 0, competenceId: 'competence123' });
+      databaseBuilder.factory.buildTube({ id: 'tube123', name: '@dvorak', index: 1, thematicId: 'thematic123' });
+      databaseBuilder.factory.buildTube({ id: 'tube456', name: '@qwerty', index: 2, thematicId: 'thematic123' });
+
+      databaseBuilder.factory.buildTutorial({ id: 'tuto1', title: 'title tuto1', format: 'format tuto1', duration: 'duration tuto1', source: 'source tuto1', link: 'link tuto1', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto2', title: 'title tuto2', format: 'format tuto2', duration: 'duration tuto2', source: 'source tuto2', link: 'link tuto2', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto3', title: 'title tuto3', format: 'format tuto3', duration: 'duration tuto3', source: 'source tuto3', link: 'link tuto3', locale: 'fr' });
+      databaseBuilder.factory.buildTutorial({ id: 'tuto4', title: 'title tuto4', format: 'format tuto4', duration: 'duration tuto4', source: 'source tuto4', link: 'link tuto4', locale: 'fr' });
+
+      databaseBuilder.factory.buildSkill({
+        id: 'skill1',
+        hintStatus: Skill.HINT_STATUSES.VALIDE,
+        tutorialIds: ['tuto1', 'tuto2'],
+        learningMoreTutorialIds: ['tuto4'],
+        status: Skill.STATUSES.ACTIF,
+        tubeId: 'tube456',
+        description: 'Ancienne description',
+        level: 3,
+        internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+        version: 1,
+        descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+      });
+      databaseBuilder.factory.buildSkill({
+        id: 'skill2',
+        activatedAt: '2025-10-14T17:06:00Z',
+        archivedAt: '2025-10-14T17:07:00Z',
+        obsoletedAt: '2025-10-14T17:08:00Z',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: [
+        'id persistant',
+        'Statut de l\'indice',
+        'Comprendre (id persistant)',
+        'En savoir plus (id persistant)',
+        'Status',
+        'Tube (id persistant)',
+        'Description',
+        'Level',
+        'Internationalisation',
+        'Version',
+        'Statut de la description',
+      ] });
+
+      await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+        {
+          id: 'skill1',
+          hintStatus: Skill.HINT_STATUSES.ARCHIVE,
+          status: Skill.STATUSES.ARCHIVE,
+          tubeId: 'tube123',
+          description: 'Un premier acquis',
+          level: 2,
+          internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+          version: 2,
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.ARCHIVE,
+          activatedAt: null,
+          archivedAt: null,
+          obsoletedAt: null,
+          createdAt: new Date('2025-10-14T00:00:00Z'),
+          updatedAt: expect.any(Date),
+        },
+        {
+          id: 'skill2',
+          hintStatus: Skill.HINT_STATUSES.VALIDE,
+          status: Skill.STATUSES.ACTIF,
+          tubeId: 'tube456',
+          description: 'Un deuxième acquis',
+          level: 6,
+          internationalisation: Skill.INTERNATIONALISATIONS.UNION_EUROPEENNE,
+          version: 3,
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+          activatedAt: new Date('2025-10-14T17:06:00Z'),
+          archivedAt: new Date('2025-10-14T17:07:00Z'),
+          obsoletedAt: new Date('2025-10-14T17:08:00Z'),
+          createdAt: new Date('2025-10-14T13:58:00Z'),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
+      await expect(knex.select('*').from(TUTORIALS_RELATION_TABLE_NAME).orderBy(['skillId', 'type', 'tutorialId'])).resolves.toStrictEqual([
+        { skillId: 'skill1', type: 'learningMore', tutorialId: 'tuto2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { skillId: 'skill1', type: 'learningMore', tutorialId: 'tuto3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { skillId: 'skill1', type: 'understanding', tutorialId: 'tuto1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { skillId: 'skill2', type: 'learningMore', tutorialId: 'tuto3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { skillId: 'skill2', type: 'understanding', tutorialId: 'tuto2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { skillId: 'skill2', type: 'understanding', tutorialId: 'tuto4', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
+    });
+
+    describe('when dryRun is true', () => {
+      it('reads skills from airtable and stops', async () => {
+        // given
+        const options = { dryRun: true };
+
+        const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
+          new Airtable.Record(AIRTABLE_NAME, 'rec123', {
+            fields: {
+              'id persistant': 'skill1',
+              'Statut de l\'indice': Skill.HINT_STATUSES.ARCHIVE,
+              'Comprendre (id persistant)': ['tuto1'],
+              'En savoir plus (id persistant)': ['tuto2', 'tuto3'],
+              'Status': Skill.STATUSES.ARCHIVE,
+              'Tube (id persistant)': ['tube123'],
+              'Description': 'Un premier acquis',
+              'Level': 2,
+              'Internationalisation': Skill.INTERNATIONALISATIONS.FRANCE,
+              'Version': 2,
+              'Statut de la description': Skill.DESCRIPTION_STATUSES.ARCHIVE,
+            },
+            createdTime: '2025-10-14T00:00:00Z',
+          }),
+          new Airtable.Record(AIRTABLE_NAME, 'rec456', {
+            fields: {
+              'id persistant': 'skill2',
+              'Statut de l\'indice': Skill.HINT_STATUSES.VALIDE,
+              'Comprendre (id persistant)': ['tuto2', 'tuto4'],
+              'En savoir plus (id persistant)': ['tuto3'],
+              'Status': Skill.STATUSES.ACTIF,
+              'Tube (id persistant)': ['tube456'],
+              'Description': 'Un deuxième acquis',
+              'Level': 6,
+              'Internationalisation': Skill.INTERNATIONALISATIONS.UNION_EUROPEENNE,
+              'Version': 3,
+              'Statut de la description': Skill.DESCRIPTION_STATUSES.VALIDE,
+            },
+            createdTime: '2025-10-14T13:58:00Z',
+          }),
+        ]);
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk123', name: 'Un référentiel' });
+        databaseBuilder.factory.buildArea({ id: 'area123', code: '1', frameworkId: 'recFmk123' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence123', index: '1.1', areaId: 'area123' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic123', index: 0, competenceId: 'competence123' });
+        databaseBuilder.factory.buildTube({ id: 'tube123', name: '@dvorak', index: 1, thematicId: 'thematic123' });
+        databaseBuilder.factory.buildTube({ id: 'tube456', name: '@qwerty', index: 2, thematicId: 'thematic123' });
+
+        databaseBuilder.factory.buildTutorial({ id: 'tuto1', title: 'title tuto1', format: 'format tuto1', duration: 'duration tuto1', source: 'source tuto1', link: 'link tuto1', locale: 'fr' });
+        databaseBuilder.factory.buildTutorial({ id: 'tuto2', title: 'title tuto2', format: 'format tuto2', duration: 'duration tuto2', source: 'source tuto2', link: 'link tuto2', locale: 'fr' });
+        databaseBuilder.factory.buildTutorial({ id: 'tuto3', title: 'title tuto3', format: 'format tuto3', duration: 'duration tuto3', source: 'source tuto3', link: 'link tuto3', locale: 'fr' });
+        databaseBuilder.factory.buildTutorial({ id: 'tuto4', title: 'title tuto4', format: 'format tuto4', duration: 'duration tuto4', source: 'source tuto4', link: 'link tuto4', locale: 'fr' });
+
+        databaseBuilder.factory.buildSkill({
+          id: 'skill1',
+          hintStatus: Skill.HINT_STATUSES.VALIDE,
+          tutorialIds: ['tuto1', 'tuto2'],
+          learningMoreTutorialIds: ['tuto4'],
+          status: Skill.STATUSES.ACTIF,
+          tubeId: 'tube456',
+          description: 'Ancienne description',
+          level: 3,
+          internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+          version: 1,
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+          createdAt: '2025-10-06T00:00:00Z',
+          updatedAt: '2025-10-06T10:00:00Z',
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'skill2',
+          activatedAt: '2025-10-14T17:06:00Z',
+          archivedAt: '2025-10-14T17:07:00Z',
+          obsoletedAt: '2025-10-14T17:08:00Z',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: [
+          'id persistant',
+          'Statut de l\'indice',
+          'Comprendre (id persistant)',
+          'En savoir plus (id persistant)',
+          'Status',
+          'Tube (id persistant)',
+          'Description',
+          'Level',
+          'Internationalisation',
+          'Version',
+          'Statut de la description',
+        ] });
+
+        await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
+          {
+            id: 'skill1',
+            hintStatus: Skill.HINT_STATUSES.VALIDE,
+            status: Skill.STATUSES.ACTIF,
+            tubeId: 'tube456',
+            description: 'Ancienne description',
+            level: 3,
+            internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+            version: 1,
+            descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+            activatedAt: null,
+            archivedAt: null,
+            obsoletedAt: null,
+            createdAt: new Date('2025-10-06T00:00:00Z'),
+            updatedAt: new Date('2025-10-06T10:00:00Z'),
+          },
+          {
+            id: 'skill2',
+            hintStatus: null,
+            status: null,
+            tubeId: null,
+            description: null,
+            level: null,
+            internationalisation: null,
+            version: null,
+            descriptionStatus: null,
+            activatedAt: new Date('2025-10-14T17:06:00Z'),
+            archivedAt: new Date('2025-10-14T17:07:00Z'),
+            obsoletedAt: new Date('2025-10-14T17:08:00Z'),
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          },
+        ]);
+
+        await expect(knex.select('*').from(TUTORIALS_RELATION_TABLE_NAME).orderBy(['skillId', 'type', 'tutorialId'])).resolves.toStrictEqual([
+          { skillId: 'skill1', type: 'learningMore', tutorialId: 'tuto4', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { skillId: 'skill1', type: 'understanding', tutorialId: 'tuto1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { skillId: 'skill1', type: 'understanding', tutorialId: 'tuto2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-skill.js
+++ b/api/tests/tooling/database-builder/factory/build-skill.js
@@ -1,18 +1,38 @@
 import { databaseBuffer } from '../database-buffer.js';
 
 export function buildSkill({
-  id = 'skill123',
-  activatedAt = null,
-  archivedAt = null,
-  obsoletedAt = null,
+  id,
+  status,
+  hintStatus,
+  descriptionStatus,
+  description,
+  level,
+  internationalisation,
+  version,
+  tubeId,
+  activatedAt,
+  archivedAt,
+  obsoletedAt,
+  createdAt,
+  updatedAt,
 } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'skills',
     values: {
       id,
+      status,
+      hintStatus,
+      descriptionStatus,
+      description,
+      level,
+      internationalisation,
+      version,
+      tubeId,
       activatedAt,
       archivedAt,
       obsoletedAt,
+      createdAt,
+      updatedAt,
     },
   });
 }

--- a/api/tests/tooling/database-builder/factory/build-skill.js
+++ b/api/tests/tooling/database-builder/factory/build-skill.js
@@ -10,13 +10,15 @@ export function buildSkill({
   internationalisation,
   version,
   tubeId,
+  tutorialIds,
+  learningMoreTutorialIds,
   activatedAt,
   archivedAt,
   obsoletedAt,
   createdAt,
   updatedAt,
 } = {}) {
-  return databaseBuffer.pushInsertable({
+  const skill = databaseBuffer.pushInsertable({
     tableName: 'skills',
     values: {
       id,
@@ -35,4 +37,15 @@ export function buildSkill({
       updatedAt,
     },
   });
+  tutorialIds?.forEach((tutorialId) => databaseBuffer.pushInsertable({
+    tableName: 'skills-tutorials',
+    autoId: false,
+    values: { skillId: id, tutorialId, type: 'understanding', createdAt, updatedAt },
+  }));
+  learningMoreTutorialIds?.forEach((tutorialId) => databaseBuffer.pushInsertable({
+    tableName: 'skills-tutorials',
+    autoId: false,
+    values: { skillId: id, tutorialId, type: 'learningMore', createdAt, updatedAt },
+  }));
+  return { ...skill, tutorialIds, learningMoreTutorialIds };
 }

--- a/api/tests/tooling/database-builder/factory/build-skill.js
+++ b/api/tests/tooling/database-builder/factory/build-skill.js
@@ -2,7 +2,6 @@ import { databaseBuffer } from '../database-buffer.js';
 
 export function buildSkill({
   id = 'skill123',
-  airtableId = 'recSkill123',
   activatedAt = null,
   archivedAt = null,
   obsoletedAt = null,
@@ -11,7 +10,6 @@ export function buildSkill({
     tableName: 'skills',
     values: {
       id,
-      airtableId,
       activatedAt,
       archivedAt,
       obsoletedAt,


### PR DESCRIPTION
## 🍂 Problème

On souhaite sortir d’Airtable.

## 🌰 Proposition

 - Mise à jour de la table `skills` et création de la table `skills-tutorials` dans Postgres
 - Écriture des acquis en double dans Airtable et Postgres
 - Création d’un script de migration des acquis existants (réexécutable)
 - Écriture des acquis dans Postgres dans les seeds

## 🍁 Remarques

N/A

## 🪵 Pour tester

Vérifier que les acquis, ainsi que leurs liens avec les tutos, sont bien dans Postgres avec les bonnes données.

 - Créer une compétence et vérifier que l’acquis workbench correspondant est bien dans Postgres
 - Créer un acquis en le rattachant à des tutos et vérifier qu’il est bien dans Postgres avec ses liens de tutos
 - Modifier l’acquis ainsi que ses tutos et vérifier que les modifs sont bien répercutées dans Postgres
 - Cloner l’acquis et vérifier que le nouvel acquis est bien dans Postgres avec ses liens de tutos