### PR TITLE
[BUGFIX] Réparer l'alignement du bouton dans la création/modification d'un tutoriel (PIX-20035)

### DIFF
--- a/pix-editor/app/styles/components/pop-in/tutorial.scss
+++ b/pix-editor/app/styles/components/pop-in/tutorial.scss
@@ -1,3 +1,14 @@
 .tutorial-pop-in {
   width: min(48rem, 100% - var(--pix-spacing-4x));
+
+  .pix-button {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .tutorial-form label.span-three {
+    align-items: center;
+    display: flex;
+  }
 }


### PR DESCRIPTION
## 🍂 Problème

Dans la création/modification d'un tutoriel, l'icône et le texte du bouton "Enregistrer" ne sont pas alignés.
Idem pour le bouton "Coup de coeur"

<img width="134" height="42" src="https://github.com/user-attachments/assets/6a8240dc-56d2-43e4-a6bc-affcee4bb753" />
<img width="145" height="52" src="https://github.com/user-attachments/assets/623de0b3-51b4-45ed-a25d-a9e5d1c75782" />

## 🌰 Proposition

Réaligner les deux

## 🪵 Pour tester

- Aller dans une compétence, vue "Acquis"
- Modifier la compétence
- Trouver la partie tutoriels
- Vérifier que les alignements sont OK en création et édition

<img width="128" height="48" src="https://github.com/user-attachments/assets/5afb05d9-e601-4a9a-85a3-822331c8c6a9" />
<img width="174" height="76" src="https://github.com/user-attachments/assets/40977a39-14b9-44cc-ab3a-c14e789f3838" />
