### PR TITLE
[TECH] Ajout stylistic dans le front et les scripts (PIX-20125)

### DIFF
--- a/pix-editor/.prettierrc
+++ b/pix-editor/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": "true"
+}

--- a/pix-editor/app/adapters/airtable.js
+++ b/pix-editor/app/adapters/airtable.js
@@ -5,7 +5,6 @@ import chunk from 'lodash/chunk';
 const ID_PERSISTANT_FIELD = 'id persistant';
 
 export default class AirtableAdapter extends RESTAdapter {
-
   namespace = '/api/airtable/changelog';
 
   @service session;
@@ -25,10 +24,12 @@ export default class AirtableAdapter extends RESTAdapter {
     const serializer = store.serializerFor(type.modelName);
     if (serializer.primaryKey === ID_PERSISTANT_FIELD) {
       const url = this.buildURL(type.modelName, id, snapshot, 'findMany');
-      return this.ajax(url, 'GET', { data: {
-        filterByFormula: `AND(FIND('${id}', {id persistant}))`,
-        maxRecords: 1,
-      } });
+      return this.ajax(url, 'GET', {
+        data: {
+          filterByFormula: `AND(FIND('${id}', {id persistant}))`,
+          maxRecords: 1,
+        },
+      });
     }
     return super.findRecord(store, type, id, snapshot);
   }

--- a/pix-editor/app/adapters/changelog-entry.js
+++ b/pix-editor/app/adapters/changelog-entry.js
@@ -1,4 +1,3 @@
 import NoteAdapter from './note';
 
-export default class ChangelogEntryAdapter extends NoteAdapter {
-}
+export default class ChangelogEntryAdapter extends NoteAdapter {}

--- a/pix-editor/app/adapters/competence-overview.js
+++ b/pix-editor/app/adapters/competence-overview.js
@@ -1,9 +1,12 @@
 import ApplicationAdapter from './application';
 
 export default class CompetenceOverviewAdapter extends ApplicationAdapter {
-
   urlForFindRecord(id) {
-    const [competenceId, view, locale] = id.split(':');
+    const [
+      competenceId,
+      view,
+      locale,
+    ] = id.split(':');
     let url = this.buildURL('competences', competenceId);
     url += `/overviews/${view}`;
     if (locale) url += `?locale=${locale}`;

--- a/pix-editor/app/adapters/config.js
+++ b/pix-editor/app/adapters/config.js
@@ -1,7 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class ConfigAdapter extends ApplicationAdapter {
-
   urlForFindRecord() {
     const baseUrl = this.buildURL();
     return `${baseUrl}/config`;

--- a/pix-editor/app/adapters/note.js
+++ b/pix-editor/app/adapters/note.js
@@ -1,7 +1,6 @@
 import AirtableAdapter from './airtable';
 
 export default class NoteAdapter extends AirtableAdapter {
-
   pathForType() {
     return 'Notes';
   }

--- a/pix-editor/app/adapters/static-course.js
+++ b/pix-editor/app/adapters/static-course.js
@@ -1,7 +1,6 @@
 import ApplicationAdapter from './application';
 
 export default class StaticCourseAdapter extends ApplicationAdapter {
-
   createRecord(store, type, snapshot) {
     const payload = preparePayloadForCreateAndUpdate(this.serialize(snapshot), snapshot.adapterOptions);
     const url = this.buildURL(type.modelName, snapshot.id, snapshot, 'createRecord');

--- a/pix-editor/app/adapters/user.js
+++ b/pix-editor/app/adapters/user.js
@@ -3,7 +3,7 @@ import ApplicationAdapter from './application';
 export default class UserAdapter extends ApplicationAdapter {
   get headers() {
     if (this.apiKeyForAuthenticationTrial) {
-      return { 'Authorization': `Bearer ${this.apiKeyForAuthenticationTrial}` };
+      return { Authorization: `Bearer ${this.apiKeyForAuthenticationTrial}` };
     }
     return super.headers;
   }

--- a/pix-editor/app/components/alternatives.js
+++ b/pix-editor/app/components/alternatives.js
@@ -3,7 +3,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class Alternatives extends Component {
-
   @tracked competence = null;
   @tracked arePerimeDeclisDisplayed = false;
 

--- a/pix-editor/app/components/competence-header.gjs
+++ b/pix-editor/app/components/competence-header.gjs
@@ -11,11 +11,7 @@ export default class CompetenceHeader extends Component {
   @action
   setLocale(locale) {
     if (locale === 'source') locale = undefined;
-    this.router.transitionTo({
-      queryParams: {
-        locale,
-      },
-    });
+    this.router.transitionTo({ queryParams: { locale } });
   }
 
   @action

--- a/pix-editor/app/components/competence-overview/competence-overview-skill.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview-skill.gjs
@@ -4,7 +4,6 @@ import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 
 export default class CompetenceOverviewSkill extends Component {
-
   get modifier() {
     if (this.args.skillOverview.validatedChallengesCount) return 'validated';
     if (this.args.skillOverview.proposedChallengesCount) return 'proposed';

--- a/pix-editor/app/components/competence/competence-footer.js
+++ b/pix-editor/app/components/competence/competence-footer.js
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CompetenceFooter extends Component {
-
   @service access;
 
   get isOverview() {

--- a/pix-editor/app/components/competence/competence-grid-thematic.js
+++ b/pix-editor/app/components/competence/competence-grid-thematic.js
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CompetenceCompetenceGridThematicComponent extends Component {
-
   @service access;
 
   get isOverview() {
@@ -25,9 +24,7 @@ export default class CompetenceCompetenceGridThematicComponent extends Component
 
   get tubeOverviewsOrTubes() {
     if (this.isOverview) {
-      return this.args.thematicOverview.tubeOverviews.map((tubeOverview) => ({
-        tubeOverview,
-      }));
+      return this.args.thematicOverview.tubeOverviews.map((tubeOverview) => ({ tubeOverview }));
     }
     return this.tubes.map((tube) => ({ tube }));
   }

--- a/pix-editor/app/components/competence/competence-grid-tube.js
+++ b/pix-editor/app/components/competence/competence-grid-tube.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class CompetenceCompetenceGridTubeComponent extends Component {
-
   get isOverview() {
     return this.args.tubeOverview != null;
   }

--- a/pix-editor/app/components/competence/competence-grid.js
+++ b/pix-editor/app/components/competence/competence-grid.js
@@ -1,16 +1,13 @@
 import Component from '@glimmer/component';
 
 export default class CompetenceCompetenceGridComponent extends Component {
-
   get isOverview() {
     return this.args.competenceOverview != null;
   }
 
   get thematicOverviewsOrThematics() {
     if (this.isOverview) {
-      return this.args.competenceOverview.thematicOverviews.map((thematicOverview) => ({
-        thematicOverview,
-      }));
+      return this.args.competenceOverview.thematicOverviews.map((thematicOverview) => ({ thematicOverview }));
     }
     return this.args.competence.sortedThemes.map((thematic) => ({ thematic }));
   }

--- a/pix-editor/app/components/competence/competence-header.gjs
+++ b/pix-editor/app/components/competence/competence-header.gjs
@@ -6,16 +6,19 @@ import Component from '@glimmer/component';
 export default class CompetenceHeader extends Component {
   @service config;
 
-  sections = [{
-    label: 'Epreuves',
-    value: 'challenges',
-  }, {
-    label: 'Acquis',
-    value: 'skills',
-  }, {
-    label: 'Qualité',
-    value: 'quality',
-  },
+  sections = [
+    {
+      label: 'Epreuves',
+      value: 'challenges',
+    },
+    {
+      label: 'Acquis',
+      value: 'skills',
+    },
+    {
+      label: 'Qualité',
+      value: 'quality',
+    },
   ];
 
   languageOptions = [

--- a/pix-editor/app/components/competence/grid/cell-quality.gjs
+++ b/pix-editor/app/components/competence/grid/cell-quality.gjs
@@ -5,7 +5,6 @@ import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 
 export default class CellQuality extends Component {
-
   get qualityIndication() {
     if (this.loadingChallenges) return null;
     const productionPrototype = this.args.skill.productionPrototype;
@@ -63,8 +62,10 @@ export default class CellQuality extends Component {
     const classTuto = this.classTutorial;
     const tutoSolutionCount = this.args.skill.tutoSolution.length;
     const tutoMoreCount = this.args.skill.tutoMore.length;
-    const haveTuto = classTuto ? `<tr><td>Tuto comprendre </td><td> ${tutoSolutionCount}</td></tr>
-                                <tr><td>Tuto en savoir + </td><td> ${tutoMoreCount}</td></tr>` : '';
+    const haveTuto = classTuto
+      ? `<tr><td>Tuto comprendre </td><td> ${tutoSolutionCount}</td></tr>
+                                <tr><td>Tuto en savoir + </td><td> ${tutoMoreCount}</td></tr>`
+      : '';
     return htmlSafe(`<tr><td>Spoil </td><td> ${spoil} </td></tr>
             <tr><td>Responsive </td><td> ${responsive} </td></tr>
             <tr><td>Non/Mal voyant </td><td> ${blind} </td></tr>
@@ -99,9 +100,9 @@ export default class CellQuality extends Component {
   _colorblindWeight(colorblind) {
     const weight = 3;
     const quality = {
-      'RAS': 1,
-      'OK': 1,
-      'default': 0,
+      RAS: 1,
+      OK: 1,
+      default: 0,
     };
     return (quality[colorblind] || quality['default']) * weight;
   }

--- a/pix-editor/app/components/competence/grid/cell-skill-workbench.js
+++ b/pix-editor/app/components/competence/grid/cell-skill-workbench.js
@@ -1,24 +1,23 @@
 import Component from '@glimmer/component';
 
 export default class CompetenceGridCellSkillWorkbenchComponent extends Component {
-
   get archivedCount() {
-    const archivedSkill = this.args.skills.filter((skill)=> skill.isArchived);
+    const archivedSkill = this.args.skills.filter((skill) => skill.isArchived);
     return archivedSkill.length;
   }
 
   get obsoleteCount() {
-    const obsoleteSkills = this.args.skills.filter((skill)=> skill.isObsolete);
+    const obsoleteSkills = this.args.skills.filter((skill) => skill.isObsolete);
     return obsoleteSkills.length;
   }
 
   get draftCount() {
-    const draftSkill = this.args.skills.filter((skill)=> skill.isDraft);
+    const draftSkill = this.args.skills.filter((skill) => skill.isDraft);
     return draftSkill.length;
   }
 
   get hasActiveSkill() {
-    const activeSkill = this.args.skills.filter((skill)=> skill.isActive);
+    const activeSkill = this.args.skills.filter((skill) => skill.isActive);
     return activeSkill.length > 0;
   }
 

--- a/pix-editor/app/components/competence/grid/cell-skill.js
+++ b/pix-editor/app/components/competence/grid/cell-skill.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class CompetenceGridCellSkillComponent extends Component {
-
   get hasNoClueByLanguage() {
     switch (this.args.languageFilter) {
       case 'fr':
@@ -9,7 +8,7 @@ export default class CompetenceGridCellSkillComponent extends Component {
         return !this.args.skill.clue;
       case 'en':
         return !this.args.skill.clueEn;
-      default :
+      default:
         return true;
     }
   }
@@ -51,11 +50,11 @@ export default class CompetenceGridCellSkillComponent extends Component {
 
   _convertLanguageFilterToLanguageTutorial(language) {
     switch (language) {
-      case 'fr' :
+      case 'fr':
         return 'fr-fr';
       case 'en':
         return 'en-us';
-      default :
+      default:
         return language;
     }
   }

--- a/pix-editor/app/components/competence/grid/grid-cell.js
+++ b/pix-editor/app/components/competence/grid/grid-cell.js
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class GridCell extends Component {
-
   @service access;
   @service config;
 
@@ -30,14 +29,14 @@ export default class GridCell extends Component {
               return 'skill';
             }
             break;
-          case 'workbench' :
+          case 'workbench':
             if (skill) {
               return 'skill-workbench';
             } else if (this.access.mayEditSkills()) {
               return 'add-skill';
             }
             break;
-          case 'draft' :
+          case 'draft':
             if (skill) {
               return 'skill-draft';
             } else if (this.access.mayEditSkills()) {

--- a/pix-editor/app/components/dropdown-menu.gjs
+++ b/pix-editor/app/components/dropdown-menu.gjs
@@ -37,9 +37,7 @@ export default class DropdownMenu extends Component {
 
     computePosition(button, menu, {
       placement: 'bottom-end',
-      middleware: [flip({
-        fallbackAxisSideDirection: 'start',
-      })],
+      middleware: [flip({ fallbackAxisSideDirection: 'start' })],
     }).then(({ x, y }) => {
       Object.assign(menu.style, {
         top: `${y}px`,
@@ -99,4 +97,3 @@ export default class DropdownMenu extends Component {
     </div>
   </template>
 }
-

--- a/pix-editor/app/components/field/checkbox.js
+++ b/pix-editor/app/components/field/checkbox.js
@@ -2,7 +2,11 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 export default class Checkbox extends Component {
-  ignorableAttrs = ['checked', 'label', 'disabled'];
+  ignorableAttrs = [
+    'checked',
+    'label',
+    'disabled',
+  ];
 
   elementId = 'checkbox-' + guidFor(this);
 }

--- a/pix-editor/app/components/field/mde.js
+++ b/pix-editor/app/components/field/mde.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class Mde extends Component {
-
   @tracked maximized = false;
 
   get safeHelpContent() {

--- a/pix-editor/app/components/field/quality.js
+++ b/pix-editor/app/components/field/quality.js
@@ -8,22 +8,26 @@ export default class Quality extends Component {
     { value: 'KO', label: 'KO' },
     { value: 'A tester', label: 'A tester' },
   ];
+
   accessibility2Options = [
     { value: 'RAS', label: 'RAS' },
     { value: 'OK', label: 'OK' },
     { value: 'KO', label: 'KO' },
   ];
+
   responsiveOptions = [
     { value: 'Tablette', label: 'Tablette' },
     { value: 'Smartphone', label: 'Smartphone' },
     { value: 'Tablette/Smartphone', label: 'Tablette/Smartphone' },
     { value: 'Non', label: 'Non' },
   ];
+
   spoilOptions = [
     { value: 'Non Sp', label: 'Non Sp' },
     { value: 'Difficilement Sp', label: 'Difficilement Sp' },
     { value: 'Facilement Sp', label: 'Facilement Sp' },
   ];
+
   deafAndHardOfHearingOptions = [
     { value: 'RAS', label: 'RAS' },
     { value: 'OK', label: 'OK' },

--- a/pix-editor/app/components/field/textarea.gjs
+++ b/pix-editor/app/components/field/textarea.gjs
@@ -10,7 +10,6 @@ import { tracked } from '@glimmer/tracking';
 import { not } from 'ember-truth-helpers';
 
 export default class FieldTextarea extends Component {
-
   @tracked maximized = false;
 
   get safeHelpContent() {

--- a/pix-editor/app/components/field/toggle-field.js
+++ b/pix-editor/app/components/field/toggle-field.js
@@ -26,5 +26,4 @@ export default class FieldToggleFieldComponent extends Component {
       this.args.setDisplayField(true);
     }
   }
-
 }

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -10,7 +10,7 @@ export default class ChallengeForm extends Component {
 
   @tracked languageOptions = [];
   options = {
-    'types': [
+    types: [
       { value: 'QCU', label: 'QCU' },
       { value: 'QCM', label: 'QCM' },
       { value: 'QROC', label: 'QROC' },
@@ -18,15 +18,49 @@ export default class ChallengeForm extends Component {
       { value: 'QROCM-dep', label: 'QROCM-dep' },
       { value: 'autoReply', label: 'Embed-auto' },
     ],
-    'pedagogy': [{ label: 'e-preuve', value: 'e-preuve' }, { label: 'q-savoir', value: 'q-savoir' }, { label: 'q-situation', value: 'q-situation' }],
-    'declinable': [{ label: 'facilement', value: 'facilement' }, { label: 'difficilement', value: 'difficilement' }, { label: 'permutation', value: 'permutation' }, { label: 'non', value: 'non' }],
-    'format': [{ label: 'petit', value: 'petit' }, { label: 'mots', value: 'mots' }, { label: 'phrase', value: 'phrase' }, { label: 'paragraphe', value: 'paragraphe' }, { label: 'nombre', value: 'nombre' }],
-    'accessibility1': ['RAS', 'OK', 'Acquis Non Pertinent', 'KO', 'A tester'],
-    'accessibility2': ['RAS', 'OK', 'KO'],
-    'responsive': ['Tablette', 'Smartphone', 'Tablette/Smartphone', 'Non'],
-    'spoil': ['Non Sp', 'Difficilement Sp', 'Facilement Sp'],
-    'locales': this.languageOptions,
-    'contextualizedFields': [
+    pedagogy: [
+      { label: 'e-preuve', value: 'e-preuve' },
+      { label: 'q-savoir', value: 'q-savoir' },
+      { label: 'q-situation', value: 'q-situation' },
+    ],
+    declinable: [
+      { label: 'facilement', value: 'facilement' },
+      { label: 'difficilement', value: 'difficilement' },
+      { label: 'permutation', value: 'permutation' },
+      { label: 'non', value: 'non' },
+    ],
+    format: [
+      { label: 'petit', value: 'petit' },
+      { label: 'mots', value: 'mots' },
+      { label: 'phrase', value: 'phrase' },
+      { label: 'paragraphe', value: 'paragraphe' },
+      { label: 'nombre', value: 'nombre' },
+    ],
+    accessibility1: [
+      'RAS',
+      'OK',
+      'Acquis Non Pertinent',
+      'KO',
+      'A tester',
+    ],
+    accessibility2: [
+      'RAS',
+      'OK',
+      'KO',
+    ],
+    responsive: [
+      'Tablette',
+      'Smartphone',
+      'Tablette/Smartphone',
+      'Non',
+    ],
+    spoil: [
+      'Non Sp',
+      'Difficilement Sp',
+      'Facilement Sp',
+    ],
+    locales: this.languageOptions,
+    contextualizedFields: [
       { value: 'instruction', label: 'Consigne' },
       { value: 'embed', label: 'Embed' },
       { value: 'illustration', label: 'Illustration' },
@@ -37,6 +71,7 @@ export default class ChallengeForm extends Component {
       { value: 'solution', label: 'Réponse' },
     ],
   };
+
   helpInstructions = '<u>Style d’écriture :</u><br>*Écriture en italique*<br>**Écriture en gras**<br>***Écriture en italique et gras***<br><br><u>Aller à la ligne :</u><br>Phrase 1<br><br>Phrase 2<br><br><u>Liste :</u><br>- texte item 1<br>- texte item 2<br><br><u>Paragraphe avec retrait précédé d’un trait vertical gris :</u><br>> texte 1ere ligne<br>><br>> texte 3e ligne<br><br><u>Lien vers une page web :</u><br>[mot cliquable](url avec protocole)';
   helpUrlsToConsult = '<p>Séparer les liens par un retour à la ligne</p>';
 
@@ -128,7 +163,7 @@ export default class ChallengeForm extends Component {
       return null;
     }
 
-    return this.options.types.find((type)=> type.value === actualType).value;
+    return this.options.types.find((type) => type.value === actualType).value;
   }
 
   get challengeFormatValue() {
@@ -136,7 +171,7 @@ export default class ChallengeForm extends Component {
       return 'mots';
     }
 
-    return this.options.format.find((format)=> format.value === this.args.challenge.format).value;
+    return this.options.format.find((format) => format.value === this.args.challenge.format).value;
   }
 
   get challengeGeographyValue() {

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -221,9 +221,13 @@ class FormField {
     this.value = value;
   }
 
-  validate() { throw new Error('implement me'); }
+  validate() {
+    throw new Error('implement me');
+  }
 
-  getValueForSubmit() { throw new Error('implement me'); }
+  getValueForSubmit() {
+    throw new Error('implement me');
+  }
 }
 
 class ThematicIdsField extends FormField {
@@ -247,7 +251,9 @@ class ThematicIdsField extends FormField {
     return this.value?.split(',').every((thematicId) => this.availableThematicIds?.includes(thematicId.trim()));
   }
 
-  getValueForSubmit() { return this.value.split(',').map((element) => element.trim()).join(','); }
+  getValueForSubmit() {
+    return this.value.split(',').map((element) => element.trim()).join(',');
+  }
 }
 
 class NameField extends FormField {
@@ -261,7 +267,9 @@ class NameField extends FormField {
       : STATES.ERROR;
   }
 
-  getValueForSubmit() { return this.value.trim(); }
+  getValueForSubmit() {
+    return this.value.trim();
+  }
 }
 
 class CompetenceIdField extends FormField {
@@ -280,4 +288,3 @@ class CompetenceIdField extends FormField {
     }
   }
 }
-

--- a/pix-editor/app/components/form/note.gjs
+++ b/pix-editor/app/components/form/note.gjs
@@ -18,7 +18,8 @@ const statusList = [
   {
     label: 'archive',
     value: 'ARCHIVED',
-  }];
+  },
+];
 
 export default class NoteForm extends Component {
   @tracked status;

--- a/pix-editor/app/components/form/select-location.gjs
+++ b/pix-editor/app/components/form/select-location.gjs
@@ -20,7 +20,11 @@ export default class FormSelectLocation extends Component {
   constructor(...args) {
     super(...args);
 
-    const supportedVariants = ['prototype', 'skill', 'tube'];
+    const supportedVariants = [
+      'prototype',
+      'skill',
+      'tube',
+    ];
     if (!supportedVariants.includes(this.args.variant)) {
       throw new Error(`[Form::SelectLocation] the @variant argument must be a valid option (${supportedVariants})`);
     }
@@ -235,7 +239,7 @@ export default class FormSelectLocation extends Component {
       this.args.onSubmit(skill);
     }
     if (this.isMovingSkill) {
-      const tube = this.tubeList.find((tube)=> tube.id === this.selectedTubeId);
+      const tube = this.tubeList.find((tube) => tube.id === this.selectedTubeId);
       this.args.onSubmit(competence, tube, this.selectedLevel);
     }
   }

--- a/pix-editor/app/components/form/skill.gjs
+++ b/pix-editor/app/components/form/skill.gjs
@@ -12,28 +12,36 @@ const descriptionStatusList = [
   {
     label: 'Proposé',
     value: 'Proposé',
-  }, {
+  },
+  {
     label: 'Validé',
     value: 'Validé',
-  }, {
+  },
+  {
     label: 'pré-validé',
     value: 'pré-validé',
-  }, {
+  },
+  {
     label: 'à soumettre',
     value: 'à soumettre',
-  }, {
+  },
+  {
     label: 'à retravailler',
     value: 'à retravailler',
-  }, {
+  },
+  {
     label: 'archivé',
     value: 'archivé',
   },
 ];
-const clueStatusList = [ ...descriptionStatusList, { label: 'inapplicable', value: 'inapplicable' }];
-const i18nOptionList = [{ label: 'France', value: 'France' }, { label: 'Monde', value: 'Monde' }, { label: 'Union Européenne', value: 'Union Européenne' }];
+const clueStatusList = [...descriptionStatusList, { label: 'inapplicable', value: 'inapplicable' }];
+const i18nOptionList = [
+  { label: 'France', value: 'France' },
+  { label: 'Monde', value: 'Monde' },
+  { label: 'Union Européenne', value: 'Union Européenne' },
+];
 
 export default class SkillForm extends Component {
-
   @action
   setDescriptionStatus(value) {
     this.args.skill.descriptionStatus = value;

--- a/pix-editor/app/components/form/static-course.js
+++ b/pix-editor/app/components/form/static-course.js
@@ -142,9 +142,13 @@ class FormField {
     this.value = value;
   }
 
-  validate() { throw new Error('implement me'); }
+  validate() {
+    throw new Error('implement me');
+  }
 
-  getValueForSubmit() { throw new Error('implement me'); }
+  getValueForSubmit() {
+    throw new Error('implement me');
+  }
 }
 
 class NameField extends FormField {
@@ -158,14 +162,19 @@ class NameField extends FormField {
       : STATES.ERROR;
   }
 
-  getValueForSubmit() { return this.value.trim(); }
+  getValueForSubmit() {
+    return this.value.trim();
+  }
 }
 
 class DescriptionField extends FormField {
+  validate() {
+    return STATES.SUCCESS;
+  }
 
-  validate() { return STATES.SUCCESS; }
-
-  getValueForSubmit() { return this.value.trim(); }
+  getValueForSubmit() {
+    return this.value.trim();
+  }
 }
 
 class ChallengeIdsField extends FormField {

--- a/pix-editor/app/components/form/tutorial.gjs
+++ b/pix-editor/app/components/form/tutorial.gjs
@@ -25,9 +25,36 @@ export default class TutorialForm extends Component {
   @service idGenerator;
 
   options = {
-    format: ['audio', 'frise', 'image', 'jeu', 'outil', 'page', 'pdf', 'site', 'slide', 'son', 'vidéo'],
-    level: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
-    license: ['CC-BY-SA', '(c)', 'Youtube'],
+    format: [
+      'audio',
+      'frise',
+      'image',
+      'jeu',
+      'outil',
+      'page',
+      'pdf',
+      'site',
+      'slide',
+      'son',
+      'vidéo',
+    ],
+    level: [
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+    ],
+    license: [
+      'CC-BY-SA',
+      '(c)',
+      'Youtube',
+    ],
   };
 
   constructor() {
@@ -80,11 +107,7 @@ export default class TutorialForm extends Component {
       return;
     }
     const queryLowerCase = query.toLowerCase();
-    this.tagListOptions = await this.store.query('tag', {
-      filter: {
-        title: queryLowerCase,
-      },
-    })
+    this.tagListOptions = await this.store.query('tag', { filter: { title: queryLowerCase } })
       .then((tags) => {
         const results = tags.map((tag) => ({ label: tag.get('title'), value: tag.get('id') }));
         results.push({ label: 'Ajouter', description: 'Créer un tag', value: 'create' });
@@ -99,11 +122,7 @@ export default class TutorialForm extends Component {
       return;
     }
     const queryLowerCaseWithEscapedQuote = query.toLowerCase().replaceAll('\'', '\\\'');
-    this.sourceList = await this.store.query('tutorial', {
-      filter: {
-        source: queryLowerCaseWithEscapedQuote,
-      },
-    })
+    this.sourceList = await this.store.query('tutorial', { filter: { source: queryLowerCaseWithEscapedQuote } })
       .then((tutorials) => {
         const results = tutorials.map((tutorial) => (tutorial.get('source')));
         results.push(query);
@@ -136,11 +155,7 @@ export default class TutorialForm extends Component {
         }
       }
     } else {
-      this.args.tutorial.tags = await this.store.query('tag', {
-        filter: {
-          ids: selectedTagIds,
-        },
-      });
+      this.args.tutorial.tags = await this.store.query('tag', { filter: { ids: selectedTagIds } });
     }
   }
 

--- a/pix-editor/app/components/form/whitelisted-url.js
+++ b/pix-editor/app/components/form/whitelisted-url.js
@@ -132,9 +132,13 @@ class FormField {
     this.value = value;
   }
 
-  validate() { throw new Error('implement me'); }
+  validate() {
+    throw new Error('implement me');
+  }
 
-  getValueForSubmit() { throw new Error('implement me'); }
+  getValueForSubmit() {
+    throw new Error('implement me');
+  }
 }
 
 class UrlField extends FormField {
@@ -158,16 +162,23 @@ class UrlField extends FormField {
     }
   }
 
-  getValueForSubmit() { return this.value.trim(); }
+  getValueForSubmit() {
+    return this.value.trim();
+  }
 }
 
 class CommentField extends FormField {
+  get isValid() {
+    return true;
+  };
 
-  get isValid() { return true; };
+  validate() {
+    this.state = FormField.STATES.SUCCESS;
+  }
 
-  validate() { this.state = FormField.STATES.SUCCESS; }
-
-  getValueForSubmit() { return this.value.trim(); }
+  getValueForSubmit() {
+    return this.value.trim();
+  }
 }
 
 class RelatedSkillNamesField extends FormField {

--- a/pix-editor/app/components/list/alternatives.js
+++ b/pix-editor/app/components/list/alternatives.js
@@ -4,36 +4,40 @@ import { inject as service } from '@ember/service';
 import SortedList from './sorted';
 
 export default class AlternativesList extends SortedList {
-
   @service router;
 
-  headers = [{
-    name: 'Indice',
-    valuePath: 'alternativeVersion',
-    maxWidth: 50,
-  }, {
-    name: 'Consigne',
-    valuePath: 'instruction',
-  }, {
-    name: 'Langue(s)',
-    valuePath: 'locales',
-    maxWidth: 80,
-    minWidth: 75,
-    locales: true,
-  }, {
-    name: 'Auteur',
-    valuePath: 'author',
-    maxWidth: 80,
-  }, {
-    name: 'Statut',
-    valuePath: 'status',
-    maxWidth: 130,
-    style: true,
-  }];
+  headers = [
+    {
+      name: 'Indice',
+      valuePath: 'alternativeVersion',
+      maxWidth: 50,
+    },
+    {
+      name: 'Consigne',
+      valuePath: 'instruction',
+    },
+    {
+      name: 'Langue(s)',
+      valuePath: 'locales',
+      maxWidth: 80,
+      minWidth: 75,
+      locales: true,
+    },
+    {
+      name: 'Auteur',
+      valuePath: 'author',
+      maxWidth: 80,
+    },
+    {
+      name: 'Statut',
+      valuePath: 'status',
+      maxWidth: 130,
+      style: true,
+    },
+  ];
 
   @action
   selectRow(row) {
     this.router.transitionTo('authenticated.competence.prototypes.single.alternatives.single', row);
   }
-
 }

--- a/pix-editor/app/components/list/archive.js
+++ b/pix-editor/app/components/list/archive.js
@@ -4,44 +4,48 @@ import { inject as service } from '@ember/service';
 import SortedList from './sorted';
 
 export default class ArchiveList extends SortedList {
-
   @service router;
 
   list = [{ instruction: 'coucou' }];
 
-  headers = [{
-    name: 'Version',
-    valuePath: 'version',
-    maxWidth: 80,
-  }, {
-    name: 'Prototype',
-    valuePath: 'isPrototype',
-    maxWidth: 80,
-    yesno: true,
-  },
-  {
-    name: 'Consigne',
-    valuePath: 'instruction',
-  }, {
-    name: 'Langue(s)',
-    valuePath: 'locales',
-    maxWidth: 80,
-    minWidth: 75,
-    locales: true,
-  }, {
-    name: 'Auteur',
-    valuePath: 'author',
-    maxWidth: 100,
-  }, {
-    name: 'Statut',
-    valuePath: 'status',
-    maxWidth: 100,
-    style: true,
-  }];
+  headers = [
+    {
+      name: 'Version',
+      valuePath: 'version',
+      maxWidth: 80,
+    },
+    {
+      name: 'Prototype',
+      valuePath: 'isPrototype',
+      maxWidth: 80,
+      yesno: true,
+    },
+    {
+      name: 'Consigne',
+      valuePath: 'instruction',
+    },
+    {
+      name: 'Langue(s)',
+      valuePath: 'locales',
+      maxWidth: 80,
+      minWidth: 75,
+      locales: true,
+    },
+    {
+      name: 'Auteur',
+      valuePath: 'author',
+      maxWidth: 100,
+    },
+    {
+      name: 'Statut',
+      valuePath: 'status',
+      maxWidth: 100,
+      style: true,
+    },
+  ];
 
   @action
   selectRow(row) {
     this.router.transitionTo('authenticated.competence.skills.single.archive.single', row);
   }
-
 }

--- a/pix-editor/app/components/list/events-log.js
+++ b/pix-editor/app/components/list/events-log.js
@@ -1,26 +1,31 @@
 import SortedList from './sorted';
 
 export default class EventsLogList extends SortedList {
-
-  headers = [{
-    name: 'Acquis',
-    valuePath: 'skillName',
-    maxWidth: 150,
-    skill: true,
-  }, {
-    name: 'Description',
-    valuePath: 'text',
-  }, {
-    name: 'Date',
-    valuePath: 'date',
-    maxWidth: 100,
-  }, {
-    name: 'Auteur',
-    valuePath: 'author',
-    maxWidth: 100,
-  }, {
-    name: 'Action',
-    valuePath: 'action',
-    maxWidth: 150,
-  }];
+  headers = [
+    {
+      name: 'Acquis',
+      valuePath: 'skillName',
+      maxWidth: 150,
+      skill: true,
+    },
+    {
+      name: 'Description',
+      valuePath: 'text',
+    },
+    {
+      name: 'Date',
+      valuePath: 'date',
+      maxWidth: 100,
+    },
+    {
+      name: 'Auteur',
+      valuePath: 'author',
+      maxWidth: 100,
+    },
+    {
+      name: 'Action',
+      valuePath: 'action',
+      maxWidth: 150,
+    },
+  ];
 }

--- a/pix-editor/app/components/list/notes.js
+++ b/pix-editor/app/components/list/notes.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import SortedList from './sorted';
 
 export default class NoteList extends SortedList {
-
   sortHandlers = {
     date: {
       type: 'date',
@@ -12,11 +11,13 @@ export default class NoteList extends SortedList {
   };
 
   get headers() {
-    const headers = [{
-      name: 'Date',
-      valuePath: 'date',
-      maxWidth: 150,
-    }];
+    const headers = [
+      {
+        name: 'Date',
+        valuePath: 'date',
+        maxWidth: 150,
+      },
+    ];
     if (this.displayAuthor) {
       headers.push({
         name: 'Auteur',

--- a/pix-editor/app/components/list/prototypes.js
+++ b/pix-editor/app/components/list/prototypes.js
@@ -4,37 +4,40 @@ import { inject as service } from '@ember/service';
 import SortedList from './sorted';
 
 export default class PrototypesList extends SortedList {
-
   @service router;
 
-  headers = [{
-    name: 'Version',
-    valuePath: 'version',
-    maxWidth: 150,
-  }, {
-    name: 'Consigne',
-    valuePath: 'instruction',
-  }, {
-    name: 'Auteur',
-    valuePath: 'author',
-    maxWidth: 150,
-  }, {
-    name: 'Statut',
-    valuePath: 'status',
-    maxWidth: 150,
-    style: true,
-  }];
+  headers = [
+    {
+      name: 'Version',
+      valuePath: 'version',
+      maxWidth: 150,
+    },
+    {
+      name: 'Consigne',
+      valuePath: 'instruction',
+    },
+    {
+      name: 'Auteur',
+      valuePath: 'author',
+      maxWidth: 150,
+    },
+    {
+      name: 'Statut',
+      valuePath: 'status',
+      maxWidth: 150,
+      style: true,
+    },
+  ];
 
   sortTypes = {
-    'Version': 'string',
-    'instruction': 'string',
-    'type': 'string',
-    'status': 'string',
+    Version: 'string',
+    instruction: 'string',
+    type: 'string',
+    status: 'string',
   };
 
   @action
   selectRow(row) {
     this.router.transitionTo('authenticated.competence.prototypes.single', row);
   }
-
 }

--- a/pix-editor/app/components/list/skills.js
+++ b/pix-editor/app/components/list/skills.js
@@ -4,26 +4,30 @@ import { inject as service } from '@ember/service';
 import SortedList from './sorted';
 
 export default class ListSkillsComponent extends SortedList {
-
   @service router;
 
-  headers = [{
-    name: 'Version',
-    valuePath: 'version',
-    maxWidth: 100,
-  }, {
-    name: 'Description',
-    valuePath: 'description',
-  }, {
-    name: 'Epreuves',
-    valuePath: 'challenges.length',
-    maxWidth: 200,
-  }, {
-    name: 'Statut',
-    valuePath: 'status',
-    maxWidth: 200,
-    style: true,
-  }];
+  headers = [
+    {
+      name: 'Version',
+      valuePath: 'version',
+      maxWidth: 100,
+    },
+    {
+      name: 'Description',
+      valuePath: 'description',
+    },
+    {
+      name: 'Epreuves',
+      valuePath: 'challenges.length',
+      maxWidth: 200,
+    },
+    {
+      name: 'Statut',
+      valuePath: 'status',
+      maxWidth: 200,
+      style: true,
+    },
+  ];
 
   @action
   selectRow(skill) {

--- a/pix-editor/app/components/list/sorted.js
+++ b/pix-editor/app/components/list/sorted.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import ENV from 'pixeditor/config/environment';
 
 export default class SortedList extends Component {
-
   @tracked ascending = true;
   @tracked sortField = null;
   @tracked sorts = [];
@@ -61,10 +60,12 @@ export default class SortedList extends Component {
       this.sorts = params;
     } else {
       this.ascending = !this.ascending;
-      this.sorts = [{
-        valuePath: this.sortField,
-        isAscending: this.ascending,
-      }];
+      this.sorts = [
+        {
+          valuePath: this.sortField,
+          isAscending: this.ascending,
+        },
+      ];
     }
   }
 }

--- a/pix-editor/app/components/list/workbench.js
+++ b/pix-editor/app/components/list/workbench.js
@@ -4,33 +4,37 @@ import { inject as service } from '@ember/service';
 import SortedList from './sorted';
 
 export default class CompetencesList extends SortedList {
-
   @service router;
   @service currentData;
 
-  headers = [{
-    name: 'Auteur',
-    valuePath: 'authorText',
-    maxWidth: 150,
-  }, {
-    name: 'Consigne',
-    valuePath: 'instruction',
-  }, {
-    name: 'Modalité',
-    valuePath: 'type',
-    maxWidth: 150,
-  }, {
-    name: 'Statut',
-    valuePath: 'status',
-    maxWidth: 150,
-    style: true,
-  }];
+  headers = [
+    {
+      name: 'Auteur',
+      valuePath: 'authorText',
+      maxWidth: 150,
+    },
+    {
+      name: 'Consigne',
+      valuePath: 'instruction',
+    },
+    {
+      name: 'Modalité',
+      valuePath: 'type',
+      maxWidth: 150,
+    },
+    {
+      name: 'Statut',
+      valuePath: 'status',
+      maxWidth: 150,
+      style: true,
+    },
+  ];
 
   sortTypes = {
-    'authorText': 'string',
-    'instruction': 'string',
-    'type': 'string',
-    'status': 'string',
+    authorText: 'string',
+    instruction: 'string',
+    type: 'string',
+    status: 'string',
   };
 
   get current() {
@@ -41,5 +45,4 @@ export default class CompetencesList extends SortedList {
   selectRow(row) {
     this.router.transitionTo(this.args.link, this.args.competenceModel, row);
   }
-
 }

--- a/pix-editor/app/components/pop-in/changelog.js
+++ b/pix-editor/app/components/pop-in/changelog.js
@@ -4,7 +4,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class PopinChangelog extends Component {
-
   @service notify;
 
   @tracked _value = null;

--- a/pix-editor/app/components/pop-in/confirm.js
+++ b/pix-editor/app/components/pop-in/confirm.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class PopInConfirm extends Component {
-
   get title() {
     return this.args.title || 'no_title';
   }

--- a/pix-editor/app/components/pop-in/new-framework.js
+++ b/pix-editor/app/components/pop-in/new-framework.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 export default class PopInNewFrameworkComponent extends Component {
-
   get hasEmptyMandatoryField() {
     const framework = this.args.framework;
     return this._fieldIsEmpty(framework?.name);

--- a/pix-editor/app/components/pop-in/pdf-entries.gjs
+++ b/pix-editor/app/components/pop-in/pdf-entries.gjs
@@ -9,9 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { t } from 'ember-intl';
 
 export default class PopinPDFEntries extends Component {
-  options = {
-    language: [{ value: 'en', label: 'Anglais' }, { value: 'fr', label: 'Français' }],
-  };
+  options = { language: [{ value: 'en', label: 'Anglais' }, { value: 'fr', label: 'Français' }] };
 
   @tracked title = 'Liste des thèmes et des sujets abordés dans Pix';
   @tracked language = false;

--- a/pix-editor/app/components/pop-in/select-location.gjs
+++ b/pix-editor/app/components/pop-in/select-location.gjs
@@ -8,7 +8,6 @@ import { t } from 'ember-intl';
 import FormSelectLocation from '../form/select-location';
 
 export default class PopinSelectLocation extends Component {
-
   @tracked disableActionButton = this.args.variant !== 'skill';
 
   get actionButtonTitle() {

--- a/pix-editor/app/components/pop-in/single-entry.js
+++ b/pix-editor/app/components/pop-in/single-entry.js
@@ -3,7 +3,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class PopinSingleEntry extends Component {
-
   @tracked value = '';
 
   constructor() {

--- a/pix-editor/app/components/pop-in/sorting.gjs
+++ b/pix-editor/app/components/pop-in/sorting.gjs
@@ -9,7 +9,6 @@ import sortableItem from 'ember-sortable/modifiers/sortable-item';
 import _ from 'lodash';
 
 export default class PopInSortingComponent extends Component {
-
   get models() {
     return _.sortBy(this.args.model, 'index');
   }

--- a/pix-editor/app/components/pop-in/threshold-calculation.js
+++ b/pix-editor/app/components/pop-in/threshold-calculation.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 export default class PopinThresholdCalculation extends Component {
-
   get selectedSkills() {
     const selectedSkills = [];
     const areas = this.args.model;
@@ -32,7 +31,7 @@ export default class PopinThresholdCalculation extends Component {
 
   get selectedSkillsLevels() {
     const levels = [];
-    this.selectedSkills.forEach((skill)=>{
+    this.selectedSkills.forEach((skill) => {
       if (!levels.includes(skill.level)) {
         levels.push(skill.level);
       }

--- a/pix-editor/app/components/pop-in/tube-level.js
+++ b/pix-editor/app/components/pop-in/tube-level.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 export default class PopinTubeLevel extends Component {
-
   get title() {
     return this.args.tube?.name || 'no_tube';
   }
@@ -15,7 +14,16 @@ export default class PopinTubeLevel extends Component {
       const isSelected = selected.includes(skill.pixId);
       orderedSkills[level - 1] = { skill, isSelected };
       return orderedSkills;
-    }, [null, null, null, null, null, null, null, null]);
+    }, [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]);
   }
 
   get mayUnset() {

--- a/pix-editor/app/components/pop-in/tutorial.gjs
+++ b/pix-editor/app/components/pop-in/tutorial.gjs
@@ -6,7 +6,6 @@ import { t } from 'ember-intl';
 import TutorialForm from '../form/tutorial';
 
 export default class TutorialPopIn extends Component {
-
   get hasEmptyMandatoryField() {
     const tutorial = this.args.tutorial;
     return tutorial && (

--- a/pix-editor/app/components/sidebar/export.js
+++ b/pix-editor/app/components/sidebar/export.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class SidebarExportComponent extends Component {
-
   @service('file-saver') fileSaver;
   @service notify;
   @service loader;
@@ -54,11 +53,19 @@ export default class SidebarExportComponent extends Component {
               tube.productionSkills.reduce((table, skill) => {
                 table[skill.level - 1] = skill.name;
                 return table;
-              }, ['░', '░', '░', '░', '░', '░', '░', '░']).join(','),
+              }, [
+                '░',
+                '░',
+                '░',
+                '░',
+                '░',
+                '░',
+                '░',
+                '░',
+              ]).join(','),
             ];
             fields = fields.map((field) => this._formatCSVString(field));
             return content + '\n' + fields.join(',');
-
           }, content);
         }, content);
       }, content);
@@ -71,5 +78,4 @@ export default class SidebarExportComponent extends Component {
     }
     return ' ';
   }
-
 }

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -61,4 +61,3 @@ export default class SidebarMain extends Component {
     this.versionManager.toggleV2();
   }
 }
-

--- a/pix-editor/app/components/sidebar/search.gjs
+++ b/pix-editor/app/components/sidebar/search.gjs
@@ -6,7 +6,6 @@ import { tracked } from '@glimmer/tracking';
 import { uniqBy } from 'lodash';
 
 export default class SidebarSearch extends Component {
-
   routeModel = null;
 
   @service store;
@@ -40,9 +39,7 @@ export default class SidebarSearch extends Component {
 
   async searchSkillsByName(skillName) {
     const skills = await this.store.query('skill', {
-      filter: {
-        name: skillName,
-      },
+      filter: { name: skillName },
       page: { limit: 20 },
       sort: 'name,-version',
     });
@@ -60,11 +57,7 @@ export default class SidebarSearch extends Component {
   }
 
   async searchChallengesById(challengeId) {
-    const challenges = await this.store.query('challenge', {
-      filter: {
-        ids: [challengeId],
-      },
-    });
+    const challenges = await this.store.query('challenge', { filter: { ids: [challengeId] } });
     return challenges.map((challenge) => ({
       title: challenge.id,
       transition: {
@@ -75,11 +68,7 @@ export default class SidebarSearch extends Component {
   }
 
   async searchLocalizedChallengesById(localizedChallengeId) {
-    const results = await this.store.query('localized-challenge', {
-      filter: {
-        ids: [localizedChallengeId],
-      },
-    });
+    const results = await this.store.query('localized-challenge', { filter: { ids: [localizedChallengeId] } });
     return results.map((result) => ({
       title: result.id,
       transition: {
@@ -91,12 +80,8 @@ export default class SidebarSearch extends Component {
 
   async searchChallengesByText(text) {
     const challenges = await this.store.query('challenge', {
-      filter: {
-        search: text.toLowerCase(),
-      },
-      page: {
-        size: 20,
-      },
+      filter: { search: text.toLowerCase() },
+      page: { size: 20 },
     });
     return challenges.map((challenge) => ({
       title: challenge.instruction.substr(0, 100),

--- a/pix-editor/app/components/statistics/i18n.js
+++ b/pix-editor/app/components/statistics/i18n.js
@@ -5,7 +5,6 @@ const OCCIDENT = 1;
 const AFRICA = 2;
 const UNESCO = 3;
 export default class StatisticsI18nComponent extends Component {
-
   _i18nAreas = new Map([
     ['Neutre', NEUTRAL],
     ['Institutions internationales', NEUTRAL],
@@ -82,7 +81,12 @@ export default class StatisticsI18nComponent extends Component {
         }, new Map());
 
         const countries = current.countries;
-        const areaCounts = [[0, 0], [0, 0], [0, 0], [0, 0]];
+        const areaCounts = [
+          [0, 0],
+          [0, 0],
+          [0, 0],
+          [0, 0],
+        ];
 
         for (const [country, values] of competenceCountries) {
           if (!countries.has(country)) {
@@ -156,6 +160,7 @@ export default class StatisticsI18nComponent extends Component {
       }, current);
     }, 0);
   }
+
   get i18nWorldSkills() {
     return this.i18nSkills('Monde');
   }
@@ -189,5 +194,4 @@ export default class StatisticsI18nComponent extends Component {
   get i18nUnescoCountries() {
     return this.i18nCountries(UNESCO);
   }
-
 }

--- a/pix-editor/app/components/statistics/production.js
+++ b/pix-editor/app/components/statistics/production.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class StatisticsProductionComponent extends Component {
-
   get productionTubeCounts() {
     return this.productionCounts((competence) => {
       return competence.productionTubeCount;
@@ -60,5 +59,4 @@ export default class StatisticsProductionComponent extends Component {
   productionTotal(productionCounts) {
     return Object.values(productionCounts).reduce((current, value) => current + value, 0);
   }
-
 }

--- a/pix-editor/app/components/target-profile/area-profile.js
+++ b/pix-editor/app/components/target-profile/area-profile.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 
 export default class AreaProfile extends Component {
-
   get filteredCompetences() {
     const area = this.args.area;
     if (this.args.filter) {

--- a/pix-editor/app/components/target-profile/competence-profile.gjs
+++ b/pix-editor/app/components/target-profile/competence-profile.gjs
@@ -5,7 +5,6 @@ import Component from '@glimmer/component';
 import ThemeProfile from './theme-profile';
 
 export default class CompetenceProfile extends Component {
-
   get filteredTheme() {
     const competence = this.args.competence;
     if (this.args.filter) {

--- a/pix-editor/app/components/target-profile/pdf-export.js
+++ b/pix-editor/app/components/target-profile/pdf-export.js
@@ -38,11 +38,61 @@ const pSize = 7.4;
 const footerSize = 4;
 const margin = 15;
 const areaTitleHeight = 69;
-const fontColor = [65, 70, 87];
-const lightGrey = [250, 250, 250];
-const grey = [240, 240, 240];
-const colors = [[241, 161, 65], [87, 200, 132], [18, 163, 255], [255, 63, 148], [87, 77, 166], [56, 138, 255]];
-const areaGradient = [area1bg, area2bg, area3bg, area4bg, area5bg, area6bg];
+const fontColor = [
+  65,
+  70,
+  87,
+];
+const lightGrey = [
+  250,
+  250,
+  250,
+];
+const grey = [
+  240,
+  240,
+  240,
+];
+const colors = [
+  [
+    241,
+    161,
+    65,
+  ],
+  [
+    87,
+    200,
+    132,
+  ],
+  [
+    18,
+    163,
+    255,
+  ],
+  [
+    255,
+    63,
+    148,
+  ],
+  [
+    87,
+    77,
+    166,
+  ],
+  [
+    56,
+    138,
+    255,
+  ],
+];
+const areaGradient = [
+  area1bg,
+  area2bg,
+  area3bg,
+  area4bg,
+  area5bg,
+  area6bg,
+];
 
 const defaultLanguage = 'fr';
 
@@ -64,7 +114,6 @@ function createOffscreenCanvas(width, height) {
 }
 
 export default class TargetProfilePdfExportComponent extends Component {
-
   @tracked displayTitleInput = false;
 
   @action
@@ -139,27 +188,29 @@ export default class TargetProfilePdfExportComponent extends Component {
         competences.forEach((competence) => {
           const competenceColor = colors[i];
           const competenceName = this._getTranslatedCompetenceName(language, competence);
-          const tableHead = [[
-            {
-              content: `${competence.code} ${competenceName}`,
-              colSpan: 3,
-              rowSpan: 1,
-              styles: {
-                cellPadding: {
-                  left: margin,
-                  top: competenceTitleCellPadding,
-                  right: margin,
-                  bottom: competenceTitleCellPadding,
+          const tableHead = [
+            [
+              {
+                content: `${competence.code} ${competenceName}`,
+                colSpan: 3,
+                rowSpan: 1,
+                styles: {
+                  cellPadding: {
+                    left: margin,
+                    top: competenceTitleCellPadding,
+                    right: margin,
+                    bottom: competenceTitleCellPadding,
+                  },
+                  fillColor: lightGrey,
+                  font: 'RobotoCondensed',
+                  fontStyle: 'bold',
+                  fontSize: competenceTitleSize,
+                  textColor: competenceColor,
+                  valign: 'middle',
                 },
-                fillColor: lightGrey,
-                font: 'RobotoCondensed',
-                fontStyle: 'bold',
-                fontSize: competenceTitleSize,
-                textColor: competenceColor,
-                valign: 'middle',
               },
-            },
-          ]];
+            ],
+          ];
 
           const themes = hasSelectedTubes ? competence.sortedThemes.filter((theme) => theme.hasSelectedProductionTube) : competence.sortedThemes.filter((theme) => theme.hasProductionTubes);
 
@@ -224,11 +275,9 @@ export default class TargetProfilePdfExportComponent extends Component {
             }
           });
           y = 15 + pdf.lastAutoTable.finalY;
-
         });
         pdf.addPage();
       }
-
     }
     const pageCount = pdf.internal.getNumberOfPages();
     for (let i = 2; i <= pageCount; i++) {
@@ -250,43 +299,47 @@ export default class TargetProfilePdfExportComponent extends Component {
     const firstTube = tubes.shift();
     const { tubeName, tubeDescription } = this._getTranslatedTubeNameAndDescription(language, firstTube);
     const themeName = this._getTranslatedThemeName(language, theme);
-    const firstCell = [{
-      content: themeName,
-      rowSpan,
-      styles: {
-        cellPadding: { top: cellPaddingTop, right: 5, bottom: 1, left: margin },
-        cellWidth: 80,
-        valign: 'middle',
-        font: 'RobotoCondensed',
-        fontStyle: 'bold',
-        fontSize: pSize + 1,
-        textColor: fontColor,
-        fillColor: lightGrey,
+    const firstCell = [
+      {
+        content: themeName,
+        rowSpan,
+        styles: {
+          cellPadding: { top: cellPaddingTop, right: 5, bottom: 1, left: margin },
+          cellWidth: 80,
+          valign: 'middle',
+          font: 'RobotoCondensed',
+          fontStyle: 'bold',
+          fontSize: pSize + 1,
+          textColor: fontColor,
+          fillColor: lightGrey,
+        },
       },
-    }, {
-      content: tubeName,
-      styles: {
-        cellPadding: { top: cellPaddingTop, right: 5, bottom: 1, left: 1 },
-        cellWidth: 100,
-        valign: 'middle',
-        font: 'RobotoCondensed',
-        fontStyle: 'normal',
-        fontSize: pSize,
-        textColor: fontColor,
-        fillColor: lightGrey,
+      {
+        content: tubeName,
+        styles: {
+          cellPadding: { top: cellPaddingTop, right: 5, bottom: 1, left: 1 },
+          cellWidth: 100,
+          valign: 'middle',
+          font: 'RobotoCondensed',
+          fontStyle: 'normal',
+          fontSize: pSize,
+          textColor: fontColor,
+          fillColor: lightGrey,
+        },
       },
-    }, {
-      content: tubeDescription,
-      styles: {
-        cellPadding: { top: cellPaddingTop, right: 5, bottom: 1, left: 1 },
-        fontSize: pSize,
-        valign: 'middle',
-        font: 'RobotoCondensed',
-        fontStyle: 'light',
-        textColor: fontColor,
-        fillColor: lightGrey,
+      {
+        content: tubeDescription,
+        styles: {
+          cellPadding: { top: cellPaddingTop, right: 5, bottom: 1, left: 1 },
+          fontSize: pSize,
+          valign: 'middle',
+          font: 'RobotoCondensed',
+          fontStyle: 'light',
+          textColor: fontColor,
+          fillColor: lightGrey,
+        },
       },
-    }];
+    ];
     return tubes.reduce((values, tube, index) => {
       const fillColor = index % 2 === 0 ? grey : lightGrey;
       const { tubeName, tubeDescription } = this._getTranslatedTubeNameAndDescription(language, tube);
@@ -315,7 +368,8 @@ export default class TargetProfilePdfExportComponent extends Component {
             textColor: fontColor,
             fillColor,
           },
-        }];
+        },
+      ];
       values.push(cells);
       return values;
     }, [firstCell]);
@@ -401,7 +455,7 @@ export default class TargetProfilePdfExportComponent extends Component {
 
   _generateCenteredLongText(pdf, text, breakX, breakY, positionY) {
     const lines = pdf.splitTextToSize(text, breakX);
-    lines.forEach((line)=>{
+    lines.forEach((line) => {
       pdf.text(line, this._getCenteredX(pdf, line), positionY);
       positionY += breakY;
     });

--- a/pix-editor/app/components/target-profile/theme-profile.js
+++ b/pix-editor/app/components/target-profile/theme-profile.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 export default class ThemeProfile extends Component {
-
   get filteredTubes() {
     const theme = this.args.theme;
     if (this.args.filter) {

--- a/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
+++ b/pix-editor/app/components/whitelisted-urls/related-skill-cell.gjs
@@ -3,7 +3,6 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 export default class RelatedSkillCell extends Component {
-
   constructor(...args) {
     super(...args);
     this.id = 'related-skill-cell-' + guidFor(this);

--- a/pix-editor/app/controllers/authenticated/area-management/new.js
+++ b/pix-editor/app/controllers/authenticated/area-management/new.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 export default class AreaManagementNewController extends Controller {
-
   @service loader;
   @service notify;
   @service router;

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 export default class CompetenceManagementNewController extends Controller {
-
   @service idGenerator;
   @service loader;
   @service notify;

--- a/pix-editor/app/controllers/authenticated/competence-management/single.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/single.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class CompetenceManagementSingleController extends Controller {
-
   @service access;
   @service notify;
   @service loader;
@@ -38,7 +37,7 @@ export default class CompetenceManagementSingleController extends Controller {
     this.loader.start();
     const competence = this.model;
     return competence.save()
-      .then(()=> {
+      .then(() => {
         this.edition = false;
         this.loader.stop();
         this.notify.message('Compétence mise à jour');

--- a/pix-editor/app/controllers/authenticated/competence.js
+++ b/pix-editor/app/controllers/authenticated/competence.js
@@ -5,11 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class CompetenceController extends Controller {
-  queryParams = [{
-    'leftMaximized': {
-      scope: 'controller',
-    },
-  }];
+  queryParams = [{ leftMaximized: { scope: 'controller' } }];
 
   @tracked view;
   @tracked languageFilter;
@@ -176,7 +172,12 @@ export default class CompetenceController extends Controller {
       .map((filledSkill) => {
         const tube = filledSkill.tube;
         const description = this._formatCSVString(filledSkill.description);
-        return [competence.name, tube.get('name'), filledSkill.name, description];
+        return [
+          competence.name,
+          tube.get('name'),
+          filledSkill.name,
+          description,
+        ];
       });
     const contentCSV = skillData.filter((data) => data !== false).reduce((content, data) => {
       return content + `\n${data.map((item) => item ? `"${item}"` : ' ').join(',')}`;

--- a/pix-editor/app/controllers/authenticated/competence/prototypes.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes.js
@@ -1,4 +1,3 @@
 import Controller from '@ember/controller';
 
-export default class PrototypesController extends Controller {
-}
+export default class PrototypesController extends Controller {}

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/list.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/list.js
@@ -4,9 +4,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListController extends Controller {
-
   @controller('authenticated.competence')
-    parentController;
+  parentController;
 
   @service access;
   @service config;

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class LocalizedController extends Controller {
-
   @service router;
   @service access;
   @service notify;

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
@@ -6,7 +6,6 @@ import * as Sentry from '@sentry/ember';
 import Prototype from './single';
 
 export default class NewController extends Prototype {
-
   creation = true;
   queryParams = ['from', 'fromSkill'];
   @tracked from = '';

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class AlternativesController extends Controller {
-
   queryParams = ['rightMaximized'];
 
   @tracked rightMaximized = false;

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/single.js
@@ -4,11 +4,10 @@ import { action } from '@ember/object';
 import PrototypeController from '../../single';
 
 export default class SingleController extends PrototypeController {
-
   elementClass = 'alternative-challenge';
 
   @controller('authenticated.competence.prototypes.single.alternatives')
-    parentController;
+  parentController;
 
   get maximized() {
     return this.parentController.rightMaximized;

--- a/pix-editor/app/controllers/authenticated/competence/quality/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/quality/single.js
@@ -1,4 +1,3 @@
 import Skill from '../skills/single';
 
-export default class SingleController extends Skill {
-}
+export default class SingleController extends Skill {}

--- a/pix-editor/app/controllers/authenticated/competence/skills/list.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/list.js
@@ -3,9 +3,8 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceHistoryListController extends Controller {
-
   @controller('authenticated.competence')
-    parentController;
+  parentController;
 
   @service access;
   @service currentData;

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class SingleController extends Controller {
-
   wasMaximized = false;
   changelogCallback = null;
 
@@ -17,7 +16,8 @@ export default class SingleController extends Controller {
   @tracked isStatusActionMenuOpen = false;
 
   @controller('authenticated.competence')
-    parentController;
+  parentController;
+
   @service access;
   @service changelogEntry;
   @service config;

--- a/pix-editor/app/controllers/authenticated/competence/skills/single/archive.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single/archive.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CompetenceSkillsSingleArchiveController extends Controller {
-
   @controller('authenticated.competence') competenceController;
 
   get skill() {
@@ -59,5 +58,4 @@ export default class CompetenceSkillsSingleArchiveController extends Controller 
     this.maximizeRight(false);
     this.router.transitionTo('authenticated.competence.skills.single.archive');
   }
-
 }

--- a/pix-editor/app/controllers/authenticated/competence/skills/single/archive/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single/archive/single.js
@@ -4,11 +4,10 @@ import { action } from '@ember/object';
 import PrototypeController from '../../../prototypes/single';
 
 export default class SingleController extends PrototypeController {
-
   elementClass = 'archive-challenge';
 
   @controller('authenticated.competence.skills.single.archive')
-    parentController;
+  parentController;
 
   get maximized() {
     return this.parentController.rightMaximized;
@@ -37,6 +36,4 @@ export default class SingleController extends PrototypeController {
   minimize() {
     this.parentController.maximizeRight(false);
   }
-
 }
-

--- a/pix-editor/app/controllers/authenticated/competence/themes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/themes/new.js
@@ -5,7 +5,6 @@ import * as Sentry from '@sentry/ember';
 import CompetenceThemesSingleController from './single';
 
 export default class CompetenceThemesNewController extends CompetenceThemesSingleController {
-
   creation = true;
 
   @service currentData;

--- a/pix-editor/app/controllers/authenticated/competence/themes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/themes/single.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class CompetenceThemesSingleController extends Controller {
-
   @service access;
   @service config;
   @service notify;
@@ -21,7 +20,7 @@ export default class CompetenceThemesSingleController extends Controller {
   }
 
   @controller('authenticated.competence')
-    parentController;
+  parentController;
 
   get mayEdit() {
     return this.access.mayEditSkills();
@@ -49,7 +48,7 @@ export default class CompetenceThemesSingleController extends Controller {
     this.loader.start();
     const theme = this.theme;
     return theme.save()
-      .then(()=> {
+      .then(() => {
         this.edition = false;
         this.loader.stop();
         this.notify.message('Thématique mis à jour');

--- a/pix-editor/app/controllers/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/single.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class SingleController extends Controller {
-
   @tracked edition = false;
   @tracked displaySelectLocation = false;
 
@@ -17,7 +16,7 @@ export default class SingleController extends Controller {
   }
 
   @controller('authenticated.competence')
-    parentController;
+  parentController;
 
   get maximized() {
     return this.parentController.leftMaximized;
@@ -85,7 +84,7 @@ export default class SingleController extends Controller {
     this.loader.start();
     const tube = this.tube;
     return tube.save()
-      .then(()=> {
+      .then(() => {
         this.edition = false;
         this.loader.stop();
         this.notify.message('Tube mis à jour');

--- a/pix-editor/app/controllers/authenticated/events-log.js
+++ b/pix-editor/app/controllers/authenticated/events-log.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class EventsLogController extends Controller {
-
   @service paginatedQuery;
   @tracked offset;
 

--- a/pix-editor/app/controllers/authenticated/missions/list.js
+++ b/pix-editor/app/controllers/authenticated/missions/list.js
@@ -7,7 +7,12 @@ import MissionSummary from '../../../models/mission-summary';
 
 export default class MissionsListController extends Controller {
   @service router;
-  queryParams = ['pageNumber', 'pageSize', 'statuses'];
+  queryParams = [
+    'pageNumber',
+    'pageSize',
+    'statuses',
+  ];
+
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
   @tracked statuses = [];

--- a/pix-editor/app/controllers/authenticated/static-courses/list.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/list.js
@@ -5,7 +5,14 @@ import { tracked } from '@glimmer/tracking';
 
 export default class StaticCoursesController extends Controller {
   @service router;
-  queryParams = ['pageNumber', 'pageSize', 'isActive', 'name', 'tagIds'];
+  queryParams = [
+    'pageNumber',
+    'pageSize',
+    'isActive',
+    'name',
+    'tagIds',
+  ];
+
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
   @tracked showActiveOnly = true;

--- a/pix-editor/app/controllers/authenticated/statistics.js
+++ b/pix-editor/app/controllers/authenticated/statistics.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 
 export default class StatisticsController extends Controller {
-
   get competenceCodes() {
     return this.model.reduce((current, area) => {
       current.push(area.sortedCompetences.map((competence) => competence.code));

--- a/pix-editor/app/controllers/authenticated/target-profile.js
+++ b/pix-editor/app/controllers/authenticated/target-profile.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 export default class TargetProfileController extends Controller {
-
   @tracked selectedTubeSkills = [];
   @tracked tubeSkills = [];
   @tracked selectedTube = null;
@@ -103,7 +102,7 @@ export default class TargetProfileController extends Controller {
 
   _getThematicTubeSkills(tube) {
     const productionSkill = tube.productionSkills;
-    return productionSkill.filter((skill)=>{
+    return productionSkill.filter((skill) => {
       return tube.selectedSkills.includes(skill.pixId);
     });
   }
@@ -258,7 +257,7 @@ export default class TargetProfileController extends Controller {
   }
 
   _emptyOpenFile() {
-    //TODO: find a better way to be able to reload same file
+    // TODO: find a better way to be able to reload same file
     document.getElementById('target-profile__open-file').value = '';
   }
 
@@ -273,7 +272,7 @@ export default class TargetProfileController extends Controller {
   }
 
   _determineFileType(data) {
-    if (Array.isArray(data) && data.length > 0 && typeof(data[0]) === 'string') {
+    if (Array.isArray(data) && data.length > 0 && typeof (data[0]) === 'string') {
       return 'orga';
     }
     return 'editor';

--- a/pix-editor/app/deprecation-workflow.js
+++ b/pix-editor/app/deprecation-workflow.js
@@ -1,10 +1,10 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
 setupDeprecationWorkflow({
-  'workflow': [
+  workflow: [
     {
-      'handler': 'warn', // this deprecation is only on EmberTable package
-      'matchId': 'template-action',
+      handler: 'warn', // this deprecation is only on EmberTable package
+      matchId: 'template-action',
     },
   ],
 });

--- a/pix-editor/app/helpers/flag-for-language.js
+++ b/pix-editor/app/helpers/flag-for-language.js
@@ -1,12 +1,12 @@
 import { helper } from '@ember/component/helper';
 
 const flagsForLanguages = {
-  fr: '🇫🇷',
+  'fr': '🇫🇷',
   'fr-fr': '🇫🇷',
-  en: '🇬🇧',
-  es: '🇪🇸',
+  'en': '🇬🇧',
+  'es': '🇪🇸',
   'es-419': '🌎',
-  nl: '🇳🇱',
+  'nl': '🇳🇱',
 };
 
 export function flagForLanguage([language]) {

--- a/pix-editor/app/models/area.js
+++ b/pix-editor/app/models/area.js
@@ -40,6 +40,7 @@ export default class AreaModel extends Model {
       return count + competence.selectedProductionTubeCount;
     }, 0);
   }
+
   get selectedThematicResultTubeCount() {
     return this.competencesArray.reduce((count, competence) => {
       return count + competence.selectedThematicResultTubeCount;

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import _ from 'lodash';
 
 export default class ChallengeModel extends Model {
-
   @attr('string') airtableId;
   @attr instruction;
   @attr alternativeInstruction;
@@ -32,7 +31,12 @@ export default class ChallengeModel extends Model {
   @attr accessibility2;
   @attr spoil;
   @attr responsive;
-  @attr({ defaultValue: function() { return []; } }) locales;
+  @attr({
+    defaultValue: function () {
+      return [];
+    },
+  }) locales;
+
   @attr alternativeLocales;
   @attr geography;
   @attr urlsToConsult;
@@ -44,7 +48,12 @@ export default class ChallengeModel extends Model {
   @attr('date') archivedAt;
   @attr('date') madeObsoleteAt;
   @attr('boolean') shuffled;
-  @attr({ defaultValue: function() { return []; } }) contextualizedFields;
+  @attr({
+    defaultValue: function () {
+      return [];
+    },
+  }) contextualizedFields;
+
   @attr requireGafamWebsiteAccess;
   @attr isIncompatibleIpadCertif;
   @attr deafAndHardOfHearing;
@@ -200,7 +209,12 @@ export default class ChallengeModel extends Model {
 
   get isTextBased() {
     const type = this.type;
-    return ['QROC', 'QROCM', 'QROCM-ind', 'QROCM-dep'].includes(type);
+    return [
+      'QROC',
+      'QROCM',
+      'QROCM-ind',
+      'QROCM-dep',
+    ].includes(type);
   }
 
   get timerOn() {
@@ -282,7 +296,15 @@ export default class ChallengeModel extends Model {
   }
 
   async duplicate() {
-    const ignoredFields = ['skill', 'author', 'airtableId', 'updatedAt', 'archivedAt', 'madeObsoleteAt', 'validatedAt'];
+    const ignoredFields = [
+      'skill',
+      'author',
+      'airtableId',
+      'updatedAt',
+      'archivedAt',
+      'madeObsoleteAt',
+      'validatedAt',
+    ];
     if (this.isPrototype) {
       ignoredFields.push('version');
     } else {
@@ -300,7 +322,14 @@ export default class ChallengeModel extends Model {
   }
 
   async copyForDifferentSkill() {
-    const ignoredFields = ['skill', 'airtableId', 'updatedAt', 'archivedAt', 'madeObsoleteAt', 'validatedAt'];
+    const ignoredFields = [
+      'skill',
+      'airtableId',
+      'updatedAt',
+      'archivedAt',
+      'madeObsoleteAt',
+      'validatedAt',
+    ];
     const data = this._getJSON(ignoredFields);
 
     data.status = 'proposé';

--- a/pix-editor/app/models/competence.js
+++ b/pix-editor/app/models/competence.js
@@ -2,7 +2,6 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import sortBy from 'lodash/sortBy';
 
 export default class CompetenceModel extends Model {
-
   @attr title;
   @attr titleEn;
   @attr description;

--- a/pix-editor/app/models/framework.js
+++ b/pix-editor/app/models/framework.js
@@ -1,7 +1,6 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class FrameworkModel extends Model {
-
   static pix1DFrameworkName = 'Pix 1D';
 
   @attr name;

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -1,10 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import Challenge from 'pixeditor/models/challenge';
 
-const inProductionCombinations = [
-  'validé:validé',
-  'archivé:validé',
-];
+const inProductionCombinations = ['validé:validé', 'archivé:validé'];
 
 export default class LocalizedChallengeModel extends Model {
   @attr embedURL;

--- a/pix-editor/app/models/mission-summary.js
+++ b/pix-editor/app/models/mission-summary.js
@@ -34,7 +34,6 @@ export default class MissionSummary extends Model {
 
   get isExperimental() {
     return this.status === MissionSummary.statuses.EXPERIMENTAL;
-
   }
 
   get isValidated() {

--- a/pix-editor/app/models/note.js
+++ b/pix-editor/app/models/note.js
@@ -2,7 +2,6 @@ import { inject as service } from '@ember/service';
 import Model, { attr } from '@ember-data/model';
 
 export default class NoteModel extends Model {
-
   @service changelogEntry;
 
   @attr text;
@@ -23,15 +22,15 @@ export default class NoteModel extends Model {
   get actionCSS() {
     const changelogEntry = this.changelogEntry;
     switch (this.action) {
-      case changelogEntry.deleteAction :
+      case changelogEntry.deleteAction:
         return 'delete-log';
-      case changelogEntry.createAction :
+      case changelogEntry.createAction:
         return 'create-log';
-      case changelogEntry.archiveAction :
+      case changelogEntry.archiveAction:
         return 'archive-log';
-      case changelogEntry.modifyAction :
+      case changelogEntry.modifyAction:
         return 'modify-log';
-      case changelogEntry.moveAction :
+      case changelogEntry.moveAction:
         return 'move-log';
       default:
         return '';

--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -3,7 +3,6 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { tracked } from '@glimmer/tracking';
 
 export default class SkillModel extends Model {
-
   _pinnedRelationships = {};
 
   @attr name;
@@ -254,5 +253,4 @@ export default class SkillModel extends Model {
     }
     return extractedLanguages;
   }
-
 }

--- a/pix-editor/app/models/theme.js
+++ b/pix-editor/app/models/theme.js
@@ -2,7 +2,6 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import sortBy from 'lodash/sortBy';
 
 export default class ThemeModel extends Model {
-
   @attr pixId;
   @attr name;
   @attr nameEnUs;

--- a/pix-editor/app/models/tube.js
+++ b/pix-editor/app/models/tube.js
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import sortBy from 'lodash/sortBy';
 
 export default class TubeModel extends Model {
-
   selectedSkills = [];
   selectedThematicResultSkills = [];
 
@@ -109,6 +108,14 @@ export default class TubeModel extends Model {
         grid[skill.level - 1] = [skill];
       }
       return grid;
-    }, [false, false, false, false, false, false, false]);
+    }, [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
   }
 }

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -6,22 +6,22 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function() {
+Router.map(function () {
   this.route('login', { path: 'connexion' });
-  this.route('authenticated', { path: '' }, function() {
-    this.route('v2', { path: '/v2/competences/:competence_id' }, function() {
-      this.route('competence-overview', { path: '/:overview' }, function() {
+  this.route('authenticated', { path: '' }, function () {
+    this.route('v2', { path: '/v2/competences/:competence_id' }, function () {
+      this.route('competence-overview', { path: '/:overview' }, function () {
         this.route('challenges', { path: '/skills/:skill_id/challenges' });
         this.route('localized-challenges', { path: '/skills/:skill_id/localized-challenges' });
       });
       this.route('challenge', { path: '/:overview/skills/:skill_id/challenges/:challenge_id' });
       this.route('localized-challenge', { path: '/:overview/skills/:skill_id/localized-challenges/:localized_challenge_id' });
     });
-    this.route('competence', { path: '/competence/:competence_id' }, function() {
-      this.route('prototypes', function() {
+    this.route('competence', { path: '/competence/:competence_id' }, function () {
+      this.route('prototypes', function () {
         this.route('new');
-        this.route('single', { path: '/:prototype_id' }, function() {
-          this.route('alternatives', function() {
+        this.route('single', { path: '/:prototype_id' }, function () {
+          this.route('alternatives', function () {
             this.route('new');
             this.route('single', { path: '/:alternative_id' });
             this.route('localized', { path: '/:alternative_id/localized/:localized_challenge_id' });
@@ -30,32 +30,32 @@ Router.map(function() {
         this.route('localized', { path: '/:prototype_id/localized/:localized_challenge_id' });
         this.route('list', { path: '/list/:tube_id/:skill_id' });
       });
-      this.route('tubes', function() {
+      this.route('tubes', function () {
         this.route('single', { path: '/:tube_id' });
         this.route('new');
       });
-      this.route('skills', function() {
-        this.route('single', { path: '/:skill_id' }, function() {
-          this.route('archive', function() {
+      this.route('skills', function () {
+        this.route('single', { path: '/:skill_id' }, function () {
+          this.route('archive', function () {
             this.route('single', { path: '/:challenge_id' });
           });
         });
         this.route('new', { path: '/new/:tube_id/:level' });
         this.route('list', { path: '/list/:tube_id/:level' });
       });
-      this.route('quality', function() {
+      this.route('quality', function () {
         this.route('single', { path: '/:skill_id' });
       });
-      this.route('i18n', function() {
+      this.route('i18n', function () {
         this.route('single', { path: '/:skill_id' });
       });
 
-      this.route('themes', function() {
+      this.route('themes', function () {
         this.route('single', { path: '/:theme_id' });
         this.route('new');
       });
     });
-    this.route('competence-management', function() {
+    this.route('competence-management', function () {
       this.route('new', { path: 'new/:area_id' });
       this.route('single', { path: '/:competence_id' });
     });
@@ -64,30 +64,30 @@ Router.map(function() {
     this.route('target-profile');
     this.route('statistics');
     this.route('events-log');
-    this.route('area-management', function() {
+    this.route('area-management', function () {
       this.route('new', { path: 'new/:framework_id' });
     });
-    this.route('static-courses', function() {
+    this.route('static-courses', function () {
       this.route('list', { path: '/' });
       this.route('new');
-      this.route('static-course', { path: '/:static_course_id' }, function() {
+      this.route('static-course', { path: '/:static_course_id' }, function () {
         this.route('details', { path: '/' });
         this.route('edit');
       });
     });
-    this.route('missions', function() {
+    this.route('missions', function () {
       this.route('list', { path: '/' });
       this.route('new');
-      this.route('mission', { path: '/:mission_id' }, function() {
+      this.route('mission', { path: '/:mission_id' }, function () {
         this.route('details', { path: '/' });
         this.route('edit');
       });
     });
     this.route('synchronize-translations');
-    this.route('whitelisted-urls', function() {
+    this.route('whitelisted-urls', function () {
       this.route('list', { path: '/' });
       this.route('new');
-      this.route('whitelisted-url', { path: '/:whitelisted_url_id' }, function() {
+      this.route('whitelisted-url', { path: '/:whitelisted_url_id' }, function () {
         this.route('edit');
       });
     });

--- a/pix-editor/app/routes/authenticated.js
+++ b/pix-editor/app/routes/authenticated.js
@@ -27,5 +27,4 @@ export default class AuthenticatedRoute extends Route {
     }
     return frameworks;
   }
-
 }

--- a/pix-editor/app/routes/authenticated/area-management/new.js
+++ b/pix-editor/app/routes/authenticated/area-management/new.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class AreaManagementNewRoute extends Route {
-
   @service currentData;
   @service idGenerator;
   @service store;

--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
-
   @service router;
   @service store;
   @service versionManager;

--- a/pix-editor/app/routes/authenticated/competence-management/single.js
+++ b/pix-editor/app/routes/authenticated/competence-management/single.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceManagementSingleRoute extends Route {
-
   @service currentData;
   @service store;
 
@@ -27,8 +26,8 @@ export default class CompetenceManagementSingleRoute extends Route {
   @action
   willTransition(transition) {
     const controller = this.controllerFor('authenticated.competence-management.single');
-    if (controller.edition &&
-      !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
+    if (controller.edition
+      && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else if (controller.edition) {
       controller.model.rollbackAttributes();

--- a/pix-editor/app/routes/authenticated/competence.js
+++ b/pix-editor/app/routes/authenticated/competence.js
@@ -7,12 +7,8 @@ export default class CompetenceRoute extends Route {
   @service router;
 
   queryParams = {
-    view: {
-      refreshModel: true,
-    },
-    languageFilter: {
-      refreshModel: true,
-    },
+    view: { refreshModel: true },
+    languageFilter: { refreshModel: true },
   };
 
   model(params) {

--- a/pix-editor/app/routes/authenticated/competence/index.js
+++ b/pix-editor/app/routes/authenticated/competence/index.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceIndexRoute extends Route {
-
   @service router;
 
   redirect() {

--- a/pix-editor/app/routes/authenticated/competence/prototypes.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class PrototypesRoute extends Route {
-
   @service currentData;
   @service store;
   @service router;
@@ -13,12 +12,12 @@ export default class PrototypesRoute extends Route {
   refreshing = false;
 
   beforeModel(transition) {
-    if (!['production', 'workbench', 'workbench-list'].includes(transition.to.queryParams.view)) {
-      this.router.replaceWith({
-        queryParams: {
-          view: 'production',
-        },
-      });
+    if (![
+      'production',
+      'workbench',
+      'workbench-list',
+    ].includes(transition.to.queryParams.view)) {
+      this.router.replaceWith({ queryParams: { view: 'production' } });
     }
   }
 

--- a/pix-editor/app/routes/authenticated/competence/prototypes/index.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/index.js
@@ -7,7 +7,11 @@ export default class PrototypesIndexRoute extends Route {
     competenceController.setSection('challenges');
     competenceController.maximizeLeft(false);
     const view = competenceController.view;
-    if (!['production', 'workbench', 'workbench-list'].includes(view)) {
+    if (![
+      'production',
+      'workbench',
+      'workbench-list',
+    ].includes(view)) {
       competenceController.setView('production');
     }
   }

--- a/pix-editor/app/routes/authenticated/competence/prototypes/list.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/list.js
@@ -3,17 +3,13 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ListRoute extends Route {
-
   @service router;
   @service store;
 
   async model(params) {
-    const [tube, skill] = await Promise.all([
-      this.store.findRecord('tube', params.tube_id),
-      this.store.findRecord('skill', params.skill_id),
-    ]);
+    const [tube, skill] = await Promise.all([this.store.findRecord('tube', params.tube_id), this.store.findRecord('skill', params.skill_id)]);
     const skills = await tube.rawSkills;
-    await Promise.all(skills.map((skill)=> skill.challenges));
+    await Promise.all(skills.map((skill) => skill.challenges));
     return { skills: tube.filledSkills[skill.level - 1], skill };
   }
 

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class SingleRoute extends Route {
-
   @service currentData;
   @service router;
   @service store;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 
 export default class AlternativesRoute extends Route {
-
   async model() {
     const prototype = this.modelFor('authenticated.competence.prototypes.single');
     await prototype.skill.get('challenges');
@@ -16,5 +15,4 @@ export default class AlternativesRoute extends Route {
   resetController(controller) {
     controller.rightMaximized = false;
   }
-
 }

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class SingleRoute extends Route {
-
   @service store;
   templateName = 'authenticated/competence/prototypes/single';
 

--- a/pix-editor/app/routes/authenticated/competence/quality.js
+++ b/pix-editor/app/routes/authenticated/competence/quality.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class QualityRoute extends Route {
-
   @service router;
 
   refreshing = false;

--- a/pix-editor/app/routes/authenticated/competence/quality/single.js
+++ b/pix-editor/app/routes/authenticated/competence/quality/single.js
@@ -18,8 +18,8 @@ export default class SingleRoute extends SkillRoute {
 
   @action
   willTransition(transition) {
-    if (this.controllerFor('authenticated.competence.quality.single').edition &&
-        !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
+    if (this.controllerFor('authenticated.competence.quality.single').edition
+      && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else {
       this.controllerFor('authenticated.competence.quality.single').model.rollbackAttributes();

--- a/pix-editor/app/routes/authenticated/competence/skills.js
+++ b/pix-editor/app/routes/authenticated/competence/skills.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default class SkillsRoute extends Route {
-
   async model() {
     const competence = this.modelFor('authenticated.competence');
     if (this.refreshing) {

--- a/pix-editor/app/routes/authenticated/competence/skills/index.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/index.js
@@ -6,7 +6,11 @@ export default class SkillsIndexRoute extends Route {
     const competenceController = this.controllerFor('authenticated.competence');
     competenceController.setSection('skills');
     const view = competenceController.view;
-    if (!['production', 'workbench', 'draft'].includes(view)) {
+    if (![
+      'production',
+      'workbench',
+      'draft',
+    ].includes(view)) {
       competenceController.setView('production');
     }
     competenceController.maximizeLeft(false);

--- a/pix-editor/app/routes/authenticated/competence/skills/list.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/list.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceSkillsListRoute extends Route {
-
   @service store;
 
   async model(params) {

--- a/pix-editor/app/routes/authenticated/competence/skills/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class SingleRoute extends Route {
-
   @service currentData;
   @service router;
   @service store;
@@ -36,8 +35,8 @@ export default class SingleRoute extends Route {
 
   @action
   async willTransition(transition) {
-    if (this.controllerFor('authenticated.competence.skills.single').edition &&
-      !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
+    if (this.controllerFor('authenticated.competence.skills.single').edition
+      && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else {
       const modelSkillSingle = this.controllerFor('authenticated.competence.skills.single').model;

--- a/pix-editor/app/routes/authenticated/competence/skills/single/archive.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single/archive.js
@@ -5,4 +5,3 @@ export default class CompetenceSkillsSingleArchiveRoute extends Route {
     await skill.challenges;
   }
 }
-

--- a/pix-editor/app/routes/authenticated/competence/skills/single/archive/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single/archive/single.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceSkillsSingleArchiveSingleRoute extends Route {
-
   @service store;
   model(params) {
     return this.store.findRecord('challenge', params.challenge_id);

--- a/pix-editor/app/routes/authenticated/competence/themes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/themes/new.js
@@ -8,9 +8,7 @@ export default class CompetenceThemesNewRoute extends CompetenceThemesSingleRout
   @service idGenerator;
 
   model() {
-    return this.store.createRecord('theme', {
-      pixId: this.idGenerator.newId('thematic'),
-    });
+    return this.store.createRecord('theme', { pixId: this.idGenerator.newId('thematic') });
   }
 
   setupController(controller) {

--- a/pix-editor/app/routes/authenticated/competence/themes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/themes/single.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceThemesSingleRoute extends Route {
-
   @service store;
 
   model(params) {
@@ -20,8 +19,8 @@ export default class CompetenceThemesSingleRoute extends Route {
   @action
   willTransition(transition) {
     const controller = this.controllerFor('authenticated.competence.tubes.single');
-    if (controller.edition &&
-      !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
+    if (controller.edition
+      && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else if (controller.edition) {
       controller.model.rollbackAttributes();

--- a/pix-editor/app/routes/authenticated/competence/tubes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/tubes/new.js
@@ -3,12 +3,7 @@ import { inject as service } from '@ember/service';
 import Tube from './single';
 
 export default class NewRoute extends Tube {
-
-  queryParams = {
-    themeId: {
-      refreshModel: true,
-    },
-  };
+  queryParams = { themeId: { refreshModel: true } };
 
   templateName = 'authenticated/competence/tubes/single';
   @service idGenerator;

--- a/pix-editor/app/routes/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/tubes/single.js
@@ -3,7 +3,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class SingleRoute extends Route {
-
   @service currentData;
   @service store;
 
@@ -20,8 +19,8 @@ export default class SingleRoute extends Route {
 
   @action
   willTransition(transition) {
-    if (this.controllerFor('authenticated.competence.tubes.single').edition &&
-      !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
+    if (this.controllerFor('authenticated.competence.tubes.single').edition
+      && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else {
       return true;

--- a/pix-editor/app/routes/authenticated/events-log.js
+++ b/pix-editor/app/routes/authenticated/events-log.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class EventsLogRoute extends Route {
-
   @service paginatedQuery;
 
   model() {

--- a/pix-editor/app/routes/authenticated/missions/list.js
+++ b/pix-editor/app/routes/authenticated/missions/list.js
@@ -3,15 +3,9 @@ import { inject as service } from '@ember/service';
 
 export default class MissionsRoute extends Route {
   queryParams = {
-    pageNumber: {
-      refreshModel: true,
-    },
-    pageSize: {
-      refreshModel: true,
-    },
-    statuses: {
-      refreshModel: true,
-    },
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    statuses: { refreshModel: true },
   };
 
   @service store;
@@ -23,9 +17,7 @@ export default class MissionsRoute extends Route {
         size: params.pageSize,
       },
 
-      filter: {
-        statuses: params.statuses,
-      },
+      filter: { statuses: params.statuses },
     }, { reload: true });
     return {
       missions,

--- a/pix-editor/app/routes/authenticated/skill.js
+++ b/pix-editor/app/routes/authenticated/skill.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class SkillRoute extends Route {
-
   @service router;
   @service store;
 

--- a/pix-editor/app/routes/authenticated/static-courses/list.js
+++ b/pix-editor/app/routes/authenticated/static-courses/list.js
@@ -3,21 +3,11 @@ import { inject as service } from '@ember/service';
 
 export default class StaticCoursesRoute extends Route {
   queryParams = {
-    pageNumber: {
-      refreshModel: true,
-    },
-    pageSize: {
-      refreshModel: true,
-    },
-    isActive: {
-      refreshModel: true,
-    },
-    name: {
-      refreshModel: true,
-    },
-    tagIds: {
-      refreshModel: true,
-    },
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    isActive: { refreshModel: true },
+    name: { refreshModel: true },
+    tagIds: { refreshModel: true },
   };
 
   @service store;

--- a/pix-editor/app/routes/authenticated/statistics.js
+++ b/pix-editor/app/routes/authenticated/statistics.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class StatisticsRoute extends Route {
-
   @service currentData;
 
   model() {
@@ -25,5 +24,4 @@ export default class StatisticsRoute extends Route {
         return Promise.all(getChallenges);
       });
   }
-
 }

--- a/pix-editor/app/routes/authenticated/target-profile.js
+++ b/pix-editor/app/routes/authenticated/target-profile.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 
 export default class TargetProfileRoute extends Route {
-
   model() {
     return this.modelFor('authenticated');
   }

--- a/pix-editor/app/routes/authenticated/v2.js
+++ b/pix-editor/app/routes/authenticated/v2.js
@@ -6,11 +6,7 @@ export default class V2Route extends Route {
   @service router;
   @service versionManager;
 
-  queryParams = {
-    locale: {
-      refreshModel: true,
-    },
-  };
+  queryParams = { locale: { refreshModel: true } };
 
   async model(params) {
     const competence = await this.store.findRecord('competence', params.competence_id);

--- a/pix-editor/app/routes/authenticated/v2/challenge.js
+++ b/pix-editor/app/routes/authenticated/v2/challenge.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
-
   @service router;
   @service store;
 

--- a/pix-editor/app/routes/authenticated/v2/competence-overview.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CompetenceOverviewRoute extends Route {
-
   @service router;
   @service store;
   @service versionManager;

--- a/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class LocalizedChallengesRoute extends Route {
-
   @service router;
   @service store;
   @service versionManager;

--- a/pix-editor/app/routes/authenticated/v2/localized-challenge.js
+++ b/pix-editor/app/routes/authenticated/v2/localized-challenge.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
-
   @service router;
   @service store;
 

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
@@ -3,12 +3,8 @@ import { inject as service } from '@ember/service';
 
 export default class WhitelistedUrlsRoute extends Route {
   queryParams = {
-    url: {
-      refreshModel: true,
-    },
-    names: {
-      refreshModel: true,
-    },
+    url: { refreshModel: true },
+    names: { refreshModel: true },
   };
 
   @service store;

--- a/pix-editor/app/serializers/airtable.js
+++ b/pix-editor/app/serializers/airtable.js
@@ -2,7 +2,6 @@ import RESTSerializer from '@ember-data/serializer/rest';
 import { pluralize } from 'ember-inflector';
 
 export default class AirtableSerializer extends RESTSerializer {
-
   payloadKeyFromModelName(modelName) {
     return super.payloadKeyFromModelName(modelName);
   }
@@ -14,9 +13,7 @@ export default class AirtableSerializer extends RESTSerializer {
       payload[modelNamePlural] = payload.records;
       delete payload.records;
 
-      payload.meta = {
-        offset: payload.offset,
-      };
+      payload.meta = { offset: payload.offset };
       delete payload.offset;
 
       payload[modelNamePlural].forEach((record) => {
@@ -85,7 +82,6 @@ export default class AirtableSerializer extends RESTSerializer {
     const key = relationship.key;
 
     if (this.shouldSerializeHasMany(snapshot, key, relationship)) {
-
       const hasMany = snapshot.hasMany(key);
 
       if (hasMany !== undefined) {

--- a/pix-editor/app/serializers/changelog-entry.js
+++ b/pix-editor/app/serializers/changelog-entry.js
@@ -1,4 +1,3 @@
 import NoteSerializer from './note';
 
-export default class ChangelogEntryClass extends NoteSerializer {
-}
+export default class ChangelogEntryClass extends NoteSerializer {}

--- a/pix-editor/app/serializers/config.js
+++ b/pix-editor/app/serializers/config.js
@@ -1,7 +1,6 @@
 import ApplicationSerializer from './application';
 
 export default class ConfigSerializer extends ApplicationSerializer {
-
   extractId() {
     return 'pix-editor-global-config';
   }

--- a/pix-editor/app/serializers/note.js
+++ b/pix-editor/app/serializers/note.js
@@ -47,5 +47,4 @@ export default class NoteSerializer extends AirtableSerializer {
       return super.serializeAttribute(...arguments);
     }
   }
-
 }

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -164,6 +164,7 @@ export default class AccessService extends Service {
   mayCreateOrEditStaticCourse() {
     return this.isEditor();
   }
+
   mayCreateOrEditMission() {
     return this.isEditor();
   }
@@ -194,7 +195,7 @@ export default class AccessService extends Service {
 
   getLevel(accessString) {
     switch (accessString) {
-      case 'readpixonly' :
+      case 'readpixonly':
         return READ_PIX_ONLY;
       case 'readonly':
         return READ_ONLY;

--- a/pix-editor/app/services/ajax-queue.js
+++ b/pix-editor/app/services/ajax-queue.js
@@ -3,7 +3,6 @@ import { default as PQueue } from 'p-queue';
 import ENV from 'pixeditor/config/environment';
 
 export default class AjaxQueueService extends Service {
-
   constructor() {
     super(...arguments);
     this._queue = new PQueue({ concurrency: ENV.APP.MAX_CONCURRENT_AJAX_CALLS });

--- a/pix-editor/app/services/changelog-entry.js
+++ b/pix-editor/app/services/changelog-entry.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 
 export default class ChangelogEntryService extends Service {
-
   skill = 'acquis';
   challenge = 'épreuve';
   deleteAction = 'suppression';

--- a/pix-editor/app/services/notify.js
+++ b/pix-editor/app/services/notify.js
@@ -14,5 +14,4 @@ export default class NotifyService extends Service {
   error(text) {
     this.target.showMessage(text, false);
   }
-
 }

--- a/pix-editor/app/services/phrase.js
+++ b/pix-editor/app/services/phrase.js
@@ -7,9 +7,7 @@ export default class PhraseService extends Service {
   async download(fetchFn = fetch) {
     await fetchFn('/api/phrase/download', {
       method: 'POST',
-      headers: {
-        authorization: `Bearer ${this.session.data.authenticated.apiKey}`,
-      },
+      headers: { authorization: `Bearer ${this.session.data.authenticated.apiKey}` },
     });
   }
 }

--- a/pix-editor/app/services/storage.js
+++ b/pix-editor/app/services/storage.js
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/ember';
 import fetch from 'fetch';
 
 export default class StorageService extends Service {
-
   @service config;
   @service filePath;
   @service session;
@@ -90,7 +89,7 @@ export default class StorageService extends Service {
       }
       const response = await fetchFn('/api/file-storage-token', {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${this.session.data.authenticated.apiKey}` },
+        headers: { Authorization: `Bearer ${this.session.data.authenticated.apiKey}` },
       });
       if (!response.ok) {
         console.error('could not get storage token');

--- a/pix-editor/config/ember-intl.js
+++ b/pix-editor/config/ember-intl.js
@@ -1,6 +1,6 @@
 /* jshint node:true */
 
-module.exports = function(/* environment */) {
+module.exports = function (/* environment */) {
   return {
     /**
      * Merges the fallback locale's translations into all other locales as a

--- a/pix-editor/config/environment.js
+++ b/pix-editor/config/environment.js
@@ -1,16 +1,17 @@
+/* eslint-disable @stylistic/object-curly-newline */
 'use strict';
 
 function _isFeatureEnabled(environmentVariable) {
   return environmentVariable === 'true';
 }
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   const ENV = {
-    modulePrefix: 'pixeditor',
+    'modulePrefix': 'pixeditor',
     environment,
-    rootURL: '/',
-    locationType: 'history',
-    EmberENV: {
+    'rootURL': '/',
+    'locationType': 'history',
+    'EmberENV': {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
@@ -18,7 +19,7 @@ module.exports = function(environment) {
       EXTEND_PROTOTYPES: false,
     },
 
-    APP: {
+    'APP': {
       // Here you can pass flags/options to your application instance
       // when it is created
       version: require('../package.json').version,
@@ -44,21 +45,13 @@ module.exports = function(environment) {
       },
     },
 
-    sentry: {
-      enabled: _isFeatureEnabled(process.env.SENTRY_ENABLED),
-    },
+    'sentry': { enabled: _isFeatureEnabled(process.env.SENTRY_ENABLED) },
 
-    'ember-simple-auth': {
-      routeAfterAuthentication: 'authenticated',
-    },
+    'ember-simple-auth': { routeAfterAuthentication: 'authenticated' },
 
-    'ember-cli-notifications': {
-      autoClear: true,
-    },
+    'ember-cli-notifications': { autoClear: true },
 
-    'ember-cli-mirage': {
-      usingProxy: true,
-    },
+    'ember-cli-mirage': { usingProxy: true },
   };
 
   if (environment === 'development') {
@@ -80,9 +73,7 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
 
-    ENV['ember-cli-notifications'] = {
-      autoClear: false,
-    };
+    ENV['ember-cli-notifications'] = { autoClear: false };
   }
 
   return ENV;
@@ -96,4 +87,3 @@ function _getEnvironmentVariableAsNumber({ environmentVariableName, defaultValue
   }
   throw new Error(`Invalid value '${valueToValidate}' for environment variable '${environmentVariableName}'. It should be a number greater than or equal ${minValue}.`);
 }
-

--- a/pix-editor/config/targets.js
+++ b/pix-editor/config/targets.js
@@ -6,6 +6,4 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-module.exports = {
-  browsers,
-};
+module.exports = { browsers };

--- a/pix-editor/ember-cli-build.js
+++ b/pix-editor/ember-cli-build.js
@@ -2,21 +2,15 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
-    sassOptions: {
-      includePaths: ['node_modules/@1024pix/pix-ui/addon/styles'],
-    },
-    babel: {
-      plugins: [
-        require.resolve('ember-concurrency/async-arrow-task-transform'),
-      ],
-    },
+    sassOptions: { includePaths: ['node_modules/@1024pix/pix-ui/addon/styles'] },
+    babel: { plugins: [require.resolve('ember-concurrency/async-arrow-task-transform')] },
 
     // Add options here
-    /*babel: {
+    /* babel: {
       sourceMaps: 'inline'
-    }*/
+    } */
   });
 
   // Use `app.import` to add additional libraries to the generated
@@ -33,21 +27,21 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
   app.import('node_modules/semantic-ui-css/semantic.css');
 
-  //TODO: remove this once outline icons are included in ember-semantic-ui
-  ['eot', 'svg', 'ttf', 'woff', 'woff2'].forEach((type) => {
+  // TODO: remove this once outline icons are included in ember-semantic-ui
+  [
+    'eot',
+    'svg',
+    'ttf',
+    'woff',
+    'woff2',
+  ].forEach((type) => {
     ['brand', 'outline'].forEach((asset) => {
-      app.import(`node_modules/semantic-ui-css/themes/default/assets/fonts/${asset}-icons.${type}`, {
-        destDir: 'assets/themes/default/assets/fonts',
-      });
+      app.import(`node_modules/semantic-ui-css/themes/default/assets/fonts/${asset}-icons.${type}`, { destDir: 'assets/themes/default/assets/fonts' });
     });
-    app.import(`node_modules/semantic-ui-css/themes/default/assets/fonts/icons.${type}`, {
-      destDir: 'assets/themes/default/assets/fonts',
-    });
+    app.import(`node_modules/semantic-ui-css/themes/default/assets/fonts/icons.${type}`, { destDir: 'assets/themes/default/assets/fonts' });
   });
 
-  app.import('node_modules/semantic-ui-css/themes/default/assets/images/flags.png', {
-    destDir: 'assets/themes/default/assets/images',
-  });
+  app.import('node_modules/semantic-ui-css/themes/default/assets/images/flags.png', { destDir: 'assets/themes/default/assets/images' });
 
   const { Webpack } = require('@embroider/webpack');
 
@@ -55,14 +49,6 @@ module.exports = function(defaults) {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
     staticModifiers: true,
-    packagerOptions: {
-      webpackConfig: {
-        resolve: {
-          fallback: {
-            crypto: false,
-          },
-        },
-      },
-    },
+    packagerOptions: { webpackConfig: { resolve: { fallback: { crypto: false } } } },
   });
 };

--- a/pix-editor/eslint.config.mjs
+++ b/pix-editor/eslint.config.mjs
@@ -1,4 +1,3 @@
-import pixRecommendedConfig from '@1024pix/eslint-plugin/config';
 import babelParser from '@babel/eslint-parser';
 import emberParser from 'ember-eslint-parser';
 import emberRecommendedConfig from 'eslint-plugin-ember/configs/recommended';
@@ -10,11 +9,19 @@ import globals from 'globals';
 const unconventionalJsFiles = ['blueprints/**/files/*', 'app/vendor/*'];
 const compiledOutputFiles = ['dist/*', 'tmp/*'];
 const dependenciesFiles = ['bower_components/*', 'node_modules/*'];
-const miscFiles = ['coverage/*', '!**/.*', '**/.eslintcache'];
-const emberTryFiles = ['.node_modules.ember-try/*', 'bower.json.ember-try', 'package.json.ember-try'];
+const miscFiles = [
+  'coverage/*',
+  '!**/.*',
+  '**/.eslintcache',
+];
+const emberTryFiles = [
+  '.node_modules.ember-try/*',
+  'bower.json.ember-try',
+  'package.json.ember-try',
+];
+import stylistic from '@stylistic/eslint-plugin';
 
 const nodeFiles = [
-  'eslint.config.cjs',
   '.template-lintrc.js',
   'ember-cli-build.js',
   'testem.js',
@@ -28,19 +35,45 @@ const nodeFiles = [
 ];
 
 export default [
-  ...pixRecommendedConfig,
   ...emberRecommendedConfig,
   ...emberGjsRecommendedConfig,
   qunitRecommendedConfig,
+  stylistic.configs.customize({
+    'jsx': false,
+    'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
+    'object-curly-spacing': ['error', 'always'],
+    'quote-props': ['error', 'as-needed'],
+    'quotes': 'single',
+    'semi': true,
+    'space-before-function-paren': ['error', { anonymous: 'never', named: 'never', asyncArrow: 'ignore' }],
+    'space-infix-ops': ['error'],
+  }),
   {
-    ignores: [...unconventionalJsFiles, ...compiledOutputFiles, ...dependenciesFiles, ...miscFiles, ...emberTryFiles],
+    plugins: { '@stylistic': stylistic },
+    rules: {
+      '@stylistic/array-bracket-newline': ['error', { multiline: true }],
+      '@stylistic/array-element-newline': ['error', { multiline: true, minItems: 3 }],
+      '@stylistic/arrow-parens': ['error', 'always'],
+      '@stylistic/brace-style': ['error', '1tbs'],
+      '@stylistic/curly-newline': ['error', { consistent: true, ClassBody: { minElements: 1 } }],
+      '@stylistic/object-curly-newline': ['error', { multiline: true }],
+      '@stylistic/function-call-spacing': ['error', 'never'],
+      '@stylistic/switch-colon-spacing': ['error', { after: true, before: false }],
+    },
+  },
+  {
+    ignores: [
+      ...unconventionalJsFiles,
+      ...compiledOutputFiles,
+      ...dependenciesFiles,
+      ...miscFiles,
+      ...emberTryFiles,
+    ],
   },
   {
     ignores: ['**/*.yaml'],
     languageOptions: {
-      globals: {
-        ...globals.browser,
-      },
+      globals: { ...globals.browser },
 
       parser: babelParser,
       ecmaVersion: 2018,
@@ -49,28 +82,14 @@ export default [
       parserOptions: {
         requireConfigFile: false,
 
-        babelOptions: {
-          plugins: [
-            [
-              '@babel/plugin-proposal-decorators',
-              {
-                version: 'legacy',
-              },
-            ],
-          ],
-        },
+        babelOptions: { plugins: [['@babel/plugin-proposal-decorators', { version: 'legacy' }]] },
       },
     },
 
     rules: {
       'no-setter-return': 'off',
 
-      'ember/no-controller-access-in-routes': [
-        'error',
-        {
-          allowControllerFor: true,
-        },
-      ],
+      'ember/no-controller-access-in-routes': ['error', { allowControllerFor: true }],
 
       'qunit/require-expect': ['error', 'except-simple'],
       'ember/template-no-let-reference': 'off',
@@ -88,9 +107,7 @@ export default [
     files: nodeFiles,
 
     languageOptions: {
-      globals: {
-        ...globals.node,
-      },
+      globals: { ...globals.node },
 
       ecmaVersion: 5,
       sourceType: 'script',

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -17,7 +17,6 @@ export default function makeServer(config) {
 }
 
 function routes() {
-
   this.namespace = 'api';
 
   this.get('/users/me', ({ users }) => users.first());
@@ -55,10 +54,8 @@ function routes() {
   this.get('/areas');
   this.post('/areas');
 
-  this.get('/attachments', function(schema, request) {
-    const {
-      'filter[localizedChallengeId]': localizedChallengeId,
-    } = request.queryParams;
+  this.get('/attachments', function (schema, request) {
+    const { 'filter[localizedChallengeId]': localizedChallengeId } = request.queryParams;
     return schema.attachments.all().filter((attachment) => [localizedChallengeId].includes(attachment.localizedChallengeId));
   });
   this.get('/attachments/:id');
@@ -69,7 +66,7 @@ function routes() {
   this.get('/competences');
   this.get('/competences/:id');
   this.patch('/competences/:id');
-  this.post('/competences', function(schema) {
+  this.post('/competences', function (schema) {
     const competence = this.normalizedRequestAttrs();
     const area = schema.areas.find(competence.areaId);
     const areaCompetences = schema.competences.where({ areaId: competence.areaId });
@@ -160,7 +157,7 @@ function routes() {
     return createdSkill;
   });
 
-  this.post('/skills/clone', function(schema, request) {
+  this.post('/skills/clone', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const level = attributes.level;
     const skillToClone = schema.skills.findBy({ pixId: attributes.skillIdToClone });
@@ -273,12 +270,10 @@ function routes() {
     return challenge;
   });
 
-  //TODO extraire le contenu des configs liées aux missions dans un fichier dédié
-  this.get('/missions', function(schema, request) {
+  // TODO extraire le contenu des configs liées aux missions dans un fichier dédié
+  this.get('/missions', function (schema, request) {
     const queryParams = request.queryParams;
-    const {
-      'filter[statuses]': statuses,
-    } = queryParams;
+    const { 'filter[statuses]': statuses } = queryParams;
     let allmissionSummaries;
     if (statuses) {
       allmissionSummaries = schema.missionSummaries.where((mission) => statuses.includes(mission.status)).models;
@@ -299,14 +294,14 @@ function routes() {
     return json;
   });
 
-  this.post('/missions', function(schema, request) {
+  this.post('/missions', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const mission = schema.create('mission', { ...attributes });
     schema.create('mission-summary', { id: mission.id, ...attributes });
     return mission;
   });
 
-  this.get('/missions/:id', function(schema, request) {
+  this.get('/missions/:id', function (schema, request) {
     const id = request.params.id;
     const mission = schema.missions.find(id);
     if (mission) return mission;
@@ -321,15 +316,17 @@ function routes() {
     });
   });
 
-  this.patch('/missions/:id', function(schema, request) {
+  this.patch('/missions/:id', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     if (attributes.name === 'will trigger error') {
       return new Response(400, {}, {
-        errors: [{
-          status: '400',
-          title: 'Bad Request',
-          detail: 'La mission ne peut pas être mise à jour car les épreuves X, Y ne sont pas au statut VALIDE.',
-        }],
+        errors: [
+          {
+            status: '400',
+            title: 'Bad Request',
+            detail: 'La mission ne peut pas être mise à jour car les épreuves X, Y ne sont pas au statut VALIDE.',
+          },
+        ],
       });
     }
     const id = request.params.id;
@@ -339,7 +336,7 @@ function routes() {
     return mission;
   });
 
-  this.get('/static-course-summaries', function(schema, request) {
+  this.get('/static-course-summaries', function (schema, request) {
     const queryParams = request.queryParams;
     const {
       'filter[isActive]': isActiveFilter,
@@ -386,7 +383,7 @@ function routes() {
 
   this.get('/static-course-tags');
 
-  this.post('/static-courses', function(schema, request) {
+  this.post('/static-courses', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const tagIds = attributes['tag-ids'];
     const tags = schema.staticCourseTags.all().models.filter(({ id }) => tagIds.includes(id));
@@ -399,7 +396,7 @@ function routes() {
     });
   });
 
-  this.put('/static-courses/:id', function(schema, request) {
+  this.put('/static-courses/:id', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const tagIds = attributes['tag-ids'];
     const tags = schema.staticCourseTags.all().models.filter(({ id }) => tagIds.includes(id));
@@ -413,7 +410,7 @@ function routes() {
     return staticCourse;
   });
 
-  this.put('/static-courses/:id/deactivate', function(schema, request) {
+  this.put('/static-courses/:id/deactivate', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const staticCourse = schema.staticCourses.find(request.params.id);
     staticCourse.update({
@@ -423,7 +420,7 @@ function routes() {
     return staticCourse;
   });
 
-  this.put('/static-courses/:id/reactivate', function(schema, request) {
+  this.put('/static-courses/:id/reactivate', function (schema, request) {
     const staticCourse = schema.staticCourses.find(request.params.id);
     staticCourse.update({
       isActive: true,
@@ -432,16 +429,14 @@ function routes() {
     return staticCourse;
   });
 
-  this.get('/tags', function(schema, request) {
-    const {
-      'filter[title]': title,
-    } = request.queryParams;
+  this.get('/tags', function (schema, request) {
+    const { 'filter[title]': title } = request.queryParams;
     return schema.tags.all().filter((tag) => tag.title.toLowerCase().includes(title.toLowerCase()));
   });
   this.get('/tags/:id');
   this.post('/tags');
 
-  this.get('/tutorials', function(schema, request) {
+  this.get('/tutorials', function (schema, request) {
     const {
       'filter[title]': title,
       'filter[source]': source,
@@ -457,7 +452,7 @@ function routes() {
 
   this.get('/whitelisted-urls');
   this.delete('/whitelisted-urls/:id');
-  this.patch('/whitelisted-urls/:id', function(schema, request) {
+  this.patch('/whitelisted-urls/:id', function (schema, request) {
     const attributes = JSON.parse(request.requestBody).data.attributes;
     const whitelistedUrl = schema.whitelistedUrls.find(request.params.id);
     whitelistedUrl.update({
@@ -472,7 +467,7 @@ function routes() {
     });
     return whitelistedUrl;
   });
-  this.post('/whitelisted-urls', function(schema, request) {
+  this.post('/whitelisted-urls', function (schema, request) {
     const whitelistedUrl = JSON.parse(request.requestBody).data.attributes;
     return schema.create('whitelisted-url', {
       url: whitelistedUrl.url,
@@ -486,13 +481,13 @@ function routes() {
     });
   });
 
-  this.post('/phrase/download', function() {
+  this.post('/phrase/download', function () {
     return { ok: 'cool' };
   });
 }
 
 function _serializeModel(instance, modelName) {
-  const serializer = new (getDsSerializers()[modelName]);
+  const serializer = new (getDsSerializers()[modelName])();
   const payload = { id: instance.id, fields: { [serializer.primaryKey]: instance.id } };
   const model = new getDsModels();
   const relationships = model[modelName].relationships;
@@ -515,7 +510,7 @@ function _serializeModel(instance, modelName) {
 }
 
 function _deserializePayload(payload, modelName) {
-  const serializer = new (getDsSerializers()[modelName]);
+  const serializer = new (getDsSerializers()[modelName])();
   for (const [key, value] of Object.entries(serializer.attrs)) {
     const payloadValue = payload.fields[value];
     if (payloadValue && Array.isArray(payloadValue) && key[key.length - 1] !== 's') {

--- a/pix-editor/mirage/factories/area.js
+++ b/pix-editor/mirage/factories/area.js
@@ -11,4 +11,3 @@ export default Factory.extend({
   titleEnUs: '',
 
 });
-

--- a/pix-editor/mirage/factories/attachment.js
+++ b/pix-editor/mirage/factories/attachment.js
@@ -9,4 +9,3 @@ export default Factory.extend({
   size: 123,
 
 });
-

--- a/pix-editor/mirage/factories/challenge.js
+++ b/pix-editor/mirage/factories/challenge.js
@@ -11,7 +11,9 @@ export default Factory.extend({
   t2Status: 't2',
   t3Status: 't3',
   pedagogy: 'pedagogy',
-  author() { return ['author']; },
+  author() {
+    return ['author'];
+  },
   declinable: 'declinable',
   version: 'version',
   genealogy: 'Prototype 1',
@@ -34,6 +36,7 @@ export default Factory.extend({
   noValidationNeeded: false,
   attachments: null,
   updatedAt: '2021-10-02T14:00:00.000Z',
-  contextualizedFields() { return ['illustration', 'instruction']; },
+  contextualizedFields() {
+    return ['illustration', 'instruction'];
+  },
 });
-

--- a/pix-editor/mirage/factories/competence.js
+++ b/pix-editor/mirage/factories/competence.js
@@ -9,4 +9,3 @@ export default Factory.extend({
   pixId: '',
   source: 'Pix',
 });
-

--- a/pix-editor/mirage/factories/localized-challenge.js
+++ b/pix-editor/mirage/factories/localized-challenge.js
@@ -1,6 +1,3 @@
 import { Factory } from 'miragejs';
 
-export default Factory.extend({
-  locale: 'fr',
-});
-
+export default Factory.extend({ locale: 'fr' });

--- a/pix-editor/mirage/factories/skill.js
+++ b/pix-editor/mirage/factories/skill.js
@@ -16,4 +16,3 @@ export default Factory.extend({
   createdAt: '2018-12-11T13:38:35.000Z',
   version: 1,
 });
-

--- a/pix-editor/mirage/factories/tube.js
+++ b/pix-editor/mirage/factories/tube.js
@@ -9,4 +9,3 @@ export default Factory.extend({
   practicalDescriptionEn: 'practicalDescriptionEn',
   pixId: 'pixId',
 });
-

--- a/pix-editor/mirage/factories/user.js
+++ b/pix-editor/mirage/factories/user.js
@@ -18,4 +18,3 @@ export default Factory.extend({
     return 'default-valid-api-key';
   },
 });
-

--- a/pix-editor/mirage/scenarios/default.js
+++ b/pix-editor/mirage/scenarios/default.js
@@ -1,5 +1,4 @@
-
-export default function(server) {
+export default function (server) {
   server.create('config', 'default');
   server.create('user', { trigram: 'ABC' });
 

--- a/pix-editor/mirage/serializers/application.js
+++ b/pix-editor/mirage/serializers/application.js
@@ -1,5 +1,3 @@
 import { JSONAPISerializer } from 'miragejs';
 
-export default JSONAPISerializer.extend({
-  alwaysIncludeLinkageData: true,
-});
+export default JSONAPISerializer.extend({ alwaysIncludeLinkageData: true });

--- a/pix-editor/mirage/serializers/challenge.js
+++ b/pix-editor/mirage/serializers/challenge.js
@@ -2,6 +2,4 @@ import ApplicationSerializer from './application';
 
 const include = ['challengeLocales'];
 
-export default ApplicationSerializer.extend({
-  include,
-});
+export default ApplicationSerializer.extend({ include });

--- a/pix-editor/mirage/serializers/static-course-summary.js
+++ b/pix-editor/mirage/serializers/static-course-summary.js
@@ -2,6 +2,4 @@ import ApplicationSerializer from './application';
 
 const include = ['tags'];
 
-export default ApplicationSerializer.extend({
-  include,
-});
+export default ApplicationSerializer.extend({ include });

--- a/pix-editor/mirage/serializers/static-course.js
+++ b/pix-editor/mirage/serializers/static-course.js
@@ -2,6 +2,4 @@ import ApplicationSerializer from './application';
 
 const include = ['challengeSummaries', 'tags'];
 
-export default ApplicationSerializer.extend({
-  include,
-});
+export default ApplicationSerializer.extend({ include });

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -33,6 +33,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@playwright/test": "1.56.1",
         "@sentry/ember": "^10.0.0",
+        "@stylistic/eslint-plugin": "^5.5.0",
         "acorn": "^8.8.1",
         "base-x": "^5.0.0",
         "canvg": "^4.0.1",
@@ -774,7 +775,6 @@
       "version": "9.10.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "autoprefixer": "^9.0.0",
         "balanced-match": "^1.0.0",
@@ -946,7 +946,6 @@
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2660,7 +2659,6 @@
       "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2716,7 +2714,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2740,7 +2737,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2846,7 +2842,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -2863,7 +2858,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -2882,7 +2876,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -2912,7 +2905,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.16.6",
@@ -2946,7 +2938,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0",
         "@embroider/macros": "^1.16.6",
@@ -2963,7 +2954,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -3016,7 +3006,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -3035,7 +3024,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -4242,7 +4230,6 @@
       "integrity": "sha512-wQtibrTbsTyqkF14m1pFwaLECzda7ObY9HpCPpRghYkgBcnwlD2dBpvfYtamMK1HCh59vEZ3OdrxEBU9jKLyng==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.8.7",
@@ -4259,7 +4246,6 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -4900,7 +4886,6 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5141,7 +5126,6 @@
       "version": "3.4.19",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.14.5",
         "@babel/parser": "^7.14.5",
@@ -5907,7 +5891,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8775,6 +8761,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@typescript-eslint/types": "^8.46.1",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -9093,6 +9113,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
+      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@warp-drive/build-config": {
       "version": "0.0.0-beta.7",
       "dev": true,
@@ -9123,7 +9157,6 @@
       "version": "0.0.0-beta.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/macros": "^1.16.6",
         "@warp-drive/build-config": "0.0.0-beta.7"
@@ -9312,10 +9345,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9367,7 +9401,6 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11669,7 +11702,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -16882,7 +16914,6 @@
       "integrity": "sha512-PJNJ3Ib1IP85NJlw/AdzX76ZIDcyAAFJfDz/wFJQ+hqTFNWsjVjXl20X3ePQkKfZZlF421EC5nsLBOwbHqsh9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pnpm/find-workspace-dir": "^7.0.2",
         "babel-remove-types": "^1.0.0",
@@ -18544,7 +18575,6 @@
       "version": "3.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.22.20",
         "@embroider/macros": "^1.13.2",
@@ -19561,7 +19591,6 @@
       "version": "5.3.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ember-data/adapter": "5.3.9",
         "@ember-data/debug": "5.3.9",
@@ -21784,7 +21813,6 @@
       "integrity": "sha512-E+NnmzybMRWn1JyEfDxY7arjOTJLIcGjcXnUxizgjD4TlvO1s3O65blZt+Xq2C2AFSPeqHLC6PXd6XHYM8BxdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.11"
       },
@@ -22525,7 +22553,6 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -23160,7 +23187,6 @@
       "integrity": "sha512-vAuumvTYgfFpP0LgK1uw2vBEnD7bv1JYh0JUwkFfBiAkCGV7HkjVWNcgQ2agwarfzxLgEaC0hWlOn9adwJmlNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.9.0",
         "@embroider/macros": "^1.16.12",
@@ -25282,7 +25308,6 @@
       "version": "5.12.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
@@ -27987,7 +28012,6 @@
       "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -28358,15 +28382,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -28376,9 +28400,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -32350,7 +32374,6 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -32448,7 +32471,6 @@
       "version": "0.1.48",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@miragejs/pretender-node-polyfill": "^0.1.0",
         "inflected": "^2.0.4",
@@ -33618,12 +33640,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -33900,7 +33921,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -34229,7 +34249,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -34275,7 +34294,6 @@
       "version": "0.36.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -34617,7 +34635,6 @@
       "version": "2.23.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",
@@ -35339,8 +35356,7 @@
     "node_modules/route-recognizer": {
       "version": "0.3.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/router_js": {
       "version": "8.0.6",
@@ -35366,7 +35382,6 @@
       "version": "4.8.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -36815,7 +36830,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -38058,7 +38072,6 @@
       "integrity": "sha512-0Jl43A1SDZd+yYCJvXfgDSn4Wk/zcawkyFTBPqOETU5UJRngnVEnQ8oOjawqPRg6qja3sKjIQ8z6X9xJzcUTUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -38834,7 +38847,6 @@
       "version": "5.97.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -47,6 +47,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@playwright/test": "1.56.1",
     "@sentry/ember": "^10.0.0",
+    "@stylistic/eslint-plugin": "^5.5.0",
     "acorn": "^8.8.1",
     "base-x": "^5.0.0",
     "canvg": "^4.0.1",

--- a/pix-editor/playwright.config.js
+++ b/pix-editor/playwright.config.js
@@ -79,4 +79,3 @@ module.exports = defineConfig({
   /* Global setup for authentication contexts. */
   globalSetup: require.resolve('./playwright.global-setup'),
 });
-

--- a/pix-editor/server/index.js
+++ b/pix-editor/server/index.js
@@ -1,6 +1,6 @@
 const morgan = require('morgan');
 
-module.exports = function(app, options) {
+module.exports = function (app, options) {
   if (options.proxy) {
     const proxy = require('http-proxy').createProxyServer({
       target: options.proxy,

--- a/pix-editor/testem.js
+++ b/pix-editor/testem.js
@@ -4,12 +4,8 @@ const config = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   reporter: 'dot',
-  launch_in_ci: [
-    'Chrome',
-  ],
-  launch_in_dev: [
-    'Chrome',
-  ],
+  launch_in_ci: ['Chrome'],
+  launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
   browser_args: {
     Chrome: {
@@ -31,7 +27,8 @@ const config = {
 
 module.exports = process.env.CI
   ? {
-    ...config,
-    reporter: 'xunit',
-    report_file: './test-results/report.xml',
-  } : config;
+      ...config,
+      reporter: 'xunit',
+      report_file: './test-results/report.xml',
+    }
+  : config;

--- a/pix-editor/tests/acceptance/area-management/new-test.js
+++ b/pix-editor/tests/acceptance/area-management/new-test.js
@@ -6,13 +6,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | area-management/new', function(hooks) {
-
+module('Acceptance | area-management/new', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     // given
     store = this.owner.lookup('service:store');
     this.server.create('config', 'default');
@@ -24,7 +23,7 @@ module('Acceptance | area-management/new', function(hooks) {
     return authenticateSession();
   });
 
-  test('it should create a new area', async function(assert) {
+  test('it should create a new area', async function (assert) {
     // given
     const newAreaTitle = 'Nouveau titre';
 
@@ -43,8 +42,7 @@ module('Acceptance | area-management/new', function(hooks) {
     assert.strictEqual(currentURL(), '/');
   });
 
-  test('it should cancel creation', async function(assert) {
-
+  test('it should cancel creation', async function (assert) {
     // when
     await visit('/area-management/new/recFramework1');
     await click(find('[data-test-cancel-button]'));

--- a/pix-editor/tests/acceptance/competence-management/new-test.js
+++ b/pix-editor/tests/acceptance/competence-management/new-test.js
@@ -7,13 +7,12 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | competence-management/new', function(hooks) {
-
+module('Acceptance | competence-management/new', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let store, originalWindowConfirm;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     // given
     originalWindowConfirm = window.confirm;
     store = this.owner.lookup('service:store');
@@ -28,11 +27,11 @@ module('Acceptance | competence-management/new', function(hooks) {
     return authenticateSession();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     window.confirm = originalWindowConfirm;
   });
 
-  test('it should create a new competence', async function(assert) {
+  test('it should create a new competence', async function (assert) {
     // given
     const newCompetenceTitle = 'Nouveau titre';
 
@@ -53,7 +52,7 @@ module('Acceptance | competence-management/new', function(hooks) {
     assert.strictEqual(currentURL(), `/competence/${newCompetence.id}/skills?view=workbench`);
   });
 
-  test('it should cancel creation', async function(assert) {
+  test('it should cancel creation', async function (assert) {
     // when
     await visit('/competence-management/new/recArea1');
     await click(find('[data-test-cancel-button]'));
@@ -63,7 +62,7 @@ module('Acceptance | competence-management/new', function(hooks) {
     assert.strictEqual(currentURL(), '/');
   });
 
-  test('it should prevent transition', async function(assert) {
+  test('it should prevent transition', async function (assert) {
     // given
     const confirmStub = sinon.stub(window, 'confirm');
     confirmStub.returns(false);

--- a/pix-editor/tests/acceptance/competence-management/single-test.js
+++ b/pix-editor/tests/acceptance/competence-management/single-test.js
@@ -7,13 +7,12 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | competence-management/single', function(hooks) {
-
+module('Acceptance | competence-management/single', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let store, originalWindowConfirm;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     // given
     originalWindowConfirm = window.confirm;
     store = this.owner.lookup('service:store');
@@ -26,11 +25,11 @@ module('Acceptance | competence-management/single', function(hooks) {
     return authenticateSession();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     window.confirm = originalWindowConfirm;
   });
 
-  test('it should edit a competence', async function(assert) {
+  test('it should edit a competence', async function (assert) {
     // given
     const newCompetenceTitle = 'Nouveau titre';
 
@@ -46,7 +45,7 @@ module('Acceptance | competence-management/single', function(hooks) {
     assert.strictEqual(competence.title, 'Nouveau titre');
   });
 
-  test('it should cancel edit', async function(assert) {
+  test('it should cancel edit', async function (assert) {
     // given
     const newCompetenceTitle = 'Nouveau titre';
 
@@ -62,7 +61,7 @@ module('Acceptance | competence-management/single', function(hooks) {
     assert.strictEqual(competence.title, 'Titre');
   });
 
-  test('it should prevent transition on edition', async function(assert) {
+  test('it should prevent transition on edition', async function (assert) {
     // given
     const confirmStub = sinon.stub(window, 'confirm');
     confirmStub.returns(false);

--- a/pix-editor/tests/acceptance/competence/prototypes/list-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/list-test.js
@@ -17,14 +17,13 @@ const deadSkillId = 'recDeadSkill';
 const deadSkillPixId = 'pixDeadSkill';
 const challengeId2 = 'recChallenge2';
 
-module('Acceptance | competence/prototypes/list', function() {
-  module('visiting /competence/:competence_id/prototypes/list/:tube_id/:skill_id', function(hooks) {
-
+module('Acceptance | competence/prototypes/list', function () {
+  module('visiting /competence/:competence_id/prototypes/list/:tube_id/:skill_id', function (hooks) {
     setupApplicationTest(hooks);
     setupMirage(hooks);
 
-    hooks.beforeEach(async function() {
-      //given
+    hooks.beforeEach(async function () {
+      // given
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC' });
 
@@ -35,7 +34,13 @@ module('Acceptance | competence/prototypes/list', function() {
       this.server.create('skill', { id: deadSkillId, pixId: deadSkillPixId, name: skillName, version: 1, status: 'périmé', challengeIds: [] });
       this.server.create('skill', { id: skillId2, pixId: skillPixId2, name: skillName, version: 2, createdAt: '2018-12-11T13:38:35.000Z', status: 'en construction', challengeIds: [challengeId2] });
       this.server.create('skill', { id: 'recSkill3', challengeIds: ['recChallenge3'] });
-      this.server.create('tube', { id: tubeId1, rawSkillIds: [skillId1, skillId2, deadSkillId] });
+      this.server.create('tube', {
+        id: tubeId1, rawSkillIds: [
+          skillId1,
+          skillId2,
+          deadSkillId,
+        ],
+      });
       this.server.create('tube', { id: 'recTube2', rawSkillIds: ['recSkill3'] });
       this.server.create('theme', { id: 'recTheme1', rawTubeIds: [tubeId1] });
       this.server.create('theme', { id: 'recTheme2', rawTubeIds: ['recTube2'] });
@@ -54,16 +59,20 @@ module('Acceptance | competence/prototypes/list', function() {
       await visit(`/competence/${competenceId1}/prototypes/list/${tubeId1}/${skillId1}?view=workbench`);
     });
 
-    test('it should display a list of prototype of `skill1`', function(assert) {
+    test('it should display a list of prototype of `skill1`', function (assert) {
       // then
       assert.dom('[data-test-skill-tab].active').hasText(`${skillName} v.3`);
       assert.dom('[data-test-prototype-list] tbody tr').exists({ count: 1 });
       assert.dom('[data-test-prototype-list]').includesText('instructionsChallenge1');
     });
 
-    test('it should display a list of skill tab sorted by date', function(assert) {
-      //given
-      const expectedResult = [`${skillName} v.3`, `${skillName} v.2`, `${skillName} v.1`];
+    test('it should display a list of skill tab sorted by date', function (assert) {
+      // given
+      const expectedResult = [
+        `${skillName} v.3`,
+        `${skillName} v.2`,
+        `${skillName} v.1`,
+      ];
 
       // then
       const tabs = this.element.querySelectorAll('[data-test-skill-tab]');
@@ -73,10 +82,10 @@ module('Acceptance | competence/prototypes/list', function() {
       });
     });
 
-    test('it should display a list of prototype of selected skill', async function(assert) {
-      //when
+    test('it should display a list of prototype of selected skill', async function (assert) {
+      // when
       await click(findAll('[data-test-skill-tab]')[1]);
-      await waitUntil(function() {
+      await waitUntil(function () {
         return find('[data-test-prototype-list]').textContent.includes('instructionsChallenge2');
       }, { timeout: 1000 });
 
@@ -86,11 +95,11 @@ module('Acceptance | competence/prototypes/list', function() {
       assert.dom('[data-test-prototype-list]').includesText('instructionsChallenge2');
     });
 
-    test('it should call prototype/new with good query params', async function(assert) {
-      //given
+    test('it should call prototype/new with good query params', async function (assert) {
+      // given
       const expectedResult = `/competence/recCompetence1_1/prototypes/new?from=${challengeId2}`;
 
-      //when
+      // when
       await click(findAll('[data-test-skill-tab]')[1]);
       await click(find('[data-test-new-prototype-action]'));
       // Ugly hack to wait for ToastUI to be ready
@@ -98,7 +107,7 @@ module('Acceptance | competence/prototypes/list', function() {
       // Attempted to access the computed <pixeditor@component:tui-editor::ember393>.options on a destroyed object, which is not allowed
       await runTask(this, async () => { }, 100);
 
-      //then
+      // then
       assert.strictEqual(currentURL().indexOf(expectedResult), 0);
     });
   });

--- a/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/localized-test.js
@@ -6,12 +6,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | Controller | Localized Challenge', function(hooks) {
+module('Acceptance | Controller | Localized Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let localizedChallenge;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -31,29 +31,41 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', code: '1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: challenge.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 0,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: challenge.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     return authenticateSession();
   });
 
-  test('it should display the localized challenge', async function(assert) {
+  test('it should display the localized challenge', async function (assert) {
     const screen = await visit('/');
     await click(await screen.findByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: '1.1 Title' }));
@@ -75,7 +87,7 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     assert.ok(translationsLink.getAttribute('href').endsWith('/translations/en/framework-name/Pix/area-code/1'), 'href ends with /translations/en/framework-name/Pix/area-code/1');
   });
 
-  test('it should go back to the original challenge', async function(assert) {
+  test('it should go back to the original challenge', async function (assert) {
     const screen = await visit('/');
     await click(await screen.findByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: '1.1 Title' }));
@@ -87,8 +99,8 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
     assert.dom(screen.getByText('Version en')).exists();
   });
 
-  module('#edit localized challenge status', function() {
-    test('should set localized status to `validé`', async function(assert) {
+  module('#edit localized challenge status', function () {
+    test('should set localized status to `validé`', async function (assert) {
       const screen = await visit('/');
       await click(await screen.findByRole('button', { name: '1. Information et données' }));
       await click(screen.getByRole('link', { name: '1.1 Title' }));
@@ -103,7 +115,7 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
       assert.dom(screen.getByText('En prod')).exists();
     });
 
-    test('should set localized status to `proposé`', async function(assert) {
+    test('should set localized status to `proposé`', async function (assert) {
       localizedChallenge.update({ status: 'validé' });
       const screen = await visit('/');
       await click(await screen.findByRole('button', { name: '1. Information et données' }));
@@ -118,11 +130,10 @@ module('Acceptance | Controller | Localized Challenge', function(hooks) {
 
       assert.dom(screen.getByText('Pas en prod')).exists();
     });
-
   });
 
-  module('#edit localized challenge', function() {
-    test('should display edition form', async function(assert) {
+  module('#edit localized challenge', function () {
+    test('should display edition form', async function (assert) {
       const screen = await visit('/');
       await click(await screen.findByRole('button', { name: '1. Information et données' }));
       await click(screen.getByRole('link', { name: '1.1 Title' }));

--- a/pix-editor/tests/acceptance/competence/prototypes/single-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/single-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | Controller | Get Challenge', function(hooks) {
+module('Acceptance | Controller | Get Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -23,22 +23,34 @@ module('Acceptance | Controller | Get Challenge', function(hooks) {
     const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: prototype.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-workbench`,
@@ -49,7 +61,7 @@ module('Acceptance | Controller | Get Challenge', function(hooks) {
     return authenticateSession();
   });
 
-  test('it should display the challenge', async function(assert) {
+  test('it should display the challenge', async function (assert) {
     const screen = await visit('/');
     await click(await screen.findByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: 'Code Title' }));
@@ -58,8 +70,8 @@ module('Acceptance | Controller | Get Challenge', function(hooks) {
     assert.dom('time').hasAttribute('datetime', '2021-10-04T14:00:00.000Z');
   });
 
-  test('it should change prototype location', async function(assert) {
-    //when
+  test('it should change prototype location', async function (assert) {
+    // when
     const screen = await visit('/competence/recCompetence1.1/prototypes/recChallenge2?leftMaximized=false&view=workbench');
     await click(screen.getByRole('button', { name: 'Déplacer l\'épreuve' }));
     await click(screen.getByLabelText('Acquis'));
@@ -68,7 +80,7 @@ module('Acceptance | Controller | Get Challenge', function(hooks) {
     await click(await screen.findByRole('button', { name: 'Enregistrer' }));
     const store = this.owner.lookup('service:store');
 
-    //then
+    // then
     const challenge = await store.peekRecord('challenge', 'recChallenge2');
     assert.ok(await screen.findByText('Changement d\'acquis effectué pour le prototype'));
     assert.strictEqual(challenge.skill.get('id'), 'recSkill2');

--- a/pix-editor/tests/acceptance/competence/skills/single-test.js
+++ b/pix-editor/tests/acceptance/competence/skills/single-test.js
@@ -7,12 +7,12 @@ import { module, test } from 'qunit';
 import { waitForSelectToBeClosed } from '../../../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | skill | single', function(hooks) {
+module('Acceptance | skill | single', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let skill1, competence1, tube1;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -24,37 +24,49 @@ module('Acceptance | skill | single', function(hooks) {
     competence1 = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: [theme1.id], rawTubeIds: [tube1.id] });
     this.server.create('competence-overview', {
       id: `${competence1.pixId}:challenges-workbench`,
-      thematicOverviews: [{
-        id: theme1.id,
-        name: theme1.name,
-        tubeOverviews: [{
-          id: tube1.id,
-          name: tube1.name,
-          skillOverviews: [{
-            id: skill1.id,
-            name: skill1.name,
-            prototypeId: challenge2.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 2,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: theme1.id,
+          name: theme1.name,
+          tubeOverviews: [
+            {
+              id: tube1.id,
+              name: tube1.name,
+              skillOverviews: [
+                {
+                  id: skill1.id,
+                  name: skill1.name,
+                  prototypeId: challenge2.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     const area1 = this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: [competence1.id] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: [area1.id] });
     return authenticateSession();
   });
 
-  test('close single', async function(assert) {
+  test('close single', async function (assert) {
     await visit(`/competence/${competence1.id}/skills/new/${tube1.id}/0?leftMaximized=true&view=workbench`);
     await click(find('.icon.window.close'));
 
     assert.strictEqual(currentURL(), `/competence/${competence1.id}/skills?view=workbench`);
   });
 
-  module('#createSkill', function() {
-    test('it should create a new skill', async function(assert) {
+  module('#createSkill', function () {
+    test('it should create a new skill', async function (assert) {
       // given
       const screen = await visit(`/competence/${competence1.id}/skills?view=workbench`);
       const store = this.owner.lookup('service:store');
@@ -82,7 +94,7 @@ module('Acceptance | skill | single', function(hooks) {
       assert.strictEqual(currentURL(), `/competence/${competence1.id}/skills/new/recTube1/2?leftMaximized=true&view=workbench`);
     });
 
-    test('it should create a new skill version', async function(assert) {
+    test('it should create a new skill version', async function (assert) {
       // given
       const screen = await visit(`/competence/${competence1.id}/skills?view=workbench`);
       const store = this.owner.lookup('service:store');
@@ -107,8 +119,8 @@ module('Acceptance | skill | single', function(hooks) {
     });
   });
 
-  module('#duplicateToLocation', function() {
-    test('it should duplicate a skill and his challenges to new location', async function(assert) {
+  module('#duplicateToLocation', function () {
+    test('it should duplicate a skill and his challenges to new location', async function (assert) {
       // given
       const SKILL_LEVEL_CHOOSE = 4;
       const store = this.owner.lookup('service:store');
@@ -132,8 +144,8 @@ module('Acceptance | skill | single', function(hooks) {
     });
   });
 
-  module('#Modify skill', function() {
-    test('it should modify skill and proto', async function(assert) {
+  module('#Modify skill', function () {
+    test('it should modify skill and proto', async function (assert) {
       // given
       const challengeProto = this.server.create('challenge', {
         id: 'recChallengeProto',

--- a/pix-editor/tests/acceptance/create-challenge-alternative-test.js
+++ b/pix-editor/tests/acceptance/create-challenge-alternative-test.js
@@ -9,13 +9,13 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Controller | Create alternative challenge', function(hooks) {
+module('Acceptance | Controller | Create alternative challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let challenge;
   let skill;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -26,29 +26,41 @@ module('Acceptance | Controller | Create alternative challenge', function(hooks)
     const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: challenge.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: challenge.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     return authenticateSession();
   });
 
-  test('create a challenge alternative', async function(assert) {
+  test('create a challenge alternative', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -78,7 +90,7 @@ module('Acceptance | Controller | Create alternative challenge', function(hooks)
     assert.ok(attachments.every((record) => !record.isNew));
   });
 
-  test('create a challenge alternative clone the attachments', async function(assert) {
+  test('create a challenge alternative clone the attachments', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       cloneFile() { }
@@ -110,7 +122,7 @@ module('Acceptance | Controller | Create alternative challenge', function(hooks)
     assert.strictEqual(clonedAttachment.url, 'data:2,');
   });
 
-  test('create a challenge alternative don\'t clone deleted attachments', async function(assert) {
+  test('create a challenge alternative don\'t clone deleted attachments', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       cloneFile() { }

--- a/pix-editor/tests/acceptance/create-challenge-test.js
+++ b/pix-editor/tests/acceptance/create-challenge-test.js
@@ -10,11 +10,11 @@ import sinon from 'sinon';
 import { waitForSelectToBeClosed } from '../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Create-Challenge', function(hooks) {
+module('Acceptance | Create-Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -45,7 +45,7 @@ module('Acceptance | Create-Challenge', function(hooks) {
     return authenticateSession();
   });
 
-  test('creating a new challenge', async function(assert) {
+  test('creating a new challenge', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -118,4 +118,3 @@ module('Acceptance | Create-Challenge', function(hooks) {
     assert.strictEqual((await screen.getByLabelText('Responsive')).childNodes[3].textContent, 'Non');
   });
 });
-

--- a/pix-editor/tests/acceptance/create-framework-test.js
+++ b/pix-editor/tests/acceptance/create-framework-test.js
@@ -6,12 +6,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Create-Framework', function(hooks) {
+module('Acceptance | Create-Framework', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
@@ -20,7 +20,7 @@ module('Acceptance | Create-Framework', function(hooks) {
     return authenticateSession();
   });
 
-  test('it should create a new framework', async function(assert) {
+  test('it should create a new framework', async function (assert) {
     // given
     const newFrameworkName = 'Nouveau titre';
 
@@ -37,5 +37,4 @@ module('Acceptance | Create-Framework', function(hooks) {
     assert.dom(find('[data-test-main-message]')).hasText('Référentiel créé');
     assert.strictEqual(currentURL(), '/');
   });
-
 });

--- a/pix-editor/tests/acceptance/create-tutorial-test.js
+++ b/pix-editor/tests/acceptance/create-tutorial-test.js
@@ -6,20 +6,15 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Create-Tutorial', function(hooks) {
+module('Acceptance | Create-Tutorial', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let competence, skill;
-  hooks.beforeEach(function() {
-    this.server.create('config', {
-      tutorialLocaleToLanguageMap: {
-        fr: 'Français',
-      },
-    });
+  hooks.beforeEach(function () {
+    this.server.create('config', { tutorialLocaleToLanguageMap: { fr: 'Français' } });
 
     this.server.create('user', { trigram: 'ABC' });
-    this.server.create('tag', { id: 'recTag1',
-    });
+    this.server.create('tag', { id: 'recTag1' });
     this.server.create('tutorial', { id: 'recTuto1', source: 'ma source' });
 
     this.server.create('challenge', { id: 'recChallenge1' });
@@ -44,13 +39,11 @@ module('Acceptance | Create-Tutorial', function(hooks) {
     return authenticateSession();
   });
 
-  test('create a new tutorial', async function(assert) {
+  test('create a new tutorial', async function (assert) {
     // when
     const screen = await visit(`/competence/${competence.id}/skills/${skill.id}?view=production`);
     await click(screen.getByRole('button', { name: 'Modifier' }));
-    const createTutorialLink = screen.getByRole('button', {
-      name: 'Ajouter un tutoriel Pour réussir la prochaine fois',
-    });
+    const createTutorialLink = screen.getByRole('button', { name: 'Ajouter un tutoriel Pour réussir la prochaine fois' });
 
     await click(createTutorialLink);
 
@@ -113,13 +106,11 @@ module('Acceptance | Create-Tutorial', function(hooks) {
     assert.strictEqual(screen.getAllByText('Super tag').length, 2);
   });
 
-  test('verify if the url link is valid', async function(assert) {
+  test('verify if the url link is valid', async function (assert) {
     // when
     const screen = await visit(`/competence/${competence.id}/skills/${skill.id}?view=production`);
     await clickByText('Modifier');
-    const createTutorialLink = screen.getByRole('button', {
-      name: 'Ajouter un tutoriel Pour réussir la prochaine fois',
-    });
+    const createTutorialLink = screen.getByRole('button', { name: 'Ajouter un tutoriel Pour réussir la prochaine fois' });
 
     await click(createTutorialLink);
 
@@ -146,4 +137,3 @@ module('Acceptance | Create-Tutorial', function(hooks) {
     assert.dom(screen.getByLabelText('Lien *')).hasValue('PASBONLELINK');
   });
 });
-

--- a/pix-editor/tests/acceptance/home-test.js
+++ b/pix-editor/tests/acceptance/home-test.js
@@ -5,16 +5,13 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-const competenceIds = [
-  'recCompetence1.1',
-  'recCompetence2.1',
-];
+const competenceIds = ['recCompetence1.1', 'recCompetence2.1'];
 
-module('Acceptance | Home', function(hooks) {
+module('Acceptance | Home', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -25,7 +22,7 @@ module('Acceptance | Home', function(hooks) {
     return authenticateSession();
   });
 
-  test('visiting /', async function(assert) {
+  test('visiting /', async function (assert) {
     // when
     const screen = await visit('/');
 

--- a/pix-editor/tests/acceptance/localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/localized-challenge-test.js
@@ -6,12 +6,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Localized-Challenge', function(hooks) {
+module('Acceptance | Localized-Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When interacting with a prototype', function(hooks) {
-    hooks.beforeEach(function() {
+  module('When interacting with a prototype', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC' });
 
@@ -36,29 +36,41 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       });
       this.server.create('competence-overview', {
         id: `${competence.pixId}:challenges-production`,
-        thematicOverviews: [{
-          id: thematic.id,
-          name: thematic.name,
-          tubeOverviews: [{
-            id: tube.id,
-            name: tube.name,
-            skillOverviews: [{
-              id: skill1.id,
-              name: skill1.name,
-              prototypeId: prototype1.id,
-              isPrototypeDeclinable: true,
-              proposedChallengesCount: 2,
-              validatedChallengesCount: 1,
-            }, {
-              id: skill2.id,
-              name: skill2.name,
-              prototypeId: prototype2.id,
-              isPrototypeDeclinable: true,
-              proposedChallengesCount: 2,
-              validatedChallengesCount: 1,
-            }, null, null, null, null, null],
-          }],
-        }],
+        thematicOverviews: [
+          {
+            id: thematic.id,
+            name: thematic.name,
+            tubeOverviews: [
+              {
+                id: tube.id,
+                name: tube.name,
+                skillOverviews: [
+                  {
+                    id: skill1.id,
+                    name: skill1.name,
+                    prototypeId: prototype1.id,
+                    isPrototypeDeclinable: true,
+                    proposedChallengesCount: 2,
+                    validatedChallengesCount: 1,
+                  },
+                  {
+                    id: skill2.id,
+                    name: skill2.name,
+                    prototypeId: prototype2.id,
+                    isPrototypeDeclinable: true,
+                    proposedChallengesCount: 2,
+                    validatedChallengesCount: 1,
+                  },
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                ],
+              },
+            ],
+          },
+        ],
       });
       this.server.create('area', {
         id: 'recArea1',
@@ -70,7 +82,7 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       return authenticateSession();
     });
 
-    test('should display a default embedUrl if is empty but not for primary', async function(assert) {
+    test('should display a default embedUrl if is empty but not for primary', async function (assert) {
       // when
       const screen = await visit('/');
       await click(await screen.findByRole('button', { name: '1. Information et données' }));
@@ -81,7 +93,7 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       // then
       assert.dom(await screen.queryByText('https://mon-site.fr/my-link.html?lang=nl', { exact: false })).exists();
     });
-    test('should not display a default url if primary does not have any', async function(assert) {
+    test('should not display a default url if primary does not have any', async function (assert) {
       // given
       this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId1', embedURL: null });
       this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
@@ -99,7 +111,7 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       assert.dom(await screen.queryByText('Embed URL auto-générée', { exact: false })).doesNotExist();
     });
 
-    test('should display an embed url if localized challenge has one', async function(assert) {
+    test('should display an embed url if localized challenge has one', async function (assert) {
       // given
       this.server.create('localized-challenge', { id: 'recChallenge2ES', challengeId: 'recChallenge2', locale: 'es', embedURL: 'https://mon-site.fr/my-es-link.html' });
 
@@ -116,8 +128,8 @@ module('Acceptance | Localized-Challenge', function(hooks) {
     });
   });
 
-  module('When interacting with an alternative', function(hooks) {
-    hooks.beforeEach(function() {
+  module('When interacting with an alternative', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC' });
 
@@ -138,22 +150,34 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       });
       this.server.create('competence-overview', {
         id: `${competence.pixId}:challenges-production`,
-        thematicOverviews: [{
-          id: thematic.id,
-          name: thematic.name,
-          tubeOverviews: [{
-            id: tube.id,
-            name: tube.name,
-            skillOverviews: [{
-              id: skill.id,
-              name: skill.name,
-              prototypeId: prototype.id,
-              isPrototypeDeclinable: true,
-              proposedChallengesCount: 3,
-              validatedChallengesCount: 1,
-            }, null, null, null, null, null, null],
-          }],
-        }],
+        thematicOverviews: [
+          {
+            id: thematic.id,
+            name: thematic.name,
+            tubeOverviews: [
+              {
+                id: tube.id,
+                name: tube.name,
+                skillOverviews: [
+                  {
+                    id: skill.id,
+                    name: skill.name,
+                    prototypeId: prototype.id,
+                    isPrototypeDeclinable: true,
+                    proposedChallengesCount: 3,
+                    validatedChallengesCount: 1,
+                  },
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                ],
+              },
+            ],
+          },
+        ],
       });
       this.server.create('area', {
         id: 'recArea1',
@@ -165,7 +189,7 @@ module('Acceptance | Localized-Challenge', function(hooks) {
       return authenticateSession();
     });
 
-    test('should display a default embedUrl if is empty but not for primary', async function(assert) {
+    test('should display a default embedUrl if is empty but not for primary', async function (assert) {
       // when
       const screen = await visit('/');
       await clickByText('Nom du domaine');

--- a/pix-editor/tests/acceptance/login-test.js
+++ b/pix-editor/tests/acceptance/login-test.js
@@ -7,19 +7,19 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Login', function(hooks) {
+module('Acceptance | Login', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   const VALID_API_KEY = 'valid-api-key';
   const INVALID_API_KEY = 'invalid-api-key';
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
   });
 
-  module('when user is not authenticated', function(hooks) {
-    hooks.beforeEach(function() {
+  module('when user is not authenticated', function (hooks) {
+    hooks.beforeEach(function () {
       // FIXME move this in mirage's configuration and remove direct dependency on miragejs
       this.server.get('/users/me', ({ users }, request) => {
         const apiKey = request.requestHeaders && request.requestHeaders['Authorization'];
@@ -27,7 +27,7 @@ module('Acceptance | Login', function(hooks) {
       });
     });
 
-    test('it should lead to login page', async function(assert) {
+    test('it should lead to login page', async function (assert) {
       // when
       await visit('/statistics');
 
@@ -35,7 +35,7 @@ module('Acceptance | Login', function(hooks) {
       assert.strictEqual(currentURL(), '/connexion');
     });
 
-    test('redirect to / when logging in with a valid api key', async function(assert) {
+    test('redirect to / when logging in with a valid api key', async function (assert) {
       // given
       await visit('/');
 
@@ -47,7 +47,7 @@ module('Acceptance | Login', function(hooks) {
       assert.strictEqual(currentURL(), '/');
     });
 
-    test('remain on login page when logging in with a invalid api key', async function(assert) {
+    test('remain on login page when logging in with a invalid api key', async function (assert) {
       // given
       await visit('/');
 
@@ -59,7 +59,7 @@ module('Acceptance | Login', function(hooks) {
       assert.strictEqual(currentURL(), '/connexion');
     });
 
-    test('redirect to the page the user initially intended to visit', async function(assert) {
+    test('redirect to the page the user initially intended to visit', async function (assert) {
       // given
       this.server.create('framework', { id: 'recFramework0', name: 'Pix' });
       await visit('/statistics');
@@ -73,11 +73,11 @@ module('Acceptance | Login', function(hooks) {
     });
   });
 
-  module('when user is already authenticated', function(hooks) {
-    hooks.beforeEach(function() {
+  module('when user is already authenticated', function (hooks) {
+    hooks.beforeEach(function () {
       return authenticateSession();
     });
-    test('it should redirect to root page when trying to visit login page', async function(assert) {
+    test('it should redirect to root page when trying to visit login page', async function (assert) {
       // when
       await visit('/connexion');
 
@@ -86,4 +86,3 @@ module('Acceptance | Login', function(hooks) {
     });
   });
 });
-

--- a/pix-editor/tests/acceptance/missions/creation-test.js
+++ b/pix-editor/tests/acceptance/missions/creation-test.js
@@ -5,11 +5,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 
-module('Acceptance | Missions | Creation', function(hooks) {
+module('Acceptance | Missions | Creation', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     this.server.create('config', 'default');
@@ -21,14 +21,13 @@ module('Acceptance | Missions | Creation', function(hooks) {
     this.server.create('mission-summary', { name: 'Mission 2', competence: 'Autres', createdAt: '2023/12/11', status: 'INACTIVE' });
   });
 
-  module('when user does not have write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user does not have write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('user', { trigram: 'ABC', access: 'readonly' });
       return authenticateSession();
     });
 
-    test('should prevent user from being able to access creation form', async function(assert) {
+    test('should prevent user from being able to access creation form', async function (assert) {
       // when
       const screen = await visit('/');
       await clickByName('Sélectionner un référentiel');
@@ -38,19 +37,17 @@ module('Acceptance | Missions | Creation', function(hooks) {
 
       // then
       assert.dom(screen.queryByText('Créer une nouvelle mission')).doesNotExist();
-
     });
   });
 
-  module('when user has write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user has write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'admin' });
       return authenticateSession();
     });
 
-    test('should be able to access mission creation', async function(assert) {
+    test('should be able to access mission creation', async function (assert) {
       // given
       const screen = await visit('/');
       await clickByName('Sélectionner un référentiel');
@@ -65,7 +62,7 @@ module('Acceptance | Missions | Creation', function(hooks) {
       assert.strictEqual(currentURL(), '/missions/new');
     });
 
-    test('should be able to create a mission', async function(assert) {
+    test('should be able to create a mission', async function (assert) {
       // given
       const screen = await visit('/missions/new');
 
@@ -86,7 +83,7 @@ module('Acceptance | Missions | Creation', function(hooks) {
       assert.dom(screen.queryByText('Nouvelle mission de test')).exists();
     });
 
-    test('should be able to cancel a mission creation', async function(assert) {
+    test('should be able to cancel a mission creation', async function (assert) {
       // given
       const screen = await visit('/missions/new');
 

--- a/pix-editor/tests/acceptance/missions/details_test.js
+++ b/pix-editor/tests/acceptance/missions/details_test.js
@@ -5,11 +5,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 
-module('Acceptance | Missions | Details', function(hooks) {
+module('Acceptance | Missions | Details', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     this.server.create('config', 'default');
@@ -25,7 +25,7 @@ module('Acceptance | Missions | Details', function(hooks) {
     return authenticateSession();
   });
 
-  test('it displays all Pix 1D missions', async function(assert) {
+  test('it displays all Pix 1D missions', async function (assert) {
     // when
     const screen = await visit('/missions');
     await click(screen.getAllByRole('row')[1]);
@@ -34,7 +34,7 @@ module('Acceptance | Missions | Details', function(hooks) {
     assert.strictEqual(currentURL(), '/missions/1');
   });
 
-  test('should display mission details', async function(assert) {
+  test('should display mission details', async function (assert) {
     // when
     const screen = await visit('/missions/1');
     // then
@@ -45,7 +45,7 @@ module('Acceptance | Missions | Details', function(hooks) {
     assert.dom(screen.getByRole('link', { name: 'http://url-example.net' })).exists();
   });
 
-  test('it redirects to missions list', async function(assert) {
+  test('it redirects to missions list', async function (assert) {
     // when
     const screen = await visit('/missions/1');
     await click(screen.getByRole('link', { name: 'Retour à la liste des missions' }));

--- a/pix-editor/tests/acceptance/missions/edit_test.js
+++ b/pix-editor/tests/acceptance/missions/edit_test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Missions | Edit', function(hooks) {
+module('Acceptance | Missions | Edit', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('theme', { id: 'recTheme1' });
     this.server.create('competence', { id: 'recCompetence1.1', pixId: 'recCompetence1.1', rawThemeIds: ['recTheme1'], title: 'Notre compétence' });
@@ -31,14 +31,14 @@ module('Acceptance | Missions | Edit', function(hooks) {
     });
   });
 
-  module('when user has write access', function(hooks) {
-    hooks.beforeEach(function() {
+  module('when user has write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'admin' });
       return authenticateSession();
     });
 
-    test('should be able to edit a mission', async function(assert) {
+    test('should be able to edit a mission', async function (assert) {
       // given
       await visit('/missions/2');
 
@@ -49,7 +49,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       assert.strictEqual(currentURL(), '/missions/2/edit');
     });
 
-    test('should save updated informations', async function(assert) {
+    test('should save updated informations', async function (assert) {
       // given
       this.server.create('mission', {
         id: 3,
@@ -87,7 +87,7 @@ module('Acceptance | Missions | Edit', function(hooks) {
       assert.dom(screen.getByText('http://doc.com')).exists();
     });
 
-    test('should display errors if any', async function(assert) {
+    test('should display errors if any', async function (assert) {
       // given
       this.server.create('mission', {
         id: 3,

--- a/pix-editor/tests/acceptance/missions/list_test.js
+++ b/pix-editor/tests/acceptance/missions/list_test.js
@@ -5,11 +5,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
 
-module('Acceptance | Missions | List', function(hooks) {
+module('Acceptance | Missions | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
@@ -21,7 +21,7 @@ module('Acceptance | Missions | List', function(hooks) {
     return authenticateSession();
   });
 
-  test('it displays all Pix 1D missions', async function(assert) {
+  test('it displays all Pix 1D missions', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
@@ -35,7 +35,7 @@ module('Acceptance | Missions | List', function(hooks) {
     assert.dom(screen.queryByText('Mission 2')).exists();
   });
 
-  test('should display only validated missions', async function(assert) {
+  test('should display only validated missions', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
@@ -50,7 +50,7 @@ module('Acceptance | Missions | List', function(hooks) {
     assert.dom(screen.queryByText('Mission 2')).doesNotExist();
   });
 
-  test('should display only mission validée et expérimental', async function(assert) {
+  test('should display only mission validée et expérimental', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Sélectionner un référentiel');
@@ -66,5 +66,4 @@ module('Acceptance | Missions | List', function(hooks) {
     assert.dom(screen.queryByText('Mission 3')).exists();
     assert.dom(screen.queryByText('Mission 2')).doesNotExist();
   });
-
 });

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-attachment-test.js
@@ -10,11 +10,11 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
+module('Acceptance | Modify-Challenge-Attachment', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -25,29 +25,41 @@ module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
     const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: prototype.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     return authenticateSession();
   });
 
-  test('adding attachments', async function(assert) {
+  test('adding attachments', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -81,7 +93,7 @@ module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
     assert.strictEqual(attachments.length, 1);
   });
 
-  test('replace attachment', async function(assert) {
+  test('replace attachment', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -126,7 +138,7 @@ module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
     assert.strictEqual(attachments[0].url, 'data-attachmentB:,');
   });
 
-  test('delete attachment', async function(assert) {
+  test('delete attachment', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'attachment', challengeId: 'recChallenge1', filename: 'attachment.png' });
 
@@ -148,7 +160,7 @@ module('Acceptance | Modify-Challenge-Attachment', function(hooks) {
     assert.ok(attachments.every((record) => !record.isDeleted));
   });
 
-  test('cancel adding an attachment', async function(assert) {
+  test('cancel adding an attachment', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'attachment', challengeId: 'recChallenge1', filename: 'attachment.png' });
 

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-illustration-test.js
@@ -10,11 +10,11 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
+module('Acceptance | Modify-Challenge-Illustration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -25,29 +25,41 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
     const competence = this.server.create('competence', { id: 'recCompetence1.1', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: prototype.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     return authenticateSession();
   });
 
-  test('adding illustration', async function(assert) {
+  test('adding illustration', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -80,7 +92,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
     assert.ok(attachments.every((record) => !record.isNew));
   });
 
-  test('replace illustration', async function(assert) {
+  test('replace illustration', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -125,7 +137,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
     assert.strictEqual(attachments[0].url, 'data-illustrationB:,');
   });
 
-  test('delete illustration', async function(assert) {
+  test('delete illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1' });
     class StorageServiceStub extends Service {
@@ -154,7 +166,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
     assert.ok(attachments.every((record) => !record.isDeleted));
   });
 
-  test('update illustration', async function(assert) {
+  test('update illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1' });
     class StorageServiceStub extends Service {
@@ -188,7 +200,7 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
     assert.strictEqual(newIllustration.url, 'data:,');
   });
 
-  test('delete and upload a new illustration', async function(assert) {
+  test('delete and upload a new illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1' });
     class StorageServiceStub extends Service {
@@ -222,5 +234,4 @@ module('Acceptance | Modify-Challenge-Illustration', function(hooks) {
     assert.ok(attachments.every((record) => !record.isModified));
     assert.strictEqual(newIllustration.url, 'data:,');
   });
-
 });

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -7,20 +7,20 @@ import { module, test } from 'qunit';
 import { waitForSelectToBeClosed } from '../../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Modify-Challenge', function(hooks) {
+module('Acceptance | Modify-Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
     return authenticateSession();
   });
 
-  module('modifying a draft challenge', function(hooks) {
-    hooks.beforeEach(function() {
+  module('modifying a draft challenge', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('challenge', {
         id: 'recChallenge1',
         accessibility1: 'RAS',
@@ -67,28 +67,40 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       });
       this.server.create('competence-overview', {
         id: `${competence.pixId}:challenges-workbench`,
-        thematicOverviews: [{
-          airtableId: thematic.id,
-          name: thematic.name,
-          tubeOverviews: [{
-            airtableId: tube.id,
-            name: tube.name,
-            skillOverviews: [{
-              airtableId: skill.id,
-              name: skill.name,
-              proposedChallengesCount: 2,
-              validatedChallengesCount: 0,
-              archivedChallengesCount: 0,
-              obsoleteChallengesCount: 0,
-            }, null, null, null, null, null, null],
-          }],
-        }],
+        thematicOverviews: [
+          {
+            airtableId: thematic.id,
+            name: thematic.name,
+            tubeOverviews: [
+              {
+                airtableId: tube.id,
+                name: tube.name,
+                skillOverviews: [
+                  {
+                    airtableId: skill.id,
+                    name: skill.name,
+                    proposedChallengesCount: 2,
+                    validatedChallengesCount: 0,
+                    archivedChallengesCount: 0,
+                    obsoleteChallengesCount: 0,
+                  },
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                ],
+              },
+            ],
+          },
+        ],
       });
       this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('can modify attributes when challenge is a prototype', async function(assert) {
+    test('can modify attributes when challenge is a prototype', async function (assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -143,7 +155,7 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       assert.true(screen.getByRole('checkbox', { name: 'Validation par l\'embed (Pix Junior)' }).checked);
     });
 
-    test('can modify common attributes but not the quality attributes when challenge is an alternative', async function(assert) {
+    test('can modify common attributes but not the quality attributes when challenge is an alternative', async function (assert) {
       await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -175,8 +187,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     });
   });
 
-  module('modifying a production challenge', function(hooks) {
-    hooks.beforeEach(function() {
+  module('modifying a production challenge', function (hooks) {
+    hooks.beforeEach(function () {
       const prototype = this.server.create('challenge', {
         id: 'recChallenge1',
         accessibility1: 'RAS',
@@ -201,28 +213,40 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       const competence = this.server.create('competence', { id: 'recCompetence1.1', code: '1', title: 'titre compétence', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
       this.server.create('competence-overview', {
         id: `${competence.pixId}:challenges-production`,
-        thematicOverviews: [{
-          id: thematic.id,
-          name: thematic.name,
-          tubeOverviews: [{
-            id: tube.id,
-            name: tube.name,
-            skillOverviews: [{
-              id: skill.id,
-              name: skill.name,
-              prototypeId: prototype.id,
-              isPrototypeDeclinable: true,
-              proposedChallengesCount: 1,
-              validatedChallengesCount: 0,
-            }, null, null, null, null, null, null],
-          }],
-        }],
+        thematicOverviews: [
+          {
+            id: thematic.id,
+            name: thematic.name,
+            tubeOverviews: [
+              {
+                id: tube.id,
+                name: tube.name,
+                skillOverviews: [
+                  {
+                    id: skill.id,
+                    name: skill.name,
+                    prototypeId: prototype.id,
+                    isPrototypeDeclinable: true,
+                    proposedChallengesCount: 1,
+                    validatedChallengesCount: 0,
+                  },
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                ],
+              },
+            ],
+          },
+        ],
       });
       this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('can modify attributes', async function(assert) {
+    test('can modify attributes', async function (assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -264,7 +288,7 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       assert.deepEqual(challenge.geography, 'JP');
     });
 
-    test('modify a challenge\'s urlsToConsult when playing around with the field', async function(assert) {
+    test('modify a challenge\'s urlsToConsult when playing around with the field', async function (assert) {
       // when
       const store = this.owner.lookup('service:store');
 
@@ -293,8 +317,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     });
   });
 
-  module('modifying an archived challenge', function(hooks) {
-    hooks.beforeEach(function() {
+  module('modifying an archived challenge', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('challenge', {
         id: 'recChallenge1',
         accessibility1: 'RAS',
@@ -323,28 +347,40 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       });
       this.server.create('competence-overview', {
         id: `${competence.pixId}:challenges-workbench`,
-        thematicOverviews: [{
-          airtableId: thematic.id,
-          name: thematic.name,
-          tubeOverviews: [{
-            airtableId: tube.id,
-            name: tube.name,
-            skillOverviews: [{
-              airtableId: skill.id,
-              name: skill.name,
-              proposedChallengesCount: 2,
-              validatedChallengesCount: 0,
-              archivedChallengesCount: 0,
-              obsoleteChallengesCount: 0,
-            }, null, null, null, null, null, null],
-          }],
-        }],
+        thematicOverviews: [
+          {
+            airtableId: thematic.id,
+            name: thematic.name,
+            tubeOverviews: [
+              {
+                airtableId: tube.id,
+                name: tube.name,
+                skillOverviews: [
+                  {
+                    airtableId: skill.id,
+                    name: skill.name,
+                    proposedChallengesCount: 2,
+                    validatedChallengesCount: 0,
+                    archivedChallengesCount: 0,
+                    obsoleteChallengesCount: 0,
+                  },
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                ],
+              },
+            ],
+          },
+        ],
       });
       this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('can modify attributes', async function(assert) {
+    test('can modify attributes', async function (assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -396,8 +432,8 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     });
   });
 
-  module('modifying an obsolete challenge', function(hooks) {
-    hooks.beforeEach(function() {
+  module('modifying an obsolete challenge', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('challenge', {
         id: 'recChallenge1',
         accessibility1: 'RAS',
@@ -426,28 +462,40 @@ module('Acceptance | Modify-Challenge', function(hooks) {
       });
       this.server.create('competence-overview', {
         id: `${competence.pixId}:challenges-workbench`,
-        thematicOverviews: [{
-          airtableId: thematic.id,
-          name: thematic.name,
-          tubeOverviews: [{
-            airtableId: tube.id,
-            name: tube.name,
-            skillOverviews: [{
-              airtableId: skill.id,
-              name: skill.name,
-              proposedChallengesCount: 2,
-              validatedChallengesCount: 0,
-              archivedChallengesCount: 0,
-              obsoleteChallengesCount: 0,
-            }, null, null, null, null, null, null],
-          }],
-        }],
+        thematicOverviews: [
+          {
+            airtableId: thematic.id,
+            name: thematic.name,
+            tubeOverviews: [
+              {
+                airtableId: tube.id,
+                name: tube.name,
+                skillOverviews: [
+                  {
+                    airtableId: skill.id,
+                    name: skill.name,
+                    proposedChallengesCount: 2,
+                    validatedChallengesCount: 0,
+                    archivedChallengesCount: 0,
+                    obsoleteChallengesCount: 0,
+                  },
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                ],
+              },
+            ],
+          },
+        ],
       });
       this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
       this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     });
 
-    test('cannot modify an obsolete challenge', async function(assert) {
+    test('cannot modify an obsolete challenge', async function (assert) {
       const screen = await visit('/');
       await clickByText('1. Information et données');
       await clickByText('1 titre compétence');
@@ -459,4 +507,3 @@ module('Acceptance | Modify-Challenge', function(hooks) {
     });
   });
 });
-

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
@@ -10,11 +10,11 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
+module('Acceptance | Modify-Localized-Challenge-Attachment', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -41,22 +41,34 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: prototype.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', {
       id: 'recArea1',
@@ -74,7 +86,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     return authenticateSession();
   });
 
-  test('adding attachments', async function(assert) {
+  test('adding attachments', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() {
@@ -111,7 +123,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     assert.strictEqual(attachments.length, 1);
   });
 
-  test('adding attachments on localized challenge with illustration', async function(assert) {
+  test('adding attachments on localized challenge with illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1', localizedChallengeId: 'recChallenge1NL' });
 
@@ -143,7 +155,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     assert.dom(screen.getByRole('heading', { name: 'Illustration' })).exists();
   });
 
-  test('replace attachment', async function(assert) {
+  test('replace attachment', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -186,7 +198,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     assert.strictEqual(attachments[0].url, 'data-attachmentB:,');
   });
 
-  test('delete attachment', async function(assert) {
+  test('delete attachment', async function (assert) {
     // given
     this.server.create('attachment', {
       id: 'recAttachment1',
@@ -217,7 +229,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function(hooks) {
     assert.ok(attachments.every((record) => !record.isDeleted));
   });
 
-  test('cancel adding an attachment', async function(assert) {
+  test('cancel adding an attachment', async function (assert) {
     // given
     this.server.create('attachment', {
       id: 'recAttachment1',

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
@@ -10,11 +10,11 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
+module('Acceptance | Modify-Localized-Challenge-Illustration', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -31,22 +31,34 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     this.server.create('competence', { id: 'recCompetence2.1', pixId: 'pixId recCompetence2.1', rawThemeIds: ['recTheme2'], rawTubeIds: ['recTube2'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill1.id,
-            name: skill1.name,
-            prototypeId: prototype1.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill1.id,
+                  name: skill1.name,
+                  prototypeId: prototype1.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('area', { id: 'recArea2', name: '2. Communication et collaboration', code: '2', competenceIds: ['recCompetence2.1'] });
@@ -54,7 +66,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     return authenticateSession();
   });
 
-  test('adding illustration', async function(assert) {
+  test('adding illustration', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -94,7 +106,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     assert.dom(await within(popIn).findByRole('img')).hasAttribute('src', 'data:,');
   });
 
-  test('replace illustration', async function(assert) {
+  test('replace illustration', async function (assert) {
     // given
     class StorageServiceStub extends Service {
       uploadFile() { }
@@ -140,7 +152,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     assert.strictEqual(attachments[0].url, 'data-illustrationB:,');
   });
 
-  test('delete illustration', async function(assert) {
+  test('delete illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1', localizedChallengeId: 'recChallenge1NL' });
     class StorageServiceStub extends Service {
@@ -170,7 +182,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     assert.ok(attachments.every((record) => !record.isDeleted));
   });
 
-  test('update illustration', async function(assert) {
+  test('update illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1', localizedChallengeId: 'recChallenge1NL' });
     class StorageServiceStub extends Service {
@@ -206,7 +218,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     assert.strictEqual(newIllustration.url, 'data:,');
   });
 
-  test('delete and upload a new illustration', async function(assert) {
+  test('delete and upload a new illustration', async function (assert) {
     // given
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'recChallenge1', localizedChallengeId: 'recChallenge1NL' });
 
@@ -241,5 +253,4 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function(hooks) {
     assert.ok(attachments.every((record) => !record.isModified));
     assert.strictEqual(newIllustration.url, 'data:,');
   });
-
 });

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-test.js
@@ -7,11 +7,11 @@ import { module, test } from 'qunit';
 import { waitForSelectToBeClosed } from '../../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Modify-Localized-Challenge', function(hooks) {
+module('Acceptance | Modify-Localized-Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -24,29 +24,41 @@ module('Acceptance | Modify-Localized-Challenge', function(hooks) {
     const competence = this.server.create('competence', { id: 'recCompetence1.1', title: 'ma competence', pixId: 'pixId recCompetence1.1', rawThemeIds: ['recTheme1'], rawTubeIds: ['recTube1'] });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: thematic.id,
-        name: thematic.name,
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: prototype.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', { id: 'recArea1', name: '1. Information et données', code: '1', competenceIds: ['recCompetence1.1'] });
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
     return authenticateSession();
   });
 
-  test('should modify attributes in localized challenge', async function(assert) {
+  test('should modify attributes in localized challenge', async function (assert) {
     // when
     const store = this.owner.lookup('service:store');
 

--- a/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
+++ b/pix-editor/tests/acceptance/navigate-through-frameworks-test.js
@@ -5,64 +5,69 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Navigate through frameworks', function(hooks) {
+module('Acceptance | Navigate through frameworks', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let apiKey, screen;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
     this.server.create('framework', { id: 'recFramework1', name: 'Pix' });
     return authenticateSession();
   });
 
-  for (const role of ['readonly', 'replicator', 'editor', 'admin']) {
-    module(`when user is ${role}`, function(hooks) {
-      hooks.beforeEach(async function() {
-        //given
+  for (const role of [
+    'readonly',
+    'replicator',
+    'editor',
+    'admin',
+  ]) {
+    module(`when user is ${role}`, function (hooks) {
+      hooks.beforeEach(async function () {
+        // given
         this.server.create('user', { apiKey, trigram: 'ABC', access: role });
 
-        //when
+        // when
         screen = await visit('/');
       });
 
-      test('it should display select framework', async function(assert) {
+      test('it should display select framework', async function (assert) {
         // then
         assert.dom(await screen.findByLabelText('Sélectionner un référentiel')).exists();
       });
 
-      test('it should display generator target profile link', async function(assert) {
+      test('it should display generator target profile link', async function (assert) {
         // then
         assert.dom('[data-test-target-profile-link]').exists();
       });
 
-      test('it should display search bar', async function(assert) {
+      test('it should display search bar', async function (assert) {
         // then
         assert.dom(await screen.findByLabelText('Rechercher un acquis ou une épreuve...')).exists();
       });
     });
   }
 
-  module('when user is `readpixonly`', function(hooks) {
-    hooks.beforeEach(async function() {
-      //given
+  module('when user is `readpixonly`', function (hooks) {
+    hooks.beforeEach(async function () {
+      // given
       this.server.create('user', { apiKey, trigram: 'ABC', access: 'readpixonly' });
 
       // when
       screen = await visit('/');
     });
 
-    test('it should not have access to framework list', async function(assert) {
+    test('it should not have access to framework list', async function (assert) {
       // then
       assert.strictEqual(await screen.queryByLabelText('Sélectionner un référentiel'), null);
     });
 
-    test('it should not display generator target profile link', async function(assert) {
+    test('it should not display generator target profile link', async function (assert) {
       // then
       assert.dom('[data-test-target-profile-link]').doesNotExist();
     });
 
-    test('it should not display search bar', function(assert) {
+    test('it should not display search bar', function (assert) {
       // then
       assert.dom('.sidebar-search').doesNotExist();
     });

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Search', function(hooks) {
+module('Acceptance | Search', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -21,7 +21,7 @@ module('Acceptance | Search', function(hooks) {
     this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1' });
     this.server.create('skill', { id: 'recSkill2', name: '@skill1', challengeIds: [], status: 'archivé', version: 2, pixId: 'skill2' });
     const skill = this.server.create('skill', { id: 'recSkill1', name: '@skill1', challengeIds: ['recChallenge1', 'challengeChallenge1'], pixId: 'skill1', version: 1 });
-    const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill2', 'recSkill1' ] });
+    const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill2', 'recSkill1'] });
     const competence = this.server.create('competence', {
       id: 'recCompetence1.1',
       pixId: 'pixId recCompetence1.1',
@@ -29,22 +29,34 @@ module('Acceptance | Search', function(hooks) {
     });
     this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production`,
-      thematicOverviews: [{
-        id: 'pas de thématique',
-        name: 'on m\'a oublié :(',
-        tubeOverviews: [{
-          id: tube.id,
-          name: tube.name,
-          skillOverviews: [{
-            id: skill.id,
-            name: skill.name,
-            prototypeId: prototype.id,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 0,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'pas de thématique',
+          name: 'on m\'a oublié :(',
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 0,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('area', {
       id: 'recArea1',
@@ -56,7 +68,7 @@ module('Acceptance | Search', function(hooks) {
     return authenticateSession();
   });
 
-  test('search a challenge by rec id', async function(assert) {
+  test('search a challenge by rec id', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1?view=production';
 
@@ -70,7 +82,7 @@ module('Acceptance | Search', function(hooks) {
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by challenge id', async function(assert) {
+  test('search a challenge by challenge id', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1?view=production';
 
@@ -84,7 +96,7 @@ module('Acceptance | Search', function(hooks) {
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by localized challenge id', async function(assert) {
+  test('search a challenge by localized challenge id', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/challengeLocalizedChallenge1?view=production';
 
@@ -98,7 +110,7 @@ module('Acceptance | Search', function(hooks) {
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by text', async function(assert) {
+  test('search a challenge by text', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1?view=production';
 
@@ -112,7 +124,7 @@ module('Acceptance | Search', function(hooks) {
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a skill by name - starting with @', async function(assert) {
+  test('search a skill by name - starting with @', async function (assert) {
     // given
     const expectedUrl = '/competence/recCompetence1.1/skills/recSkill1?view=production';
 

--- a/pix-editor/tests/acceptance/static-courses/activation-test.js
+++ b/pix-editor/tests/acceptance/static-courses/activation-test.js
@@ -6,12 +6,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Static Courses | Activation', function(hooks) {
+module('Acceptance | Static Courses | Activation', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let staticCourse, staticCourseSummary;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     staticCourseSummary = this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', challengeCount: 3, createdAt: new Date('2020-01-01'), isActive: true });
@@ -50,15 +50,14 @@ module('Acceptance | Static Courses | Activation', function(hooks) {
     });
   });
 
-  module('when user does not have write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user does not have write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'readonly' });
       return authenticateSession();
     });
 
-    test('should prevent user from being able to deactivate static course', async function(assert) {
+    test('should prevent user from being able to deactivate static course', async function (assert) {
       // when
       const screen = await visit('/');
       await clickByName('Tests statiques');
@@ -70,16 +69,15 @@ module('Acceptance | Static Courses | Activation', function(hooks) {
     });
   });
 
-  module('when user has write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user has write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'admin' });
       return authenticateSession();
     });
 
-    module('when static course is inactive', function() {
-      test('should reactivate the static course', async function(assert) {
+    module('when static course is inactive', function () {
+      test('should reactivate the static course', async function (assert) {
         // given
         staticCourseSummary.update({ isActive: false });
         staticCourse.update({ isActive: false });
@@ -99,8 +97,8 @@ module('Acceptance | Static Courses | Activation', function(hooks) {
       });
     });
 
-    module('when static course is active', function() {
-      test('should deactivate the static course', async function(assert) {
+    module('when static course is active', function () {
+      test('should deactivate the static course', async function (assert) {
         // given
         const screen = await visit('/');
         await clickByName('Tests statiques');

--- a/pix-editor/tests/acceptance/static-courses/creation-test.js
+++ b/pix-editor/tests/acceptance/static-courses/creation-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Static Courses | Creation', function(hooks) {
+module('Acceptance | Static Courses | Creation', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', challengeCount: 3, createdAt: new Date('2020-01-01') });
@@ -51,15 +51,14 @@ module('Acceptance | Static Courses | Creation', function(hooks) {
     });
   });
 
-  module('when user does not have write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user does not have write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'readonly' });
       return authenticateSession();
     });
 
-    test('should prevent user from being able to access creation form', async function(assert) {
+    test('should prevent user from being able to access creation form', async function (assert) {
       // when
       const screen = await visit('/');
       await clickByName('Tests statiques');
@@ -71,15 +70,14 @@ module('Acceptance | Static Courses | Creation', function(hooks) {
     });
   });
 
-  module('when user has write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user has write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'admin' });
       return authenticateSession();
     });
 
-    test('should create a static course', async function(assert) {
+    test('should create a static course', async function (assert) {
       // given
       const screen = await visit('/');
       await clickByName('Tests statiques');
@@ -111,7 +109,7 @@ module('Acceptance | Static Courses | Creation', function(hooks) {
       assert.dom(screen.getByText('COUleur')).exists();
     });
 
-    test('should cancel static course creation', async function(assert) {
+    test('should cancel static course creation', async function (assert) {
       // given
       const screen = await visit('/');
       await clickByName('Tests statiques');

--- a/pix-editor/tests/acceptance/static-courses/details-test.js
+++ b/pix-editor/tests/acceptance/static-courses/details-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Static Courses | Details', function(hooks) {
+module('Acceptance | Static Courses | Details', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const tag = this.server.create('static-course-tag', { id: 123, label: 'Mon super tag' });
     this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01') });
     this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: true, challengeCount: 10, createdAt: new Date('2019-01-01') });
@@ -52,7 +52,7 @@ module('Acceptance | Static Courses | Details', function(hooks) {
     return authenticateSession();
   });
 
-  test('should access to static course details when clicking on an row entry in the list', async function(assert) {
+  test('should access to static course details when clicking on an row entry in the list', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');
@@ -61,7 +61,13 @@ module('Acceptance | Static Courses | Details', function(hooks) {
     // then
     assert.strictEqual(currentURL(), '/static-courses/courseA');
     // information section
-    const [nameItem, descriptionItem, statusItem, createdAtItem, updatedAtItem] = screen.getAllByRole('listitem');
+    const [
+      nameItem,
+      descriptionItem,
+      statusItem,
+      createdAtItem,
+      updatedAtItem,
+    ] = screen.getAllByRole('listitem');
     const removeWhitespacesFnc = (str) => str
       .trim()
       .replace(/\s{2,}/g, '')
@@ -72,10 +78,32 @@ module('Acceptance | Static Courses | Details', function(hooks) {
     assert.strictEqual(removeWhitespacesFnc(createdAtItem.textContent), 'Crée le:01/01/2021');
     assert.strictEqual(removeWhitespacesFnc(updatedAtItem.textContent), 'Dernière modification:02/02/2021');
     // challenges section
-    const [, chalBRow, chalARow, chalCRow] = screen.getAllByRole('row');
-    const [indexCellB, idCellB, instructionCellB, skillNameCellB, statusCellB] = chalBRow.cells;
-    const [indexCellA, idCellA, instructionCellA, skillNameCellA, statusCellA] = chalARow.cells;
-    const [indexCellC, idCellC, instructionCellC, skillNameCellC, statusCellC] = chalCRow.cells;
+    const [
+      , chalBRow,
+      chalARow,
+      chalCRow,
+    ] = screen.getAllByRole('row');
+    const [
+      indexCellB,
+      idCellB,
+      instructionCellB,
+      skillNameCellB,
+      statusCellB,
+    ] = chalBRow.cells;
+    const [
+      indexCellA,
+      idCellA,
+      instructionCellA,
+      skillNameCellA,
+      statusCellA,
+    ] = chalARow.cells;
+    const [
+      indexCellC,
+      idCellC,
+      instructionCellC,
+      skillNameCellC,
+      statusCellC,
+    ] = chalCRow.cells;
     assert.strictEqual(removeWhitespacesFnc(indexCellB.textContent), '1');
     assert.strictEqual(removeWhitespacesFnc(idCellB.textContent), 'chalB');
     assert.strictEqual(removeWhitespacesFnc(instructionCellB.textContent), 'instruction chalB');
@@ -94,7 +122,7 @@ module('Acceptance | Static Courses | Details', function(hooks) {
     assert.dom(screen.getByText('Mon super tag')).exists();
   });
 
-  test('should go back to static course list when clicking on "Retour" button', async function(assert) {
+  test('should go back to static course list when clicking on "Retour" button', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');

--- a/pix-editor/tests/acceptance/static-courses/edition-test.js
+++ b/pix-editor/tests/acceptance/static-courses/edition-test.js
@@ -6,12 +6,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Static Courses | Edition', function(hooks) {
+module('Acceptance | Static Courses | Edition', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let staticCourse, staticCourseSummary;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     staticCourseSummary = this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', challengeCount: 3, createdAt: new Date('2020-01-01'), isActive: true });
@@ -54,15 +54,14 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
     });
   });
 
-  module('when user does not have write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user does not have write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'readonly' });
       return authenticateSession();
     });
 
-    test('should prevent user from being able to access edition form through action button', async function(assert) {
+    test('should prevent user from being able to access edition form through action button', async function (assert) {
       // when
       const screen = await visit('/');
       await clickByName('Tests statiques');
@@ -73,7 +72,7 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
       assert.strictEqual(currentURL(), '/static-courses/courseA');
     });
 
-    test('should prevent user from being able to access edition form through URL', async function(assert) {
+    test('should prevent user from being able to access edition form through URL', async function (assert) {
       // when
       await visit('/static-courses/courseA/edit');
 
@@ -82,17 +81,15 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
     });
   });
 
-  module('when user has write access', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('when user has write access', function (hooks) {
+    hooks.beforeEach(function () {
       this.server.create('config', 'default');
       this.server.create('user', { trigram: 'ABC', access: 'admin' });
       return authenticateSession();
     });
 
-    module('when static course is inactive', function() {
-
-      test('should not be able to edit the static course through the action button', async function(assert) {
+    module('when static course is inactive', function () {
+      test('should not be able to edit the static course through the action button', async function (assert) {
         // given
         staticCourseSummary.update({ isActive: false });
         staticCourse.update({ isActive: false });
@@ -109,7 +106,7 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
         assert.strictEqual(currentURL(), '/static-courses/courseA');
       });
 
-      test('should not be able to edit the static course by navigating directly to the edition page', async function(assert) {
+      test('should not be able to edit the static course by navigating directly to the edition page', async function (assert) {
         // given
         staticCourseSummary.update({ isActive: false });
         staticCourse.update({ isActive: false });
@@ -122,7 +119,7 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
       });
     });
 
-    test('should edit the static course', async function(assert) {
+    test('should edit the static course', async function (assert) {
       // given
       const screen = await visit('/');
       await clickByName('Tests statiques');
@@ -150,7 +147,7 @@ module('Acceptance | Static Courses | Edition', function(hooks) {
       assert.dom(screen.getByText('tagC')).exists();
     });
 
-    test('should cancel static course edition', async function(assert) {
+    test('should cancel static course edition', async function (assert) {
       // given
       const screen = await visit('/');
       await clickByName('Tests statiques');

--- a/pix-editor/tests/acceptance/static-courses/list-test.js
+++ b/pix-editor/tests/acceptance/static-courses/list-test.js
@@ -6,20 +6,18 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Static Courses | List', function(hooks) {
+module('Acceptance | Static Courses | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
-    const tags = [
-      this.server.create('static-course-tag', { id: 'tagA', label: 'tagA' }),
-      this.server.create('static-course-tag', { id: 'tagB', label: 'tagB' }),
-    ];
+    const tags = [this.server.create('static-course-tag', { id: 'tagA', label: 'tagA' }), this.server.create('static-course-tag', { id: 'tagB', label: 'tagB' })];
     this.server.create('static-course-summary', { id: 'courseA', name: 'Premier test statique', isActive: true, challengeCount: 3, createdAt: new Date('2020-01-01'), tags: [...tags] });
     this.server.create('static-course-summary', { id: 'courseB', name: 'Deuxième test statique', isActive: false, challengeCount: 10, createdAt: new Date('2019-01-01'), tags: [] });
-    this.server.create('static-course-summary', { id: 'courseC', name: 'Troisième test statique', isActive: true, challengeCount: 10, createdAt: new Date('2019-01-01'), tags:
+    this.server.create('static-course-summary', {
+      id: 'courseC', name: 'Troisième test statique', isActive: true, challengeCount: 10, createdAt: new Date('2019-01-01'), tags:
         [this.server.create('static-course-tag', { id: 'tagCId', label: 'tagC' })],
     });
 
@@ -27,7 +25,7 @@ module('Acceptance | Static Courses | List', function(hooks) {
     return authenticateSession();
   });
 
-  test('should display active static courses by default when accessing list', async function(assert) {
+  test('should display active static courses by default when accessing list', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');
@@ -38,7 +36,7 @@ module('Acceptance | Static Courses | List', function(hooks) {
     assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
   });
 
-  test('should display all static courses when accessing list and toggling filter', async function(assert) {
+  test('should display all static courses when accessing list and toggling filter', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');
@@ -53,8 +51,7 @@ module('Acceptance | Static Courses | List', function(hooks) {
     assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
   });
 
-  test('should display only static courses with searched tag in the tag filter', async function(assert) {
-
+  test('should display only static courses with searched tag in the tag filter', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');
@@ -72,7 +69,7 @@ module('Acceptance | Static Courses | List', function(hooks) {
     assert.dom(screen.queryByText('Deuxième test statique')).doesNotExist();
   });
 
-  test('should render correctly a row', async function(assert) {
+  test('should render correctly a row', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Tests statiques');

--- a/pix-editor/tests/acceptance/synchronize_translations_test.js
+++ b/pix-editor/tests/acceptance/synchronize_translations_test.js
@@ -6,17 +6,17 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Synchronize Translations', function(hooks) {
+module('Acceptance | Synchronize Translations', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
     return authenticateSession();
   });
 
-  test('should display page to synchronize translations', async function(assert) {
+  test('should display page to synchronize translations', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Récupérer les traductions');

--- a/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/challenges-production_test.js
@@ -8,12 +8,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | competences | challenge-production', function(hooks) {
+module('Acceptance | competences | challenge-production', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   const skillId = 'skill1', skillName = '@tube1', prototypeId = 'prototype1';
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     window.localStorage.setItem('v2', 'true');
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
@@ -29,45 +29,69 @@ module('Acceptance | competences | challenge-production', function(hooks) {
       id: 'competence1:challenges-production',
       name: '1.1 ma compétence',
       airtableId: 'recCompetence1',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: skillId,
-            name: skillName,
-            prototypeId,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 1,
-            airtableId: skillId,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: skillId,
+                  name: skillName,
+                  prototypeId,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 1,
+                  airtableId: skillId,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: 'competence1:challenges-production:nl',
       name: '1.1 ma compétence',
       airtableId: 'recCompetence1',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: skillId,
-            name: skillName,
-            prototypeId,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 0,
-            validatedChallengesCount: 1,
-            airtableId: skillId,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: skillId,
+                  name: skillName,
+                  prototypeId,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                  airtableId: skillId,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     const skill = this.server.create('skill', {
       id: skillId,
@@ -108,7 +132,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     return authenticateSession();
   });
 
-  test('should visit challenge production v2', async function(assert) {
+  test('should visit challenge production v2', async function (assert) {
     // when
     const screen = await visit('/v2/competences/recCompetence1/challenges-production');
 
@@ -125,7 +149,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     assert.dom(screen.queryByTitle('Nombre d\'épreuves en cours de construction')).doesNotExist();
   });
 
-  test('should display a challenge production list', async function(assert) {
+  test('should display a challenge production list', async function (assert) {
     // when
     const screen = await visit('/v2/competences/recCompetence1/challenges-production');
     await clickByText('@tube1');
@@ -135,7 +159,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     assert.strictEqual(currentURL(), `/v2/competences/recCompetence1/challenges-production/skills/${skillId}/challenges`);
   });
 
-  test('it should navigate to challenge view', async function(assert) {
+  test('it should navigate to challenge view', async function (assert) {
     await visit('/v2/competences/recCompetence1/challenges-production');
     await clickByText('@tube1');
     await clickByText('Proto');
@@ -148,7 +172,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     assert.strictEqual(currentURL(), `/v2/competences/recCompetence1/challenges-production/skills/${skillId}/challenges/challengeIdProto`);
   });
 
-  test('should display a localized challenge production list', async function(assert) {
+  test('should display a localized challenge production list', async function (assert) {
     // when
     const screen = await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
     await clickByText('@tube1');
@@ -158,7 +182,7 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     assert.strictEqual(currentURL(), `/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges?locale=nl`);
   });
 
-  test('it should navigate to localized-challenge view', async function(assert) {
+  test('it should navigate to localized-challenge view', async function (assert) {
     await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
     await clickByText('@tube1');
     await clickByText('Proto');
@@ -170,5 +194,4 @@ module('Acceptance | competences | challenge-production', function(hooks) {
     await clickByText('hallo mama');
     assert.strictEqual(currentURL(), `/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges/localizedChallengeIdProto?locale=nl`);
   });
-
 });

--- a/pix-editor/tests/acceptance/v2/competence-overview/expand-collapse-close-multiplanels_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/expand-collapse-close-multiplanels_test.js
@@ -7,12 +7,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | expand-collapse-close-multipanels', function(hooks) {
+module('Acceptance | expand-collapse-close-multipanels', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   const skillId = 'skill1', skillName = '@tube1', prototypeId = 'prototype1';
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     window.localStorage.setItem('v2', 'true');
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
@@ -28,44 +28,68 @@ module('Acceptance | expand-collapse-close-multipanels', function(hooks) {
       id: 'competence1:challenges-production',
       name: '1.1 ma compétence',
       airtableId: 'recCompetence1',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: skillId,
-            name: skillName,
-            prototypeId,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 1,
-            airtableId: skillId,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: skillId,
+                  name: skillName,
+                  prototypeId,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 1,
+                  airtableId: skillId,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: 'competence1:challenges-production:nl',
       name: '1.1 ma compétence',
       airtableId: 'recCompetence1',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: skillId,
-            name: skillName,
-            prototypeId,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 0,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: skillId,
+                  name: skillName,
+                  prototypeId,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     const skill = this.server.create('skill', {
       id: skillId,
@@ -84,7 +108,7 @@ module('Acceptance | expand-collapse-close-multipanels', function(hooks) {
     return authenticateSession();
   });
 
-  test('should correctly expand / collapse panels according to scenario', async function(assert) {
+  test('should correctly expand / collapse panels according to scenario', async function (assert) {
     // Grid only
     await visit('/v2/competences/recCompetence1/challenges-production');
     assert.dom('.competence-overview-grid').isVisible();

--- a/pix-editor/tests/acceptance/v2/competence-overview/fetch-translations_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/fetch-translations_test.js
@@ -7,12 +7,12 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | fetch-translations', function(hooks) {
+module('Acceptance | fetch-translations', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   const skillId = 'skill1', skillName = '@tube1', prototypeId = 'prototype1';
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     window.localStorage.setItem('v2', 'true');
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
@@ -28,44 +28,68 @@ module('Acceptance | fetch-translations', function(hooks) {
       id: 'competence1:challenges-production',
       name: '1.1 ma compétence',
       airtableId: 'recCompetence1',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: skillId,
-            name: skillName,
-            prototypeId,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 1,
-            airtableId: skillId,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: skillId,
+                  name: skillName,
+                  prototypeId,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 1,
+                  airtableId: skillId,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: 'competence1:challenges-production:nl',
       name: '1.1 ma compétence',
       airtableId: 'recCompetence1',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: skillId,
-            name: skillName,
-            prototypeId,
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 0,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: skillId,
+                  name: skillName,
+                  prototypeId,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     const skill = this.server.create('skill', {
       id: skillId,
@@ -84,20 +108,20 @@ module('Acceptance | fetch-translations', function(hooks) {
     return authenticateSession();
   });
 
-  module('when not filtering by language', function() {
-    test('should not display fetch translations button', async function(assert) {
+  module('when not filtering by language', function () {
+    test('should not display fetch translations button', async function (assert) {
       await visit('/v2/competences/recCompetence1/challenges-production');
       assert.dom('.competence-overview-actions__fetch').isNotVisible();
     });
   });
 
-  module('when filtering by language', function() {
-    test('should display fetch translations button', async function(assert) {
+  module('when filtering by language', function () {
+    test('should display fetch translations button', async function (assert) {
       await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
       assert.dom('.competence-overview-actions__fetch').isVisible();
     });
 
-    test('fetch button should work', async function(assert) {
+    test('fetch button should work', async function (assert) {
       const screen = await visit('/v2/competences/recCompetence1/challenges-production?locale=nl');
       await click(screen.getByRole('button', { name: 'Récupérer les traductions' }));
       assert.dom(await screen.findByText('Téléchargement des traductions depuis Phrase effectué.')).exists();

--- a/pix-editor/tests/acceptance/v2/competence-overview/navigation-primary-localized_test.js
+++ b/pix-editor/tests/acceptance/v2/competence-overview/navigation-primary-localized_test.js
@@ -8,11 +8,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | navigation-primary-localized', function(hooks) {
+module('Acceptance | navigation-primary-localized', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     window.localStorage.setItem('v2', 'true');
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
@@ -26,64 +26,100 @@ module('Acceptance | navigation-primary-localized', function(hooks) {
       id: 'competence1:challenges-production',
       airtableId: 'recCompetence1',
       name: '1.1 ma compétence',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: 'skill1',
-            name: '@tube1',
-            prototypeId: 'prototype1',
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: 'skill1',
+                  name: '@tube1',
+                  prototypeId: 'prototype1',
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: 'competence1:challenges-production:fr',
       airtableId: 'recCompetence1',
       name: '1.1 ma compétence',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: 'skill1',
-            name: '@tube1',
-            prototypeId: 'prototype1',
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: 'skill1',
+                  name: '@tube1',
+                  prototypeId: 'prototype1',
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: 'competence1:challenges-production:nl',
       airtableId: 'recCompetence1',
       name: '1.1 ma compétence',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: 'skill1',
-            name: '@tube1',
-            prototypeId: 'prototype1',
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 0,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: 'skill1',
+                  name: '@tube1',
+                  prototypeId: 'prototype1',
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     const skill = this.server.create('skill', {
       id: 'skill1',
@@ -128,7 +164,7 @@ module('Acceptance | navigation-primary-localized', function(hooks) {
     return authenticateSession();
   });
 
-  test('should navigate from primary to some locale back and forth seamlessly', async function(assert) {
+  test('should navigate from primary to some locale back and forth seamlessly', async function (assert) {
     // First we are on the primary
     const screen = await visit('/v2/competences/recCompetence1/challenges-production/skills/skill1/challenges');
     assert.strictEqual(currentURL(), '/v2/competences/recCompetence1/challenges-production/skills/skill1/challenges');

--- a/pix-editor/tests/acceptance/v2/navigation-v1-v2_test.js
+++ b/pix-editor/tests/acceptance/v2/navigation-v1-v2_test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | navigation-v1-v2', function(hooks) {
+module('Acceptance | navigation-v1-v2', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.owner.lookup('service:store');
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
@@ -23,50 +23,74 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
       id: 'competence1:challenges-production',
       airtableId: 'recCompetence1',
       name: '1.1 ma compétence',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: 'skill1',
-            name: '@tube1',
-            prototypeId: 'prototype1',
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 1,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: 'skill1',
+                  name: '@tube1',
+                  prototypeId: 'prototype1',
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 1,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('competence-overview', {
       id: 'competence1:challenges-production:nl',
       airtableId: 'recCompetence1',
       name: '1.1 ma compétence',
-      thematicOverviews: [{
-        id: 'thematic1',
-        name: 'thematic name',
-        tubeOverviews: [{
-          id: 'tube1',
-          name: '@tube',
-          skillOverviews: [{
-            id: 'skill1',
-            name: '@tube1',
-            prototypeId: 'prototype1',
-            isPrototypeDeclinable: true,
-            proposedChallengesCount: 0,
-            validatedChallengesCount: 1,
-          }, null, null, null, null, null, null],
-        }],
-      }],
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                {
+                  id: 'skill1',
+                  name: '@tube1',
+                  prototypeId: 'prototype1',
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
     });
     this.server.create('challenge', { id: 'prototype1', airtableId: 'airtableRecChallenge1', instruction: 'instructionsChallenge1' });
     this.server.create('skill', { id: 'skill1', challengeIds: ['prototype1'], level: 1 });
     return authenticateSession();
   });
 
-  test('should navigate to v2 route if v2 is enabled', async function(assert) {
+  test('should navigate to v2 route if v2 is enabled', async function (assert) {
     // when
     await visit('/');
 
@@ -78,7 +102,7 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/recCompetence1/challenges-production');
   });
 
-  test('should upgrade route to v2 when toggling v2 on upgradable v1 route', async function(assert) {
+  test('should upgrade route to v2 when toggling v2 on upgradable v1 route', async function (assert) {
     // when
     await visit('/competence/recCompetence1/prototypes?view=production');
     await clickByText('V2');
@@ -87,7 +111,7 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/recCompetence1/challenges-production');
   });
 
-  test('should downgrade route to v1 when toggling v1 on a v2 route', async function(assert) {
+  test('should downgrade route to v1 when toggling v1 on a v2 route', async function (assert) {
     // when
     await visit('/');
     await clickByText('V2');
@@ -98,7 +122,7 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
     assert.strictEqual(currentURL(), '/competence/recCompetence1/prototypes?view=production');
   });
 
-  test('should remember selected language when switching from/to v2', async function(assert) {
+  test('should remember selected language when switching from/to v2', async function (assert) {
     // when
     await visit('/competence/recCompetence1/prototypes?view=production&languageFilter=nl');
     await clickByText('V2');
@@ -107,7 +131,7 @@ module('Acceptance | navigation-v1-v2', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/recCompetence1/challenges-production?locale=nl');
   });
 
-  test('should move to v2 of the selected challenge', async function(assert) {
+  test('should move to v2 of the selected challenge', async function (assert) {
     // when
     await visit('/competence/recCompetence1/prototypes/prototype1?view=production');
     await clickByText('V2');

--- a/pix-editor/tests/acceptance/validate-challenge-alternative-test.js
+++ b/pix-editor/tests/acceptance/validate-challenge-alternative-test.js
@@ -6,13 +6,13 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Validate Alternative Challenge', function(hooks) {
+module('Acceptance | Validate Alternative Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let competence, store, validatedPrototype, proposedPrototype, proposedAlternative1, proposedAlternative2;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
 
     this.server.create('config', 'default');
@@ -41,7 +41,7 @@ module('Acceptance | Validate Alternative Challenge', function(hooks) {
     authenticateSession();
   });
 
-  test('validate an alternative challenge', async function(assert) {
+  test('validate an alternative challenge', async function (assert) {
     // when
     const screen = await visit(`/competence/${competence.id}/prototypes/${validatedPrototype.id}`);
     await click(screen.getByRole('button', { name: 'Déclinaisons >>' }));
@@ -63,8 +63,8 @@ module('Acceptance | Validate Alternative Challenge', function(hooks) {
     assert.ok(await screen.findByText('Mise en production réussie'));
   });
 
-  module('when prototype is proposed', function() {
-    test('validate an alternative challenge', async function(assert) {
+  module('when prototype is proposed', function () {
+    test('validate an alternative challenge', async function (assert) {
       // when
       const screen = await visit(`/competence/${competence.id}/prototypes/${proposedPrototype.id}`);
       await click(screen.getByRole('button', { name: 'Déclinaisons >>' }));

--- a/pix-editor/tests/acceptance/validate-prototype-test.js
+++ b/pix-editor/tests/acceptance/validate-prototype-test.js
@@ -8,13 +8,13 @@ import sinon from 'sinon';
 
 import { setupApplicationTest } from '../setup-application-rendering';
 
-module('Acceptance | Validate-Challenge', function(hooks) {
+module('Acceptance | Validate-Challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let competence, tube, store, messageStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     class NotifyServiceStub extends Service {
       message() {}
@@ -45,21 +45,25 @@ module('Acceptance | Validate-Challenge', function(hooks) {
     authenticateSession();
   });
 
-  module('when have one prototype in a suggestedSkill', function(hooks) {
+  module('when have one prototype in a suggestedSkill', function (hooks) {
     let proposalPrototype, suggestedSkill, draftAlternativeChallenge, obsoleteAlternativeChallenge;
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       proposalPrototype = this.server.create('challenge', { id: 'recChallenge1', status: 'proposé', genealogy: 'Prototype 1', version: 1 });
       draftAlternativeChallenge = this.server.create('challenge', { id: 'recChallenge1-1', status: 'proposé', genealogy: 'Décliné 1', version: 1, alternativeVersion: 1 });
       obsoleteAlternativeChallenge = this.server.create('challenge', { id: 'recChallenge1-2', status: 'périmé', genealogy: 'Décliné 1', version: 1, alternativeVersion: 2 });
 
-      suggestedSkill = this.server.create('skill', { id: 'recSkill1', status: 'suggested', challengeIds: ['recChallenge1', 'recChallenge1-1', 'recChallenge1-2'] });
-
-      tube.update({
-        rawSkillIds: ['recSkill1'],
+      suggestedSkill = this.server.create('skill', {
+        id: 'recSkill1', status: 'suggested', challengeIds: [
+          'recChallenge1',
+          'recChallenge1-1',
+          'recChallenge1-2',
+        ],
       });
+
+      tube.update({ rawSkillIds: ['recSkill1'] });
     });
 
-    test('validate a prototype and draft alternatives should active the parent skill', async function(assert) {
+    test('validate a prototype and draft alternatives should active the parent skill', async function (assert) {
       // when
       const screen = await visit(`/competence/${competence.id}/prototypes/${proposalPrototype.id}/alternatives?view=workbench`);
 
@@ -91,7 +95,7 @@ module('Acceptance | Validate-Challenge', function(hooks) {
       assert.strictEqual(skill.status, 'actif');
     });
 
-    test('should not validate alternative when we won\'t', async function(assert) {
+    test('should not validate alternative when we won\'t', async function (assert) {
       // when
       const screen = await visit(`/competence/${competence.id}/prototypes/${proposalPrototype.id}/alternatives?view=workbench`);
 
@@ -124,21 +128,19 @@ module('Acceptance | Validate-Challenge', function(hooks) {
     });
   });
 
-  module('when have several prototypes in activeSkill', function(hooks) {
+  module('when have several prototypes in activeSkill', function (hooks) {
     let proposalPrototype, validatePrototype, skill;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       validatePrototype = this.server.create('challenge', { id: 'recChallenge1', status: 'validé', genealogy: 'Prototype 1', version: 1 });
       proposalPrototype = this.server.create('challenge', { id: 'recChallenge2', status: 'proposé', instruction: 'Epreuve à valider', genealogy: 'Prototype 1', version: 2 });
 
       skill = this.server.create('skill', { id: 'recSkill1', status: 'actif', challengeIds: ['recChallenge1', 'recChallenge2'] });
 
-      tube.update({
-        rawSkillIds: ['recSkill1'],
-      });
+      tube.update({ rawSkillIds: ['recSkill1'] });
     });
 
-    test('validate a new prototype version should archive the old validated prototype version ', async function(assert) {
+    test('validate a new prototype version should archive the old validated prototype version ', async function (assert) {
       // when
       const screen = await visit(`competence/${competence.id}/prototypes/list/${tube.id}/${skill.id}?view=workbench`);
 
@@ -165,22 +167,20 @@ module('Acceptance | Validate-Challenge', function(hooks) {
     });
   });
 
-  module('when have several skills', function(hooks) {
+  module('when have several skills', function (hooks) {
     let actifSkill, validatedPrototype, suggestedSkill, proposalPrototype;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       proposalPrototype = this.server.create('challenge', { id: 'recChallenge2', status: 'proposé', genealogy: 'Prototype 1', version: 1 });
       suggestedSkill = this.server.create('skill', { id: 'recSkill2', status: 'suggested', challengeIds: ['recChallenge2'], version: 2 });
 
       validatedPrototype = this.server.create('challenge', { id: 'recChallenge1', status: 'validé', genealogy: 'Prototype 1', version: 1 });
       actifSkill = this.server.create('skill', { id: 'recSkill1', status: 'actif', challengeIds: ['recChallenge1'], version: 1 });
 
-      tube.update({
-        rawSkillIds: [actifSkill.id, suggestedSkill.id],
-      });
+      tube.update({ rawSkillIds: [actifSkill.id, suggestedSkill.id] });
     });
 
-    test('validate a new prototype version from a suggested skill should archive current active skill', async function(assert) {
+    test('validate a new prototype version from a suggested skill should archive current active skill', async function (assert) {
       // when
       const screen = await visit(`/competence/${competence.id}/prototypes/${validatedPrototype.id}`);
 

--- a/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/creation-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
+module('Acceptance | Whitelisted URLs | Creation', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     this.server.create('config', 'default');
@@ -53,7 +53,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
     return authenticateSession();
   });
 
-  test('should create a whitelisted url', async function(assert) {
+  test('should create a whitelisted url', async function (assert) {
     // given
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');
@@ -73,7 +73,7 @@ module('Acceptance | Whitelisted URLs | Creation', function(hooks) {
     assert.strictEqual(screen.getAllByText('Strictement égale à').length, 3);
   });
 
-  test('should create a whitelisted url without comment and different check type', async function(assert) {
+  test('should create a whitelisted url without comment and different check type', async function (assert) {
     // given
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');

--- a/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/edition-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
+module('Acceptance | Whitelisted URLs | Edition', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const notifications = this.owner.lookup('service:notifications');
     notifications.setDefaultClearDuration(50);
     this.server.create('config', 'default');
@@ -53,7 +53,7 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
     return authenticateSession();
   });
 
-  test('should edit a whitelisted url', async function(assert) {
+  test('should edit a whitelisted url', async function (assert) {
     // given
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');
@@ -72,7 +72,7 @@ module('Acceptance | Whitelisted URLs | Edition', function(hooks) {
     assert.strictEqual(screen.getAllByText('Strictement égale à').length, 2);
   });
 
-  test('should edit a whitelisted url\'s url', async function(assert) {
+  test('should edit a whitelisted url\'s url', async function (assert) {
     // given
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');

--- a/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/acceptance/whitelisted-urls/list-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../setup-application-rendering';
 
-module('Acceptance | Whitelisted URLs | List', function(hooks) {
+module('Acceptance | Whitelisted URLs | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
     this.server.create('whitelisted-url', {
@@ -51,7 +51,7 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
     return authenticateSession();
   });
 
-  test('should display whitelisted urls when accessing list', async function(assert) {
+  test('should display whitelisted urls when accessing list', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');
@@ -64,7 +64,7 @@ module('Acceptance | Whitelisted URLs | List', function(hooks) {
     assert.dom(screen.getByText('http://chiens.fr')).exists();
   });
 
-  test('should delete delete whitelisted url', async function(assert) {
+  test('should delete delete whitelisted url', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('URLs à ne pas analyser');

--- a/pix-editor/tests/e2e/login.spec.js
+++ b/pix-editor/tests/e2e/login.spec.js
@@ -5,7 +5,7 @@ test.describe('Login', () => {
     await page.goto('/');
   });
 
-  test('se connecter et se déconnecter', async function({ page }) {
+  test('se connecter et se déconnecter', async function ({ page }) {
     await expect(page).toHaveURL('/connexion');
 
     await test.step('utiliser une clé invalide', async () => {

--- a/pix-editor/tests/e2e/static-course.spec.js
+++ b/pix-editor/tests/e2e/static-course.spec.js
@@ -1,7 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Tests statiques', () => {
-
   test.use({ storageState: 'editor.storageState.json' });
 
   test.beforeEach(async ({ page }) => {
@@ -9,7 +8,7 @@ test.describe('Tests statiques', () => {
     await expect(page.getByRole('heading', { name: 'Pix Editor' })).toBeVisible({ timeout: 10000 });
   });
 
-  test('accéder au détail d\'un test statique', async function({ page }) {
+  test('accéder au détail d\'un test statique', async function ({ page }) {
     await page.getByRole('link', { name: 'Tests statiques' }).click();
     await page.getByRole('cell', { name: 'Static Course 1' }).click();
 

--- a/pix-editor/tests/integration/components/alternatives-test.js
+++ b/pix-editor/tests/integration/components/alternatives-test.js
@@ -6,12 +6,12 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../setup-intl-rendering';
 
-module('Integration | Component | alternatives', function(hooks) {
+module('Integration | Component | alternatives', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let newAlternativeStub, store, alternatives;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     alternatives = [
       store.createRecord('challenge', {
@@ -49,9 +49,7 @@ module('Integration | Component | alternatives', function(hooks) {
       version: 2,
       genealogy: 'Prototype 1',
     });
-    store.createRecord('skill', {
-      challenges: [challenge, ...alternatives],
-    });
+    store.createRecord('skill', { challenges: [challenge, ...alternatives] });
 
     newAlternativeStub = sinon.stub();
 
@@ -59,7 +57,7 @@ module('Integration | Component | alternatives', function(hooks) {
     this.set('newAlternative', newAlternativeStub);
   });
 
-  test('displays challenge\'s alternatives', async function(assert) {
+  test('displays challenge\'s alternatives', async function (assert) {
     // when
     const screen = await render(hbs`
       <Alternatives
@@ -79,7 +77,7 @@ module('Integration | Component | alternatives', function(hooks) {
     assert.dom(screen.queryByRole('button', { name: 'Nouvelle déclinaison' })).doesNotExist();
   });
 
-  test('displays obsolete alternatives when checked', async function(assert) {
+  test('displays obsolete alternatives when checked', async function (assert) {
     // when
     const screen = await render(hbs`
       <Alternatives
@@ -99,8 +97,8 @@ module('Integration | Component | alternatives', function(hooks) {
     assert.dom(screen.queryByText('ceci est une alternative périmée')).exists();
   });
 
-  [ 'validé', 'proposé'].forEach((status) => {
-    test(`alternative button exist for alternative status ${status}`, async function(assert) {
+  ['validé', 'proposé'].forEach((status) => {
+    test(`alternative button exist for alternative status ${status}`, async function (assert) {
       // when
       this.set('challenge', alternatives.find((challenge) => challenge.status === status));
       const screen = await render(hbs`
@@ -120,7 +118,7 @@ module('Integration | Component | alternatives', function(hooks) {
     });
   });
   ['périmé', 'archivé'].forEach((status) => {
-    test(`alternative button does not exist for alternative status ${status}`, async function(assert) {
+    test(`alternative button does not exist for alternative status ${status}`, async function (assert) {
       // when
       this.set('challenge', alternatives.find((challenge) => challenge.status === status));
       const screen = await render(hbs`

--- a/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
@@ -5,14 +5,14 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | challenge-view | challenge-view', function(hooks) {
+module('Integration | Component | challenge-view | challenge-view', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen, store, challengeFromStore;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
-    challengeFromStore =
-      store.createRecord('challenge', {
+    challengeFromStore
+      = store.createRecord('challenge', {
         id: 'challengeProtoValidee',
         instruction: 'instructions',
         alternativeInstruction: 'alternativeInstruction',
@@ -52,9 +52,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         contextualizedFields: 'contextualizedFields',
         updatedAt: '2021-10-02T14:00:00.000Z',
       });
-
   });
-  test('it should display readonly form', async function(assert) {
+  test('it should display readonly form', async function (assert) {
     // given
     const challenge = challengeFromStore;
     // when
@@ -101,7 +100,7 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
     assert.dom(screen.getByLabelText('Id')).hasValue('challengeProtoValidee');
   });
 
-  test('it should display actions', async function(assert) {
+  test('it should display actions', async function (assert) {
     // given
     const challenge = challengeFromStore;
 
@@ -121,9 +120,9 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
     assert.ok(link.href.endsWith('/api/urlto/challengeProtoValidee'));
   });
 
-  module('#header', function() {
-    module('when challenge is validate', function() {
-      test('it should display only "Validée" when no date provided', async function(assert) {
+  module('#header', function () {
+    module('when challenge is validate', function () {
+      test('it should display only "Validée" when no date provided', async function (assert) {
         // given
         challengeFromStore.validatedAt = null;
         challengeFromStore.status = Challenge.STATUSES.VALIDE;
@@ -143,7 +142,7 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         // then
         assert.dom(screen.getByText('Validée')).exists();
       });
-      test('it should display "Validée le 21/02/2025" when date provided', async function(assert) {
+      test('it should display "Validée le 21/02/2025" when date provided', async function (assert) {
         // given
         challengeFromStore.validatedAt = new Date('2025-02-21T12:00:00Z');
         challengeFromStore.status = Challenge.STATUSES.VALIDE;
@@ -164,8 +163,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         assert.dom(screen.getByText('Validée le 21/02/2025')).exists();
       });
     });
-    module('when challenge is archived', function() {
-      test('it should display only "Archivée" when no date provided', async function(assert) {
+    module('when challenge is archived', function () {
+      test('it should display only "Archivée" when no date provided', async function (assert) {
         // given
         challengeFromStore.archivedAt = null;
         challengeFromStore.status = Challenge.STATUSES.ARCHIVE;
@@ -185,7 +184,7 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         // then
         assert.dom(screen.getByText('Archivée')).exists();
       });
-      test('it should display "Archivée le 21/02/2025" when date provided', async function(assert) {
+      test('it should display "Archivée le 21/02/2025" when date provided', async function (assert) {
         // given
         challengeFromStore.archivedAt = new Date('2025-02-21T12:00:00Z');
         challengeFromStore.status = Challenge.STATUSES.ARCHIVE;
@@ -206,8 +205,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         assert.dom(screen.getByText('Archivée le 21/02/2025')).exists();
       });
     });
-    module('when challenge is obsolete', function() {
-      test('it should display only "Périmée" when no date provided', async function(assert) {
+    module('when challenge is obsolete', function () {
+      test('it should display only "Périmée" when no date provided', async function (assert) {
         // given
         challengeFromStore.madeObsoleteAt = null;
         challengeFromStore.status = Challenge.STATUSES.PERIME;
@@ -227,7 +226,7 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         // then
         assert.dom(screen.getByText('Périmée')).exists();
       });
-      test('it should display "Périmée le 21/02/2025" when date provided', async function(assert) {
+      test('it should display "Périmée le 21/02/2025" when date provided', async function (assert) {
         // given
         challengeFromStore.madeObsoleteAt = new Date('2025-02-21T12:00:00Z');
         challengeFromStore.status = Challenge.STATUSES.PERIME;
@@ -248,8 +247,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         assert.dom(screen.getByText('Périmée le 21/02/2025')).exists();
       });
     });
-    module('when challenge is proposed', function() {
-      test('it should display "Proposée"', async function(assert) {
+    module('when challenge is proposed', function () {
+      test('it should display "Proposée"', async function (assert) {
         // given
         challengeFromStore.status = Challenge.STATUSES.PROPOSE;
         const challenge = challengeFromStore;
@@ -269,8 +268,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         assert.dom(screen.getByText('Proposée')).exists();
       });
     });
-    module('when challenge is prototype', function() {
-      test('it should display wright title', async function(assert) {
+    module('when challenge is prototype', function () {
+      test('it should display wright title', async function (assert) {
         // given
         const challenge = challengeFromStore;
         // when
@@ -287,8 +286,8 @@ module('Integration | Component | challenge-view | challenge-view', function(hoo
         assert.dom(screen.getByText('Proto (V1)')).exists();
       });
     });
-    module('when challenge is alternative', function() {
-      test('it should display wright title', async function(assert) {
+    module('when challenge is alternative', function () {
+      test('it should display wright title', async function (assert) {
         // given
         challengeFromStore.genealogy = 'Décliné 1';
         challengeFromStore.alternativeVersion = 2;

--- a/pix-editor/tests/integration/components/challenges-production/challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/challenges-production-test.gjs
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | challenges-production | challenges-production', function(hooks) {
+module('Integration | Component | challenges-production | challenges-production', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen, store;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
     const skillInStore = store.createRecord('skill', {
       id: 'skillAId',
@@ -88,9 +88,9 @@ module('Integration | Component | challenges-production | challenges-production'
     screen = await render(<template><ChallengesProduction @skill={{skillInStore}} @challenges={{challengesInStore}} /></template>);
   });
 
-  module('when displaying the list', function() {
-    module('when box to display obsolete challenges not checked', function() {
-      test('should display all but obsolete', async function(assert) {
+  module('when displaying the list', function () {
+    module('when box to display obsolete challenges not checked', function () {
+      test('should display all but obsolete', async function (assert) {
         // then
         const validatedChallenges = screen.queryAllByText('validé');
         const obsoleteChallenges = screen.queryAllByText('périmé');
@@ -103,8 +103,8 @@ module('Integration | Component | challenges-production | challenges-production'
         assert.strictEqual(proposedChallenges.length, 1);
       });
     });
-    module('when box to display obsolete challenges checked', function() {
-      test('display all challenges', async function(assert) {
+    module('when box to display obsolete challenges checked', function () {
+      test('display all challenges', async function (assert) {
         // when
         await click(screen.getByLabelText('Afficher les épreuves périmées'));
 
@@ -122,8 +122,8 @@ module('Integration | Component | challenges-production | challenges-production'
     });
   });
 
-  module('list item', function() {
-    test('should display all expected info for a given challenge', async function(assert) {
+  module('list item', function () {
+    test('should display all expected info for a given challenge', async function (assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
       const prototype = validatedChallenges[1];
@@ -136,15 +136,15 @@ module('Integration | Component | challenges-production | challenges-production'
       assert.dom(prototype).includesText('Copier le lien de l\'épreuve challengeProtoValidee');
     });
 
-    module('copy preview url action', function() {
-      test('copy preview url button should exist', async function(assert) {
+    module('copy preview url action', function () {
+      test('copy preview url button should exist', async function (assert) {
         // then
         assert.dom(screen.getByRole('button', { name: 'Copier le lien de l\'épreuve challengeProtoValidee' })).exists();
       });
     });
 
-    module('go to preview action', function() {
-      test('should redirect to preview', async function(assert) {
+    module('go to preview action', function () {
+      test('should redirect to preview', async function (assert) {
         // when
         const a = screen.getByRole('link', { name: 'Prévisualiser l\'épreuve challengeProtoValidee' });
 

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -7,11 +7,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | challenges-production | localized-challenges-production', function(hooks) {
+module('Integration | Component | challenges-production | localized-challenges-production', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen, store, skill, challengeLocalesNl, challengeLocalesFr, challengeLocalesEs, competence;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
     skill = store.createRecord('skill', {
       id: 'skillAId',
@@ -250,8 +250,8 @@ module('Integration | Component | challenges-production | localized-challenges-p
     ];
   });
 
-  module('list item', function(hooks) {
-    hooks.beforeEach(async ()=> {
+  module('list item', function (hooks) {
+    hooks.beforeEach(async () => {
       screen = await render(<template>
         <LocalizedChallengesProduction
           @skill={{skill}}
@@ -261,7 +261,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
       </template>);
     });
 
-    test('should display all expected info for a given challenge', async function(assert) {
+    test('should display all expected info for a given challenge', async function (assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
       const prototype = validatedChallenges[1];
@@ -272,8 +272,8 @@ module('Integration | Component | challenges-production | localized-challenges-p
       assert.dom(prototype).includesText('validé');
       assert.dom(prototype).includesText('En prod');
     });
-    module('it should display actions', function() {
-      test('when have translation for current locale', async function(assert) {
+    module('it should display actions', function () {
+      test('when have translation for current locale', async function (assert) {
         // when
         await clickByText('ouvrir option pour l\'épreuve challengeProtoValide');
 
@@ -289,7 +289,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
         assert.dom(screen.getByRole('button', { name: 'Copier le lien de l\'épreuve challengeProtoValideeNl' })).exists();
       });
 
-      test('when primary is in current locale', async function(assert) {
+      test('when primary is in current locale', async function (assert) {
         // when
         await clickByText('ouvrir option pour l\'épreuve challengeDecliNl');
 
@@ -298,7 +298,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
         assert.dom(screen.queryByRole('list', { name: 'traduction' })).doesNotExist();
       });
 
-      test('when have not translation for current locale', async function(assert) {
+      test('when have not translation for current locale', async function (assert) {
         // when
         await clickByText('ouvrir option pour l\'épreuve challengeDecliProposee');
 
@@ -308,7 +308,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
       });
     });
 
-    test('should display appropriate translation statuses for each challenge', async function(assert) {
+    test('should display appropriate translation statuses for each challenge', async function (assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
 
@@ -334,8 +334,8 @@ module('Integration | Component | challenges-production | localized-challenges-p
     });
   });
 
-  module('when displaying the list', function() {
-    test('it should display only challenge who has selected locale or fr', async function(assert) {
+  module('when displaying the list', function () {
+    test('it should display only challenge who has selected locale or fr', async function (assert) {
       // given
 
       // when
@@ -353,8 +353,8 @@ module('Integration | Component | challenges-production | localized-challenges-p
       assert.strictEqual(challengeListWithoutThead.length, 3);
     });
 
-    module('when locale is not in phrase', function() {
-      test('when locale is not in phrase', async function(assert) {
+    module('when locale is not in phrase', function () {
+      test('when locale is not in phrase', async function (assert) {
         // given
 
         // when
@@ -373,8 +373,8 @@ module('Integration | Component | challenges-production | localized-challenges-p
       });
     });
 
-    module('when box to display obsolete challenges not checked', function() {
-      test('should display all but obsolete', async function(assert) {
+    module('when box to display obsolete challenges not checked', function () {
+      test('should display all but obsolete', async function (assert) {
         // when
         screen = await render(<template>
           <LocalizedChallengesProduction
@@ -396,8 +396,8 @@ module('Integration | Component | challenges-production | localized-challenges-p
         assert.strictEqual(obsoleteChallenges.length, 0);
       });
     });
-    module('when box to display obsolete challenges checked', function() {
-      test('display all challenges', async function(assert) {
+    module('when box to display obsolete challenges checked', function () {
+      test('display all challenges', async function (assert) {
         // when
         screen = await render(<template>
           <LocalizedChallengesProduction

--- a/pix-editor/tests/integration/components/competence-overview/competence-overview-skill-test.gjs
+++ b/pix-editor/tests/integration/components/competence-overview/competence-overview-skill-test.gjs
@@ -4,13 +4,12 @@ import { module, test } from 'qunit';
 import CompetenceOverviewSkill from '../../../../components/competence-overview/competence-overview-skill';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence-overview | competence-overview-skill', function(hooks) {
-
+module('Integration | Component | competence-overview | competence-overview-skill', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let screen;
 
-  test('it should display a skill cell with validated Challenges on it', async function(assert) {
+  test('it should display a skill cell with validated Challenges on it', async function (assert) {
     // given
     const skillOverview = {
       id: 'skillOverviewId',
@@ -31,10 +30,9 @@ module('Integration | Component | competence-overview | competence-overview-skil
     assert.dom(screen.queryByText('NR')).doesNotExist();
     const link = screen.getByRole('link', { name: '@skillOverviewName1 2 (2)' });
     assert.dom(link).hasClass('production-skill-overview-action--validated');
-
   });
 
-  test('it should display a skill cell with only proposed Challenges on it', async function(assert) {
+  test('it should display a skill cell with only proposed Challenges on it', async function (assert) {
     // given
     const skillOverview = {
       id: 'skillOverviewId',
@@ -56,7 +54,7 @@ module('Integration | Component | competence-overview | competence-overview-skil
     assert.dom(link).hasClass('production-skill-overview-action--proposed');
   });
 
-  test('it should display a skill cell with no challenges on it', async function(assert) {
+  test('it should display a skill cell with no challenges on it', async function (assert) {
     // given
     const skillOverview = {
       id: 'skillOverviewId',
@@ -78,7 +76,7 @@ module('Integration | Component | competence-overview | competence-overview-skil
     assert.dom(link).hasClass('production-skill-overview-action--empty');
   });
 
-  test('it should display a skill cell with no skill', async function(assert) {
+  test('it should display a skill cell with no skill', async function (assert) {
     // when
     screen = await render(<template><CompetenceOverviewSkill @skillOverview={{null}} /></template>);
 
@@ -88,7 +86,7 @@ module('Integration | Component | competence-overview | competence-overview-skil
     assert.dom(screen.queryByTitle('Nombre d\'épreuves en cours de construction')).doesNotExist();
   });
 
-  test('it should display a skill cell with `NR` challenge', async function(assert) {
+  test('it should display a skill cell with `NR` challenge', async function (assert) {
     // given
     const skillOverview = {
       id: 'skillOverviewId',

--- a/pix-editor/tests/integration/components/competence/competence-actions-test.js
+++ b/pix-editor/tests/integration/components/competence/competence-actions-test.js
@@ -5,24 +5,23 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence/competence-actions', function(hooks) {
+module('Integration | Component | competence/competence-actions', function (hooks) {
   setupIntlRenderingTest(hooks);
   let selectViewStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     selectViewStub = sinon.stub();
     this.selectView = selectViewStub;
   });
 
-  module('#skillSection', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('#skillSection', function (hooks) {
+    hooks.beforeEach(function () {
       this.section = 'skills';
       this.exportSkills = sinon.stub();
       this.refresh = sinon.stub();
     });
 
-    test('it should display draft view', async function(assert) {
+    test('it should display draft view', async function (assert) {
       // when
       await render(hbs` <Competence::CompetenceActions
             @section={{this.section}}
@@ -37,7 +36,7 @@ module('Integration | Component | competence/competence-actions', function(hooks
       assert.ok(selectViewStub.calledWith('draft'));
     });
 
-    test('it should have draft active tab if view is set to `draft`', async function(assert) {
+    test('it should have draft active tab if view is set to `draft`', async function (assert) {
       // given
       this.view = 'draft';
 
@@ -54,11 +53,10 @@ module('Integration | Component | competence/competence-actions', function(hooks
     });
   });
 
-  test('it renders', async function(assert) {
-
+  test('it renders', async function (assert) {
     // given
 
-    this.set('externalAction', ()=>{});
+    this.set('externalAction', () => {});
 
     // when
     await render(hbs` <Competence::CompetenceActions
@@ -70,6 +68,5 @@ module('Integration | Component | competence/competence-actions', function(hooks
     // then
 
     assert.dom(this.element.querySelector('.production')).hasText('En production');
-
   });
 });

--- a/pix-editor/tests/integration/components/competence/competence-footer-test.js
+++ b/pix-editor/tests/integration/components/competence/competence-footer-test.js
@@ -4,11 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence/competence-footer', function(hooks) {
+module('Integration | Component | competence/competence-footer', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-
+  test('it renders', async function (assert) {
     // given
     this.section = 'skills';
     this.competence = {};

--- a/pix-editor/tests/integration/components/competence/competence-grid-test.js
+++ b/pix-editor/tests/integration/components/competence/competence-grid-test.js
@@ -5,19 +5,17 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence-grid', function(hooks) {
+module('Integration | Component | competence-grid', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('using competence-overview', function(hooks) {
-    hooks.beforeEach(function() {
-      const competenceOverview = EmberObject.create({
-        thematicOverviews: [],
-      });
+  module('using competence-overview', function (hooks) {
+    hooks.beforeEach(function () {
+      const competenceOverview = EmberObject.create({ thematicOverviews: [] });
 
       this.set('competenceOverview', competenceOverview);
     });
 
-    test('it renders', async function(assert) {
+    test('it renders', async function (assert) {
       // when
       await render(hbs`<Competence::CompetenceGrid @competenceOverview={{this.competenceOverview}} />`);
 
@@ -26,16 +24,14 @@ module('Integration | Component | competence-grid', function(hooks) {
     });
   });
 
-  module('using competence', function(hooks) {
-    hooks.beforeEach(function() {
-      const competence = EmberObject.create({
-        sortedThemes: [],
-      });
+  module('using competence', function (hooks) {
+    hooks.beforeEach(function () {
+      const competence = EmberObject.create({ sortedThemes: [] });
 
       this.set('competence', competence);
     });
 
-    test('it renders', async function(assert) {
+    test('it renders', async function (assert) {
       // when
       await render(hbs`<Competence::CompetenceGrid @competence={{this.competence}} />`);
 

--- a/pix-editor/tests/integration/components/competence/competence-grid-thematic-test.js
+++ b/pix-editor/tests/integration/components/competence/competence-grid-thematic-test.js
@@ -7,12 +7,11 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence/competence-grid-thematic', function(hooks) {
-
+module('Integration | Component | competence/competence-grid-thematic', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('if thematic has tubes', function(hooks) {
-    hooks.beforeEach(function() {
+  module('if thematic has tubes', function (hooks) {
+    hooks.beforeEach(function () {
       const productionTube1 = EmberObject.create({
         name: '@productionTube1',
         filledProductionSkills: [],
@@ -31,7 +30,11 @@ module('Integration | Component | competence/competence-grid-thematic', function
 
       const thematic = EmberObject.create({
         name: 'Thematic',
-        tubes: [productionTube1, productionTube2, draftTube],
+        tubes: [
+          productionTube1,
+          productionTube2,
+          draftTube,
+        ],
         productionTubes: [productionTube1, productionTube2],
       });
 
@@ -52,14 +55,18 @@ module('Integration | Component | competence/competence-grid-thematic', function
 
       const thematicOverview = EmberObject.create({
         name: 'ThematicOverview',
-        tubeOverviews: [tubeOverview1, tubeOverview2, draftTubeOverview],
+        tubeOverviews: [
+          tubeOverview1,
+          tubeOverview2,
+          draftTubeOverview,
+        ],
       });
 
       this.set('thematic', thematic);
       this.set('thematicOverview', thematicOverview);
     });
 
-    test('it should display a thematic cell with appropriate rowspan', async function(assert) {
+    test('it should display a thematic cell with appropriate rowspan', async function (assert) {
       // given
       this.set('view', 'workbench');
       this.set('section', 'challenges');
@@ -75,7 +82,7 @@ module('Integration | Component | competence/competence-grid-thematic', function
     });
 
     ['workbench', 'production'].forEach((view) => {
-      test(`it should display a link to display theme management if section is skills and view is ${view}`, async function(assert) {
+      test(`it should display a link to display theme management if section is skills and view is ${view}`, async function (assert) {
         // given
         this.set('section', 'skills');
         this.set('view', view);
@@ -90,7 +97,7 @@ module('Integration | Component | competence/competence-grid-thematic', function
       });
     });
 
-    test('it should display production tubes if section is set on challenges and view is production', async function(assert) {
+    test('it should display production tubes if section is set on challenges and view is production', async function (assert) {
       // given
       this.set('view', 'production');
       this.set('section', 'challenges');
@@ -102,11 +109,14 @@ module('Integration | Component | competence/competence-grid-thematic', function
 
       // then
       assert.dom('[data-test-tube-cell]').exists({ count: 3 });
-
     });
 
-    ['skills', 'i18n', 'quality'].forEach((section) => {
-      test(`it should display production tubes if section is set on ${section} and view is production`, async function(assert) {
+    [
+      'skills',
+      'i18n',
+      'quality',
+    ].forEach((section) => {
+      test(`it should display production tubes if section is set on ${section} and view is production`, async function (assert) {
         // given
         this.set('view', 'production');
         this.set('section', section);
@@ -118,12 +128,11 @@ module('Integration | Component | competence/competence-grid-thematic', function
 
         // then
         assert.dom('[data-test-tube-cell]').exists({ count: 2 });
-
       });
     });
 
     ['skills', 'challenges'].forEach((section) => {
-      test(`it should display all tubes if section is set on ${section} and view is workbench`, async function(assert) {
+      test(`it should display all tubes if section is set on ${section} and view is workbench`, async function (assert) {
         // given
         this.set('view', 'workbench');
         this.set('section', section);
@@ -135,11 +144,10 @@ module('Integration | Component | competence/competence-grid-thematic', function
 
         // then
         assert.dom('[data-test-tube-cell]').exists({ count: 3 });
-
       });
     });
 
-    test('it should display management tube buttons if section is skills and view is workbench and mayCreateTube is true', async function(assert) {
+    test('it should display management tube buttons if section is skills and view is workbench and mayCreateTube is true', async function (assert) {
       // given
       const mayCreateTubeStub = sinon.stub().returns(true);
       class Access extends Service {
@@ -162,13 +170,11 @@ module('Integration | Component | competence/competence-grid-thematic', function
       // then
       assert.dom('[data-test-add-tube]').exists();
       assert.dom('[data-test-sort-tube]').exists();
-
     });
   });
 
-  module('if thematic has no tube', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('if thematic has no tube', function (hooks) {
+    hooks.beforeEach(function () {
       const thematic = EmberObject.create({
         name: 'Thematic',
         tubes: [],
@@ -177,13 +183,15 @@ module('Integration | Component | competence/competence-grid-thematic', function
       this.set('thematic', thematic);
     });
 
-    [{ section: 'skills', view: 'production' },
+    [
+      { section: 'skills', view: 'production' },
       { section: 'skills', view: 'workbench' },
       { section: 'challenges', view: 'production' },
       { section: 'challenges', view: 'workbench' },
       { section: 'i18n', view: null },
-      { section: 'quality', view: null }].forEach((item) => {
-      test(`it should not be display if section is ${item.section} and view is ${item.view} and mayCreateTube is false`, async function(assert) {
+      { section: 'quality', view: null },
+    ].forEach((item) => {
+      test(`it should not be display if section is ${item.section} and view is ${item.view} and mayCreateTube is false`, async function (assert) {
         // given
         const mayCreateTubeStub = sinon.stub().returns(false);
         class Access extends Service {
@@ -202,7 +210,7 @@ module('Integration | Component | competence/competence-grid-thematic', function
       });
     });
 
-    test('it should be display with a create tube button if section is skills and view is workbench and mayCreateTube is true', async function(assert) {
+    test('it should be display with a create tube button if section is skills and view is workbench and mayCreateTube is true', async function (assert) {
       // given
       const mayCreateTubeStub = sinon.stub().returns(true);
       class Access extends Service {

--- a/pix-editor/tests/integration/components/competence/competence-grid-tube-test.js
+++ b/pix-editor/tests/integration/components/competence/competence-grid-tube-test.js
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence/competence-grid-tube', function(hooks) {
+module('Integration | Component | competence/competence-grid-tube', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const store = this.owner.lookup('service:store');
 
     const productionSkill1 = store.createRecord('skill', {
@@ -16,11 +16,13 @@ module('Integration | Component | competence/competence-grid-tube', function(hoo
       name: '@productionSkill1',
       level: 1,
       status: 'actif',
-      challenges: [store.createRecord('challenge', {
-        id: 'recChallenge0',
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          id: 'recChallenge0',
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
 
     const workbenchSkill1 = store.createRecord('skill', {
@@ -40,7 +42,7 @@ module('Integration | Component | competence/competence-grid-tube', function(hoo
   });
 
   ['workbench', 'production'].forEach((view) => {
-    test(`it should display a link to display tube management if section is skills and view is ${view}`, async function(assert) {
+    test(`it should display a link to display tube management if section is skills and view is ${view}`, async function (assert) {
       // given
       this.set('section', 'skills');
       this.set('view', view);
@@ -55,8 +57,7 @@ module('Integration | Component | competence/competence-grid-tube', function(hoo
     });
   });
 
-  test('it should display a link section is set on `skills` and view on `workbench`', async function(assert) {
-
+  test('it should display a link section is set on `skills` and view on `workbench`', async function (assert) {
     // given
     this.set('view', 'workbench');
     this.set('section', 'skills');
@@ -68,10 +69,9 @@ module('Integration | Component | competence/competence-grid-tube', function(hoo
 
     // then
     assert.dom('[data-test-tube-cell] a').hasText('@tube');
-
   });
 
-  test('it should display filled skills if view is set on `workbench`', async function(assert) {
+  test('it should display filled skills if view is set on `workbench`', async function (assert) {
     // given
     this.set('view', 'workbench');
     this.set('section', 'skills');
@@ -84,10 +84,9 @@ module('Integration | Component | competence/competence-grid-tube', function(hoo
     // then
     assert.dom(screen.queryByText('@workbenchSkill2')).exists();
     assert.dom(screen.queryByText('@productionSkill1')).exists();
-
   });
 
-  test('it should display production skills if view is set on `production`', async function(assert) {
+  test('it should display production skills if view is set on `production`', async function (assert) {
     // given
     this.set('view', 'production');
     this.set('section', 'skills');
@@ -100,6 +99,5 @@ module('Integration | Component | competence/competence-grid-tube', function(hoo
     // then
     assert.dom(screen.queryByText('@workbenchSkill2')).doesNotExist();
     assert.dom(screen.queryByText('@productionSkill1')).exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/competence/competence-header-test.gjs
+++ b/pix-editor/tests/integration/components/competence/competence-header-test.gjs
@@ -4,11 +4,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | competence/competence-header', function(hooks) {
+module('Integration | Component | competence/competence-header', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen, store, competence;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
     competence = store.createRecord('competence', {
       title: 'Lancer de hache',
@@ -17,9 +17,9 @@ module('Integration | Component | competence/competence-header', function(hooks)
     });
   });
 
-  test('renders the language and the challenges menu', async function(assert) {
+  test('renders the language and the challenges menu', async function (assert) {
     // given
-    const mockFn = ()=>{};
+    const mockFn = () => {};
 
     //  when
     screen = await render(<template>

--- a/pix-editor/tests/integration/components/competence/grid/cell-production-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-production-test.js
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Integration | Component | competence/grid/cell-production', function(hooks) {
+module('Integration | Component | competence/grid/cell-production', function (hooks) {
   setupIntlRenderingTest(hooks);
   let skillOverview, skillOverviewNR, skillOverviewFR, skillOverviewDE, skillOverviewEN;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     // given
     skillOverview = EmberObject.create({
       name: 'skillOverview',
@@ -46,7 +46,7 @@ module('Integration | Component | competence/grid/cell-production', function(hoo
     });
   });
 
-  test('it should display a number of production challenges and draft alternative', async function(assert) {
+  test('it should display a number of production challenges and draft alternative', async function (assert) {
     // given
     this.set('skillOverview', skillOverview);
 
@@ -58,7 +58,7 @@ module('Integration | Component | competence/grid/cell-production', function(hoo
     assert.dom('[data-test-draft-alternative-length]').hasText('(2)');
   });
 
-  test('it should display a number of production challenges and draft alternative filtered by language', async function(assert) {
+  test('it should display a number of production challenges and draft alternative filtered by language', async function (assert) {
     // given
     this.set('languageFilter', 'Francophone');
     this.set('skillOverview', skillOverviewFR);
@@ -71,7 +71,7 @@ module('Integration | Component | competence/grid/cell-production', function(hoo
     assert.dom('[data-test-draft-alternative-length]').hasText('(1)');
   });
 
-  test('it should display `NR` if prototype is not declinable', async function(assert) {
+  test('it should display `NR` if prototype is not declinable', async function (assert) {
     // given
     this.set('skillOverview', skillOverviewNR);
 
@@ -80,10 +80,9 @@ module('Integration | Component | competence/grid/cell-production', function(hoo
 
     // then
     assert.dom('.not-declinable').hasText('NR');
-
   });
 
-  test('it should alert with danger class if have no challenge and no draft', async function(assert) {
+  test('it should alert with danger class if have no challenge and no draft', async function (assert) {
     // given
     this.set('languageFilter', 'Allemand');
     this.set('skillOverview', skillOverviewDE);
@@ -97,7 +96,7 @@ module('Integration | Component | competence/grid/cell-production', function(hoo
     assert.dom('[data-test-skill-cell]').hasClass('danger');
   });
 
-  test('it should alert with warning class if have no challenge but draft', async function(assert) {
+  test('it should alert with warning class if have no challenge but draft', async function (assert) {
     // given
     this.set('languageFilter', 'Anglais');
     this.set('skillOverview', skillOverviewEN);

--- a/pix-editor/tests/integration/components/competence/grid/cell-quality-test.gjs
+++ b/pix-editor/tests/integration/components/competence/grid/cell-quality-test.gjs
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Integration | Component | quality-view', function(hooks) {
+module('Integration | Component | quality-view', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // given
     const skill = {
       productionPrototype: {},

--- a/pix-editor/tests/integration/components/competence/grid/cell-skill-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-skill-test.js
@@ -4,9 +4,9 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Integration | Component | competence/grid/cell-skill', function(hooks) {
+module('Integration | Component | competence/grid/cell-skill', function (hooks) {
   setupIntlRenderingTest(hooks);
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     // given
     const store = this.owner.lookup('service:store');
 
@@ -34,7 +34,7 @@ module('Integration | Component | competence/grid/cell-skill', function(hooks) {
     this.set('skill', skill);
   });
 
-  test('it should display a clue status and number of tutorials ', async function(assert) {
+  test('it should display a clue status and number of tutorials ', async function (assert) {
     // when
     await render(hbs`<Competence::Grid::CellSkill @skill={{this.skill}}/>`);
 
@@ -42,11 +42,10 @@ module('Integration | Component | competence/grid/cell-skill', function(hooks) {
     assert.dom('.skill-name').hasText('skill_name');
     assert.dom('.idea.icon').hasClass('validated');
     assert.dom('.tuto-count').hasText('2 - 1');
-
   });
 
-  module('#languageFilter activated', function() {
-    test('it should display a clue status and number of tutorials filtered by language', async function(assert) {
+  module('#languageFilter activated', function () {
+    test('it should display a clue status and number of tutorials filtered by language', async function (assert) {
       // given
       this.set('languageFilter', 'en');
 
@@ -58,7 +57,7 @@ module('Integration | Component | competence/grid/cell-skill', function(hooks) {
       assert.dom('.tuto-count').hasText('1 - 0');
     });
 
-    test('it should alert with warning class if have no `tutoMore` or `tutoSolution`', async function(assert) {
+    test('it should alert with warning class if have no `tutoMore` or `tutoSolution`', async function (assert) {
       // given
       this.set('languageFilter', 'en');
 
@@ -69,7 +68,7 @@ module('Integration | Component | competence/grid/cell-skill', function(hooks) {
       assert.dom('.skill-cell').hasClass('warning');
     });
 
-    test('it should alert with danger class if have no `tutoMore` and `tutoSolution`', async function(assert) {
+    test('it should alert with danger class if have no `tutoMore` and `tutoSolution`', async function (assert) {
       // given
       this.set('languageFilter', 'de');
 

--- a/pix-editor/tests/integration/components/competence/grid/cell-skill-workbench-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-skill-workbench-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Integration | Component | competence/grid/cell-skill-workbench', function(hooks) {
+module('Integration | Component | competence/grid/cell-skill-workbench', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let store;
@@ -12,7 +12,7 @@ module('Integration | Component | competence/grid/cell-skill-workbench', functio
   const skillName = '@skill1';
   let tube;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     // given
     store = this.owner.lookup('service:store');
     skillRecord1 = store.createRecord('skill', {
@@ -20,11 +20,13 @@ module('Integration | Component | competence/grid/cell-skill-workbench', functio
       name: skillName,
       level: 1,
       status: 'actif',
-      challenges: [store.createRecord('challenge', {
-        id: 'recChallenge0',
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          id: 'recChallenge0',
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
     skillRecord2 = store.createRecord('skill', {
       id: 'rec654259',
@@ -60,28 +62,34 @@ module('Integration | Component | competence/grid/cell-skill-workbench', functio
       id: 'rec123456',
       name: 'tubeName',
       rawSkills: [
-        skillRecord1
-        , skillRecord2
-        , skillRecord3
-        , skillRecord4
-        , skillRecord5
-        , skillRecord6,
+        skillRecord1,
+        skillRecord2,
+        skillRecord3,
+        skillRecord4,
+        skillRecord5,
+        skillRecord6,
       ],
     });
     this.skill = skillRecord1;
-    this.skills = [skillRecord1, skillRecord2, skillRecord3, skillRecord4, skillRecord5, skillRecord6];
+    this.skills = [
+      skillRecord1,
+      skillRecord2,
+      skillRecord3,
+      skillRecord4,
+      skillRecord5,
+      skillRecord6,
+    ];
     this.tube = tube;
 
     // when
     await render(hbs`<Competence::Grid::CellSkillWorkbench @tube={{this.tube}} @skill={{this.skill}} @skills={{this.skills}}/>`);
   });
 
-  test('it should display a skill count by status', async function(assert) {
+  test('it should display a skill count by status', async function (assert) {
     // then
     assert.dom('[data-test-draft-count]').hasText('2');
     assert.dom('[data-test-active-count]').hasText('1');
     assert.dom('[data-test-archived-count]').hasText('2');
     assert.dom('[data-test-obsolete-count]').hasText('1');
   });
-
 });

--- a/pix-editor/tests/integration/components/competence/grid/cell-workbench-test.js
+++ b/pix-editor/tests/integration/components/competence/grid/cell-workbench-test.js
@@ -5,14 +5,14 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Integration | Component | competence/grid/cell-workbench', function(hooks) {
+module('Integration | Component | competence/grid/cell-workbench', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
   });
 
-  test('it should display a prototype count by status', async function(assert) {
+  test('it should display a prototype count by status', async function (assert) {
     // given
     const validatedPrototype = store.createRecord('challenge', {
       id: 'recChallenge0',
@@ -53,7 +53,13 @@ module('Integration | Component | competence/grid/cell-workbench', function(hook
       id: 'recSkill1',
       name: 'skill1',
       level: 1,
-      challenges: [validatedPrototype, archivedPrototype1, archivedPrototype2, draftPrototype1, deletedPrototype1],
+      challenges: [
+        validatedPrototype,
+        archivedPrototype1,
+        archivedPrototype2,
+        draftPrototype1,
+        deletedPrototype1,
+      ],
     });
     const skill2 = store.createRecord('skill', {
       id: 'recSkill2',

--- a/pix-editor/tests/integration/components/dropdown-menu-test.gjs
+++ b/pix-editor/tests/integration/components/dropdown-menu-test.gjs
@@ -4,17 +4,16 @@ import { module, test } from 'qunit';
 import DropdownMenu from '../../../components/dropdown-menu';
 import { setupIntlRenderingTest } from '../../setup-intl-rendering';
 
-module('Integration | Component | dropdown-menu', function(hooks) {
-
+module('Integration | Component | dropdown-menu', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let screen;
 
-  test('it should display menu on click', async function(assert) {
+  test('it should display menu on click', async function (assert) {
     // given
 
     // when
-    screen = await(render(<template>
+    screen = await (render(<template>
       <DropdownMenu
         @ariaLabel="dropdown menu label"
         @iconName="moreVert"

--- a/pix-editor/tests/integration/components/field/checkbox-test.js
+++ b/pix-editor/tests/integration/components/field/checkbox-test.js
@@ -4,16 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | checkbox', function(hooks) {
+module('Integration | Component | checkbox', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<Field::Checkbox @label="search" />`);
 
     assert.dom('.ui.checkbox').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/field/files-test.js
+++ b/pix-editor/tests/integration/components/field/files-test.js
@@ -4,16 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | form-files', function(hooks) {
+module('Integration | Component | form-files', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<Field::Files />`);
 
     assert.dom('.field').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/field/illustration-test.js
+++ b/pix-editor/tests/integration/components/field/illustration-test.js
@@ -4,16 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | form-illustration', function(hooks) {
+module('Integration | Component | form-illustration', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<Field::Illustration />`);
 
     assert.dom('.field').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/field/input-test.js
+++ b/pix-editor/tests/integration/components/field/input-test.js
@@ -4,16 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | form-input', function(hooks) {
+module('Integration | Component | form-input', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<Field::Input />`);
 
     assert.dom('.field').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/field/mde-test.js
+++ b/pix-editor/tests/integration/components/field/mde-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | form-mde.hbs', function(hooks) {
+module('Integration | Component | form-mde.hbs', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display Tui editor if `edition` is `true`', async function(assert) {
+  test('it should display Tui editor if `edition` is `true`', async function (assert) {
     // given
     this.set('edition', true);
 
@@ -18,7 +18,7 @@ module('Integration | Component | form-mde.hbs', function(hooks) {
     assert.dom('[data-test-tui-editor]').exists();
   });
 
-  test('it should display `MarkdownToHtml` if `edition` is `false`', async function(assert) {
+  test('it should display `MarkdownToHtml` if `edition` is `false`', async function (assert) {
     // given
     this.set('edition', false);
 

--- a/pix-editor/tests/integration/components/field/quality-test.js
+++ b/pix-editor/tests/integration/components/field/quality-test.js
@@ -4,17 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | quality', function(hooks) {
+module('Integration | Component | quality', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-
+  test('it renders', async function (assert) {
     this.set('challenge', { accessibility1: false, accessibility2: false, spoil: false, responsive: false });
 
     await render(hbs`<Field::Quality @title="form_title"
                                      @challenge={{this.challenge}} />`);
 
     assert.dom(this.element.getElementsByTagName('label')[0]).hasText('form_title');
-
   });
 });

--- a/pix-editor/tests/integration/components/field/select-search-test.gjs
+++ b/pix-editor/tests/integration/components/field/select-search-test.gjs
@@ -5,11 +5,11 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | Field | select-search', function(hooks) {
+module('Integration | Component | Field | select-search', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen;
 
-  test('renders select search correctly with label and placeholder', async function(assert) {
+  test('renders select search correctly with label and placeholder', async function (assert) {
     // given
     const resultList = [];
     const mockOnSelect = sinon.stub().resolves();
@@ -33,7 +33,7 @@ module('Integration | Component | Field | select-search', function(hooks) {
     assert.dom(screen.queryByText('Rechercher un bidule')).exists();
   });
 
-  test('shows "Recherche en cours" while results are being fetched after typing for something', async function(assert) {
+  test('shows "Recherche en cours" while results are being fetched after typing for something', async function (assert) {
     // given
     const resultList = [];
     const mockOnSelect = sinon.stub().resolves();
@@ -57,7 +57,7 @@ module('Integration | Component | Field | select-search', function(hooks) {
     assert.dom(screen.queryByText('Recherche en cours...')).exists();
   });
 
-  test('shows "Aucun résultat" when no results returned after typing for something', async function(assert) {
+  test('shows "Aucun résultat" when no results returned after typing for something', async function (assert) {
     // given
     const resultList = [];
     const mockOnInput = sinon.stub().resolves();
@@ -82,14 +82,11 @@ module('Integration | Component | Field | select-search', function(hooks) {
     assert.ok(mockOnInput.calledWith('PISTACHE'));
   });
 
-  test('shows some results after typing for something when there are some', async function(assert) {
+  test('shows some results after typing for something when there are some', async function (assert) {
     // given
     const resultList = [];
     const mockOnInput = sinon.stub().callsFake((typedSearch) => {
-      resultList.push(...[
-        `OUI ${typedSearch}`,
-        `NON ${typedSearch}`,
-      ]);
+      resultList.push(...[`OUI ${typedSearch}`, `NON ${typedSearch}`]);
     });
     const mockOnSelect = sinon.stub().resolves();
 
@@ -114,14 +111,11 @@ module('Integration | Component | Field | select-search', function(hooks) {
     assert.dom(screen.queryByText('NON CHOCOLAT')).exists();
   });
 
-  test('renders correctly yielded part when there are some results', async function(assert) {
+  test('renders correctly yielded part when there are some results', async function (assert) {
     // given
     const resultList = [];
     const mockOnInput = sinon.stub().callsFake(() => {
-      resultList.push(...[
-        { a: 'clé a 1', b: 'clé b 1' },
-        { a: 'clé a 2', b: 'clé b 2' },
-      ]);
+      resultList.push(...[{ a: 'clé a 1', b: 'clé b 1' }, { a: 'clé a 2', b: 'clé b 2' }]);
     });
     const mockOnSelect = sinon.stub().resolves();
 
@@ -149,14 +143,11 @@ module('Integration | Component | Field | select-search', function(hooks) {
     assert.dom(screen.queryByText('clé a 2 -- clé b 2')).exists();
   });
 
-  test('triggers slot when clicking on an item result', async function(assert) {
+  test('triggers slot when clicking on an item result', async function (assert) {
     // given
     const resultList = [];
     const mockOnInput = sinon.stub().callsFake((typedSearch) => {
-      resultList.push(...[
-        `OUI ${typedSearch}`,
-        `NON ${typedSearch}`,
-      ]);
+      resultList.push(...[`OUI ${typedSearch}`, `NON ${typedSearch}`]);
     });
     const mockOnSelect = sinon.stub().resolves();
 

--- a/pix-editor/tests/integration/components/field/textarea-test.gjs
+++ b/pix-editor/tests/integration/components/field/textarea-test.gjs
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | form-textarea', function(hooks) {
+module('Integration | Component | form-textarea', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     await render(<template><Textarea /></template>);
 
     assert.dom('.field').exists();

--- a/pix-editor/tests/integration/components/field/toggle-field-test.js
+++ b/pix-editor/tests/integration/components/field/toggle-field-test.js
@@ -7,11 +7,11 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | field/toggle-field', function(hooks) {
+module('Integration | Component | field/toggle-field', function (hooks) {
   setupIntlRenderingTest(hooks);
   let setDisplayFieldStub;
   let confirmAskStub;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     confirmAskStub = sinon.stub().resolves();
     class ConfirmService extends Service {
       ask = confirmAskStub;
@@ -23,7 +23,7 @@ module('Integration | Component | field/toggle-field', function(hooks) {
     this.set('setDisplayField', setDisplayFieldStub);
   });
 
-  test('if `edition` is `false` toggle button should be hidden', async function(assert) {
+  test('if `edition` is `false` toggle button should be hidden', async function (assert) {
     // given
     const modelData = EmberObject.create({ someField: '' });
     this.set('modelData', modelData);
@@ -46,14 +46,13 @@ module('Integration | Component | field/toggle-field', function(hooks) {
     assert.dom('[data-test-toggle-field-button]').doesNotExist();
   });
 
-  module('if model field is empty', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('if model field is empty', function (hooks) {
+    hooks.beforeEach(function () {
       const modelData = EmberObject.create({ someField: '' });
       this.set('modelData', modelData);
     });
 
-    test('if `displayField` is `false` yield content should be hidden', async function(assert) {
+    test('if `displayField` is `false` yield content should be hidden', async function (assert) {
       // when
       await render(hbs`
         <Field::ToggleField @edition={{true}}
@@ -73,7 +72,7 @@ module('Integration | Component | field/toggle-field', function(hooks) {
       assert.dom('.yield-content').doesNotExist();
     });
 
-    test('it should call `setDisplayField` on click with `true` as argument', async function(assert) {
+    test('it should call `setDisplayField` on click with `true` as argument', async function (assert) {
       // when
       await render(hbs`
         <Field::ToggleField @edition={{true}}
@@ -93,7 +92,7 @@ module('Integration | Component | field/toggle-field', function(hooks) {
       assert.ok(setDisplayFieldStub.calledWith(true));
     });
 
-    test('if displayField is `true` yield content should be display', async function(assert) {
+    test('if displayField is `true` yield content should be display', async function (assert) {
       // when
       await render(hbs`
         <Field::ToggleField @edition={{true}}
@@ -112,19 +111,17 @@ module('Integration | Component | field/toggle-field', function(hooks) {
       assert.dom('[data-test-toggle-field-button]').hasText('Supprimer le champ');
       assert.dom('.yield-content').exists();
     });
-
   });
 
-  module('if model field is fill', function(hooks) {
-
+  module('if model field is fill', function (hooks) {
     let modelData;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       modelData = EmberObject.create({ someField: 'Some data' });
       this.set('modelData', modelData);
     });
 
-    test('yield content should be display', async function(assert) {
+    test('yield content should be display', async function (assert) {
       // when
       await render(hbs`
         <Field::ToggleField @edition={{true}}
@@ -144,7 +141,7 @@ module('Integration | Component | field/toggle-field', function(hooks) {
       assert.dom('.yield-content').exists();
     });
 
-    test('it should call `setDisplayField` on click with `false` as argument and empty model field', async function(assert) {
+    test('it should call `setDisplayField` on click with `false` as argument and empty model field', async function (assert) {
       // when
       await render(hbs`
         <Field::ToggleField @edition={{true}}

--- a/pix-editor/tests/integration/components/form/challenge-test.js
+++ b/pix-editor/tests/integration/components/form/challenge-test.js
@@ -6,11 +6,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | challenge-form', function(hooks) {
+module('Integration | Component | challenge-form', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen;
 
-  test('it should display expected fields if challenge type is `QROC`', async function(assert) {
+  test('it should display expected fields if challenge type is `QROC`', async function (assert) {
     // Given
     const countries = [{ FR: 'France' }];
     const challengeData = EmberObject.create({ type: 'QROC', isTextBased: true, isPrototype: true });
@@ -27,7 +27,7 @@ module('Integration | Component | challenge-form', function(hooks) {
     assert.dom('[data-test-suggestion-field]').exists();
   });
 
-  test('it should hide useless fields if challenge autoReply is `true`', async function(assert) {
+  test('it should hide useless fields if challenge autoReply is `true`', async function (assert) {
     // Given
     const countries = [{ FR: 'France' }];
     const challengeData = EmberObject.create({ autoReply: true, isTextBased: true, isPrototype: true });
@@ -39,12 +39,16 @@ module('Integration | Component | challenge-form', function(hooks) {
     await render(hbs`<Form::Challenge @challenge={{this.challengeData}} @checkEmbedURL={{this.checkEmbedURL}} @countries={{this.countries}}/>`);
 
     // Then
-    ['data-test-format-field', 'data-test-tolerence-fields', 'data-test-suggestion-field'].forEach((field) => {
+    [
+      'data-test-format-field',
+      'data-test-tolerence-fields',
+      'data-test-suggestion-field',
+    ].forEach((field) => {
       assert.dom(`[${field}]`).doesNotExist();
     });
   });
 
-  test('it should display autochecked checkbox if challenge type is `QCM`', async function(assert) {
+  test('it should display autochecked checkbox if challenge type is `QCM`', async function (assert) {
     // Given
     const store = this.owner.lookup('service:store');
     const countries = [{ FR: 'France' }];
@@ -72,7 +76,7 @@ module('Integration | Component | challenge-form', function(hooks) {
     await settled();
   });
 
-  test('it should display autochecked checkbox if challenge type is `QCU`', async function(assert) {
+  test('it should display autochecked checkbox if challenge type is `QCU`', async function (assert) {
     // Given
     const countries = [{ FR: 'France' }];
     const store = this.owner.lookup('service:store');

--- a/pix-editor/tests/integration/components/form/missions-test.js
+++ b/pix-editor/tests/integration/components/form/missions-test.js
@@ -5,11 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | mission', function(hooks) {
+module('Integration | Component | mission', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('Should enable create mission button when mandatory informations have been given', async function(assert) {
-
+  test('Should enable create mission button when mandatory informations have been given', async function (assert) {
     this.set('mission', {});
     this.set('competences', [{ title: 'Notre compétence', pixId: 'pixId', themes: [{}] }]);
     this.set('submitButtonText', 'Créer la mission');
@@ -34,8 +33,7 @@ module('Integration | Component | mission', function(hooks) {
     assert.dom(button).doesNotHaveAttribute('disabled');
   });
 
-  test('Should disable create mission button when no complete informations', async function(assert) {
-
+  test('Should disable create mission button when no complete informations', async function (assert) {
     this.set('mission', {});
     this.set('competences', [{}]);
     this.set('submitButtonText', 'Créer la mission');

--- a/pix-editor/tests/integration/components/form/note-test.gjs
+++ b/pix-editor/tests/integration/components/form/note-test.gjs
@@ -4,13 +4,13 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | note-form', function(hooks) {
+module('Integration | Component | note-form', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen;
 
-  test('renders the note form with status menu', async function(assert) {
+  test('renders the note form with status menu', async function (assert) {
     // given
-    const mockFn = ()=>{};
+    const mockFn = () => {};
 
     //  when
     screen = await render(<template>

--- a/pix-editor/tests/integration/components/form/skill-test.gjs
+++ b/pix-editor/tests/integration/components/form/skill-test.gjs
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | skill-form', function(hooks) {
+module('Integration | Component | skill-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('renders the skill form with status menu', async function(assert) {
+  test('renders the skill form with status menu', async function (assert) {
     // given
     const skill = { i18n: false };
 

--- a/pix-editor/tests/integration/components/form/theme-test.js
+++ b/pix-editor/tests/integration/components/form/theme-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | form/theme', function(hooks) {
+module('Integration | Component | form/theme', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display theme name in french and in english', async function(assert) {
+  test('it should display theme name in french and in english', async function (assert) {
     // given
     const theme = {
       name: 'themeName',

--- a/pix-editor/tests/integration/components/form/tube-test.js
+++ b/pix-editor/tests/integration/components/form/tube-test.js
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | tube-form', function(hooks) {
+module('Integration | Component | tube-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display appropriate fields', async function(assert) {
+  test('it should display appropriate fields', async function (assert) {
     // given
     const tube = EmberObject.create({});
     this.set('tube', tube);
@@ -23,8 +23,8 @@ module('Integration | Component | tube-form', function(hooks) {
     assert.dom('[data-test-practical-description-en-field]').exists();
   });
 
-  module('#not edition', function(hooks) {
-    hooks.beforeEach(async function() {
+  module('#not edition', function (hooks) {
+    hooks.beforeEach(async function () {
       const tube = EmberObject.create({});
       this.set('tube', tube);
       this.set('edition', false);
@@ -33,19 +33,19 @@ module('Integration | Component | tube-form', function(hooks) {
                                    @edition={{this.edition}}/>`);
     });
 
-    test('it should display `pixId` field', function(assert) {
+    test('it should display `pixId` field', function (assert) {
       // then
       assert.dom('[data-test-pix-id-field]').exists();
     });
 
-    test('it should not display `tube.name` field', function(assert) {
+    test('it should not display `tube.name` field', function (assert) {
       // then
       assert.dom('[data-test-name-field]').doesNotExist();
     });
   });
 
-  module('#edition', function(hooks) {
-    hooks.beforeEach(async function() {
+  module('#edition', function (hooks) {
+    hooks.beforeEach(async function () {
       const tube = EmberObject.create({});
       this.set('tube', tube);
       this.set('edition', true);
@@ -54,12 +54,12 @@ module('Integration | Component | tube-form', function(hooks) {
                                    @edition={{this.edition}}/>`);
     });
 
-    test('it should not display `pixId` field', function(assert) {
+    test('it should not display `pixId` field', function (assert) {
       // then
       assert.dom('[data-test-pix-id-field]').doesNotExist();
     });
 
-    test('it should display `tube.name` field', function(assert) {
+    test('it should display `tube.name` field', function (assert) {
       // then
       assert.dom('[data-test-name-field]').exists();
     });

--- a/pix-editor/tests/integration/components/form/tutorial-test.gjs
+++ b/pix-editor/tests/integration/components/form/tutorial-test.gjs
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | tutorial-form', function(hooks) {
+module('Integration | Component | tutorial-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders tutorial languages from config', async function(assert) {
+  test('it renders tutorial languages from config', async function (assert) {
     class ConfigService extends Service {
       get tutorialLocaleToLanguageMap() {
         return {
@@ -29,7 +29,7 @@ module('Integration | Component | tutorial-form', function(hooks) {
     assert.dom(await screen.findByRole('option', { name: 'Autre Langue' })).exists();
   });
 
-  test('it shows a tutorial licenses dropdown with default empty option "Licence non renseignée"', async function(assert) {
+  test('it shows a tutorial licenses dropdown with default empty option "Licence non renseignée"', async function (assert) {
     class ConfigService extends Service {
       get tutorialLocaleToLanguageMap() {
         return {
@@ -51,7 +51,7 @@ module('Integration | Component | tutorial-form', function(hooks) {
     assert.dom(screen.getByRole('option', { name: 'CC-BY-SA' })).hasAria('selected', 'false');
   });
 
-  test('it shows a tutorial levels dropdown with default empty option "Niveau non renseigné"', async function(assert) {
+  test('it shows a tutorial levels dropdown with default empty option "Niveau non renseigné"', async function (assert) {
     class ConfigService extends Service {
       get tutorialLocaleToLanguageMap() {
         return {

--- a/pix-editor/tests/integration/components/form/whitelisted-url-test.js
+++ b/pix-editor/tests/integration/components/form/whitelisted-url-test.js
@@ -6,11 +6,10 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | Form | whitelisted-url', function(hooks) {
+module('Integration | Component | Form | whitelisted-url', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should submit correctly formed whitelisted url', async function(assert) {
-
+  test('should submit correctly formed whitelisted url', async function (assert) {
     const onSubmit = sinon.spy(() => {});
 
     this.set('submitButtonText', 'Ajouter');
@@ -55,8 +54,7 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
     assert.strictEqual(onSubmit.args[3][0].checkType, 'starts_with');
   });
 
-  test('should enable add url button when mandatory information has been given', async function(assert) {
-
+  test('should enable add url button when mandatory information has been given', async function (assert) {
     this.set('submitButtonText', 'Ajouter');
 
     const screen = await render(
@@ -74,8 +72,7 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
     assert.dom(button).doesNotHaveAttribute('disabled');
   });
 
-  test('should disable create whitelisted URL button when no complete informations', async function(assert) {
-
+  test('should disable create whitelisted URL button when no complete informations', async function (assert) {
     this.set('submitButtonText', 'Ajouter');
 
     const screen = await render(
@@ -95,7 +92,7 @@ module('Integration | Component | Form | whitelisted-url', function(hooks) {
     assert.dom(button).hasAria('disabled', 'true');
   });
 
-  test('should display errors when input values are unexpected', async function(assert) {
+  test('should display errors when input values are unexpected', async function (assert) {
     const screen = await render(
       hbs`<Form::WhitelistedUrl
         @initialUrl=""

--- a/pix-editor/tests/integration/components/list/archive-test.js
+++ b/pix-editor/tests/integration/components/list/archive-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | list/archive', function(hooks) {
+module('Integration | Component | list/archive', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/pix-editor/tests/integration/components/list/events-log-test.js
+++ b/pix-editor/tests/integration/components/list/events-log-test.js
@@ -4,11 +4,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | list/events-log', function(hooks) {
+module('Integration | Component | list/events-log', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display a list of skill logs', async function(assert) {
-    //given
+  test('it should display a list of skill logs', async function (assert) {
+    // given
     const skillLog1 = {
       recordId: 'rec123456',
       text: 'some text',
@@ -29,10 +29,10 @@ module('Integration | Component | list/events-log', function(hooks) {
 
     this.skillLogs = skillLogs;
 
-    //when
+    // when
     await render(hbs`<List::EventsLog @list={{this.skillLogs}}/>`);
 
-    //then
+    // then
     assert.strictEqual(findAll('[data-test-skillLog]').length, skillLogs.length);
   });
 });

--- a/pix-editor/tests/integration/components/list/notes-test.js
+++ b/pix-editor/tests/integration/components/list/notes-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | note-list', function(hooks) {
+module('Integration | Component | note-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   const myNote1 = {
@@ -37,68 +37,74 @@ module('Integration | Component | note-list', function(hooks) {
     date: new Date(2020, 8, 28),
     changelog: true,
   };
-  const notes = [myNote1, myNote2, otherNote, log1, log2];
-  hooks.beforeEach(function() {
+  const notes = [
+    myNote1,
+    myNote2,
+    otherNote,
+    log1,
+    log2,
+  ];
+  hooks.beforeEach(function () {
     this.set('notes', notes);
   });
 
-  test('it renders', async function(assert) {
-    //when
+  test('it renders', async function (assert) {
+    // when
     await render(hbs`<List::Notes @list={{this.notes}}/>`);
 
-    //then
+    // then
     assert.dom('.ember-table').exists();
   });
 
-  test('it should display a list of notes', async function(assert) {
-    //when
+  test('it should display a list of notes', async function (assert) {
+    // when
     await render(hbs`<List::Notes @list={{this.notes}}/>`);
 
-    //then
+    // then
     assert.dom('[data-test-note]').exists({ count: notes.length });
   });
 
-  test('it should display authors when displayAuthor is `true`', async function(assert) {
-    //given
+  test('it should display authors when displayAuthor is `true`', async function (assert) {
+    // given
     this.set('displayAuthor', true);
 
-    //when
+    // when
     await render(hbs`<List::Notes @list={{this.notes}} @displayAuthor={{this.displayAuthor}}/>`);
 
-    //then
+    // then
     assert.dom('[data-test-note] .author-note').exists();
   });
 
-  test('it should not display authors when displayAuthor is `false`', async function(assert) {
-    //given
+  test('it should not display authors when displayAuthor is `false`', async function (assert) {
+    // given
     this.set('displayAuthor', false);
 
-    //when
+    // when
     await render(hbs`<List::Notes @list={{this.notes}} @displayAuthor={{this.displayAuthor}}/>`);
 
-    //then
+    // then
     assert.dom('[data-test-note] .author-note').doesNotExist();
   });
 
-  test('it should display note status when displayStatus is `true`', async function(assert) {
-    //given
+  test('it should display note status when displayStatus is `true`', async function (assert) {
+    // given
     this.set('displayStatus', true);
 
-    //when
+    // when
     await render(hbs`<List::Notes @list={{this.notes}} @displayStatus={{this.displayStatus}}/>`);
 
-    //then
+    // then
     assert.dom('[data-test-note] .status-note').exists();
   });
 
-  test('it should not display note status when displayStatus is `false`', async function(assert) {
-    //given
+  test('it should not display note status when displayStatus is `false`', async function (assert) {
+    // given
     this.set('displayStatus', false);
 
-    //when
+    // when
     await render(hbs`<List::Notes @list={{this.notes}} @displayStatus={{this.displayStatus}}/>`);
 
-    //then
+    // then
     assert.dom('[data-test-note] .status-note').doesNotExist();
   });
 });

--- a/pix-editor/tests/integration/components/list/prototypes-test.js
+++ b/pix-editor/tests/integration/components/list/prototypes-test.js
@@ -4,16 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | prototypes-list', function(hooks) {
+module('Integration | Component | prototypes-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<List::Prototypes />`);
 
     assert.dom('.ember-table').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/list/skills-test.js
+++ b/pix-editor/tests/integration/components/list/skills-test.js
@@ -4,20 +4,14 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | list/skill', function(hooks) {
+module('Integration | Component | list/skill', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should display a list of skills', async function(assert) {
+  test('should display a list of skills', async function (assert) {
     // given
-    const challenge1 = {
-      id: 'recChallenge1',
-    };
-    const challenge2 = {
-      id: 'recChallenge2',
-    };
-    const challenge3 = {
-      id: 'recChallenge3',
-    };
+    const challenge1 = { id: 'recChallenge1' };
+    const challenge2 = { id: 'recChallenge2' };
+    const challenge3 = { id: 'recChallenge3' };
     const skill1 = {
       id: 'recSkill1',
       pixId: 'pixSkill1',

--- a/pix-editor/tests/integration/components/list/sorted-test.js
+++ b/pix-editor/tests/integration/components/list/sorted-test.js
@@ -4,16 +4,15 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | sorted-list', function(hooks) {
+module('Integration | Component | sorted-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<List::Sorted />`);
 
     assert.dom(this.element).hasText('');
-
   });
 });

--- a/pix-editor/tests/integration/components/list/workbench-test.js
+++ b/pix-editor/tests/integration/components/list/workbench-test.js
@@ -4,11 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | workbench-list', function(hooks) {
+module('Integration | Component | workbench-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-
+  test('it renders', async function (assert) {
     // given
 
     // when

--- a/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
@@ -6,19 +6,19 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | localized-challenge-view | localized-challenge-view', function(hooks) {
+module('Integration | Component | localized-challenge-view | localized-challenge-view', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen, store, challenge, competence, challengeLocale, localizedChallenge, attachment;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
     attachment = store.createRecord('attachment', { type: 'attachment' });
     competence = store.createRecord('competence', {
       id: 'competenceId',
       code: '1.1',
     });
-    challenge =
-      store.createRecord('challenge', {
+    challenge
+      = store.createRecord('challenge', {
         id: 'challengeProtoValidee',
         version: 1,
         genealogy: 'Prototype 1',
@@ -27,8 +27,8 @@ module('Integration | Component | localized-challenge-view | localized-challenge
         geography: 'FR',
         attachments: [attachment],
       });
-    localizedChallenge =
-      store.createRecord('localized-challenge', {
+    localizedChallenge
+      = store.createRecord('localized-challenge', {
         id: 'localizedChallengeId',
         locale: 'en',
         embedURL: `${challenge.embedURL}?lang=en`,
@@ -42,7 +42,7 @@ module('Integration | Component | localized-challenge-view | localized-challenge
     });
   });
 
-  test('it should display readonly form', async function(assert) {
+  test('it should display readonly form', async function (assert) {
     // when
     screen = await render(<template>
       <LocalizedChallengeView
@@ -63,8 +63,8 @@ module('Integration | Component | localized-challenge-view | localized-challenge
     assert.dom(screen.getByLabelText('Id')).hasValue('localizedChallengeId');
   });
 
-  module('when challenge has no embed URL', function() {
-    test('it should not display embed input', async function(assert) {
+  module('when challenge has no embed URL', function () {
+    test('it should not display embed input', async function (assert) {
       // given
       challenge.embedURL = null;
 
@@ -85,8 +85,8 @@ module('Integration | Component | localized-challenge-view | localized-challenge
     });
   });
 
-  module('when challenge has no attachment', function() {
-    test('it should not display attachment input', async function(assert) {
+  module('when challenge has no attachment', function () {
+    test('it should not display attachment input', async function (assert) {
       // given
       challenge.attachments = [];
 

--- a/pix-editor/tests/integration/components/login-form-test.js
+++ b/pix-editor/tests/integration/components/login-form-test.js
@@ -5,16 +5,16 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../setup-intl-rendering';
 
-module('Integration | Component | login-form', function(hooks) {
+module('Integration | Component | login-form', function (hooks) {
   setupIntlRenderingTest(hooks);
   let onLogInClickedStub;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     onLogInClickedStub = sinon.stub();
     this.onLogInClicked = onLogInClickedStub;
   });
 
-  test('it renders correctly', async function(assert) {
+  test('it renders correctly', async function (assert) {
     // when
     await render(hbs`<LoginForm @onLogInClicked={{this.onLogInClicked}} />`);
 
@@ -28,7 +28,7 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('#login-form-error-message').doesNotExist();
   });
 
-  test('it calls onLogInClicked with the API key when form is submitted', async function(assert) {
+  test('it calls onLogInClicked with the API key when form is submitted', async function (assert) {
     // given
     onLogInClickedStub.resolves();
     const apiKey = 'test-api-key-123';
@@ -43,7 +43,7 @@ module('Integration | Component | login-form', function(hooks) {
     assert.ok(onLogInClickedStub.calledWith(apiKey));
   });
 
-  test('it displays error message when login fails', async function(assert) {
+  test('it displays error message when login fails', async function (assert) {
     // given
     onLogInClickedStub.rejects(new Error('Login failed'));
     const apiKey = 'invalid-api-key';
@@ -58,7 +58,7 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('#login-form-error-message p').hasText('La clé saisie n\'a pas pu être validée ou n\'est pas valide. Vérifiez votre connexion, votre saisie ou contactez l\'équipe de développement.');
   });
 
-  test('it hides error message when a new login attempt is made', async function(assert) {
+  test('it hides error message when a new login attempt is made', async function (assert) {
     // given
     onLogInClickedStub.onFirstCall().rejects(new Error('Login failed'));
     onLogInClickedStub.onSecondCall().resolves();
@@ -82,7 +82,7 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('#login-form-error-message').doesNotExist();
   });
 
-  test('it updates the API key value when input changes', async function(assert) {
+  test('it updates the API key value when input changes', async function (assert) {
     // given
     onLogInClickedStub.resolves();
     const firstApiKey = 'first-key';

--- a/pix-editor/tests/integration/components/pop-in/challenge-log-test.js
+++ b/pix-editor/tests/integration/components/pop-in/challenge-log-test.js
@@ -6,12 +6,12 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-challenge-log', function(hooks) {
+module('Integration | Component | popin-challenge-log', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let paginatedQueryLoadNotesStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     paginatedQueryLoadNotesStub = sinon.stub();
     class PaginatedQueryService extends Service {
       query = paginatedQueryLoadNotesStub.resolves([note]);
@@ -30,32 +30,31 @@ module('Integration | Component | popin-challenge-log', function(hooks) {
       locales: ['Francophone', 'Franco Français'],
       instruction: 'Some instructions 1',
     };
-    this.closeAction = function() { };
+    this.closeAction = function () { };
     this.challenge = challenge;
   });
 
-  test('it renders', async function(assert) {
-    //when
+  test('it renders', async function (assert) {
+    // when
     await render(hbs`<PopIn::Challenge-log @close={{this.closeAction}} @challenge={{this.challenge}}/>`);
 
-    //then
+    // then
     assert.dom('.pix-modal').exists();
   });
 
-  test('it queries notes', async function(assert) {
-    //when
+  test('it queries notes', async function (assert) {
+    // when
     await render(hbs`<PopIn::Challenge-log @close={{this.closeAction}} @challenge={{this.challenge}}/>`);
 
-    //then
+    // then
     assert.deepEqual(paginatedQueryLoadNotesStub.getCall(0).args, ['note', { filterByFormula: `AND(Record_Id = '${this.challenge.id}', Statut != 'archive', Changelog='non')`, sort: [{ field: 'Date', direction: 'desc' }] }]);
   });
 
-  test('it queries changelogs', async function(assert) {
-    //when
+  test('it queries changelogs', async function (assert) {
+    // when
     await render(hbs`<PopIn::Challenge-log @close={{this.closeAction}} @challenge={{this.challenge}}/>`);
 
-    //then
+    // then
     assert.deepEqual(paginatedQueryLoadNotesStub.getCall(1).args, ['changelog-entry', { filterByFormula: `AND(Record_Id = '${this.challenge.id}', Changelog='oui')`, sort: [{ field: 'Date', direction: 'desc' }] }]);
   });
-
 });

--- a/pix-editor/tests/integration/components/pop-in/changelog-test.js
+++ b/pix-editor/tests/integration/components/pop-in/changelog-test.js
@@ -5,18 +5,18 @@ import Sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-changelog', function(hooks) {
+module('Integration | Component | popin-changelog', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    //given
+  test('it renders', async function (assert) {
+    // given
     this.approve = Sinon.stub();
 
-    //when
+    // when
     await render(hbs`<PopIn::Changelog  @onApprove={{this.approve}}/>`);
     await click('[data-test-save-changelog-button]');
 
-    //then
+    // then
     assert.true(this.approve.called);
   });
 });

--- a/pix-editor/tests/integration/components/pop-in/confirm-log-test.js
+++ b/pix-editor/tests/integration/components/pop-in/confirm-log-test.js
@@ -5,10 +5,10 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-confirm-log', function(hooks) {
+module('Integration | Component | popin-confirm-log', function (hooks) {
   setupIntlRenderingTest(hooks);
   let approveActionStub, denyActionStub;
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     // given
     approveActionStub = sinon.stub();
     denyActionStub = sinon.stub();
@@ -25,7 +25,7 @@ module('Integration | Component | popin-confirm-log', function(hooks) {
         @defaultValue={{this.defaultSaveChangelog}}/>`);
   });
 
-  test('it saves without changelog', async function(assert) {
+  test('it saves without changelog', async function (assert) {
     // when
 
     await click('[data-test-confirm-log-approve]');
@@ -36,7 +36,7 @@ module('Integration | Component | popin-confirm-log', function(hooks) {
     assert.strictEqual(approveActionStub.getCall(0).args[0], null);
   });
 
-  test('it saves with changelog', async function(assert) {
+  test('it saves with changelog', async function (assert) {
     // when
     await click('[data-test-confirm-log-check] input');
     await click('[data-test-confirm-log-approve]');
@@ -47,7 +47,7 @@ module('Integration | Component | popin-confirm-log', function(hooks) {
     assert.strictEqual(approveActionStub.getCall(0).args[0], 'Mise à jour du prototype');
   });
 
-  test('it should cancel', async function(assert) {
+  test('it should cancel', async function (assert) {
     // when
     await click('[data-test-confirm-log-cancel]');
 

--- a/pix-editor/tests/integration/components/pop-in/confirm-test.js
+++ b/pix-editor/tests/integration/components/pop-in/confirm-test.js
@@ -4,14 +4,14 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-confirm', function(hooks) {
+module('Integration | Component | popin-confirm', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
-    this.set('approveAction', function() {});
-    this.set('denyAction', function() {});
+    this.set('approveAction', function () {});
+    this.set('denyAction', function () {});
 
     await render(hbs`<PopIn::Confirm @onApprove={{this.approveAction}}
                                      @onDeny={{this.denyAction}}

--- a/pix-editor/tests/integration/components/pop-in/image-test.js
+++ b/pix-editor/tests/integration/components/pop-in/image-test.js
@@ -4,14 +4,14 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-image', function(hooks) {
+module('Integration | Component | popin-image', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    this.set('closeAction', function() {});
+    this.set('closeAction', function () {});
 
     await render(hbs`<PopIn::Image @close={{this.closeAction}}
                                    @title="image" />`);

--- a/pix-editor/tests/integration/components/pop-in/new-framework-test.js
+++ b/pix-editor/tests/integration/components/pop-in/new-framework-test.js
@@ -4,37 +4,37 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | pop-in/new-framework', function(hooks) {
+module('Integration | Component | pop-in/new-framework', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should disable save button if name field is empty', async function(assert) {
-    //given
+  test('it should disable save button if name field is empty', async function (assert) {
+    // given
     this.set('close', () => {});
     this.set('save', () => {});
     this.set('framework', { name: '' });
 
-    //when
+    // when
     await render(hbs`<PopIn::NewFramework @close={{this.close}}
                                           @save={{this.save}}
                                           @framework={{this.framework}}/>`);
 
-    //then
+    // then
     const saveButton = find('[data-test-save-action]');
     assert.dom(saveButton).hasAria('disabled', 'true');
   });
 
-  test('it should unable save button if name field is fill', async function(assert) {
+  test('it should unable save button if name field is fill', async function (assert) {
     // given
     this.set('close', () => {});
     this.set('save', () => {});
     this.set('framework', { name: 'frameworkName' });
 
-    //when
+    // when
     await render(hbs`<PopIn::NewFramework @close={{this.close}}
                                           @save={{this.save}}
                                           @framework={{this.framework}}/>`);
 
-    //then
+    // then
     const saveButton = find('[data-test-save-action]');
     assert.dom(saveButton).doesNotHaveAttribute('aria-disabled');
   });

--- a/pix-editor/tests/integration/components/pop-in/pdf-entries-test.gjs
+++ b/pix-editor/tests/integration/components/pop-in/pdf-entries-test.gjs
@@ -6,11 +6,11 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | pop-in/pdf-entries', function(hooks) {
+module('Integration | Component | pop-in/pdf-entries', function (hooks) {
   setupIntlRenderingTest(hooks);
   let screen, callBackActionStub, closeTitleInputStub;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     // given
     callBackActionStub = sinon.stub();
     closeTitleInputStub = sinon.stub();
@@ -23,7 +23,7 @@ module('Integration | Component | pop-in/pdf-entries', function(hooks) {
     /></template>);
   });
 
-  test('it should set default title and language on validate', async function(assert) {
+  test('it should set default title and language on validate', async function (assert) {
     // when
     await clickByText('Valider');
 
@@ -33,7 +33,7 @@ module('Integration | Component | pop-in/pdf-entries', function(hooks) {
     assert.deepEqual(callBackActionStub.getCall(0).args, ['Liste des thèmes et des sujets abordés dans Pix', 'fr']);
   });
 
-  test('it should set custom title and selected language on validate', async function(assert) {
+  test('it should set custom title and selected language on validate', async function (assert) {
     // when
     await fillByLabel('Titre', 'mont titre');
     await clickByText('Langue');

--- a/pix-editor/tests/integration/components/pop-in/select-location-test.gjs
+++ b/pix-editor/tests/integration/components/pop-in/select-location-test.gjs
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 import { waitForSelectToBeClosed } from '../../../helpers/wait-for-select-to-be-closed';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | pop-in-select-location / form-select-location', function(hooks) {
+module('Integration | Component | pop-in-select-location / form-select-location', function (hooks) {
   setupIntlRenderingTest(hooks);
   let framework1, framework2,
     area1_1, area1_2,
@@ -20,7 +20,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
     skill1_2_1_2_2, skill1_2_2_1_1, skill1_2_2_1_2;
   let onSubmitStub, closeModalStub, screen;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const store = this.owner.lookup('service:store');
 
     // given
@@ -104,7 +104,11 @@ module('Integration | Component | pop-in-select-location / form-select-location'
     tube1_2_1_1 = store.createRecord('tube', {
       id: 'tube1_2_1_1',
       name: 'tube1_2_1_1',
-      rawSkills: [skill1_2_1_1_1, skill1_2_1_1_2, skill1_2_1_1_3],
+      rawSkills: [
+        skill1_2_1_1_1,
+        skill1_2_1_1_2,
+        skill1_2_1_1_3,
+      ],
 
     });
     tube1_2_1_2 = store.createRecord('tube', {
@@ -191,8 +195,8 @@ module('Integration | Component | pop-in-select-location / form-select-location'
     onSubmitStub = sinon.stub();
   });
 
-  module('if variant is `prototype`', function(hooks) {
-    hooks.beforeEach(async function() {
+  module('if variant is `prototype`', function (hooks) {
+    hooks.beforeEach(async function () {
       // given
       const skill = skill1_2_1_1_2;
       const onSubmit = onSubmitStub;
@@ -212,7 +216,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       );
     });
 
-    test('it should display location fields of challenge', function(assert) {
+    test('it should display location fields of challenge', function (assert) {
       // given
       assert.dom(screen.getByLabelText('Référentiel')).hasText('pix');
       assert.dom(screen.getByLabelText('Compétence')).hasText('2.1 competence1_2_1');
@@ -220,7 +224,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       assert.dom(screen.getByLabelText('Acquis')).hasText('skill1_2_1_1_2 (v.1) 🟢');
     });
 
-    test('it should display a list of skills on click', async function(assert) {
+    test('it should display a list of skills on click', async function (assert) {
       assert.expect(0);
       // when
       await click(screen.getByLabelText('Acquis'));
@@ -234,7 +238,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       within(secondGroup).getByRole('option', { name: 'skill1_2_1_1_3 (v.2) 🔵' });
     });
 
-    test('it should load a list of skill of selected location', async function(assert) {
+    test('it should load a list of skill of selected location', async function (assert) {
       assert.expect(0);
       // when
       await click(screen.getByLabelText('Sujet'));
@@ -247,7 +251,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       screen.getByRole('option', { name: 'skill1_2_1_2_2 (v.1) 🟢' });
     });
 
-    test('move button is disabled if no location is selected', async function(assert) {
+    test('move button is disabled if no location is selected', async function (assert) {
       // when
       assert.true(screen.getByRole('button', { name: 'Déplacer' }).hasAttribute('aria-disabled', 'true')); // same skill
 
@@ -278,7 +282,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       assert.true(screen.getByRole('button', { name: 'Déplacer' }).hasAttribute('aria-disabled', 'true')); // same skill
     });
 
-    test('it should call @onSubmit with new skill location argument', async function(assert) {
+    test('it should call @onSubmit with new skill location argument', async function (assert) {
       // when
 
       await click(screen.getByLabelText('Compétence'));
@@ -301,8 +305,8 @@ module('Integration | Component | pop-in-select-location / form-select-location'
     });
   });
 
-  module('if variant is `skill`', function(hooks) {
-    hooks.beforeEach(async function() {
+  module('if variant is `skill`', function (hooks) {
+    hooks.beforeEach(async function () {
       // given
       const skill = skill1_2_1_1_2;
       const onSubmit = onSubmitStub;
@@ -321,9 +325,18 @@ module('Integration | Component | pop-in-select-location / form-select-location'
         /></template>,
       );
     });
-    test('it should display a list of all skill levels', async function(assert) {
+    test('it should display a list of all skill levels', async function (assert) {
       // given
-      const expectedOptionsResult = [1, 2, 3, 4, 5, 6, 7, 8];
+      const expectedOptionsResult = [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+      ];
 
       // when
       await click(screen.getByLabelText('Niveau'));
@@ -340,7 +353,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       });
     });
 
-    test('duplicate button is disabled when form is not submittable', async function(assert) {
+    test('duplicate button is disabled when form is not submittable', async function (assert) {
       // when
       assert.true(screen.getByRole('button', { name: 'Dupliquer' }).hasAttribute('aria-disabled', 'true'));
 
@@ -350,7 +363,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       assert.false(screen.getByRole('button', { name: 'Dupliquer' }).hasAttribute('aria-disabled', 'true'));
     });
 
-    test('it should call @onSubmit with skill copy location', async function(assert) {
+    test('it should call @onSubmit with skill copy location', async function (assert) {
       // when
       await click(screen.getByLabelText('Compétence'));
       await click(await screen.findByRole('option', { name: '1.1 competence1_1_1' }));
@@ -371,8 +384,8 @@ module('Integration | Component | pop-in-select-location / form-select-location'
     });
   });
 
-  module('if variant is `tube`', function(hooks) {
-    hooks.beforeEach(async function() {
+  module('if variant is `tube`', function (hooks) {
+    hooks.beforeEach(async function () {
       // given
       const theme = theme1_2_1_1;
       const onSubmit = onSubmitStub;
@@ -391,14 +404,14 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       );
     });
 
-    test('it should display appropriate fields', async function(assert) {
+    test('it should display appropriate fields', async function (assert) {
       // then
       assert.dom(screen.getByLabelText('Référentiel')).hasText('pix');
       assert.dom(screen.getByLabelText('Compétence')).hasText('2.1 competence1_2_1');
       assert.dom(screen.getByLabelText('Thématique *')).hasText('theme1_2_1_1');
     });
 
-    test('it should display a list of competence theme', async function(assert) {
+    test('it should display a list of competence theme', async function (assert) {
       // given
       const expectedThemeOptions = ['theme1_1_1_1', 'theme1_1_1_2'];
 
@@ -415,7 +428,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       });
     });
 
-    test('move button is disabled when form is not submittable', async function(assert) {
+    test('move button is disabled when form is not submittable', async function (assert) {
       // when
       assert.true(screen.getByRole('button', { name: 'Déplacer' }).hasAttribute('aria-disabled', 'true')); // same theme
 
@@ -446,7 +459,7 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       assert.true(screen.getByRole('button', { name: 'Déplacer' }).hasAttribute('aria-disabled', 'true')); // same theme
     });
 
-    test('it should call @onSubmit with a competence and a theme', async function(assert) {
+    test('it should call @onSubmit with a competence and a theme', async function (assert) {
       // when
       await click(screen.getByLabelText('Compétence'));
       await click(await screen.findByRole('option', { name: '1.1 competence1_1_1' }));

--- a/pix-editor/tests/integration/components/pop-in/single-entry-test.js
+++ b/pix-editor/tests/integration/components/pop-in/single-entry-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-single-entry', function(hooks) {
+module('Integration | Component | popin-single-entry', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/pix-editor/tests/integration/components/pop-in/sorting-test.js
+++ b/pix-editor/tests/integration/components/pop-in/sorting-test.js
@@ -7,11 +7,11 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | pop-in/sorting', function(hooks) {
+module('Integration | Component | pop-in/sorting', function (hooks) {
   setupIntlRenderingTest(hooks);
   let modelToSort1, modelToSort2, modelToSort3, approveActionStub, denyActionStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     // given
     modelToSort1 = EmberObject.create({
       name: 'model_1',
@@ -27,13 +27,17 @@ module('Integration | Component | pop-in/sorting', function(hooks) {
     });
     approveActionStub = sinon.stub();
     denyActionStub = sinon.stub();
-    this.set('sortingModel', [modelToSort1, modelToSort2, modelToSort3]);
+    this.set('sortingModel', [
+      modelToSort1,
+      modelToSort2,
+      modelToSort3,
+    ]);
     this.set('title', 'My title');
     this.set('approveAction', approveActionStub);
     this.set('denyAction', denyActionStub);
   });
 
-  test('it display a list of models', async function(assert) {
+  test('it display a list of models', async function (assert) {
     // when
     await render(hbs`<PopIn::Sorting @title={{this.title}}
                                      @model={{this.sortingModel}}
@@ -45,7 +49,7 @@ module('Integration | Component | pop-in/sorting', function(hooks) {
     assert.dom('[data-test-sorting-pop-in-content] li').exists({ count: 3 });
   });
 
-  test('it should reorder models', async function(assert) {
+  test('it should reorder models', async function (assert) {
     // when
     await render(hbs`<PopIn::Sorting @title={{this.title}}
                                      @model={{this.sortingModel}}
@@ -53,14 +57,16 @@ module('Integration | Component | pop-in/sorting', function(hooks) {
                                      @onApprove={{this.approveAction}} />`);
 
     const draggableItem = findAll('[data-test-sorting-pop-in-content] .sortable-item')[1];
-    await drag('mouse', draggableItem, () => { return { dy: draggableItem.offsetHeight * 2 + 1, dx: undefined };});
+    await drag('mouse', draggableItem, () => {
+      return { dy: draggableItem.offsetHeight * 2 + 1, dx: undefined };
+    });
 
     // then
     assert.strictEqual(modelToSort2.index, 2);
     assert.strictEqual(modelToSort3.index, 1);
   });
 
-  test('it should trigger approve action', async function(assert) {
+  test('it should trigger approve action', async function (assert) {
     // when
     await render(hbs`<PopIn::Sorting @title={{this.title}}
                                      @model={{this.sortingModel}}
@@ -70,10 +76,14 @@ module('Integration | Component | pop-in/sorting', function(hooks) {
     await click('[data-test-sorting-pop-in-approve]');
 
     // then
-    assert.deepEqual(approveActionStub.getCall(0).args[0], [modelToSort1, modelToSort2, modelToSort3]);
+    assert.deepEqual(approveActionStub.getCall(0).args[0], [
+      modelToSort1,
+      modelToSort2,
+      modelToSort3,
+    ]);
   });
 
-  test('it should trigger deny action', async function(assert) {
+  test('it should trigger deny action', async function (assert) {
     // when
     await render(hbs`<PopIn::Sorting @title={{this.title}}
                                      @model={{this.sortingModel}}
@@ -83,6 +93,10 @@ module('Integration | Component | pop-in/sorting', function(hooks) {
     await click('[data-test-sorting-pop-in-deny]');
 
     // then
-    assert.deepEqual(denyActionStub.getCall(0).args[0], [modelToSort1, modelToSort2, modelToSort3]);
+    assert.deepEqual(denyActionStub.getCall(0).args[0], [
+      modelToSort1,
+      modelToSort2,
+      modelToSort3,
+    ]);
   });
 });

--- a/pix-editor/tests/integration/components/pop-in/threshold-calculation-test.js
+++ b/pix-editor/tests/integration/components/pop-in/threshold-calculation-test.js
@@ -4,22 +4,24 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | pop-in/threshold-calculation', function(hooks) {
+module('Integration | Component | pop-in/threshold-calculation', function (hooks) {
   setupIntlRenderingTest(hooks);
-  test('it display a list of selected skills count by level', async function(assert) {
-    //given
+  test('it display a list of selected skills count by level', async function (assert) {
+    // given
     const tube1SelectedSkills = [
       {
         id: 'rec123456',
         name: 'tube1SelectedSkill1',
         isActive: true,
         level: 1,
-      }, {
+      },
+      {
         id: 'rec123457',
         name: 'tube1SelectedSkill2',
         isActive: true,
         level: 2,
-      }, {
+      },
+      {
         id: 'rec123458',
         name: 'tube1SelectedSkill3',
         isActive: true,
@@ -32,12 +34,14 @@ module('Integration | Component | pop-in/threshold-calculation', function(hooks)
         name: 'tube2SelectedSkill4',
         isActive: true,
         level: 4,
-      }, {
+      },
+      {
         id: 'rec223457',
         name: 'tube2SelectedSkill5',
         isActive: true,
         level: 5,
-      }, {
+      },
+      {
         id: 'rec223458',
         name: 'tube2SelectedSkill6',
         isActive: true,
@@ -50,7 +54,8 @@ module('Integration | Component | pop-in/threshold-calculation', function(hooks)
         name: 'tube2SelectedSkill7',
         isActive: true,
         level: 7,
-      }, {
+      },
+      {
         id: 'rec323457',
         name: 'tube2SelectedSkill8',
         isActive: true,
@@ -77,59 +82,62 @@ module('Integration | Component | pop-in/threshold-calculation', function(hooks)
         level: 8,
       },
     ];
-    const areas = [{
-      name: 'area1',
-      sortedCompetences: [
-        {
-          name: 'competence1',
-          productionTubes: [
-            {
-              name: 'tube1',
-              selectedLevel: 3,
-              liveSkills: tube1SelectedSkills,
-            }, {
-              name: 'tube2',
-              selectedLevel: 6,
-              liveSkills: tube2SelectedSkills,
-            },
-          ],
-        }, {
-          name: 'competence2',
-          productionTubes: [
-            {
-              name: 'tube3',
-              selectedLevel: 8,
-              liveSkills: tube3SelectedSkills,
-            },
-          ],
-        },
-      ],
-    }, {
-      name: 'area2',
-      sortedCompetences: [
-        {
-          name: 'competence3',
-          productionTubes: [
-            {
-              name: 'tube4',
-              selectedLevel: 8,
-              liveSkills: tube4SelectedSkills,
-            },
-          ],
-        },
-      ],
-    },
+    const areas = [
+      {
+        name: 'area1',
+        sortedCompetences: [
+          {
+            name: 'competence1',
+            productionTubes: [
+              {
+                name: 'tube1',
+                selectedLevel: 3,
+                liveSkills: tube1SelectedSkills,
+              },
+              {
+                name: 'tube2',
+                selectedLevel: 6,
+                liveSkills: tube2SelectedSkills,
+              },
+            ],
+          },
+          {
+            name: 'competence2',
+            productionTubes: [
+              {
+                name: 'tube3',
+                selectedLevel: 8,
+                liveSkills: tube3SelectedSkills,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'area2',
+        sortedCompetences: [
+          {
+            name: 'competence3',
+            productionTubes: [
+              {
+                name: 'tube4',
+                selectedLevel: 8,
+                liveSkills: tube4SelectedSkills,
+              },
+            ],
+          },
+        ],
+      },
     ];
     const selectedSkillsCount = tube1SelectedSkills.length + tube2SelectedSkills.length + tube3SelectedSkills.length + tube4SelectedSkills.length;
-    this.closeAction = function() {};
+    this.closeAction = function () {};
     this.areas = areas;
 
-    //when
+    // when
     await render(hbs`<PopIn::ThresholdCalculation @title="Paliers indicatifs" @close={{this.closeAction}} @model={{this.areas}}/>`);
 
-    //then
+    // then
     assert.strictEqual(this.element.querySelectorAll('tr').length, 10);
     assert.dom(this.element.querySelector('[data-test-selectedSkillsCount]')).hasText(`${selectedSkillsCount}`);
   });
 });
-

--- a/pix-editor/tests/integration/components/pop-in/tube-level-test.js
+++ b/pix-editor/tests/integration/components/pop-in/tube-level-test.js
@@ -5,11 +5,11 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | popin-tube-level', function(hooks) {
+module('Integration | Component | popin-tube-level', function (hooks) {
   setupIntlRenderingTest(hooks);
   let tube, skill1, skill2, skill5, skill6;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     // given
     skill1 = {
       id: 'rec321654',
@@ -46,11 +46,16 @@ module('Integration | Component | popin-tube-level', function(hooks) {
     this.setTubeAction = sinon.stub();
     this.clearTubeAction = sinon.stub();
     this.selectedTube = tube;
-    this.tubeSkills = [skill1, skill2, skill5, skill6];
+    this.tubeSkills = [
+      skill1,
+      skill2,
+      skill5,
+      skill6,
+    ];
     this.selectedTubeLevel = tube.selectedTubeLevel;
     this.selectedTubeSkills = tube.selectedTubeSkills;
     this.isThematicResultMode = true;
-    this.closeTubeLevel = ()=>{};
+    this.closeTubeLevel = () => {};
 
     await render(hbs`<PopIn::TubeLevel  @setTubeLevel={{this.setTubeAction}}
                                         @clearTube={{this.clearTubeAction}}
@@ -62,10 +67,19 @@ module('Integration | Component | popin-tube-level', function(hooks) {
                                         @close={{this.closeTubeLevel}}/>`);
   });
 
-  test('it should display a list of an ordered list of skills level', function(assert) {
+  test('it should display a list of an ordered list of skills level', function (assert) {
     assert.expect(8);
     // when
-    const expectedResult = ['1', '2', '', '', '5', '6', '', ''];
+    const expectedResult = [
+      '1',
+      '2',
+      '',
+      '',
+      '5',
+      '6',
+      '',
+      '',
+    ];
 
     // then
     const skillsList = this.element.querySelectorAll('.levels .level');
@@ -74,7 +88,7 @@ module('Integration | Component | popin-tube-level', function(hooks) {
     });
   });
 
-  test('it should display selected skill level', function(assert) {
+  test('it should display selected skill level', function (assert) {
     assert.expect(3);
     // when
     const expectedResult = ['1', '2'];
@@ -87,7 +101,7 @@ module('Integration | Component | popin-tube-level', function(hooks) {
     });
   });
 
-  test('it should invoke `clearTubeAction` on click on erase button', async function(assert) {
+  test('it should invoke `clearTubeAction` on click on erase button', async function (assert) {
     // when
     await click('[data-test-erase-button]');
 
@@ -95,9 +109,17 @@ module('Integration | Component | popin-tube-level', function(hooks) {
     assert.deepEqual(this.clearTubeAction.getCall(0).args, [tube]);
   });
 
-  test('it should invoke `setTubeAction` on click on skill cell', async function(assert) {
+  test('it should invoke `setTubeAction` on click on skill cell', async function (assert) {
     // when
-    const expectedResult = [tube, 5, [skill1.pixId, skill2.pixId, skill5.pixId]];
+    const expectedResult = [
+      tube,
+      5,
+      [
+        skill1.pixId,
+        skill2.pixId,
+        skill5.pixId,
+      ],
+    ];
     await click(findAll('.levels .level')[4]);
 
     // then

--- a/pix-editor/tests/integration/components/pop-in/tutorial-test.gjs
+++ b/pix-editor/tests/integration/components/pop-in/tutorial-test.gjs
@@ -4,35 +4,33 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | pop-in/tutorial', function(hooks) {
+module('Integration | Component | pop-in/tutorial', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const configService = this.owner.lookup('service:config');
-    configService.tutorialLocaleToLanguageMap = {
-      lang: 'Première langue',
-    };
+    configService.tutorialLocaleToLanguageMap = { lang: 'Première langue' };
     store = this.owner.lookup('service:store');
   });
 
-  test('save input should be disabled if mandatory field are empty', async function(assert) {
-    //given
+  test('save input should be disabled if mandatory field are empty', async function (assert) {
+    // given
     const closeFn = () => {};
     const saveTutorialFn = () => {};
 
     const emptyTutorial = store.createRecord('tutorial', {});
 
-    //when
+    // when
     const screen = await render(<template><TutorialPopin @close={{closeFn}} @tutorial={{emptyTutorial}} @saveTutorial={{saveTutorialFn}} @showModal={{true}} /></template>);
 
-    //then
+    // then
     assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).hasAria('disabled', 'true');
   });
 
-  test('save input should not be disabled if mandatory field are empty', async function(assert) {
-    //given
+  test('save input should not be disabled if mandatory field are empty', async function (assert) {
+    // given
     const closeFn = () => {};
     const saveTutorialFn = () => {};
     const filledTutorial = store.createRecord('tutorial', {
@@ -44,7 +42,7 @@ module('Integration | Component | pop-in/tutorial', function(hooks) {
       duration: '00:20:00',
     });
 
-    //when
+    // when
     const screen = await render(<template><TutorialPopin @close={{closeFn}} @tutorial={{filledTutorial}} @saveTutorial={{saveTutorialFn}} @showModal={{true}} /></template>);
 
     // then

--- a/pix-editor/tests/integration/components/sidebar/export-test.js
+++ b/pix-editor/tests/integration/components/sidebar/export-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | sidebar/export', function(hooks) {
+module('Integration | Component | sidebar/export', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 

--- a/pix-editor/tests/integration/components/sidebar/main-test.js
+++ b/pix-editor/tests/integration/components/sidebar/main-test.js
@@ -5,17 +5,18 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | main-sidebar', function(hooks) {
+module('Integration | Component | main-sidebar', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders main-sideBar', async function(assert) {
-    this.set('menuOpen', function() {});
-    this.set('openLogout', function() {});
-    this.set('closeMenu', function() {});
+  test('it renders main-sideBar', async function (assert) {
+    this.set('menuOpen', function () {});
+    this.set('openLogout', function () {});
+    this.set('closeMenu', function () {});
     this.owner.register('service:currentData', class MockService extends Service {
       getFramework() {
         return { name: 'Pix 1D' };
       }
+
       getAreas() {
         return [];
       }
@@ -27,19 +28,20 @@ module('Integration | Component | main-sidebar', function(hooks) {
     assert.dom('.main-sidebar').exists();
   });
 
-  module('the pix1d framework is selected', function() {
-    test('displays mission tab', async function(assert) {
+  module('the pix1d framework is selected', function () {
+    test('displays mission tab', async function (assert) {
       this.owner.register('service:currentData', class MockService extends Service {
         getFramework() {
           return { name: 'Pix 1D' };
         }
+
         getAreas() {
           return [];
         }
       });
-      this.set('menuOpen', function() {});
-      this.set('openLogout', function() {});
-      this.set('closeMenu', function() {});
+      this.set('menuOpen', function () {});
+      this.set('openLogout', function () {});
+      this.set('closeMenu', function () {});
 
       const screen = await render(hbs`<Sidebar::Main @openLogout={{this.openLogout}}
                                     @open={{this.menuOpen}}
@@ -48,19 +50,20 @@ module('Integration | Component | main-sidebar', function(hooks) {
     });
   });
 
-  module('the pix1d framework is not selected', function() {
-    test('does not display the Mission Pix 1D', async function(assert) {
+  module('the pix1d framework is not selected', function () {
+    test('does not display the Mission Pix 1D', async function (assert) {
       this.owner.register('service:currentData', class MockService extends Service {
         getFramework() {
           return { name: 'Pix+ Droit' };
         }
+
         getAreas() {
           return [];
         }
       });
-      this.set('menuOpen', function() {});
-      this.set('openLogout', function() {});
-      this.set('closeMenu', function() {});
+      this.set('menuOpen', function () {});
+      this.set('openLogout', function () {});
+      this.set('closeMenu', function () {});
 
       const screen = await render(hbs`<Sidebar::Main @openLogout={{this.openLogout}}
                                     @open={{this.menuOpen}}
@@ -70,4 +73,3 @@ module('Integration | Component | main-sidebar', function(hooks) {
     });
   });
 });
-

--- a/pix-editor/tests/integration/components/sidebar/navigation-test.gjs
+++ b/pix-editor/tests/integration/components/sidebar/navigation-test.gjs
@@ -7,34 +7,43 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | sidebar/navigation', function(hooks) {
+module('Integration | Component | sidebar/navigation', function (hooks) {
   setupIntlRenderingTest(hooks);
-  module('#isAdmin', function(hooks) {
+  module('#isAdmin', function (hooks) {
     let areas, frameworks, pixFramework, pixFranceFramework, closeAction, displayFrameworkList;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       closeAction = sinon.stub();
       displayFrameworkList = sinon.stub().returns(true);
 
-      areas = [{
-        name: 'area_1',
-        sortedCompetences: [{
-          id: 'competence1_1',
-          name: 'competence1_1',
-        }, {
-          id: 'competence1_2',
-          name: 'competence1_2',
-        }],
-      }, {
-        name: 'area_2',
-        sortedCompetences: [{
-          id: 'competence2_1',
-          name: 'competence2_1',
-        }, {
-          id: 'competence2_2',
-          name: 'competence2_2',
-        }],
-      }];
+      areas = [
+        {
+          name: 'area_1',
+          sortedCompetences: [
+            {
+              id: 'competence1_1',
+              name: 'competence1_1',
+            },
+            {
+              id: 'competence1_2',
+              name: 'competence1_2',
+            },
+          ],
+        },
+        {
+          name: 'area_2',
+          sortedCompetences: [
+            {
+              id: 'competence2_1',
+              name: 'competence2_1',
+            },
+            {
+              id: 'competence2_2',
+              name: 'competence2_2',
+            },
+          ],
+        },
+      ];
 
       pixFramework = {
         id: 'patate',
@@ -71,10 +80,14 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       });
     });
 
-    test('it should display a list of frameworks with a creation item', async function(assert) {
+    test('it should display a list of frameworks with a creation item', async function (assert) {
       assert.expect(3);
       // given
-      const expectedFrameworks = ['Pix', 'Pix +', 'Créer un nouveau référentiel'];
+      const expectedFrameworks = [
+        'Pix',
+        'Pix +',
+        'Créer un nouveau référentiel',
+      ];
 
       // when
       const screen = await render(<template><SidebarNavigation @displayFrameworkList={{displayFrameworkList}} @close={{closeAction}}/></template>);
@@ -88,7 +101,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       });
     });
 
-    test('it should display only a list of areas', async function(assert) {
+    test('it should display only a list of areas', async function (assert) {
       assert.expect(3);
       // given
       const expectedAreas = ['area_1', 'area_2'];
@@ -104,7 +117,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       assert.dom(await screen.queryByRole('link', { name: 'Ajouter un domaine' })).doesNotExist();
     });
 
-    test('it should display a button to create area if `source` is not `Pix`', async function(assert) {
+    test('it should display a button to create area if `source` is not `Pix`', async function (assert) {
       // given
       this.owner.register('service:currentData', class MockService extends Service {
         get isPixFramework() {
@@ -131,7 +144,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       assert.dom(screen.getByRole('link', { name: 'Ajouter un domaine' })).exists();
     });
 
-    test('it should display only a list of competences', async function(assert) {
+    test('it should display only a list of competences', async function (assert) {
       // given
       const expectedCompenteces = ['competence1_1', 'competence1_2'];
 
@@ -146,7 +159,7 @@ module('Integration | Component | sidebar/navigation', function(hooks) {
       assert.dom(await screen.queryByRole('link', { name: 'Ajouter une compétence' })).doesNotExist();
     });
 
-    test('it should display a button to create competence if `source` is not `Pix`', async function(assert) {
+    test('it should display a button to create competence if `source` is not `Pix`', async function (assert) {
       // given
       this.owner.register('service:currentData', class MockService extends Service {
         get isPixFramework() {

--- a/pix-editor/tests/integration/components/sidebar/search-test.gjs
+++ b/pix-editor/tests/integration/components/sidebar/search-test.gjs
@@ -5,10 +5,10 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | sidebar/search', function(hooks) {
+module('Integration | Component | sidebar/search', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // given
     const maySearch = sinon.stub().returns(true);
 

--- a/pix-editor/tests/integration/components/statistics/i18n-test.js
+++ b/pix-editor/tests/integration/components/statistics/i18n-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | statistics/i18n', function(hooks) {
+module('Integration | Component | statistics/i18n', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
     this.set('areas', []);
@@ -16,6 +16,5 @@ module('Integration | Component | statistics/i18n', function(hooks) {
     await render(hbs`<Statistics::I18n @areas={{this.areas}} @competenceCodes={{this.competenceCodes}}/>`);
 
     assert.dom('.ui.header').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/statistics/production-test.js
+++ b/pix-editor/tests/integration/components/statistics/production-test.js
@@ -4,10 +4,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | statistics/production', function(hooks) {
+module('Integration | Component | statistics/production', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
     this.set('areas', []);
@@ -16,6 +16,5 @@ module('Integration | Component | statistics/production', function(hooks) {
     await render(hbs`<Statistics::Production @areas={{this.areas}} @competenceCodes={{this.competenceCodes}}/>`);
 
     assert.dom('.ui.header').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/target-profile/area-profile-test.js
+++ b/pix-editor/tests/integration/components/target-profile/area-profile-test.js
@@ -5,11 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | target-profile/area-profile', function(hooks) {
+module('Integration | Component | target-profile/area-profile', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it filter', async function(assert) {
-
+  test('it filter', async function (assert) {
     // given
     const competence_1 = EmberObject.create({
       name: 'competence_1',
@@ -41,7 +40,7 @@ module('Integration | Component | target-profile/area-profile', function(hooks) 
     // when
     await render(hbs`<TargetProfile::AreaProfile @area={{this.area}} @filter={{this.filter}}/>`);
 
-    //then
+    // then
     assert.dom('[data-test-competence-profile]').exists({ count: 2 });
   });
 });

--- a/pix-editor/tests/integration/components/target-profile/competence-profile-test.gjs
+++ b/pix-editor/tests/integration/components/target-profile/competence-profile-test.gjs
@@ -5,11 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | target-profile/competence-profile', function(hooks) {
+module('Integration | Component | target-profile/competence-profile', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it filter', async function(assert) {
-
+  test('it filter', async function (assert) {
     // given
     const theme_1 = EmberObject.create({
       name: 'theme_1',
@@ -31,7 +30,11 @@ module('Integration | Component | target-profile/competence-profile', function(h
       title: 'competence_title',
       description: 'competence_description',
       code: '1',
-      sortedThemes: [theme_1, theme_2, theme_3],
+      sortedThemes: [
+        theme_1,
+        theme_2,
+        theme_3,
+      ],
     });
     const filter = true;
 
@@ -43,7 +46,7 @@ module('Integration | Component | target-profile/competence-profile', function(h
     assert.dom('[data-test-theme-profile]').exists({ count: 2 });
   });
 
-  test('it should not display empty theme', async function(assert) {
+  test('it should not display empty theme', async function (assert) {
     // given
     const theme_1 = EmberObject.create({
       name: 'theme_1',
@@ -69,6 +72,5 @@ module('Integration | Component | target-profile/competence-profile', function(h
 
     // then
     assert.dom('[data-test-theme-profile]').exists({ count: 1 });
-
   });
 });

--- a/pix-editor/tests/integration/components/target-profile/pdf-export-test.js
+++ b/pix-editor/tests/integration/components/target-profile/pdf-export-test.js
@@ -4,15 +4,14 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | target-profile/pdf-export', function(hooks) {
+module('Integration | Component | target-profile/pdf-export', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('it renders', async function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
     await render(hbs`<TargetProfile::PdfExport />`);
     assert.dom('.ui.button i.pdf').exists();
-
   });
 });

--- a/pix-editor/tests/integration/components/target-profile/theme-profile-test.js
+++ b/pix-editor/tests/integration/components/target-profile/theme-profile-test.js
@@ -5,14 +5,18 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | target-profile/theme-profile', function(hooks) {
+module('Integration | Component | target-profile/theme-profile', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it filter', async function(assert) {
+  test('it filter', async function (assert) {
     // given
     const theme = EmberObject.create({
       name: 'theme_name',
-      productionTubes: [{ selectedLevel: 5 }, { selectedLevel: 5 }, { selectedLevel: false }],
+      productionTubes: [
+        { selectedLevel: 5 },
+        { selectedLevel: 5 },
+        { selectedLevel: false },
+      ],
     });
 
     this.set('theme', theme);

--- a/pix-editor/tests/integration/components/target-profile/threshold-row-test.js
+++ b/pix-editor/tests/integration/components/target-profile/threshold-row-test.js
@@ -4,23 +4,25 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | target-profile/threshold-row', function(hooks) {
+module('Integration | Component | target-profile/threshold-row', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should render a row with a total skill count by level and a threshold', async function(assert) {
-    //given
+  test('it should render a row with a total skill count by level and a threshold', async function (assert) {
+    // given
     const selectedSkillsLevel1 = [
       {
         id: 'rec123456',
         name: 'tube1SelectedSkill1',
         isActive: true,
         level: 1,
-      }, {
+      },
+      {
         id: 'rec223457',
         name: 'tube2SelectedSkill1',
         isActive: true,
         level: 1,
-      }, {
+      },
+      {
         id: 'rec423451',
         name: 'tube2SelectedSkill1',
         isActive: true,
@@ -33,37 +35,44 @@ module('Integration | Component | target-profile/threshold-row', function(hooks)
         name: 'tube1SelectedSkill2',
         isActive: true,
         level: 2,
-      }, {
+      },
+      {
         id: 'rec123458',
         name: 'tube1SelectedSkill3',
         isActive: true,
         level: 3,
-      }, {
+      },
+      {
         id: 'rec223456',
         name: 'tube2SelectedSkill4',
         isActive: true,
         level: 4,
-      }, {
+      },
+      {
         id: 'rec223458',
         name: 'tube2SelectedSkill6',
         isActive: true,
         level: 6,
-      }, {
+      },
+      {
         id: 'rec323456',
         name: 'tube2SelectedSkill7',
         isActive: true,
         level: 7,
-      }, {
+      },
+      {
         id: 'rec323457',
         name: 'tube2SelectedSkill8',
         isActive: true,
         level: 8,
-      }, {
+      },
+      {
         id: 'rec423456',
         name: 'tube2SelectedSkill7',
         isActive: true,
         level: 7,
-      }, {
+      },
+      {
         id: 'rec423457',
         name: 'tube2SelectedSkill8',
         isActive: true,
@@ -77,10 +86,10 @@ module('Integration | Component | target-profile/threshold-row', function(hooks)
     this.selectedSkills = [...selectedSkillsLevel1, ...selectedSkillsOtherLevel];
     this.level = 1;
 
-    //when
+    // when
     await render(hbs`<TargetProfile::ThresholdRow @level={{this.level}} @selectedSkills={{this.selectedSkills}}/>`);
 
-    //then
+    // then
     assert.dom(this.element.querySelector('[data-test-skill-count]')).hasText(expectedCountResult);
     assert.dom(this.element.querySelector('[data-test-threshold]')).hasText(expectedThresholdResult);
   });

--- a/pix-editor/tests/integration/components/target-profile/tube-profile-test.js
+++ b/pix-editor/tests/integration/components/target-profile/tube-profile-test.js
@@ -4,11 +4,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | target-profile/competence-thematic-result', function(hooks) {
+module('Integration | Component | target-profile/competence-thematic-result', function (hooks) {
   setupIntlRenderingTest(hooks);
   let tube;
-  hooks.beforeEach(async function() {
-    //given
+  hooks.beforeEach(async function () {
+    // given
     tube = {
       id: 'rec123456',
       name: '@tube1',
@@ -21,35 +21,35 @@ module('Integration | Component | target-profile/competence-thematic-result', fu
     };
   });
 
-  test('it should be selected if tube have a `selectedSkillLevel` if `showTubeDetails` is `false`', async function(assert) {
-    //given
+  test('it should be selected if tube have a `selectedSkillLevel` if `showTubeDetails` is `false`', async function (assert) {
+    // given
     this.selectedLevel = 6;
     this.showTubeDetails = false;
 
-    //when
+    // when
     await render(hbs`<TargetProfile::TubeProfile @tube={{this.tube}}
                                                  @clickAction={{this.clickOnTube}}
                                                  @selectedSkillLevel={{this.selectedLevel}}
                                                  @showTubeDetails={{this.showTubeDetails}}/>`);
 
-    //then
+    // then
     assert.dom(this.element.querySelector('[data-test-tube-profile]')).hasClass('active');
     assert.dom(this.element.querySelector('.square.icon')).hasClass('active');
     assert.dom(this.element.querySelector('.square.icon')).hasClass('check');
   });
 
-  test('it should display a `selectedSkillLevel` if `showTubeDetails` is `true`', async function(assert) {
-    //given
+  test('it should display a `selectedSkillLevel` if `showTubeDetails` is `true`', async function (assert) {
+    // given
     this.showTubeDetails = true;
     this.selectedLevel = 6;
 
-    //when
+    // when
     await render(hbs`<TargetProfile::TubeProfile @tube={{this.tube}}
                                                  @clickAction={{this.clickOnTube}}
                                                  @selectedSkillLevel={{this.selectedLevel}}
                                                  @showTubeDetails={{this.showTubeDetails}}/>`);
 
-    //then
+    // then
     assert.dom('.max-skill-level').hasText('6');
   });
 });

--- a/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
+++ b/pix-editor/tests/integration/components/whitelisted-urls/list-test.js
@@ -5,12 +5,12 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | whitelisted-urls/list', function(hooks) {
+module('Integration | Component | whitelisted-urls/list', function (hooks) {
   setupIntlRenderingTest(hooks);
   let store, whitelistedUrl1, whitelistedUrl2, hour1_create, hour1_update, hour2_create;
   let onApplyFiltersClickedStub, onClearFiltersClickedStub, onDeleteItemClickedStub, onEditStub;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     store = this.owner.lookup('service:store');
     whitelistedUrl1 = store.createRecord('whitelisted-url', {
       id: '1',
@@ -50,7 +50,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     onEditStub = sinon.stub();
   });
 
-  test('it should display list of whitelisted urls passed in params and initialize filter inputs', async function(assert) {
+  test('it should display list of whitelisted urls passed in params and initialize filter inputs', async function (assert) {
     // given
     this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
     this.urlFilterValue = 'initialUrlValue';
@@ -75,34 +75,22 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
 
     // then
     assert.ok(
-      screen.getByRole('columnheader', {
-        name: 'Nom des acquis concernés',
-      }),
+      screen.getByRole('columnheader', { name: 'Nom des acquis concernés' }),
     );
     assert.ok(
-      screen.getByRole('columnheader', {
-        name: 'Type de comparaison',
-      }),
+      screen.getByRole('columnheader', { name: 'Type de comparaison' }),
     );
     assert.ok(
-      screen.getByRole('columnheader', {
-        name: 'URL',
-      }),
+      screen.getByRole('columnheader', { name: 'URL' }),
     );
     assert.ok(
-      screen.getByRole('columnheader', {
-        name: 'Commentaire',
-      }),
+      screen.getByRole('columnheader', { name: 'Commentaire' }),
     );
     assert.ok(
-      screen.getByRole('columnheader', {
-        name: 'Créée le',
-      }),
+      screen.getByRole('columnheader', { name: 'Créée le' }),
     );
     assert.ok(
-      screen.getByRole('columnheader', {
-        name: 'Modifiée le',
-      }),
+      screen.getByRole('columnheader', { name: 'Modifiée le' }),
     );
     assert.strictEqual(screen.getAllByRole('row').length, 3);
     assert.ok(screen.getByRole('cell', { name: 'https://foo.com' }), 'https://foo.com');
@@ -119,7 +107,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     assert.strictEqual(screen.getByLabelText('Nom d\'acquis').value, 'initialNamesValue');
   });
 
-  test('it should pass up typed url filter and keeping the previous names filter when applying', async function(assert) {
+  test('it should pass up typed url filter and keeping the previous names filter when applying', async function (assert) {
     // given
     this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
     this.urlFilterValue = 'initialUrlValue';
@@ -150,7 +138,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     sinon.assert.calledWithExactly(onApplyFiltersClickedStub, 'different url value', 'initialNamesValue');
   });
 
-  test('it should pass up typed names filter and keeping the previous url filter when applying', async function(assert) {
+  test('it should pass up typed names filter and keeping the previous url filter when applying', async function (assert) {
     // given
     this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
     this.urlFilterValue = 'initialUrlValue';
@@ -181,7 +169,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     sinon.assert.calledWithExactly(onApplyFiltersClickedStub, 'initialUrlValue', 'different names value');
   });
 
-  test('it should pass up both typed names and url filters when applying', async function(assert) {
+  test('it should pass up both typed names and url filters when applying', async function (assert) {
     // given
     this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
     this.urlFilterValue = 'initialUrlValue';
@@ -213,7 +201,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     sinon.assert.calledWithExactly(onApplyFiltersClickedStub, 'different url value', 'different names value');
   });
 
-  test('it should call arg function when clearing filters', async function(assert) {
+  test('it should call arg function when clearing filters', async function (assert) {
     // given
     this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
     this.urlFilterValue = 'initialUrlValue';
@@ -242,7 +230,7 @@ module('Integration | Component | whitelisted-urls/list', function(hooks) {
     assert.ok(true);
   });
 
-  test('it should call arg edit function when clicking on list item', async function(assert) {
+  test('it should call arg edit function when clicking on list item', async function (assert) {
     // given
     this.whitelistedUrls = [whitelistedUrl1, whitelistedUrl2];
     this.urlFilterValue = 'initialUrlValue';

--- a/pix-editor/tests/integration/components/whitelisted-urls/related-skill-cell-test.gjs
+++ b/pix-editor/tests/integration/components/whitelisted-urls/related-skill-cell-test.gjs
@@ -5,10 +5,10 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
-module('Integration | Component | whitelisted-urls/related-skill-cell', function(hooks) {
+module('Integration | Component | whitelisted-urls/related-skill-cell', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it should display an empty when there is no skill', async function(assert) {
+  test('it should display an empty when there is no skill', async function (assert) {
     // given
     const skills = null;
 
@@ -22,7 +22,7 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
     assert.strictEqual(content.length, 0);
   });
 
-  test('it should display a skill when there is one skill', async function(assert) {
+  test('it should display a skill when there is one skill', async function (assert) {
     // given
     const skills = '@skill1';
 
@@ -31,13 +31,7 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
       <RelatedSkillCell @skills={{skills}} />
     </template>));
     const allElementsWithSkill = await screen.queryAllByText('@skill1');
-    const [
-      skillCell,
-      tooltip,
-    ] = [
-      allElementsWithSkill.find((el) => el.hasAttribute('aria-labelledby')),
-      allElementsWithSkill.find((el) => !el.hasAttribute('aria-labelledby')),
-    ];
+    const [skillCell, tooltip] = [allElementsWithSkill.find((el) => el.hasAttribute('aria-labelledby')), allElementsWithSkill.find((el) => !el.hasAttribute('aria-labelledby'))];
     await triggerEvent(skillCell, 'mouseenter');
 
     // then
@@ -45,7 +39,7 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
     assert.dom(tooltip).isVisible();
   });
 
-  test('it should display the first skill (as in alphabetical order) and a singular version of appended sentence when there is a list of 2 skills', async function(assert) {
+  test('it should display the first skill (as in alphabetical order) and a singular version of appended sentence when there is a list of 2 skills', async function (assert) {
     // given
     const skills = '@verite2,@mensonge3';
 
@@ -62,7 +56,7 @@ module('Integration | Component | whitelisted-urls/related-skill-cell', function
     assert.dom(tooltip).isVisible();
   });
 
-  test('it should display the first skill (as in alphabetical order) and a plural version of appended sentence when there is a list of more than 2 skills', async function(assert) {
+  test('it should display the first skill (as in alphabetical order) and a plural version of appended sentence when there is a list of more than 2 skills', async function (assert) {
     // given
     const skills = '@verite2,@mensonge3,@meOperator3';
 

--- a/pix-editor/tests/setup-application-rendering.js
+++ b/pix-editor/tests/setup-application-rendering.js
@@ -5,7 +5,7 @@ export function setupApplicationTest(hooks) {
   emberSetupApplicationTest(hooks);
   setupIntl(hooks, 'fr');
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     window.localStorage.removeItem('v2');
   });
 }

--- a/pix-editor/tests/unit/adapters/airtable-test.js
+++ b/pix-editor/tests/unit/adapters/airtable-test.js
@@ -2,11 +2,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | airtable', function(hooks) {
+module('Unit | Adapter | airtable', function (hooks) {
   setupTest(hooks);
 
-  module('#updateRecord', function() {
-    test('when the primaryKey is the record id, it uses the id', function(assert) {
+  module('#updateRecord', function () {
+    test('when the primaryKey is the record id, it uses the id', function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
       const serializer = {
         primaryKey: 'Record ID',
@@ -17,15 +17,11 @@ module('Unit | Adapter | airtable', function(hooks) {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       const snapshot = {
         id: '1',
         attributes() {
-          return {
-            airtableId: 'myAirtableId',
-          };
+          return { airtableId: 'myAirtableId' };
         },
       };
 
@@ -36,7 +32,7 @@ module('Unit | Adapter | airtable', function(hooks) {
       assert.ok(adapter.ajax.calledWith('/api/airtable/changelog/testTables/1', 'PATCH', { data: {} }));
     });
 
-    test('when the primaryKey is the persistant id, it uses the record id', function(assert) {
+    test('when the primaryKey is the persistant id, it uses the record id', function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
       const serializer = {
         primaryKey: 'id persistant',
@@ -47,15 +43,11 @@ module('Unit | Adapter | airtable', function(hooks) {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       const snapshot = {
         id: '1',
         attributes() {
-          return {
-            airtableId: 'myAirtableId',
-          };
+          return { airtableId: 'myAirtableId' };
         },
       };
 
@@ -66,7 +58,7 @@ module('Unit | Adapter | airtable', function(hooks) {
       assert.ok(adapter.ajax.calledWith('/api/airtable/changelog/testTables/myAirtableId', 'PATCH', { data: {} }));
     });
 
-    test('when the primaryKey is set but the airtableId is null, it POST to create the record', function(assert) {
+    test('when the primaryKey is set but the airtableId is null, it POST to create the record', function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
       const serializer = {
         primaryKey: 'id persistant',
@@ -77,15 +69,11 @@ module('Unit | Adapter | airtable', function(hooks) {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       const snapshot = {
         id: '1',
         attributes() {
-          return {
-            airtableId: undefined,
-          };
+          return { airtableId: undefined };
         },
       };
 
@@ -97,90 +85,92 @@ module('Unit | Adapter | airtable', function(hooks) {
     });
   });
 
-  module('#findMany', function() {
+  module('#findMany', function () {
     const MAX_IDS = 3;
 
-    test('call ajax with the right parameter', function(assert) {
+    test('call ajax with the right parameter', function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
-      const serializer = {
-        primaryKey: 'id persistant',
-      };
+      const serializer = { primaryKey: 'id persistant' };
       const store = {
         serializerFor() {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       adapter.ajax = sinon.stub();
 
-      adapter.findMany(store, type, [1, 2, 3], [], MAX_IDS);
+      adapter.findMany(store, type, [
+        1,
+        2,
+        3,
+      ], [], MAX_IDS);
 
       assert.ok(adapter.ajax.called);
       assert.ok(adapter.ajax.calledWith('/api/airtable/changelog/testTables', 'GET', { data: { filterByFormula: 'OR({id persistant} = \'1\',{id persistant} = \'2\',{id persistant} = \'3\')' } }));
     });
 
-    test('split the ajax calls', function(assert) {
+    test('split the ajax calls', function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
-      const serializer = {
-        primaryKey: 'id persistant',
-      };
+      const serializer = { primaryKey: 'id persistant' };
       const store = {
         serializerFor() {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       adapter.ajax = sinon.stub().resolves({ records: ['data'] });
 
-      adapter.findMany(store, type, [1, 2, 3, 4], [], MAX_IDS);
+      adapter.findMany(store, type, [
+        1,
+        2,
+        3,
+        4,
+      ], [], MAX_IDS);
 
       assert.ok(adapter.ajax.calledTwice);
       assert.ok(adapter.ajax.getCalls()[0].calledWith('/api/airtable/changelog/testTables', 'GET', { data: { filterByFormula: 'OR({id persistant} = \'1\',{id persistant} = \'2\',{id persistant} = \'3\')' } }));
       assert.ok(adapter.ajax.getCalls()[1].calledWith('/api/airtable/changelog/testTables', 'GET', { data: { filterByFormula: 'OR({id persistant} = \'4\')' } }));
     });
 
-    test('returns response from ajax call', async function(assert) {
+    test('returns response from ajax call', async function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
-      const serializer = {
-        primaryKey: 'id persistant',
-      };
+      const serializer = { primaryKey: 'id persistant' };
       const store = {
         serializerFor() {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       adapter.ajax = sinon.stub().resolves({ records: ['data'] });
 
-      const response = await adapter.findMany(store, type, [1, 2, 3], [], MAX_IDS);
+      const response = await adapter.findMany(store, type, [
+        1,
+        2,
+        3,
+      ], [], MAX_IDS);
 
       assert.deepEqual(response, { records: ['data'] });
     });
 
-    test('merges responses from splitted ajax calls', async function(assert) {
+    test('merges responses from splitted ajax calls', async function (assert) {
       const adapter = this.owner.lookup('adapter:airtable');
-      const serializer = {
-        primaryKey: 'id persistant',
-      };
+      const serializer = { primaryKey: 'id persistant' };
       const store = {
         serializerFor() {
           return serializer;
         },
       };
-      const type = {
-        modelName: 'TestTable',
-      };
+      const type = { modelName: 'TestTable' };
       adapter.ajax = sinon.stub()
         .onFirstCall().resolves({ records: ['data'] })
         .onSecondCall().resolves({ records: ['data2'] });
 
-      const response = await adapter.findMany(store, type, [1, 2, 3, 4], [], MAX_IDS);
+      const response = await adapter.findMany(store, type, [
+        1,
+        2,
+        3,
+        4,
+      ], [], MAX_IDS);
 
       assert.deepEqual(response, { records: ['data', 'data2'] });
     });

--- a/pix-editor/tests/unit/component/field/illustration-test.js
+++ b/pix-editor/tests/unit/component/field/illustration-test.js
@@ -4,15 +4,15 @@ import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('unit | Component | field/illustration', function(hooks) {
+module('unit | Component | field/illustration', function (hooks) {
   setupTest(hooks);
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     component = createGlimmerComponent('component:field/illustration');
   });
 
-  test('it should remove old illustration before add new illustration', async function(assert) {
+  test('it should remove old illustration before add new illustration', async function (assert) {
     // given
     const removeIllustrationStub = sinon.stub().resolves();
     component.args.removeIllustration = removeIllustrationStub;

--- a/pix-editor/tests/unit/component/form/challenge-test.js
+++ b/pix-editor/tests/unit/component/form/challenge-test.js
@@ -3,21 +3,27 @@ import { module, test } from 'qunit';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('unit | Component | form/challenge', function(hooks) {
+module('unit | Component | form/challenge', function (hooks) {
   setupTest(hooks);
   let component;
 
-  hooks.beforeEach(function() {
-    component = createGlimmerComponent('component:form/challenge', {
-      challenge: {},
-    });
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:form/challenge', { challenge: {} });
   });
 
-  test('it should set locales properly', async function(assert) {
+  test('it should set locales properly', async function (assert) {
     // given
-    const input = ['en', 'fr-fr', 'fr'];
+    const input = [
+      'en',
+      'fr-fr',
+      'fr',
+    ];
 
-    const expected = ['en', 'fr-fr', 'fr'];
+    const expected = [
+      'en',
+      'fr-fr',
+      'fr',
+    ];
 
     const challenge = {
       id: 'recchallenge_1',

--- a/pix-editor/tests/unit/component/grid/grid-cell_test.js
+++ b/pix-editor/tests/unit/component/grid/grid-cell_test.js
@@ -5,17 +5,16 @@ import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('Unit | Component | competence/grid/grid-cell', function(hooks) {
+module('Unit | Component | competence/grid/grid-cell', function (hooks) {
   setupTest(hooks);
   let section, view;
-  module('#draftSkill', function(hooks) {
-
-    hooks.beforeEach(function() {
+  module('#draftSkill', function (hooks) {
+    hooks.beforeEach(function () {
       section = 'skills';
       view = 'draft';
     });
 
-    test('it should return a proper cell type if there is a skill', function(assert) {
+    test('it should return a proper cell type if there is a skill', function (assert) {
       // given
       const skill = {
         id: 'skillId',
@@ -29,7 +28,7 @@ module('Unit | Component | competence/grid/grid-cell', function(hooks) {
       // then
       assert.strictEqual(result, 'skill-draft');
     });
-    test('it should return `empty` if there isn\'t skill', function(assert) {
+    test('it should return `empty` if there isn\'t skill', function (assert) {
       // given
       const component = createGlimmerComponent('component:competence/grid/grid-cell', { section, view });
 
@@ -40,7 +39,7 @@ module('Unit | Component | competence/grid/grid-cell', function(hooks) {
       assert.strictEqual(result, 'empty');
     });
 
-    test('it should return `add-skill` if user may edit skill', function(assert) {
+    test('it should return `add-skill` if user may edit skill', function (assert) {
       // given
       class AccessService extends Service {
         constructor() {

--- a/pix-editor/tests/unit/component/sidebar/export-test.js
+++ b/pix-editor/tests/unit/component/sidebar/export-test.js
@@ -4,41 +4,29 @@ import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('unit | Component | sidebar/export', function(hooks) {
+module('unit | Component | sidebar/export', function (hooks) {
   setupTest(hooks);
   let component, areas;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     component = createGlimmerComponent('component:sidebar/export');
 
     const productionSkill_1_1 = [
-      {
-        name: 'skill1_1', level: 1,
-      }, {
-        name: 'skill1_3', level: 3,
-      }, {
-        name: 'skill1_6', level: 6,
-      },
+      { name: 'skill1_1', level: 1 },
+      { name: 'skill1_3', level: 3 },
+      { name: 'skill1_6', level: 6 },
     ];
 
     const productionSkill_1_2 = [
-      {
-        name: 'skill2_2', level: 2,
-      }, {
-        name: 'skill2_3', level: 3,
-      }, {
-        name: 'skill2_4', level: 4,
-      },
+      { name: 'skill2_2', level: 2 },
+      { name: 'skill2_3', level: 3 },
+      { name: 'skill2_4', level: 4 },
     ];
 
     const productionSkill_2_1 = [
-      {
-        name: 'skill3_1', level: 1,
-      }, {
-        name: 'skill3_5', level: 5,
-      }, {
-        name: 'skill3_6', level: 6,
-      },
+      { name: 'skill3_1', level: 1 },
+      { name: 'skill3_5', level: 5 },
+      { name: 'skill3_6', level: 6 },
     ];
 
     const productionTubes_1_1 = {
@@ -89,14 +77,16 @@ module('unit | Component | sidebar/export', function(hooks) {
       rawThemes: [theme2],
     };
 
-    areas = [{
-      name: 'area',
-      sortedCompetences: [competence1, competence2],
-      competences: [competence1, competence2],
-    }];
+    areas = [
+      {
+        name: 'area',
+        sortedCompetences: [competence1, competence2],
+        competences: [competence1, competence2],
+      },
+    ];
   });
 
-  test('it should return formatted cvs content', function(assert) {
+  test('it should return formatted cvs content', function (assert) {
     // given
     const expectedCsvContent = `"Domaine","Compétence","Thématique","Tube","Titre pratique","Description pratique","Liste des acquis"
 "area","competence1","theme1","tube1","practicalTitleFr_tube1","practicalDescriptionFr_tube1","skill1_1,░,skill1_3,░,░,skill1_6,░,░"
@@ -110,7 +100,7 @@ module('unit | Component | sidebar/export', function(hooks) {
     assert.strictEqual(csvContent, expectedCsvContent);
   });
 
-  test('it should format CSV string', function(assert) {
+  test('it should format CSV string', function (assert) {
     // given
     const string = 'hello';
     const expectedResult = '"hello"';
@@ -122,10 +112,10 @@ module('unit | Component | sidebar/export', function(hooks) {
     assert.strictEqual(result, expectedResult);
   });
 
-  module('#export', function(hooks) {
+  module('#export', function (hooks) {
     let notifyMessageStub, notifyErrorStub, loaderStartStub, loaderStopStub, buildCSVContentStub;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       notifyMessageStub = sinon.stub();
       notifyErrorStub = sinon.stub();
 
@@ -147,12 +137,10 @@ module('unit | Component | sidebar/export', function(hooks) {
       component.args.areas = areas;
     });
 
-    test('it should export subjects', async function(assert) {
+    test('it should export subjects', async function (assert) {
       // given
       const saveAsStub = sinon.stub();
-      component.fileSaver = {
-        saveAs: saveAsStub,
-      };
+      component.fileSaver = { saveAs: saveAsStub };
       // when
       await component.shareAreas();
 
@@ -164,12 +152,10 @@ module('unit | Component | sidebar/export', function(hooks) {
       assert.ok(loaderStopStub.calledOnce);
     });
 
-    test('it should catch an error if export subject failed', async function(assert) {
+    test('it should catch an error if export subject failed', async function (assert) {
       // given
       const saveAsStub = sinon.stub().throws();
-      component.fileSaver = {
-        saveAs: saveAsStub,
-      };
+      component.fileSaver = { saveAs: saveAsStub };
 
       // when
       await component.shareAreas();

--- a/pix-editor/tests/unit/component/sidebar/navigation-test.js
+++ b/pix-editor/tests/unit/component/sidebar/navigation-test.js
@@ -4,15 +4,15 @@ import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('unit | Component | sidebar/navigation', function(hooks) {
+module('unit | Component | sidebar/navigation', function (hooks) {
   setupTest(hooks);
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     component = createGlimmerComponent('component:sidebar/navigation');
   });
 
-  test('it should display newFramework pop-in', function(assert) {
+  test('it should display newFramework pop-in', function (assert) {
     // given
     const newFramework = { name: '' };
     const createRecordStub = sinon.stub().returns(newFramework);
@@ -29,7 +29,7 @@ module('unit | Component | sidebar/navigation', function(hooks) {
     assert.ok(component.displayNewFrameworkPopIn);
   });
 
-  test('it should hide newFramework pop-in', function(assert) {
+  test('it should hide newFramework pop-in', function (assert) {
     // given
     const framework = { name: 'pix +' };
     const deleteRecordStub = sinon.stub();
@@ -45,9 +45,9 @@ module('unit | Component | sidebar/navigation', function(hooks) {
     assert.notOk(component.displayNewFrameworkPopIn);
   });
 
-  module('#saveFramework', function(hooks) {
+  module('#saveFramework', function (hooks) {
     let notifyMessageStub, notifyErrorStub, loaderStartStub, loaderStopStub;
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       notifyMessageStub = sinon.stub();
       notifyErrorStub = sinon.stub();
 
@@ -65,12 +65,10 @@ module('unit | Component | sidebar/navigation', function(hooks) {
       };
     });
 
-    test('it should save the framework', async function(assert) {
+    test('it should save the framework', async function (assert) {
       // given
       const transitionToStub = sinon.stub();
-      component.router = {
-        transitionTo: transitionToStub,
-      };
+      component.router = { transitionTo: transitionToStub };
       const saveStub = sinon.stub().resolves();
       const framework = {
         id: 'patate +',
@@ -97,11 +95,9 @@ module('unit | Component | sidebar/navigation', function(hooks) {
       assert.ok(transitionToStub.calledWith('authenticated'));
     });
 
-    test('it should catch an error if save framework failed', async function(assert) {
+    test('it should catch an error if save framework failed', async function (assert) {
       // given
-      const errorMessage = {
-        'error': ['error-test'],
-      };
+      const errorMessage = { error: ['error-test'] };
       const saveStub = sinon.stub().rejects(errorMessage);
       component.newFramework = {
         name: 'pix +',

--- a/pix-editor/tests/unit/component/sidebar/search-test.js
+++ b/pix-editor/tests/unit/component/sidebar/search-test.js
@@ -4,16 +4,16 @@ import sinon from 'sinon';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('Unit | Component | sidebar/search', function(hooks) {
+module('Unit | Component | sidebar/search', function (hooks) {
   setupTest(hooks);
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     component = createGlimmerComponent('component:sidebar/search');
   });
 
-  module('#searchSkillsByName', function() {
-    test('it should query store with skill name', function(assert) {
+  module('#searchSkillsByName', function () {
+    test('it should query store with skill name', function (assert) {
     // given
       const queryStub = sinon.stub().resolves([]);
 
@@ -24,9 +24,7 @@ module('Unit | Component | sidebar/search', function(hooks) {
 
       // then
       assert.ok(queryStub.calledWith('skill', {
-        filter: {
-          name: '\\\'"\t coucou \\\'"\t',
-        },
+        filter: { name: '\\\'"\t coucou \\\'"\t' },
         page: { limit: 20 },
         sort: 'name,-version',
       }));

--- a/pix-editor/tests/unit/component/target-profile/pdf-export-test.js
+++ b/pix-editor/tests/unit/component/target-profile/pdf-export-test.js
@@ -3,18 +3,18 @@ import { module, test } from 'qunit';
 
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('Unit | Component | target-profile/pdf-export', function(hooks) {
+module('Unit | Component | target-profile/pdf-export', function (hooks) {
   setupTest(hooks);
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     component = createGlimmerComponent('component:target-profile/pdf-export');
   });
 
-  module('#_getTranslatedField', function(hooks) {
+  module('#_getTranslatedField', function (hooks) {
     let model, keys;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       model = {
         id: 'modelId',
         titleEnUs: 'English name',
@@ -26,7 +26,7 @@ module('Unit | Component | target-profile/pdf-export', function(hooks) {
       };
     });
 
-    test('it should get the english field if language is `en`', async function(assert) {
+    test('it should get the english field if language is `en`', async function (assert) {
       // given
       const language = 'en';
 
@@ -37,7 +37,7 @@ module('Unit | Component | target-profile/pdf-export', function(hooks) {
       assert.strictEqual(result, 'English name');
     });
 
-    test('it should get the french field if language is `fr`', async function(assert) {
+    test('it should get the french field if language is `fr`', async function (assert) {
       // given
       const language = 'fr';
 

--- a/pix-editor/tests/unit/controllers/area-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/area-management/new-test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | area-management/new', function(hooks) {
+module('Unit | Controller | area-management/new', function (hooks) {
   setupTest(hooks);
   let controller, transitionToRouteStub, area, framework, notifyMessageStub, notifyErrorStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
     class NotifyService extends Service {
@@ -19,19 +19,15 @@ module('Unit | Controller | area-management/new', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.area-management/new');
     transitionToRouteStub = sinon.stub();
     controller.router.transitionTo = transitionToRouteStub;
-    area = {
-      name: 'newArea',
-    };
-    framework = {
-      name: 'Pix+',
-    };
+    area = { name: 'newArea' };
+    framework = { name: 'Pix+' };
     controller.model = {
       area,
       framework,
     };
   });
 
-  test('it should cancel creation', function(assert) {
+  test('it should cancel creation', function (assert) {
     // given
     const deleteRecordStub = sinon.stub();
     controller.store.deleteRecord = deleteRecordStub;
@@ -45,9 +41,9 @@ module('Unit | Controller | area-management/new', function(hooks) {
     assert.ok(transitionToRouteStub.calledWith('authenticated'));
   });
 
-  module('#save', function(hooks) {
+  module('#save', function (hooks) {
     let loaderStartStub, loaderStopStub;
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       loaderStartStub = sinon.stub();
       loaderStopStub = sinon.stub();
 
@@ -59,7 +55,7 @@ module('Unit | Controller | area-management/new', function(hooks) {
       this.owner.register('service:loader', LoaderService);
     });
 
-    test('it should save area', async function(assert) {
+    test('it should save area', async function (assert) {
       // given
       const saveStub = sinon.stub().resolves();
       area.save = saveStub;
@@ -82,11 +78,9 @@ module('Unit | Controller | area-management/new', function(hooks) {
       assert.ok(transitionToRouteStub.calledWith('authenticated'));
     });
 
-    test('it should throw an error if saving failed', async function(assert) {
+    test('it should throw an error if saving failed', async function (assert) {
       // given
-      const errorMessage = {
-        'error': ['error-test'],
-      };
+      const errorMessage = { error: ['error-test'] };
       const saveStub = sinon.stub().rejects(errorMessage);
       area.save = saveStub;
 

--- a/pix-editor/tests/unit/controllers/authenticated-test.js
+++ b/pix-editor/tests/unit/controllers/authenticated-test.js
@@ -3,12 +3,12 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated', function(hooks) {
+module('Unit | Controller | authenticated', function (hooks) {
   setupTest(hooks);
 
   let controller, confirmAskStub, storeQueryStub, reloadStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     storeQueryStub = sinon.stub();
     class Store extends Service {
       queryRecord = storeQueryStub;
@@ -27,7 +27,7 @@ module('Unit | Controller | authenticated', function(hooks) {
     reloadStub = sinon.stub();
   });
 
-  test('it should reload when user confirms new version notification', async function(assert) {
+  test('it should reload when user confirms new version notification', async function (assert) {
     // given
     storeQueryStub.resolves({ version: 'nouvelle version' });
     confirmAskStub.resolves();
@@ -39,7 +39,7 @@ module('Unit | Controller | authenticated', function(hooks) {
     assert.true(reloadStub.calledOnce, 'window.location.reload() called');
   });
 
-  test('it should not reload when user does not confirm new version notification', async function(assert) {
+  test('it should not reload when user does not confirm new version notification', async function (assert) {
     // given
     storeQueryStub.resolves({ version: 'nouvelle version' });
     confirmAskStub.rejects();

--- a/pix-editor/tests/unit/controllers/competence-management/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/new-test.js
@@ -3,10 +3,10 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence-management/new', function(hooks) {
+module('Unit | Controller | competence-management/new', function (hooks) {
   setupTest(hooks);
   let controller, transitionToRouteStub, area, competence, notifyMessageStub, notifyErrorStub;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
     class NotifyService extends Service {
@@ -20,9 +20,7 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     controller.router.transitionTo = transitionToRouteStub;
     area = {
       source: 'Pix+',
-      framework: {
-        name: 'Pix+',
-      },
+      framework: { name: 'Pix+' },
     };
     competence = {
       code: '1.1',
@@ -35,7 +33,7 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     };
   });
 
-  test('it should cancel creation', function(assert) {
+  test('it should cancel creation', function (assert) {
     // given
     const deleteRecordStub = sinon.stub();
     controller.store.deleteRecord = deleteRecordStub;
@@ -50,9 +48,9 @@ module('Unit | Controller | competence-management/new', function(hooks) {
     assert.ok(transitionToRouteStub.calledWith('authenticated'));
   });
 
-  module('#save', function(hooks) {
+  module('#save', function (hooks) {
     let loaderStartStub, loaderStopStub;
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       loaderStartStub = sinon.stub();
       loaderStopStub = sinon.stub();
       class LoaderService extends Service {
@@ -62,19 +60,15 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       this.owner.register('service:loader', LoaderService);
     });
 
-    test('it should save competence', async function(assert) {
+    test('it should save competence', async function (assert) {
       // given
       const saveStub = sinon.stub().resolves();
       competence.save = saveStub;
       const expectedCompetence = {
         area,
         code: '1.1',
-        rawThemes: [
-          'theme',
-        ],
-        rawTubes: [
-          'tube',
-        ],
+        rawThemes: ['theme'],
+        rawTubes: ['tube'],
         save: saveStub,
       };
       // when
@@ -90,11 +84,9 @@ module('Unit | Controller | competence-management/new', function(hooks) {
       assert.ok(transitionToRouteStub.calledWith('authenticated.competence.skills', controller.model.competence.id, { queryParams: { view: 'workbench' } }));
     });
 
-    test('it should throw an error if saving failed', async function(assert) {
+    test('it should throw an error if saving failed', async function (assert) {
       // given
-      const errorMessage = {
-        'error': ['error-test'],
-      };
+      const errorMessage = { error: ['error-test'] };
       const saveStub = sinon.stub().rejects(errorMessage);
       competence.save = saveStub;
 

--- a/pix-editor/tests/unit/controllers/competence-management/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence-management/single-test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence-management/single', function(hooks) {
+module('Unit | Controller | competence-management/single', function (hooks) {
   setupTest(hooks);
   let controller, notifyMessageStub, notifyErrorStub, rollbackAttributesStub, loaderStartStub, loaderStopStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
 
@@ -36,10 +36,9 @@ module('Unit | Controller | competence-management/single', function(hooks) {
 
     controller = this.owner.lookup('controller:authenticated.competence-management/single');
     controller.model = competence;
-
   });
 
-  test('it should start edition', function(assert) {
+  test('it should start edition', function (assert) {
     // given
     controller.edition = false;
 
@@ -50,7 +49,7 @@ module('Unit | Controller | competence-management/single', function(hooks) {
     assert.ok(controller.edition);
   });
 
-  test('it should cancel edition', function(assert) {
+  test('it should cancel edition', function (assert) {
     // given
     controller.edition = true;
 
@@ -63,7 +62,7 @@ module('Unit | Controller | competence-management/single', function(hooks) {
     assert.ok(notifyMessageStub.calledWith('Modification annulée'));
   });
 
-  test('it should save modification', async function(assert) {
+  test('it should save modification', async function (assert) {
     // given
     const saveStub = sinon.stub().resolves();
     controller.model.save = saveStub;
@@ -80,11 +79,9 @@ module('Unit | Controller | competence-management/single', function(hooks) {
     assert.ok(notifyMessageStub.calledWith('Compétence mise à jour'));
   });
 
-  test('it should catch an error if save action failed', async function(assert) {
+  test('it should catch an error if save action failed', async function (assert) {
     // given
-    const errorMessage = {
-      'error': ['error'],
-    };
+    const errorMessage = { error: ['error'] };
     const saveStub = sinon.stub().rejects(errorMessage);
     controller.model.save = saveStub;
     controller.edition = true;

--- a/pix-editor/tests/unit/controllers/competence-test.js
+++ b/pix-editor/tests/unit/controllers/competence-test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence', function(hooks) {
+module('Unit | Controller | competence', function (hooks) {
   setupTest(hooks);
   let controller, theme1, theme2, notifyMessageStub, notifyErrorStub, loaderStartStub, loaderStopStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
 
@@ -31,15 +31,11 @@ module('Unit | Controller | competence', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.competence');
   });
 
-  test('it should save sorting', async function(assert) {
+  test('it should save sorting', async function (assert) {
     // given
     const saveModelStub = sinon.stub().resolves();
-    const model1 = {
-      save: saveModelStub,
-    };
-    const model2 = {
-      save: saveModelStub,
-    };
+    const model1 = { save: saveModelStub };
+    const model2 = { save: saveModelStub };
     controller.displaySortingPopIn = true;
 
     // when
@@ -53,12 +49,10 @@ module('Unit | Controller | competence', function(hooks) {
     assert.notOk(controller.displaySortingPopIn);
   });
 
-  test('it should catch error if save sorting fail', async function(assert) {
+  test('it should catch error if save sorting fail', async function (assert) {
     // given
     const saveModelStub = sinon.stub().rejects();
-    const model1 = {
-      save: saveModelStub,
-    };
+    const model1 = { save: saveModelStub };
 
     // when
     await controller._saveSorting([model1], 'successMessage', 'errorMessage');
@@ -69,15 +63,11 @@ module('Unit | Controller | competence', function(hooks) {
     assert.ok(notifyErrorStub.calledWith('errorMessage'));
   });
 
-  test('it should cancel sorting', function(assert) {
+  test('it should cancel sorting', function (assert) {
     // given
     const rollbackAttributesStub = sinon.stub();
-    const model1 = {
-      rollbackAttributes: rollbackAttributesStub,
-    };
-    const model2 = {
-      rollbackAttributes: rollbackAttributesStub,
-    };
+    const model1 = { rollbackAttributes: rollbackAttributesStub };
+    const model2 = { rollbackAttributes: rollbackAttributesStub };
     controller.displaySortingPopIn = true;
     // when
     controller._cancelSorting([model1, model2]);
@@ -87,14 +77,10 @@ module('Unit | Controller | competence', function(hooks) {
     assert.notOk(controller.displaySortingPopIn);
   });
 
-  module('#theme sorting', function(hooks) {
-    hooks.beforeEach(function() {
-      theme1 = {
-        name: 'theme1',
-      };
-      theme2 = {
-        name: 'theme2',
-      };
+  module('#theme sorting', function (hooks) {
+    hooks.beforeEach(function () {
+      theme1 = { name: 'theme1' };
+      theme2 = { name: 'theme2' };
 
       const competence = {
         name: 'competenceName',
@@ -104,7 +90,7 @@ module('Unit | Controller | competence', function(hooks) {
       controller.model = competence;
       controller.sortingModel = null;
     });
-    test('it should display sort theme pop-in', function(assert) {
+    test('it should display sort theme pop-in', function (assert) {
       // when
       controller.displaySortThemesPopIn();
 
@@ -116,7 +102,7 @@ module('Unit | Controller | competence', function(hooks) {
       assert.deepEqual(controller.sortingModel, [theme1, theme2]);
     });
 
-    test('it should cancel theme sorting', function(assert) {
+    test('it should cancel theme sorting', function (assert) {
       // given
       const cancelSortingStub = sinon.stub();
       controller._cancelSorting = cancelSortingStub;
@@ -128,7 +114,7 @@ module('Unit | Controller | competence', function(hooks) {
       assert.ok(cancelSortingStub.calledWith([theme1, theme2]));
     });
 
-    test('it should sort theme', async function(assert) {
+    test('it should sort theme', async function (assert) {
       // given
       const saveSortingStub = sinon.stub();
       controller._saveSorting = saveSortingStub;
@@ -141,21 +127,16 @@ module('Unit | Controller | competence', function(hooks) {
     });
   });
 
-  module('#tube sorting', function(hooks) {
+  module('#tube sorting', function (hooks) {
     let tube1, tube2;
 
-    hooks.beforeEach(function() {
-
-      tube1 = {
-        name: 'tube1',
-      };
-      tube2 = {
-        name: 'tube2',
-      };
+    hooks.beforeEach(function () {
+      tube1 = { name: 'tube1' };
+      tube2 = { name: 'tube2' };
       controller.sortingModel = null;
     });
 
-    test('it should display sort tubes pop-in', function(assert) {
+    test('it should display sort tubes pop-in', function (assert) {
       // when
       controller.displaySortTubesPopIn([tube1, tube2]);
 
@@ -167,7 +148,7 @@ module('Unit | Controller | competence', function(hooks) {
       assert.deepEqual(controller.sortingPopInCancelAction, controller.cancelTubesSorting);
     });
 
-    test('it should cancel tube sorting', function(assert) {
+    test('it should cancel tube sorting', function (assert) {
       // given
       const cancelSortingStub = sinon.stub();
       controller._cancelSorting = cancelSortingStub;
@@ -179,7 +160,7 @@ module('Unit | Controller | competence', function(hooks) {
       assert.ok(cancelSortingStub.calledWith([tube1, tube2]));
     });
 
-    test('it should sort tubes', async function(assert) {
+    test('it should sort tubes', async function (assert) {
       // given
       const saveSortingStub = sinon.stub();
       controller._saveSorting = saveSortingStub;

--- a/pix-editor/tests/unit/controllers/competence/prototypes/list-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/list-test.js
@@ -1,11 +1,11 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Controller | competence/prototypes/list', function(hooks) {
+module('Unit | Controller | competence/prototypes/list', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.competence/prototypes/list');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/competence/prototypes/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/new-test.js
@@ -3,17 +3,17 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/prototypes/new', function(hooks) {
+module('Unit | Controller | competence/prototypes/new', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('#_setVersion', function(hooks) {
+  module('#_setVersion', function (hooks) {
     let controller,
       messageStub,
       prototype1_1,
       newPrototype1_2,
       skill;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       controller = this.owner.lookup('controller:authenticated.competence/prototypes/new');
       messageStub = sinon.stub();
       controller._message = messageStub;
@@ -41,7 +41,7 @@ module('Unit | Controller | competence/prototypes/new', function(hooks) {
       });
     });
 
-    test('it should set proper version of a prototype', async function(assert) {
+    test('it should set proper version of a prototype', async function (assert) {
       // when
       await controller._setVersion(newPrototype1_2);
 
@@ -51,7 +51,7 @@ module('Unit | Controller | competence/prototypes/new', function(hooks) {
       assert.ok(messageStub.calledWith('Nouvelle version : 2', true));
     });
 
-    test('it should not set version if is workbench prototype', async function(assert) {
+    test('it should not set version if is workbench prototype', async function (assert) {
       // given
       skill.name = '@workbench';
 

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -5,12 +5,12 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/prototypes/single', function(hooks) {
+module('Unit | Controller | competence/prototypes/single', function (hooks) {
   setupIntlRenderingTest(hooks);
   let controller, messageStub, startStub, stopStub, errorStub;
 
-  hooks.beforeEach(function() {
-    //given
+  hooks.beforeEach(function () {
+    // given
     controller = this.owner.lookup('controller:authenticated.competence/prototypes/single');
 
     startStub = sinon.stub();
@@ -35,7 +35,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     controller._message = messageStub;
   });
 
-  module('#prototype actions', function(hooks) {
+  module('#prototype actions', function (hooks) {
     let proposalPrototype1_1,
       validatePrototype2_1,
       proposalPrototype2_2,
@@ -46,7 +46,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       skill2,
       tube;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       const saveStub = sinon.stub().resolves({});
       const store = this.owner.lookup('service:store');
 
@@ -109,37 +109,42 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         pixId: 'pix_skill2',
         status: 'actif',
         level: 1,
-        challenges: [validatePrototype2_1, validateChallenge2_1, proposalPrototype2_2, proposalChallenge2_2],
+        challenges: [
+          validatePrototype2_1,
+          validateChallenge2_1,
+          proposalPrototype2_2,
+          proposalChallenge2_2,
+        ],
         save: saveStub,
       });
       tube = store.createRecord('tube', {
         id: 'rec_tube',
         skills: [skill1, skill2],
       });
-      tube.skills.forEach((skill)=>{
+      tube.skills.forEach((skill) => {
         skill.tube = tube;
       });
     });
 
-    module('on prototype validation', function() {
-      test('it should archive previous active prototype and alternatives or delete draft alternative', async function(assert) {
-        //given
+    module('on prototype validation', function () {
+      test('it should archive previous active prototype and alternatives or delete draft alternative', async function (assert) {
+        // given
         proposalChallenge2_2.version = 1;
 
-        //when
+        // when
         await controller._archivePreviousPrototype(proposalPrototype2_2);
 
-        //then
+        // then
         assert.strictEqual(validatePrototype2_1.status, 'archivé');
         assert.strictEqual(validateChallenge2_1.status, 'archivé');
         assert.strictEqual(proposalChallenge2_2.status, 'périmé');
       });
 
-      test('it should archive the actual validated skill and is associated validated challenges or delete draft challenges if is an other version', async function(assert) {
-        //when
+      test('it should archive the actual validated skill and is associated validated challenges or delete draft challenges if is an other version', async function (assert) {
+        // when
         await controller._archiveOtherActiveSkillVersion(proposalPrototype1_1);
 
-        //then
+        // then
         assert.strictEqual(skill2.status, 'archivé');
         assert.strictEqual(validatePrototype2_1.status, 'archivé');
         assert.strictEqual(validateChallenge2_1.status, 'archivé');
@@ -147,38 +152,38 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         assert.strictEqual(proposalChallenge2_2.status, 'périmé');
       });
 
-      test('it should validate skill', async function(assert) {
-        //given
+      test('it should validate skill', async function (assert) {
+        // given
         proposalPrototype1_1.validate();
 
-        //when
+        // when
         await controller._checkSkillValidation(proposalPrototype1_1);
 
-        //then
+        // then
         assert.strictEqual(skill1.status, 'actif');
       });
 
-      test('it should validate alternatives', async function(assert) {
-        //given
+      test('it should validate alternatives', async function (assert) {
+        // given
         proposalPrototype1_1.validate();
 
-        //when
+        // when
         await controller._validateAlternatives(proposalPrototype1_1);
 
-        //then
+        // then
         assert.strictEqual(proposalChallenge1_1.status, 'validé');
       });
     });
 
-    module('on prototype archive', function() {
-      test('it should deactivate the current active skill if there is proposal prototype', async function(assert) {
+    module('on prototype archive', function () {
+      test('it should deactivate the current active skill if there is proposal prototype', async function (assert) {
         // when
         await controller._archiveOrDeactivateSkill(validatePrototype2_1);
 
         // then
         assert.strictEqual(skill2.status, 'en construction');
       });
-      test('it should archive the current active skill if there is no proposal prototype', async function(assert) {
+      test('it should archive the current active skill if there is no proposal prototype', async function (assert) {
         // given
         proposalPrototype2_2.archive();
 
@@ -188,7 +193,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         // then
         assert.strictEqual(skill2.status, 'archivé');
       });
-      test('it should not change the skill status if is not a production prototype', async function(assert) {
+      test('it should not change the skill status if is not a production prototype', async function (assert) {
         // when
         await controller._archiveOrDeactivateSkill(proposalPrototype2_2);
 
@@ -196,7 +201,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         assert.strictEqual(skill2.status, 'actif');
         assert.strictEqual(skill1.status, 'en construction');
       });
-      test('it should archive alternatives', async function(assert) {
+      test('it should archive alternatives', async function (assert) {
         // when
         await controller._archiveAlternatives(validatePrototype2_1);
 
@@ -205,22 +210,22 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       });
     });
 
-    module('on prototype obsolete', function() {
-      test('it should obsolete alternative', async function(assert) {
+    module('on prototype obsolete', function () {
+      test('it should obsolete alternative', async function (assert) {
         // when
         await controller._obsoleteAlternatives(validatePrototype2_1);
 
         // then
         assert.strictEqual(validateChallenge2_1.status, 'périmé');
       });
-      test('it should deactivate the current active skill if there is proposal prototype', async function(assert) {
+      test('it should deactivate the current active skill if there is proposal prototype', async function (assert) {
         // when
         await controller._obsoleteArchiveOrDeactivateSkill(validatePrototype2_1);
 
         // then
         assert.strictEqual(skill2.status, 'en construction');
       });
-      test('it should archive the current active skill if there is archive prototype', async function(assert) {
+      test('it should archive the current active skill if there is archive prototype', async function (assert) {
         // given
         await proposalPrototype2_2.archive();
 
@@ -230,7 +235,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         // then
         assert.strictEqual(skill2.status, 'archivé');
       });
-      test('it should delete the current active skill if there is no archive or proposal prototype', async function(assert) {
+      test('it should delete the current active skill if there is no archive or proposal prototype', async function (assert) {
         // given
         await proposalPrototype2_2.obsolete();
 
@@ -240,7 +245,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         // then
         assert.strictEqual(skill2.status, 'périmé');
       });
-      test('it should not change the skill status if is not a production prototype', async function(assert) {
+      test('it should not change the skill status if is not a production prototype', async function (assert) {
         // when
         await controller._obsoleteArchiveOrDeactivateSkill(proposalPrototype2_2);
 
@@ -250,8 +255,8 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       });
     });
 
-    module('#setSkill', function() {
-      test('it should display an error message if have no skill', async function(assert) {
+    module('#setSkill', function () {
+      test('it should display an error message if have no skill', async function (assert) {
         // when
         await controller.setSkill();
 
@@ -259,7 +264,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
         assert.ok(errorStub.calledWith('Aucun acquis sélectionné'));
       });
 
-      test('it should set a new skill for prototype and is alternative with proper version', async function(assert) {
+      test('it should set a new skill for prototype and is alternative with proper version', async function (assert) {
         // when
         await controller._setSkill(proposalPrototype1_1, skill2);
 
@@ -275,7 +280,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
   });
 
-  test('it should cancel edition', async function(assert) {
+  test('it should cancel edition', async function (assert) {
     // given
     controller.edition = true;
     controller.wasMaximized = true;
@@ -304,8 +309,8 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     assert.ok(messageStub.calledWith('Modification annulée'));
   });
 
-  module('#removeIllustration', function() {
-    test('it should remove illustration', async function(assert) {
+  module('#removeIllustration', function () {
+    test('it should remove illustration', async function (assert) {
       // given
       const deleteRecordStub = sinon.stub();
       const challenge = {
@@ -333,8 +338,8 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
   });
 
-  module('#removeAttachment', function() {
-    test('it should remove the attachment', async function(assert) {
+  module('#removeAttachment', function () {
+    test('it should remove the attachment', async function (assert) {
       // given
       const deleteRecordStub = sinon.stub();
       const challenge = {
@@ -356,9 +361,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       controller.model = challenge;
 
       // when
-      await controller.removeAttachment({
-        filename: 'file_name.pdf',
-      });
+      await controller.removeAttachment({ filename: 'file_name.pdf' });
 
       // then
       assert.ok(deleteRecordStub.calledOnce);
@@ -366,8 +369,8 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
   });
 
-  module('#UrlsToConsult', function() {
-    test('it should reset urlToConsult when urlToConsultField is closed', function(assert) {
+  module('#UrlsToConsult', function () {
+    test('it should reset urlToConsult when urlToConsultField is closed', function (assert) {
       // given
       controller.displayUrlsToConsultField = true;
       controller.urlsToConsult = 'http:://other-test.com';
@@ -389,27 +392,25 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
   });
 
-  module('_saveCheck', function(hooks) {
+  module('_saveCheck', function (hooks) {
     let challenge;
 
-    hooks.beforeEach(function() {
-      challenge = EmberObject.create({
-        id: 'recChallenge',
-      });
+    hooks.beforeEach(function () {
+      challenge = EmberObject.create({ id: 'recChallenge' });
     });
 
-    test('it returns the challenge when there is no errors', function(assert) {
+    test('it returns the challenge when there is no errors', function (assert) {
       assert.ok(controller._saveCheck(challenge));
     });
 
-    test('rejects when autoReply is true and there is no embed url', function(assert) {
+    test('rejects when autoReply is true and there is no embed url', function (assert) {
       challenge.autoReply = true;
       challenge.embedURL = '';
       assert.notOk(controller._saveCheck(challenge));
       assert.ok(errorStub.calledOnce);
     });
 
-    test('accept any solution on a QCROC', function(assert) {
+    test('accept any solution on a QCROC', function (assert) {
       challenge.type = 'QROC';
       challenge.solution = `- test
 - 'hola
@@ -419,7 +420,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
 
     ['QROCM-ind', 'QROCM-dep'].forEach((type) => {
-      test('rejects when solution is not a valid YAML on a ' + type, function(assert) {
+      test('rejects when solution is not a valid YAML on a ' + type, function (assert) {
         challenge.type = type;
         challenge.solution = `- test
 - 'hola
@@ -430,14 +431,14 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
   });
 
-  module('_handleIllustration', function(hooks) {
+  module('_handleIllustration', function (hooks) {
     let challenge;
     let storageServiceStub;
     let storeServiceStub;
     let loaderServiceStub;
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       challenge = EmberObject.create({
         id: 'recChallenge',
         illustration: {
@@ -468,7 +469,7 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       controller.store = storeServiceStub;
     });
 
-    test('it uploads file', async function(assert) {
+    test('it uploads file', async function (assert) {
       // given
       const expectedIllustration = {
         url: 'data:,',
@@ -489,15 +490,14 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
     });
   });
 
-  module('_handlePiecesJointes', function(hooks) {
+  module('_handlePiecesJointes', function (hooks) {
     let challenge;
     let storageServiceStub;
     let storeServiceStub;
     let loaderServiceStub;
     let controller;
 
-    hooks.beforeEach(function() {
-
+    hooks.beforeEach(function () {
       storeServiceStub = { createRecord: sinon.stub().returns({ save() {} }) };
 
       loaderServiceStub = { start: sinon.stub() };
@@ -505,10 +505,9 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       controller = this.owner.lookup('controller:authenticated.competence/prototypes/single');
       controller.loader = loaderServiceStub;
       controller.store = storeServiceStub;
-
     });
 
-    test('it uploads one file', async function(assert) {
+    test('it uploads one file', async function (assert) {
       // given
       const attachmentBaseName = 'attachment-base-name';
       challenge = EmberObject.create({
@@ -538,17 +537,19 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       };
       controller.storage = storageServiceStub;
 
-      const expectedPiecesJointes = [{
-        file: {
-          filePath: '',
-          name: 'attachment-base-name.pdf',
-          size: 123,
-          type: 'application/pdf',
+      const expectedPiecesJointes = [
+        {
+          file: {
+            filePath: '',
+            name: 'attachment-base-name.pdf',
+            size: 123,
+            type: 'application/pdf',
+          },
+          filename: 'attachment-base-name.pdf',
+          isNew: true,
+          url: 'data:,',
         },
-        filename: 'attachment-base-name.pdf',
-        isNew: true,
-        url: 'data:,',
-      }];
+      ];
 
       // when
       await controller._handlePiecesJointes(challenge);
@@ -559,65 +560,67 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       assert.deepEqual(challenge.piecesJointes, expectedPiecesJointes);
     });
 
-    test('it uploads two files', async function(assert) {
+    test('it uploads two files', async function (assert) {
       // given
       const attachmentBaseName = 'attachment-base-name';
       challenge = EmberObject.create({
         id: 'recChallenge',
         attachmentBaseName,
         baseNameUpdated: sinon.stub().returns(true),
-        piecesJointes: [{
-          filename: `${attachmentBaseName}.doc`,
-          file: {
-            name: `${attachmentBaseName}.doc`,
-            size: 123,
-            type: 'application/msword',
+        piecesJointes: [
+          {
+            filename: `${attachmentBaseName}.doc`,
+            file: {
+              name: `${attachmentBaseName}.doc`,
+              size: 123,
+              type: 'application/msword',
+            },
+            isNew: true,
           },
-          isNew: true,
-        }, {
-          filename: `${attachmentBaseName}.pdf`,
-          file: {
-            name: `${attachmentBaseName}.pdf`,
-            size: 123,
-            type: 'application/pdf',
+          {
+            filename: `${attachmentBaseName}.pdf`,
+            file: {
+              name: `${attachmentBaseName}.pdf`,
+              size: 123,
+              type: 'application/pdf',
+            },
+            isNew: true,
           },
-          isNew: true,
-        }],
+        ],
         attachments: [],
       });
 
       const uploadFileStub = sinon.stub();
-      uploadFileStub.onFirstCall().resolves({
-        url: 'data:,',
-      });
-      uploadFileStub.onSecondCall().resolves({
-        url: 'data:,',
-      });
+      uploadFileStub.onFirstCall().resolves({ url: 'data:,' });
+      uploadFileStub.onSecondCall().resolves({ url: 'data:,' });
       storageServiceStub = {
         uploadFile: uploadFileStub,
         renameFile: sinon.stub(),
       };
       controller.storage = storageServiceStub;
 
-      const expectedPiecesJointes = [{
-        filename: `${attachmentBaseName}.doc`,
-        url: 'data:,',
-        file: {
-          name: `${attachmentBaseName}.doc`,
-          size: 123,
-          type: 'application/msword',
+      const expectedPiecesJointes = [
+        {
+          filename: `${attachmentBaseName}.doc`,
+          url: 'data:,',
+          file: {
+            name: `${attachmentBaseName}.doc`,
+            size: 123,
+            type: 'application/msword',
+          },
+          isNew: true,
         },
-        isNew: true,
-      }, {
-        filename: `${attachmentBaseName}.pdf`,
-        url: 'data:,',
-        file: {
-          name: `${attachmentBaseName}.pdf`,
-          size: 123,
-          type: 'application/pdf',
+        {
+          filename: `${attachmentBaseName}.pdf`,
+          url: 'data:,',
+          file: {
+            name: `${attachmentBaseName}.pdf`,
+            size: 123,
+            type: 'application/pdf',
+          },
+          isNew: true,
         },
-        isNew: true,
-      }];
+      ];
 
       // when
       const newChallenge = await controller._handlePiecesJointes(challenge);
@@ -628,32 +631,33 @@ module('Unit | Controller | competence/prototypes/single', function(hooks) {
       assert.deepEqual(newChallenge.piecesJointes, expectedPiecesJointes);
     });
 
-    test('it renames attachments', async function(assert) {
+    test('it renames attachments', async function (assert) {
       const attachmentBaseName = 'attachment-base-name';
       challenge = EmberObject.create({
         id: 'recChallenge',
         attachmentBaseName: 'updated-base-name',
         baseNameUpdated: () => true,
-        attachments: [{
-          filename: attachmentBaseName + '.pdf',
-          url: 'data:,',
-          size: 123,
-          mimeType: 'application/pdf',
-          type: 'attachment',
-        }, {
-          filename: attachmentBaseName + '.png',
-          url: 'data:,',
-          size: 456,
-          mimeType: 'image/png',
-          type: 'illustration',
-        }],
+        attachments: [
+          {
+            filename: attachmentBaseName + '.pdf',
+            url: 'data:,',
+            size: 123,
+            mimeType: 'application/pdf',
+            type: 'attachment',
+          },
+          {
+            filename: attachmentBaseName + '.png',
+            url: 'data:,',
+            size: 456,
+            mimeType: 'image/png',
+            type: 'illustration',
+          },
+        ],
       });
 
       challenge.attachments.forEach((attachment) => attachment.challenge = challenge);
       challenge.piecesJointes = challenge.attachments.filter((attachment) => attachment.type === 'attachment');
-      storageServiceStub = {
-        renameFile: sinon.stub().resolves(),
-      };
+      storageServiceStub = { renameFile: sinon.stub().resolves() };
       controller.storage = storageServiceStub;
 
       const expectedPdfAttachement = {

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single/alternatives/alternative-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single/alternatives/alternative-test.js
@@ -2,11 +2,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/prototypes/single/alternatives/single', function(hooks) {
+module('Unit | Controller | competence/prototypes/single/alternatives/single', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.competence/prototypes/single/alternatives/single');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single/alternatives/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single/alternatives/new-test.js
@@ -2,11 +2,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/prototypes/single/alternatives/new', function(hooks) {
+module('Unit | Controller | competence/prototypes/single/alternatives/new', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.competence/prototypes/single/alternatives/new');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/competence/quality/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/quality/single-test.js
@@ -2,11 +2,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/quality/single', function(hooks) {
+module('Unit | Controller | competence/quality/single', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.competence/quality/single');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/competence/skills/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence/skills/new-test.js
@@ -2,11 +2,11 @@ import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/skills/new', function(hooks) {
+module('Unit | Controller | competence/skills/new', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.competence/skills/new');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/competence/skills/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/skills/single-test.js
@@ -4,14 +4,14 @@ import sinon from 'sinon';
 
 import { setupIntlRenderingTest } from '../../../../setup-intl-rendering';
 
-module('Unit | Controller | competence/skills/single', function(hooks) {
+module('Unit | Controller | competence/skills/single', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let storeStub, controller, changelogEntryService;
   const date = '14/07/1986';
   const author = 'DEV';
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     controller = this.owner.lookup('controller:authenticated.competence/skills/single');
     changelogEntryService = this.owner.lookup('service:ChangelogEntry');
     class ConfigService extends Service {
@@ -19,14 +19,15 @@ module('Unit | Controller | competence/skills/single', function(hooks) {
         super(...arguments);
         this.author = author;
       }
+
       ask = sinon.stub().resolves();
     }
     this.owner.unregister('service:Config');
     this.owner.register('service:Config', ConfigService);
   });
 
-  test('it should create a skill changelogEntry', async function(assert) {
-    //given
+  test('it should create a skill changelogEntry', async function (assert) {
+    // given
     const note = { save: sinon.stub().resolves() };
     storeStub = { createRecord: sinon.stub().returns(note) };
     controller.store = storeStub;
@@ -47,18 +48,18 @@ module('Unit | Controller | competence/skills/single', function(hooks) {
       action,
     };
 
-    //when
+    // when
     await controller._handleSkillChangelog(skill, changelogValue, action);
 
-    //then
+    // then
     const storeResult = storeStub.createRecord.getCall(0).args;
-    //stub createdAt
+    // stub createdAt
     storeResult[1].createdAt = date;
     assert.deepEqual(storeStub.createRecord.getCall(0).args, ['changelog-entry', expectedChangelog]);
   });
 
-  test('it should create a challenge changelogEntry', async function(assert) {
-    //given
+  test('it should create a challenge changelogEntry', async function (assert) {
+    // given
     const note = { save: sinon.stub().resolves() };
     storeStub = { createRecord: sinon.stub().returns(note) };
     controller.store = storeStub;
@@ -76,17 +77,17 @@ module('Unit | Controller | competence/skills/single', function(hooks) {
       elementType: changelogEntryService.challenge,
     };
 
-    //when
+    // when
     await controller._handleChallengeChangelog(challenge, changelogValue);
 
-    //then
+    // then
     const storeResult = storeStub.createRecord.getCall(0).args;
-    //stub createdAt
+    // stub createdAt
     storeResult[1].createdAt = date;
     assert.deepEqual(storeStub.createRecord.getCall(0).args, ['changelog-entry', expectedChangelog]);
   });
 
-  test('it should clone skill with new location', async function(assert) {
+  test('it should clone skill with new location', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
 

--- a/pix-editor/tests/unit/controllers/competence/skills/single/archive-test.js
+++ b/pix-editor/tests/unit/controllers/competence/skills/single/archive-test.js
@@ -1,11 +1,11 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Controller | competence/skills/single/archive', function(hooks) {
+module('Unit | Controller | competence/skills/single/archive', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.competence/skills/single/archive');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/competence/themes/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence/themes/new-test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence/themes/new', function(hooks) {
+module('Unit | Controller | competence/themes/new', function (hooks) {
   setupTest(hooks);
   let controller, notifyMessageStub, notifyErrorStub, loaderStartStub, loaderStopStub, deleteRecordStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
 
@@ -37,17 +37,15 @@ module('Unit | Controller | competence/themes/new', function(hooks) {
     this.owner.register('service:store', StoreService);
 
     controller = this.owner.lookup('controller:authenticated.competence/themes/new');
-    controller.model = {} ;
+    controller.model = {};
     controller.edition = true;
   });
 
-  test('it should cancel creation', function(assert) {
+  test('it should cancel creation', function (assert) {
     // given
     controller.model.name = 'newTheme';
     const parentControllerSendStub = sinon.stub();
-    controller.parentController = {
-      send: parentControllerSendStub,
-    };
+    controller.parentController = { send: parentControllerSendStub };
 
     // when
     controller.cancelEdit();
@@ -59,13 +57,11 @@ module('Unit | Controller | competence/themes/new', function(hooks) {
     assert.ok(parentControllerSendStub.calledWith('closeChildComponent'));
   });
 
-  test('it should save record', async function(assert) {
+  test('it should save record', async function (assert) {
     // given
     class CurrentDataService extends Service {
       getCompetence() {
-        return {
-          name: 'Competence',
-        };
+        return { name: 'Competence' };
       }
     }
     this.owner.register('service:currentData', CurrentDataService);
@@ -88,20 +84,16 @@ module('Unit | Controller | competence/themes/new', function(hooks) {
     assert.ok(transitionToRouteStub.calledOnce);
   });
 
-  test('it should catch an error if save action failed', async function(assert) {
+  test('it should catch an error if save action failed', async function (assert) {
     // given
     class CurrentDataService extends Service {
       getCompetence() {
-        return {
-          name: 'Competence',
-        };
+        return { name: 'Competence' };
       }
     }
     this.owner.register('service:currentData', CurrentDataService);
 
-    const errorMessage = {
-      'error': ['error-test'],
-    };
+    const errorMessage = { error: ['error-test'] };
     const saveStub = sinon.stub().rejects(errorMessage);
     controller.model.save = saveStub;
 

--- a/pix-editor/tests/unit/controllers/competence/themes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/themes/single-test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence/themes/single', function(hooks) {
+module('Unit | Controller | competence/themes/single', function (hooks) {
   setupTest(hooks);
   let controller, notifyMessageStub, notifyErrorStub, rollbackAttributesStub, loaderStartStub, loaderStopStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
 
@@ -36,10 +36,9 @@ module('Unit | Controller | competence/themes/single', function(hooks) {
 
     controller = this.owner.lookup('controller:authenticated.competence/themes/single');
     controller.model = theme;
-
   });
 
-  test('it should cancel edition', function(assert) {
+  test('it should cancel edition', function (assert) {
     // given
     controller.edition = true;
 
@@ -52,7 +51,7 @@ module('Unit | Controller | competence/themes/single', function(hooks) {
     assert.ok(notifyMessageStub.calledWith('Modification annulée'));
   });
 
-  test('it should save modification', async function(assert) {
+  test('it should save modification', async function (assert) {
     // given
     const saveStub = sinon.stub().resolves();
     controller.model.save = saveStub;
@@ -69,11 +68,9 @@ module('Unit | Controller | competence/themes/single', function(hooks) {
     assert.ok(notifyMessageStub.calledWith('Thématique mis à jour'));
   });
 
-  test('it should catch an error if save action failed', async function(assert) {
+  test('it should catch an error if save action failed', async function (assert) {
     // given
-    const errorMessage = {
-      'error': ['error-test'],
-    };
+    const errorMessage = { error: ['error-test'] };
     const saveStub = sinon.stub().rejects(errorMessage);
     controller.model.save = saveStub;
     controller.edition = true;

--- a/pix-editor/tests/unit/controllers/competence/tubes/new-test.js
+++ b/pix-editor/tests/unit/controllers/competence/tubes/new-test.js
@@ -4,12 +4,12 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence/tubes/new', function(hooks) {
+module('Unit | Controller | competence/tubes/new', function (hooks) {
   setupTest(hooks);
 
   let controller, notifyMessageStub, notifyErrorStub, loaderStartStub, loaderStopStub, deleteRecordStub, themeRollbackAttributesStub;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
 
@@ -40,21 +40,15 @@ module('Unit | Controller | competence/tubes/new', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.competence/tubes/new');
 
     themeRollbackAttributesStub = sinon.stub();
-    controller.model = EmberObject.create({
-      theme: {
-        rollbackAttributes: themeRollbackAttributesStub,
-      },
-    });
+    controller.model = EmberObject.create({ theme: { rollbackAttributes: themeRollbackAttributesStub } });
     controller.edition = true;
   });
 
-  test('it should cancel creation', async function(assert) {
+  test('it should cancel creation', async function (assert) {
     // given
     controller.model.name = 'newTube';
     const parentControllerSendStub = sinon.stub();
-    controller.parentController = {
-      send: parentControllerSendStub,
-    };
+    controller.parentController = { send: parentControllerSendStub };
 
     // when
     await controller.cancelEdit();
@@ -67,7 +61,7 @@ module('Unit | Controller | competence/tubes/new', function(hooks) {
     assert.ok(parentControllerSendStub.calledWith('closeChildComponent'));
   });
 
-  test('it should save record', async function(assert) {
+  test('it should save record', async function (assert) {
     // given
     const transitionToRouteStub = sinon.stub();
     controller.router.transitionTo = transitionToRouteStub;
@@ -89,11 +83,9 @@ module('Unit | Controller | competence/tubes/new', function(hooks) {
     assert.ok(transitionToRouteStub.calledWith('authenticated.competence.tubes.single', competence, controller.model));
   });
 
-  test('it should catch an error if save action failed', async function(assert) {
+  test('it should catch an error if save action failed', async function (assert) {
     // given
-    const errorMessage = {
-      'error': ['error-test'],
-    };
+    const errorMessage = { error: ['error-test'] };
     const saveStub = sinon.stub().rejects(errorMessage);
     controller.model.save = saveStub;
 

--- a/pix-editor/tests/unit/controllers/competence/tubes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/tubes/single-test.js
@@ -3,13 +3,12 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | competence/tubes/single', function(hooks) {
+module('Unit | Controller | competence/tubes/single', function (hooks) {
   setupTest(hooks);
 
   let controller, store, notifyMessageStub, notifyErrorStub, loaderStartStub, loaderStopStub;
 
-  hooks.beforeEach(function() {
-
+  hooks.beforeEach(function () {
     notifyMessageStub = sinon.stub();
     notifyErrorStub = sinon.stub();
 
@@ -39,10 +38,9 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
 
     controller = this.owner.lookup('controller:authenticated.competence/tubes/single');
     controller.model = tube;
-
   });
 
-  test('it should save modifications', async function(assert) {
+  test('it should save modifications', async function (assert) {
     // given
     const reloadSkillsStub = sinon.stub();
     controller.model.hasMany('rawSkills').reload = reloadSkillsStub;
@@ -63,11 +61,9 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
     assert.ok(reloadSkillsStub.calledOnce);
   });
 
-  test('it should catch an error if save action failed', async function(assert) {
+  test('it should catch an error if save action failed', async function (assert) {
     // given
-    const errorMessage = {
-      'error': ['error-test'],
-    };
+    const errorMessage = { error: ['error-test'] };
     const saveStub = sinon.stub().rejects(errorMessage);
     controller.model.save = saveStub;
     controller.edition = true;
@@ -83,7 +79,7 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
     assert.ok(notifyErrorStub.calledWith('Erreur lors de la mise à jour du tube'));
   });
 
-  test('it should start edition', function(assert) {
+  test('it should start edition', function (assert) {
     // given
     const sendStub = sinon.stub();
     controller.send = sendStub;
@@ -99,15 +95,15 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
     assert.ok(sendStub.calledWith('maximize'));
   });
 
-  module('#cancelEdition', function(hooks) {
+  module('#cancelEdition', function (hooks) {
     let rollbackAttributesStub;
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       rollbackAttributesStub = sinon.stub();
       controller.model.rollbackAttributes = rollbackAttributesStub;
       controller.edition = true;
     });
 
-    test('it should cancel edition', function(assert) {
+    test('it should cancel edition', function (assert) {
       // given
       this.wasMaximized = true;
 
@@ -120,7 +116,7 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
       assert.ok(notifyMessageStub.calledWith('Modification annulée'));
     });
 
-    test('it should send `minimize` if `wasMaximized` is `false`', function(assert) {
+    test('it should send `minimize` if `wasMaximized` is `false`', function (assert) {
       // given
       const sendStub = sinon.stub();
       controller.send = sendStub;
@@ -133,7 +129,7 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
       assert.ok(sendStub.calledWith('minimize'));
     });
 
-    test('it should close and cancel edition', function(assert) {
+    test('it should close and cancel edition', function (assert) {
       // given
       const parentControllerSendStub = sinon.stub();
       controller.parentController.send = parentControllerSendStub;
@@ -149,9 +145,9 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
     });
   });
 
-  module('#setCompetence', function(hooks) {
+  module('#setCompetence', function (hooks) {
     let newTheme, newCompetence;
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       newTheme = store.createRecord('theme', {
         id: 'recTheme0',
         name: 'themeName',
@@ -162,7 +158,7 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
       });
     });
 
-    test('it should set a competence and a theme', async function(assert) {
+    test('it should set a competence and a theme', async function (assert) {
       // given
       const transitionToRouteStub = sinon.stub();
       controller.router.transitionTo = transitionToRouteStub;
@@ -184,11 +180,9 @@ module('Unit | Controller | competence/tubes/single', function(hooks) {
       assert.deepEqual(theme, newTheme);
     });
 
-    test('it should catch an error if action failed', async function(assert) {
+    test('it should catch an error if action failed', async function (assert) {
       // given
-      const errorMessage = {
-        'error': ['error-test'],
-      };
+      const errorMessage = { error: ['error-test'] };
       const saveStub = sinon.stub().rejects(errorMessage);
       controller.model.save = saveStub;
 

--- a/pix-editor/tests/unit/controllers/statistics-test.js
+++ b/pix-editor/tests/unit/controllers/statistics-test.js
@@ -1,11 +1,11 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Controller | statistics', function(hooks) {
+module('Unit | Controller | statistics', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:authenticated.statistics');
     assert.ok(controller);
   });

--- a/pix-editor/tests/unit/controllers/target-profile-test.js
+++ b/pix-editor/tests/unit/controllers/target-profile-test.js
@@ -3,11 +3,10 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | target-profile', function(hooks) {
+module('Unit | Controller | target-profile', function (hooks) {
   setupTest(hooks);
   let store, tube1, skill1, skill2, skill5, skill6, skill7, skill8, skill9, tube2, areas, framework, controller;
-  hooks.beforeEach(function() {
-
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     // given
     skill1 = store.createRecord('skill', {
@@ -42,11 +41,20 @@ module('Unit | Controller | target-profile', function(hooks) {
       id: 'rec123456',
       pixId: 'pix123456',
       name: 'tube1',
-      rawSkills: [skill1, skill2, skill5, skill6],
+      rawSkills: [
+        skill1,
+        skill2,
+        skill5,
+        skill6,
+      ],
     });
     tube1.selectedLevel = 5;
     tube1.selectedThematicResultLevel = 2;
-    tube1.selectedSkills = [skill1.pixId, skill2.pixId, skill5.pixId];
+    tube1.selectedSkills = [
+      skill1.pixId,
+      skill2.pixId,
+      skill5.pixId,
+    ];
     tube1.selectedThematicResultSkills = [skill1.pixId, skill2.pixId];
     skill7 = store.createRecord('skill', {
       id: 'recSkill2_1_1',
@@ -73,11 +81,19 @@ module('Unit | Controller | target-profile', function(hooks) {
       id: 'rec123457',
       pixId: 'pix123457',
       name: 'tube2',
-      rawSkills: [skill7, skill8, skill9],
+      rawSkills: [
+        skill7,
+        skill8,
+        skill9,
+      ],
     });
     tube2.selectedLevel = 4;
     tube2.selectedThematicResultLevel = 1;
-    tube2.selectedSkills = [skill7.pixId, skill8.pixId, skill9.pixId];
+    tube2.selectedSkills = [
+      skill7.pixId,
+      skill8.pixId,
+      skill9.pixId,
+    ];
     tube2.selectedThematicResultSkills = [skill7.pixId];
 
     const area1 = store.createRecord('area', {
@@ -108,7 +124,7 @@ module('Unit | Controller | target-profile', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.target-profile');
   });
 
-  test('it should set tube-level arguments for production tube', function(assert) {
+  test('it should set tube-level arguments for production tube', function (assert) {
     // when
     controller.displayTube(tube1);
 
@@ -122,7 +138,7 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.ok(controller.displayTubeLevel);
   });
 
-  test('it should set a profile tube, with a level and a list of production skill id under this level ', function(assert) {
+  test('it should set a profile tube, with a level and a list of production skill id under this level ', function (assert) {
     // when
     controller.setProfileTube(tube1, 2, [skill1.pixId, skill2.pixId]);
 
@@ -130,15 +146,23 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual([tube1.selectedLevel, tube1.selectedSkills], [2, [skill1.pixId, skill2.pixId]]);
   });
 
-  test('it should set a profile tube, with a levelMax if have no level parameter', function(assert) {
+  test('it should set a profile tube, with a levelMax if have no level parameter', function (assert) {
     // when
     controller.setProfileTube(tube1);
 
     // then
-    assert.deepEqual([tube1.selectedLevel, tube1.selectedSkills], [6, [skill1.pixId, skill2.pixId, skill5.pixId, skill6.pixId]]);
+    assert.deepEqual([tube1.selectedLevel, tube1.selectedSkills], [
+      6,
+      [
+        skill1.pixId,
+        skill2.pixId,
+        skill5.pixId,
+        skill6.pixId,
+      ],
+    ]);
   });
 
-  test('it should reset a profile tube', function(assert) {
+  test('it should reset a profile tube', function (assert) {
     // when
     controller.unsetProfileTube(tube1);
 
@@ -146,13 +170,17 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual([tube1.selectedLevel, tube1.selectedSkills], [false, []]);
   });
 
-  test('it should set tube-level arguments for thematic result tube', function(assert) {
+  test('it should set tube-level arguments for thematic result tube', function (assert) {
     // when
     controller.displayThematicResultTube(tube1);
 
     const expectedResult = [
       tube1,
-      [skill1, skill2, skill5],
+      [
+        skill1,
+        skill2,
+        skill5,
+      ],
       tube1.selectedThematicResultLevel,
       tube1.selectedThematicResultSkills,
       controller.setThematicResultTube,
@@ -161,20 +189,22 @@ module('Unit | Controller | target-profile', function(hooks) {
     ];
 
     // then
-    const tubeLevelArguments = [controller.selectedTube,
+    const tubeLevelArguments = [
+      controller.selectedTube,
       controller.tubeSkills,
       controller.selectedTubeLevel,
       controller.selectedTubeSkills,
       controller.setTubeAction,
       controller.clearTubeAction,
-      controller.displayTubeLevel];
+      controller.displayTubeLevel,
+    ];
 
     assert.expect(tubeLevelArguments.length);
     tubeLevelArguments.forEach((value, i) => {
       assert.deepEqual(value, expectedResult[i]);
     });
   });
-  test('it should set a thematic result tube, with a level and a list of production skill id under this level ', function(assert) {
+  test('it should set a thematic result tube, with a level and a list of production skill id under this level ', function (assert) {
     // when
     controller.setThematicResultTube(tube1, 1, [skill1.pixId]);
 
@@ -182,7 +212,7 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual([tube1.selectedThematicResultLevel, tube1.selectedThematicResultSkills], [1, [skill1.pixId]]);
   });
 
-  test('it should reset a thematic result tube', function(assert) {
+  test('it should reset a thematic result tube', function (assert) {
     // when
     controller.unsetThematicResultTube(tube1);
 
@@ -190,7 +220,7 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual([tube1.selectedThematicResultLevel, tube1.selectedThematicResultSkills], [false, []]);
   });
 
-  test('it generate a file with a list of profile skills ids', function(assert) {
+  test('it generate a file with a list of profile skills ids', function (assert) {
     // given
     const fileSaverStub = sinon.stub();
     controller.fileSaver.saveAs = fileSaverStub;
@@ -204,7 +234,7 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual(controller.fileSaver.saveAs.getCall(0).args[0], expectedResult);
   });
 
-  test('it generate a file with a list of thematic result skills ids', function(assert) {
+  test('it generate a file with a list of thematic result skills ids', function (assert) {
     // given
     const fileSaverStub = sinon.stub();
     controller.fileSaver.saveAs = fileSaverStub;
@@ -218,7 +248,7 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual(controller.fileSaver.saveAs.getCall(0).args[0], expectedResult);
   });
 
-  test('it should save profile state', function(assert) {
+  test('it should save profile state', function (assert) {
     // given
     const fileSaverStub = sinon.stub();
     controller.fileSaver.saveAs = fileSaverStub;
@@ -228,12 +258,22 @@ module('Unit | Controller | target-profile', function(hooks) {
       {
         id: 'pix123456',
         level: 5,
-        skills: ['pix321654', 'pix321655', 'pix321656'],
-      }, {
+        skills: [
+          'pix321654',
+          'pix321655',
+          'pix321656',
+        ],
+      },
+      {
         id: 'pix123457',
         level: 4,
-        skills: ['pixSkill2_1_1', 'pixSkill2_1_2', 'pixSkill2_1_4'],
-      }]);
+        skills: [
+          'pixSkill2_1_1',
+          'pixSkill2_1_2',
+          'pixSkill2_1_4',
+        ],
+      },
+    ]);
 
     // when
     controller.save();
@@ -242,8 +282,8 @@ module('Unit | Controller | target-profile', function(hooks) {
     assert.deepEqual(fileSaverStub.getCall(0).args[0], expectedResult);
   });
 
-  module('_determineFileType', function() {
-    test('should return orga when the file is an array of strings', function(assert) {
+  module('_determineFileType', function () {
+    test('should return orga when the file is an array of strings', function (assert) {
       // given
       const data = ['1', '2'];
 
@@ -254,7 +294,7 @@ module('Unit | Controller | target-profile', function(hooks) {
       assert.strictEqual(result, 'orga');
     });
 
-    test('should return editor when the file is an array of objects', function(assert) {
+    test('should return editor when the file is an array of objects', function (assert) {
       // given
       const data = [{ id: '1' }, { id: '2' }];
 
@@ -266,10 +306,10 @@ module('Unit | Controller | target-profile', function(hooks) {
     });
   });
 
-  module('_buildTargetProfileFromFile', function(hooks) {
+  module('_buildTargetProfileFromFile', function (hooks) {
     let skill10, skill11, skill12, tube3, area3, framework2;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       skill10 = store.createRecord('skill', {
         pixId: 'pixSkill3_1_1',
         name: 'skill3_1_1',
@@ -291,20 +331,19 @@ module('Unit | Controller | target-profile', function(hooks) {
       tube3 = store.createRecord('tube', {
         pixId: 'pix666457',
         name: 'tube3',
-        rawSkills: [skill10, skill11, skill12],
+        rawSkills: [
+          skill10,
+          skill11,
+          skill12,
+        ],
       });
-      area3 = store.createRecord('area', {
-        competences: [store.createRecord('competence', {
-          rawTubes: [tube3],
-        })],
-      });
+      area3 = store.createRecord('area', { competences: [store.createRecord('competence', { rawTubes: [tube3] })] });
       framework2 = store.createRecord('framework', {
         name: 'Pix+',
         areas: [area3],
       });
 
       this.owner.register('service:currentData', class MockService extends Service {
-
         getAreas() {
           return [area3, ...areas];
         }
@@ -315,13 +354,14 @@ module('Unit | Controller | target-profile', function(hooks) {
       });
     });
 
-    test('it should build a profile state from pix-editor json file', async function(assert) {
+    test('it should build a profile state from pix-editor json file', async function (assert) {
       // given
       const fileContent = [
         {
           id: 'pix123456',
           level: 'max',
-        }, {
+        },
+        {
           id: 'pix666457',
           level: 2,
           skills: ['pixSkill3_1_1', 'pixSkill3_1_2'],
@@ -340,7 +380,7 @@ module('Unit | Controller | target-profile', function(hooks) {
       assert.deepEqual(controller._selectedFrameworks, expectedSelectedFrameworks);
     });
 
-    test('it should build a profile state from orga json file', async function(assert) {
+    test('it should build a profile state from orga json file', async function (assert) {
       // given
       const fileContent = ['pix123456', 'pix666457'];
 

--- a/pix-editor/tests/unit/helpers/convert-language-as-flag-test.js
+++ b/pix-editor/tests/unit/helpers/convert-language-as-flag-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 
 import { convertLanguageAsFlag } from '../../../helpers/convert-language-as-flag';
 
-module('Unit | Helpers | convert language as flag', function() {
+module('Unit | Helpers | convert language as flag', function () {
   [
     { expected: 'fr', language: 'fr' },
     { expected: 'fr fr-fr', language: 'fr-fr' },
@@ -14,7 +14,7 @@ module('Unit | Helpers | convert language as flag', function() {
     { expected: 'es', language: 'es' },
     { expected: 'es', language: 'es-419' },
   ].forEach((item) => {
-    test(`it should return ${item.expected} if language is ${item.language}`, function(assert) {
+    test(`it should return ${item.expected} if language is ${item.language}`, function (assert) {
       // when
       const result = convertLanguageAsFlag([item.language]);
 

--- a/pix-editor/tests/unit/helpers/flag-for-language_test.js
+++ b/pix-editor/tests/unit/helpers/flag-for-language_test.js
@@ -1,8 +1,8 @@
 import { flagForLanguage } from 'pixeditor/helpers/flag-for-language';
 import { module, test } from 'qunit';
 
-module('Unit | Helpers | flag for language', function() {
-  test('it should return the expected flag emoji for language "fr"', function(assert) {
+module('Unit | Helpers | flag for language', function () {
+  test('it should return the expected flag emoji for language "fr"', function (assert) {
     // when
     const result = flagForLanguage(['fr']);
 
@@ -10,7 +10,7 @@ module('Unit | Helpers | flag for language', function() {
     assert.strictEqual(result, '🇫🇷');
   });
 
-  test('it should return the expected flag emoji for language "fr-fr"', function(assert) {
+  test('it should return the expected flag emoji for language "fr-fr"', function (assert) {
     // when
     const result = flagForLanguage(['fr-fr']);
 
@@ -18,7 +18,7 @@ module('Unit | Helpers | flag for language', function() {
     assert.strictEqual(result, '🇫🇷');
   });
 
-  test('it should return the expected flag emoji for language "es"', function(assert) {
+  test('it should return the expected flag emoji for language "es"', function (assert) {
     // when
     const result = flagForLanguage(['es']);
 
@@ -26,7 +26,7 @@ module('Unit | Helpers | flag for language', function() {
     assert.strictEqual(result, '🇪🇸');
   });
 
-  test('it should return the expected flag emoji for language "es-419"', function(assert) {
+  test('it should return the expected flag emoji for language "es-419"', function (assert) {
     // when
     const result = flagForLanguage(['es-419']);
 
@@ -34,7 +34,7 @@ module('Unit | Helpers | flag for language', function() {
     assert.strictEqual(result, '🌎');
   });
 
-  test('it should return the expected flag emoji for language "nl"', function(assert) {
+  test('it should return the expected flag emoji for language "nl"', function (assert) {
     // when
     const result = flagForLanguage(['nl']);
 

--- a/pix-editor/tests/unit/models/challenge-test.js
+++ b/pix-editor/tests/unit/models/challenge-test.js
@@ -3,11 +3,11 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Model | challenge', function(hooks) {
+module('Unit | Model | challenge', function (hooks) {
   setupTest(hooks);
   let store, idGeneratorStub, alternative, prototype;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
 
     class ConfigService extends Service {
@@ -126,8 +126,8 @@ module('Unit | Model | challenge', function(hooks) {
     };
   });
 
-  module('#duplicate', function() {
-    test('it should duplicate challenge to create new prototype version', async function(assert) {
+  module('#duplicate', function () {
+    test('it should duplicate challenge to create new prototype version', async function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
 
@@ -187,7 +187,7 @@ module('Unit | Model | challenge', function(hooks) {
       assert.strictEqual(clonedChallenge.noValidationNeeded, prototype.noValidationNeeded, 'champ noValidationNeeded');
     });
 
-    test('it should duplicate challenge to create new alternative version', async function(assert) {
+    test('it should duplicate challenge to create new alternative version', async function (assert) {
       // given
       const challenge = store.createRecord('challenge', alternative);
 
@@ -247,7 +247,7 @@ module('Unit | Model | challenge', function(hooks) {
       assert.strictEqual(clonedChallenge.noValidationNeeded, alternative.noValidationNeeded, 'champ noValidationNeeded');
     });
 
-    test('it should clone the attachments', async function(assert) {
+    test('it should clone the attachments', async function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
       const illustration = store.createRecord('attachment', { id: 'rec1234156', filename: 'filename.test', url: 'data:;', size: 10, mimeType: 'image/png', type: 'illustration', alt: 'alt message', challenge });
@@ -264,8 +264,8 @@ module('Unit | Model | challenge', function(hooks) {
     });
   });
 
-  module('#copyForDifferentSkill', function() {
-    test('it should create a copy of the challenge for a different skill', async function(assert) {
+  module('#copyForDifferentSkill', function () {
+    test('it should create a copy of the challenge for a different skill', async function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
 
@@ -281,7 +281,7 @@ module('Unit | Model | challenge', function(hooks) {
       assert.notOk(skill);
     });
 
-    test('it should clone the attachments', async function(assert) {
+    test('it should clone the attachments', async function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
       const illustration = store.createRecord('attachment', { id: 'rec1234156', filename: 'filename.test', url: 'data:;', size: 10, mimeType: 'image/png', type: 'illustration', alt: 'alt message', challenge });
@@ -298,8 +298,8 @@ module('Unit | Model | challenge', function(hooks) {
     });
   });
 
-  module('#baseNameUpdated', function() {
-    test('it should return true if the base name is updated', function(assert) {
+  module('#baseNameUpdated', function () {
+    test('it should return true if the base name is updated', function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
       store.createRecord('attachment', { id: 'rec1234156', filename: 'filename.test', url: 'data:;', size: 10, mimeType: 'image/png', type: 'attachment', challenge });
@@ -311,7 +311,7 @@ module('Unit | Model | challenge', function(hooks) {
       assert.true(challenge.baseNameUpdated());
     });
 
-    test('it should return false if the base name is not updated', function(assert) {
+    test('it should return false if the base name is not updated', function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
       store.createRecord('attachment', { id: 'rec1234156', filename: 'filename.test', url: 'data:;', size: 10, mimeType: 'image/png', type: 'attachment', challenge });
@@ -323,7 +323,7 @@ module('Unit | Model | challenge', function(hooks) {
       assert.false(challenge.baseNameUpdated());
     });
 
-    test('it should return true if the base name undefined', function(assert) {
+    test('it should return true if the base name undefined', function (assert) {
       // given
       const challenge = store.createRecord('challenge', prototype);
       store.createRecord('attachment', { id: 'rec1234156', filename: 'filename.test', url: 'data:;', size: 10, mimeType: 'image/png', type: 'attachment', challenge });
@@ -331,11 +331,10 @@ module('Unit | Model | challenge', function(hooks) {
       // then
       assert.false(challenge.baseNameUpdated());
     });
-
   });
 
-  module('#getNextAlternativeVersion', function() {
-    test('it should return 1 if no other alternatives', function(assert) {
+  module('#getNextAlternativeVersion', function () {
+    test('it should return 1 if no other alternatives', function (assert) {
       // given
       const proto = store.createRecord('challenge', {
         id: 'challengeProto',
@@ -350,7 +349,7 @@ module('Unit | Model | challenge', function(hooks) {
       assert.strictEqual(nextAlternativeVersion, 1);
     });
 
-    test('it should return "highest current decli + 1" when there are alternatives', function(assert) {
+    test('it should return "highest current decli + 1" when there are alternatives', function (assert) {
       // given
       const skill = store.createRecord('skill', {});
       const proto = store.createRecord('challenge', {

--- a/pix-editor/tests/unit/models/competence-test.js
+++ b/pix-editor/tests/unit/models/competence-test.js
@@ -1,19 +1,15 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Model | competence', function(hooks) {
+module('Unit | Model | competence', function (hooks) {
   setupTest(hooks);
 
-  test('it should return live theme', function(assert) {
+  test('it should return live theme', function (assert) {
     const store = this.owner.lookup('service:store');
 
-    const liveTheme = store.createRecord('theme', {
-      name: 'liveTheme',
-    });
+    const liveTheme = store.createRecord('theme', { name: 'liveTheme' });
 
-    const workbenchTheme = store.createRecord('theme', {
-      name: 'workbench_theme',
-    });
+    const workbenchTheme = store.createRecord('theme', { name: 'workbench_theme' });
 
     const competence = store.createRecord('competence', {
       title: 'competence1',
@@ -23,20 +19,16 @@ module('Unit | Model | competence', function(hooks) {
     assert.deepEqual(competence.themes, [liveTheme]);
   });
 
-  module('#productionTubes', function() {
-    test('returns tubes with valided skills', function(assert) {
+  module('#productionTubes', function () {
+    test('returns tubes with valided skills', function (assert) {
       const store = this.owner.lookup('service:store');
 
       const liveTube = store.createRecord('tube', {
         name: 'liveTube',
-        rawSkills: [
-          store.createRecord('skill', { status: 'actif' }),
-        ],
+        rawSkills: [store.createRecord('skill', { status: 'actif' })],
       });
 
-      const workbenchTube = store.createRecord('tube', {
-        name: 'workbenchTube',
-      });
+      const workbenchTube = store.createRecord('tube', { name: 'workbenchTube' });
 
       const competence = store.createRecord('competence', {
         title: 'competence1',
@@ -47,13 +39,11 @@ module('Unit | Model | competence', function(hooks) {
     });
   });
 
-  module('#getAreaCode', function() {
-    test('should return area code', function(assert) {
+  module('#getAreaCode', function () {
+    test('should return area code', function (assert) {
       const store = this.owner.lookup('service:store');
 
-      const competence = store.createRecord('competence', {
-        code: '2.4',
-      });
+      const competence = store.createRecord('competence', { code: '2.4' });
 
       assert.strictEqual(competence.areaCode, '2');
     });

--- a/pix-editor/tests/unit/models/framework-test.js
+++ b/pix-editor/tests/unit/models/framework-test.js
@@ -1,23 +1,18 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Model | framework', function(hooks) {
+module('Unit | Model | framework', function (hooks) {
   setupTest(hooks);
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
   });
 
-  module('#sortedAreas', function() {
-    test('it should return areas sorted by code', function(assert) {
+  module('#sortedAreas', function () {
+    test('it should return areas sorted by code', function (assert) {
       // given
-      const framework = store.createRecord('framework', {
-        areas: [
-          store.createRecord('area', { code: '10' }),
-          store.createRecord('area', { code: '9' }),
-        ],
-      });
+      const framework = store.createRecord('framework', { areas: [store.createRecord('area', { code: '10' }), store.createRecord('area', { code: '9' })] });
 
       // when
       const sortedAreas = framework.sortedAreas;

--- a/pix-editor/tests/unit/models/localized-challenge-test.js
+++ b/pix-editor/tests/unit/models/localized-challenge-test.js
@@ -1,15 +1,15 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Model | localized-challenge', function(hooks) {
+module('Unit | Model | localized-challenge', function (hooks) {
   setupTest(hooks);
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
   });
 
-  module('#statusCSS', function() {
+  module('#statusCSS', function () {
     [
       { challengeStatus: 'validé', localizedChallengeStatus: 'proposé', expectedStatus: 'suggested' },
       { challengeStatus: 'validé', localizedChallengeStatus: 'validé', expectedStatus: 'validated' },
@@ -19,8 +19,8 @@ module('Unit | Model | localized-challenge', function(hooks) {
       { challengeStatus: 'archivé', localizedChallengeStatus: 'validé', expectedStatus: 'validated' },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'proposé', expectedStatus: 'suggested' },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'validé', expectedStatus: 'suggested' },
-    ].forEach(({ challengeStatus, localizedChallengeStatus, expectedStatus })=> {
-      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} css status should be ${expectedStatus}`, function(assert) {
+    ].forEach(({ challengeStatus, localizedChallengeStatus, expectedStatus }) => {
+      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} css status should be ${expectedStatus}`, function (assert) {
         const localizedChallenge = store.createRecord('localized-challenge', {
           id: 'rec123456',
           status: localizedChallengeStatus,
@@ -36,7 +36,7 @@ module('Unit | Model | localized-challenge', function(hooks) {
     });
   });
 
-  module('#statusText', function() {
+  module('#statusText', function () {
     [
       { challengeStatus: 'validé', localizedChallengeStatus: 'proposé', expectedText: 'Pas en prod' },
       { challengeStatus: 'validé', localizedChallengeStatus: 'validé', expectedText: 'En prod' },
@@ -46,8 +46,8 @@ module('Unit | Model | localized-challenge', function(hooks) {
       { challengeStatus: 'archivé', localizedChallengeStatus: 'validé', expectedText: 'En prod' },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'proposé', expectedText: 'Pas en prod' },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'validé', expectedText: 'Pas en prod' },
-    ].forEach(({ challengeStatus, localizedChallengeStatus, expectedText })=> {
-      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} css status should be ${expectedText}`, function(assert) {
+    ].forEach(({ challengeStatus, localizedChallengeStatus, expectedText }) => {
+      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} css status should be ${expectedText}`, function (assert) {
         const localizedChallenge = store.createRecord('localized-challenge', {
           id: 'rec123456',
           status: localizedChallengeStatus,
@@ -63,7 +63,7 @@ module('Unit | Model | localized-challenge', function(hooks) {
     });
   });
 
-  module('#isInProduction', function() {
+  module('#isInProduction', function () {
     [
       { challengeStatus: 'validé', localizedChallengeStatus: 'proposé', expected: false },
       { challengeStatus: 'validé', localizedChallengeStatus: 'validé', expected: true },
@@ -73,8 +73,8 @@ module('Unit | Model | localized-challenge', function(hooks) {
       { challengeStatus: 'archivé', localizedChallengeStatus: 'validé', expected: true },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'proposé', expected: false },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'validé', expected: false },
-    ].forEach(({ challengeStatus, localizedChallengeStatus, expected })=> {
-      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} should ${expected ? '' : 'not '}be in production`, function(assert) {
+    ].forEach(({ challengeStatus, localizedChallengeStatus, expected }) => {
+      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} should ${expected ? '' : 'not '}be in production`, function (assert) {
         const localizedChallenge = store.createRecord('localized-challenge', {
           id: 'rec123456',
           status: localizedChallengeStatus,
@@ -89,7 +89,7 @@ module('Unit | Model | localized-challenge', function(hooks) {
     });
   });
 
-  module('#isStatusEditable', function() {
+  module('#isStatusEditable', function () {
     [
       { challengeStatus: 'validé', localizedChallengeStatus: 'proposé', expected: true },
       { challengeStatus: 'validé', localizedChallengeStatus: 'validé', expected: true },
@@ -99,8 +99,8 @@ module('Unit | Model | localized-challenge', function(hooks) {
       { challengeStatus: 'archivé', localizedChallengeStatus: 'validé', expected: true },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'proposé', expected: false },
       { challengeStatus: 'périmé', localizedChallengeStatus: 'validé', expected: false },
-    ].forEach(({ challengeStatus, localizedChallengeStatus, expected })=> {
-      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} status is ${expected ? '' : 'not '}editable`, function(assert) {
+    ].forEach(({ challengeStatus, localizedChallengeStatus, expected }) => {
+      test(`when challenge is ${challengeStatus} and localized challenge status is ${localizedChallengeStatus} status is ${expected ? '' : 'not '}editable`, function (assert) {
         const localizedChallenge = store.createRecord('localized-challenge', {
           id: 'rec123456',
           status: localizedChallengeStatus,
@@ -113,7 +113,5 @@ module('Unit | Model | localized-challenge', function(hooks) {
         assert.strictEqual(localizedChallenge.isStatusEditable, expected);
       });
     });
-
   });
 });
-

--- a/pix-editor/tests/unit/models/skill-test.js
+++ b/pix-editor/tests/unit/models/skill-test.js
@@ -2,7 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Model | skill', function(hooks) {
+module('Unit | Model | skill', function (hooks) {
   setupTest(hooks);
   let store;
   const challenge1 = {
@@ -25,11 +25,11 @@ module('Unit | Model | skill', function(hooks) {
     locales: ['Franco Français'],
     status: 'validé',
   };
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
   });
 
-  test('it should return a map of unique language and alternatives', function(assert) {
+  test('it should return a map of unique language and alternatives', function (assert) {
     // given
     const skill = store.createRecord('skill', {
       id: 'rec123456',
@@ -49,7 +49,7 @@ module('Unit | Model | skill', function(hooks) {
     assert.strictEqual(languagesAndAlternativesCount.get('Anglais'), 2);
   });
 
-  test('it should return an array of unique language sorted', function(assert) {
+  test('it should return an array of unique language sorted', function (assert) {
     // given
     const skill = store.createRecord('skill', {
       id: 'rec123456',
@@ -64,22 +64,22 @@ module('Unit | Model | skill', function(hooks) {
 
     // when
     const languages = skill.languages;
-    const expected = ['Anglais', 'Franco Français', 'Francophone'];
+    const expected = [
+      'Anglais',
+      'Franco Français',
+      'Francophone',
+    ];
 
     // then
     assert.deepEqual(languages, expected);
   });
 
-  test('it should clone skill with save method and adapterOptions', async function(assert) {
+  test('it should clone skill with save method and adapterOptions', async function (assert) {
     // given
     const level = Symbol('level');
-    const storeStub = {
-      createRecord: sinon.stub(),
-    };
+    const storeStub = { createRecord: sinon.stub() };
     const saveStub = sinon.stub();
-    storeStub.createRecord.returns({
-      save: saveStub,
-    });
+    storeStub.createRecord.returns({ save: saveStub });
 
     const tube = store.createRecord('tube', { pixId: 'tubeId' });
     const skill = store.createRecord('skill', {

--- a/pix-editor/tests/unit/models/theme-test.js
+++ b/pix-editor/tests/unit/models/theme-test.js
@@ -1,37 +1,37 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Model | theme', function(hooks) {
+module('Unit | Model | theme', function (hooks) {
   setupTest(hooks);
   let store;
   let tube_1, tube_2, tube_3, tube_4;
   let theme;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
 
     const activeSkill_1 = store.createRecord('skill', {
       status: 'actif',
-      challenges: [ store.createRecord('challenge', {
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
     const activeSkill_2 = store.createRecord('skill', {
       status: 'actif',
-      challenges: [ store.createRecord('challenge', {
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
 
-    const deadSkill = store.createRecord('skill', {
-      status: 'périmé',
-    });
+    const deadSkill = store.createRecord('skill', { status: 'périmé' });
 
-    tube_1 = store.createRecord('tube', {
-      name: '@workbench',
-    });
+    tube_1 = store.createRecord('tube', { name: '@workbench' });
 
     tube_2 = store.createRecord('tube', {
       name: '@tube_2',
@@ -63,18 +63,22 @@ module('Unit | Model | theme', function(hooks) {
     });
   });
 
-  test('it should not return workbench tubes', function(assert) {
+  test('it should not return workbench tubes', function (assert) {
     assert.expect(3);
     // when
     const tubes = theme.tubes;
 
     // then
     tubes.forEach((tube) => {
-      assert.ok(['@tube_2', '@tube_3', '@tube_4'].includes(tube.name));
+      assert.ok([
+        '@tube_2',
+        '@tube_3',
+        '@tube_4',
+      ].includes(tube.name));
     });
   });
 
-  test('it should return sorted production tubes', function(assert) {
+  test('it should return sorted production tubes', function (assert) {
     assert.expect(2);
     // when
     const tubes = theme.productionTubes;
@@ -86,7 +90,7 @@ module('Unit | Model | theme', function(hooks) {
     });
   });
 
-  test('it should return number of  selected tubes', function(assert) {
+  test('it should return number of  selected tubes', function (assert) {
     // when
     const selectedProductionTubeLength = theme.selectedProductionTubeLength;
 
@@ -94,24 +98,20 @@ module('Unit | Model | theme', function(hooks) {
     assert.strictEqual(selectedProductionTubeLength, 1);
   });
 
-  module('#hasSelectedProductionTube', function() {
-    test('it should be true if has selected tube', function(assert) {
+  module('#hasSelectedProductionTube', function () {
+    test('it should be true if has selected tube', function (assert) {
       // when
       const hasSelectedProductionTube = theme.hasSelectedProductionTube;
 
       // then
       assert.ok(hasSelectedProductionTube);
-
     });
 
-    test('it should be false if has no selected tube', function(assert) {
+    test('it should be false if has no selected tube', function (assert) {
       // given
       theme = store.createRecord('theme', {
         name: 'themeName',
-        rawTubes: [
-          tube_1,
-          tube_3,
-        ],
+        rawTubes: [tube_1, tube_3],
       });
 
       // when
@@ -119,8 +119,6 @@ module('Unit | Model | theme', function(hooks) {
 
       // then
       assert.notOk(hasSelectedProductionTube);
-
     });
   });
-
 });

--- a/pix-editor/tests/unit/models/tube-test.js
+++ b/pix-editor/tests/unit/models/tube-test.js
@@ -1,23 +1,25 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Model | tube', function(hooks) {
+module('Unit | Model | tube', function (hooks) {
   setupTest(hooks);
   let store;
   let skillRecord1, skillRecord2, skillRecord3, skillRecord4, skillRecord5, skillRecord6;
   let tube;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     skillRecord1 = store.createRecord('skill', {
       id: 'rec654258',
       level: 1,
       status: 'actif',
-      challenges: [store.createRecord('challenge', {
-        id: 'recChallenge0',
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          id: 'recChallenge0',
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
     skillRecord2 = store.createRecord('skill', {
       id: 'rec654259',
@@ -28,21 +30,25 @@ module('Unit | Model | tube', function(hooks) {
       id: 'rec654260',
       level: 3,
       status: 'actif',
-      challenges: [store.createRecord('challenge', {
-        id: 'recChallenge1',
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          id: 'recChallenge1',
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
     skillRecord4 = store.createRecord('skill', {
       id: 'rec654261',
       level: 4,
       status: 'actif',
-      challenges: [store.createRecord('challenge', {
-        id: 'recChallenge2',
-        genealogy: 'Prototype 1',
-        status: 'validé',
-      })],
+      challenges: [
+        store.createRecord('challenge', {
+          id: 'recChallenge2',
+          genealogy: 'Prototype 1',
+          status: 'validé',
+        }),
+      ],
     });
     skillRecord5 = store.createRecord('skill', {
       id: 'rec664261',
@@ -59,17 +65,17 @@ module('Unit | Model | tube', function(hooks) {
       id: 'rec123456',
       name: 'tubeName',
       rawSkills: [
-        skillRecord1
-        , skillRecord2
-        , skillRecord3
-        , skillRecord4
-        , skillRecord5
-        , skillRecord6,
+        skillRecord1,
+        skillRecord2,
+        skillRecord3,
+        skillRecord4,
+        skillRecord5,
+        skillRecord6,
       ],
     });
   });
 
-  test('it should return an array of skill with status is not `archivé` or `périmé`', function(assert) {
+  test('it should return an array of skill with status is not `archivé` or `périmé`', function (assert) {
     assert.expect(4);
     // given
     const wrongStatus = ['archivé', 'périmé'];
@@ -83,9 +89,17 @@ module('Unit | Model | tube', function(hooks) {
     });
   });
 
-  test('it should return an array of all versions skills sorted and positioned by level', function(assert) {
+  test('it should return an array of all versions skills sorted and positioned by level', function (assert) {
     // given
-    const expectedArray = [[skillRecord1, skillRecord2], false, [skillRecord3], [skillRecord4], [skillRecord5], [skillRecord6], false];
+    const expectedArray = [
+      [skillRecord1, skillRecord2],
+      false,
+      [skillRecord3],
+      [skillRecord4],
+      [skillRecord5],
+      [skillRecord6],
+      false,
+    ];
 
     // when
     const filledSkills = tube.filledSkills;
@@ -94,10 +108,17 @@ module('Unit | Model | tube', function(hooks) {
     assert.deepEqual(filledSkills, expectedArray);
   });
 
-  test('it should return an array of productionSkill positioned by level', function(assert) {
-
+  test('it should return an array of productionSkill positioned by level', function (assert) {
     // given
-    const expectedArray = [skillRecord1, false, skillRecord3, skillRecord4, false, false, false];
+    const expectedArray = [
+      skillRecord1,
+      false,
+      skillRecord3,
+      skillRecord4,
+      false,
+      false,
+      false,
+    ];
 
     // when
     const filledSkills = tube.filledProductionSkills;
@@ -105,9 +126,9 @@ module('Unit | Model | tube', function(hooks) {
     // then
     assert.deepEqual(filledSkills, expectedArray);
   });
-  module('#draftSkill', function(hooks) {
+  module('#draftSkill', function (hooks) {
     let skillRecord5v2, skillRecord1v2;
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async function () {
       skillRecord1v2 = store.createRecord('skill', {
         id: 'skillRecord1v2',
         level: 1,
@@ -126,9 +147,17 @@ module('Unit | Model | tube', function(hooks) {
       tube.rawSkills = rawSkills;
     });
 
-    test('it should return an array of draftSkill positioned by level', function(assert) {
+    test('it should return an array of draftSkill positioned by level', function (assert) {
       // given
-      const expectedArray = [[skillRecord1v2], false, false, false, [skillRecord5, skillRecord5v2], false, false];
+      const expectedArray = [
+        [skillRecord1v2],
+        false,
+        false,
+        false,
+        [skillRecord5, skillRecord5v2],
+        false,
+        false,
+      ];
 
       // when
       const filledSkills = tube.filledDraftSkills;
@@ -137,9 +166,17 @@ module('Unit | Model | tube', function(hooks) {
       assert.deepEqual(filledSkills, expectedArray);
     });
 
-    test('it should return an array of last draftSkill positioned by level', function(assert) {
+    test('it should return an array of last draftSkill positioned by level', function (assert) {
       // given
-      const expectedArray = [skillRecord1v2, false, false, false, skillRecord5v2, false, false];
+      const expectedArray = [
+        skillRecord1v2,
+        false,
+        false,
+        false,
+        skillRecord5v2,
+        false,
+        false,
+      ];
 
       // when
       const filledSkills = tube.filledLastDraftSkills;
@@ -149,10 +186,14 @@ module('Unit | Model | tube', function(hooks) {
     });
   });
 
-  module('#productionSkills', function() {
-    test('returns validated skills in the tube', function(assert) {
+  module('#productionSkills', function () {
+    test('returns validated skills in the tube', function (assert) {
       assert.strictEqual(tube.productionSkillCount, 3);
-      assert.deepEqual(tube.productionSkills, [skillRecord1, skillRecord3, skillRecord4]);
+      assert.deepEqual(tube.productionSkills, [
+        skillRecord1,
+        skillRecord3,
+        skillRecord4,
+      ]);
       assert.ok(tube.hasProductionSkills);
     });
   });

--- a/pix-editor/tests/unit/routes/challenge-test.js
+++ b/pix-editor/tests/unit/routes/challenge-test.js
@@ -2,7 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | challenge', function(hooks) {
+module('Unit | Route | challenge', function (hooks) {
   setupTest(hooks);
 
   let route;
@@ -19,23 +19,17 @@ module('Unit | Route | challenge', function(hooks) {
   let primaryLocalizedAlternative;
   let secondaryLocalizedAlternative;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated.challenge');
 
     route.versionManager = {};
 
-    route.router = {
-      transitionTo: sinon.stub(),
-    };
+    route.router = { transitionTo: sinon.stub() };
 
     const store = this.owner.lookup('service:store');
 
-    const competence = store.createRecord('competence', {
-      id: competenceId,
-    });
-    const tube = store.createRecord('tube', {
-      competence,
-    });
+    const competence = store.createRecord('competence', { id: competenceId });
+    const tube = store.createRecord('tube', { competence });
     const skill = store.createRecord('skill', {
       id: skillId,
       tube,
@@ -70,19 +64,19 @@ module('Unit | Route | challenge', function(hooks) {
     });
   });
 
-  module('#afterModel', function() {
-    module('when in v2', function(hooks) {
-      hooks.beforeEach(function() {
+  module('#afterModel', function () {
+    module('when in v2', function (hooks) {
+      hooks.beforeEach(function () {
         route.versionManager.isV2 = true;
       });
 
-      module('when prototype is in production', function(hooks) {
-        hooks.beforeEach(function() {
+      module('when prototype is in production', function (hooks) {
+        hooks.beforeEach(function () {
           prototype.status = 'validé';
         });
 
-        module('when navigating to prototype’s primary', function() {
-          test('redirects to v2 challenge', async function(assert) {
+        module('when navigating to prototype’s primary', function () {
+          test('redirects to v2 challenge', async function (assert) {
             // given
             const model = primaryLocalizedPrototype;
 
@@ -102,8 +96,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to alternative’s primary', function() {
-          test('redirects to v2 challenge', async function(assert) {
+        module('when navigating to alternative’s primary', function () {
+          test('redirects to v2 challenge', async function (assert) {
             // given
             const model = primaryLocalizedAlternative;
 
@@ -123,8 +117,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to prototype’s secondary', function() {
-          test('redirects to v1 localized challenge', async function(assert) {
+        module('when navigating to prototype’s secondary', function () {
+          test('redirects to v1 localized challenge', async function (assert) {
             // given
             const model = secondaryLocalizedPrototype;
 
@@ -143,8 +137,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to alternative’s secondary', function() {
-          test('redirects to v1 localized challenge', async function(assert) {
+        module('when navigating to alternative’s secondary', function () {
+          test('redirects to v1 localized challenge', async function (assert) {
             // given
             const model = secondaryLocalizedAlternative;
 
@@ -165,13 +159,13 @@ module('Unit | Route | challenge', function(hooks) {
         });
       });
 
-      module('when prototype is not in production', function(hooks) {
-        hooks.beforeEach(function() {
+      module('when prototype is not in production', function (hooks) {
+        hooks.beforeEach(function () {
           prototype.status = 'périmé';
         });
 
-        module('when navigating to prototype’s primary', function() {
-          test('redirects to v1 challenge', async function(assert) {
+        module('when navigating to prototype’s primary', function () {
+          test('redirects to v1 challenge', async function (assert) {
             // given
             const model = primaryLocalizedPrototype;
 
@@ -190,8 +184,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to alternative’s primary', function() {
-          test('redirects to v1 challenge', async function(assert) {
+        module('when navigating to alternative’s primary', function () {
+          test('redirects to v1 challenge', async function (assert) {
             // given
             const model = primaryLocalizedAlternative;
 
@@ -213,18 +207,18 @@ module('Unit | Route | challenge', function(hooks) {
       });
     });
 
-    module('when in v1', function(hooks) {
-      hooks.beforeEach(function() {
+    module('when in v1', function (hooks) {
+      hooks.beforeEach(function () {
         route.versionManager.isV2 = false;
       });
 
-      module('when prototype is in production', function(hooks) {
-        hooks.beforeEach(function() {
+      module('when prototype is in production', function (hooks) {
+        hooks.beforeEach(function () {
           prototype.status = 'validé';
         });
 
-        module('when navigating to prototype’s primary', function() {
-          test('redirects to v1 challenge', async function(assert) {
+        module('when navigating to prototype’s primary', function () {
+          test('redirects to v1 challenge', async function (assert) {
             // given
             const model = primaryLocalizedPrototype;
 
@@ -243,8 +237,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to alternative’s primary', function() {
-          test('redirects to v1 challenge', async function(assert) {
+        module('when navigating to alternative’s primary', function () {
+          test('redirects to v1 challenge', async function (assert) {
             // given
             const model = primaryLocalizedAlternative;
 
@@ -264,8 +258,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to prototype’s secondary', function() {
-          test('redirects to v1 localized challenge', async function(assert) {
+        module('when navigating to prototype’s secondary', function () {
+          test('redirects to v1 localized challenge', async function (assert) {
             // given
             const model = secondaryLocalizedPrototype;
 
@@ -284,8 +278,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to alternative’s secondary', function() {
-          test('redirects to v1 localized challenge', async function(assert) {
+        module('when navigating to alternative’s secondary', function () {
+          test('redirects to v1 localized challenge', async function (assert) {
             // given
             const model = secondaryLocalizedAlternative;
 
@@ -306,13 +300,13 @@ module('Unit | Route | challenge', function(hooks) {
         });
       });
 
-      module('when prototype is not in production', function(hooks) {
-        hooks.beforeEach(function() {
+      module('when prototype is not in production', function (hooks) {
+        hooks.beforeEach(function () {
           prototype.status = 'périmé';
         });
 
-        module('when navigating to prototype’s primary', function() {
-          test('redirects to v1 challenge', async function(assert) {
+        module('when navigating to prototype’s primary', function () {
+          test('redirects to v1 challenge', async function (assert) {
             // given
             const model = primaryLocalizedPrototype;
 
@@ -331,8 +325,8 @@ module('Unit | Route | challenge', function(hooks) {
           });
         });
 
-        module('when navigating to alternative’s primary', function() {
-          test('redirects to v1 challenge', async function(assert) {
+        module('when navigating to alternative’s primary', function () {
+          test('redirects to v1 challenge', async function (assert) {
             // given
             const model = primaryLocalizedAlternative;
 

--- a/pix-editor/tests/unit/serializers/airtable-test.js
+++ b/pix-editor/tests/unit/serializers/airtable-test.js
@@ -2,28 +2,32 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Serializer | airtable', function(hooks) {
+module('Unit | Serializer | airtable', function (hooks) {
   setupTest(hooks);
   let store, modelFor;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     modelFor = store.modelFor;
     store.modelFor = sinon.stub().returns({
-      determineRelationshipType() { return 'manyToMany'; },
+      determineRelationshipType() {
+        return 'manyToMany';
+      },
       attributes: {
         key: 'key',
-        has() { return true; },
+        has() {
+          return true;
+        },
       },
     });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     store.modelFor = modelFor;
   });
 
-  module('#serialize', function() {
-    test('it should serialize hasMany relation', function(assert) {
+  module('#serialize', function () {
+    test('it should serialize hasMany relation', function (assert) {
       // given
       const serializer = store.serializerFor('airtable');
       const snapshot = {
@@ -31,16 +35,22 @@ module('Unit | Serializer | airtable', function(hooks) {
         eachRelationship(callback) {
           callback('key', { kind: 'hasMany', key: 'key' });
         },
-        hasMany() { return [
-          {
-            id: 1,
-            attributes() {return {};},
-          },
-          {
-            id: 2,
-            attributes() {return {};},
-          },
-        ]; },
+        hasMany() {
+          return [
+            {
+              id: 1,
+              attributes() {
+                return {};
+              },
+            },
+            {
+              id: 2,
+              attributes() {
+                return {};
+              },
+            },
+          ];
+        },
       };
 
       // when
@@ -50,7 +60,7 @@ module('Unit | Serializer | airtable', function(hooks) {
       assert.deepEqual(serialized, { key: [1, 2] });
     });
 
-    test('it should verify primaryKey to serialise', function(assert) {
+    test('it should verify primaryKey to serialise', function (assert) {
       // given
       const serializer = store.serializerFor('airtable');
       const snapshot = {
@@ -58,10 +68,16 @@ module('Unit | Serializer | airtable', function(hooks) {
         eachRelationship(callback) {
           callback('key', { kind: 'hasMany', key: 'key' });
         },
-        hasMany() { return [{
-          id: 'primaryKey',
-          attributes() { return { airtableId: 'MyIdea' }; },
-        }]; },
+        hasMany() {
+          return [
+            {
+              id: 'primaryKey',
+              attributes() {
+                return { airtableId: 'MyIdea' };
+              },
+            },
+          ];
+        },
       };
 
       // when

--- a/pix-editor/tests/unit/serializers/area-test.js
+++ b/pix-editor/tests/unit/serializers/area-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | area', function(hooks) {
+module('Unit | Serializer | area', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('area', {});
 

--- a/pix-editor/tests/unit/serializers/changelog-entry-test.js
+++ b/pix-editor/tests/unit/serializers/changelog-entry-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | changelog entry', function(hooks) {
+module('Unit | Serializer | changelog entry', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('changelog-entry', {});
 

--- a/pix-editor/tests/unit/serializers/competence-test.js
+++ b/pix-editor/tests/unit/serializers/competence-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | competence', function(hooks) {
+module('Unit | Serializer | competence', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('competence', {});
 

--- a/pix-editor/tests/unit/serializers/note-test.js
+++ b/pix-editor/tests/unit/serializers/note-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | note', function(hooks) {
+module('Unit | Serializer | note', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('note', {});
 

--- a/pix-editor/tests/unit/serializers/skill-test.js
+++ b/pix-editor/tests/unit/serializers/skill-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | skill', function(hooks) {
+module('Unit | Serializer | skill', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('skill', {});
 

--- a/pix-editor/tests/unit/serializers/tube-test.js
+++ b/pix-editor/tests/unit/serializers/tube-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | tube', function(hooks) {
+module('Unit | Serializer | tube', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('tube', {});
 

--- a/pix-editor/tests/unit/serializers/tutorial-test.js
+++ b/pix-editor/tests/unit/serializers/tutorial-test.js
@@ -1,10 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Serializer | tutorial', function(hooks) {
+module('Unit | Serializer | tutorial', function (hooks) {
   setupTest(hooks);
 
-  test('it serializes records', function(assert) {
+  test('it serializes records', function (assert) {
     const store = this.owner.lookup('service:store');
     const record = store.createRecord('tutorial', {});
 

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Service | access', function(hooks) {
+module('Unit | Service | access', function (hooks) {
   setupTest(hooks);
 
   const REPLICATOR = 2;
@@ -11,7 +11,7 @@ module('Unit | Service | access', function(hooks) {
   const ADMIN = 4;
   let accessService;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     accessService = this.owner.lookup('service:access');
   });
 
@@ -26,9 +26,8 @@ module('Unit | Service | access', function(hooks) {
     owner.register('service:config', ConfigService);
   }
 
-  module('mayEdit', function() {
-
-    test('it should return `false` if challenge is obsolete', function(assert) {
+  module('mayEdit', function () {
+    test('it should return `false` if challenge is obsolete', function (assert) {
       // given
       const challenge = EmberObject.create({
         id: 'rec123656',
@@ -36,16 +35,16 @@ module('Unit | Service | access', function(hooks) {
         isObsolete: true,
       });
 
-      //when
+      // when
       const accessResult = accessService.mayEdit(challenge);
 
-      //then
+      // then
       assert.notOk(accessResult);
     });
 
-    module('#liveChallenge', function(hooks) {
+    module('#liveChallenge', function (hooks) {
       let validatedChallenge, archivedChallenge;
-      hooks.beforeEach(function() {
+      hooks.beforeEach(function () {
         validatedChallenge = EmberObject.create({
           id: 'recChallenge1',
           name: 'challenge',
@@ -58,27 +57,26 @@ module('Unit | Service | access', function(hooks) {
           isArchived: true,
         });
       });
-      test('it should return `true` if challenge is live and level is `EDITOR`', function(assert) {
-        //when
+      test('it should return `true` if challenge is live and level is `EDITOR`', function (assert) {
+        // when
         _stubAccessLevel(EDITOR, this.owner);
 
-        //then
+        // then
         assert.ok(accessService.mayEdit(validatedChallenge));
         assert.ok(accessService.mayEdit(archivedChallenge));
-
       });
-      test('it should return `true` if challenge is live and level is `ADMIN`', function(assert) {
-        //when
+      test('it should return `true` if challenge is live and level is `ADMIN`', function (assert) {
+        // when
         _stubAccessLevel(ADMIN, this.owner);
 
-        //then
+        // then
         assert.ok(accessService.mayEdit(validatedChallenge));
         assert.ok(accessService.mayEdit(archivedChallenge));
       });
     });
 
-    test('it should return `true` when level is `REPLICATOR` only if challenge is not in production and is not a prototype', function(assert) {
-      //given
+    test('it should return `true` when level is `REPLICATOR` only if challenge is not in production and is not a prototype', function (assert) {
+      // given
       const validatedChallenge = EmberObject.create({
         id: 'rec123655',
         name: 'validatedChallenge',
@@ -94,32 +92,32 @@ module('Unit | Service | access', function(hooks) {
         name: 'challenge',
       });
 
-      //when
+      // when
       _stubAccessLevel(REPLICATOR, this.owner);
 
-      //then
+      // then
       assert.notOk(accessService.mayEdit(validatedChallenge));
       assert.notOk(accessService.mayEdit(prototypeChallenge));
       assert.ok(accessService.mayEdit(challenge));
     });
   });
 
-  module('mayChangeLocalizedChallengeStatus', function() {
-    test('it should return `false` if localized challenge is not editable', function(assert) {
+  module('mayChangeLocalizedChallengeStatus', function () {
+    test('it should return `false` if localized challenge is not editable', function (assert) {
       // given
       const localizedChallenge = EmberObject.create({
         id: 'rec123656',
         isStatusEditable: false,
       });
 
-      //when
+      // when
       const accessResult = accessService.mayChangeLocalizedChallengeStatus(localizedChallenge);
 
-      //then
+      // then
       assert.notOk(accessResult);
     });
 
-    test('it should return `false` if localized challenge is editable and user is not admin', function(assert) {
+    test('it should return `false` if localized challenge is editable and user is not admin', function (assert) {
       // given
       const localizedChallenge = EmberObject.create({
         id: 'rec123656',
@@ -127,14 +125,14 @@ module('Unit | Service | access', function(hooks) {
       });
       _stubAccessLevel(EDITOR, this.owner);
 
-      //when
+      // when
       const accessResult = accessService.mayChangeLocalizedChallengeStatus(localizedChallenge);
 
-      //then
+      // then
       assert.notOk(accessResult);
     });
 
-    test('it should return `true` if localized challenge is editable and user is admin', function(assert) {
+    test('it should return `true` if localized challenge is editable and user is admin', function (assert) {
       // given
       const localizedChallenge = EmberObject.create({
         id: 'rec123656',
@@ -142,58 +140,57 @@ module('Unit | Service | access', function(hooks) {
       });
       _stubAccessLevel(ADMIN, this.owner);
 
-      //when
+      // when
       const accessResult = accessService.mayChangeLocalizedChallengeStatus(localizedChallenge);
 
-      //then
+      // then
       assert.ok(accessResult);
     });
-
   });
 
-  module('mayAccessWhitelistedUrls', function() {
-    test('it should return `false` when is not editor', function(assert) {
+  module('mayAccessWhitelistedUrls', function () {
+    test('it should return `false` when is not editor', function (assert) {
       // given
       _stubAccessLevel(REPLICATOR, this.owner);
 
-      //when
+      // when
       const accessResult = accessService.mayAccessWhitelistedUrls();
 
-      //then
+      // then
       assert.notOk(accessResult);
     });
 
-    test('it should return `true` when is editor or above', function(assert) {
+    test('it should return `true` when is editor or above', function (assert) {
       _stubAccessLevel(ADMIN, this.owner);
       const accessResultAsAdmin = accessService.mayAccessWhitelistedUrls();
       _stubAccessLevel(EDITOR, this.owner);
       const accessResultAsEditor = accessService.mayAccessWhitelistedUrls();
 
-      //then
+      // then
       assert.ok(accessResultAsAdmin);
       assert.ok(accessResultAsEditor);
     });
   });
 
-  module('mayCreateOrEditWhitelistedUrl', function() {
-    test('it should return `false` when is not editor', function(assert) {
+  module('mayCreateOrEditWhitelistedUrl', function () {
+    test('it should return `false` when is not editor', function (assert) {
       // given
       _stubAccessLevel(REPLICATOR, this.owner);
 
-      //when
+      // when
       const accessResult = accessService.mayCreateOrEditWhitelistedUrl();
 
-      //then
+      // then
       assert.notOk(accessResult);
     });
 
-    test('it should return `true` when is editor or above', function(assert) {
+    test('it should return `true` when is editor or above', function (assert) {
       _stubAccessLevel(ADMIN, this.owner);
       const accessResultAsAdmin = accessService.mayCreateOrEditWhitelistedUrl();
       _stubAccessLevel(EDITOR, this.owner);
       const accessResultAsEditor = accessService.mayCreateOrEditWhitelistedUrl();
 
-      //then
+      // then
       assert.ok(accessResultAsAdmin);
       assert.ok(accessResultAsEditor);
     });

--- a/pix-editor/tests/unit/services/ajax-queue-test.js
+++ b/pix-editor/tests/unit/services/ajax-queue-test.js
@@ -2,28 +2,29 @@ import { setupTest } from 'ember-qunit';
 import ENV from 'pixeditor/config/environment';
 import { module, test } from 'qunit';
 
-module('Unit | Service | ajax-queue', function(hooks) {
+module('Unit | Service | ajax-queue', function (hooks) {
   setupTest(hooks);
   let ajaxQueueService;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     ajaxQueueService = this.owner.lookup('service:ajax-queue');
   });
 
-  module('add()', function() {
-
-    test('should execute the passed job', async function(assert) {
+  module('add()', function () {
+    test('should execute the passed job', async function (assert) {
       // given
       const expectedValue = 1;
 
       // when
-      const actualValue = await ajaxQueueService.add(async () => { return expectedValue; });
+      const actualValue = await ajaxQueueService.add(async () => {
+        return expectedValue;
+      });
 
       // then
       assert.strictEqual(actualValue, expectedValue);
     });
 
-    test('should execute concurrently as many jobs as indicated in settings file', async function(assert) {
+    test('should execute concurrently as many jobs as indicated in settings file', async function (assert) {
       // given
       let counter = 0, maxCounter = 0;
       async function job() {

--- a/pix-editor/tests/unit/services/changelog-entry-test.js
+++ b/pix-editor/tests/unit/services/changelog-entry-test.js
@@ -1,20 +1,20 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Service | changelog-entry', function(hooks) {
+module('Unit | Service | changelog-entry', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it should return an elementType', function(assert) {
+  test('it should return an elementType', function (assert) {
     assert.expect(2);
-    //given
+    // given
     const keys = ['skill', 'challenge'];
     const expectedResults = ['acquis', 'épreuve'];
 
-    //when
+    // when
     const service = this.owner.lookup('service:changelog-entry');
 
-    //then
+    // then
     keys.forEach((key, index) => {
       assert.strictEqual(service[key], expectedResults[index]);
     });

--- a/pix-editor/tests/unit/services/confirm-test.js
+++ b/pix-editor/tests/unit/services/confirm-test.js
@@ -3,17 +3,17 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | confirm', function(hooks) {
+module('Unit | Service | confirm', function (hooks) {
   setupTest(hooks);
   let service, startStub, stopStub;
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     service = this.owner.lookup('service:confirm');
     startStub = sinon.stub();
     stopStub = sinon.stub();
   });
 
-  module('#loader management', function(hooks) {
-    hooks.beforeEach(function() {
+  module('#loader management', function (hooks) {
+    hooks.beforeEach(function () {
       service.setTarget({
         confirmAsk(title, text, callback) {
           callback(true);
@@ -21,7 +21,7 @@ module('Unit | Service | confirm', function(hooks) {
       });
     });
 
-    test('it should manage loader if `isLoading` is `true`', async function(assert) {
+    test('it should manage loader if `isLoading` is `true`', async function (assert) {
       // given
       class LoaderService extends Service {
         start = startStub;
@@ -38,7 +38,7 @@ module('Unit | Service | confirm', function(hooks) {
       assert.ok(stopStub.calledOnce);
     });
 
-    test('it should not manage loader if `isLoading` is `false`', async function(assert) {
+    test('it should not manage loader if `isLoading` is `false`', async function (assert) {
       // given
       class LoaderService extends Service {
         start = startStub;
@@ -56,7 +56,7 @@ module('Unit | Service | confirm', function(hooks) {
     });
   });
 
-  test('It should reject promise if callback return `false`', async function(assert) {
+  test('It should reject promise if callback return `false`', async function (assert) {
     // given
     class LoaderService extends Service {
       start = startStub;
@@ -70,7 +70,7 @@ module('Unit | Service | confirm', function(hooks) {
         callback(false);
       },
     });
-    await assert.rejects(service.ask()) ;
+    await assert.rejects(service.ask());
     assert.ok(stopStub.calledOnce);
     assert.notOk(startStub.calledOnce);
   });

--- a/pix-editor/tests/unit/services/current-data-test.js
+++ b/pix-editor/tests/unit/services/current-data-test.js
@@ -1,25 +1,19 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Service | current-data', function(hooks) {
+module('Unit | Service | current-data', function (hooks) {
   setupTest(hooks);
   let competence, service, pixFramework, pixFranceFramework, pix1dFramework, pixArea, pix1dArea, pixFranceArea, pix1dThematic, pix1dCompetence, prototype;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     const store = this.owner.lookup('service:store');
 
     // Given
-    prototype = store.createRecord('challenge', {
-      id: 'prototype',
-    });
+    prototype = store.createRecord('challenge', { id: 'prototype' });
 
-    competence = store.createRecord('competence', {
-      id: 'competence',
-    });
+    competence = store.createRecord('competence', { id: 'competence' });
 
-    pix1dThematic = store.createRecord('theme', {
-      id: 'thematic',
-    });
+    pix1dThematic = store.createRecord('theme', { id: 'thematic' });
 
     pix1dCompetence = store.createRecord('competence', {
       id: 'pix1dCompetence',
@@ -61,22 +55,34 @@ module('Unit | Service | current-data', function(hooks) {
     });
 
     service = this.owner.lookup('service:current-data');
-    service.setFrameworks([pixFramework, pixFranceFramework, pix1dFramework]);
+    service.setFrameworks([
+      pixFramework,
+      pixFranceFramework,
+      pix1dFramework,
+    ]);
     service.setFramework(pixFramework);
-    service.setAreas([pixArea, pixFranceArea, pix1dArea]);
+    service.setAreas([
+      pixArea,
+      pixFranceArea,
+      pix1dArea,
+    ]);
     service.setCompetence(competence);
     service.setPrototype(prototype);
   });
 
-  test('it should return frameworks', function(assert) {
+  test('it should return frameworks', function (assert) {
     // when
     const frameworks = service.getFrameworks();
 
     // then
-    assert.deepEqual(frameworks, [pixFramework, pixFranceFramework, pix1dFramework]);
+    assert.deepEqual(frameworks, [
+      pixFramework,
+      pixFranceFramework,
+      pix1dFramework,
+    ]);
   });
 
-  test('it should return one framework', function(assert) {
+  test('it should return one framework', function (assert) {
     // when
     const framework = service.getFramework();
 
@@ -84,15 +90,19 @@ module('Unit | Service | current-data', function(hooks) {
     assert.deepEqual(framework, pixFramework);
   });
 
-  test('it should return all areas when argument is `false`', function(assert) {
+  test('it should return all areas when argument is `false`', function (assert) {
     // when
     const areas = service.getAreas(false);
 
     // then
-    assert.deepEqual(areas, [pixArea, pixFranceArea, pix1dArea]);
+    assert.deepEqual(areas, [
+      pixArea,
+      pixFranceArea,
+      pix1dArea,
+    ]);
   });
 
-  test('it should return areas of set framework when have no argument ', async function(assert) {
+  test('it should return areas of set framework when have no argument ', async function (assert) {
     // when
     const areas = service.getAreas();
 
@@ -100,7 +110,7 @@ module('Unit | Service | current-data', function(hooks) {
     assert.deepEqual(areas, [pixArea]);
   });
 
-  test('it should return competence', function(assert) {
+  test('it should return competence', function (assert) {
     // when
     const competenceResult = service.getCompetence();
 
@@ -108,7 +118,7 @@ module('Unit | Service | current-data', function(hooks) {
     assert.deepEqual(competenceResult, competence);
   });
 
-  test('it should return prototype', function(assert) {
+  test('it should return prototype', function (assert) {
     // when
     const prototypeResult = service.getPrototype();
 
@@ -116,7 +126,7 @@ module('Unit | Service | current-data', function(hooks) {
     assert.deepEqual(prototypeResult, prototype);
   });
 
-  test('it should return `true` if is a pix framework', function(assert) {
+  test('it should return `true` if is a pix framework', function (assert) {
     // when
     const isPixFrameworkResult = service.isPixFramework;
 
@@ -124,7 +134,7 @@ module('Unit | Service | current-data', function(hooks) {
     assert.ok(isPixFrameworkResult);
   });
 
-  test('it should return `false` if is not a pix framework', function(assert) {
+  test('it should return `false` if is not a pix framework', function (assert) {
     // given
     service.setFramework(pixFranceFramework);
 
@@ -135,7 +145,7 @@ module('Unit | Service | current-data', function(hooks) {
     assert.notOk(isPixFrameworkResult);
   });
 
-  test('it should return competences for pix1d', async function(assert) {
+  test('it should return competences for pix1d', async function (assert) {
     // when
     const competencesResult = await service.getCompetencesFromPix1DFramework();
 
@@ -143,7 +153,7 @@ module('Unit | Service | current-data', function(hooks) {
     assert.deepEqual(competencesResult, [pix1dCompetence]);
   });
 
-  test('it should return thematics for pix1d', async function(assert) {
+  test('it should return thematics for pix1d', async function (assert) {
     // when
     const thematicsResult = await service.getThematicsFromPix1DFramework();
 

--- a/pix-editor/tests/unit/services/id-generator-test.js
+++ b/pix-editor/tests/unit/services/id-generator-test.js
@@ -1,15 +1,15 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-module('Unit | Service | id-generator', function(hooks) {
+module('Unit | Service | id-generator', function (hooks) {
   setupTest(hooks);
 
-  test('it generates an id', function(assert) {
+  test('it generates an id', function (assert) {
     const idGenerator = this.owner.lookup('service:id-generator');
     assert.ok(idGenerator.newId().match(/^rec[a-zA-Z0-9]+$/));
   });
 
-  test('it generates an id with a defined prefix', function(assert) {
+  test('it generates an id with a defined prefix', function (assert) {
     const idGenerator = this.owner.lookup('service:id-generator');
     assert.ok(idGenerator.newId('skill').match(/^skill[a-zA-Z0-9]+$/));
   });

--- a/pix-editor/tests/unit/services/phrase-test.js
+++ b/pix-editor/tests/unit/services/phrase-test.js
@@ -3,10 +3,10 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | storage', function(hooks) {
+module('Unit | Service | storage', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     class sessionServiceStub extends Service {
       get data() {
         return { authenticated: { apiKey: 'someApiKey' } };
@@ -15,8 +15,8 @@ module('Unit | Service | storage', function(hooks) {
     this.owner.register('service:session', sessionServiceStub);
   });
 
-  module('download', function() {
-    test('it should trigger API call', async function(assert) {
+  module('download', function () {
+    test('it should trigger API call', async function (assert) {
       // given
       const phraseService = this.owner.lookup('service:phrase');
       const fetch = sinon.stub().resolves();
@@ -26,13 +26,13 @@ module('Unit | Service | storage', function(hooks) {
 
       // then
       assert.ok(fetch.calledOnce);
-      assert.deepEqual(fetch.args[0], ['/api/phrase/download', {
-        method: 'POST',
-        headers: {
-          authorization: 'Bearer someApiKey',
+      assert.deepEqual(fetch.args[0], [
+        '/api/phrase/download',
+        {
+          method: 'POST',
+          headers: { authorization: 'Bearer someApiKey' },
         },
-      }]);
+      ]);
     });
-
   });
 });

--- a/pix-editor/tests/unit/services/storage-test.js
+++ b/pix-editor/tests/unit/services/storage-test.js
@@ -3,10 +3,10 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | storage', function(hooks) {
+module('Unit | Service | storage', function (hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     class sessionServiceStub extends Service {
       get data() {
         return { authenticated: { apiKey: 'someApiKey' } };
@@ -15,8 +15,8 @@ module('Unit | Service | storage', function(hooks) {
     this.owner.register('service:session', sessionServiceStub);
   });
 
-  module('uploadFile', function() {
-    test('it should use file.name when filename is not defined', async function(assert) {
+  module('uploadFile', function () {
+    test('it should use file.name when filename is not defined', async function (assert) {
       // given
       const storageService = this.owner.lookup('service:storage');
       storageService.getStorageToken = sinon.stub().resolves();
@@ -25,7 +25,9 @@ module('Unit | Service | storage', function(hooks) {
       configService.storagePost = 'https://dl.ovh.com/bucket/';
 
       const date = {
-        now() { return 'NOW'; },
+        now() {
+          return 'NOW';
+        },
       };
 
       const file = {
@@ -49,7 +51,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.deepEqual(uploadedFile, expectedUploadedFile);
     });
 
-    test('it should use filename when it is defined', async function(assert) {
+    test('it should use filename when it is defined', async function (assert) {
       // given
       const storageService = this.owner.lookup('service:storage');
       storageService.getStorageToken = sinon.stub().resolves();
@@ -58,7 +60,9 @@ module('Unit | Service | storage', function(hooks) {
       configService.storagePost = 'https://dl.ovh.com/bucket/';
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       const file = {
@@ -84,7 +88,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.deepEqual(uploadedFile, expectedUploadedFile);
     });
 
-    test('it should add Content-Type header to illustration type', async function(assert) {
+    test('it should add Content-Type header to illustration type', async function (assert) {
       // given
       const storageService = this.owner.lookup('service:storage');
       storageService.getStorageToken = sinon.stub().resolves('some-token');
@@ -93,7 +97,9 @@ module('Unit | Service | storage', function(hooks) {
       configService.storagePost = 'https://dl.pix.fr/';
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       const file = {
@@ -119,7 +125,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.deepEqual(headers, expectedHeaders);
     });
 
-    test('it should add Content-* headers to attachment type', async function(assert) {
+    test('it should add Content-* headers to attachment type', async function (assert) {
       // given
       const storageService = this.owner.lookup('service:storage');
       storageService.getStorageToken = sinon.stub().resolves('some-token');
@@ -128,7 +134,9 @@ module('Unit | Service | storage', function(hooks) {
       configService.storagePost = 'https://dl.pix.fr/';
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       const file = {
@@ -156,12 +164,12 @@ module('Unit | Service | storage', function(hooks) {
     });
   });
 
-  module('cloneFile', function(hooks) {
+  module('cloneFile', function (hooks) {
     let storageService;
     let fetch;
     const storageToken = 'HaveFun';
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       storageService = this.owner.lookup('service:storage');
       storageService.getStorageToken = sinon.stub().resolves(storageToken);
 
@@ -172,12 +180,14 @@ module('Unit | Service | storage', function(hooks) {
       fetch = sinon.stub();
     });
 
-    test('it should clone a file', async function(assert) {
+    test('it should clone a file', async function (assert) {
       // given
       fetch.resolves();
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       // when
@@ -186,21 +196,26 @@ module('Unit | Service | storage', function(hooks) {
       // then
       assert.strictEqual(uploadedUrl, 'https://dl.ovh.com/bucket/NOW2/NOW.txt');
       assert.ok(fetch.calledOnce);
-      assert.deepEqual(fetch.args[0], [uploadedUrl, {
-        method: 'PUT',
-        headers: {
-          'X-Auth-Token': storageToken,
-          'X-Copy-From': '/bucket/NOW.txt',
+      assert.deepEqual(fetch.args[0], [
+        uploadedUrl,
+        {
+          method: 'PUT',
+          headers: {
+            'X-Auth-Token': storageToken,
+            'X-Copy-From': '/bucket/NOW.txt',
+          },
         },
-      }]);
+      ]);
     });
 
-    test('it should clone a file when the file is in a sub directory', async function(assert) {
+    test('it should clone a file when the file is in a sub directory', async function (assert) {
       // given
       fetch.resolves();
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       // when
@@ -209,25 +224,28 @@ module('Unit | Service | storage', function(hooks) {
       // then
       assert.strictEqual(uploadedUrl, 'https://dl.ovh.com/bucket/NOW2/test.txt');
       assert.ok(fetch.calledOnce);
-      assert.deepEqual(fetch.args[0], [uploadedUrl, {
-        method: 'PUT',
-        headers: {
-          'X-Auth-Token': storageToken,
-          'X-Copy-From': '/bucket/NOW/test.txt',
+      assert.deepEqual(fetch.args[0], [
+        uploadedUrl,
+        {
+          method: 'PUT',
+          headers: {
+            'X-Auth-Token': storageToken,
+            'X-Copy-From': '/bucket/NOW/test.txt',
+          },
         },
-      }]);
+      ]);
     });
 
-    test('it should retry when token has expired', async function(assert) {
+    test('it should retry when token has expired', async function (assert) {
       // given
-      fetch.onFirstCall().rejects({
-        status: 401,
-      });
+      fetch.onFirstCall().rejects({ status: 401 });
 
       fetch.onSecondCall().resolves();
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       // when
@@ -236,24 +254,27 @@ module('Unit | Service | storage', function(hooks) {
       // then
       assert.strictEqual(uploadedUrl, 'https://dl.ovh.com/bucket/NOW2/NOW.txt');
       assert.ok(fetch.calledTwice);
-      assert.deepEqual(fetch.args[0], [uploadedUrl, {
-        method: 'PUT',
-        headers: {
-          'X-Auth-Token': storageToken,
-          'X-Copy-From': '/bucket/NOW.txt',
+      assert.deepEqual(fetch.args[0], [
+        uploadedUrl,
+        {
+          method: 'PUT',
+          headers: {
+            'X-Auth-Token': storageToken,
+            'X-Copy-From': '/bucket/NOW.txt',
+          },
         },
-      }]);
+      ]);
     });
 
-    test('it should retry when token has expired only one time', async function(assert) {
+    test('it should retry when token has expired only one time', async function (assert) {
       assert.expect(2);
       // given
-      fetch.rejects({
-        status: 401,
-      });
+      fetch.rejects({ status: 401 });
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       // then
@@ -268,15 +289,15 @@ module('Unit | Service | storage', function(hooks) {
       assert.ok(fetch.calledTwice);
     });
 
-    test('it should raise error when API call failed', async function(assert) {
+    test('it should raise error when API call failed', async function (assert) {
       assert.expect(2);
       // given
-      fetch.rejects({
-        status: 400,
-      });
+      fetch.rejects({ status: 400 });
 
       const date = {
-        now() { return 'NOW2'; },
+        now() {
+          return 'NOW2';
+        },
       };
 
       // then
@@ -292,9 +313,8 @@ module('Unit | Service | storage', function(hooks) {
     });
   });
 
-  module('getStorageToken', function() {
-
-    test('it calls api', async function(assert) {
+  module('getStorageToken', function () {
+    test('it calls api', async function (assert) {
       const storageService = this.owner.lookup('service:storage');
 
       const token = 'token';
@@ -308,16 +328,17 @@ module('Unit | Service | storage', function(hooks) {
       const fetchedToken = await storageService.getStorageToken(false, fetch);
 
       assert.ok(fetch.calledOnce);
-      assert.deepEqual(fetch.args[0], ['/api/file-storage-token', {
-        method: 'POST',
-        headers: {
-          'Authorization': 'Bearer someApiKey',
+      assert.deepEqual(fetch.args[0], [
+        '/api/file-storage-token',
+        {
+          method: 'POST',
+          headers: { Authorization: 'Bearer someApiKey' },
         },
-      }]);
+      ]);
       assert.strictEqual(fetchedToken, token);
     });
 
-    test('it returns the previously stored token', async function(assert) {
+    test('it returns the previously stored token', async function (assert) {
       const storageService = this.owner.lookup('service:storage');
       const configService = this.owner.lookup('service:config');
       const token = 'token';
@@ -330,7 +351,7 @@ module('Unit | Service | storage', function(hooks) {
       assert.strictEqual(fetchedToken, token);
     });
 
-    test('it always calls the api when renew is true', async function(assert) {
+    test('it always calls the api when renew is true', async function (assert) {
       const storageService = this.owner.lookup('service:storage');
 
       const configService = this.owner.lookup('service:config');
@@ -346,22 +367,23 @@ module('Unit | Service | storage', function(hooks) {
       const fetchedToken = await storageService.getStorageToken(true, fetch);
 
       assert.ok(fetch.calledOnce);
-      assert.deepEqual(fetch.args[0], ['/api/file-storage-token', {
-        method: 'POST',
-        headers: {
-          'Authorization': 'Bearer someApiKey',
+      assert.deepEqual(fetch.args[0], [
+        '/api/file-storage-token',
+        {
+          method: 'POST',
+          headers: { Authorization: 'Bearer someApiKey' },
         },
-      }]);
+      ]);
       assert.strictEqual(fetchedToken, token);
     });
   });
 
-  module('renameFile', function(hooks) {
+  module('renameFile', function (hooks) {
     let storageService;
     let fetch;
     const storageToken = 'HaveFun';
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       storageService = this.owner.lookup('service:storage');
       storageService.getStorageToken = sinon.stub().resolves(storageToken);
 
@@ -372,7 +394,7 @@ module('Unit | Service | storage', function(hooks) {
       fetch = sinon.stub();
     });
 
-    test('it should rename the header of file', async function(assert) {
+    test('it should rename the header of file', async function (assert) {
       // given
       fetch.resolves();
 
@@ -381,20 +403,21 @@ module('Unit | Service | storage', function(hooks) {
 
       // then
       assert.ok(fetch.calledOnce);
-      assert.deepEqual(fetch.args[0], ['https://dl.ovh.com/bucket/NOW.txt', {
-        method: 'POST',
-        headers: {
-          'X-Auth-Token': storageToken,
-          'Content-Disposition': 'attachment; filename="update-file-name.jpg"',
+      assert.deepEqual(fetch.args[0], [
+        'https://dl.ovh.com/bucket/NOW.txt',
+        {
+          method: 'POST',
+          headers: {
+            'X-Auth-Token': storageToken,
+            'Content-Disposition': 'attachment; filename="update-file-name.jpg"',
+          },
         },
-      }]);
+      ]);
     });
 
-    test('it should retry when token has expired', async function(assert) {
+    test('it should retry when token has expired', async function (assert) {
       // given
-      fetch.onFirstCall().rejects({
-        status: 401,
-      });
+      fetch.onFirstCall().rejects({ status: 401 });
 
       fetch.onSecondCall().resolves();
 
@@ -403,21 +426,22 @@ module('Unit | Service | storage', function(hooks) {
 
       // then
       assert.ok(fetch.calledTwice);
-      assert.deepEqual(fetch.args[0], ['https://dl.ovh.com/bucket/NOW.txt', {
-        method: 'POST',
-        headers: {
-          'X-Auth-Token': storageToken,
-          'Content-Disposition': 'attachment; filename="update-file-name.jpg"',
+      assert.deepEqual(fetch.args[0], [
+        'https://dl.ovh.com/bucket/NOW.txt',
+        {
+          method: 'POST',
+          headers: {
+            'X-Auth-Token': storageToken,
+            'Content-Disposition': 'attachment; filename="update-file-name.jpg"',
+          },
         },
-      }]);
+      ]);
     });
 
-    test('it should retry when token has expired only one time', async function(assert) {
+    test('it should retry when token has expired only one time', async function (assert) {
       assert.expect(2);
       // given
-      fetch.rejects({
-        status: 401,
-      });
+      fetch.rejects({ status: 401 });
 
       // then
       try {
@@ -431,12 +455,10 @@ module('Unit | Service | storage', function(hooks) {
       assert.ok(fetch.calledTwice);
     });
 
-    test('it should raise error when API call failed', async function(assert) {
+    test('it should raise error when API call failed', async function (assert) {
       assert.expect(2);
       // given
-      fetch.rejects({
-        status: 400,
-      });
+      fetch.rejects({ status: 400 });
 
       // then
       try {
@@ -450,5 +472,4 @@ module('Unit | Service | storage', function(hooks) {
       assert.ok(fetch.calledOnce);
     });
   });
-
 });

--- a/scripts/common/token.js
+++ b/scripts/common/token.js
@@ -2,29 +2,27 @@ import axios from 'axios';
 
 export default async function getToken() {
   const data = {
-    'auth': {
-      'identity': {
-        'methods': ['password'],
-        'password': {
-          'user': {
-            'name': process.env.BUCKET_USER,
-            'domain': { 'id': 'default' },
-            'password': process.env.BUCKET_PASSWORD,
-          }
-        }
+    auth: {
+      identity: {
+        methods: ['password'],
+        password: {
+          user: {
+            name: process.env.BUCKET_USER,
+            domain: { id: 'default' },
+            password: process.env.BUCKET_PASSWORD,
+          },
+        },
       },
-      'scope': {
-        'project': {
-          'name': process.env.STORAGE_TENANT,
-          'domain': { 'id': 'default' }
-        }
-      }
-    }
+      scope: {
+        project: {
+          name: process.env.STORAGE_TENANT,
+          domain: { id: 'default' },
+        },
+      },
+    },
   };
 
-  const response = await axios.post(process.env.TOKEN_URL, JSON.stringify(data), {
-    headers: { 'Content-Type': 'application/json' }
-  });
+  const response = await axios.post(process.env.TOKEN_URL, JSON.stringify(data), { headers: { 'Content-Type': 'application/json' } });
 
   return response.headers['x-subject-token'];
 }

--- a/scripts/compare-challenges-and-attachments/index.js
+++ b/scripts/compare-challenges-and-attachments/index.js
@@ -14,7 +14,7 @@ async function main() {
     await limit(async () => {
       const errors = await checkChallengeAttachments(challenge, attachments, remoteChecksumComputer);
       if (_.isEmpty(errors)) {
-        challengeCount ++;
+        challengeCount++;
         console.log(challengeCount / challenges.length * 100 + '%');
       } else {
         console.error(`Found inconsistent challenge and attachments: challenge ${challenge.id} should have these attachments ${JSON.stringify(errors)}`);
@@ -51,7 +51,7 @@ function formatChallengeAttachment(attachment) {
     alt: attachment.fields.alt || '',
     mimeType: attachment.fields.mimeType,
     type: attachment.fields.type,
-    url: attachment.fields.url
+    url: attachment.fields.url,
   };
 }
 
@@ -96,11 +96,10 @@ function sanitizeAltText(text) {
 }
 
 async function remoteChecksumComputer(url) {
-
   const response = await axios({
     url,
     method: 'GET',
-    responseType: 'stream'
+    responseType: 'stream',
   });
 
   return hash(response.data.pipe, { algorithm: 'sha1' });
@@ -109,4 +108,3 @@ async function remoteChecksumComputer(url) {
 if (process.env.NODE_ENV !== 'test') {
   main();
 }
-

--- a/scripts/compare-challenges-and-attachments/index.test.js
+++ b/scripts/compare-challenges-and-attachments/index.test.js
@@ -2,15 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { checkChallengeAttachments } from './index.js';
 
-describe('checkChallengeAttachments', function() {
-
-  it('returns empty table when attachments are correct for given challenge', async function() {
+describe('checkChallengeAttachments', function () {
+  it('returns empty table when attachments are correct for given challenge', async function () {
     const illustration = {
-      'filename': 'mailPJ.png',
-      'id': 'attcKBWOyCUyATJ93',
-      'size': 49502,
-      'type': 'image/png',
-      'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+      filename: 'mailPJ.png',
+      id: 'attcKBWOyCUyATJ93',
+      size: 49502,
+      type: 'image/png',
+      url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
     };
 
     const challenge = {
@@ -22,7 +21,7 @@ describe('checkChallengeAttachments', function() {
     };
 
     const attachment = {
-      'fields': {
+      fields: {
         'id': 'attcKBWOyCUyATJ93',
         'Record ID': 'reczu9rZzvVD07Gme',
         'challengeId': ['some-challenge-id'],
@@ -33,7 +32,7 @@ describe('checkChallengeAttachments', function() {
         'url': 'https://dl.pix.fr/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
         'alt': 'alternative text',
       },
-      'id': 'reczu9rZzvVD07Gme'
+      id: 'reczu9rZzvVD07Gme',
     };
 
     const remoteChecksumComputer = vi.fn().mockResolvedValue('sha1');
@@ -45,13 +44,13 @@ describe('checkChallengeAttachments', function() {
     expect(differences).to.deep.equal([]);
   });
 
-  it('returns array containing illustrations with wrong checksum', async function() {
+  it('returns array containing illustrations with wrong checksum', async function () {
     const illustration = {
-      'filename': 'mailPJ.png',
-      'id': 'attcKBWOyCUyATJ93',
-      'size': 49502,
-      'type': 'image/png',
-      'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+      filename: 'mailPJ.png',
+      id: 'attcKBWOyCUyATJ93',
+      size: 49502,
+      type: 'image/png',
+      url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
     };
 
     const challenge = {
@@ -63,7 +62,7 @@ describe('checkChallengeAttachments', function() {
     };
 
     const attachment = {
-      'fields': {
+      fields: {
         'id': 'attcKBWOyCUyATJ93',
         'Record ID': 'reczu9rZzvVD07Gme',
         'challengeId': ['some-challenge-id'],
@@ -74,17 +73,17 @@ describe('checkChallengeAttachments', function() {
         'url': 'https://dl.pix.fr/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
         'alt': 'alternative text',
       },
-      'id': 'reczu9rZzvVD07Gme'
+      id: 'reczu9rZzvVD07Gme',
     };
 
     const attachments = [attachment];
     const expectedDifference = {
-      'checksum': 'checksum',
-      'alt': 'alternative text',
-      'filename': 'mailPJ.png',
-      'mimeType': 'image/png',
-      'size': 49502,
-      'type': 'illustration',
+      checksum: 'checksum',
+      alt: 'alternative text',
+      filename: 'mailPJ.png',
+      mimeType: 'image/png',
+      size: 49502,
+      type: 'illustration',
     };
 
     const remoteChecksumComputer = vi.fn();
@@ -96,13 +95,13 @@ describe('checkChallengeAttachments', function() {
     expect(differences).to.deep.equal([expectedDifference]);
   });
 
-  it('returns table containing missing illustration when any', async function() {
+  it('returns table containing missing illustration when any', async function () {
     const illustration = {
-      'filename': 'mailPJ.png',
-      'id': 'attcKBWOyCUyATJ93',
-      'size': 49502,
-      'type': 'image/png',
-      'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+      filename: 'mailPJ.png',
+      id: 'attcKBWOyCUyATJ93',
+      size: 49502,
+      type: 'image/png',
+      url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
     };
 
     const challenge = {
@@ -115,14 +114,14 @@ describe('checkChallengeAttachments', function() {
 
     const attachments = [];
     const expectedDifference = {
-      'alt': 'alternative text',
-      'checksum': 'checksum',
-      'filename': 'mailPJ.png',
-      'mimeType': 'image/png',
-      'size': 49502,
-      'type': 'illustration',
+      alt: 'alternative text',
+      checksum: 'checksum',
+      filename: 'mailPJ.png',
+      mimeType: 'image/png',
+      size: 49502,
+      type: 'illustration',
     };
-    
+
     const remoteChecksumComputer = vi.fn();
     remoteChecksumComputer.mockResolvedValue('checksum');
 
@@ -131,13 +130,13 @@ describe('checkChallengeAttachments', function() {
     expect(differences).to.deep.equal([expectedDifference]);
   });
 
-  it('returns table containing missing attachment when any', async function() {
+  it('returns table containing missing attachment when any', async function () {
     const attachment = {
-      'filename': 'mailPJ.png',
-      'id': 'attcKBWOyCUyATJ93',
-      'size': 49502,
-      'type': 'image/png',
-      'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+      filename: 'mailPJ.png',
+      id: 'attcKBWOyCUyATJ93',
+      size: 49502,
+      type: 'image/png',
+      url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
     };
 
     const challenge = {
@@ -149,12 +148,12 @@ describe('checkChallengeAttachments', function() {
 
     const attachments = [];
     const expectedDifference = {
-      'alt': '',
-      'checksum': 'checksum',
-      'filename': 'mailPJ.png',
-      'mimeType': 'image/png',
-      'size': 49502,
-      'type': 'attachment',
+      alt: '',
+      checksum: 'checksum',
+      filename: 'mailPJ.png',
+      mimeType: 'image/png',
+      size: 49502,
+      type: 'attachment',
     };
 
     const remoteChecksumComputer = vi.fn();
@@ -165,13 +164,13 @@ describe('checkChallengeAttachments', function() {
     expect(differences).to.deep.equal([expectedDifference]);
   });
 
-  it('ignore when attachments alt have space before new line', async function() {
+  it('ignore when attachments alt have space before new line', async function () {
     const illustration = {
-      'filename': 'mailPJ.png',
-      'id': 'attcKBWOyCUyATJ93',
-      'size': 49502,
-      'type': 'image/png',
-      'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+      filename: 'mailPJ.png',
+      id: 'attcKBWOyCUyATJ93',
+      size: 49502,
+      type: 'image/png',
+      url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
     };
 
     const challenge = {
@@ -183,7 +182,7 @@ describe('checkChallengeAttachments', function() {
     };
 
     const attachment = {
-      'fields': {
+      fields: {
         'id': 'attcKBWOyCUyATJ93',
         'Record ID': 'reczu9rZzvVD07Gme',
         'challengeId': ['some-challenge-id'],
@@ -194,11 +193,11 @@ describe('checkChallengeAttachments', function() {
         'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
         'alt': 'alternative text .\ntest',
       },
-      'id': 'reczu9rZzvVD07Gme'
+      id: 'reczu9rZzvVD07Gme',
     };
 
     const attachments = [attachment];
-    
+
     const remoteChecksumComputer = vi.fn();
     remoteChecksumComputer.mockResolvedValue('checksum');
 
@@ -207,4 +206,3 @@ describe('checkChallengeAttachments', function() {
     expect(differences).to.deep.equal([]);
   });
 });
-

--- a/scripts/compare-releases-integrity/index.js
+++ b/scripts/compare-releases-integrity/index.js
@@ -15,7 +15,7 @@ async function main() {
   const differences = await compareReleases(
     { url: baseUrl1, token: token1 },
     { url: baseUrl2, token: token2 },
-    remoteChecksumComputer
+    remoteChecksumComputer,
   );
 
   console.log(differences);
@@ -63,9 +63,7 @@ export async function compareReleases({ url: urlLeft, token: tokenLeft }, { url:
 }
 
 async function getRelease(url, token) {
-  const { data: { content: { challenges } } } = await axios.get(url, {
-    headers: { 'Authorization': 'Bearer ' + token }
-  });
+  const { data: { content: { challenges } } } = await axios.get(url, { headers: { Authorization: 'Bearer ' + token } });
   return challenges;
 }
 

--- a/scripts/compare-releases-integrity/index.test.js
+++ b/scripts/compare-releases-integrity/index.test.js
@@ -3,16 +3,13 @@ import nock from 'nock';
 
 import { replaceAttachmentsUrlByChecksum, compareReleases, remoteChecksumComputer } from './index.js';
 
-describe('Scripts | Compare Release Integrity', function() {
-  describe('#replaceAttachmentsUrlByChecksum', function() {
-    it('returns challenge with attachments url replaced by checksum', async function() {
+describe('Scripts | Compare Release Integrity', function () {
+  describe('#replaceAttachmentsUrlByChecksum', function () {
+    it('returns challenge with attachments url replaced by checksum', async function () {
       const initialChallenge = {
         some: 'property',
         illustrationUrl: 'illustration-url',
-        attachments: [
-          'attachments-url-1',
-          'attachments-url-2',
-        ],
+        attachments: ['attachments-url-1', 'attachments-url-2'],
       };
 
       const remoteChecksumComputerStub = vi.fn();
@@ -31,7 +28,7 @@ describe('Scripts | Compare Release Integrity', function() {
       expect(remoteChecksumComputerStub).toHaveBeenCalledWith('attachments-url-2');
     });
 
-    it('should works when there is no attachments', async function() {
+    it('should works when there is no attachments', async function () {
       const initialChallenge = {
         some: 'property',
         illustrationUrl: 'illustration-url',
@@ -50,13 +47,10 @@ describe('Scripts | Compare Release Integrity', function() {
       expect(remoteChecksumComputerStub).toHaveBeenCalledWith('illustration-url');
     });
 
-    it('should works when there is no illustrations', async function() {
+    it('should works when there is no illustrations', async function () {
       const initialChallenge = {
         some: 'property',
-        attachments: [
-          'attachments-url-1',
-          'attachments-url-2',
-        ],
+        attachments: ['attachments-url-1', 'attachments-url-2'],
       };
 
       const remoteChecksumComputerStub = vi.fn();
@@ -74,29 +68,21 @@ describe('Scripts | Compare Release Integrity', function() {
     });
   });
 
-  describe('#compareReleases', function() {
-    beforeEach(function() {
+  describe('#compareReleases', function () {
+    beforeEach(function () {
       nock.cleanAll();
       nock.disableNetConnect();
     });
 
-    it('should return an empty table when there is no differences', async function() {
+    it('should return an empty table when there is no differences', async function () {
       const remoteChecksumComputer = vi.fn();
-      const productionRelease = {
-        content: {
-          challenges: [{ id: 1 }]
-        }
-      };
+      const productionRelease = { content: { challenges: [{ id: 1 }] } };
       const url1Scope = nock('http://example.org')
         .matchHeader('Authorization', 'Bearer myToken1')
         .get('/api/releases/latest')
         .reply(200, productionRelease);
 
-      const newRelease = {
-        content: {
-          challenges: [{ id: 1 }]
-        }
-      };
+      const newRelease = { content: { challenges: [{ id: 1 }] } };
       const url2Scope = nock('http://example.com')
         .matchHeader('Authorization', 'Bearer myToken2')
         .get('/api/releases/latest')
@@ -105,7 +91,7 @@ describe('Scripts | Compare Release Integrity', function() {
       const differences = await compareReleases(
         { url: 'http://example.org/api/releases/latest', token: 'myToken1' },
         { url: 'http://example.com/api/releases/latest', token: 'myToken2' },
-        remoteChecksumComputer
+        remoteChecksumComputer,
       );
 
       expect(differences).to.deep.equal([]);
@@ -113,29 +99,15 @@ describe('Scripts | Compare Release Integrity', function() {
       expect(url2Scope.isDone()).toBe(true);
     });
 
-    it('should return an empty table when there is no differences when challenges are not ordered', async function() {
+    it('should return an empty table when there is no differences when challenges are not ordered', async function () {
       const remoteChecksumComputer = vi.fn();
-      const productionRelease = {
-        content: {
-          challenges: [
-            { id: 1 },
-            { id: 2 },
-          ],
-        },
-      };
+      const productionRelease = { content: { challenges: [{ id: 1 }, { id: 2 }] } };
       const url1Scope = nock('http://example.org')
         .matchHeader('Authorization', 'Bearer myToken1')
         .get('/api/releases/latest')
         .reply(200, productionRelease);
 
-      const newRelease = {
-        content: {
-          challenges: [
-            { id: 2 },
-            { id: 1 },
-          ],
-        },
-      };
+      const newRelease = { content: { challenges: [{ id: 2 }, { id: 1 }] } };
       const url2Scope = nock('http://example.com')
         .matchHeader('Authorization', 'Bearer myToken2')
         .get('/api/releases/latest')
@@ -144,7 +116,7 @@ describe('Scripts | Compare Release Integrity', function() {
       const differences = await compareReleases(
         { url: 'http://example.org/api/releases/latest', token: 'myToken1' },
         { url: 'http://example.com/api/releases/latest', token: 'myToken2' },
-        remoteChecksumComputer
+        remoteChecksumComputer,
       );
 
       expect(differences).to.deep.equal([]);
@@ -152,23 +124,15 @@ describe('Scripts | Compare Release Integrity', function() {
       expect(url2Scope.isDone()).toBe(true);
     });
 
-    it('should ignore text with space before new line', async function() {
+    it('should ignore text with space before new line', async function () {
       const remoteChecksumComputer = vi.fn();
-      const productionRelease = {
-        content: {
-          challenges: [{ id: 1, illustrationAlt: 'alternative text . \ntest' }]
-        }
-      };
+      const productionRelease = { content: { challenges: [{ id: 1, illustrationAlt: 'alternative text . \ntest' }] } };
       const url1Scope = nock('http://example.org')
         .matchHeader('Authorization', 'Bearer myToken1')
         .get('/api/releases/latest')
         .reply(200, productionRelease);
 
-      const newRelease = {
-        content: {
-          challenges: [{ id: 1, illustrationAlt: 'alternative text .\ntest' }]
-        }
-      };
+      const newRelease = { content: { challenges: [{ id: 1, illustrationAlt: 'alternative text .\ntest' }] } };
       const url2Scope = nock('http://example.com')
         .matchHeader('Authorization', 'Bearer myToken2')
         .get('/api/releases/latest')
@@ -177,7 +141,7 @@ describe('Scripts | Compare Release Integrity', function() {
       const differences = await compareReleases(
         { url: 'http://example.org/api/releases/latest', token: 'myToken1' },
         { url: 'http://example.com/api/releases/latest', token: 'myToken2' },
-        remoteChecksumComputer
+        remoteChecksumComputer,
       );
 
       expect(differences).to.deep.equal([]);
@@ -185,7 +149,7 @@ describe('Scripts | Compare Release Integrity', function() {
       url2Scope.done();
     });
 
-    it('should return the differences', async function() {
+    it('should return the differences', async function () {
       const remoteChecksumComputer = vi.fn()
         .mockResolvedValueOnce('sha1')
         .mockResolvedValueOnce('sha2');
@@ -194,11 +158,13 @@ describe('Scripts | Compare Release Integrity', function() {
 
       const productionRelease = {
         content: {
-          challenges: [{
-            id: 'recCorruptedChallenge',
-            illustrationUrl: 'illustration-url',
-          }]
-        }
+          challenges: [
+            {
+              id: 'recCorruptedChallenge',
+              illustrationUrl: 'illustration-url',
+            },
+          ],
+        },
       };
       nock('http://example.org')
         .get('/api/releases/latest')
@@ -206,11 +172,13 @@ describe('Scripts | Compare Release Integrity', function() {
 
       const newRelease = {
         content: {
-          challenges: [{
-            id: 'recCorruptedChallenge',
-            illustrationUrl: 'illustration-corrupted-url',
-          }]
-        }
+          challenges: [
+            {
+              id: 'recCorruptedChallenge',
+              illustrationUrl: 'illustration-corrupted-url',
+            },
+          ],
+        },
       };
       nock('http://example.com')
         .get('/api/releases/latest')
@@ -219,29 +187,31 @@ describe('Scripts | Compare Release Integrity', function() {
       const differences = await compareReleases(
         { url: 'http://example.org/api/releases/latest', token: 'myToken1' },
         { url: 'http://example.com/api/releases/latest', token: 'myToken2' },
-        remoteChecksumComputer
+        remoteChecksumComputer,
       );
 
       expect(differences).to.deep.equal([expectedDifference]);
     });
 
-    it('should return the differences when the number of challenges differ', async function() {
+    it('should return the differences when the number of challenges differ', async function () {
       const remoteChecksumComputer = vi.fn()
         .mockResolvedValueOnce('sha1')
         .mockResolvedValueOnce('sha2');
 
-      const expectedDifference = ['2', '4', '5'];
+      const expectedDifference = [
+        '2',
+        '4',
+        '5',
+      ];
 
       const productionRelease = {
         content: {
-          challenges: [{
-            id: '1',
-          },{
-            id: '2',
-          }, {
-            id: '3',
-          }]
-        }
+          challenges: [
+            { id: '1' },
+            { id: '2' },
+            { id: '3' },
+          ],
+        },
       };
       nock('http://example.org')
         .get('/api/releases/latest')
@@ -249,16 +219,13 @@ describe('Scripts | Compare Release Integrity', function() {
 
       const newRelease = {
         content: {
-          challenges: [{
-            id: '1',
-          }, {
-            id: '5',
-          }, {
-            id: '3',
-          }, {
-            id: '4',
-          }]
-        }
+          challenges: [
+            { id: '1' },
+            { id: '5' },
+            { id: '3' },
+            { id: '4' },
+          ],
+        },
       };
       nock('http://example.com')
         .get('/api/releases/latest')
@@ -267,20 +234,20 @@ describe('Scripts | Compare Release Integrity', function() {
       const differences = await compareReleases(
         { url: 'http://example.org/api/releases/latest', token: 'myToken1' },
         { url: 'http://example.com/api/releases/latest', token: 'myToken2' },
-        remoteChecksumComputer
+        remoteChecksumComputer,
       );
 
       expect(differences).to.deep.equal(expectedDifference);
     });
   });
 
-  describe('#remoteChecksumComputer', function() {
-    beforeEach(function() {
+  describe('#remoteChecksumComputer', function () {
+    beforeEach(function () {
       nock.cleanAll();
       nock.disableNetConnect();
     });
 
-    it('compute the hash of the remote file', async function() {
+    it('compute the hash of the remote file', async function () {
       const requestCall = nock('http://example.net')
         .get('/file.jpg')
         .reply(200, 'test');
@@ -290,7 +257,7 @@ describe('Scripts | Compare Release Integrity', function() {
       expect(requestCall.isDone()).toBe(true);
     });
 
-    it('returns an error when the server returns an error', async function() {
+    it('returns an error when the server returns an error', async function () {
       const requestCall = nock('http://example.net')
         .get('/file.jpg')
         .reply(400, '');

--- a/scripts/copy-skills-and-set-challenges-as-focusable/airtable-fields.js
+++ b/scripts/copy-skills-and-set-challenges-as-focusable/airtable-fields.js
@@ -7,13 +7,14 @@ export const USEFUL_SKILL_FIELDS = [
   'Compétence',
   'Comprendre',
   'En savoir plus',
-  'Tags', 'Description',
+  'Tags',
+  'Description',
   'Statut de la description',
   'Level',
   'Tube',
   'Status',
   'Internationalisation',
-  'Version'
+  'Version',
 ];
 
 export const USEFUL_CHALLENGE_FIELDS = [

--- a/scripts/copy-skills-and-set-challenges-as-focusable/index.js
+++ b/scripts/copy-skills-and-set-challenges-as-focusable/index.js
@@ -50,9 +50,7 @@ async function main() {
 }
 
 function createAirtableClient() {
-  return new Airtable({
-    apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  return new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE);
 }
 
 function getBaseSkills(table) {
@@ -93,14 +91,16 @@ export async function findSkill(base, persistentId) {
 }
 
 export async function duplicateSkill(base, idGenerator, skill) {
-  const createdSkills = await base.create([{
-    fields: {
-      ...skill.fields,
-      'id persistant': idGenerator('skill'),
-      Version: skill.get('Version') + 1,
-      Status: 'en construction',
-    }
-  }]);
+  const createdSkills = await base.create([
+    {
+      fields: {
+        ...skill.fields,
+        'id persistant': idGenerator('skill'),
+        'Version': skill.get('Version') + 1,
+        'Status': 'en construction',
+      },
+    },
+  ]);
   return createdSkills[0];
 }
 
@@ -121,7 +121,7 @@ export async function cloneAttachmentsFromAChallenge(base, token, challengePersi
       'mimeType',
       'type',
     ],
-    filterByFormula : `{challengeId persistant} = '${challengePersistentId}'`
+    filterByFormula: `{challengeId persistant} = '${challengePersistentId}'`,
   }).all();
 
   const duplicatedAttachments = await Promise.all(attachments.map((attachment) => {
@@ -139,7 +139,7 @@ async function cloneAndPrepareAttachment(attachment, token, clock) {
     fields: {
       ...attachment.fields,
       url: attachmentUrl,
-    }
+    },
   };
 }
 
@@ -151,7 +151,7 @@ async function cloneFile(token, originalUrl, randomString, filename, clock = Dat
     headers: {
       'X-Auth-Token': token,
       'X-Copy-From': process.env.BUCKET_NAME + parsedUrl.pathname,
-    }
+    },
   };
 
   try {
@@ -171,7 +171,7 @@ export function prepareNewChallenge(challenge, destinationSkillId, newAttachment
       'Acquix': [destinationSkillId],
       'Focalisée': true,
       'files': newAttachmentsId,
-    }
+    },
   };
 }
 
@@ -192,9 +192,7 @@ export function activateSkill(base, skill) {
 function changeSkillStatus(base, skill, status) {
   const updatedSkill = {
     id: skill.getId(),
-    fields: {
-      'Status': status,
-    },
+    fields: { Status: status },
   };
 
   return base.update([updatedSkill]);
@@ -204,9 +202,7 @@ export function archiveChallenges(base, challenges) {
   const archivedChallenges = challenges.map((challenge) => {
     return {
       id: challenge.getId(),
-      fields: {
-        'Statut': 'archivé',
-      },
+      fields: { Statut: 'archivé' },
     };
   });
 
@@ -218,7 +214,7 @@ export async function bulkCreate(base, records) {
 }
 
 export async function bulkUpdate(base, records) {
-  const uniqRecords = _.uniqBy(records,'id');
+  const uniqRecords = _.uniqBy(records, 'id');
   return bulkOnBase(base, 'update', uniqRecords);
 }
 

--- a/scripts/copy-skills-and-set-challenges-as-focusable/index.test.js
+++ b/scripts/copy-skills-and-set-challenges-as-focusable/index.test.js
@@ -18,9 +18,9 @@ import {
   activateSkill,
 } from './index.js';
 
-describe('Copy skills and set challenges as focusable', function() {
-  describe('#findSkill', function() {
-    it('should call airtable to find a skill', async function() {
+describe('Copy skills and set challenges as focusable', function () {
+  describe('#findSkill', function () {
+    it('should call airtable to find a skill', async function () {
       const persistentId = 1;
       const airtableData = [
         new AirtableRecord('Skill', 'recAirtableId1', {
@@ -28,60 +28,54 @@ describe('Copy skills and set challenges as focusable', function() {
             'id persistant': '1',
             'Version': 2,
             'Status': 'actif',
-            'Description': 'Coucou'
+            'Description': 'Coucou',
           },
         }),
       ];
-      const base = {
-        select: vi.fn().mockReturnValue({
-          all: vi.fn().mockResolvedValue(airtableData)
-        }),
-      };
+      const base = { select: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue(airtableData) }) };
       const skill = await findSkill(base, persistentId);
 
       expect(base.select).toHaveBeenCalledWith({
         fields: USEFUL_SKILL_FIELDS,
-        filterByFormula : '{id persistant} = \'1\'',
-        maxRecords: 1
+        filterByFormula: '{id persistant} = \'1\'',
+        maxRecords: 1,
       });
       expect(skill).to.deep.equal(airtableData[0]);
     });
   });
 
-  describe('#duplicateSkill', function() {
-    it('should duplicate skill', async function() {
-      const skill  = new AirtableRecord('Skill', 'recAirtableId1', {
+  describe('#duplicateSkill', function () {
+    it('should duplicate skill', async function () {
+      const skill = new AirtableRecord('Skill', 'recAirtableId1', {
         fields: {
           'id persistant': '1',
           'Version': 2,
           'Status': 'actif',
-          'Description': 'Coucou'
+          'Description': 'Coucou',
         },
       });
-      const createdAirtableData = [
-        new AirtableRecord('Skill', 'recNewSkillId'),
-      ];
-      const base = {
-        create: vi.fn().mockResolvedValue(createdAirtableData),
-      };
+      const createdAirtableData = [new AirtableRecord('Skill', 'recNewSkillId')];
+      const base = { create: vi.fn().mockResolvedValue(createdAirtableData) };
       const idGenerator = (prefix) => `${prefix}IdPersistantRandom`;
 
       const createdSkill = await duplicateSkill(base, idGenerator, skill);
 
       expect(createdSkill).to.deep.equal(createdAirtableData[0]);
-      expect(base.create).toHaveBeenCalledWith([{
-        fields: {
-          'id persistant': 'skillIdPersistantRandom',
-          'Version': 3,
-          'Status': 'en construction',
-          'Description': 'Coucou',
-        }
-      }]);
+      expect(base.create).toHaveBeenCalledWith([
+        {
+          fields: {
+            'id persistant': 'skillIdPersistantRandom',
+            'Version': 3,
+            'Status': 'en construction',
+            'Description': 'Coucou',
+          },
+        },
+      ]);
     });
   });
 
-  describe('#findChallengesFromASkill', function() {
-    it('should find challenges from a skill when status is validated, validated without tests and pre-validated', async function() {
+  describe('#findChallengesFromASkill', function () {
+    it('should find challenges from a skill when status is validated, validated without tests and pre-validated', async function () {
       const skillPersistentId = 1;
       const airtableData = [
         new AirtableRecord('Challenges', 'recAirtableId1', {
@@ -93,25 +87,21 @@ describe('Copy skills and set challenges as focusable', function() {
           },
         }),
       ];
-      const base = {
-        select: vi.fn().mockReturnValue({
-          all: vi.fn().mockResolvedValue(airtableData)
-        }),
-      };
+      const base = { select: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue(airtableData) }) };
 
       await findChallengesFromASkill(base, skillPersistentId);
 
       expect(base.select).toHaveBeenCalledWith({
         fields: USEFUL_CHALLENGE_FIELDS,
-        filterByFormula : 'AND(FIND(\'1\', ARRAYJOIN({Acquix (id persistant)})), {Statut} = \'validé\'))',
+        filterByFormula: 'AND(FIND(\'1\', ARRAYJOIN({Acquix (id persistant)})), {Statut} = \'validé\'))',
       });
     });
   });
 
-  describe('#prepareNewChallenge', function() {
-    it('should create the updated airtable serialization', function() {
+  describe('#prepareNewChallenge', function () {
+    it('should create the updated airtable serialization', function () {
       const destinationSkillId = 2;
-      const challenge =  new AirtableRecord('Challenges', 'recAirtableId1', {
+      const challenge = new AirtableRecord('Challenges', 'recAirtableId1', {
         fields: {
           'id persistant': '1',
           'Statut': 'validé',
@@ -137,14 +127,14 @@ describe('Copy skills and set challenges as focusable', function() {
     });
   });
 
-  describe('#cloneAttachmentsFromAChallenge', function() {
-    beforeEach(function() {
+  describe('#cloneAttachmentsFromAChallenge', function () {
+    beforeEach(function () {
       nock.cleanAll();
       nock.disableNetConnect();
       process.env.BUCKET_NAME = 'bucket name';
     });
 
-    it('should retrieve challenge attachments from a challenge and clone them', async function() {
+    it('should retrieve challenge attachments from a challenge and clone them', async function () {
       const challengePersistantId = 1;
       const airtableAttachments = [
         new AirtableRecord('Attachments', 'recAttachmentAirtableId1', {
@@ -160,14 +150,9 @@ describe('Copy skills and set challenges as focusable', function() {
           },
         }),
       ];
-      const newAirtableAttachments = [
-        new AirtableRecord('Attachments', 'recNewAttachmentAirtableId1'),
-        new AirtableRecord('Attachments', 'recNewAttachmentAirtableId2'),
-      ];
+      const newAirtableAttachments = [new AirtableRecord('Attachments', 'recNewAttachmentAirtableId1'), new AirtableRecord('Attachments', 'recNewAttachmentAirtableId2')];
       const base = {
-        select: vi.fn().mockReturnValue({
-          all: vi.fn().mockResolvedValue(airtableAttachments)
-        }),
+        select: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue(airtableAttachments) }),
         create: vi.fn().mockResolvedValue(newAirtableAttachments),
       };
 
@@ -183,7 +168,11 @@ describe('Copy skills and set challenges as focusable', function() {
         .put('/recAttachmentAirtableId2123456/attachment2.pdf')
         .reply(200);
 
-      const result = await cloneAttachmentsFromAChallenge(base, token, challengePersistantId, { now() { return '123456'; } });
+      const result = await cloneAttachmentsFromAChallenge(base, token, challengePersistantId, {
+        now() {
+          return '123456';
+        },
+      });
 
       expect(base.select).toHaveBeenCalledWith({
         fields: [
@@ -194,7 +183,7 @@ describe('Copy skills and set challenges as focusable', function() {
           'mimeType',
           'type',
         ],
-        filterByFormula : '{challengeId persistant} = \'1\''
+        filterByFormula: '{challengeId persistant} = \'1\'',
       });
 
       cloneFileCall.done();
@@ -218,9 +207,8 @@ describe('Copy skills and set challenges as focusable', function() {
     });
   });
 
-  describe('#archiveChallenges', function() {
-
-    it('should archive challenges', async function() {
+  describe('#archiveChallenges', function () {
+    it('should archive challenges', async function () {
       const challenges = [
         new AirtableRecord('Challenges', 'recAirtableId1', {
           fields: {
@@ -239,32 +227,25 @@ describe('Copy skills and set challenges as focusable', function() {
           },
         }),
       ];
-      const base = {
-        update: vi.fn(),
-      };
+      const base = { update: vi.fn() };
 
       await archiveChallenges(base, challenges);
 
       expect(base.update).toHaveBeenCalledWith([
         {
           id: 'recAirtableId1',
-          fields: {
-            'Statut': 'archivé'
-          },
+          fields: { Statut: 'archivé' },
         },
         {
           id: 'recAirtableId2',
-          fields: {
-            'Statut': 'archivé',
-          },
+          fields: { Statut: 'archivé' },
         },
       ]);
     });
   });
 
-  describe('#archiveSkill', function() {
-
-    it('should archive skill', async function() {
+  describe('#archiveSkill', function () {
+    it('should archive skill', async function () {
       const skill = new AirtableRecord('Skills', 'recAirtableId1', {
         fields: {
           'id persistant': '1',
@@ -272,26 +253,21 @@ describe('Copy skills and set challenges as focusable', function() {
           'Description': 'Coucou',
         },
       });
-      const base = {
-        update: vi.fn(),
-      };
+      const base = { update: vi.fn() };
 
       await archiveSkill(base, skill);
 
       expect(base.update).toHaveBeenCalledWith([
         {
           id: 'recAirtableId1',
-          fields: {
-            'Status': 'archivé'
-          },
+          fields: { Status: 'archivé' },
         },
       ]);
     });
   });
 
-  describe('#activateSkill', function() {
-
-    it('should activate skill', async function() {
+  describe('#activateSkill', function () {
+    it('should activate skill', async function () {
       const skill = new AirtableRecord('Skills', 'recAirtableId1', {
         fields: {
           'id persistant': '1',
@@ -299,29 +275,23 @@ describe('Copy skills and set challenges as focusable', function() {
           'Description': 'Coucou',
         },
       });
-      const base = {
-        update: vi.fn(),
-      };
+      const base = { update: vi.fn() };
 
       await activateSkill(base, skill);
 
       expect(base.update).toHaveBeenCalledWith([
         {
           id: 'recAirtableId1',
-          fields: {
-            'Status': 'actif'
-          },
+          fields: { Status: 'actif' },
         },
       ]);
     });
   });
 
-  describe('#bulkCreate', function() {
-    it('should create the records and return the result', async function() {
+  describe('#bulkCreate', function () {
+    it('should create the records and return the result', async function () {
       const expectedResult = [Symbol()];
-      const base = {
-        create: vi.fn().mockResolvedValue(expectedResult),
-      };
+      const base = { create: vi.fn().mockResolvedValue(expectedResult) };
       const records = [1];
 
       const result = await bulkCreate(base, records);
@@ -329,26 +299,33 @@ describe('Copy skills and set challenges as focusable', function() {
       expect(result).to.deep.equal(expectedResult);
     });
 
-    it('should create the records by batch of 10 and return the result', async function() {
+    it('should create the records by batch of 10 and return the result', async function () {
       const expectedResult = [Symbol()];
-      const base = {
-        create: vi.fn().mockResolvedValue(expectedResult),
-      };
+      const base = { create: vi.fn().mockResolvedValue(expectedResult) };
       const records = _.times(11).map((i) => i);
 
       const result = await bulkCreate(base, records);
-      expect(base.create).toHaveBeenCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(base.create).toHaveBeenCalledWith([
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+      ]);
       expect(base.create).toHaveBeenCalledWith([10]);
       expect(result).to.deep.equal(expectedResult.concat(expectedResult));
     });
   });
 
-  describe('#bulkUpdate', function() {
-    it('should update the records and return the result', async function() {
+  describe('#bulkUpdate', function () {
+    it('should update the records and return the result', async function () {
       const expectedResult = [{ id: 'rec123' }];
-      const base = {
-        update: vi.fn().mockResolvedValue(expectedResult),
-      };
+      const base = { update: vi.fn().mockResolvedValue(expectedResult) };
       const records = [{ id: 1 }];
 
       const result = await bulkUpdate(base, records);
@@ -356,11 +333,9 @@ describe('Copy skills and set challenges as focusable', function() {
       expect(result).to.deep.equal(expectedResult);
     });
 
-    it('should remove duplicate records before update', async function() {
+    it('should remove duplicate records before update', async function () {
       const expectedResult = [{ id: 'rec123' }];
-      const base = {
-        update: vi.fn().mockResolvedValue(expectedResult),
-      };
+      const base = { update: vi.fn().mockResolvedValue(expectedResult) };
       const records = [{ id: 1 }, { id: 1 }];
 
       const result = await bulkUpdate(base, records);
@@ -368,12 +343,12 @@ describe('Copy skills and set challenges as focusable', function() {
       expect(result).to.deep.equal(expectedResult);
     });
 
-    it('should update the records by batch of 10 and return the result', async function() {
+    it('should update the records by batch of 10 and return the result', async function () {
       const expectedResult = [Symbol()];
-      const base = {
-        update: vi.fn().mockResolvedValue(expectedResult),
-      };
-      const records = _.times(11).map((i) => { return { id: i }; });
+      const base = { update: vi.fn().mockResolvedValue(expectedResult) };
+      const records = _.times(11).map((i) => {
+        return { id: i };
+      });
 
       const result = await bulkUpdate(base, records);
       expect(base.update).toHaveBeenCalledWith([

--- a/scripts/enable-shuffled-on-challenges/index.js
+++ b/scripts/enable-shuffled-on-challenges/index.js
@@ -9,14 +9,12 @@ const logger = createLogger({
     format.colorize(),
     format.simple(),
   ),
-  transports: [
-    new transports.Console(),
-  ]
+  transports: [new transports.Console()],
 });
 
 const enableShuffledOnChallenges = async ({ airtableClient, dryRun, sample }) => {
   const excludedSkillIds = await readExcludes({ airtableClient });
-  
+
   const challenges = await _listChallengesToBeShuffled({ airtableClient, excludedSkillIds, sample });
 
   if (!dryRun) {
@@ -37,12 +35,12 @@ async function readExcludes({ airtableClient }) {
   const ws = wb.Sheets[wb.SheetNames[0]];
   const excludes = xlsxUtils.sheet_to_json(ws, { header: [undefined, 'skillName'], range: 1 });
 
-  const airtableSkills = await airtableClient.table('Acquis').select({ fields:['Nom'] }).all();
+  const airtableSkills = await airtableClient.table('Acquis').select({ fields: ['Nom'] }).all();
 
   return excludes.map(({ skillName }) => {
     return {
       skillIds: airtableSkills.filter(
-        (skill) => skillName.localeCompare(skill.get('Nom'), 'fr', { sensitivity: 'base' }) === 0
+        (skill) => skillName.localeCompare(skill.get('Nom'), 'fr', { sensitivity: 'base' }) === 0,
       ).map((skill) => skill.id),
       skillName,
     };
@@ -76,13 +74,13 @@ async function _listChallengesToBeShuffled({ airtableClient, excludedSkillIds, s
 
   let prevLength = airtableChallenges.length;
   airtableChallenges = airtableChallenges.filter(
-    (challenge) => challenge.get('Acquix')?.every((skillId) => !excludedSkillIds.includes(skillId) ?? true)
+    (challenge) => challenge.get('Acquix')?.every((skillId) => !excludedSkillIds.includes(skillId) ?? true),
   );
   logger.info(`Excluded ${prevLength - airtableChallenges.length} from a total of ${prevLength} QCU/QCM challenges`);
 
   prevLength = airtableChallenges.length;
   airtableChallenges = airtableChallenges.filter(
-    (challenge) => !challenge.get('shuffled')
+    (challenge) => !challenge.get('shuffled'),
   );
   logger.info(`${prevLength - airtableChallenges.length} of ${prevLength} challenges are already shuffled`);
 
@@ -101,9 +99,7 @@ async function _shuffleChallenges(challenges, { airtableClient }) {
   for (const chunk of chunks(challenges, 10)) {
     await airtableClient.table('Epreuves').update(chunk.map((challenge) => ({
       id: challenge.id,
-      fields: {
-        shuffled: true,
-      },
+      fields: { shuffled: true },
     })));
 
     updatedCount += chunk.length;
@@ -120,10 +116,7 @@ function* chunks(array, chunkSize) {
 function _writeReport(challenges) {
   const wb = xlsxUtils.book_new();
 
-  const ws = xlsxUtils.aoa_to_sheet([
-    ['ID Épreuve'],
-    ...challenges.map((challenge) => [challenge.id]),
-  ]);
+  const ws = xlsxUtils.aoa_to_sheet([['ID Épreuve'], ...challenges.map((challenge) => [challenge.id])]);
 
   xlsxUtils.book_append_sheet(wb, ws, 'Challenges');
 
@@ -173,6 +166,4 @@ async function main() {
   }
 })();
 
-export default {
-  enableShuffledOnChallenges,
-};
+export default { enableShuffledOnChallenges };

--- a/scripts/eslint.config.mjs
+++ b/scripts/eslint.config.mjs
@@ -1,92 +1,69 @@
 import globals from 'globals';
 import mocha from 'eslint-plugin-mocha';
+import stylistic from '@stylistic/eslint-plugin';
 
 export default [
-    {
-        files: ['**/*.js'],
-        languageOptions: {
-            globals: {
-                ...globals.node,
-            },
-            parserOptions: {
-                ecmaVersion: 2020,
-                sourceType: 'module',
-                requireConfigFile: false,
-                babelOptions: {
-                    parserOpts: {
-                        plugins: ['importAssertions'],
-                    },
-                },
-            },
-        },
-        rules: {
-            'arrow-parens': ['error', 'always'],
-            'computed-property-spacing': ['error', 'never'],
-            'eol-last': ['error'],
-
-            indent: [
-                'error',
-                2,
-                {
-                    SwitchCase: 1,
-                },
-            ],
-
-            'keyword-spacing': ['error'],
-            'linebreak-style': ['error', 'unix'],
-
-            'no-multiple-empty-lines': [
-                'error',
-                {
-                    max: 1,
-                    maxEOF: 1,
-                },
-            ],
-
-            'no-unused-vars': [
-                'error',
-                {
-                    argsIgnorePattern: '_',
-                    varsIgnorePattern: '_',
-                },
-            ],
-
-            'no-var': ['error'],
-            'object-curly-spacing': ['error', 'always'],
-            'prefer-const': ['error'],
-            quotes: ['error', 'single'],
-            semi: ['error', 'always'],
-            'space-before-blocks': ['error'],
-
-            'space-before-function-paren': [
-                'error',
-                {
-                    anonymous: 'never',
-                    named: 'never',
-                    asyncArrow: 'ignore',
-                },
-            ],
-
-            'space-in-parens': ['error'],
-            'space-infix-ops': ['error'],
-
-            'no-restricted-syntax': [
-                'error',
-                {
-                    selector:
-                        'NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])',
-                    message: 'Use only ISO8601 UTC syntax (\'2019-03-12T01:02:03Z\') in Date constructor',
-                },
-            ],
-        },
+  stylistic.configs.customize({
+    'jsx': false,
+    'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
+    'object-curly-spacing': ['error', 'always'],
+    'quote-props': ['error', 'as-needed'],
+    'quotes': 'single',
+    'semi': true,
+    'space-before-function-paren': ['error', { anonymous: 'never', named: 'never', asyncArrow: 'ignore' }],
+    'space-infix-ops': ['error'],
+  }),
+  {
+    plugins: { '@stylistic': stylistic },
+    rules: {
+      '@stylistic/array-bracket-newline': ['error', { multiline: true }],
+      '@stylistic/array-element-newline': ['error', { multiline: true, minItems: 3 }],
+      '@stylistic/arrow-parens': ['error', 'always'],
+      '@stylistic/brace-style': ['error', '1tbs'],
+      '@stylistic/curly-newline': ['error', { consistent: true, ClassBody: { minElements: 1 } }],
+      '@stylistic/object-curly-newline': ['error', { multiline: true }],
+      '@stylistic/function-call-spacing': ['error', 'never'],
+      '@stylistic/switch-colon-spacing': ['error', { after: true, before: false }],
     },
-    {
-        ...mocha.configs.recommended,
-        files: ['**/*.test.js'],
-        rules: {
-            ...mocha.configs.recommended.rules,
-            'mocha/no-identical-title': 'error',
-            'mocha/no-exclusive-tests': 'error',
-        },
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      globals: { ...globals.node },
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        requireConfigFile: false,
+        babelOptions: { parserOpts: { plugins: ['importAssertions'] } },
+      },
     },
-]
+    rules: {
+      'no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '_',
+          varsIgnorePattern: '_',
+        },
+      ],
+      'no-var': ['error'],
+      'prefer-const': ['error'],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])',
+          message: 'Use only ISO8601 UTC syntax (\'2019-03-12T01:02:03Z\') in Date constructor',
+        },
+      ],
+    },
+  },
+  {
+    ...mocha.configs.recommended,
+    files: ['**/*.test.js'],
+    rules: {
+      ...mocha.configs.recommended.rules,
+      'mocha/no-identical-title': 'error',
+      'mocha/no-exclusive-tests': 'error',
+    },
+  },
+];

--- a/scripts/list-duplicated-attachments/index.js
+++ b/scripts/list-duplicated-attachments/index.js
@@ -3,17 +3,13 @@ import { fileURLToPath } from 'node:url';
 import { extname } from 'node:path';
 
 export async function listDuplicatedAttachments({ lcmsApiKey }) {
-  const res = await fetch('https://lcms.pix.fr/api/releases/latest', {
-    headers: {
-      Authorization: `Bearer ${lcmsApiKey}`,
-    },
-  });
+  const res = await fetch('https://lcms.pix.fr/api/releases/latest', { headers: { Authorization: `Bearer ${lcmsApiKey}` } });
   if (!res.ok) {
     throw new Error(res.statusText);
   }
 
   const { content: { challenges } } = await res.json();
- 
+
   const challengesWithDuplicatedAttachments = challenges.filter(challengeHasDuplicateAttachments);
 
   challengesWithDuplicatedAttachments.forEach((challenge) => {

--- a/scripts/migrate-attachments-from-airtable/index.test.js
+++ b/scripts/migrate-attachments-from-airtable/index.test.js
@@ -7,33 +7,32 @@ import {
   renameFileToImport,
 } from './index.js';
 
-describe('Scripts | Migrate attachment from Airtable', function() {
-  describe('challengeAttachmentsToCsv', function() {
-
-    it('returns illustration as CSV string', function() {
+describe('Scripts | Migrate attachment from Airtable', function () {
+  describe('challengeAttachmentsToCsv', function () {
+    it('returns illustration as CSV string', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'thumbnails': {
-          'full': {
-            'height': 356,
-            'url': 'https://dl.airtable.com/KBwIk4uSTUEoUPtUlkYJ_full_mailPJ.png',
-            'width': 1096
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        thumbnails: {
+          full: {
+            height: 356,
+            url: 'https://dl.airtable.com/KBwIk4uSTUEoUPtUlkYJ_full_mailPJ.png',
+            width: 1096,
           },
-          'large': {
-            'height': 356,
-            'url': 'https://dl.airtable.com/g39wHIzTyy3isaTsn4BQ_large_mailPJ.png',
-            'width': 1096
+          large: {
+            height: 356,
+            url: 'https://dl.airtable.com/g39wHIzTyy3isaTsn4BQ_large_mailPJ.png',
+            width: 1096,
           },
-          'small': {
-            'height': 36,
-            'url': 'https://dl.airtable.com/2ADEU4ljTK32ts6nbkeA_small_mailPJ.png',
-            'width': 111
-          }
+          small: {
+            height: 36,
+            url: 'https://dl.airtable.com/2ADEU4ljTK32ts6nbkeA_small_mailPJ.png',
+            width: 111,
+          },
         },
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const challenge = {
@@ -52,30 +51,30 @@ describe('Scripts | Migrate attachment from Airtable', function() {
       expect(csv).to.equal(expectedCsv);
     });
 
-    it('returns illustration as CSV string with no alt text', function() {
+    it('returns illustration as CSV string with no alt text', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'thumbnails': {
-          'full': {
-            'height': 356,
-            'url': 'https://dl.airtable.com/KBwIk4uSTUEoUPtUlkYJ_full_mailPJ.png',
-            'width': 1096
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        thumbnails: {
+          full: {
+            height: 356,
+            url: 'https://dl.airtable.com/KBwIk4uSTUEoUPtUlkYJ_full_mailPJ.png',
+            width: 1096,
           },
-          'large': {
-            'height': 356,
-            'url': 'https://dl.airtable.com/g39wHIzTyy3isaTsn4BQ_large_mailPJ.png',
-            'width': 1096
+          large: {
+            height: 356,
+            url: 'https://dl.airtable.com/g39wHIzTyy3isaTsn4BQ_large_mailPJ.png',
+            width: 1096,
           },
-          'small': {
-            'height': 36,
-            'url': 'https://dl.airtable.com/2ADEU4ljTK32ts6nbkeA_small_mailPJ.png',
-            'width': 111
-          }
+          small: {
+            height: 36,
+            url: 'https://dl.airtable.com/2ADEU4ljTK32ts6nbkeA_small_mailPJ.png',
+            width: 111,
+          },
         },
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const challenge = {
@@ -93,68 +92,68 @@ describe('Scripts | Migrate attachment from Airtable', function() {
       expect(csv).to.equal(expectedCsv);
     });
 
-    it('returns attachments as CSV string', function() {
+    it('returns attachments as CSV string', function () {
       const attachments = [
         {
-          'filename': 'Pix_etoile.odp',
-          'id': 'attmRoYR3AfCyUiLW',
-          'size': 21258,
-          'type': 'application/vnd.oasis.opendocument.presentation',
-          'url': 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp'
+          filename: 'Pix_etoile.odp',
+          id: 'attmRoYR3AfCyUiLW',
+          size: 21258,
+          type: 'application/vnd.oasis.opendocument.presentation',
+          url: 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp',
         },
         {
-          'filename': 'Pix_etoile.pptx',
-          'id': 'attLwY7ni4a6Naboz',
-          'size': 34753,
-          'thumbnails': {
-            'large': {
-              'height': 240,
-              'url': 'https://dl.airtable.com/attLwY7ni4a6Naboz-1a5ab1ea4c7a527b-320x240.jpg',
-              'width': 320
+          filename: 'Pix_etoile.pptx',
+          id: 'attLwY7ni4a6Naboz',
+          size: 34753,
+          thumbnails: {
+            large: {
+              height: 240,
+              url: 'https://dl.airtable.com/attLwY7ni4a6Naboz-1a5ab1ea4c7a527b-320x240.jpg',
+              width: 320,
             },
-            'small': {
-              'height': 32,
-              'url': 'https://dl.airtable.com/attLwY7ni4a6Naboz-fe6474e0106877ac-32x32.jpg',
-              'width': 32
-            }
+            small: {
+              height: 32,
+              url: 'https://dl.airtable.com/attLwY7ni4a6Naboz-fe6474e0106877ac-32x32.jpg',
+              width: 32,
+            },
           },
-          'type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-          'url': 'https://dl.airtable.com/.attachments/3ff6e126ae8aa58d6b1109fd61db414c/cdd2a4fe/Pix_etoile.pptx'
-        }
+          type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          url: 'https://dl.airtable.com/.attachments/3ff6e126ae8aa58d6b1109fd61db414c/cdd2a4fe/Pix_etoile.pptx',
+        },
       ];
 
       const challenge = {
         fields: {
           'Pièce jointe': attachments,
           'Record ID': 'some-challenge-id',
-        }
+        },
       };
 
       const bucketBaseUrl = 'https://dl.ovh.com/bucket/';
-      const expectedCsv = '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id"' + '\n' +
-                        '"attLwY7ni4a6Naboz","Pix_etoile.pptx","34753","","https://dl.ovh.com/bucket/some-challenge-id_attachment_Pix_etoile.pptx","application/vnd.openxmlformats-officedocument.presentationml.presentation","attachment","some-challenge-id"';
+      const expectedCsv = '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id"' + '\n'
+        + '"attLwY7ni4a6Naboz","Pix_etoile.pptx","34753","","https://dl.ovh.com/bucket/some-challenge-id_attachment_Pix_etoile.pptx","application/vnd.openxmlformats-officedocument.presentationml.presentation","attachment","some-challenge-id"';
 
       const csv = challengeAttachmentsToCsv(challenge, { bucketBaseUrl });
 
       expect(csv).to.equal(expectedCsv);
     });
 
-    it('returns attachments and illustrations as CSV string', function() {
+    it('returns attachments and illustrations as CSV string', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const attachments = [
         {
-          'filename': 'Pix_etoile.odp',
-          'id': 'attmRoYR3AfCyUiLW',
-          'size': 21258,
-          'type': 'application/vnd.oasis.opendocument.presentation',
-          'url': 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp'
+          filename: 'Pix_etoile.odp',
+          id: 'attmRoYR3AfCyUiLW',
+          size: 21258,
+          type: 'application/vnd.oasis.opendocument.presentation',
+          url: 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp',
         },
       ];
 
@@ -168,21 +167,21 @@ describe('Scripts | Migrate attachment from Airtable', function() {
       };
 
       const bucketBaseUrl = 'https://dl.ovh.com/bucket/';
-      const expectedCsv = '"attcKBWOyCUyATJ93","mailPJ.png","49502","alternative text","https://dl.ovh.com/bucket/some-challenge-id_illustration_mailPJ.png","image/png","illustration","some-challenge-id"' + '\n' +
-                        '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id"';
+      const expectedCsv = '"attcKBWOyCUyATJ93","mailPJ.png","49502","alternative text","https://dl.ovh.com/bucket/some-challenge-id_illustration_mailPJ.png","image/png","illustration","some-challenge-id"' + '\n'
+        + '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id"';
 
       const csv = challengeAttachmentsToCsv(challenge, { bucketBaseUrl });
 
       expect(csv).to.equal(expectedCsv);
     });
 
-    it('returns illustration as CSV string with escaped alternative text', function() {
+    it('returns illustration as CSV string with escaped alternative text', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const challenge = {
@@ -200,26 +199,25 @@ describe('Scripts | Migrate attachment from Airtable', function() {
 
       expect(csv).to.equal(expectedCsv);
     });
-
   });
 
-  describe('challengesAttachmentsToCsv', function() {
-    it('returns a csv string with a header and lines', function() {
+  describe('challengesAttachmentsToCsv', function () {
+    it('returns a csv string with a header and lines', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const attachments = [
         {
-          'filename': 'Pix_etoile.odp',
-          'id': 'attmRoYR3AfCyUiLW',
-          'size': 21258,
-          'type': 'application/vnd.oasis.opendocument.presentation',
-          'url': 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp'
+          filename: 'Pix_etoile.odp',
+          id: 'attmRoYR3AfCyUiLW',
+          size: 21258,
+          type: 'application/vnd.oasis.opendocument.presentation',
+          url: 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp',
         },
       ];
 
@@ -234,11 +232,11 @@ describe('Scripts | Migrate attachment from Airtable', function() {
 
       const challenges = [challenge, challenge];
       const bucketBaseUrl = 'https://dl.ovh.com/bucket/';
-      const expectedCsv = 'id,filename,size,alt,url,mimeType,type,challengeId' + '\n' +
-          '"attcKBWOyCUyATJ93","mailPJ.png","49502","alternative text","https://dl.ovh.com/bucket/some-challenge-id2_illustration_mailPJ.png","image/png","illustration","some-challenge-id2"' + '\n' +
-                        '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id2_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id2"' + '\n' +
-    '"attcKBWOyCUyATJ93","mailPJ.png","49502","alternative text","https://dl.ovh.com/bucket/some-challenge-id2_illustration_mailPJ.png","image/png","illustration","some-challenge-id2"' + '\n' +
-    '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id2_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id2"';
+      const expectedCsv = 'id,filename,size,alt,url,mimeType,type,challengeId' + '\n'
+        + '"attcKBWOyCUyATJ93","mailPJ.png","49502","alternative text","https://dl.ovh.com/bucket/some-challenge-id2_illustration_mailPJ.png","image/png","illustration","some-challenge-id2"' + '\n'
+        + '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id2_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id2"' + '\n'
+        + '"attcKBWOyCUyATJ93","mailPJ.png","49502","alternative text","https://dl.ovh.com/bucket/some-challenge-id2_illustration_mailPJ.png","image/png","illustration","some-challenge-id2"' + '\n'
+        + '"attmRoYR3AfCyUiLW","Pix_etoile.odp","21258","","https://dl.ovh.com/bucket/some-challenge-id2_attachment_Pix_etoile.odp","application/vnd.oasis.opendocument.presentation","attachment","some-challenge-id2"';
 
       const csv = challengesAttachmentsToCsv(challenges, { bucketBaseUrl });
 
@@ -246,13 +244,9 @@ describe('Scripts | Migrate attachment from Airtable', function() {
     });
   });
 
-  describe('challenges doesn\'t have any attachments and illustration', function() {
-    it('should return a challenge csv file without attachments and illustration', function() {
-      const challenge = {
-        fields: {
-          'Record ID': 'some-challenge-id',
-        },
-      };
+  describe('challenges doesn\'t have any attachments and illustration', function () {
+    it('should return a challenge csv file without attachments and illustration', function () {
+      const challenge = { fields: { 'Record ID': 'some-challenge-id' } };
 
       const challenges = [challenge, challenge];
       const bucketBaseUrl = 'https://dl.ovh.com/bucket/';
@@ -264,14 +258,14 @@ describe('Scripts | Migrate attachment from Airtable', function() {
     });
   });
 
-  describe('rename files', function() {
-    it('should rename illustration', function() {
+  describe('rename files', function () {
+    it('should rename illustration', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const challenge = {
@@ -289,14 +283,14 @@ describe('Scripts | Migrate attachment from Airtable', function() {
       expect(stubRenameSync).toHaveBeenCalledWith('attcKBWOyCUyATJ93.png', 'some-challenge-id_illustration_mailPJ.png');
     });
 
-    it('should rename attachment', function() {
+    it('should rename attachment', function () {
       const attachments = [
         {
-          'filename': 'Pix_etoile.odp',
-          'id': 'attmRoYR3AfCyUiLW',
-          'size': 21258,
-          'type': 'application/vnd.oasis.opendocument.presentation',
-          'url': 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp'
+          filename: 'Pix_etoile.odp',
+          id: 'attmRoYR3AfCyUiLW',
+          size: 21258,
+          type: 'application/vnd.oasis.opendocument.presentation',
+          url: 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp',
         },
       ];
 
@@ -315,30 +309,30 @@ describe('Scripts | Migrate attachment from Airtable', function() {
       expect(stubRenameSync).toHaveBeenCalledWith('attmRoYR3AfCyUiLW.odp', 'some-challenge-id2_attachment_Pix_etoile.odp');
     });
 
-    it('should rename illustration and attachments', function() {
+    it('should rename illustration and attachments', function () {
       const illustration = {
-        'filename': 'mailPJ.png',
-        'id': 'attcKBWOyCUyATJ93',
-        'size': 49502,
-        'type': 'image/png',
-        'url': 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png'
+        filename: 'mailPJ.png',
+        id: 'attcKBWOyCUyATJ93',
+        size: 49502,
+        type: 'image/png',
+        url: 'https://dl.airtable.com/aa1yQxsRL2AdZYaZQNB2_mailPJ.png',
       };
 
       const attachments = [
         {
-          'filename': 'Pix_etoile.odp',
-          'id': 'attmRoYR3AfCyUiLW',
-          'size': 21258,
-          'type': 'application/vnd.oasis.opendocument.presentation',
-          'url': 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp'
+          filename: 'Pix_etoile.odp',
+          id: 'attmRoYR3AfCyUiLW',
+          size: 21258,
+          type: 'application/vnd.oasis.opendocument.presentation',
+          url: 'https://dl.airtable.com/.attachments/afccd3fd63ded48bec58499f6024abce/5839412f/Pix_etoile.odp',
         },
         {
-          'filename': 'Pix_etoile.pptx',
-          'id': 'attLwY7ni4a6Naboz',
-          'size': 34753,
-          'type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-          'url': 'https://dl.airtable.com/.attachments/3ff6e126ae8aa58d6b1109fd61db414c/cdd2a4fe/Pix_etoile.pptx'
-        }
+          filename: 'Pix_etoile.pptx',
+          id: 'attLwY7ni4a6Naboz',
+          size: 34753,
+          type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          url: 'https://dl.airtable.com/.attachments/3ff6e126ae8aa58d6b1109fd61db414c/cdd2a4fe/Pix_etoile.pptx',
+        },
       ];
 
       const challenge = {
@@ -360,8 +354,8 @@ describe('Scripts | Migrate attachment from Airtable', function() {
     });
   });
 
-  describe('Attachment url', function() {
-    it('should construct attachment url', function() {
+  describe('Attachment url', function () {
+    it('should construct attachment url', function () {
       const challengeId = 'some-challenge-id3';
       const filename = 'Pix etoile.odp';
       const bucketBaseUrl = 'https://dl.ovh.com/bucket/';

--- a/scripts/migrate-attachments-in-subfolder/index.js
+++ b/scripts/migrate-attachments-in-subfolder/index.js
@@ -6,24 +6,22 @@ import pLimit from 'p-limit';
 const limit = pLimit(10);
 
 function getBaseAttachments() {
-  const base = new Airtable({
-    apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE);
 
   return base('Attachments');
 }
 
 function eachRecord(callback) {
-  getBaseAttachments().select({
-    view: 'Grid view'
-  }).eachPage(async function page(records, fetchNextPage) {
+  getBaseAttachments().select({ view: 'Grid view' }).eachPage(async function page(records, fetchNextPage) {
     records.forEach(async (record) => {
       await limit(() => callback(record));
     });
 
     fetchNextPage();
   }, function done(err) {
-    if (err) { console.error(err); return; }
+    if (err) {
+      console.error(err);
+    }
   });
 }
 
@@ -39,7 +37,7 @@ export async function cloneFile(token, originalUrl, randomString, filename, cloc
     headers: {
       'X-Auth-Token': token,
       'X-Copy-From': process.env.BUCKET_NAME + parsedUrl.pathname,
-    }
+    },
   };
 
   try {
@@ -56,9 +54,7 @@ export async function updateRecord(base, id, url) {
     base.update([
       {
         id,
-        fields: {
-          url,
-        },
+        fields: { url },
       },
     ], (err) => {
       if (err) reject();

--- a/scripts/migrate-attachments-in-subfolder/index.test.js
+++ b/scripts/migrate-attachments-in-subfolder/index.test.js
@@ -5,10 +5,9 @@ const { Record: AirtableRecord } = airtable;
 
 import { shouldBeMigrated, cloneFile, updateRecord } from './index.js';
 
-describe('Migrate attachments in subfolder', function() {
-
-  describe('#shouldBeMigrated', function() {
-    it('returns false if the url ends with the filename', function() {
+describe('Migrate attachments in subfolder', function () {
+  describe('#shouldBeMigrated', function () {
+    it('returns false if the url ends with the filename', function () {
       const record = new AirtableRecord('Attachment', '1', {
         fields: {
           url: 'https://dl.example.net/1234567/toto.ods',
@@ -18,7 +17,7 @@ describe('Migrate attachments in subfolder', function() {
       expect(shouldBeMigrated(record)).to.be.false;
     });
 
-    it('returns false if the url ends with the encoded filename', function() {
+    it('returns false if the url ends with the encoded filename', function () {
       const record = new AirtableRecord('Attachment', '1', {
         fields: {
           url: 'https://dl.example.net/1234567/toto%20filename.ods',
@@ -28,7 +27,7 @@ describe('Migrate attachments in subfolder', function() {
       expect(shouldBeMigrated(record)).to.be.false;
     });
 
-    it('returns true if the url does not end with the filename', function() {
+    it('returns true if the url does not end with the filename', function () {
       const record = new AirtableRecord('Attachment', '1', {
         fields: {
           url: 'https://dl.example.net/1234567.ods',
@@ -38,7 +37,7 @@ describe('Migrate attachments in subfolder', function() {
       expect(shouldBeMigrated(record)).to.be.true;
     });
 
-    it('returns true if the last segment of url is not the filename', function() {
+    it('returns true if the last segment of url is not the filename', function () {
       const record = new AirtableRecord('Attachment', '1', {
         fields: {
           url: 'https://dl.example.net/rec_1234567_toto.ods',
@@ -49,13 +48,13 @@ describe('Migrate attachments in subfolder', function() {
     });
   });
 
-  describe('#cloneFile', function() {
-    beforeEach(function() {
+  describe('#cloneFile', function () {
+    beforeEach(function () {
       nock.cleanAll();
       nock.disableNetConnect();
     });
 
-    it('clone the file to a subdir', async function() {
+    it('clone the file to a subdir', async function () {
       const clock = { now: () => '123456' };
 
       process.env.BUCKET_NAME = 'bucket name';
@@ -72,7 +71,7 @@ describe('Migrate attachments in subfolder', function() {
       expect(newUrl).to.equal('https://dl.pix.fr/randomstring123456/toto.ods');
     });
 
-    it('encode the filename when cloing', async function() {
+    it('encode the filename when cloing', async function () {
       const clock = { now: () => '123456' };
 
       process.env.BUCKET_NAME = 'bucket name';
@@ -90,8 +89,8 @@ describe('Migrate attachments in subfolder', function() {
     });
   });
 
-  describe('#updateRecord', function() {
-    it('updates url in attachment record', async function() {
+  describe('#updateRecord', function () {
+    it('updates url in attachment record', async function () {
       const base = {
         update: vi.fn().mockImplementation((_, cb) => {
           cb();
@@ -102,10 +101,8 @@ describe('Migrate attachments in subfolder', function() {
         [
           {
             id: 'rec123',
-            fields: {
-              url: 'https://dl.pix.fr/6789/toto.ods'
-            }
-          }
+            fields: { url: 'https://dl.pix.fr/6789/toto.ods' },
+          },
         ],
         expect.any(Function),
       );

--- a/scripts/migrate-static-courses-from-airtable/index.js
+++ b/scripts/migrate-static-courses-from-airtable/index.js
@@ -1,24 +1,30 @@
 import { Client } from 'pg';
 import Airtable from 'airtable';
 
-(async function() {
+(async function () {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
 
   try {
-    const airtableClient = new Airtable({
-      apiKey: process.env.AIRTABLE_API_KEY,
-    }).base(process.env.AIRTABLE_BASE);
+    const airtableClient = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE);
 
     console.log('reading all static courses from Airtable...');
     const allStaticCourses = await airtableClient.table('Tests').select({
-      fields: ['id persistant', 'Nom', 'Description', 'Épreuves (id persistant)', 'created_at', 'updated_at', 'Nb d\'épreuves'],
+      fields: [
+        'id persistant',
+        'Nom',
+        'Description',
+        'Épreuves (id persistant)',
+        'created_at',
+        'updated_at',
+        'Nb d\'épreuves',
+      ],
     }).all();
     console.log('done');
 
     const filteredStaticCourses = allStaticCourses
       .filter((course) => course.fields['Nom'] != null
-                && course.fields['Nb d\'épreuves'] !== 0
-                && course.fields['Épreuves (id persistant)'].toString().length <= 1000
+        && course.fields['Nb d\'épreuves'] !== 0
+        && course.fields['Épreuves (id persistant)'].toString().length <= 1000,
       );
     console.log(filteredStaticCourses.length);
 
@@ -58,4 +64,3 @@ import Airtable from 'airtable';
     await client.end();
   }
 })();
-

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -26,10 +26,11 @@
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
       },
       "devDependencies": {
-        "@eslint/js": "^9.9.0",
+        "@eslint/js": "^9.38.0",
+        "@stylistic/eslint-plugin": "^5.5.0",
         "@types/pg": "^8.6.6",
         "@types/pg-cursor": "^2.7.0",
-        "eslint": "^9.9.0",
+        "eslint": "^9.38.0",
         "eslint-plugin-mocha": "^11.2.0",
         "globals": "^16.0.0",
         "nock": "^14.0.0",
@@ -525,9 +526,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -535,13 +536,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
-      "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -549,10 +550,36 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.16.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -587,21 +614,38 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.0.tgz",
-      "integrity": "sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.16.0",
+        "levn": "^0.4.1"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -619,6 +663,30 @@
         "lodash.uniq": "^4.5.0"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -633,9 +701,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -669,41 +737,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@open-draft/deferred-promise": {
@@ -1026,6 +1059,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@typescript-eslint/types": "^8.46.1",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1047,6 +1114,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1085,6 +1159,20 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
+      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.0.5",
@@ -1214,12 +1302,11 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1232,6 +1319,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -1261,6 +1349,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1270,15 +1359,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1299,7 +1379,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -1326,7 +1407,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base-x": {
       "version": "3.0.11",
@@ -1371,6 +1453,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1471,7 +1554,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1646,28 +1730,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.0.tgz",
-      "integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.17.1",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.9.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.1",
+        "@eslint/core": "^0.16.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.38.0",
+        "@eslint/plugin-kit": "^0.4.0",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.0",
-        "@nodelib/fs.walk": "^1.2.8",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.0.2",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.1.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1677,15 +1765,11 @@
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -1733,9 +1817,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
-      "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1762,9 +1846,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1775,15 +1859,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.12.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.0.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1793,9 +1877,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1881,28 +1965,21 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/fecha": {
       "version": "4.2.3",
@@ -2160,19 +2237,21 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2231,15 +2310,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -2276,6 +2346,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2294,7 +2365,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2451,6 +2523,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2623,6 +2696,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -2659,7 +2733,6 @@
       "version": "8.11.4",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.4.tgz",
       "integrity": "sha512-pWb7JKPxGk1UFbtq7jQ0m3IfPpb7LLACCEyN8/u9DYEom+Q/BSKy+4TRl4+Hh003AOYhppB/z+QK87/hx/bk0w==",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.6.3",
         "pg-pool": "^3.6.2",
@@ -2820,7 +2893,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2938,29 +3010,10 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -2980,18 +3033,9 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -3032,29 +3076,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.49.0",
         "@rollup/rollup-win32-x64-msvc": "4.49.0",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -3175,23 +3196,12 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3214,12 +3224,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3329,6 +3333,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -29,10 +29,11 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.0",
+    "@eslint/js": "^9.38.0",
+    "@stylistic/eslint-plugin": "^5.5.0",
     "@types/pg": "^8.6.6",
     "@types/pg-cursor": "^2.7.0",
-    "eslint": "^9.9.0",
+    "eslint": "^9.38.0",
     "eslint-plugin-mocha": "^11.2.0",
     "globals": "^16.0.0",
     "nock": "^14.0.0",

--- a/scripts/populate-alpha-and-delta-column-with-csv/index.js
+++ b/scripts/populate-alpha-and-delta-column-with-csv/index.js
@@ -25,13 +25,15 @@ export function parseData(csvData) {
   return new Promise((resolve, reject) => {
     const result = [];
 
-    parseString(csvData, { headers: (headers) => {
-      const missingHeaders = getMissingHeaders(headers);
-      if (missingHeaders.length > 0) {
-        reject(new Error(`Missing header: ${missingHeaders.join(',')}`));
-      }
-      return headers.map((h) => HEADERS_MAPPING[h]);
-    } })
+    parseString(csvData, {
+      headers: (headers) => {
+        const missingHeaders = getMissingHeaders(headers);
+        if (missingHeaders.length > 0) {
+          reject(new Error(`Missing header: ${missingHeaders.join(',')}`));
+        }
+        return headers.map((h) => HEADERS_MAPPING[h]);
+      },
+    })
       .on('error', (error) => {
         console.error(error);
         reject(error);
@@ -59,7 +61,7 @@ export async function findAirtableIds(base, challengesWithPersistentIds) {
     const data = challengesWithPersistentIds.find((row) => row.id === airtableRecord.get('id persistant'));
     return {
       ...data,
-      id: airtableRecord.id
+      id: airtableRecord.id,
     };
   });
 }
@@ -70,7 +72,7 @@ export async function updateRecords(base, data) {
       id,
       fields: {
         'Difficulté calculée': `${delta}`,
-        'Discrimination calculée': `${alpha}`
+        'Discrimination calculée': `${alpha}`,
       },
     };
   });
@@ -94,11 +96,10 @@ export async function updateRecords(base, data) {
 }
 
 export async function clearDifficultyAndDiscriminant(base) {
-
   try {
     const records = await base.select({
       fields: ['Difficulté calculée', 'Discrimination calculée'],
-      filterByFormula: 'OR({Difficulté calculée}, {Discrimination calculée})'
+      filterByFormula: 'OR({Difficulté calculée}, {Discrimination calculée})',
     }).all();
 
     console.log(`Purging ${records.length} records`);
@@ -107,8 +108,8 @@ export async function clearDifficultyAndDiscriminant(base) {
       id,
       fields: {
         'Difficulté calculée': null,
-        'Discrimination calculée': null
-      }
+        'Discrimination calculée': null,
+      },
     }));
 
     const chunks = _.chunk(recordsWithoutDifficultyAndDiscriminant, 10);
@@ -130,9 +131,7 @@ export async function clearDifficultyAndDiscriminant(base) {
 }
 
 function getBaseChallenges() {
-  const base = new Airtable({
-    apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE);
 
   return base('Epreuves');
 }

--- a/scripts/populate-alpha-and-delta-column-with-csv/index.test.js
+++ b/scripts/populate-alpha-and-delta-column-with-csv/index.test.js
@@ -5,20 +5,23 @@ const { Record: AirtableRecord } = airtable;
 
 import { parseData, findAirtableIds, updateRecords, clearDifficultyAndDiscriminant } from './index.js';
 
-describe('Populate alpha and delta column', function() {
-  describe('#parseData', function() {
-    it('should return a object table with challenge persistent id, alpha and delta', async function() {
+describe('Populate alpha and delta column', function () {
+  describe('#parseData', function () {
+    it('should return a object table with challenge persistent id, alpha and delta', async function () {
       const csvData = 'items,difficulties,discriminants\nrec1,0.8423189520825876,1.6760518550872801\nrec2,-0.9423189520825878,2.6760518550872802';
 
-      const expectedResult = [{
-        id: 'rec1',
-        alpha: '1.6760518550872801',
-        delta: '0.8423189520825876',
-      }, {
-        id: 'rec2',
-        alpha: '2.6760518550872802',
-        delta: '-0.9423189520825878',
-      }];
+      const expectedResult = [
+        {
+          id: 'rec1',
+          alpha: '1.6760518550872801',
+          delta: '0.8423189520825876',
+        },
+        {
+          id: 'rec2',
+          alpha: '2.6760518550872802',
+          delta: '-0.9423189520825878',
+        },
+      ];
 
       const result = await parseData(csvData);
 
@@ -26,46 +29,37 @@ describe('Populate alpha and delta column', function() {
     });
   });
 
-  describe('#findAirtableIds', function() {
-    it('should request airtable with the persistent ids', async function() {
-      const data = [{
-        id: 'recPix1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recPix2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
-
-      const airtableData = [
-        new AirtableRecord('Challenge', 'recAirtableId1', {
-          fields: {
-            'id persistant': 'recPix1'
-          },
-        }),
-        new AirtableRecord('Challenge', 'recAirtableId2', {
-          fields: {
-            'id persistant': 'recPix2'
-          },
-        })
+  describe('#findAirtableIds', function () {
+    it('should request airtable with the persistent ids', async function () {
+      const data = [
+        {
+          id: 'recPix1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recPix2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
       ];
 
-      const base = {
-        select: vi.fn().mockReturnValue({
-          all: vi.fn().mockResolvedValue(airtableData)
-        }),
-      };
+      const airtableData = [new AirtableRecord('Challenge', 'recAirtableId1', { fields: { 'id persistant': 'recPix1' } }), new AirtableRecord('Challenge', 'recAirtableId2', { fields: { 'id persistant': 'recPix2' } })];
 
-      const expectedResult = [{
-        id: 'recAirtableId1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recAirtableId2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
+      const base = { select: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue(airtableData) }) };
+
+      const expectedResult = [
+        {
+          id: 'recAirtableId1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recAirtableId2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
+      ];
 
       const result = await findAirtableIds(base, data);
 
@@ -77,17 +71,20 @@ describe('Populate alpha and delta column', function() {
     });
   });
 
-  describe('#updateRecords', function() {
-    it('updates alpha and delta in challenges records', async function() {
-      const data = [{
-        id: 'recAirtableId1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recAirtableId2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
+  describe('#updateRecords', function () {
+    it('updates alpha and delta in challenges records', async function () {
+      const data = [
+        {
+          id: 'recAirtableId1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recAirtableId2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
+      ];
       const base = {
         update: vi.fn().mockImplementation((_, cb) => {
           cb();
@@ -100,27 +97,27 @@ describe('Populate alpha and delta column', function() {
             id: 'recAirtableId1',
             fields: {
               'Difficulté calculée': '0.654321',
-              'Discrimination calculée': '0.123'
-            }
+              'Discrimination calculée': '0.123',
+            },
           },
           {
             id: 'recAirtableId2',
             fields: {
               'Difficulté calculée': '0.98765432166556',
-              'Discrimination calculée': '-0.321'
-            }
-          }
+              'Discrimination calculée': '-0.321',
+            },
+          },
         ],
         expect.any(Function),
       );
     });
 
-    it('should batch updates with up to 10 records at a time', async function() {
+    it('should batch updates with up to 10 records at a time', async function () {
       const data = _.times(11).map((index) => {
         return {
           id: index,
           alpha: 1,
-          delta: 2
+          delta: 2,
         };
       });
       const base = {
@@ -133,23 +130,21 @@ describe('Populate alpha and delta column', function() {
     });
   });
 
-  describe('#clearDifficultyAndDiscriminant', function() {
-    it('deletes value of difficulty and discriminant in challenges records', async function() {
+  describe('#clearDifficultyAndDiscriminant', function () {
+    it('deletes value of difficulty and discriminant in challenges records', async function () {
       const recordsCount = 100;
       const records = _.range(0, recordsCount)
         .map((recordIndex) => ({
           id: `recAirtableId${recordIndex}`,
           fields: {
             'Difficulté calculée': '0.98765432166556',
-            'Discrimination calculée': '-0.321'
-          }
+            'Discrimination calculée': '-0.321',
+          },
         }));
 
       const base = {
         update: vi.fn(),
-        select: vi.fn().mockReturnValue({
-          all: vi.fn().mockResolvedValue(records),
-        }),
+        select: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue(records) }),
       };
 
       const updatedRecords = [];
@@ -168,4 +163,3 @@ describe('Populate alpha and delta column', function() {
     });
   });
 });
-

--- a/scripts/populate-alpha-and-delta-column/index.js
+++ b/scripts/populate-alpha-and-delta-column/index.js
@@ -52,7 +52,7 @@ export async function findAirtableIds(base, challengesWithPersistentIds) {
     const data = challengesWithPersistentIds.find((row) => row.id === airtableRecord.get('id persistant'));
     return {
       ...data,
-      id: airtableRecord.id
+      id: airtableRecord.id,
     };
   });
 }
@@ -63,7 +63,7 @@ export async function updateRecords(base, data) {
       id,
       fields: {
         'Difficulté calculée': `${delta}`,
-        'Discrimination calculée': `${alpha}`
+        'Discrimination calculée': `${alpha}`,
       },
     };
   });
@@ -87,9 +87,7 @@ export async function updateRecords(base, data) {
 }
 
 function getBaseChallenges() {
-  const base = new Airtable({
-    apiKey: process.env.AIRTABLE_API_KEY
-  }).base(process.env.AIRTABLE_BASE);
+  const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE);
 
   return base('Epreuves');
 }

--- a/scripts/populate-alpha-and-delta-column/index.test.js
+++ b/scripts/populate-alpha-and-delta-column/index.test.js
@@ -6,10 +6,10 @@ const { Record: AirtableRecord } = airtable;
 import { matchData, findAirtableIds, updateRecords } from './index.js';
 import { parseData } from '../populate-alpha-and-delta-column-with-csv/index.js';
 
-describe('Populate alpha and delta column', function() {
-  describe('#parseData', function() {
-    describe('when an expected header is missing', function() {
-      it('should throw an error', async function() {
+describe('Populate alpha and delta column', function () {
+  describe('#parseData', function () {
+    describe('when an expected header is missing', function () {
+      it('should throw an error', async function () {
         const data = 'missing,difficulties\nrec1,0.8423189520825876\nrec2,-0.9423189520825878';
         const dataPromise = parseData(data);
         const parseDataError = await dataPromise.catch((error) => error);
@@ -19,45 +19,55 @@ describe('Populate alpha and delta column', function() {
     });
   });
 
-  describe('#matchData', function() {
-    it('should return a object table with challenge persistent id, alpha and delta',  async function() {
+  describe('#matchData', function () {
+    it('should return a object table with challenge persistent id, alpha and delta', async function () {
       const csvData = 'ChallengeIdHash,challengeId\nhash1,recPix1\nhash2,recPix2';
-      const jsonData = [{
-        id: 'hash1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'hash2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
-      const expectedResult = [{
-        id: 'recPix1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recPix2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
+      const jsonData = [
+        {
+          id: 'hash1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'hash2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
+      ];
+      const expectedResult = [
+        {
+          id: 'recPix1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recPix2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
+      ];
 
       const result = await matchData(csvData, jsonData);
 
       expect(result).to.deep.equal(expectedResult);
     });
 
-    it('should ignore entries with not match',  async function() {
+    it('should ignore entries with not match', async function () {
       const csvData = 'ChallengeIdHash,challengeId\nhash1,recPix1\nhash2,recPix2';
-      const jsonData = [{
-        id: 'hash1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }];
-      const expectedResult = [{
-        id: 'recPix1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }];
+      const jsonData = [
+        {
+          id: 'hash1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+      ];
+      const expectedResult = [
+        {
+          id: 'recPix1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+      ];
 
       const result = await matchData(csvData, jsonData);
 
@@ -65,46 +75,37 @@ describe('Populate alpha and delta column', function() {
     });
   });
 
-  describe('#findAirtableIds', function() {
-    it('should request airtable with the persistent ids', async function() {
-      const data = [{
-        id: 'recPix1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recPix2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
-
-      const airtableData = [
-        new AirtableRecord('Challenge', 'recAirtableId1', {
-          fields: {
-            'id persistant': 'recPix1'
-          },
-        }),
-        new AirtableRecord('Challenge', 'recAirtableId2', {
-          fields: {
-            'id persistant': 'recPix2'
-          },
-        })
+  describe('#findAirtableIds', function () {
+    it('should request airtable with the persistent ids', async function () {
+      const data = [
+        {
+          id: 'recPix1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recPix2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
       ];
 
-      const base = {
-        select: vi.fn().mockReturnValue({
-          all: vi.fn().mockResolvedValue(airtableData)
-        }),
-      };
+      const airtableData = [new AirtableRecord('Challenge', 'recAirtableId1', { fields: { 'id persistant': 'recPix1' } }), new AirtableRecord('Challenge', 'recAirtableId2', { fields: { 'id persistant': 'recPix2' } })];
 
-      const expectedResult = [{
-        id: 'recAirtableId1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recAirtableId2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
+      const base = { select: vi.fn().mockReturnValue({ all: vi.fn().mockResolvedValue(airtableData) }) };
+
+      const expectedResult = [
+        {
+          id: 'recAirtableId1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recAirtableId2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
+      ];
 
       const result = await findAirtableIds(base, data);
 
@@ -116,17 +117,20 @@ describe('Populate alpha and delta column', function() {
     });
   });
 
-  describe('#updateRecords', function() {
-    it('updates alpha and delta in challenges records', async function() {
-      const data = [{
-        id: 'recAirtableId1',
-        alpha: 0.123,
-        delta: 0.654321,
-      }, {
-        id: 'recAirtableId2',
-        alpha: -0.321,
-        delta: 0.98765432166556,
-      }];
+  describe('#updateRecords', function () {
+    it('updates alpha and delta in challenges records', async function () {
+      const data = [
+        {
+          id: 'recAirtableId1',
+          alpha: 0.123,
+          delta: 0.654321,
+        },
+        {
+          id: 'recAirtableId2',
+          alpha: -0.321,
+          delta: 0.98765432166556,
+        },
+      ];
       const base = {
         update: vi.fn().mockImplementation((_, cb) => {
           cb();
@@ -139,27 +143,27 @@ describe('Populate alpha and delta column', function() {
             id: 'recAirtableId1',
             fields: {
               'Difficulté calculée': '0.654321',
-              'Discrimination calculée': '0.123'
-            }
+              'Discrimination calculée': '0.123',
+            },
           },
           {
             id: 'recAirtableId2',
             fields: {
               'Difficulté calculée': '0.98765432166556',
-              'Discrimination calculée': '-0.321'
-            }
-          }
+              'Discrimination calculée': '-0.321',
+            },
+          },
         ],
         expect.any(Function),
       );
     });
 
-    it('should batch updates with up to 10 records at a time', async function() {
+    it('should batch updates with up to 10 records at a time', async function () {
       const data = _.times(11).map((index) => {
         return {
           id: index,
           alpha: 1,
-          delta: 2
+          delta: 2,
         };
       });
       const base = {
@@ -172,4 +176,3 @@ describe('Populate alpha and delta column', function() {
     });
   });
 });
-

--- a/scripts/restore-challenges-validated-and-archived-at/index.js
+++ b/scripts/restore-challenges-validated-and-archived-at/index.js
@@ -10,10 +10,10 @@ function getStatus(status) {
   }[status] ?? status;
 }
 
-(async function() {
+(async function () {
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   let cursor;
-      
+
   try {
     await client.connect();
     const result = await client.query('SELECT "createdAt" FROM releases ORDER BY "createdAt" limit 1');
@@ -109,13 +109,15 @@ async function _parseReleases(cursor) {
 async function _parseChangelog(oldestReleaseDate) {
   const challengesInfo = new Map();
 
-  const changelogAirtableClient = new Airtable({
-    apiKey: process.env.AIRTABLE_API_KEY,
-  }).base(process.env.AIRTABLE_EDITOR_BASE);
+  const changelogAirtableClient = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_EDITOR_BASE);
 
   console.log(`reading all changelogs older than ${oldestReleaseDate} from Airtable changelog base...`);
   const allChangelogs = await changelogAirtableClient.table('Notes').select({
-    fields: ['Texte', 'Record_Id', 'Date'],
+    fields: [
+      'Texte',
+      'Record_Id',
+      'Date',
+    ],
   }).all();
   console.log('done');
 
@@ -179,18 +181,21 @@ async function _parseChangelog(oldestReleaseDate) {
 }
 
 async function _updateAirtable(challengesInfo) {
-  const challengesToUpdate = [...challengesInfo.values()].filter(({ validatedAt,archivedAt, madeObsoleteAt })=> validatedAt || archivedAt || madeObsoleteAt);
-  console.log('validated:', [...challengesInfo.values()].filter(({ validatedAt })=>validatedAt).length);
-  console.log('archived:', [...challengesInfo.values()].filter(({ archivedAt })=>archivedAt).length);
-  console.log('madeObsoleteAt:', [...challengesInfo.values()].filter(({ madeObsoleteAt })=>madeObsoleteAt).length);
+  const challengesToUpdate = [...challengesInfo.values()].filter(({ validatedAt, archivedAt, madeObsoleteAt }) => validatedAt || archivedAt || madeObsoleteAt);
+  console.log('validated:', [...challengesInfo.values()].filter(({ validatedAt }) => validatedAt).length);
+  console.log('archived:', [...challengesInfo.values()].filter(({ archivedAt }) => archivedAt).length);
+  console.log('madeObsoleteAt:', [...challengesInfo.values()].filter(({ madeObsoleteAt }) => madeObsoleteAt).length);
 
-  const airtableClient =  new Airtable({
-    apiKey: process.env.AIRTABLE_API_KEY,
-  }).base(process.env.AIRTABLE_BASE);
+  const airtableClient = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE);
 
   console.log('reading all challenges from Airtable...');
   const allChallenges = await airtableClient.table('Epreuves').select({
-    fields: ['id persistant', 'validated_at', 'archived_at', 'made_obsolete_at'],
+    fields: [
+      'id persistant',
+      'validated_at',
+      'archived_at',
+      'made_obsolete_at',
+    ],
   }).all();
   console.log('done');
 
@@ -201,7 +206,7 @@ async function _updateAirtable(challengesInfo) {
     });
     const update = {
       id: airtableChallenge.id,
-      fields: {}
+      fields: {},
     };
     if (challengeToUpdate.validatedAt != null && airtableChallenge.fields['validated_at'] == null) {
       update.fields['validated_at'] = challengeToUpdate.validatedAt;

--- a/scripts/reverse-static-courses-challenges-order/index.js
+++ b/scripts/reverse-static-courses-challenges-order/index.js
@@ -1,6 +1,6 @@
 import { knex } from '../../api/db/knex-database-connection';
 
-(async function() {
+(async function () {
   const staticCourses = await knex('static_courses')
     .select('id', 'name', 'challengeIds');
   for (const staticCourse of staticCourses) {
@@ -8,9 +8,6 @@ import { knex } from '../../api/db/knex-database-connection';
     const reversedChallengeIds = challengeIds.reverse();
     await knex('static_courses')
       .where('id', staticCourse.id)
-      .update({
-        challengeIds: reversedChallengeIds.join(','),
-      });
+      .update({ challengeIds: reversedChallengeIds.join(',') });
   }
 })();
-

--- a/scripts/set-headers-to-attachments/index.js
+++ b/scripts/set-headers-to-attachments/index.js
@@ -19,14 +19,14 @@ export async function setHeadersToAttachments(attachments) {
       headers: {
         'Content-Type': attachment.fields.mimeType,
         'X-Auth-Token': token,
-      }
+      },
     };
     if (attachment.fields.type === 'attachment') {
       config.headers['Content-Disposition'] = `attachment; filename="${encodeURIComponent(attachment.fields.filename)}"`;
     }
     try {
       await limit(() => {
-        count ++;
+        count++;
         console.log(`Progress: ${count / attachments.length * 100}`);
         return axios.post(attachment.fields.url, {}, config);
       });

--- a/scripts/set-headers-to-attachments/index.test.js
+++ b/scripts/set-headers-to-attachments/index.test.js
@@ -3,8 +3,8 @@ import nock from 'nock';
 
 import { setHeadersToAttachments } from './index.js';
 
-describe('Set headers to attachments', function() {
-  it('set header Content-Disposition only to type attachments', async function() {
+describe('Set headers to attachments', function () {
+  it('set header Content-Disposition only to type attachments', async function () {
     process.env.TOKEN_URL = 'https://auth.cloud.ovh.net/v3/auth/tokens';
     process.env.BUCKET_USER = 'user';
     process.env.BUCKET_PASSWORD = 'password';
@@ -25,34 +25,32 @@ describe('Set headers to attachments', function() {
 
     const getTokenApiCall = nock('https://auth.cloud.ovh.net/v3')
       .post('/auth/tokens', {
-        'auth': {
-          'identity': {
-            'methods': ['password'],
-            'password': {
-              'user': {
-                'name': 'user',
-                'domain': { 'id': 'default' },
-                'password':'password'
-              }
-            }
+        auth: {
+          identity: {
+            methods: ['password'],
+            password: {
+              user: {
+                name: 'user',
+                domain: { id: 'default' },
+                password: 'password',
+              },
+            },
           },
-          'scope': {
-            'project': {
-              'name': 'tenant name',
-              'domain': { 'id': 'default' }
-            }
-          }
-        }
+          scope: {
+            project: {
+              name: 'tenant name',
+              domain: { id: 'default' },
+            },
+          },
+        },
       })
-      .reply(200, {}, {
-        'x-subject-token': 'TOKEN'
-      });
+      .reply(200, {}, { 'x-subject-token': 'TOKEN' });
 
     nock.disableNetConnect();
 
     const attachments = [
       {
-        'fields': {
+        fields: {
           'id': 'attcKBWOyCUyATJ93',
           'Record ID': 'reczu9rZzvVD07Gme',
           'challengeId': ['some-challenge-id'],
@@ -62,10 +60,10 @@ describe('Set headers to attachments', function() {
           'type': 'illustration',
           'url': 'https://dl.pix.fr/illustration1.png',
           'alt': 'alternative text',
-        }
+        },
       },
       {
-        'fields': {
+        fields: {
           'id': 'attcKBWOyCUyATJ932',
           'Record ID': 'reczu9rZzvVD07Gme2',
           'challengeId': ['some-challenge-id'],
@@ -75,7 +73,7 @@ describe('Set headers to attachments', function() {
           'type': 'attachment',
           'url': 'https://dl.pix.fr/attachment1.png',
           'alt': '',
-        }
+        },
       },
     ];
 


### PR DESCRIPTION
## 🍂 Problème

Avec le passage d’ESLint en V9, beaucoup de règles sont dépréciées et seront supprimées en V11. Plus d’infos [par ici](https://eslint.org/blog/2023/10/deprecating-formatting-rules/).

## 🌰 Proposition

Ajouter et configurer le plugin stylistic pour gérer ces règles dans le front et les scripts

## 🍁 Remarques

- Pour avoir un aperçu des règles dépréciées, il est possible de lancer la commande npx eslint --inspect-config
- Le plugin stylistic reprend les règles de lint qu'on utilisait avant (et qui sont dépréciées) + quelques règles prettier qui étaient utiles

## 🪵 Pour tester

CI au vert
