### PR TITLE
[BUGFIX] Refaire fonctionner le bouton Traductions vers Phrase de la V1 (PIX-20009)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -55,7 +55,7 @@ export default class LocalizedController extends Controller {
   }
 
   get translationsUrl() {
-    return new URL(`${this.localizedChallenge.translations}/area-code/${this.competence.areaCode}`, window.location).href;
+    return new URL(`${this.localizedChallenge.translations}/framework-name/${this.competence.source}/area-code/${this.competence.areaCode}`, window.location).href;
   }
 
   get challengeRoute() {

--- a/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
@@ -72,7 +72,7 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     assert.dom(header).hasText(/Pas en prod/);
 
     const translationsLink = await screen.findByText('Traductions');
-    assert.ok(translationsLink.getAttribute('href').endsWith('/translations/en/area-code/1'), 'href ends with /translations/en/area-code/1');
+    assert.ok(translationsLink.getAttribute('href').endsWith('/translations/en/framework-name/Pix/area-code/1'), 'href ends with /translations/en/framework-name/Pix/area-code/1');
   });
 
   test('it should go back to the original challenge', async function(assert) {


### PR DESCRIPTION
## 🍂 Problème
Depuis l'introduction d'un nouveau référentiel dans Phrase, les liens qui mènent vers les traductions de Phrase ont changé. Cela a été répercuté sur le bouton d'action de la v2, mais pas sur celui de la v1

## 🌰 Proposition
Réparer le bouton de Traductions de la v1

## 🍁 Remarques
RAS

## 🪵 Pour tester
Aller sur le ref coeur, puis sur une épreuve traduite en v1, et survoler le bouton `Traductions`, et constater que l'url affichée en bas à gauche du navigateur se termine bien par `framework-name/Pix/area-code/1` (l'area-code n'est pas forcément 1, c'est pour l'exemple)