### PR TITLE
[TECH] Double lecture des acquis (PIX-19947)

### DIFF
--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -88,19 +88,24 @@ export async function listByTubeId(tubeId) {
 }
 
 export async function listActiveByCompetenceId(competenceId) {
-  const datasourceSkills = await skillDatasource.listActiveByCompetenceId(competenceId);
-  if (!datasourceSkills) return [];
+  const [airtableDtos, pgDtos] = await Promise.all([
+    skillDatasource.listActiveByCompetenceId(competenceId),
+    selectSkills()
+      .where('thematics.competenceId', competenceId)
+      .where('skills.status', Skill.STATUSES.ACTIF)
+      .orderBy('skills.id'),
+  ]);
+
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+
+  if (!airtableDtos) return [];
+
   const translations = await translationRepository.listByEntities(
     model,
-    datasourceSkills.map(({ id }) => id),
+    airtableDtos.map(({ id }) => id),
   );
-  const skillsDataFromPG = await knex(TABLE_NAME)
-    .select('*')
-    .whereIn(
-      'id',
-      datasourceSkills.map(({ id }) => id),
-    );
-  return toDomainList(datasourceSkills, translations, skillsDataFromPG);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export async function listByCompetenceId(competenceId) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -53,19 +53,22 @@ export async function getByAirtableId(id) {
 
 export async function getManyByAirtableIds(ids) {
   if (!ids?.length) return [];
-  const datasourceSkills = await skillDatasource.getManyByAirtableIds(ids);
-  if (!datasourceSkills) return [];
+  const airtableDtos = await skillDatasource.getManyByAirtableIds(ids);
+  if (!airtableDtos) return [];
   const translations = await translationRepository.listByEntities(
     model,
-    datasourceSkills.map(({ id }) => id),
+    airtableDtos.map(({ id }) => id),
   );
-  const skillsDataFromPG = await knex(TABLE_NAME)
-    .select('*')
+  const pgDtos = await selectSkills()
     .whereIn(
-      'id',
-      datasourceSkills.map(({ id }) => id),
-    );
-  return toDomainList(datasourceSkills, translations, skillsDataFromPG);
+      'skills.id',
+      airtableDtos.map(({ id }) => id),
+    )
+    .orderBy('skills.id');
+
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export async function listByTubeId(tubeId) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -104,23 +104,29 @@ export async function listActiveByCompetenceId(competenceId) {
 }
 
 export async function listByCompetenceId(competenceId) {
-  const datasourceSkills = await skillDatasource.listByCompetenceId(competenceId);
-  if (!datasourceSkills) return [];
+  const [airtableDtos, pgDtos] = await Promise.all([
+    skillDatasource.listByCompetenceId(competenceId),
+    selectSkills().where('thematics.competenceId', competenceId).orderBy('skills.id'),
+  ]);
+
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+
+  if (!airtableDtos) return [];
+
   const translations = await translationRepository.listByEntities(
     model,
-    datasourceSkills.map(({ id }) => id),
+    airtableDtos.map(({ id }) => id),
   );
-  const skillsDataFromPG = await knex(TABLE_NAME)
-    .select('*')
-    .whereIn(
-      'id',
-      datasourceSkills.map(({ id }) => id),
-    );
-  return toDomainList(datasourceSkills, translations, skillsDataFromPG);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export async function search(params) {
-  let query = selectSkills().whereRaw('?? || ?? ilike ?', ['tubes.name', 'skills.level', `${params.filter.name}%`]);
+  let query = selectSkills().whereRaw("?? || coalesce(??::varchar, '') ilike ?", [
+    'tubes.name',
+    'skills.level',
+    `${params.filter.name}%`,
+  ]);
   if (params.sort) {
     params.sort.forEach(([field, direction]) => {
       query = query.orderBy(field, direction);
@@ -150,7 +156,7 @@ export function selectSkills() {
   return knex
     .select(
       'skills.*',
-      knex.raw('?? || ?? as ??', ['tubes.name', 'skills.level', 'name']),
+      knex.raw("?? || coalesce(??::varchar, '') as ??", ['tubes.name', 'skills.level', 'name']),
       'thematics.competenceId',
       knex.raw(
         'coalesce((??), \'[]\') as "tutorialIds"',

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -114,19 +114,30 @@ export async function listByCompetenceId(competenceId) {
 }
 
 export async function search(params) {
-  const datasourceSkills = await skillDatasource.search(params);
-  if (!datasourceSkills) return [];
+  let query = selectSkills().whereRaw('?? || ?? ilike ?', ['tubes.name', 'skills.level', `${params.filter.name}%`]);
+  if (params.sort) {
+    params.sort.forEach(([field, direction]) => {
+      query = query.orderBy(field, direction);
+    });
+  } else {
+    query = query.orderBy('skills.id');
+  }
+  if (params.page?.limit) {
+    query = query.limit(params.page?.limit);
+  }
+
+  const [airtableDtos, pgDtos] = await Promise.all([skillDatasource.search(params), query]);
+
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+
+  if (!airtableDtos) return [];
+
   const translations = await translationRepository.listByEntities(
     model,
-    datasourceSkills.map(({ id }) => id),
+    airtableDtos.map(({ id }) => id),
   );
-  const skillsDataFromPG = await knex(TABLE_NAME)
-    .select('*')
-    .whereIn(
-      'id',
-      datasourceSkills.map(({ id }) => id),
-    );
-  return toDomainList(datasourceSkills, translations, skillsDataFromPG);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export function selectSkills() {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -5,7 +5,7 @@ import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { areArrayEquals, areNullableValuesEqual, compareDtosLists } from './migration-from-airtable.js';
+import { areArrayEquals, areNullableValuesEqual, compareDtosLists, compareDtos } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'skills';
 const TUTORIALS_RELATION_TABLE_NAME = 'skills-tutorials';
@@ -28,13 +28,16 @@ export async function list() {
 }
 
 export async function get(id) {
-  const [[skillDTO], translations] = await Promise.all([
+  const [[airtableDto], pgDto, translations] = await Promise.all([
     skillDatasource.filter({ filter: { ids: [id] } }),
+    selectSkills().where('skills.id', id).first(),
     translationRepository.listByEntity(model, id),
   ]);
-  if (!skillDTO) return null;
-  const skillDataFromPG = await knex(TABLE_NAME).select('*').where({ id }).first();
-  return toDomain(skillDTO, translations, skillDataFromPG);
+
+  compareDtos(airtableDto, pgDto, compareSkillDtos);
+
+  if (!airtableDto) return null;
+  return toDomain(airtableDto, translations, pgDto);
 }
 
 export async function getByAirtableId(id) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -41,11 +41,14 @@ export async function get(id) {
 }
 
 export async function getByAirtableId(id) {
-  const datasourceSkill = await skillDatasource.find(id);
-  if (!datasourceSkill) return null;
-  const translations = await translationRepository.listByEntity(model, datasourceSkill.id);
-  const skillDataFromPG = await knex(TABLE_NAME).select('*').where({ id: datasourceSkill.id }).first();
-  return toDomain(datasourceSkill, translations, skillDataFromPG);
+  const airtableDto = await skillDatasource.find(id);
+  if (!airtableDto) return null;
+  const translations = await translationRepository.listByEntity(model, airtableDto.id);
+  const pgDto = await selectSkills().where('skills.id', airtableDto.id).first();
+
+  compareDtos(airtableDto, pgDto, compareSkillDtos);
+
+  return toDomain(airtableDto, translations, pgDto);
 }
 
 export async function getManyByAirtableIds(ids) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -5,6 +5,7 @@ import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
 import { knex } from '../../../db/knex-database-connection.js';
+import { areArrayEquals, areNullableValuesEqual, compareDtosLists } from './migration-from-airtable.js';
 
 const TABLE_NAME = 'skills';
 const TUTORIALS_RELATION_TABLE_NAME = 'skills-tutorials';
@@ -15,12 +16,15 @@ const TUTORIAL_RELATION_TYPES = {
 const model = 'skill';
 
 export async function list() {
-  const [datasourceSkills, translations] = await Promise.all([
+  const [airtableDtos, pgDtos, translations] = await Promise.all([
     skillDatasource.list(),
+    selectSkills().orderBy('id'),
     translationRepository.listByModel(model),
   ]);
-  const skillsDataFromPG = await knex(TABLE_NAME).select('*');
-  return toDomainList(datasourceSkills, translations, skillsDataFromPG);
+
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export async function get(id) {
@@ -122,6 +126,41 @@ export async function search(params) {
   return toDomainList(datasourceSkills, translations, skillsDataFromPG);
 }
 
+export function selectSkills() {
+  return knex
+    .select(
+      'skills.*',
+      knex.raw('?? || ?? as ??', ['tubes.name', 'skills.level', 'name']),
+      'thematics.competenceId',
+      knex.raw(
+        'coalesce((??), \'[]\') as "tutorialIds"',
+        knex
+          .select(knex.raw('json_agg(??)', 'skills-tutorials.tutorialId'))
+          .from('skills-tutorials')
+          .where('skills-tutorials.skillId', knex.ref('skills.id'))
+          .where('skills-tutorials.type', TUTORIAL_RELATION_TYPES.UNDERSTANDING),
+      ),
+      knex.raw(
+        'coalesce((??), \'[]\') as "learningMoreTutorialIds"',
+        knex
+          .select(knex.raw('json_agg(??)', 'skills-tutorials.tutorialId'))
+          .from('skills-tutorials')
+          .where('skills-tutorials.skillId', knex.ref('skills.id'))
+          .where('skills-tutorials.type', TUTORIAL_RELATION_TYPES.LEARNING_MORE),
+      ),
+      knex.raw(
+        'coalesce((??), \'[]\') as "challengeIds"',
+        knex
+          .select(knex.raw('json_agg(??)', 'challenges.id'))
+          .from('challenges')
+          .where('challenges.skillId', knex.ref('skills.id')),
+      ),
+    )
+    .from('skills')
+    .leftOuterJoin('tubes', 'tubes.id', 'skills.tubeId')
+    .leftOuterJoin('thematics', 'thematics.id', 'tubes.thematicId');
+}
+
 export async function create(skill) {
   return knex.transaction(async (transaction) => {
     const createdSkillDTO = await skillDatasource.create(skill);
@@ -221,6 +260,48 @@ export async function update(skill) {
 
     return toDomain(updatedSkillDto, translations, skillDataFromPG);
   });
+}
+
+function compareSkillDtos(airtableDto, pgDto) {
+  const diff = [];
+  if (airtableDto.id !== pgDto.id) diff.push(`skill airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (!areNullableValuesEqual(airtableDto.status, pgDto.status))
+    diff.push(`skill airtable status "${airtableDto.status}" != postgres status "${pgDto.status}"`);
+  if (!areNullableValuesEqual(airtableDto.hintStatus, pgDto.hintStatus))
+    diff.push(`skill airtable hintStatus "${airtableDto.hintStatus}" != postgres hintStatus "${pgDto.hintStatus}"`);
+  if (!areNullableValuesEqual(airtableDto.descriptionStatus, pgDto.descriptionStatus))
+    diff.push(
+      `skill airtable descriptionStatus "${airtableDto.descriptionStatus}" != postgres descriptionStatus "${pgDto.descriptionStatus}"`,
+    );
+  if (!areNullableValuesEqual(airtableDto.description, pgDto.description))
+    diff.push(`skill airtable description "${airtableDto.description}" != postgres description "${pgDto.description}"`);
+  if (!areNullableValuesEqual(airtableDto.level, pgDto.level))
+    diff.push(`skill airtable level "${airtableDto.level}" != postgres level "${pgDto.level}"`);
+  if (!areNullableValuesEqual(airtableDto.internationalisation, pgDto.internationalisation))
+    diff.push(
+      `skill airtable internationalisation "${airtableDto.internationalisation}" != postgres internationalisation "${pgDto.internationalisation}"`,
+    );
+  if (!areNullableValuesEqual(airtableDto.version, pgDto.version))
+    diff.push(`skill airtable version "${airtableDto.version}" != postgres version "${pgDto.version}"`);
+  if (!areNullableValuesEqual(airtableDto.tubeId, pgDto.tubeId))
+    diff.push(`skill airtable tubeId "${airtableDto.tubeId}" != postgres tubeId "${pgDto.tubeId}"`);
+  if (airtableDto.name !== pgDto.name)
+    diff.push(`skill airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
+  if (!areNullableValuesEqual(airtableDto.competenceId, pgDto.competenceId))
+    diff.push(
+      `skill airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
+    );
+  if (!areArrayEquals(airtableDto.tutorialIds, pgDto.tutorialIds))
+    diff.push(`skill airtable tutorialIds "${airtableDto.tutorialIds}" != postgres tutorialIds "${pgDto.tutorialIds}"`);
+  if (!areArrayEquals(airtableDto.learningMoreTutorialIds, pgDto.learningMoreTutorialIds))
+    diff.push(
+      `skill airtable learningMoreTutorialIds "${airtableDto.learningMoreTutorialIds}" != postgres learningMoreTutorialIds "${pgDto.learningMoreTutorialIds}"`,
+    );
+  if (!areArrayEquals(airtableDto.challengeIds, pgDto.challengeIds))
+    diff.push(
+      `skill airtable challengeIds "${airtableDto.challengeIds}" != postgres challengeIds "${pgDto.challengeIds}"`,
+    );
+  return diff;
 }
 
 function toDomainList(datasourceSkills, translations, skillsDataFromPG) {

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -72,19 +72,19 @@ export async function getManyByAirtableIds(ids) {
 }
 
 export async function listByTubeId(tubeId) {
-  const datasourceSkills = await skillDatasource.filterByTubeId(tubeId);
-  if (!datasourceSkills) return [];
+  const [airtableDtos, pgDtos] = await Promise.all([
+    skillDatasource.filterByTubeId(tubeId),
+    selectSkills().where('skills.tubeId', tubeId),
+  ]);
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+
+  if (!airtableDtos) return [];
   const translations = await translationRepository.listByEntities(
     model,
-    datasourceSkills.map(({ id }) => id),
+    airtableDtos.map(({ id }) => id),
   );
-  const skillsDataFromPG = await knex(TABLE_NAME)
-    .select('*')
-    .whereIn(
-      'id',
-      datasourceSkills.map(({ id }) => id),
-    );
-  return toDomainList(datasourceSkills, translations, skillsDataFromPG);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export async function listActiveByCompetenceId(competenceId) {

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -144,22 +144,21 @@ function selectTubes() {
     .join('thematics', 'thematics.id', `${TABLE_NAME}.thematicId`);
 }
 
-function compareTubeDtos(airtableSkill, pgSkill) {
+function compareTubeDtos(airtableDto, pgDto) {
   const diff = [];
-  if (airtableSkill.id !== pgSkill.id)
-    diff.push(`tube airtable id "${airtableSkill.id}" != postgres id "${pgSkill.id}"`);
-  if (airtableSkill.name !== pgSkill.name)
-    diff.push(`tube airtable name "${airtableSkill.name}" != postgres name "${pgSkill.name}"`);
-  if (!areNullableValuesEqual(airtableSkill.index, pgSkill.index))
-    diff.push(`tube airtable index "${airtableSkill.index}" != postgres index "${pgSkill.index}"`);
-  if (airtableSkill.thematicId !== pgSkill.thematicId)
-    diff.push(`tube airtable thematicId "${airtableSkill.thematicId}" != postgres thematicId "${pgSkill.thematicId}"`);
-  if (airtableSkill.competenceId !== pgSkill.competenceId)
+  if (airtableDto.id !== pgDto.id) diff.push(`tube airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.name !== pgDto.name)
+    diff.push(`tube airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
+  if (!areNullableValuesEqual(airtableDto.index, pgDto.index))
+    diff.push(`tube airtable index "${airtableDto.index}" != postgres index "${pgDto.index}"`);
+  if (airtableDto.thematicId !== pgDto.thematicId)
+    diff.push(`tube airtable thematicId "${airtableDto.thematicId}" != postgres thematicId "${pgDto.thematicId}"`);
+  if (airtableDto.competenceId !== pgDto.competenceId)
     diff.push(
-      `tube airtable competenceId "${airtableSkill.competenceId}" != postgres competenceId "${pgSkill.competenceId}"`,
+      `tube airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
     );
-  if (!areArrayEquals(airtableSkill.skillIds, pgSkill.skillIds))
-    diff.push(`tube airtable skillIds "${airtableSkill.skillIds}" != postgres skillIds "${pgSkill.skillIds}"`);
+  if (!areArrayEquals(airtableDto.skillIds, pgDto.skillIds))
+    diff.push(`tube airtable skillIds "${airtableDto.skillIds}" != postgres skillIds "${pgDto.skillIds}"`);
   return diff;
 }
 

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -929,6 +929,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube1',
+          challengeIds: ['recChallenge1'],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkill2',
@@ -939,6 +942,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube1',
+          challengeIds: ['recChallenge2', 'recChallenge21'],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkill3',
@@ -949,6 +955,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ARCHIVE,
           competenceId,
           tubeId: 'recTube2',
+          challengeIds: ['recChallenge3'],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkill4',
@@ -959,6 +968,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube2',
+          challengeIds: ['recChallenge4', 'recChallenge41'],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkill5',
@@ -969,6 +981,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.EN_CONSTRUCTION,
           competenceId,
           tubeId: 'recTube2',
+          challengeIds: ['recChallenge5', 'recChallenge51'],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkill6',
@@ -979,6 +994,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.PERIME,
           competenceId,
           tubeId: 'recTube3',
+          challengeIds: ['recChallenge6'],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkill7',
@@ -989,15 +1007,22 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.EN_CONSTRUCTION,
           competenceId,
           tubeId: 'recTube3',
+          challengeIds: [],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
         {
           id: 'recSkillWorkbench',
           airtableId: 'recAirtableSkillWorkbench',
           name: '@workbench',
+          level: null,
           competenceId,
           tubeId: 'recTubeWorkbench',
+          challengeIds: [],
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
         },
-      ];
+      ].map(domainBuilder.buildSkillDatasourceObject);
 
       skills.forEach(databaseBuilder.factory.buildSkill);
 
@@ -1017,7 +1042,7 @@ describe('Acceptance | Route | competence-overviews', () => {
         .reply(200, { records: airtableSkills });
 
       const challenges = [
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge1',
           airtableId: 'recAirtableChallenge1',
           skillId: 'recSkill1',
@@ -1025,9 +1050,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge2',
           airtableId: 'recAirtableChallenge2',
           skillId: 'recSkill2',
@@ -1035,8 +1060,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge21',
           airtableId: 'recAirtableChallenge21',
           skillId: 'recSkill2',
@@ -1044,9 +1069,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 2,
           status: Challenge.STATUSES.PROPOSE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge3',
           airtableId: 'recAirtableChallenge3',
           skillId: 'recSkill3',
@@ -1054,9 +1079,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.ARCHIVE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge4',
           airtableId: 'recAirtableChallenge4',
           skillId: 'recSkill4',
@@ -1064,8 +1089,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.PERIME,
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge41',
           airtableId: 'recAirtableChallenge41',
           skillId: 'recSkill4',
@@ -1073,9 +1098,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 2,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge5',
           airtableId: 'recAirtableChallenge5',
           skillId: 'recSkill5',
@@ -1083,8 +1108,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.PERIME,
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge51',
           airtableId: 'recAirtableChallenge51',
           skillId: 'recSkill5',
@@ -1092,9 +1117,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 2,
           status: Challenge.STATUSES.PROPOSE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge6',
           airtableId: 'recAirtableChallenge6',
           skillId: 'recSkill6',
@@ -1102,8 +1127,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.PERIME,
           competenceId,
-        }),
-      ];
+        },
+      ].map(domainBuilder.buildChallengeDatasourceObject);
 
       challenges.forEach(databaseBuilder.factory.buildChallenge);
 

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -214,6 +214,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube1',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          challengeIds: ['recChallenge1', 'recChallenge11', 'recChallenge12'],
         },
         {
           id: 'recSkill2',
@@ -223,6 +226,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube1',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          challengeIds: ['recChallenge2', 'recChallenge21'],
         },
         {
           id: 'recSkill3',
@@ -232,6 +238,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube2',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          challengeIds: ['recChallenge3', 'recChallenge31'],
         },
         {
           id: 'recSkill4',
@@ -241,6 +250,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube4',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          challengeIds: ['recChallenge4'],
         },
         {
           id: 'recSkill5',
@@ -250,8 +262,11 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Skill.STATUSES.ACTIF,
           competenceId,
           tubeId: 'recTube5',
+          tutorialIds: [],
+          learningMoreTutorialIds: [],
+          challengeIds: ['recChallenge5'],
         },
-      ];
+      ].map(domainBuilder.buildSkillDatasourceObject);
 
       skills.forEach(databaseBuilder.factory.buildSkill);
 
@@ -271,7 +286,7 @@ describe('Acceptance | Route | competence-overviews', () => {
         .reply(200, { records: airtableSkills });
 
       const challenges = [
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge1',
           airtableId: 'recAirtableChallenge1',
           skillId: 'recSkill1',
@@ -280,8 +295,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge11',
           airtableId: 'recAirtableChallenge11',
           skillId: 'recSkill1',
@@ -290,8 +305,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: [LOCALE.FRENCH_FRANCE],
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge2',
           airtableId: 'recAirtableChallenge2',
           skillId: 'recSkill2',
@@ -300,9 +315,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge3',
           airtableId: 'recAirtableChallenge3',
           skillId: 'recSkill3',
@@ -311,8 +326,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 2,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge31',
           airtableId: 'recAirtableChallenge31',
           skillId: 'recSkill3',
@@ -320,8 +335,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 2,
           status: Challenge.STATUSES.PROPOSE,
           competenceId,
-        }),
-        domainBuilder.buildChallengeDatasourceObject({
+        },
+        {
           id: 'recChallenge4',
           airtableId: 'recAirtableChallenge4',
           skillId: 'recSkill4',
@@ -330,9 +345,9 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
+        },
 
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge5',
           airtableId: 'recAirtableChallenge5',
           skillId: 'recSkill5',
@@ -341,15 +356,15 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 1,
           status: Challenge.STATUSES.VALIDE,
           competenceId,
-        }),
-      ];
+        },
+      ].map(domainBuilder.buildChallengeDatasourceObject);
 
       challenges.forEach(databaseBuilder.factory.buildChallenge);
 
       const airtableChallenges = challenges.map(airtableBuilder.factory.buildChallenge);
 
       const englishChallenges = [
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge12',
           airtableId: 'recAirtableChallenge12',
           skillId: 'recSkill1',
@@ -358,15 +373,15 @@ describe('Acceptance | Route | competence-overviews', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: [LOCALE.ENGLISH_SPOKEN],
           competenceId,
-        }),
-      ];
+        },
+      ].map(domainBuilder.buildChallengeDatasourceObject);
 
       englishChallenges.forEach(databaseBuilder.factory.buildChallenge);
 
       const airtableEnglishChallenges = englishChallenges.map(airtableBuilder.factory.buildChallenge);
 
       const noiseChallenges = [
-        domainBuilder.buildChallengeDatasourceObject({
+        {
           id: 'recChallenge21',
           airtableId: 'recAirtableChallenge21',
           skillId: 'recSkill2',
@@ -375,8 +390,8 @@ describe('Acceptance | Route | competence-overviews', () => {
           version: 2,
           status: Challenge.STATUSES.PROPOSE,
           competenceId,
-        }),
-      ];
+        },
+      ].map(domainBuilder.buildChallengeDatasourceObject);
 
       noiseChallenges.forEach(databaseBuilder.factory.buildChallenge);
 

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -82,7 +82,7 @@ async function mockCurrentContent() {
     tubes: [
       {
         id: 'recTube0',
-        name: 'Nom du Tube',
+        name: '@tube',
         practicalTitle_i18n: {
           fr: 'Titre pratique du Tube - fr',
           en: 'Titre pratique du Tube - en',
@@ -103,7 +103,7 @@ async function mockCurrentContent() {
     skills: [
       {
         id: 'recSkill0',
-        name: 'Nom de l‘Acquis',
+        name: '@tube1',
         hint_i18n: {
           fr: 'Indice - fr',
           en: 'Indice - en',
@@ -291,7 +291,7 @@ async function mockCurrentContent() {
     frameworks: [
       buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] }),
     ],
-    skills: [buildSkill(expectedCurrentContent.skills[0])],
+    skills: [buildSkill({ ...expectedCurrentContent.skills[0], challengeIds: ['recChallenge0'] })],
     thematics: [
       buildThematic({
         ...expectedCurrentContent.thematics[0],
@@ -314,6 +314,7 @@ async function mockCurrentContent() {
   databaseBuilder.factory.buildTube(expectedCurrentContent.tubes[0]);
   expectedCurrentContent.tutorials.forEach(databaseBuilder.factory.buildTutorial);
   databaseBuilder.factory.buildSkill(expectedCurrentContent.skills[0]);
+  databaseBuilder.factory.buildChallenge(expectedCurrentContent.challenges[0]);
 
   databaseBuilder.factory.buildStaticCourse({
     id: 'recCourse0',
@@ -444,7 +445,6 @@ async function mockCurrentContent() {
     value: expectedCurrentContent.challenges[0].illustrationAlt,
   });
 
-  databaseBuilder.factory.buildChallenge(expectedCurrentContent.challenges[0]);
   databaseBuilder.factory.buildLocalizedChallenge({
     id: expectedCurrentContent.challenges[0].id,
     challengeId: expectedCurrentContent.challenges[0].id,
@@ -523,7 +523,7 @@ async function mockContentForRelease() {
     tubes: [
       {
         id: 'recTube0',
-        name: 'Nom du Tube',
+        name: '@zobi',
         competenceId: 'recCompetence0',
         thematicId: 'recThematic0',
         skillIds: ['recSkill0'],
@@ -544,7 +544,7 @@ async function mockContentForRelease() {
     skills: [
       {
         id: 'recSkill0',
-        name: 'Nom de l‘Acquis',
+        name: '@zobi1',
         hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
         tutorialIds: ['recTutorial0'],
         learningMoreTutorialIds: ['recTutorial1'],
@@ -760,7 +760,7 @@ async function mockContentForRelease() {
     frameworks: [
       buildFramework({ ...expectedCurrentContent.frameworks[0], areaIds: [expectedCurrentContent.areas[0].id] }),
     ],
-    skills: [buildSkill(expectedCurrentContent.skills[0])],
+    skills: [buildSkill({ ...expectedCurrentContent.skills[0], challengeIds: ['recChallenge0', 'recChallenge0_1'] })],
     thematics: [buildThematic(expectedCurrentContent.thematics[0])],
     tubes: [buildTube(expectedCurrentContent.tubes[0])],
     tutorials: expectedCurrentContent.tutorials.map(buildTutorial),

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -111,6 +111,7 @@ async function mockCurrentContent() {
       thematicId: expectedThematic.id,
       competenceId: expectedCompetence.id,
       skillIds: ['recSkill1'],
+      name: '@dvorak',
     }),
   );
   expectedCurrentContent.tubes = [
@@ -127,6 +128,7 @@ async function mockCurrentContent() {
     tubeId: expectedTube.id,
     tutorialIds: ['recTuto1'],
     learningMoreTutorialIds: ['recTuto2'],
+    name: '@dvorak5',
     createdAt: '2023-10-05T18:08:00Z',
     activatedAt: '2023-11-06T18:08:00.000Z',
     archivedAt: '2023-12-07T18:08:00.000Z',
@@ -295,7 +297,13 @@ async function mockCurrentContent() {
     competences: [buildCompetence({ ...expectedCompetence, tubeIds: [expectedTube.id] })],
     thematics: [buildThematic(expectedThematic)],
     tubes: [buildTube({ ...expectedTube, competenceId: expectedCompetence.id, skillIds: [baseSkill.id] })],
-    skills: [buildSkill(expectedCurrentContent.skills[0])],
+    skills: [
+      buildSkill({
+        ...expectedCurrentContent.skills[0],
+        competenceId: expectedCompetence.id,
+        challengeIds: ['challenge-id', 'challenge-id-alt'],
+      }),
+    ],
     challenges: [
       buildChallenge({
         ...expectedChallenge,

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -462,54 +462,52 @@ describe('Application | Route | Skills', () => {
 
     describe('with ids filter', () => {
       beforeEach(async () => {
-        const airtableSkills = [
-          airtableBuilder.factory.buildSkill(
-            domainBuilder.buildSkillDatasourceObject({
-              id: 'skill1',
-              airtableId: 'recSkill1',
-              createdAt: '2025-01-06T13:50:47.437Z',
-              description: 'premier acquis',
-              descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
-              hintStatus: Skill.HINT_STATUSES.VALIDE,
-              internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-              level: 4,
-              name: '@skill4',
-              pixValue: 1.5,
-              status: Skill.STATUSES.ACTIF,
-              version: 1,
-              tubeId: 'tube1',
-              tubeAirtableId: 'recTube1',
-              tutorialIds: ['tuto1'],
-              tutorialAirtableIds: ['recTuto1'],
-              learningMoreTutorialIds: ['tuto2', 'tuto3'],
-              learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
-              challengeIds: ['challenge1', 'challenge2'],
-            }),
-          ),
-          airtableBuilder.factory.buildSkill(
-            domainBuilder.buildSkillDatasourceObject({
-              id: 'skill2',
-              airtableId: 'recSkill2',
-              createdAt: '2025-01-06T13:51:04.381Z',
-              description: 'deuxième acquis',
-              descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
-              hintStatus: Skill.HINT_STATUSES.PROPOSE,
-              internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
-              level: 3,
-              name: '@skill3',
-              pixValue: 1.8,
-              status: Skill.STATUSES.EN_CONSTRUCTION,
-              version: 2,
-              tubeId: 'tube2',
-              tubeAirtableId: 'recTube2',
-              tutorialIds: ['tuto2'],
-              tutorialAirtableIds: ['recTuto2'],
-              learningMoreTutorialIds: ['tuto3', 'tuto4'],
-              learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
-              challengeIds: ['challenge3', 'challenge4', 'challenge5'],
-            }),
-          ),
-        ];
+        const skill1 = domainBuilder.buildSkillDatasourceObject({
+          id: 'skill1',
+          airtableId: 'recSkill1',
+          createdAt: '2025-01-06T13:50:47.437Z',
+          description: 'premier acquis',
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+          hintStatus: Skill.HINT_STATUSES.VALIDE,
+          internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+          level: 4,
+          name: '@skill4',
+          pixValue: 1.5,
+          status: Skill.STATUSES.ACTIF,
+          version: 1,
+          tubeId: 'tube1',
+          tubeAirtableId: 'recTube1',
+          tutorialIds: ['tuto1'],
+          tutorialAirtableIds: ['recTuto1'],
+          learningMoreTutorialIds: ['tuto2', 'tuto3'],
+          learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
+          challengeIds: ['challenge1', 'challenge2'],
+          competenceId: 'competence1',
+        });
+        const skill2 = domainBuilder.buildSkillDatasourceObject({
+          id: 'skill2',
+          airtableId: 'recSkill2',
+          createdAt: '2025-01-06T13:51:04.381Z',
+          description: 'deuxième acquis',
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
+          hintStatus: Skill.HINT_STATUSES.PROPOSE,
+          internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+          level: 3,
+          name: '@skill3',
+          pixValue: 1.8,
+          status: Skill.STATUSES.EN_CONSTRUCTION,
+          version: 2,
+          tubeId: 'tube2',
+          tubeAirtableId: 'recTube2',
+          tutorialIds: ['tuto2'],
+          tutorialAirtableIds: ['recTuto2'],
+          learningMoreTutorialIds: ['tuto3', 'tuto4'],
+          learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
+          challengeIds: ['challenge3', 'challenge4', 'challenge5'],
+          competenceId: 'competence1',
+        });
+
+        const airtableSkills = [airtableBuilder.factory.buildSkill(skill1), airtableBuilder.factory.buildSkill(skill2)];
 
         airtableSkillsScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Acquis')
@@ -525,6 +523,40 @@ describe('Application | Route | Skills', () => {
         databaseBuilder.factory.buildTranslation({ key: 'skill.skill1.hint', locale: 'en', value: 'A clue' });
         databaseBuilder.factory.buildTranslation({ key: 'skill.skill2.hint', locale: 'fr', value: 'Un autre indice' });
         databaseBuilder.factory.buildTranslation({ key: 'skill.skill2.hint', locale: 'en', value: 'An other clue' });
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+        databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+        databaseBuilder.factory.buildTube({ id: 'tube2', name: '@skill', thematicId: 'thematic1' });
+        ['tuto1', 'tuto2', 'tuto3', 'tuto4'].forEach((tutorialId) => {
+          databaseBuilder.factory.buildTutorial(
+            domainBuilder.buildTutorialDatasourceObject({
+              id: tutorialId,
+              tagIds: [],
+            }),
+          );
+        });
+        databaseBuilder.factory.buildSkill(skill1);
+        databaseBuilder.factory.buildSkill(skill2);
+        skill1.challengeIds.forEach((challengeId) => {
+          databaseBuilder.factory.buildChallenge(
+            domainBuilder.buildChallengeDatasourceObject({
+              id: challengeId,
+              skillId: skill1.id,
+            }),
+          );
+        });
+
+        skill2.challengeIds.forEach((challengeId) => {
+          databaseBuilder.factory.buildChallenge(
+            domainBuilder.buildChallengeDatasourceObject({
+              id: challengeId,
+              skillId: skill2.id,
+            }),
+          );
+        });
 
         await databaseBuilder.commit();
       });

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -932,35 +932,58 @@ describe('Application | Route | Skills', () => {
     let airtableSkillScope;
 
     beforeEach(async () => {
-      const airtableSkill = airtableBuilder.factory.buildSkill(
-        domainBuilder.buildSkillDatasourceObject({
-          id: 'skill1',
-          airtableId: 'recSkill1',
-          createdAt: '2025-01-06T13:50:47.437Z',
-          description: 'premier acquis',
-          descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
-          hintStatus: Skill.HINT_STATUSES.VALIDE,
-          internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-          level: 4,
-          name: '@skill4',
-          pixValue: 1.5,
-          status: Skill.STATUSES.ACTIF,
-          version: 1,
-          tubeId: 'tube1',
-          tubeAirtableId: 'recTube1',
-          tutorialIds: ['tuto1'],
-          tutorialAirtableIds: ['recTuto1'],
-          learningMoreTutorialIds: ['tuto2', 'tuto3'],
-          learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
-          challengeIds: ['challenge1', 'challenge2'],
-        }),
-      );
+      const skill = domainBuilder.buildSkillDatasourceObject({
+        id: 'skill1',
+        airtableId: 'recSkill1',
+        createdAt: '2025-01-06T13:50:47.437Z',
+        description: 'premier acquis',
+        descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+        hintStatus: Skill.HINT_STATUSES.VALIDE,
+        internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+        level: 4,
+        name: '@skill4',
+        pixValue: 1.5,
+        status: Skill.STATUSES.ACTIF,
+        version: 1,
+        tubeId: 'tube1',
+        tubeAirtableId: 'recTube1',
+        tutorialIds: ['tuto1'],
+        tutorialAirtableIds: ['recTuto1'],
+        learningMoreTutorialIds: ['tuto2', 'tuto3'],
+        learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
+        challengeIds: ['challenge1', 'challenge2'],
+        competenceId: 'competence1',
+      });
+      const airtableSkill = airtableBuilder.factory.buildSkill(skill);
 
       airtableSkillScope = nock('https://api.airtable.com')
         .get('/v0/airtableBaseValue/Acquis/recSkill1')
         .query({})
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
         .reply(200, airtableSkill);
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+      [...skill.tutorialIds, ...skill.learningMoreTutorialIds].forEach((tutorialId) => {
+        databaseBuilder.factory.buildTutorial(
+          domainBuilder.buildTutorialDatasourceObject({
+            id: tutorialId,
+            tagIds: [],
+          }),
+        );
+      });
+      databaseBuilder.factory.buildSkill(skill);
+      skill.challengeIds.forEach((challengeId) => {
+        databaseBuilder.factory.buildChallenge(
+          domainBuilder.buildChallengeDatasourceObject({
+            id: challengeId,
+            skillId: skill.id,
+          }),
+        );
+      });
 
       databaseBuilder.factory.buildTranslation({ key: 'skill.skill1.hint', locale: 'fr', value: 'Un indice' });
       databaseBuilder.factory.buildTranslation({ key: 'skill.skill1.hint', locale: 'en', value: 'A clue' });
@@ -1420,13 +1443,13 @@ describe('Application | Route | Skills', () => {
       skillDataObject = domainBuilder.buildSkillDatasourceObject({
         airtableId: 'skillAirtableId',
         id: 'skillIdPersistant',
-        name: 'Un nom généré par Airtable',
+        name: '@foo7',
         hintStatus: skillAttributes['clue-status'],
         tutorialIds: ['tutorialIdPersistant'],
         tutorialAirtableIds: ['tutorialAirtableId'],
         learningMoreTutorialIds: ['tutorialLMIdPersistant'],
         learningMoreTutorialAirtableIds: ['tutorialLMAirtableId'],
-        competenceId: 'UneCompetenceId',
+        competenceId: 'competence1',
         pixValue: 789,
         status: skillAttributes['status'],
         tubeId: 'tubeIdPersistant',
@@ -1500,6 +1523,14 @@ describe('Application | Route | Skills', () => {
         locale: 'fr',
       });
       databaseBuilder.factory.buildSkill(skillDataObject);
+      skillDataObject.challengeIds.forEach((challengeId) => {
+        databaseBuilder.factory.buildChallenge(
+          domainBuilder.buildChallengeDatasourceObject({
+            id: challengeId,
+            skillId: skillDataObject.id,
+          }),
+        );
+      });
 
       databaseBuilder.factory.buildTranslation({
         locale: 'fr',

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -1699,8 +1699,11 @@ describe('Application | Route | Skills', () => {
         airtableId: 'recSkill1Tube1',
         tubeId: 'tube1',
         tubeAirtableId: 'recTube1',
+        name: '@tube1',
         level: 1,
         version: 1,
+        competenceId: 'competence1',
+        challengeIds: ['validatedChallengeProto'],
       });
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -1122,21 +1122,31 @@ describe('Application | Route | Skills', () => {
       };
 
       const skills = [
-        {
+        domainBuilder.buildSkillDatasourceObject({
           id: 'skill1Tube1',
           airtableId: 'recSkill1Tube1',
           tubeId: 'tube1',
           tubeAirtableId: 'recTube1',
           level: 1,
           version: 1,
-        },
-        {
+          name: '@tube1',
+          competenceId: 'competence1',
+          challengeIds: [],
+          tutorialIds: ['tuto1', 'tuto3'],
+          learningMoreTutorialIds: ['tuto2'],
+        }),
+        domainBuilder.buildSkillDatasourceObject({
           id: 'skill2Tube1',
           airtableId: 'recSkill2Tube1',
           tubeId: 'tube1',
           tubeAirtableId: 'recTube1',
           level: 2,
-        },
+          name: '@tube2',
+          competenceId: 'competence1',
+          challengeIds: [],
+          tutorialIds: ['tuto2', 'tuto3'],
+          learningMoreTutorialIds: [],
+        }),
       ];
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -1430,7 +1440,9 @@ describe('Application | Route | Skills', () => {
         { key: 'skill.nouvelAcquis.hint', locale: 'fr', value: 'L indice de mon nouvel acquis' },
       ]);
 
-      await expect(knex.select('*').from('skills-tutorials').orderBy(['type', 'tutorialId'])).resolves.toStrictEqual([
+      await expect(
+        knex.select('*').from('skills-tutorials').where('skillId', 'nouvelAcquis').orderBy(['type', 'tutorialId']),
+      ).resolves.toStrictEqual([
         {
           type: 'learningMore',
           skillId: 'nouvelAcquis',
@@ -1819,24 +1831,27 @@ describe('Application | Route | Skills', () => {
         index: 5,
         competenceId: 'competence1',
         thematicId: 'thematic1',
-        skillIds: ['skill1', 'skill2', 'skill1Tube1'],
+        skillIds: ['skill1Tube1', 'skill2Tube1'],
       };
       const airtableTube = airtableBuilder.factory.buildTube(domainBuilder.buildTubeDatasourceObject(tube));
       databaseBuilder.factory.buildTube(tube);
-      databaseBuilder.factory.buildSkill({ id: 'skill1', tubeId: tube.id });
-      databaseBuilder.factory.buildSkill({ id: 'skill2', tubeId: tube.id });
+      const skillAlreadyAtDestinationTubeLevel = domainBuilder.buildSkillDatasourceObject({
+        id: 'skill2Tube1',
+        airtableId: 'recSkill2Tube1',
+        tubeId: 'tube1',
+        tubeAirtableId: 'recTube1',
+        level: 2,
+        version: 1,
+        name: '@tube2',
+        competenceId: 'competence1',
+        challengeIds: [],
+      });
+      databaseBuilder.factory.buildSkill(skillAlreadyAtDestinationTubeLevel);
       databaseBuilder.factory.buildSkill(skillToClone);
 
       const airtableSkillToClone = airtableBuilder.factory.buildSkill(skillToClone);
       const airtableSkillAlreadyAtDestinationTubeLevel = airtableBuilder.factory.buildSkill(
-        domainBuilder.buildSkillDatasourceObject({
-          id: 'skill2Tube1',
-          airtableId: 'recSkill2Tube1',
-          tubeId: 'tube1',
-          tubeAirtableId: 'recTube1',
-          level: 2,
-          version: 1,
-        }),
+        skillAlreadyAtDestinationTubeLevel,
       );
       const airtableSkills = [airtableSkillToClone, airtableSkillAlreadyAtDestinationTubeLevel];
       const skillTradFr = databaseBuilder.factory.buildTranslation({

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -222,54 +222,54 @@ describe('Application | Route | Skills', () => {
 
     describe('with no filters', () => {
       beforeEach(async () => {
-        const airtableSkills = [
-          airtableBuilder.factory.buildSkill(
-            domainBuilder.buildSkillDatasourceObject({
-              id: 'skill1',
-              airtableId: 'recSkill1',
-              createdAt: '2025-01-06T13:50:47.437Z',
-              description: 'premier acquis',
-              descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
-              hintStatus: Skill.HINT_STATUSES.VALIDE,
-              internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-              level: 4,
-              name: '@skill4',
-              pixValue: 1.5,
-              status: Skill.STATUSES.ACTIF,
-              version: 1,
-              tubeId: 'tube1',
-              tubeAirtableId: 'recTube1',
-              tutorialIds: ['tuto1'],
-              tutorialAirtableIds: ['recTuto1'],
-              learningMoreTutorialIds: ['tuto2', 'tuto3'],
-              learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
-              challengeIds: ['challenge1', 'challenge2'],
-            }),
-          ),
-          airtableBuilder.factory.buildSkill(
-            domainBuilder.buildSkillDatasourceObject({
-              id: 'skill2',
-              airtableId: 'recSkill2',
-              createdAt: '2025-01-06T13:51:04.381Z',
-              description: 'deuxième acquis',
-              descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
-              hintStatus: Skill.HINT_STATUSES.PROPOSE,
-              internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
-              level: 3,
-              name: '@skill3',
-              pixValue: 1.8,
-              status: Skill.STATUSES.EN_CONSTRUCTION,
-              version: 2,
-              tubeId: 'tube2',
-              tubeAirtableId: 'recTube2',
-              tutorialIds: ['tuto2'],
-              tutorialAirtableIds: ['recTuto2'],
-              learningMoreTutorialIds: ['tuto3', 'tuto4'],
-              learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
-              challengeIds: ['challenge3', 'challenge4', 'challenge5'],
-            }),
-          ),
+        const skills = [
+          domainBuilder.buildSkillDatasourceObject({
+            id: 'skill1',
+            airtableId: 'recSkill1',
+            createdAt: '2025-01-06T13:50:47.437Z',
+            description: 'premier acquis',
+            descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+            hintStatus: Skill.HINT_STATUSES.VALIDE,
+            internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+            level: 4,
+            name: '@skill4',
+            pixValue: 1.5,
+            status: Skill.STATUSES.ACTIF,
+            version: 1,
+            tubeId: 'tube1',
+            tubeAirtableId: 'recTube1',
+            tutorialIds: ['tuto1'],
+            tutorialAirtableIds: ['recTuto1'],
+            learningMoreTutorialIds: ['tuto2', 'tuto3'],
+            learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
+            challengeIds: ['challenge1', 'challenge2'],
+            competenceId: 'competence1',
+          }),
+          domainBuilder.buildSkillDatasourceObject({
+            id: 'skill2',
+            airtableId: 'recSkill2',
+            createdAt: '2025-01-06T13:51:04.381Z',
+            description: 'deuxième acquis',
+            descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
+            hintStatus: Skill.HINT_STATUSES.PROPOSE,
+            internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+            level: 3,
+            name: '@acquis3',
+            pixValue: 1.8,
+            status: Skill.STATUSES.EN_CONSTRUCTION,
+            version: 2,
+            tubeId: 'tube2',
+            tubeAirtableId: 'recTube2',
+            tutorialIds: ['tuto2'],
+            tutorialAirtableIds: ['recTuto2'],
+            learningMoreTutorialIds: ['tuto3', 'tuto4'],
+            learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
+            challengeIds: ['challenge3', 'challenge4', 'challenge5'],
+            competenceId: 'competence1',
+          }),
         ];
+
+        const airtableSkills = skills.map(airtableBuilder.factory.buildSkill);
 
         airtableSkillsScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Acquis')
@@ -279,6 +279,25 @@ describe('Application | Route | Skills', () => {
           })
           .matchHeader('authorization', 'Bearer airtableApiKeyValue')
           .reply(200, { records: airtableSkills });
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+        databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+        databaseBuilder.factory.buildTube({ id: 'tube2', name: '@acquis', thematicId: 'thematic1' });
+
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto1', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto2', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto3', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto4', tagIds: [] }));
+
+        skills.forEach((skill) => {
+          databaseBuilder.factory.buildSkill(skill);
+          skill.challengeIds.forEach((id) =>
+            databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id, skillId: skill.id })),
+          );
+        });
 
         databaseBuilder.factory.buildTranslation({ key: 'skill.skill1.hint', locale: 'fr', value: 'Un indice' });
         databaseBuilder.factory.buildTranslation({ key: 'skill.skill1.hint', locale: 'en', value: 'A clue' });
@@ -380,7 +399,7 @@ describe('Application | Route | Skills', () => {
                 'description-status': 'Proposé',
                 i18n: 'Monde',
                 level: 3,
-                name: '@skill3',
+                name: '@acquis3',
                 status: 'en construction',
                 version: 2,
               },
@@ -2147,15 +2166,13 @@ describe('Application | Route | Skills', () => {
       await expect(
         knex.select('*').from('skills-tutorials').where('skillId', 'clonedAcquisId').orderBy(['type', 'tutorialId']),
       ).resolves.toStrictEqual([
-        ...skillToClone.learningMoreTutorialIds
-          .toSorted()
-          .map((tutorialId) => ({
-            type: 'learningMore',
-            skillId: 'clonedAcquisId',
-            tutorialId,
-            createdAt: expect.any(Date),
-            updatedAt: expect.any(Date),
-          })),
+        ...skillToClone.learningMoreTutorialIds.toSorted().map((tutorialId) => ({
+          type: 'learningMore',
+          skillId: 'clonedAcquisId',
+          tutorialId,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        })),
         ...skillToClone.tutorialIds.map((tutorialId) => ({
           type: 'understanding',
           skillId: 'clonedAcquisId',

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -684,59 +684,81 @@ describe('Application | Route | Skills', () => {
 
     describe('with name filter, page limit and sort', () => {
       beforeEach(async () => {
-        const airtableSkills = [
-          airtableBuilder.factory.buildSkill(
-            domainBuilder.buildSkillDatasourceObject({
-              id: 'skill1',
-              airtableId: 'recSkill1',
-              createdAt: '2025-01-06T13:50:47.437Z',
-              description: 'premier acquis',
-              descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
-              hintStatus: Skill.HINT_STATUSES.VALIDE,
-              internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-              level: 3,
-              name: '@skill3',
-              pixValue: 1.5,
-              status: Skill.STATUSES.ACTIF,
-              version: 1,
-              tubeId: 'tube1',
-              tubeAirtableId: 'recTube1',
-              tutorialIds: ['tuto1'],
-              tutorialAirtableIds: ['recTuto1'],
-              learningMoreTutorialIds: ['tuto2', 'tuto3'],
-              learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
-              challengeIds: ['challenge1', 'challenge2'],
-            }),
-          ),
-          airtableBuilder.factory.buildSkill(
-            domainBuilder.buildSkillDatasourceObject({
-              id: 'skill2',
-              airtableId: 'recSkill2',
-              createdAt: '2025-01-06T13:51:04.381Z',
-              description: 'deuxième acquis',
-              descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
-              hintStatus: Skill.HINT_STATUSES.PROPOSE,
-              internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
-              level: 4,
-              name: '@skill4',
-              pixValue: 1.8,
-              status: Skill.STATUSES.EN_CONSTRUCTION,
-              version: 2,
-              tubeId: 'tube2',
-              tubeAirtableId: 'recTube2',
-              tutorialIds: ['tuto2'],
-              tutorialAirtableIds: ['recTuto2'],
-              learningMoreTutorialIds: ['tuto3', 'tuto4'],
-              learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
-              challengeIds: ['challenge3', 'challenge4', 'challenge5'],
-            }),
-          ),
+        const skills = [
+          domainBuilder.buildSkillDatasourceObject({
+            id: 'skill1',
+            airtableId: 'recSkill1',
+            createdAt: '2025-01-06T13:50:47.437Z',
+            description: 'premier acquis',
+            descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+            hintStatus: Skill.HINT_STATUSES.VALIDE,
+            internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+            level: 3,
+            name: '@skill3',
+            pixValue: 1.5,
+            status: Skill.STATUSES.ACTIF,
+            version: 1,
+            tubeId: 'tube1',
+            tubeAirtableId: 'recTube1',
+            tutorialIds: ['tuto1'],
+            tutorialAirtableIds: ['recTuto1'],
+            learningMoreTutorialIds: ['tuto2', 'tuto3'],
+            learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
+            challengeIds: ['challenge1', 'challenge2'],
+            competenceId: 'competence1',
+          }),
+          domainBuilder.buildSkillDatasourceObject({
+            id: 'skill2',
+            airtableId: 'recSkill2',
+            createdAt: '2025-01-06T13:51:04.381Z',
+            description: 'deuxième acquis',
+            descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
+            hintStatus: Skill.HINT_STATUSES.PROPOSE,
+            internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+            level: 4,
+            name: '@skill4',
+            pixValue: 1.8,
+            status: Skill.STATUSES.EN_CONSTRUCTION,
+            version: 2,
+            tubeId: 'tube2',
+            tubeAirtableId: 'recTube2',
+            tutorialIds: ['tuto2'],
+            tutorialAirtableIds: ['recTuto2'],
+            learningMoreTutorialIds: ['tuto3', 'tuto4'],
+            learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
+            challengeIds: ['challenge3', 'challenge4', 'challenge5'],
+            competenceId: 'competence1',
+          }),
         ];
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+        databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+        databaseBuilder.factory.buildTube({ id: 'tube2', name: '@skill', thematicId: 'thematic1' });
+
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto1', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto2', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto3', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto4', tagIds: [] }));
+
+        skills.forEach((skill) => {
+          databaseBuilder.factory.buildSkill(skill);
+
+          skill.challengeIds.forEach((id) =>
+            databaseBuilder.factory.buildChallenge(
+              domainBuilder.buildChallengeDatasourceObject({ id, skillId: skill.id }),
+            ),
+          );
+        });
+
+        const airtableSkills = skills.map(airtableBuilder.factory.buildSkill);
 
         airtableSkillsScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Acquis')
           .query({
-            filterByFormula: 'FIND("needle", LOWER(Nom))',
+            filterByFormula: 'FIND("@skil", LOWER(Nom))',
             fields: { '': skillDatasource.usedFields },
             sort: [{ field: 'Nom', direction: 'asc' }],
             maxRecords: 10,
@@ -759,7 +781,7 @@ describe('Application | Route | Skills', () => {
         // when
         const response = await server.inject({
           method: 'GET',
-          url: '/api/skills?filter[name]=Needle&page[limit]=10&sort=name',
+          url: '/api/skills?filter[name]=@SkiL&page[limit]=10&sort=name',
           headers: generateAuthorizationHeader(editorUser),
         });
 

--- a/api/tests/integration/domain/services/mission-validator_test.js
+++ b/api/tests/integration/domain/services/mission-validator_test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { Mission, Skill } from '../../../../lib/domain/models/index.js';
 import * as missionValidator from '../../../../lib/domain/services/mission-validator.js';
 import { InvalidMissionContentError, MissionIntroductionMediaError } from '../../../../lib/domain/errors.js';
-import { airtableBuilder, databaseBuilder } from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 
 describe('Integration | Validator | Mission', function () {
   describe('status validation', function () {
@@ -114,23 +114,34 @@ describe('Integration | Validator | Mission', function () {
             databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
             databaseBuilder.factory.buildThematic(thematic);
             databaseBuilder.factory.buildTube(tube);
+            const skill1 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ACTIF,
+              name: '@Pix1D-recherche_di1',
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+            });
+            const skill2 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION,
+              name: '@Pix1D-recherche_di1',
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+            });
+            databaseBuilder.factory.buildSkill(skill1);
+            databaseBuilder.factory.buildSkill(skill2);
             await databaseBuilder.commit();
 
             airtableBuilder.mockLists({
-              skills: [
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.ACTIF,
-                }),
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1Bis',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.EN_CONSTRUCTION,
-                }),
-              ],
+              skills: [airtableBuilder.factory.buildSkill(skill1), airtableBuilder.factory.buildSkill(skill2)],
               tubes: [airtableBuilder.factory.buildTube(tube)],
               thematics: [airtableBuilder.factory.buildThematic(thematic)],
             });
@@ -170,6 +181,7 @@ describe('Integration | Validator | Mission', function () {
               name: '@Pix1D-recherche_di',
               thematicId: 'Thematic1',
               competenceId: 'competence1',
+              skillIds: ['skillTuto1', 'skillTuto1Bis'],
             };
 
             databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -177,23 +189,34 @@ describe('Integration | Validator | Mission', function () {
             databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
             databaseBuilder.factory.buildThematic(thematic);
             databaseBuilder.factory.buildTube(tube);
+            const skill1 = domainBuilder.buildSkill({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.ARCHIVE,
+              competenceId: 'competence1',
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              challengeIds: [],
+              name: '@Pix1D-recherche_di1',
+            });
+            const skill2 = domainBuilder.buildSkill({
+              id: 'skillTuto1Bis',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.PERIME,
+              competenceId: 'competence1',
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              challengeIds: [],
+              name: '@Pix1D-recherche_di1',
+            });
+            databaseBuilder.factory.buildSkill(skill1);
+            databaseBuilder.factory.buildSkill(skill2);
             await databaseBuilder.commit();
 
             airtableBuilder.mockLists({
-              skills: [
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.ARCHIVE,
-                }),
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1Bis',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.PERIME,
-                }),
-              ],
+              skills: [airtableBuilder.factory.buildSkill(skill1), airtableBuilder.factory.buildSkill(skill2)],
               tubes: [airtableBuilder.factory.buildTube(tube)],
               thematics: [airtableBuilder.factory.buildThematic(thematic)],
             });
@@ -233,6 +256,7 @@ describe('Integration | Validator | Mission', function () {
               name: '@Pix1D-recherche_di',
               thematicId: 'Thematic1',
               competenceId: 'competence1',
+              skillIds: ['skillTuto1', 'skillTuto1Bis', 'skillTuto2'],
             };
 
             databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -240,28 +264,48 @@ describe('Integration | Validator | Mission', function () {
             databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
             databaseBuilder.factory.buildThematic(thematic);
             databaseBuilder.factory.buildTube(tube);
+            const skill1 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto1',
+              name: '@Pix1D-recherche_di1',
+              tubeId: 'tubeTuto',
+              level: 1,
+              status: Skill.STATUSES.ACTIF,
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+            });
+            const skill2 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto1Bis',
+              name: '@Pix1D-recherche_di1',
+              tubeId: 'tubeTuto',
+              level: 1,
+              status: Skill.STATUSES.EN_CONSTRUCTION,
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+            });
+            const skill3 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto2',
+              name: '@Pix1D-recherche_di2',
+              tubeId: 'tubeTuto',
+              level: 2,
+              status: Skill.STATUSES.EN_CONSTRUCTION,
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+            });
+            [skill1, skill2, skill3].forEach(databaseBuilder.factory.buildSkill);
+
             await databaseBuilder.commit();
 
             airtableBuilder.mockLists({
               skills: [
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.ACTIF,
-                }),
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1Bis',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.EN_CONSTRUCTION,
-                }),
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto2',
-                  level: 2,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.EN_CONSTRUCTION,
-                }),
+                airtableBuilder.factory.buildSkill(skill1),
+                airtableBuilder.factory.buildSkill(skill2),
+                airtableBuilder.factory.buildSkill(skill3),
               ],
               tubes: [airtableBuilder.factory.buildTube(tube)],
               thematics: [airtableBuilder.factory.buildThematic(thematic)],
@@ -304,6 +348,7 @@ describe('Integration | Validator | Mission', function () {
               name: '@Pix1D-recherche_di',
               thematicId: 'Thematic1',
               competenceId: 'competence1',
+              skillIds: ['skillTuto1', 'skillTuto2'],
             };
 
             databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -311,23 +356,34 @@ describe('Integration | Validator | Mission', function () {
             databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
             databaseBuilder.factory.buildThematic(thematic);
             databaseBuilder.factory.buildTube(tube);
+            const skill1 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto1',
+              level: 1,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION,
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+              name: '@Pix1D-recherche_di1',
+            });
+            const skill2 = domainBuilder.buildSkillDatasourceObject({
+              id: 'skillTuto2',
+              level: 2,
+              tubeId: 'tubeTuto',
+              status: Skill.STATUSES.EN_CONSTRUCTION,
+              tutorialIds: [],
+              learningMoreTutorialIds: [],
+              competenceId: 'competence1',
+              challengeIds: [],
+              name: '@Pix1D-recherche_di2',
+            });
+            databaseBuilder.factory.buildSkill(skill1);
+            databaseBuilder.factory.buildSkill(skill2);
             await databaseBuilder.commit();
 
             airtableBuilder.mockLists({
-              skills: [
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto1',
-                  level: 1,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.EN_CONSTRUCTION,
-                }),
-                airtableBuilder.factory.buildSkill({
-                  id: 'skillTuto2',
-                  level: 2,
-                  tubeId: 'tubeTuto',
-                  status: Skill.STATUSES.EN_CONSTRUCTION,
-                }),
-              ],
+              skills: [airtableBuilder.factory.buildSkill(skill1), airtableBuilder.factory.buildSkill(skill2)],
               tubes: [airtableBuilder.factory.buildTube(tube)],
               thematics: [airtableBuilder.factory.buildThematic(thematic)],
             });

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -35,6 +35,7 @@ describe('Integration | Usecases | create mission', function () {
       name: '@Pix1D-recherche_di',
       thematicId: 'Thematic',
       competenceId: 'competence1',
+      skillIds: ['skillTuto2'],
     };
 
     databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -42,17 +43,22 @@ describe('Integration | Usecases | create mission', function () {
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic(thematic);
     databaseBuilder.factory.buildTube(tube);
+    const skill = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillTuto2',
+      level: 2,
+      tubeId: 'tubeTuto',
+      status: Skill.STATUSES.EN_CONSTRUCTION,
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      name: '@Pix1D-recherche_di2',
+      challengeIds: [],
+    });
+    databaseBuilder.factory.buildSkill(skill);
     await databaseBuilder.commit();
 
     airtableBuilder.mockLists({
-      skills: [
-        airtableBuilder.factory.buildSkill({
-          id: 'skillTuto2',
-          level: 2,
-          tubeId: 'tubeTuto',
-          status: Skill.STATUSES.EN_CONSTRUCTION,
-        }),
-      ],
+      skills: [airtableBuilder.factory.buildSkill(skill)],
       tubes: [airtableBuilder.factory.buildTube(tube)],
       thematics: [airtableBuilder.factory.buildThematic(thematic)],
     });

--- a/api/tests/integration/domain/usecases/update-mission_test.js
+++ b/api/tests/integration/domain/usecases/update-mission_test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { InvalidMissionContentError } from '../../../../lib/domain/errors.js';
 import { updateMission } from '../../../../lib/domain/usecases/index.js';
-import { airtableBuilder, databaseBuilder } from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import { Mission, Skill } from '../../../../lib/domain/models/index.js';
 import * as missionRepository from '../../../../lib/infrastructure/repositories/mission-repository.js';
 
@@ -33,6 +33,7 @@ describe('Integration | Usecases | Update mission', function () {
       name: '@Pix1D-recherche_di',
       thematicId: 'Thematic',
       competenceId: 'competence1',
+      skillIds: ['skillTuto2'],
     };
 
     databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -40,17 +41,22 @@ describe('Integration | Usecases | Update mission', function () {
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic(thematic);
     databaseBuilder.factory.buildTube(tube);
+    const skill = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillTuto2',
+      level: 2,
+      tubeId: 'tubeTuto',
+      status: Skill.STATUSES.EN_CONSTRUCTION,
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: [],
+      name: '@Pix1D-recherche_di2',
+    });
+    databaseBuilder.factory.buildSkill(skill);
     await databaseBuilder.commit();
 
     airtableBuilder.mockLists({
-      skills: [
-        airtableBuilder.factory.buildSkill({
-          id: 'skillTuto2',
-          level: 2,
-          tubeId: 'tubeTuto',
-          status: Skill.STATUSES.EN_CONSTRUCTION,
-        }),
-      ],
+      skills: [airtableBuilder.factory.buildSkill(skill)],
       tubes: [airtableBuilder.factory.buildTube(tube)],
       thematics: [airtableBuilder.factory.buildThematic(thematic)],
     });

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -530,7 +530,7 @@ function _mockRichAirtableContent() {
   const airtableThematic211 = airtableBuilder.factory.buildThematic(thematic211);
   const tube1111 = {
     id: 'tube1111',
-    name: 'tube1111 name',
+    name: '@tube1111',
     title: 'tube1111 title',
     description: 'tube1111 description',
     practicalTitle_i18n: {
@@ -550,7 +550,7 @@ function _mockRichAirtableContent() {
   const airtableTube1111 = airtableBuilder.factory.buildTube(tube1111);
   const tube1121 = {
     id: 'tube1121',
-    name: 'tube1121 name',
+    name: '@tube1121',
     title: 'tube1121 title',
     description: 'tube1121 description',
     practicalTitle_i18n: {
@@ -570,7 +570,7 @@ function _mockRichAirtableContent() {
   const airtableTube1121 = airtableBuilder.factory.buildTube(tube1121);
   const tube1211 = {
     id: 'tube1211',
-    name: 'tube1211 name',
+    name: '@tube1211',
     title: 'tube1211 title',
     description: 'tube1211 description',
     practicalTitle_i18n: {
@@ -590,7 +590,7 @@ function _mockRichAirtableContent() {
   const airtableTube1211 = airtableBuilder.factory.buildTube(tube1211);
   const tube1212 = {
     id: 'tube1212',
-    name: 'tube1212 name',
+    name: '@tube1212',
     title: 'tube1212 title',
     description: 'tube1212 description',
     practicalTitle_i18n: {
@@ -610,7 +610,7 @@ function _mockRichAirtableContent() {
   const airtableTube1212 = airtableBuilder.factory.buildTube(tube1212);
   const tube2111 = {
     id: 'tube2111',
-    name: 'tube2111 name',
+    name: '@tube2111',
     title: 'tube2111 title',
     description: 'tube2111 description',
     practicalTitle_i18n: {
@@ -651,7 +651,7 @@ function _mockRichAirtableContent() {
   const airtableTutorial2 = airtableBuilder.factory.buildTutorial(tutorial2);
   const skill11111 = {
     id: 'skill11111',
-    name: 'skill11111 name',
+    name: '@tube11114',
     hintStatus: SkillForRelease.HINT_STATUSES.PROPOSE,
     tutorialIds: ['tutorial2'],
     learningMoreTutorialIds: ['tutorial1'],
@@ -668,7 +668,7 @@ function _mockRichAirtableContent() {
   const airtableSkill11111 = airtableBuilder.factory.buildSkill(skill11111);
   const skill11112 = {
     id: 'skill11112',
-    name: 'skill11112 name',
+    name: '@tube11113',
     hintStatus: SkillForRelease.HINT_STATUSES.VALIDE,
     tutorialIds: [],
     learningMoreTutorialIds: [],
@@ -685,7 +685,7 @@ function _mockRichAirtableContent() {
   const airtableSkill11112 = airtableBuilder.factory.buildSkill(skill11112);
   const skill12121 = {
     id: 'skill12121',
-    name: 'skill12121 name',
+    name: '@tube12122',
     hintStatus: SkillForRelease.HINT_STATUSES.PRE_VALIDE,
     tutorialIds: [],
     learningMoreTutorialIds: [],
@@ -697,12 +697,13 @@ function _mockRichAirtableContent() {
     level: 2,
     internationalisation: SkillForRelease.INTERNATIONALISATIONS.UNION_EUROPEENNE,
     version: 12121,
+    challengeIds: ['challenge121211', 'challenge121212'],
   };
   databaseBuilder.factory.buildSkill(skill12121);
   const airtableSkill12121 = airtableBuilder.factory.buildSkill(skill12121);
   const skill21111 = {
     id: 'skill21111',
-    name: 'skill21111 name',
+    name: '@tube21111',
     hintStatus: SkillForRelease.HINT_STATUSES.A_SOUMETTRE,
     tutorialIds: [],
     learningMoreTutorialIds: [],
@@ -714,6 +715,7 @@ function _mockRichAirtableContent() {
     level: 1,
     internationalisation: SkillForRelease.INTERNATIONALISATIONS.MONDE,
     version: 21111,
+    challengeIds: ['challenge211111', 'challenge211112', 'challenge211113'],
   };
   databaseBuilder.factory.buildSkill(skill21111);
   const airtableSkill21111 = airtableBuilder.factory.buildSkill(skill21111);
@@ -1094,7 +1096,7 @@ function _getRichCurrentContentDTO() {
   const expectedTubeDTOs = [
     {
       id: 'tube1111',
-      name: 'tube1111 name',
+      name: '@tube1111',
       practicalTitle_i18n: {
         fr: 'tube1111 practicalTitleFrFr from PG',
         en: 'tube1111 practicalTitleEnUs from PG',
@@ -1111,7 +1113,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'tube1121',
-      name: 'tube1121 name',
+      name: '@tube1121',
       practicalTitle_i18n: {
         fr: 'tube1121 practicalTitleFrFr from PG',
         en: 'tube1121 practicalTitleEnUs from PG',
@@ -1128,7 +1130,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'tube1211',
-      name: 'tube1211 name',
+      name: '@tube1211',
       practicalTitle_i18n: {
         fr: 'tube1211 practicalTitleFrFr from PG',
         en: 'tube1211 practicalTitleEnUs from PG',
@@ -1145,7 +1147,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'tube1212',
-      name: 'tube1212 name',
+      name: '@tube1212',
       practicalTitle_i18n: {
         fr: 'tube1212 practicalTitleFrFr from PG',
         en: 'tube1212 practicalTitleEnUs from PG',
@@ -1162,7 +1164,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'tube2111',
-      name: 'tube2111 name',
+      name: '@tube2111',
       practicalTitle_i18n: {
         fr: 'tube2111 practicalTitleFrFr from PG',
         en: 'tube2111 practicalTitleEnUs from PG',
@@ -1181,7 +1183,7 @@ function _getRichCurrentContentDTO() {
   const expectedSkillDTOs = [
     {
       id: 'skill11111',
-      name: 'skill11111 name',
+      name: '@tube11114',
       hint_i18n: {
         fr: 'skill11111 hintFrFr',
         en: 'skill11111 hintEnUs',
@@ -1198,7 +1200,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'skill11112',
-      name: 'skill11112 name',
+      name: '@tube11113',
       hint_i18n: {
         fr: 'skill11112 hintFrFr',
         en: 'skill11112 hintEnUs',
@@ -1215,7 +1217,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'skill12121',
-      name: 'skill12121 name',
+      name: '@tube12122',
       hint_i18n: {
         fr: 'skill12121 hintFrFr',
         en: 'skill12121 hintEnUs',
@@ -1232,7 +1234,7 @@ function _getRichCurrentContentDTO() {
     },
     {
       id: 'skill21111',
-      name: 'skill21111 name',
+      name: '@tube21111',
       hint_i18n: {
         fr: 'skill21111 hintFrFr',
         en: 'skill21111 hintEnUs',

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -467,6 +467,7 @@ describe('Integration | Repository | skill-repository', () => {
             learningMoreTutorialIds: ['tuto2', 'tuto3'],
             learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
             challengeIds: ['challenge1', 'challenge2'],
+            competenceId: 'competence1',
           },
           {
             id: 'skill2',
@@ -492,6 +493,7 @@ describe('Integration | Repository | skill-repository', () => {
             learningMoreTutorialIds: ['tuto3', 'tuto4'],
             learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
             challengeIds: ['challenge3', 'challenge4', 'challenge5'],
+            competenceId: 'competence1',
           },
         ];
         const airtableSkills = skills.map((skill) =>
@@ -514,6 +516,33 @@ describe('Integration | Repository | skill-repository', () => {
             value: skill.hint_i18n.en,
           });
         });
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+        databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+        databaseBuilder.factory.buildTube({ id: 'tube2', name: '@skill', thematicId: 'thematic1' });
+        ['tuto1', 'tuto2', 'tuto3', 'tuto4'].forEach((tutorialId) => {
+          databaseBuilder.factory.buildTutorial(
+            domainBuilder.buildTutorialDatasourceObject({
+              id: tutorialId,
+              tagIds: [],
+            }),
+          );
+        });
+        skills.forEach(databaseBuilder.factory.buildSkill);
+        skills.forEach((skill) =>
+          skill.challengeIds.forEach((challengeId) => {
+            databaseBuilder.factory.buildChallenge(
+              domainBuilder.buildChallengeDatasourceObject({
+                id: challengeId,
+                skillId: skill.id,
+              }),
+            );
+          }),
+        );
+
         await databaseBuilder.commit();
         const ids = skills.map((skill) => skill.id);
 

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -188,7 +188,7 @@ describe('Integration | Repository | skill-repository', () => {
       const skill1 = {
         id: 'skill1',
         airtableId: 'recId1',
-        name: 'Acquis 1',
+        name: '@foo4',
         description: 'Description Acquis 1',
         descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
         hintStatus: Skill.HINT_STATUSES.VALIDE,
@@ -203,10 +203,27 @@ describe('Integration | Repository | skill-repository', () => {
         tubeAirtableId: 'recTube1',
         level: 4,
         internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-        version: '1',
+        version: 1,
         challengeIds: ['challenge12kwuefn2s', 'challengeJqdqwjcd1'],
         createdAt: '2025-01-06T08:58:57.465Z',
       };
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+
+      [...skill1.tutorialIds, ...skill1.learningMoreTutorialIds].forEach((id) =>
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id, tagIds: [] })),
+      );
+
+      databaseBuilder.factory.buildSkill(skill1);
+      skill1.challengeIds.forEach((id) =>
+        databaseBuilder.factory.buildChallenge(
+          domainBuilder.buildChallengeDatasourceObject({ id, skillId: skill1.id }),
+        ),
+      );
 
       databaseBuilder.factory.buildTranslation({
         key: 'skill.skill1.hint',
@@ -268,7 +285,7 @@ describe('Integration | Repository | skill-repository', () => {
         domainBuilder.buildSkill({
           id: 'skill1',
           airtableId: 'recId1',
-          name: 'Acquis 1',
+          name: '@foo4',
           description: 'Description Acquis 1',
           descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
           hint_i18n: {
@@ -287,7 +304,7 @@ describe('Integration | Repository | skill-repository', () => {
           tubeAirtableId: 'recTube1',
           level: 4,
           internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-          version: '1',
+          version: 1,
           challengeIds: ['challenge12kwuefn2s', 'challengeJqdqwjcd1'],
           createdAt: '2025-01-06T08:58:57.465Z',
         }),

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -11,62 +11,88 @@ describe('Integration | Repository | skill-repository', () => {
   describe('#list', () => {
     it('should return the list of all skills', async () => {
       // given
+      const skills = [
+        {
+          id: 'skill1',
+          airtableId: 'recId1',
+          name: '@foo4',
+          description: 'Description Acquis 1',
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
+          hintStatus: Skill.HINT_STATUSES.VALIDE,
+          tutorialIds: ['tuto1', 'tuto2'],
+          tutorialAirtableIds: ['recTuto1', 'recTuto2'],
+          learningMoreTutorialIds: ['tuto3', 'tuto4'],
+          learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
+          pixValue: 2.5,
+          competenceId: 'competence1',
+          status: Skill.STATUSES.PERIME,
+          tubeId: 'tube1',
+          tubeAirtableId: 'recTube1',
+          level: 4,
+          internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
+          version: 1,
+          challengeIds: ['challenge123184r9124'],
+          createdAt: '2025-01-01T09:58:57.465Z',
+          activatedAt: '2023-11-06T18:08:00Z',
+          archivedAt: '2023-12-07T18:08:00Z',
+          obsoletedAt: '2024-01-08T18:08:00Z',
+        },
+        {
+          id: 'skill2',
+          airtableId: 'recId2',
+          name: '@bar6',
+          description: 'Description Acquis 2',
+          descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
+          hintStatus: Skill.HINT_STATUSES.PROPOSE,
+          tutorialIds: ['tuto5'],
+          tutorialAirtableIds: ['recTuto5'],
+          learningMoreTutorialIds: ['tuto6'],
+          learningMoreTutorialAirtableIds: ['recTuto6'],
+          pixValue: 1.6,
+          competenceId: 'competence2',
+          status: 'actif',
+          tubeId: 'tube2',
+          tubeAirtableId: 'recTube2',
+          level: 6,
+          internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
+          version: 2,
+          challengeIds: ['challengesdgff230fj38cs'],
+          createdAt: '2025-01-02T07:58:57.465Z',
+        },
+      ];
+
       const airtableScope = airtableBuilder
         .mockList({ tableName: 'Acquis' })
-        .returns([
-          airtableBuilder.factory.buildSkill({
-            id: 'skill1',
-            airtableId: 'recId1',
-            name: 'Acquis 1',
-            description: 'Description Acquis 1',
-            descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
-            hintStatus: Skill.HINT_STATUSES.VALIDE,
-            tutorialIds: ['tuto1', 'tuto2'],
-            tutorialAirtableIds: ['recTuto1', 'recTuto2'],
-            learningMoreTutorialIds: ['tuto3', 'tuto4'],
-            learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
-            pixValue: 2.5,
-            competenceId: 'competence1',
-            status: Skill.STATUSES.PERIME,
-            tubeId: 'tube1',
-            tubeAirtableId: 'recTube1',
-            level: 4,
-            internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-            version: '1',
-            challengeIds: ['challenge123184r9124'],
-            createdAt: '2025-01-01T09:58:57.465Z',
-          }),
-          airtableBuilder.factory.buildSkill({
-            id: 'skill2',
-            airtableId: 'recId2',
-            name: 'Acquis 2',
-            description: 'Description Acquis 2',
-            descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
-            hintStatus: Skill.HINT_STATUSES.PROPOSE,
-            tutorialIds: ['tuto5'],
-            tutorialAirtableIds: ['recTuto5'],
-            learningMoreTutorialIds: ['tuto6'],
-            learningMoreTutorialAirtableIds: ['recTuto6'],
-            pixValue: 1.6,
-            competenceId: 'competence2',
-            status: 'actif',
-            tubeId: 'tube2',
-            tubeAirtableId: 'recTube2',
-            level: 6,
-            internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
-            version: '2',
-            challengeIds: ['challengesdgff230fj38cs'],
-            createdAt: '2025-01-02T07:58:57.465Z',
-          }),
-        ])
+        .returns(skills.map(airtableBuilder.factory.buildSkill))
         .activate().nockScope;
 
-      databaseBuilder.factory.buildSkill({
-        id: 'skill1',
-        activatedAt: new Date('2023-11-06T18:08:00Z'),
-        archivedAt: new Date('2023-12-07T18:08:00Z'),
-        obsoletedAt: new Date('2024-01-08T18:08:00Z'),
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+
+      databaseBuilder.factory.buildCompetence({ id: 'competence2', index: '1.2', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic2', competenceId: 'competence2' });
+      databaseBuilder.factory.buildTube({ id: 'tube2', name: '@bar', thematicId: 'thematic2' });
+
+      databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto1', tagIds: [] }));
+      databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto2', tagIds: [] }));
+      databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto3', tagIds: [] }));
+      databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto4', tagIds: [] }));
+      databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto5', tagIds: [] }));
+      databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto6', tagIds: [] }));
+
+      skills.forEach((skill) => {
+        databaseBuilder.factory.buildSkill(skill);
+        skill.challengeIds.forEach((id) =>
+          databaseBuilder.factory.buildChallenge(
+            domainBuilder.buildChallengeDatasourceObject({ id, skillId: skill.id }),
+          ),
+        );
       });
+
       databaseBuilder.factory.buildTranslation({
         key: 'skill.skill1.hint',
         locale: 'fr',
@@ -91,14 +117,14 @@ describe('Integration | Repository | skill-repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const skills = await skillRepository.list();
+      const results = await skillRepository.list();
 
       // then
-      expect(skills).toEqual([
+      expect(results).toEqual([
         domainBuilder.buildSkill({
           id: 'skill1',
           airtableId: 'recId1',
-          name: 'Acquis 1',
+          name: '@foo4',
           description: 'Description Acquis 1',
           descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
           hint_i18n: {
@@ -117,7 +143,7 @@ describe('Integration | Repository | skill-repository', () => {
           tubeAirtableId: 'recTube1',
           level: 4,
           internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-          version: '1',
+          version: 1,
           challengeIds: ['challenge123184r9124'],
           createdAt: '2025-01-01T09:58:57.465Z',
           activatedAt: new Date('2023-11-06T18:08:00Z'),
@@ -127,7 +153,7 @@ describe('Integration | Repository | skill-repository', () => {
         domainBuilder.buildSkill({
           id: 'skill2',
           airtableId: 'recId2',
-          name: 'Acquis 2',
+          name: '@bar6',
           description: 'Description Acquis 2',
           descriptionStatus: Skill.DESCRIPTION_STATUSES.PROPOSE,
           hint_i18n: {
@@ -146,7 +172,7 @@ describe('Integration | Repository | skill-repository', () => {
           tubeAirtableId: 'recTube2',
           level: 6,
           internationalisation: Skill.INTERNATIONALISATIONS.MONDE,
-          version: '2',
+          version: 2,
           challengeIds: ['challengesdgff230fj38cs'],
           createdAt: '2025-01-02T07:58:57.465Z',
         }),

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -583,6 +583,7 @@ describe('Integration | Repository | skill-repository', () => {
             learningMoreTutorialIds: ['tuto2', 'tuto3'],
             learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
             challengeIds: ['challenge1', 'challenge2'],
+            competenceId: 'competence1',
           },
           {
             id: 'skill2',
@@ -601,24 +602,35 @@ describe('Integration | Repository | skill-repository', () => {
             pixValue: 1.8,
             status: Skill.STATUSES.EN_CONSTRUCTION,
             version: 2,
-            tubeId: 'tube2',
-            tubeAirtableId: 'recTube2',
+            tubeId: 'tube1',
+            tubeAirtableId: 'recTube1',
             tutorialIds: ['tuto2'],
             tutorialAirtableIds: ['recTuto2'],
             learningMoreTutorialIds: ['tuto3', 'tuto4'],
             learningMoreTutorialAirtableIds: ['recTuto3', 'recTuto4'],
             challengeIds: ['challenge3', 'challenge4', 'challenge5'],
+            competenceId: 'competence1',
           },
         ];
-        const airtableSkills = skills.map((skill) =>
-          airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject(skill)),
-        );
-        const findRecordsSpy = vi
-          .spyOn(airtable, 'findRecords')
-          .mockResolvedValueOnce(
-            airtableSkills.map((airtableSkill) => new Airtable.Record('Acquis', airtableSkill.id, airtableSkill)),
-          );
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+        databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto1', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto2', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto3', tagIds: [] }));
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id: 'tuto4', tagIds: [] }));
+
         skills.forEach((skill) => {
+          databaseBuilder.factory.buildSkill(skill);
+
+          skill.challengeIds.forEach((id) =>
+            databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id, skillId: skill.id })),
+          );
+
           databaseBuilder.factory.buildTranslation({
             key: `skill.${skill.id}.hint`,
             locale: 'fr',
@@ -630,6 +642,16 @@ describe('Integration | Repository | skill-repository', () => {
             value: skill.hint_i18n.en,
           });
         });
+
+        const airtableSkills = skills.map((skill) =>
+          airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject(skill)),
+        );
+        const findRecordsSpy = vi
+          .spyOn(airtable, 'findRecords')
+          .mockResolvedValueOnce(
+            airtableSkills.map((airtableSkill) => new Airtable.Record('Acquis', airtableSkill.id, airtableSkill)),
+          );
+
         await databaseBuilder.commit();
 
         const params = {

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -301,7 +301,7 @@ describe('Integration | Repository | skill-repository', () => {
       const skill1 = {
         id: 'skill1',
         airtableId: 'recId1',
-        name: 'Acquis 1',
+        name: '@foo4',
         description: 'Description Acquis 1',
         descriptionStatus: Skill.DESCRIPTION_STATUSES.VALIDE,
         hintStatus: Skill.HINT_STATUSES.VALIDE,
@@ -316,10 +316,27 @@ describe('Integration | Repository | skill-repository', () => {
         tubeAirtableId: 'recTube1',
         level: 4,
         internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-        version: '1',
+        version: 1,
         challengeIds: ['challenge12kwuefn2s', 'challengeJqdqwjcd1'],
         createdAt: '2025-01-06T08:58:57.465Z',
       };
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@foo', thematicId: 'thematic1' });
+
+      [...skill1.tutorialIds, ...skill1.learningMoreTutorialIds].forEach((id) =>
+        databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ id, tagIds: [] })),
+      );
+
+      databaseBuilder.factory.buildSkill(skill1);
+      skill1.challengeIds.forEach((id) =>
+        databaseBuilder.factory.buildChallenge(
+          domainBuilder.buildChallengeDatasourceObject({ id, skillId: skill1.id }),
+        ),
+      );
 
       databaseBuilder.factory.buildTranslation({
         key: 'skill.skill1.hint',
@@ -379,7 +396,7 @@ describe('Integration | Repository | skill-repository', () => {
         domainBuilder.buildSkill({
           id: 'skill1',
           airtableId: 'recId1',
-          name: 'Acquis 1',
+          name: '@foo4',
           description: 'Description Acquis 1',
           hint_i18n: {
             fr: 'Indice acquis 1',
@@ -398,7 +415,7 @@ describe('Integration | Repository | skill-repository', () => {
           tubeAirtableId: 'recTube1',
           level: 4,
           internationalisation: Skill.INTERNATIONALISATIONS.FRANCE,
-          version: '1',
+          version: 1,
           challengeIds: ['challenge12kwuefn2s', 'challengeJqdqwjcd1'],
           createdAt: '2025-01-06T08:58:57.465Z',
         }),

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -715,6 +715,7 @@ describe('Integration | Repository | skill-repository', () => {
           learningMoreTutorialIds: ['tuto2', 'tuto3'],
           learningMoreTutorialAirtableIds: ['recTuto2', 'recTuto3'],
           challengeIds: ['challenge1', 'challenge2'],
+          competenceId: 'competence1',
         };
         const airtableSkill = airtableBuilder.factory.buildSkill(domainBuilder.buildSkillDatasourceObject(skill));
         const findRecordSpy = vi
@@ -730,6 +731,30 @@ describe('Integration | Repository | skill-repository', () => {
           locale: 'en',
           value: skill.hint_i18n.en,
         });
+
+        databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+        databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+        databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+        databaseBuilder.factory.buildTube({ id: 'tube1', name: '@skill', thematicId: 'thematic1' });
+        [...skill.tutorialIds, ...skill.learningMoreTutorialIds].forEach((tutorialId) => {
+          databaseBuilder.factory.buildTutorial(
+            domainBuilder.buildTutorialDatasourceObject({
+              id: tutorialId,
+              tagIds: [],
+            }),
+          );
+        });
+        databaseBuilder.factory.buildSkill(skill);
+        skill.challengeIds.forEach((challengeId) => {
+          databaseBuilder.factory.buildChallenge(
+            domainBuilder.buildChallengeDatasourceObject({
+              id: challengeId,
+              skillId: skill.id,
+            }),
+          );
+        });
+
         await databaseBuilder.commit();
         const id = skill.id;
 


### PR DESCRIPTION
## 🍂 Problème

On souhaite sortir d’Airtable.

## 🌰 Proposition

Lire les acquis dans Airtable et Postgres, et comparer les résultats :
 - Émettre un warning en cas de différence
 - En test lever une erreur en cas de différence

## 🍁 Remarques

N/A

## 🪵 Pour tester

Consulter les différentes vue de plusieurs compétences en v1 et v2.
Consulter le détail d’un acquis.
Faire une recherche d’acquis.

Vérifier qu’aucun warning ne remonte dans les logs (level 40).