### PR TITLE
[BUGFIX] Valeurs par défaut pour les colonnes booléennes des épreuves (PIX-20145)

### DIFF
--- a/api/db/migrations/20251027101606_challenges-booleans-default-value.js
+++ b/api/db/migrations/20251027101606_challenges-booleans-default-value.js
@@ -1,0 +1,24 @@
+const TABLE_NAME = 'challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.boolean('t1Status').notNullable().defaultTo(false).alter();
+    table.boolean('t2Status').notNullable().defaultTo(false).alter();
+    table.boolean('t3Status').notNullable().defaultTo(false).alter();
+    table.boolean('autoReply').notNullable().defaultTo(false).alter();
+    table.boolean('focusable').notNullable().defaultTo(false).alter();
+    table.boolean('shuffled').notNullable().defaultTo(false).alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down() {
+  // no down
+}


### PR DESCRIPTION
## 🍂 Problème

On a des erreurs 500 sur la création de challenges, à cause de colonnes booléennes pas valorisées.

## 🌰 Proposition

Mettre une valeur par défaut pour toutes les colonnes booléennes.

## 🍁 Remarques

N/A

## 🪵 Pour tester

N/A