### PR TITLE
[BUGFIX] Correction ordre de tri des tags de tutos (PIX-19995)

### DIFF
--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -40,7 +40,7 @@ export async function getManyByAirtableIds(airtableIds) {
 export async function searchByTitle(title) {
   const [airtableDtos = [], pgDtos] = await Promise.all([
     tagDatasource.searchByTitle(title),
-    knex.select('*').from(TABLE_NAME).whereILike('title', `%${title}%`).orderBy('title').limit(4),
+    knex.select('*').from(TABLE_NAME).whereILike('title', `%${title}%`).orderByRaw('?? collate ??', ['title', 'fr-x-icu']).limit(4),
   ]);
 
   compareDtosLists(airtableDtos, pgDtos, compareTagDtos);

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -63,9 +63,9 @@ export async function findByTitle(title) {
 
 function compareTagDtos(airtableTag, pgTag) {
   const diff = [];
-  if (airtableTag.id !== pgTag.id) diff.push(`thematic airtable id "${airtableTag.id}" != postgres id "${pgTag.id}"`);
-  if (airtableTag.title !== pgTag.title) diff.push(`thematic airtable title "${airtableTag.title}" != postgres title "${pgTag.title}"`);
-  if (!areNullableValuesEqual(airtableTag.notes, pgTag.notes)) diff.push(`thematic airtable notes "${airtableTag.notes}" != postgres notes "${pgTag.notes}"`);
+  if (airtableTag.id !== pgTag.id) diff.push(`tag airtable id "${airtableTag.id}" != postgres id "${pgTag.id}"`);
+  if (airtableTag.title !== pgTag.title) diff.push(`tag airtable title "${airtableTag.title}" != postgres title "${pgTag.title}"`);
+  if (!areNullableValuesEqual(airtableTag.notes, pgTag.notes)) diff.push(`tag airtable notes "${airtableTag.notes}" != postgres notes "${pgTag.notes}"`);
   return diff;
 }
 

--- a/api/tests/acceptance/application/tags_test.js
+++ b/api/tests/acceptance/application/tags_test.js
@@ -305,15 +305,18 @@ describe('Application | Route | Tags', () => {
       context('when searching by titles', function() {
         it('should respond with status 200 and related tags, limited by 4 tags and sorted by title', async () => {
           // given
-          databaseBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', title: 'france' });
-          databaseBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' });
-          databaseBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'frontieRe' });
+          databaseBuilder.factory.buildTag({ id: 'tagId3', notes: 'une note', title: 'france' });
+          databaseBuilder.factory.buildTag({ id: 'tagId4', title: 'freT' });
+          databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'frontieRe' });
+          databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'ééééfréééé' });
+          databaseBuilder.factory.buildTag({ id: 'tagId5', title: 'FR' });
           await databaseBuilder.commit();
 
           const airtableTags = [
+            airtableBuilder.factory.buildTag({ id: 'tagId1', airtableId: 'tagAirtableId1', title: 'ééééfréééé' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId5', airtableId: 'tagAirtableId5', title: 'FR' }),
             airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', title: 'france' }),
             airtableBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' }),
-            airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'frontieRe' }),
           ];
           airtableSearchTagsScope = nock('https://api.airtable.com')
             .get('/v0/airtableBaseValue/Tags')
@@ -342,6 +345,22 @@ describe('Application | Route | Tags', () => {
             data: [
               {
                 type: 'tags',
+                id: 'tagAirtableId1',
+                attributes: {
+                  'pix-id': 'tagId1',
+                  'title': 'ééééfréééé',
+                },
+              },
+              {
+                type: 'tags',
+                id: 'tagAirtableId5',
+                attributes: {
+                  'pix-id': 'tagId5',
+                  'title': 'FR',
+                },
+              },
+              {
+                type: 'tags',
                 id: 'tagAirtableId3',
                 attributes: {
                   'pix-id': 'tagId3',
@@ -355,14 +374,6 @@ describe('Application | Route | Tags', () => {
                 attributes: {
                   'pix-id': 'tagId4',
                   'title': 'freT',
-                },
-              },
-              {
-                type: 'tags',
-                id: 'tagAirtableId2',
-                attributes: {
-                  'pix-id': 'tagId2',
-                  'title': 'frontieRe',
                 },
               },
             ],


### PR DESCRIPTION
## 🍂 Problème

Lors de la recherche de tags de tutos (limitée à 4 occurences), les tags remontés par Airtable et PG ne sont pas les mêmes.
Airtable effectue un tri insensible à la casse et aux accents.
PG est par défaut sur un tri sensible à la casse et aux accents.

## 🌰 Proposition

Corriger l’ordre de tri de PG.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Aller sur une modif de tuto et vérifier que la recherche de tags fonctionne toujours.