### PR TITLE
[TECH] Double lecture des compétences (PIX-19945)

### DIFF
--- a/api/lib/domain/models/Competence.js
+++ b/api/lib/domain/models/Competence.js
@@ -9,6 +9,7 @@ export class Competence {
     thematicIds,
     thematicAirtableIds,
     tubeAirtableIds,
+    tubeIds,
     skillIds,
     name_i18n,
     description_i18n,
@@ -22,6 +23,7 @@ export class Competence {
     this.thematicIds = thematicIds;
     this.thematicAirtableIds = thematicAirtableIds;
     this.tubeAirtableIds = tubeAirtableIds;
+    this.tubeIds = tubeIds;
     this.skillIds = skillIds;
     this.name_i18n = name_i18n;
     this.description_i18n = description_i18n;

--- a/api/lib/domain/usecases/create-competence.js
+++ b/api/lib/domain/usecases/create-competence.js
@@ -15,16 +15,13 @@ import * as idGenerator from '../../infrastructure/utils/id-generator.js';
 import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 export async function createCompetence(competence) {
-  const [area, competences] = await Promise.all([
-    areaRepository.getByAirtableId(competence.areaAirtableId),
-    competenceRepository.listByAreaAirtableId(competence.areaAirtableId),
-  ]);
+  const area = await areaRepository.getByAirtableId(competence.areaAirtableId);
 
   if (!area) {
     throw new BadRequestError('unknown area');
   }
 
-  const indexInArea = (competences?.length ?? 0) + 1;
+  const indexInArea = (area.competenceIds?.length ?? 0) + 1;
   competence.index = `${area.code}.${indexInArea}`;
 
   const createdCompetence = await competenceRepository.create(competence);

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -17,6 +17,7 @@ export const competenceDatasource = datasource.extend({
     'Thematiques (id persistant)',
     'Origine2',
     'Tubes',
+    'Tubes (id persistant)',
   ],
 
   sortField: 'Sous-domaine',
@@ -33,6 +34,7 @@ export const competenceDatasource = datasource.extend({
       thematicAirtableIds: airtableRecord.get('Thematiques') ?? [],
       origin: airtableRecord.get('Origine2')[0],
       tubeAirtableIds: airtableRecord.get('Tubes') ?? [],
+      tubeIds: airtableRecord.get('Tubes (id persistant)') ?? [],
     };
   },
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -1,4 +1,3 @@
-import { stringValue } from '../../airtable.js';
 import { datasource } from './datasource.js';
 
 export const competenceDatasource = datasource.extend({
@@ -46,9 +45,5 @@ export const competenceDatasource = datasource.extend({
         Domaine: [competence.areaAirtableId],
       }
     };
-  },
-
-  async listByAreaAirtableId(areaAirtableId) {
-    return this.filter({ filter: { formula: `Domaine = ${stringValue(areaAirtableId)}` } });
   },
 });

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -6,7 +6,7 @@ import * as competenceTranslations from '../translations/competence.js';
 import { Competence } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { areArrayEquals, compareDtosLists } from './migration-from-airtable.js';
+import { areArrayEquals, compareDtos, compareDtosLists } from './migration-from-airtable.js';
 
 const model = 'competence';
 const TABLE_NAME = 'competences';
@@ -36,12 +36,17 @@ export async function getMany(ids) {
 }
 
 export async function get(id) {
-  const [[competenceDTO], translations] = await Promise.all([
+  const [[airtableDto], pgDto, translations] = await Promise.all([
     competenceDatasource.filter({ filter: { ids: [id] } }),
+    selectCompetences().where('competences.id', id).first(),
     translationRepository.listByEntity(model, id),
   ]);
-  if (!competenceDTO) return null;
-  return toDomain(competenceDTO, translations);
+
+  compareDtos(airtableDto, pgDto, compareCompetenceDtos);
+
+  if (!airtableDto) return null;
+
+  return toDomain(airtableDto, translations);
 }
 
 export async function getByAirtableId(airtableId) {

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -50,10 +50,17 @@ export async function get(id) {
 }
 
 export async function getByAirtableId(airtableId) {
-  const competenceDTO = await competenceDatasource.find(airtableId);
-  if (!competenceDTO) return null;
-  const translations = await translationRepository.listByEntity(model, competenceDTO.id);
-  return toDomain(competenceDTO, translations);
+  const airtableDto = await competenceDatasource.find(airtableId);
+  if (!airtableDto) return null;
+
+  const [pgDto, translations] = await Promise.all([
+    selectCompetences().where('competences.id', airtableDto.id).first(),
+    translationRepository.listByEntity(model, airtableDto.id),
+  ]);
+
+  compareDtos(airtableDto, pgDto, compareCompetenceDtos);
+
+  return toDomain(airtableDto, translations);
 }
 
 export async function listByAreaAirtableId(areaAirtableId) {

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -63,12 +63,6 @@ export async function getByAirtableId(airtableId) {
   return toDomain(airtableDto, translations);
 }
 
-export async function listByAreaAirtableId(areaAirtableId) {
-  const competenceDTOs = await competenceDatasource.listByAreaAirtableId(areaAirtableId);
-  const translations = await translationRepository.listByEntities(model, competenceDTOs.map(({ id }) => id));
-  return toDomainList(competenceDTOs, translations);
-}
-
 export async function create(competence) {
   competence.id = idGenerator.generateNewId('competence');
 

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -6,24 +6,33 @@ import * as competenceTranslations from '../translations/competence.js';
 import { Competence } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { areArrayEquals, compareDtosLists } from './migration-from-airtable.js';
 
 const model = 'competence';
 const TABLE_NAME = 'competences';
 
 export async function list() {
-  const [datasourceCompetences, translations] = await Promise.all([
+  const [airtableDtos, pgDtos, translations] = await Promise.all([
     competenceDatasource.list(),
+    selectCompetences().orderBy('competences.index'),
     translationRepository.listByModel(model),
-  ]) ;
-  return toDomainList(datasourceCompetences, translations);
+  ]);
+
+  compareDtosLists(airtableDtos, pgDtos, compareCompetenceDtos);
+
+  return toDomainList(airtableDtos, translations);
 }
 
 export async function getMany(ids) {
-  const [datasourceCompetences, translations] = await Promise.all([
+  const [airtableDtos, pgDtos, translations] = await Promise.all([
     competenceDatasource.filter({ filter: { ids } }),
+    selectCompetences().whereIn('competences.id').orderBy('competences.index'),
     translationRepository.listByEntities(model, ids),
   ]);
-  return toDomainList(datasourceCompetences, translations);
+
+  compareDtosLists(airtableDtos, pgDtos, compareCompetenceDtos);
+
+  return toDomainList(airtableDtos, translations);
 }
 
 export async function get(id) {
@@ -76,6 +85,52 @@ export async function update(competence) {
   await translationRepository.save({ translations });
 
   return competence;
+}
+
+function selectCompetences() {
+  return knex.select(
+    'competences.*',
+    'frameworks.name as origin',
+    knex.raw(
+      'coalesce((??), \'[]\') as "thematicIds"',
+      knex
+        .select(knex.raw('json_agg(??)', 'thematics.id'))
+        .from('thematics')
+        .where('thematics.competenceId', '=', knex.ref('competences.id')),
+    ),
+    knex.raw(
+      'coalesce((??), \'[]\') as "tubeIds"',
+      knex
+        .select(knex.raw('json_agg(??)', 'tubes.id'))
+        .from('thematics')
+        .join('tubes', 'tubes.thematicId', 'thematics.id')
+        .where('thematics.competenceId', '=', knex.ref('competences.id')),
+    ),
+    knex.raw(
+      'coalesce((??), \'[]\') as "skillIds"',
+      knex
+        .select(knex.raw('json_agg(??)', 'skills.id'))
+        .from('thematics')
+        .join('tubes', 'tubes.thematicId', 'thematics.id')
+        .join('skills', 'skills.tubeId', 'tubes.id')
+        .where('thematics.competenceId', '=', knex.ref('competences.id')),
+    ),
+  )
+    .from('competences')
+    .join('areas', 'areas.id', 'competences.areaId')
+    .join('frameworks', 'frameworks.id', 'areas.frameworkId');
+}
+
+function compareCompetenceDtos(airtableCompetence, pgCompetence) {
+  const diff = [];
+  if (airtableCompetence.id !== pgCompetence.id) diff.push(`competence airtable id "${airtableCompetence.id}" != postgres id "${pgCompetence.id}"`);
+  if (airtableCompetence.index !== pgCompetence.index) diff.push(`competence airtable index "${airtableCompetence.index}" != postgres index "${pgCompetence.index}"`);
+  if (airtableCompetence.areaId !== pgCompetence.areaId) diff.push(`competence airtable areaId "${airtableCompetence.areaId}" != postgres areaId "${pgCompetence.areaId}"`);
+  if (airtableCompetence.origin !== pgCompetence.origin) diff.push(`competence airtable origin "${airtableCompetence.origin}" != postgres origin "${pgCompetence.origin}"`);
+  if (!areArrayEquals(airtableCompetence.thematicIds, pgCompetence.thematicIds)) diff.push(`competence airtable thematicIds "${airtableCompetence.thematicIds}" != postgres thematicIds "${pgCompetence.thematicIds}"`);
+  if (!areArrayEquals(airtableCompetence.tubeIds, pgCompetence.tubeIds)) diff.push(`competence airtable tubeIds "${airtableCompetence.tubeIds}" != postgres tubeIds "${pgCompetence.tubeIds}"`);
+  if (!areArrayEquals(airtableCompetence.skillIds, pgCompetence.skillIds)) diff.push(`competence airtable skillIds "${airtableCompetence.skillIds}" != postgres skillIds "${pgCompetence.skillIds}"`);
+  return diff;
 }
 
 function toDomainList(datasourceCompetences, translations) {

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -26,7 +26,7 @@ export async function list() {
 export async function getMany(ids) {
   const [airtableDtos, pgDtos, translations] = await Promise.all([
     competenceDatasource.filter({ filter: { ids } }),
-    selectCompetences().whereIn('competences.id').orderBy('competences.index'),
+    selectCompetences().whereIn('competences.id', ids).orderBy('competences.index'),
     translationRepository.listByEntities(model, ids),
   ]);
 

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -24,53 +24,91 @@ describe('Acceptance | Route | competences', () => {
     let airtableCompetencesScope;
 
     beforeEach(async () => {
-      const airtableCompetences = [
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+      const competences = [
+        {
           id: 'competence1',
           airtableId: 'recCompetence1',
           index: '1.1',
           areaAirtableId: 'recArea1',
+          areaId: 'area1',
           origin: 'Pix',
           thematicAirtableIds: ['recThematic1', 'recThematic2'],
+          thematicIds: ['thematic1', 'thematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2', 'recTube3', 'recTube4', 'recTube5'],
-        })),
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+          tubeIds: ['tube1', 'tube2', 'tube3', 'tube4', 'tube5'],
+          skillAirtableIds: [],
+          skillIds: [],
+        },
+        {
           id: 'competence11',
           airtableId: 'recCompetence11',
           index: '1.1',
           areaAirtableId: 'recArea11',
+          areaId: 'area11',
           origin: 'Pix Junior',
           thematicAirtableIds: ['recThematic11', 'recThematic12'],
+          thematicIds: ['thematic11', 'thematic12'],
           tubeAirtableIds: ['recTube11', 'recTube12', 'recTube13'],
-        })),
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+          tubeIds: ['tube11', 'tube12', 'tube13'],
+          skillAirtableIds: [],
+          skillIds: [],
+        },
+        {
           id: 'competence2',
           airtableId: 'recCompetence2',
           index: '1.2',
           areaAirtableId: 'recArea1',
+          areaId: 'area1',
           origin: 'Pix',
           thematicAirtableIds: ['recThematic3'],
+          thematicIds: ['thematic3'],
           tubeAirtableIds: ['recTube6', 'recTube7'],
-        })),
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+          tubeIds: ['tube6', 'tube7'],
+          skillAirtableIds: [],
+          skillIds: [],
+        },
+        {
           id: 'competence12',
           airtableId: 'recCompetence12',
           index: '1.2',
           areaAirtableId: 'recArea11',
+          areaId: 'area11',
           origin: 'Pix Junior',
           thematicAirtableIds: ['recThematic13', 'recThematic14'],
+          thematicIds: ['thematic13', 'thematic14'],
           tubeAirtableIds: ['recTube14', 'recTube15', 'recTube16', 'recTube17'],
-        })),
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+          tubeIds: ['tube14', 'tube15', 'tube16', 'tube17'],
+          skillAirtableIds: [],
+          skillIds: [],
+        },
+        {
           id: 'competence3',
           airtableId: 'recCompetence3',
           index: '2.1',
           areaAirtableId: 'recArea2',
+          areaId: 'area2',
           origin: 'Pix',
           thematicAirtableIds: ['recThematic4', 'recThematic5'],
+          thematicIds: ['thematic4', 'thematic5'],
           tubeAirtableIds: ['recTube8', 'recTube9'],
-        })),
+          tubeIds: ['tube8', 'tube9'],
+          skillAirtableIds: [],
+          skillIds: [],
+        },
       ];
+
+      databaseBuilder.factory.buildFramework({ id: 'pix', name: 'Pix' });
+      databaseBuilder.factory.buildFramework({ id: 'junior', name: 'Pix Junior' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'pix' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'pix' });
+      databaseBuilder.factory.buildArea({ id: 'area11', code: '1', frameworkId: 'junior' });
+      competences.forEach((competence) => {
+        databaseBuilder.factory.buildCompetence(competence);
+        competence.thematicIds.forEach((id) => databaseBuilder.factory.buildThematic({ id, competenceId: competence.id }));
+        competence.tubeIds.forEach((id, index) => databaseBuilder.factory.buildTube({ id, name: `@${id}`, thematicId: competence.thematicIds[index % competence.thematicIds.length] }));
+      });
+
+      const airtableCompetences = competences.map((competence) => airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject(competence)));
 
       airtableCompetencesScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Competences')

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -340,15 +340,28 @@ describe('Acceptance | Route | competences', () => {
     let airtableCompetence, airtableCompetenceScope;
 
     beforeEach(async () => {
-      airtableCompetence = airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+      const competence = {
         id: 'competence2',
         airtableId: 'recCompetence2',
         index: '1.2',
+        areaId: 'area1',
         areaAirtableId: 'recArea1',
         origin: 'Pix',
         thematicAirtableIds: ['recThematic3'],
+        thematicIds: ['thematic3'],
         tubeAirtableIds: ['recTube6', 'recTube7'],
-      }));
+        tubeIds: ['tube6', 'tube7'],
+        skillAirtableIds: [],
+        skillIds: [],
+      };
+
+      databaseBuilder.factory.buildFramework({ id: 'pix', name: 'Pix' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'pix' });
+      databaseBuilder.factory.buildCompetence(competence);
+      competence.thematicIds.forEach((id) => databaseBuilder.factory.buildThematic({ id, competenceId: competence.id }));
+      competence.tubeIds.forEach((id, index) => databaseBuilder.factory.buildTube({ id, name: `@${id}`, thematicId: competence.thematicIds[index % competence.thematicIds.length] }));
+
+      airtableCompetence = airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject(competence));
 
       airtableCompetenceScope = nock('https://api.airtable.com')
         .get(`/v0/airtableBaseValue/Competences/${airtableCompetence.id}`)
@@ -847,7 +860,7 @@ describe('Acceptance | Route | competences', () => {
     let airtableCompetence, airtableCompetenceScope, pixApiCacheScope;
 
     beforeEach(async () => {
-      airtableCompetence = airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+      const competence = {
         id: 'competence4',
         airtableId: 'recCompetence4',
         index: '2.2',
@@ -857,8 +870,18 @@ describe('Acceptance | Route | competences', () => {
         thematicIds: ['thematic9'],
         thematicAirtableIds: ['recThematic9'],
         tubeAirtableIds: ['recTube8', 'recTube9'],
-        skillIds: ['skill7', 'skill8', 'skill8'],
-      }));
+        tubeIds: ['tube8', 'tube9'],
+        skillIds: ['skill7', 'skill8', 'skill9'],
+      };
+
+      databaseBuilder.factory.buildFramework({ id: 'pix', name: 'Pix' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'pix' });
+      databaseBuilder.factory.buildCompetence(competence);
+      competence.thematicIds.forEach((id) => databaseBuilder.factory.buildThematic({ id, competenceId: competence.id }));
+      competence.tubeIds.forEach((id, index) => databaseBuilder.factory.buildTube({ id, name: `@${id}`, thematicId: competence.thematicIds[index % competence.thematicIds.length] }));
+      competence.skillIds.forEach((id, index) => databaseBuilder.factory.buildSkill({ id, tubeId: competence.tubeIds[index % competence.tubeIds.length] }));
+
+      airtableCompetence = airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject(competence));
 
       airtableCompetenceScope = nock('https://api.airtable.com')
         .get(`/v0/airtableBaseValue/Competences/${airtableCompetence.id}`)
@@ -883,7 +906,7 @@ describe('Acceptance | Route | competences', () => {
           id: 'competence4',
           index: '2.2',
           areaId: 'area2',
-          skillIds: ['skill7', 'skill8', 'skill8'],
+          skillIds: ['skill7', 'skill8', 'skill9'],
           thematicIds: ['thematic9'],
           origin: 'Pix',
           name_i18n: {

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -457,7 +457,6 @@ describe('Acceptance | Route | competences', () => {
 
   describe('POST /competences', async () => {
     let airtableAreaScope;
-    let airtableCompetencesScope;
     let airtableCreateCompetenceScope;
     let airtableCreateThematicScope;
     let airtableCreateTubeScope;
@@ -488,24 +487,6 @@ describe('Acceptance | Route | competences', () => {
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk' });
       databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk1' });
       databaseBuilder.factory.buildCompetence({ id: 'competence3', index: '2.1', areaId: 'area2' });
-
-      const airtableCompetences = [
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
-          id: 'competence3',
-          airtableId: 'recCompetence3',
-          index: '2.1',
-          areaAirtableId: 'recArea2',
-        })),
-      ];
-
-      airtableCompetencesScope = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Competences')
-        .query({
-          fields: { '': competenceDatasource.usedFields },
-          filterByFormula: 'Domaine = "recArea2"',
-        })
-        .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-        .reply(200, { records: airtableCompetences });
 
       const airtableCompetence = airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
         id: 'competence4',
@@ -846,7 +827,6 @@ describe('Acceptance | Route | competences', () => {
       ]);
 
       expect(airtableAreaScope.isDone()).toBe(true);
-      expect(airtableCompetencesScope.isDone()).toBe(true);
       expect(airtableCreateCompetenceScope.isDone()).toBe(true);
       expect(airtableCreateThematicScope.isDone()).toBe(true);
       expect(airtableCreateTubeScope.isDone()).toBe(true);

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -31,7 +31,16 @@ describe('Acceptance | Route | competence-overviews', () => {
       databaseBuilder.factory.buildCompetence({ id: competenceId, index: '2.2', areaId: 'area1' });
 
       const airtableCompetences = [
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({ id: competenceId, airtableId: 'recAirtableCompetence1', index: '2.2' })),
+        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+          id: competenceId,
+          airtableId: 'recAirtableCompetence1',
+          index: '2.2',
+          origin: 'Fmk 1',
+          areaId: 'area1',
+          thematicIds: ['recThematic1', 'recThematic2', 'recThematic3', 'recThematic4'],
+          tubeIds: ['recTube1', 'recTube2', 'recTube3', 'recTube4', 'recTube5', 'recTube6'],
+          skillIds: ['recSkill1', 'recSkill2', 'recSkill3', 'recSkill4', 'recSkill5'],
+        })),
       ];
       databaseBuilder.factory.buildTranslation({
         key: 'competence.recCompetence1.name',
@@ -496,7 +505,16 @@ describe('Acceptance | Route | competence-overviews', () => {
       databaseBuilder.factory.buildCompetence({ id: competenceId, index: '2.2', areaId: 'area1' });
 
       const airtableCompetences = [
-        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({ id: competenceId, airtableId: 'recAirtableCompetence1', index: '2.2' })),
+        airtableBuilder.factory.buildCompetence(domainBuilder.buildCompetenceDatasourceObject({
+          id: competenceId,
+          airtableId: 'recAirtableCompetence1',
+          index: '2.2',
+          origin: 'Fmk 1',
+          areaId: 'area1',
+          thematicIds: ['recThematic1', 'recThematic2', 'recThematic3', 'recThematicWorkbench'],
+          tubeIds: ['recTube1', 'recTube2', 'recTube3', 'recTube4', 'recTubeWorkbench'],
+          skillIds: ['recSkill1', 'recSkill2', 'recSkill3', 'recSkill4', 'recSkill5', 'recSkill6', 'recSkill7', 'recSkillWorkbench'],
+        })),
       ];
       databaseBuilder.factory.buildTranslation({
         key: 'competence.recCompetence1.name',

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -47,7 +47,7 @@ async function mockCurrentContent() {
         nl: 'Nom de la Compétence - nl',
       },
       areaId: 'recArea0',
-      origin: 'Pix',
+      origin: 'Nom du referentiel',
       skillIds: ['recSkill0'],
       thematicIds: ['recThematic0'],
       description_i18n: {
@@ -264,7 +264,7 @@ async function mockCurrentContent() {
       ...expectedCurrentContent.challenges[0],
       files: attachments.map(({ id: fileId, localizedChallengeId }) => ({ fileId, localizedChallengeId }))
     })],
-    competences: [buildCompetence(expectedCurrentContent.competences[0])],
+    competences: [buildCompetence({ ...expectedCurrentContent.competences[0], tubeIds: [expectedCurrentContent.tubes[0].id] })],
     frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],
     skills: [buildSkill(expectedCurrentContent.skills[0])],
     thematics: [buildThematic({ ...expectedCurrentContent.thematics[0], airtableId: expectedCurrentContent.thematics[0].id + 'Airtable' })],
@@ -451,7 +451,7 @@ async function mockContentForRelease() {
       id: 'recCompetence0',
       index: '1.1',
       areaId: 'recArea0',
-      origin: 'Pix',
+      origin: 'Nom du referentiel',
       skillIds: ['recSkill0'],
       thematicIds: ['recThematic0'],
       name_i18n: {
@@ -693,11 +693,11 @@ async function mockContentForRelease() {
         version: 8,
       }),
     ],
-    competences: [buildCompetence(expectedCurrentContent.competences[0])],
+    competences: [buildCompetence({ ...expectedCurrentContent.competences[0], tubeIds: [expectedCurrentContent.tubes[0].id] })],
     frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],
     skills: [buildSkill(expectedCurrentContent.skills[0])],
-    thematics: [buildThematic({ ...expectedCurrentContent.thematics[0], airtableId: expectedCurrentContent.thematics[0] + 'Airtable' })],
-    tubes: [buildTube({ ...expectedCurrentContent.tubes[0], thematicAirtableId: expectedCurrentContent.thematics[0] + 'Airtable' })],
+    thematics: [buildThematic(expectedCurrentContent.thematics[0])],
+    tubes: [buildTube(expectedCurrentContent.tubes[0])],
     tutorials: expectedCurrentContent.tutorials.map(buildTutorial),
   });
 

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -84,20 +84,24 @@ async function mockCurrentContent() {
       fr: 'Description française',
       en: 'Description anglaise',
     },
+    skillIds: ['recSkill1'],
+    origin: 'Nom du referentiel',
   }));
   expectedCurrentContent.competences = [expectedCompetence];
 
   const expectedThematic = omit(['airtableId', 'competenceAirtableId', 'tubeAirtableIds'], domainBuilder.buildThematic({
+    id: 'recThematic1',
     name_i18n: {
       fr: 'Thématique en fr',
       en: 'Thematic in en',
     },
     competenceId: expectedCompetence.id,
-    tubeIds: ['tubeTIddrkopID23Fp'],
+    tubeIds: ['recTube1'],
   }));
   expectedCurrentContent.thematics = [expectedThematic];
 
   const expectedTube = omit(['airtableId', 'index', 'competenceAirtableId', 'skillAirtableIds', 'thematicAirtableId'], domainBuilder.buildTube({
+    id: 'recTube1',
     thematicId: expectedThematic.id,
     competenceId: expectedCompetence.id,
     skillIds: ['recSkill1'],
@@ -266,11 +270,11 @@ async function mockCurrentContent() {
   expectedCurrentContent.skills.forEach(databaseBuilder.factory.buildSkill);
 
   airtableBuilder.mockLists({
-    frameworks: [buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] })],
-    areas: [buildArea(expectedCurrentContent.areas[0])],
-    competences: [buildCompetence(expectedCurrentContent.competences[0])],
-    thematics: [buildThematic(expectedCurrentContent.thematics[0])],
-    tubes: [buildTube({ ...expectedCurrentContent.tubes[0], competenceId: expectedCompetence.id, skillIds: [expectedCurrentContent.skills[0].id] })],
+    frameworks: [buildFramework({ ...expectedFramework, areaIds: [expectedArea.id] })],
+    areas: [buildArea(expectedArea)],
+    competences: [buildCompetence({ ...expectedCompetence, tubeIds: [expectedTube.id] })],
+    thematics: [buildThematic(expectedThematic)],
+    tubes: [buildTube({ ...expectedTube, competenceId: expectedCompetence.id, skillIds: [baseSkill.id] })],
     skills: [buildSkill(expectedCurrentContent.skills[0])],
     challenges: [buildChallenge({
       ...expectedChallenge,

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -75,7 +75,7 @@ async function mockCurrentContent() {
   const expectedArea = new AreaForReplication({ name: area.name, ...area });
   expectedCurrentContent.areas = [{ ...expectedArea }];
 
-  const expectedCompetence = omit(['airtableId', 'thematicAirtableIds', 'tubeAirtableIds', 'areaAirtableId'], domainBuilder.buildCompetence({
+  const expectedCompetence = omit(['airtableId', 'thematicAirtableIds', 'tubeAirtableIds', 'tubeIds', 'areaAirtableId'], domainBuilder.buildCompetence({
     name_i18n: {
       fr: 'Français',
       en: 'English',

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -15,8 +15,8 @@ describe('Integration | Repository | competence-repository', () => {
   describe('#list', () => {
     it('should return the list of all competences', async () => {
       // given
-      const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns([
-        airtableBuilder.factory.buildCompetence({
+      const competences = [
+        {
           id: 'competence1',
           index: '1.1',
           origin: 'Pix',
@@ -27,8 +27,8 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic1', 'thematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2'],
           tubeIds: ['tube1', 'tube2'],
-        }),
-        airtableBuilder.factory.buildCompetence({
+        },
+        {
           id: 'competence2',
           index: '1.2',
           origin: 'Pix',
@@ -39,8 +39,22 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic3', 'thematic4'],
           tubeAirtableIds: ['recTube3', 'recTube4'],
           tubeIds: ['tube3', 'tube4'],
-        }),
-      ]).activate().nockScope;
+        },
+      ];
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Pix' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk1' });
+      competences.forEach((competence) => {
+        databaseBuilder.factory.buildCompetence(competence);
+        competence.thematicIds.forEach((id) => databaseBuilder.factory.buildThematic({ id, competenceId: competence.id }));
+        competence.tubeIds.forEach((id, index) => databaseBuilder.factory.buildTube({ id, name: `@${id}`, thematicId: competence.thematicIds[index % competence.thematicIds.length] }));
+        competence.skillIds.forEach((id, index) => databaseBuilder.factory.buildSkill({ id, tubeId: competence.tubeIds[index % competence.tubeIds.length] }));
+      });
+
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns(
+        competences.map((competence) => airtableBuilder.factory.buildCompetence(competence)),
+      ).activate().nockScope;
 
       databaseBuilder.factory.buildTranslation({
         key: 'competence.competence1.name',
@@ -86,10 +100,10 @@ describe('Integration | Repository | competence-repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const competences = await competenceRepository.list();
+      const actualCompetences = await competenceRepository.list();
 
       // then
-      expect(competences).toEqual([
+      expect(actualCompetences).toEqual([
         domainBuilder.buildCompetence({
           id: 'competence1',
           airtableId: 'competence1',

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -26,6 +26,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicAirtableIds: ['recThematic1', 'recThematic2'],
           thematicIds: ['thematic1', 'thematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2'],
+          tubeIds: ['tube1', 'tube2'],
         }),
         airtableBuilder.factory.buildCompetence({
           id: 'competence2',
@@ -37,6 +38,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicAirtableIds: ['recThematic3', 'recThematic4'],
           thematicIds: ['thematic3', 'thematic4'],
           tubeAirtableIds: ['recTube3', 'recTube4'],
+          tubeIds: ['tube3', 'tube4'],
         }),
       ]).activate().nockScope;
 
@@ -99,6 +101,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic1', 'thematic2'],
           thematicAirtableIds: ['recThematic1', 'recThematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2'],
+          tubeIds: ['tube1', 'tube2'],
           name_i18n: {
             fr: 'Nom compétence 1',
             en: 'Competence 1 name',
@@ -119,6 +122,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic3', 'thematic4'],
           thematicAirtableIds: ['recThematic3', 'recThematic4'],
           tubeAirtableIds: ['recTube3', 'recTube4'],
+          tubeIds: ['tube3', 'tube4'],
           name_i18n: {
             fr: 'Nom compétence 2',
             en: 'Competence 2 name',
@@ -148,6 +152,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicAirtableIds: ['recThematic1', 'recThematic2'],
           thematicIds: ['thematic1', 'thematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2'],
+          tubeIds: ['tube1', 'tube2'],
         }),
         airtableBuilder.factory.buildCompetence({
           id: 'competence2',
@@ -159,6 +164,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicAirtableIds: ['recThematic3', 'recThematic4'],
           thematicIds: ['thematic3', 'thematic4'],
           tubeAirtableIds: ['recTube3', 'recTube4'],
+          tubeIds: ['tube3', 'tube4'],
         }),
       ]).activate().nockScope;
 
@@ -231,6 +237,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic1', 'thematic2'],
           thematicAirtableIds: ['recThematic1', 'recThematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2'],
+          tubeIds: ['tube1', 'tube2'],
           name_i18n: {
             fr: 'Nom compétence 1',
             en: 'Competence 1 name',
@@ -251,6 +258,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic3', 'thematic4'],
           thematicAirtableIds: ['recThematic3', 'recThematic4'],
           tubeAirtableIds: ['recTube3', 'recTube4'],
+          tubeIds: ['tube3', 'tube4'],
           name_i18n: {
             fr: 'Nom compétence 2',
             en: 'Competence 2 name',
@@ -281,6 +289,7 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic3', 'thematic4'],
           thematicAirtableIds: ['recThematic3', 'recThematic4'],
           tubeAirtableIds: ['recTube1', 'recTube2', 'recTube3'],
+          tubeIds: ['tube1', 'tube2', 'tube3'],
         }),
       ]).activate().nockScope;
 
@@ -342,6 +351,7 @@ describe('Integration | Repository | competence-repository', () => {
         thematicIds: ['thematic3', 'thematic4'],
         thematicAirtableIds: ['recThematic3', 'recThematic4'],
         tubeAirtableIds: ['recTube1', 'recTube2', 'recTube3'],
+        tubeIds: ['tube1', 'tube2', 'tube3'],
         name_i18n: {
           fr: 'Nom compétence 2',
           en: 'Competence 2 name',
@@ -454,6 +464,7 @@ describe('Integration | Repository | competence-repository', () => {
         thematicAirtableIds: [],
         thematicIds: [],
         tubeAirtableIds: [],
+        tubeIds: [],
       }));
 
       expect(generateNewId).toHaveBeenCalledExactlyOnceWith('competence');

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -306,19 +306,29 @@ describe('Integration | Repository | competence-repository', () => {
     it('should return the competence by its id', async () => {
       // given
       const competenceId = 'competence2';
+
+      const competence = {
+        id: competenceId,
+        index: '1.2',
+        origin: 'Pix',
+        areaId: 'area2',
+        areaAirtableId: 'recArea2',
+        skillIds: ['skill3', 'skill4'],
+        thematicIds: ['thematic3', 'thematic4'],
+        thematicAirtableIds: ['recThematic3', 'recThematic4'],
+        tubeAirtableIds: ['recTube1', 'recTube2', 'recTube3'],
+        tubeIds: ['tube1', 'tube2', 'tube3'],
+      };
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Pix' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence(competence);
+      competence.thematicIds.forEach((id) => databaseBuilder.factory.buildThematic({ id, competenceId: competence.id }));
+      competence.tubeIds.forEach((id, index) => databaseBuilder.factory.buildTube({ id, name: `@${id}`, thematicId: competence.thematicIds[index % competence.thematicIds.length] }));
+      competence.skillIds.forEach((id, index) => databaseBuilder.factory.buildSkill({ id, tubeId: competence.tubeIds[index % competence.tubeIds.length] }));
+
       const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns([
-        airtableBuilder.factory.buildCompetence({
-          id: 'competence2',
-          index: '1.2',
-          origin: 'Pix',
-          areaId: 'area2',
-          areaAirtableId: 'recArea2',
-          skillIds: ['skill3', 'skill4'],
-          thematicIds: ['thematic3', 'thematic4'],
-          thematicAirtableIds: ['recThematic3', 'recThematic4'],
-          tubeAirtableIds: ['recTube1', 'recTube2', 'recTube3'],
-          tubeIds: ['tube1', 'tube2', 'tube3'],
-        }),
+        airtableBuilder.factory.buildCompetence(competence),
       ]).activate().nockScope;
 
       databaseBuilder.factory.buildTranslation({
@@ -365,10 +375,10 @@ describe('Integration | Repository | competence-repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const competence = await competenceRepository.get(competenceId);
+      const actualCompetence = await competenceRepository.get(competenceId);
 
       // then
-      expect(competence).toStrictEqual(domainBuilder.buildCompetence({
+      expect(actualCompetence).toStrictEqual(domainBuilder.buildCompetence({
         id: 'competence2',
         airtableId: 'competence2',
         index: '1.2',

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -155,8 +155,8 @@ describe('Integration | Repository | competence-repository', () => {
   describe('getMany', () => {
     it('should return the list of all competences having given ids with translations', async () => {
       // given
-      const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns([
-        airtableBuilder.factory.buildCompetence({
+      const competences = [
+        {
           id: 'competence1',
           index: '1.1',
           origin: 'Pix',
@@ -167,8 +167,8 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic1', 'thematic2'],
           tubeAirtableIds: ['recTube1', 'recTube2'],
           tubeIds: ['tube1', 'tube2'],
-        }),
-        airtableBuilder.factory.buildCompetence({
+        },
+        {
           id: 'competence2',
           index: '1.2',
           origin: 'Pix',
@@ -179,8 +179,22 @@ describe('Integration | Repository | competence-repository', () => {
           thematicIds: ['thematic3', 'thematic4'],
           tubeAirtableIds: ['recTube3', 'recTube4'],
           tubeIds: ['tube3', 'tube4'],
-        }),
-      ]).activate().nockScope;
+        },
+      ];
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Pix' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk1' });
+      competences.forEach((competence) => {
+        databaseBuilder.factory.buildCompetence(competence);
+        competence.thematicIds.forEach((id) => databaseBuilder.factory.buildThematic({ id, competenceId: competence.id }));
+        competence.tubeIds.forEach((id, index) => databaseBuilder.factory.buildTube({ id, name: `@${id}`, thematicId: competence.thematicIds[index % competence.thematicIds.length] }));
+        competence.skillIds.forEach((id, index) => databaseBuilder.factory.buildSkill({ id, tubeId: competence.tubeIds[index % competence.tubeIds.length] }));
+      });
+
+      const airtableScope = airtableBuilder.mockList({ tableName: 'Competences' }).returns(
+        competences.map(airtableBuilder.factory.buildCompetence)
+      ).activate().nockScope;
 
       databaseBuilder.factory.buildTranslation({
         key: 'competence.competence1.name',
@@ -236,10 +250,10 @@ describe('Integration | Repository | competence-repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const competences = await competenceRepository.getMany(['competence1', 'competence2']);
+      const actualCompetences = await competenceRepository.getMany(['competence1', 'competence2']);
 
       // then
-      expect(competences).toEqual([
+      expect(actualCompetences).toEqual([
         domainBuilder.buildCompetence({
           id: 'competence1',
           airtableId: 'competence1',

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -444,6 +444,7 @@ function _mockRichAirtableContent() {
     areaId: 'area1',
     skillIds: ['skill11111', 'skill11112'],
     thematicIds: ['thematic111', 'thematic112'],
+    tubeIds: ['tube1111', 'tube1121'],
     origin: 'FrameworkA',
   };
   databaseBuilder.factory.buildCompetence(competence11);
@@ -454,6 +455,7 @@ function _mockRichAirtableContent() {
     areaId: 'area1',
     skillIds: ['skill12121'],
     thematicIds: ['thematic121'],
+    tubeIds: ['tube1211', 'tube1212'],
     origin: 'FrameworkA',
   };
   databaseBuilder.factory.buildCompetence(competence12);
@@ -464,6 +466,7 @@ function _mockRichAirtableContent() {
     areaId: 'area2',
     skillIds: ['skill21111'],
     thematicIds: ['thematic211'],
+    tubeIds: ['tube2111'],
     origin: 'FrameworkA',
   };
   databaseBuilder.factory.buildCompetence(competence21);

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -9,6 +9,7 @@ export function buildCompetence({
   thematicAirtableIds,
   origin,
   tubeAirtableIds,
+  tubeIds,
 } = {}) {
   return {
     id: airtableId ?? id,
@@ -22,6 +23,7 @@ export function buildCompetence({
       'Thematiques': thematicAirtableIds,
       'Origine2': [origin],
       'Tubes': tubeAirtableIds,
+      'Tubes (id persistant)': tubeIds,
     },
   };
 }

--- a/api/tests/tooling/domain-builder/factory/build-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-competence.js
@@ -12,6 +12,7 @@ export function buildCompetence({
   thematicIds = ['recThematic1'],
   thematicAirtableIds = ['recpq782rf2h3df'],
   tubeAirtableIds = ['recP12434hvf34', 'recO01dh3298cf'],
+  tubeIds = ['tubeP12434hvf34', 'tubeO01dh3298cf'],
   origin = 'Pix',
 } = {}) {
   return new Competence({
@@ -26,6 +27,7 @@ export function buildCompetence({
     thematicIds,
     thematicAirtableIds,
     tubeAirtableIds,
+    tubeIds,
     origin,
   });
 }

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-competence-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-competence-datasource-object.js
@@ -19,6 +19,7 @@ export function buildCompetenceDatasourceObject({
   thematicIds = ['recFvllz2Ckz'],
   thematicAirtableIds = ['recpq782rf2h3df'],
   tubeAirtableIds = ['recP12434hvf34', 'recO01dh3298cf'],
+  tubeIds = ['tubeP12434hvf34', 'tubeO01dh3298cf'],
 } = {}) {
 
   return {
@@ -32,5 +33,6 @@ export function buildCompetenceDatasourceObject({
     thematicIds,
     thematicAirtableIds,
     tubeAirtableIds,
+    tubeIds,
   };
 }

--- a/api/tests/unit/domain/usecases/create-competence_test.js
+++ b/api/tests/unit/domain/usecases/create-competence_test.js
@@ -24,7 +24,6 @@ describe('Unit | Domain | Usecases | create competence', function() {
 
   beforeEach(() => {
     vi.spyOn(areaRepository, 'getByAirtableId');
-    vi.spyOn(competenceRepository, 'listByAreaAirtableId');
     vi.spyOn(competenceRepository, 'create');
     vi.spyOn(thematicRepository, 'create');
     vi.spyOn(tubeRepository, 'create');
@@ -43,7 +42,6 @@ describe('Unit | Domain | Usecases | create competence', function() {
       const areaAirtableId = 'unknown area id';
 
       areaRepository.getByAirtableId.mockResolvedValueOnce(undefined);
-      competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
 
       const competence = domainBuilder.buildCompetence({
         areaAirtableId,
@@ -57,7 +55,6 @@ describe('Unit | Domain | Usecases | create competence', function() {
       await expect(result).rejects.toHaveProperty('message', 'unknown area');
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
-      expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
     });
   });
 
@@ -68,14 +65,8 @@ describe('Unit | Domain | Usecases | create competence', function() {
 
       areaRepository.getByAirtableId.mockResolvedValueOnce(domainBuilder.buildArea({
         code: '24',
+        competenceIds: ['competence1', 'competence2', 'competence3', 'competence4', 'competence5']
       }));
-      competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([
-        domainBuilder.buildCompetence(),
-        domainBuilder.buildCompetence(),
-        domainBuilder.buildCompetence(),
-        domainBuilder.buildCompetence(),
-        domainBuilder.buildCompetence(),
-      ]);
       const createdCompetence = domainBuilder.buildCompetence({
         areaAirtableId,
         thematicIds: [],
@@ -119,7 +110,6 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(result).toHaveProperty('tubeAirtableIds', [createdTube.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
-      expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.create).toHaveBeenCalledWith(competence);
       expect(thematicRepository.create).toHaveBeenCalledWith(new Thematic({
         name_i18n: { fr: 'workbench_24_6' },
@@ -167,8 +157,8 @@ describe('Unit | Domain | Usecases | create competence', function() {
 
       areaRepository.getByAirtableId.mockResolvedValueOnce(domainBuilder.buildArea({
         code: '24',
+        competenceIds: [],
       }));
-      competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
       const createdCompetence = domainBuilder.buildCompetence({
         areaAirtableId,
         thematicIds: [],
@@ -212,7 +202,6 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(result).toHaveProperty('tubeAirtableIds', [createdTube.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
-      expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.create).toHaveBeenCalledWith(competence);
       expect(thematicRepository.create).toHaveBeenCalledWith(new Thematic({
         name_i18n: { fr: 'workbench_24_1' },
@@ -259,9 +248,9 @@ describe('Unit | Domain | Usecases | create competence', function() {
       const areaAirtableId = 'areaAirtableId';
 
       areaRepository.getByAirtableId.mockResolvedValueOnce(domainBuilder.buildArea({
-        code: '24'
+        code: '24',
+        competenceIds: [],
       }));
-      competenceRepository.listByAreaAirtableId.mockResolvedValueOnce([]);
       const createdCompetence = domainBuilder.buildCompetence({
         thematicIds: [],
         thematicAirtableIds: [],
@@ -304,7 +293,6 @@ describe('Unit | Domain | Usecases | create competence', function() {
       expect(result).toHaveProperty('tubeAirtableIds', [createdTube.airtableId]);
 
       expect(areaRepository.getByAirtableId).toHaveBeenCalledWith(areaAirtableId);
-      expect(competenceRepository.listByAreaAirtableId).toHaveBeenCalledWith(areaAirtableId);
       expect(competenceRepository.create).toHaveBeenCalledWith(competence);
       expect(thematicRepository.create).toHaveBeenCalledWith(new Thematic({
         name_i18n: { fr: 'workbench_24_1' },


### PR DESCRIPTION
## 🍂 Problème

On souhaite sortir d’Airtable

## 🌰 Proposition

Lire les compétences dans Airtable et Postgres, et comparer les résultats :
 - Émettre un warning en cas de différence
 - En test lever une erreur en cas de différence

## 🍁 Remarques

N/A

## 🪵 Pour tester

Aller sur une ou plusieurs compétences, consulter le détail d’une compétence, etc.

Vérifier qu’aucun warning ne remonte dans les logs (level 40).