### PR TITLE
[FEATURE] Double lecture des tutoriels (PIX-19989)

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -20,8 +20,6 @@ export const tutorialDatasource = datasource.extend({
     'CoupDeCoeur',
     'Tags',
     'Tags (id persistant)',
-    'Solution à',
-    'En savoir plus',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -39,8 +37,6 @@ export const tutorialDatasource = datasource.extend({
       crush: airtableRecord.get('CoupDeCoeur') === 'YES',
       tagAirtableIds: airtableRecord.get('Tags') ?? [],
       tagIds: airtableRecord.get('Tags (id persistant)') ?? [],
-      tutorialForSkills: airtableRecord.get('Solution à'),
-      furtherInformation: airtableRecord.get('En savoir plus'),
     };
   },
 

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -2,6 +2,7 @@ import { Tutorial } from '../../domain/models/index.js';
 import { tutorialDatasource } from '../datasources/airtable/index.js';
 import { generateNewId } from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { areArrayEquals, areNullableValuesEqual, compareDtos } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'tutorials';
 const TAGS_RELATION_TABLE_NAME = 'tutorials-tutorial_tags';
@@ -71,10 +72,15 @@ export async function update(tutorial) {
   });
 }
 
-export async function getByAirtableId(tutorialId) {
-  const datasourceTutorial = await tutorialDatasource.find(tutorialId);
-  if (!datasourceTutorial) return null;
-  return toDomain(datasourceTutorial);
+export async function getByAirtableId(airtableId) {
+  const airtableDto = await tutorialDatasource.find(airtableId);
+  if (!airtableDto) return null;
+
+  const pgDto = await selectTutorials().where('id', airtableDto.id).first();
+
+  compareDtos(airtableDto, pgDto, compareTutorialDtos);
+
+  return toDomain(airtableDto);
 }
 
 export async function getManyByAirtableIds(airtableIds) {
@@ -113,6 +119,35 @@ async function _delete(ids) {
 }
 
 export { _delete as delete };
+
+function selectTutorials() {
+  return knex.select(
+    '*',
+    knex.raw(
+      'coalesce((??), \'[]\') as "tagIds"',
+      knex
+        .select(knex.raw('json_agg(??)', 'tutorials-tutorial_tags.tutorialTagId'))
+        .from('tutorials-tutorial_tags')
+        .where('tutorials-tutorial_tags.tutorialId', '=', knex.ref('tutorials.id')),
+    ),
+  ).from('tutorials');
+}
+
+function compareTutorialDtos(airtableTutorial, pgTutorial) {
+  const diff = [];
+  if (airtableTutorial.id !== pgTutorial.id) diff.push(`tutorial airtable id "${airtableTutorial.id}" != postgres id "${pgTutorial.id}"`);
+  if (airtableTutorial.title !== pgTutorial.title) diff.push(`tutorial airtable title "${airtableTutorial.title}" != postgres title "${pgTutorial.title}"`);
+  if (airtableTutorial.duration !== pgTutorial.duration) diff.push(`tutorial airtable duration "${airtableTutorial.duration}" != postgres duration "${pgTutorial.duration}"`);
+  if (airtableTutorial.source !== pgTutorial.source) diff.push(`tutorial airtable source "${airtableTutorial.source}" != postgres source "${pgTutorial.source}"`);
+  if (airtableTutorial.format !== pgTutorial.format) diff.push(`tutorial airtable format "${airtableTutorial.format}" != postgres format "${pgTutorial.format}"`);
+  if (airtableTutorial.link !== pgTutorial.link) diff.push(`tutorial airtable link "${airtableTutorial.link}" != postgres link "${pgTutorial.link}"`);
+  if (!areNullableValuesEqual(airtableTutorial.license, pgTutorial.license)) diff.push(`tutorial airtable license "${airtableTutorial.license}" != postgres license "${pgTutorial.license}"`);
+  if (!areNullableValuesEqual(airtableTutorial.level, pgTutorial.level)) diff.push(`tutorial airtable level "${airtableTutorial.level}" != postgres level "${pgTutorial.level}"`);
+  if (airtableTutorial.crush !== pgTutorial.crush) diff.push(`tutorial airtable crush "${airtableTutorial.crush}" != postgres crush "${pgTutorial.crush}"`);
+  if (!areNullableValuesEqual(airtableTutorial.locale, pgTutorial.locale)) diff.push(`tutorial airtable locale "${airtableTutorial.locale}" != postgres locale "${pgTutorial.locale}"`);
+  if (!areArrayEquals(airtableTutorial.tagIds, pgTutorial.tagIds)) diff.push(`tutorial airtable tagIds "${airtableTutorial.tagIds}" != postgres tagIds "${pgTutorial.tagIds}"`);
+  return diff;
+}
 
 function toDomain(datasourceTutorial) {
   return new Tutorial(datasourceTutorial);

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -96,9 +96,15 @@ export async function getManyByAirtableIds(airtableIds) {
 }
 
 export async function searchByTitle(title) {
-  const datasourceTutorials = await tutorialDatasource.searchByTitle(title);
-  if (!datasourceTutorials) return [];
-  return datasourceTutorials.map(toDomain);
+  const [airtableDtos, pgDtos] = await Promise.all([
+    tutorialDatasource.searchByTitle(title),
+    selectTutorials().whereILike('title', `%${title}%`).orderByRaw('?? collate ??', ['title', 'fr-x-icu']).limit(100),
+  ]);
+
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos);
+
+  if (!airtableDtos) return [];
+  return airtableDtos.map(toDomain);
 }
 
 export async function searchBySource(source) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -108,9 +108,15 @@ export async function searchByTitle(title) {
 }
 
 export async function searchBySource(source) {
-  const datasourceTutorials = await tutorialDatasource.searchBySource(source);
-  if (!datasourceTutorials) return [];
-  return datasourceTutorials.map(toDomain);
+  const [airtableDtos, pgDtos] = await Promise.all([
+    tutorialDatasource.searchBySource(source),
+    selectTutorials().whereILike('source', `%${source}%`).orderByRaw('?? collate ??', ['title', 'fr-x-icu']).limit(4),
+  ]);
+
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos);
+
+  if (!airtableDtos) return [];
+  return airtableDtos.map(toDomain);
 }
 
 export async function searchByTagTitles(tagTitles) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -127,6 +127,8 @@ export async function getMany(ids) {
 async function _delete(ids) {
   const airtableIds = Object.entries(await tutorialDatasource.getAirtableIdsByIds(ids)).map(([, airtableId]) => airtableId);
   await tutorialDatasource.delete(airtableIds);
+  await knex.delete().from('tutorials-tutorial_tags').whereIn('tutorialId', ids);
+  await knex.delete().from('tutorials').whereIn('id', ids);
 }
 
 export { _delete as delete };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -2,7 +2,7 @@ import { Tutorial } from '../../domain/models/index.js';
 import { tutorialDatasource } from '../datasources/airtable/index.js';
 import { generateNewId } from '../utils/id-generator.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { areArrayEquals, areNullableValuesEqual, compareDtos } from './migration-from-airtable.js';
+import { areArrayEquals, areNullableValuesEqual, compareDtos, compareDtosLists } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'tutorials';
 const TAGS_RELATION_TABLE_NAME = 'tutorials-tutorial_tags';
@@ -85,9 +85,14 @@ export async function getByAirtableId(airtableId) {
 
 export async function getManyByAirtableIds(airtableIds) {
   if (!airtableIds?.length) return [];
-  const datasourceTutorials = await tutorialDatasource.getManyByAirtableIds(airtableIds);
-  if (!datasourceTutorials) return [];
-  return datasourceTutorials.map(toDomain);
+  const airtableDtos = await tutorialDatasource.getManyByAirtableIds(airtableIds);
+  if (!airtableDtos) return [];
+
+  const pgDtos = await selectTutorials().whereIn('id', airtableDtos.map(({ id }) => id)).orderBy('id');
+
+  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos);
+
+  return airtableDtos.map(toDomain);
 }
 
 export async function searchByTitle(title) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -120,9 +120,27 @@ export async function searchBySource(source) {
 }
 
 export async function searchByTagTitles(tagTitles) {
-  const datasourceTutorials = await tutorialDatasource.searchByTagTitles(tagTitles);
-  if (!datasourceTutorials) return [];
-  return datasourceTutorials.map(toDomain);
+  let tutorialsQuery = selectTutorials().orderByRaw('?? collate ??', ['title', 'fr-x-icu']).limit(100);
+
+  for (const tagTitle of tagTitles) {
+    tutorialsQuery = tutorialsQuery.whereIn(
+      'id',
+      knex.select('tutorials-tutorial_tags.tutorialId')
+        .from('tutorial_tags')
+        .join('tutorials-tutorial_tags', 'tutorials-tutorial_tags.tutorialTagId', 'tutorial_tags.id')
+        .whereILike('tutorial_tags.title', `%${tagTitle}%`),
+    );
+  }
+
+  const [airtableDtos, pgDtos] = await Promise.all([
+    tutorialDatasource.searchByTagTitles(tagTitles),
+    tutorialsQuery,
+  ]);
+
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos);
+
+  if (!airtableDtos) return [];
+  return airtableDtos.map(toDomain);
 }
 
 export async function getMany(ids) {

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -114,8 +114,14 @@ export async function searchByTagTitles(tagTitles) {
 }
 
 export async function getMany(ids) {
-  const datasourceTutorials = await tutorialDatasource.filter({ filter: { ids } });
-  return datasourceTutorials.map(toDomain);
+  const [airtableDtos, pgDtos] = await Promise.all([
+    tutorialDatasource.filter({ filter: { ids } }),
+    selectTutorials().whereIn('id', ids).orderBy('id'),
+  ]);
+
+  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos);
+
+  return airtableDtos.map(toDomain);
 }
 
 async function _delete(ids) {

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -742,8 +742,8 @@ describe('Application | Route | Tutorials', () => {
       context('when searching by tutorial title', function() {
         it('should respond with status 200 and relevant tutorials, limited by 100 tutorials and sorted by title', async () => {
           // given
-          const airtableTutorials = [
-            airtableBuilder.factory.buildTutorial({
+          const tutorials = [
+            {
               id: 'tutorialId1',
               airtableId: 'tutorialAirtableId1',
               title: 'mon titre 1',
@@ -756,8 +756,9 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.ONE,
               crush: true,
               tagAirtableIds: ['tagAirtableId1'],
-            }),
-            airtableBuilder.factory.buildTutorial({
+              tagIds: ['tagId1'],
+            },
+            {
               id: 'tutorialId2',
               airtableId: 'tutorialAirtableId2',
               title: 'mon titre 2',
@@ -769,9 +770,15 @@ describe('Application | Route | Tutorials', () => {
               license: Tutorial.LICENSES.CCBYSA,
               level: Tutorial.LEVELS.TWO,
               crush: false,
-              tagAirtableIds: [],
-            }),
+              tagIds: [],
+            },
           ];
+
+          databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'tag 1' });
+          tutorials.forEach(databaseBuilder.factory.buildTutorial);
+          await databaseBuilder.commit();
+
+          const airtableTutorials = tutorials.map(airtableBuilder.factory.buildTutorial);
           airtableSearchTutorialByTitleScope = nock('https://api.airtable.com')
             .get('/v0/airtableBaseValue/Tutoriels')
             .query({

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -860,8 +860,8 @@ describe('Application | Route | Tutorials', () => {
       context('when searching by tutorial source', function() {
         it('should respond with status 200 and relevant tutorials, limited by 4 tutorials and sorted by title', async () => {
           // given
-          const airtableTutorials = [
-            airtableBuilder.factory.buildTutorial({
+          const tutorials = [
+            {
               id: 'tutorialId1',
               airtableId: 'tutorialAirtableId1',
               title: 'mon titre 1',
@@ -874,8 +874,9 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.ONE,
               crush: true,
               tagAirtableIds: ['tagAirtableId1'],
-            }),
-            airtableBuilder.factory.buildTutorial({
+              tagIds: ['tagId1'],
+            },
+            {
               id: 'tutorialId2',
               airtableId: 'tutorialAirtableId2',
               title: 'mon titre 2',
@@ -888,8 +889,15 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.TWO,
               crush: false,
               tagAirtableIds: [],
-            }),
+              tagIds: [],
+            },
           ];
+
+          databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'tag 1' });
+          tutorials.forEach(databaseBuilder.factory.buildTutorial);
+          await databaseBuilder.commit();
+
+          const airtableTutorials = tutorials.map(airtableBuilder.factory.buildTutorial);
           airtableSearchTutorialBySourceScope = nock('https://api.airtable.com')
             .get('/v0/airtableBaseValue/Tutoriels')
             .query({

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -1088,8 +1088,8 @@ describe('Application | Route | Tutorials', () => {
       context('when searching by ids', function() {
         it('should respond with status 200 and relevant tutorials', async () => {
           // given
-          const airtableTutorials = [
-            airtableBuilder.factory.buildTutorial({
+          const tutorials = [
+            {
               id: 'tutorialId1',
               airtableId: 'tutorialAirtableId1',
               title: 'mon titre 1',
@@ -1102,8 +1102,9 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.ONE,
               crush: true,
               tagAirtableIds: ['tagAirtableId1', 'tagAirtableId2'],
-            }),
-            airtableBuilder.factory.buildTutorial({
+              tagIds: ['tagId1', 'tagId2'],
+            },
+            {
               id: 'tutorialId2',
               airtableId: 'tutorialAirtableId2',
               title: 'mon titre 2',
@@ -1116,8 +1117,17 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.TWO,
               crush: false,
               tagAirtableIds: ['tagAirtableId1', 'tagAirtableId3'],
-            }),
+              tagIds: ['tagId1', 'tagId3'],
+            },
           ];
+
+          databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'tag 1' });
+          databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'tag 2' });
+          databaseBuilder.factory.buildTag({ id: 'tagId3', title: 'tag 3' });
+          tutorials.forEach(databaseBuilder.factory.buildTutorial);
+          await databaseBuilder.commit();
+
+          const airtableTutorials = tutorials.map(airtableBuilder.factory.buildTutorial);
           airtableGetManyTutorialsScope = nock('https://api.airtable.com')
             .get('/v0/airtableBaseValue/Tutoriels')
             .query({

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -979,8 +979,8 @@ describe('Application | Route | Tutorials', () => {
       context('when searching by tag titles', function() {
         it('should respond with status 200 and relevant tutorials, limited by 100 tutorials and sorted by title', async () => {
           // given
-          const airtableTutorials = [
-            airtableBuilder.factory.buildTutorial({
+          const tutorials = [
+            {
               id: 'tutorialId1',
               airtableId: 'tutorialAirtableId1',
               title: 'mon titre 1',
@@ -993,8 +993,9 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.ONE,
               crush: true,
               tagAirtableIds: ['tagAirtableId1', 'tagAirtableId2'],
-            }),
-            airtableBuilder.factory.buildTutorial({
+              tagIds: ['tagId1', 'tagId2'],
+            },
+            {
               id: 'tutorialId2',
               airtableId: 'tutorialAirtableId2',
               title: 'mon titre 2',
@@ -1007,8 +1008,17 @@ describe('Application | Route | Tutorials', () => {
               level: Tutorial.LEVELS.TWO,
               crush: false,
               tagAirtableIds: ['tagAirtableId1', 'tagAirtableId3'],
-            }),
+              tagIds: ['tagId1', 'tagId3'],
+            },
           ];
+
+          databaseBuilder.factory.buildTag({ id: 'tagId1', title: 'AWESOME YOUTUBE VIDEO' });
+          databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'yearlymotion' });
+          databaseBuilder.factory.buildTag({ id: 'tagId3', title: 'monthlymotion' });
+          tutorials.forEach(databaseBuilder.factory.buildTutorial);
+          await databaseBuilder.commit();
+
+          const airtableTutorials = tutorials.map(airtableBuilder.factory.buildTutorial);
           airtableSearchTutorialByTagTitlesScope = nock('https://api.airtable.com')
             .get('/v0/airtableBaseValue/Tutoriels')
             .query({

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -316,7 +316,7 @@ describe('Application | Route | Tutorials', () => {
     context('success', function() {
       it('should respond with status 200 and tutorial', async () => {
         // given
-        const airtableTutorial = airtableBuilder.factory.buildTutorial({
+        const tutorial = {
           id: 'tutorialId',
           airtableId: 'tutorialAirtableId',
           title: 'mon titre',
@@ -328,8 +328,15 @@ describe('Application | Route | Tutorials', () => {
           license: Tutorial.LICENSES.C,
           level: Tutorial.LEVELS.TWO,
           crush: true,
+          tagIds: ['tagId1', 'tagId2'],
           tagAirtableIds: ['tagAirtableId1', 'tagAirtableId2'],
-        });
+        };
+
+        tutorial.tagIds.forEach((id) => databaseBuilder.factory.buildTag({ id, title: `${id} title` }));
+        databaseBuilder.factory.buildTutorial(tutorial);
+        await databaseBuilder.commit();
+
+        const airtableTutorial = airtableBuilder.factory.buildTutorial(tutorial);
         airtableGetTutorialScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Tutoriels/tutorialAirtableId')
           .query({})
@@ -546,23 +553,7 @@ describe('Application | Route | Tutorials', () => {
         databaseBuilder.factory.buildTag({ id: 'tagId2', title: 'title2' });
         databaseBuilder.factory.buildTag({ id: 'tagId3', title: 'title3' });
 
-        databaseBuilder.factory.buildTutorial({
-          id: 'tutorialId',
-          title: 'mon titre old',
-          format: Tutorial.FORMATS.FRISE,
-          duration: '06:06:06',
-          source: 'Mon grenier old',
-          link: 'https://coucou.old',
-          locale: 'nl',
-          license: Tutorial.LICENSES.YOUTUBE,
-          level: Tutorial.LEVELS.FOUR,
-          crush: false,
-          tagIds: ['tagId3']
-        });
-
-        await databaseBuilder.commit();
-
-        const originalAirtableTutorial = airtableBuilder.factory.buildTutorial({
+        const tutorial = {
           id: 'tutorialId',
           airtableId: 'tutorialAirtableId',
           title: 'mon titre old',
@@ -574,8 +565,15 @@ describe('Application | Route | Tutorials', () => {
           license: Tutorial.LICENSES.YOUTUBE,
           level: Tutorial.LEVELS.FOUR,
           crush: false,
+          tagIds: ['tagId3'],
           tagAirtableIds: ['tagAirtableId3'],
-        });
+        };
+
+        databaseBuilder.factory.buildTutorial(tutorial);
+
+        await databaseBuilder.commit();
+
+        const originalAirtableTutorial = airtableBuilder.factory.buildTutorial(tutorial);
         airtableGetTutorialScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Tutoriels/tutorialAirtableId')
           .query({})

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -630,8 +630,6 @@ function _mockRichAirtableContent() {
     source: 'tutorial1 source',
     link: 'tutorial1 link',
     locale: 'fr',
-    tutorialForSkills: 'tutorial1 tutorialForSkills',
-    furtherInformation: 'tutorial1 furtherInformation',
   };
   databaseBuilder.factory.buildTutorial(tutorial1);
   const airtableTutorial1 = airtableBuilder.factory.buildTutorial(tutorial1);
@@ -643,8 +641,6 @@ function _mockRichAirtableContent() {
     source: 'tutorial2 source',
     link: 'tutorial2 link',
     locale: 'fr-fr',
-    tutorialForSkills: 'tutorial2 tutorialForSkills',
-    furtherInformation: 'tutorial2 furtherInformation',
   };
   databaseBuilder.factory.buildTutorial(tutorial2);
   const airtableTutorial2 = airtableBuilder.factory.buildTutorial(tutorial2);

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -26,8 +26,6 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
             CoupDeCoeur: 'YES',
             Tags: ['recTag1', 'recTag2'],
             'Tags (id persistant)': ['tag1', 'tag2'],
-            'Solution à': ['recSkill1', 'recSkill2'],
-            'En savoir plus': ['recSkill1', 'recSkill3'],
           },
         }),
         new Airtable.Record(AIRTABLE_NAME, 'recTuto2', {

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -4,7 +4,7 @@ import * as airtable from '../../../../lib/infrastructure/airtable.js';
 import * as tutorialRepository from '../../../../lib/infrastructure/repositories/tutorial-repository.js';
 import { Tutorial } from '../../../../lib/domain/models/Tutorial.js';
 import { tutorialDatasource } from '../../../../lib/infrastructure/datasources/airtable/tutorial-datasource.js';
-import { airtableBuilder, databaseBuilder } from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, knex } from '../../../test-helper.js';
 
 const AIRTABLE_NAME = 'Tutoriels';
 
@@ -102,20 +102,53 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
   describe('#delete', () => {
     it('deletes records corresponding to given ids', async () => {
       // given
-      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
-        new Airtable.Record(AIRTABLE_NAME, 'recTuto1', {
-          fields: {
-            'Record ID': 'recTuto1',
-            'id persistant': 'tuto1',
-          },
-        }),
-        new Airtable.Record(AIRTABLE_NAME, 'recTuto2', {
-          fields: {
-            'Record ID': 'recTuto2',
-            'id persistant': 'tuto2',
-          },
-        }),
-      ]);
+      const tutorials = [
+        {
+          airtableId: 'recTuto1',
+          id: 'tuto1',
+          title: 'title 1',
+          duration: 'duration 1',
+          source: 'source 1',
+          format: 'format 1',
+          link: 'link 1',
+          locale: 'locale 1',
+          tagIds: ['tag1', 'tag2'],
+        },
+        {
+          airtableId: 'recTuto2',
+          id: 'tuto2',
+          title: 'title 2',
+          duration: 'duration 2',
+          source: 'source 2',
+          format: 'format 2',
+          link: 'link 2',
+          locale: 'locale 2',
+          tagIds: ['tag2', 'tag3'],
+        },
+      ];
+
+      databaseBuilder.factory.buildTag({ id: 'tag1', title: 'tag 1' });
+      databaseBuilder.factory.buildTag({ id: 'tag2', title: 'tag 2' });
+      databaseBuilder.factory.buildTag({ id: 'tag3', title: 'tag 3' });
+      tutorials.forEach(databaseBuilder.factory.buildTutorial);
+      databaseBuilder.factory.buildTutorial({
+        airtableId: 'recTuto3',
+        id: 'tuto3',
+        title: 'title 3',
+        duration: 'duration 3',
+        source: 'source 3',
+        format: 'format 3',
+        link: 'link 3',
+        locale: 'locale 3',
+        tagIds: ['tag1', 'tag3'],
+      });
+      await databaseBuilder.commit();
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce(
+        tutorials.map((tutorial) => new Airtable.Record(AIRTABLE_NAME, tutorial.airtableId, {
+          fields: { 'id persistant': tutorial.id, 'Record ID': tutorial.airtableId },
+        })),
+      );
 
       const deleteRecords = vi.spyOn(airtable, 'deleteRecords').mockResolvedValueOnce();
 
@@ -123,6 +156,28 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
       await tutorialRepository.delete(['tuto1', 'tuto2']);
 
       // then
+      await expect(knex.select('*').from('tutorials').orderBy('id')).resolves.toStrictEqual([
+        {
+          id: 'tuto3',
+          title: 'title 3',
+          duration: 'duration 3',
+          source: 'source 3',
+          format: 'format 3',
+          link: 'link 3',
+          locale: 'locale 3',
+          crush: false,
+          level: null,
+          license: null,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        }
+      ]);
+
+      await expect(knex.select('*').from('tutorials-tutorial_tags').orderBy(['tutorialId', 'tutorialTagId'])).resolves.toStrictEqual([
+        { tutorialId: 'tuto3', tutorialTagId: 'tag1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { tutorialId: 'tuto3', tutorialTagId: 'tag3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
+
       expect(findRecords).toHaveBeenCalledExactlyOnceWith(AIRTABLE_NAME, {
         fields: ['Record ID', 'id persistant'],
         filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant})',

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -4,6 +4,7 @@ import * as airtable from '../../../../lib/infrastructure/airtable.js';
 import * as tutorialRepository from '../../../../lib/infrastructure/repositories/tutorial-repository.js';
 import { Tutorial } from '../../../../lib/domain/models/Tutorial.js';
 import { tutorialDatasource } from '../../../../lib/infrastructure/datasources/airtable/tutorial-datasource.js';
+import { airtableBuilder, databaseBuilder } from '../../../test-helper.js';
 
 const AIRTABLE_NAME = 'Tutoriels';
 
@@ -11,46 +12,54 @@ describe('Integration | Infrastructure | Repository | Tutorial', () => {
   describe('#getMany', () => {
     it('returns corresponding tutorials for given ids', async () => {
       // given
-      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
-        new Airtable.Record(AIRTABLE_NAME, 'recTuto1', {
-          fields: {
-            'id persistant': 'tuto1',
-            Durée: 'Durée 1',
-            Format: 'Format 1',
-            Lien: 'Lien 1',
-            Source: 'Source 1',
-            Titre: 'Titre 1',
-            Langue: 'Langue 1',
-            License: 'License 1',
-            niveau: 'niveau 1',
-            CoupDeCoeur: 'YES',
-            Tags: ['recTag1', 'recTag2'],
-            'Tags (id persistant)': ['tag1', 'tag2'],
-          },
-        }),
-        new Airtable.Record(AIRTABLE_NAME, 'recTuto2', {
-          fields: {
-            'id persistant': 'tuto2',
-            Durée: 'Durée 2',
-            Format: 'Format 2',
-            Lien: 'Lien 2',
-            Source: 'Source 2',
-            Titre: 'Titre 2',
-            Langue: 'Langue 2',
-            License: 'License 2',
-            niveau: 'niveau 2',
-            CoupDeCoeur: 'NON',
-            Tags: ['recTag2', 'recTag3'],
-            'Tags (id persistant)': ['tag2', 'tag3'],
-          },
-        }),
-      ]);
+      const tutorials = [
+        {
+          id: 'tuto1',
+          airtableId: 'recTuto1',
+          duration: 'Durée 1',
+          format: 'Format 1',
+          link: 'Lien 1',
+          source: 'Source 1',
+          title: 'Titre 1',
+          locale: 'Langue 1',
+          license: 'License 1',
+          level: 'niveau 1',
+          crush: true,
+          tagAirtableIds: ['recTag1', 'recTag2'],
+          tagIds: ['tag1', 'tag2'],
+        },
+        {
+          id: 'tuto2',
+          airtableId: 'recTuto2',
+          duration: 'Durée 2',
+          format: 'Format 2',
+          link: 'Lien 2',
+          source: 'Source 2',
+          title: 'Titre 2',
+          locale: 'Langue 2',
+          license: 'License 2',
+          level: 'niveau 2',
+          crush: false,
+          tagAirtableIds: ['recTag2', 'recTag3'],
+          tagIds: ['tag2', 'tag3'],
+        },
+      ];
+
+      databaseBuilder.factory.buildTag({ id: 'tag1', title: 'tag 1' });
+      databaseBuilder.factory.buildTag({ id: 'tag2', title: 'tag 2' });
+      databaseBuilder.factory.buildTag({ id: 'tag3', title: 'tag 3' });
+      tutorials.forEach(databaseBuilder.factory.buildTutorial);
+      await databaseBuilder.commit();
+
+      const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce(
+        tutorials.map((tutorial) => new Airtable.Record(AIRTABLE_NAME, tutorial.airtableId, airtableBuilder.factory.buildTutorial(tutorial))),
+      );
 
       // when
-      const tutorials = await tutorialRepository.getMany(['tuto1', 'tuto2']);
+      const actualTutorials = await tutorialRepository.getMany(['tuto1', 'tuto2']);
 
       // then
-      expect(tutorials).toStrictEqual([
+      expect(actualTutorials).toStrictEqual([
         new Tutorial({
           airtableId: 'recTuto1',
           id: 'tuto1',

--- a/api/tests/scripts/delete-tutorials_test.js
+++ b/api/tests/scripts/delete-tutorials_test.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
 
-import { airtableBuilder } from '../test-helper.js';
+import { airtableBuilder, databaseBuilder } from '../test-helper.js';
 import { DeleteTutorials } from '../../scripts/delete-tutorials.js';
 import { logger } from '../../lib/infrastructure/logger.js';
 import { tutorialDatasource } from '../../lib/infrastructure/datasources/airtable/index.js';
@@ -22,16 +22,33 @@ describe('Script | DeleteTutorials', () => {
         id: ['tuto1', 'tuto2', 'tuto3']
       };
 
-      const records = [
-        airtableBuilder.factory.buildTutorial({
+      const tutorials = [
+        {
           airtableId: 'recTuto1',
           id: 'tuto1',
-        }),
-        airtableBuilder.factory.buildTutorial({
+          title: 'title 1',
+          duration: 'duration 1',
+          source: 'source 1',
+          format: 'format 1',
+          link: 'link 1',
+          locale: 'locale 1',
+        },
+        {
           airtableId: 'recTuto3',
           id: 'tuto3',
-        }),
+          title: 'title 3',
+          duration: 'duration 3',
+          source: 'source 3',
+          format: 'format 3',
+          link: 'link 3',
+          locale: 'locale 3',
+        },
       ];
+
+      tutorials.forEach(databaseBuilder.factory.buildTutorial);
+      await databaseBuilder.commit();
+
+      const records = tutorials.map(airtableBuilder.factory.buildTutorial);
 
       const getManyScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Tutoriels')
@@ -85,16 +102,33 @@ describe('Script | DeleteTutorials', () => {
           id: ['tuto1', 'tuto2', 'tuto3']
         };
 
-        const records = [
-          airtableBuilder.factory.buildTutorial({
+        const tutorials = [
+          {
             airtableId: 'recTuto1',
             id: 'tuto1',
-          }),
-          airtableBuilder.factory.buildTutorial({
+            title: 'title 1',
+            duration: 'duration 1',
+            source: 'source 1',
+            format: 'format 1',
+            link: 'link 1',
+            locale: 'locale 1',
+          },
+          {
             airtableId: 'recTuto3',
             id: 'tuto3',
-          }),
+            title: 'title 3',
+            duration: 'duration 3',
+            source: 'source 3',
+            format: 'format 3',
+            link: 'link 3',
+            locale: 'locale 3',
+          },
         ];
+
+        tutorials.forEach(databaseBuilder.factory.buildTutorial);
+        await databaseBuilder.commit();
+
+        const records = tutorials.map(airtableBuilder.factory.buildTutorial);
 
         const getManyScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Tutoriels')

--- a/api/tests/scripts/delete-tutorials_test.js
+++ b/api/tests/scripts/delete-tutorials_test.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import nock from 'nock';
 
-import { airtableBuilder, databaseBuilder } from '../test-helper.js';
+import { airtableBuilder, databaseBuilder, knex } from '../test-helper.js';
 import { DeleteTutorials } from '../../scripts/delete-tutorials.js';
 import { logger } from '../../lib/infrastructure/logger.js';
 import { tutorialDatasource } from '../../lib/infrastructure/datasources/airtable/index.js';
@@ -15,13 +15,9 @@ describe('Script | DeleteTutorials', () => {
   });
 
   describe('#handle', () => {
-    it('deletes existing tutorials corresponding to given ids', async () => {
-      // given
-      const options = {
-        dryRun: false,
-        id: ['tuto1', 'tuto2', 'tuto3']
-      };
+    let getManyScope, getAirtableIdsByIdsScope, deleteScope;
 
+    beforeEach(async () => {
       const tutorials = [
         {
           airtableId: 'recTuto1',
@@ -32,6 +28,7 @@ describe('Script | DeleteTutorials', () => {
           format: 'format 1',
           link: 'link 1',
           locale: 'locale 1',
+          tagIds: ['tag1', 'tag2'],
         },
         {
           airtableId: 'recTuto3',
@@ -42,15 +39,30 @@ describe('Script | DeleteTutorials', () => {
           format: 'format 3',
           link: 'link 3',
           locale: 'locale 3',
+          tagIds: ['tag2', 'tag3'],
         },
       ];
 
+      databaseBuilder.factory.buildTag({ id: 'tag1', title: 'tag 1' });
+      databaseBuilder.factory.buildTag({ id: 'tag2', title: 'tag 2' });
+      databaseBuilder.factory.buildTag({ id: 'tag3', title: 'tag 3' });
       tutorials.forEach(databaseBuilder.factory.buildTutorial);
+      databaseBuilder.factory.buildTutorial({
+        airtableId: 'recTuto4',
+        id: 'tuto4',
+        title: 'title 4',
+        duration: 'duration 4',
+        source: 'source 4',
+        format: 'format 4',
+        link: 'link 4',
+        locale: 'locale 4',
+        tagIds: ['tag1', 'tag3'],
+      });
       await databaseBuilder.commit();
 
       const records = tutorials.map(airtableBuilder.factory.buildTutorial);
 
-      const getManyScope = nock('https://api.airtable.com')
+      getManyScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Tutoriels')
         .query({
           filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant},"tuto3" = {id persistant})',
@@ -59,7 +71,7 @@ describe('Script | DeleteTutorials', () => {
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, { records });
 
-      const getAirtableIdsByIdsScope = nock('https://api.airtable.com')
+      getAirtableIdsByIdsScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Tutoriels')
         .query({
           filterByFormula: 'OR("tuto1" = {id persistant},"tuto3" = {id persistant})',
@@ -74,7 +86,7 @@ describe('Script | DeleteTutorials', () => {
           },
         })) });
 
-      const deleteScope = nock('https://api.airtable.com')
+      deleteScope = nock('https://api.airtable.com')
         .delete('/v0/airtableBaseValue/Tutoriels')
         .query({
           'records[]': ['recTuto1', 'recTuto3'],
@@ -84,11 +96,40 @@ describe('Script | DeleteTutorials', () => {
           { deleted: true, id: 'recTuto1', },
           { deleted: true, id: 'recTuto3', },
         ] });
+    });
+
+    it('deletes existing tutorials corresponding to given ids', async () => {
+      // given
+      const options = {
+        dryRun: false,
+        id: ['tuto1', 'tuto2', 'tuto3']
+      };
 
       // when
       await script.handle({ options, logger });
 
       // then
+      await expect(knex.select('*').from('tutorials').orderBy('id')).resolves.toStrictEqual([
+        {
+          id: 'tuto4',
+          title: 'title 4',
+          duration: 'duration 4',
+          source: 'source 4',
+          format: 'format 4',
+          link: 'link 4',
+          locale: 'locale 4',
+          crush: false,
+          level: null,
+          license: null,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+      await expect(knex.select('*').from('tutorials-tutorial_tags').orderBy(['tutorialId', 'tutorialTagId'])).resolves.toStrictEqual([
+        { tutorialId: 'tuto4', tutorialTagId: 'tag1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        { tutorialId: 'tuto4', tutorialTagId: 'tag3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+      ]);
+
       expect(getManyScope.isDone()).toBe(true);
       expect(getAirtableIdsByIdsScope.isDone()).toBe(true);
       expect(deleteScope.isDone()).toBe(true);
@@ -102,9 +143,12 @@ describe('Script | DeleteTutorials', () => {
           id: ['tuto1', 'tuto2', 'tuto3']
         };
 
-        const tutorials = [
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        await expect(knex.select('*').from('tutorials').orderBy('id')).resolves.toStrictEqual([
           {
-            airtableId: 'recTuto1',
             id: 'tuto1',
             title: 'title 1',
             duration: 'duration 1',
@@ -112,9 +156,13 @@ describe('Script | DeleteTutorials', () => {
             format: 'format 1',
             link: 'link 1',
             locale: 'locale 1',
+            crush: false,
+            level: null,
+            license: null,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
           },
           {
-            airtableId: 'recTuto3',
             id: 'tuto3',
             title: 'title 3',
             duration: 'duration 3',
@@ -122,28 +170,39 @@ describe('Script | DeleteTutorials', () => {
             format: 'format 3',
             link: 'link 3',
             locale: 'locale 3',
+            crush: false,
+            level: null,
+            license: null,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
           },
-        ];
+          {
+            id: 'tuto4',
+            title: 'title 4',
+            duration: 'duration 4',
+            source: 'source 4',
+            format: 'format 4',
+            link: 'link 4',
+            locale: 'locale 4',
+            crush: false,
+            level: null,
+            license: null,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          },
+        ]);
+        await expect(knex.select('*').from('tutorials-tutorial_tags').orderBy(['tutorialId', 'tutorialTagId'])).resolves.toStrictEqual([
+          { tutorialId: 'tuto1', tutorialTagId: 'tag1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tuto1', tutorialTagId: 'tag2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tuto3', tutorialTagId: 'tag2', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tuto3', tutorialTagId: 'tag3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tuto4', tutorialTagId: 'tag1', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+          { tutorialId: 'tuto4', tutorialTagId: 'tag3', createdAt: expect.any(Date), updatedAt: expect.any(Date) },
+        ]);
 
-        tutorials.forEach(databaseBuilder.factory.buildTutorial);
-        await databaseBuilder.commit();
-
-        const records = tutorials.map(airtableBuilder.factory.buildTutorial);
-
-        const getManyScope = nock('https://api.airtable.com')
-          .get('/v0/airtableBaseValue/Tutoriels')
-          .query({
-            filterByFormula: 'OR("tuto1" = {id persistant},"tuto2" = {id persistant},"tuto3" = {id persistant})',
-            'fields[]': tutorialDatasource.usedFields,
-          })
-          .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-          .reply(200, { records });
-
-        // when
-        await script.handle({ options, logger });
-
-        // then
         expect(getManyScope.isDone()).toBe(true);
+        expect(getAirtableIdsByIdsScope.isDone()).toBe(false);
+        expect(deleteScope.isDone()).toBe(false);
       });
     });
   });

--- a/api/tests/tooling/airtable-builder/factory/build-tutorial.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tutorial.js
@@ -12,8 +12,6 @@ export function buildTutorial({
   crush,
   tagAirtableIds,
   tagIds,
-  tutorialForSkills,
-  furtherInformation,
 } = {}) {
   return {
     id: airtableId,
@@ -30,8 +28,6 @@ export function buildTutorial({
       'CoupDeCoeur': crush ? 'YES' : null,
       'Tags': tagAirtableIds ?? [],
       'Tags (id persistant)': tagIds ?? [],
-      'Solution à': tutorialForSkills,
-      'En savoir plus': furtherInformation,
     },
   };
 }

--- a/api/tests/tooling/domain-builder/factory/build-tutorial-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-tutorial-for-release.js
@@ -9,8 +9,6 @@ export function buildTutorialForRelease(
     source = 'Source Example, Example',
     title = 'Communiquer',
     locale = 'fr-fr',
-    tutorialForSkills = ['skillId1'],
-    furtherInformation = ['skillId2'],
   } = {}) {
   return new TutorialForRelease({
     id,
@@ -20,7 +18,5 @@ export function buildTutorialForRelease(
     source,
     title,
     locale,
-    tutorialForSkills,
-    furtherInformation,
   });
 }

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-tutorial-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-tutorial-datasource-object.js
@@ -16,8 +16,6 @@ export function buildTutorialDatasourceObject(
     crush = true,
     tagAirtableIds = ['tagAirtableId1'],
     tagIds = ['tagId1'],
-    tutorialForSkills = ['skillId1'],
-    furtherInformation = ['skillId2'],
   } = {}) {
   return {
     id,
@@ -33,7 +31,5 @@ export function buildTutorialDatasourceObject(
     crush,
     tagAirtableIds,
     tagIds,
-    tutorialForSkills,
-    furtherInformation,
   };
 }

--- a/api/tests/unit/infrastructure/transformers/tutorial-transformer_test.js
+++ b/api/tests/unit/infrastructure/transformers/tutorial-transformer_test.js
@@ -11,7 +11,5 @@ describe('Unit | Infrastructure | tutorial-transformer', function() {
 
     expect(tutorials.length).to.equal(1);
     expect(tutorials[0].duration).to.exist;
-    expect(tutorials[0].tutorialForSkills).to.not.exist;
-    expect(tutorials[0].furtherInformation).to.not.exist;
   });
 });


### PR DESCRIPTION
## 🍂 Problème

On souhaite sortir d’Airtable.

## 🌰 Proposition

Lire les tutoriels dans Airtable et Postgres, et comparer les résultats :
 - Émettre un warning en cas de différence
 - En test lever une erreur en cas de différence

## 🍁 Remarques

Il y a un commit de rattrapage pour la suppression des tutoriels qui n’écrivait pas dans Postgres.

## 🪵 Pour tester

Aller en édition sur un acquis et faire de la recherche de tuto dans tous les sens...

Vérifier qu’aucun warning ne remonte dans les logs (level 40).