### PR TITLE
[BUGFIX] Correction type colonne `tutorials.link` (PIX-20010)

### DIFF
--- a/api/db/migrations/20251014083623_alter-tutorials-link-type.js
+++ b/api/db/migrations/20251014083623_alter-tutorials-link-type.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'tutorials';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.text('link').notNullable().alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.string('link').notNullable().alter();
+  });
+}


### PR DESCRIPTION
## 🍂 Problème

La colonne `tutorials.link` est trop petite pour stocker les liens de certains tutos d’intégration et de prod.

## 🌰 Proposition

Changer le type de la colonne pour pouvoir stocker les liens longs.

## 🍁 Remarques

N/A

## 🪵 Pour tester

N/A