### PR TITLE
[BUGFIX] Rend la taille de tranche définissable par option dans le script de migration des épreuves depuis Airtable.

### DIFF
--- a/api/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg.js
@@ -17,6 +17,12 @@ export class CopyChallengesFromAirtableToPg extends Script {
           demandOption: false,
           default: true,
         },
+        chunkSize: {
+          type: 'number',
+          describe: 'size of inserted chunk',
+          demandOption: false,
+          default: 500,
+        },
       },
     });
   }
@@ -99,7 +105,7 @@ export class CopyChallengesFromAirtableToPg extends Script {
 
     if (options.dryRun) return;
 
-    for (const chunk of chunks(challenges, 1000)) {
+    for (const chunk of chunks(challenges, options.chunkSize)) {
       await knex.insert(chunk).into('challenges').onConflict('id').merge();
     }
     logger.info({ count: challenges.length }, 'Inserted challenges into postgres');

--- a/api/tests/integration/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg_test.js
@@ -124,9 +124,9 @@ describe('Integration | Scripts | CopyChallengesFromAirtableToPg', () => {
       await knex.delete().from(TABLE_NAME);
     });
 
-    it('reads skills from airtable and saves these to postgres', async () => {
+    it('reads challenges from airtable and saves these to postgres', async () => {
       // given
-      const options = { dryRun: false };
+      const options = { dryRun: false, chunkSize: 500 };
 
       // when
       await script.handle({ options, logger });
@@ -240,9 +240,9 @@ describe('Integration | Scripts | CopyChallengesFromAirtableToPg', () => {
     });
 
     describe('when dryRun is true', () => {
-      it('reads skills from airtable and stops', async () => {
+      it('reads challenges from airtable and stops', async () => {
         // given
-        const options = { dryRun: true };
+        const options = { dryRun: true, chunkSize: 500 };
 
         // when
         await script.handle({ options, logger });


### PR DESCRIPTION
## 🍂 Problème

La requête permettant d'insérer les épreuves depuis Airtable vers PG a une taille max qui est atteinte avec le script de migration.
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌰 Proposition

On rend la taille de tranche définissable par option du script.
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

RAS
<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

```
scalingo -a pix-lcms-review-pr1196 run "cd api && node scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg.js --chunkSize=10"
```

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
