### PR TITLE
[FEATURE] Enlever les notes de la création de tutoriel (PIX-20030)

### DIFF
--- a/api/db/migrations/20251023131427_drop-notes-column-in-tags-table.js
+++ b/api/db/migrations/20251023131427_drop-notes-column-in-tags-table.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'tutorial_tags';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn('notes');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down() {
+  // no rollback
+}

--- a/api/db/seeds/data/tags.js
+++ b/api/db/seeds/data/tags.js
@@ -20,7 +20,6 @@ export function buildTag({ title, index, databaseBuilder }) {
     id: tagId,
     title,
     description: `description for ${tagId}`,
-    notes: `notes for ${tagId}`,
     skillAirtableIds: [],
     tutorialAirtableIds: [],
   };
@@ -37,7 +36,7 @@ export async function persistTags({ items, airtableClient, logger }) {
 }
 
 export async function copyTutorialTagsFromAirtable({ airtableClient, databaseBuilder, logger }) {
-  const airtableTutorialTags = await  airtableClient.table('Tags').select({ fields: ['id persistant', 'Nom', 'Notes'] }).all();
+  const airtableTutorialTags = await  airtableClient.table('Tags').select({ fields: ['id persistant', 'Nom'] }).all();
 
   logger.info(`Copying ${airtableTutorialTags.length} tutorial tags from airtable...`);
 
@@ -45,7 +44,6 @@ export async function copyTutorialTagsFromAirtable({ airtableClient, databaseBui
     databaseBuilder.factory.buildTag({
       id: record.get('id persistant'),
       title: record.get('Nom'),
-      notes: record.get('Notes'),
       createdAt: record._rawJson.createdTime,
       updatedAt: new Date(),
     });

--- a/api/lib/application/tags.js
+++ b/api/lib/application/tags.js
@@ -24,7 +24,6 @@ export function register(server) {
               type: Joi.string().required().equal('tags'),
               attributes: {
                 'title': Joi.string().required(),
-                'notes': Joi.string().allow(null),
               },
             },
           }),

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -1,8 +1,7 @@
 export class Tag {
-  constructor({ id, airtableId, title, notes }) {
+  constructor({ id, airtableId, title }) {
     this.id = id;
     this.airtableId = airtableId;
     this.title = title;
-    this.notes = notes;
   }
 }

--- a/api/lib/infrastructure/datasources/airtable/tag-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tag-datasource.js
@@ -10,7 +10,6 @@ export const tagDatasource = datasource.extend({
   usedFields: [
     'id persistant',
     'Nom',
-    'Notes',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -18,7 +17,6 @@ export const tagDatasource = datasource.extend({
       id: airtableRecord.get('id persistant'),
       airtableId: airtableRecord.id,
       title: airtableRecord.get('Nom'),
-      notes: airtableRecord.get('Notes'),
     };
   },
 
@@ -27,7 +25,6 @@ export const tagDatasource = datasource.extend({
       fields: {
         'id persistant': model.id,
         Nom: model.title,
-        Notes: model.notes,
       },
     };
     if (model.airtableId) airtableObject.id = model.airtableId;

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -2,7 +2,7 @@ import { Tag } from '../../domain/models/index.js';
 import { tagDatasource } from '../datasources/airtable/index.js';
 import { generateNewId } from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { areNullableValuesEqual, compareDtos, compareDtosLists } from './migration-from-airtable.js';
+import { compareDtos, compareDtosLists } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'tutorial_tags';
 
@@ -10,7 +10,7 @@ export async function create(tag) {
   tag.id = generateNewId('tag');
   const [datasourceTag] = await Promise.all([
     tagDatasource.create(tag),
-    knex(TABLE_NAME).insert({ id: tag.id, title: tag.title, notes: tag.notes }),
+    knex(TABLE_NAME).insert({ id: tag.id, title: tag.title }),
   ]);
   return toDomain(datasourceTag);
 }
@@ -65,7 +65,6 @@ function compareTagDtos(airtableTag, pgTag) {
   const diff = [];
   if (airtableTag.id !== pgTag.id) diff.push(`tag airtable id "${airtableTag.id}" != postgres id "${pgTag.id}"`);
   if (airtableTag.title !== pgTag.title) diff.push(`tag airtable title "${airtableTag.title}" != postgres title "${pgTag.title}"`);
-  if (!areNullableValuesEqual(airtableTag.notes, pgTag.notes)) diff.push(`tag airtable notes "${airtableTag.notes}" != postgres notes "${pgTag.notes}"`);
   return diff;
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/tag-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tag-serializer.js
@@ -7,14 +7,12 @@ const serializer = new Serializer('tag', {
   attributes: [
     'pixId',
     'title',
-    'notes',
   ],
   transform(tag) {
     return {
       id: tag.airtableId,
       pixId: tag.id,
       title: tag.title,
-      notes: tag.notes,
     };
   },
 });

--- a/api/scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg.js
@@ -24,14 +24,13 @@ export class CopyTutorialTagsFromAirtableToPg extends Script {
     logger.info({ dryRun: options.dryRun }, 'Script options');
 
     const airtableTutorialTags = await airtable.findRecords('Tags', {
-      fields: ['id persistant', 'Nom', 'Notes'],
+      fields: ['id persistant', 'Nom'],
     });
     logger.info({ count: airtableTutorialTags.length }, 'Loaded tutorial tags from airtable');
 
     const tutorialTags = airtableTutorialTags.map((record) => ({
       id: record.get('id persistant'),
       title: record.get('Nom'),
-      notes: record.get('Notes'),
       createdAt: record._rawJson.createdTime,
       updatedAt: knex.fn.now(),
     }));

--- a/api/tests/acceptance/application/tags_test.js
+++ b/api/tests/acceptance/application/tags_test.js
@@ -31,8 +31,7 @@ describe('Application | Route | Tags', () => {
             data: {
               type: 'tags',
               attributes: {
-                'title': 'Internet',
-                'notes': 'une note',
+                'title': 'Internet'
               },
             },
           },
@@ -57,8 +56,7 @@ describe('Application | Route | Tags', () => {
             data: {
               type: 'tags',
               attributes: {
-                'titlee': 'Internet',
-                'notes': 'une note',
+                'titlee': 'Internet'
               },
             },
           },
@@ -101,8 +99,7 @@ describe('Application | Route | Tags', () => {
             data: {
               type: 'tags',
               attributes: {
-                'title': 'FRUITS',
-                'notes': 'une note',
+                'title': 'FRUITS'
               },
             },
           },
@@ -132,14 +129,13 @@ describe('Application | Route | Tags', () => {
           });
         const generateNewId = vi.spyOn(idGenerator, 'generateNewId');
         generateNewId.mockReturnValue('tagId2');
-        const createdAirtableTag = airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'Internet', notes: 'une note' });
+        const createdAirtableTag = airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'Internet' });
         airtableCreateTagScope = nock('https://api.airtable.com')
           .post('/v0/airtableBaseValue/Tags/', {
             records: [{
               fields: {
                 'id persistant': 'tagId2',
-                'Nom': 'Internet',
-                'Notes': 'une note',
+                'Nom': 'Internet'
               },
             }],
           })
@@ -156,8 +152,7 @@ describe('Application | Route | Tags', () => {
             data: {
               type: 'tags',
               attributes: {
-                'title': 'Internet',
-                'notes': 'une note',
+                'title': 'Internet'
               },
             },
           },
@@ -172,8 +167,7 @@ describe('Application | Route | Tags', () => {
             id: 'tagAirtableId2',
             attributes: {
               'pix-id': 'tagId2',
-              'title': 'Internet',
-              'notes': 'une note',
+              'title': 'Internet'
             },
           },
         });
@@ -183,7 +177,6 @@ describe('Application | Route | Tags', () => {
         await expect(knex('tutorial_tags').select().first()).resolves.toEqual({
           id: 'tagId2',
           title: 'Internet',
-          notes: 'une note',
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
         });
@@ -239,14 +232,12 @@ describe('Application | Route | Tags', () => {
         databaseBuilder.factory.buildTag({
           id: 'tagId1',
           title: 'Fruits',
-          notes: 'une note',
         });
         await databaseBuilder.commit();
         const airtableTag = airtableBuilder.factory.buildTag({
           id: 'tagId1',
           airtableId: 'tagAirtableId1',
           title: 'Fruits',
-          notes: 'une note',
         });
         airtableGetTagScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Tags/tagAirtableId1')
@@ -271,7 +262,6 @@ describe('Application | Route | Tags', () => {
             attributes: {
               'pix-id': 'tagId1',
               'title': 'Fruits',
-              'notes': 'une note',
             },
           },
         });
@@ -305,7 +295,7 @@ describe('Application | Route | Tags', () => {
       context('when searching by titles', function() {
         it('should respond with status 200 and related tags, limited by 4 tags and sorted by title', async () => {
           // given
-          databaseBuilder.factory.buildTag({ id: 'tagId3', notes: 'une note', title: 'france' });
+          databaseBuilder.factory.buildTag({ id: 'tagId3', title: 'france' });
           databaseBuilder.factory.buildTag({ id: 'tagId4', title: 'freT' });
           databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'frontieRe' });
           databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'ééééfréééé' });
@@ -315,7 +305,7 @@ describe('Application | Route | Tags', () => {
           const airtableTags = [
             airtableBuilder.factory.buildTag({ id: 'tagId1', airtableId: 'tagAirtableId1', title: 'ééééfréééé' }),
             airtableBuilder.factory.buildTag({ id: 'tagId5', airtableId: 'tagAirtableId5', title: 'FR' }),
-            airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', title: 'france' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', title: 'france' }),
             airtableBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' }),
           ];
           airtableSearchTagsScope = nock('https://api.airtable.com')
@@ -365,7 +355,6 @@ describe('Application | Route | Tags', () => {
                 attributes: {
                   'pix-id': 'tagId3',
                   'title': 'france',
-                  'notes': 'une note',
                 },
               },
               {
@@ -385,13 +374,13 @@ describe('Application | Route | Tags', () => {
       context('when searching by ids', function() {
         it('should respond with status 200 and related tags', async () => {
           // given
-          databaseBuilder.factory.buildTag({ id: 'tagId3', notes: 'une note', title: 'france' });
+          databaseBuilder.factory.buildTag({ id: 'tagId3', title: 'france' });
           databaseBuilder.factory.buildTag({ id: 'tagId4', title: 'freT' });
           databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'frontieRe' });
           await databaseBuilder.commit();
 
           const airtableTags = [
-            airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', notes: 'une note', title: 'france' }),
+            airtableBuilder.factory.buildTag({ id: 'tagId3', airtableId: 'tagAirtableId3', title: 'france' }),
             airtableBuilder.factory.buildTag({ id: 'tagId4', airtableId: 'tagAirtableId4', title: 'freT' }),
             airtableBuilder.factory.buildTag({ id: 'tagId2', airtableId: 'tagAirtableId2', title: 'frontieRe' }),
           ];
@@ -425,7 +414,6 @@ describe('Application | Route | Tags', () => {
                 attributes: {
                   'pix-id': 'tagId3',
                   'title': 'france',
-                  'notes': 'une note',
                 },
               },
               {

--- a/api/tests/integration/scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg_test.js
@@ -31,7 +31,6 @@ describe('Integration | Scripts | CopyTutorialTagsFromAirtableToPg', () => {
           fields: {
             'id persistant': 'tag123',
             Nom: '@azerty',
-            Notes: 'notes de tag',
           },
           createdTime: '2025-10-06T00:00:00Z',
         }),
@@ -39,7 +38,6 @@ describe('Integration | Scripts | CopyTutorialTagsFromAirtableToPg', () => {
           fields: {
             'id persistant': 'tag456',
             Nom: '@qwerty',
-            Notes: 'autres notes de tag',
           },
           createdTime: '2025-10-06T13:58:00Z',
         }),
@@ -49,20 +47,18 @@ describe('Integration | Scripts | CopyTutorialTagsFromAirtableToPg', () => {
       await script.handle({ options, logger });
 
       // then
-      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Nom', 'Notes'] });
+      expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Nom'] });
 
       await expect(knex.select('*').from(TABLE_NAME).orderBy('createdAt')).resolves.toStrictEqual([
         {
           id: 'tag123',
           title: '@azerty',
-          notes: 'notes de tag',
           createdAt: new Date('2025-10-06T00:00:00Z'),
           updatedAt: expect.any(Date),
         },
         {
           id: 'tag456',
           title: '@qwerty',
-          notes: 'autres notes de tag',
           createdAt: new Date('2025-10-06T13:58:00Z'),
           updatedAt: expect.any(Date),
         },
@@ -79,7 +75,6 @@ describe('Integration | Scripts | CopyTutorialTagsFromAirtableToPg', () => {
             fields: {
               'id persistant': 'tag123',
               Nom: '@azerty',
-              Notes: 'notes de tag',
             },
             createdTime: '2025-10-06T00:00:00Z',
           }),
@@ -87,17 +82,16 @@ describe('Integration | Scripts | CopyTutorialTagsFromAirtableToPg', () => {
             fields: {
               'id persistant': 'tag456',
               Nom: '@qwerty',
-              Notes: 'autres notes de tag',
             },
             createdTime: '2025-10-06T13:58:00Z',
           }),
         ]);
-        
+
         // when
         await script.handle({ options, logger });
 
         // then
-        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Nom', 'Notes'] });
+        expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, { fields: ['id persistant', 'Nom'] });
 
         await expect(knex.select('*').from(TABLE_NAME)).resolves.toStrictEqual([]);
       });

--- a/api/tests/tooling/airtable-builder/factory/build-tag.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tag.js
@@ -3,14 +3,12 @@ export function buildTag(
     id,
     airtableId = id,
     title,
-    notes,
   } = {}) {
   return {
     id: airtableId,
     'fields': {
       'id persistant': id,
       'Nom': title,
-      'Notes': notes,
     },
   };
 }

--- a/api/tests/tooling/database-builder/factory/build-tag.js
+++ b/api/tests/tooling/database-builder/factory/build-tag.js
@@ -1,9 +1,9 @@
 import { databaseBuffer } from '../database-buffer.js';
 
-export function buildTag({ id, title, notes, createdAt, updatedAt } = {}) {
+export function buildTag({ id, title, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'tutorial_tags',
     autoId: false,
-    values: { id, title, notes, createdAt, updatedAt },
+    values: { id, title, createdAt, updatedAt },
   });
 }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/tag-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/tag-serializer_test.js
@@ -9,8 +9,7 @@ describe('Unit | Serializer | JSONAPI | tag-serializer', () => {
       const tag = new Tag({
         id: 'recTag1',
         airtableId: 'recAirtable1',
-        title: 'Internet',
-        notes: 'une note',
+        title: 'Internet'
       });
 
       // when
@@ -23,7 +22,6 @@ describe('Unit | Serializer | JSONAPI | tag-serializer', () => {
           id: 'recAirtable1',
           attributes: {
             title: 'Internet',
-            notes: 'une note',
             'pix-id': 'recTag1',
           },
         },
@@ -37,7 +35,6 @@ describe('Unit | Serializer | JSONAPI | tag-serializer', () => {
       const id = 'recAirtableTag1';
       const attributes = {
         'title': 'Internet',
-        'notes': 'une note',
       };
       const payload = {
         data: {
@@ -55,7 +52,6 @@ describe('Unit | Serializer | JSONAPI | tag-serializer', () => {
         id: null,
         airtableId: 'recAirtableTag1',
         title: 'Internet',
-        notes: 'une note',
       }));
     });
   });

--- a/pix-editor/app/components/form/tutorial.gjs
+++ b/pix-editor/app/components/form/tutorial.gjs
@@ -11,17 +11,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import { eq } from 'ember-truth-helpers';
 
-function parseTitleAndNotes(query) {
-  const hasNote = query.includes('[');
-
-  if (!hasNote) {
-    return { title: query, notes: null };
-  }
-
-  const [, title, notes] = query.match(/^(.+?)\[(.+?)\]/);
-  return { title, notes };
-}
-
 function formattedOptionList(list) {
   return list.map((option) => ({ label: option, value: option }));
 }
@@ -98,7 +87,7 @@ export default class TutorialForm extends Component {
     })
       .then((tags) => {
         const results = tags.map((tag) => ({ label: tag.get('title'), value: tag.get('id') }));
-        results.push({ label: 'Ajouter', description: 'Créer un tag[note]', value: 'create' });
+        results.push({ label: 'Ajouter', description: 'Créer un tag', value: 'create' });
         return results;
       });
   }
@@ -134,11 +123,8 @@ export default class TutorialForm extends Component {
     const shouldCreate = selectedTagIds.includes('create');
     if (shouldCreate) {
       try {
-        const { title, notes } = parseTitleAndNotes(this.currentQuery);
-        const storedTag = await this.store.createRecord('tag', {
-          title,
-          notes,
-        }).save();
+        const title = this.currentQuery;
+        const storedTag = await this.store.createRecord('tag', { title }).save();
         tags.push(storedTag);
         this.tagListOptions.push({ label: storedTag.title, value: storedTag.id });
       } catch (err) {

--- a/pix-editor/app/models/tag.js
+++ b/pix-editor/app/models/tag.js
@@ -2,6 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TagModel extends Model {
   @attr title;
-  @attr notes;
   @attr pixId;
 }

--- a/pix-editor/mirage/factories/tag.js
+++ b/pix-editor/mirage/factories/tag.js
@@ -3,5 +3,4 @@ import { Factory } from 'miragejs';
 export default Factory.extend({
   title: 'mon tag',
   description: 'description',
-  notes: 'ma note',
 });


### PR DESCRIPTION
## 🍂 Problème

Aujourd’hui des notes sont saisissable à la création d’un nouveau tag pour les tutos. Ces notes ne sont ensuite plus consultables depuis pixEditor. Elles ne sont pas utilisées par le métier. 

## 🌰 Proposition

Supprimer le fait de pouvoir renseigner des notes au niveau des tags des tutos

## 🪵 Pour tester

- Aller dans une compétence, vue "Acquis"
- Modifier l’acquis
- Trouver la partie tutoriels
- Créer un tag, vérifier que la création de note ne peut plus se faire