### PR TITLE
[TECH] Supprime la dépendance `hapi-pino`.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -20,6 +20,12 @@ function _getStringArray(stringWithCommas, defaultStringArray) {
   return defaultStringArray;
 }
 
+function _getLogForHumans() {
+  const processOutputingToTerminal = process.stdout.isTTY;
+  const forceJSONLogs = process.env.LOG_FOR_HUMANS === 'false';
+  return processOutputingToTerminal && !forceJSONLogs;
+}
+
 export const rootPath = path.normalize(__dirname + '/..');
 
 export let port = parseInt(process.env.PORT, 10) || 3002;
@@ -46,8 +52,9 @@ export const logging = {
   logLevel: process.env.LOG_LEVEL || 'info',
   logOpsMetrics: isFeatureEnabled(process.env.LOG_OPS_METRICS),
   emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,
-  prettyPrint: isFeatureEnabled(process.env.LOG_PRETTY_PRINT),
   debugSections: process.env.LOG_DEBUG?.split(',') ?? [],
+  logForHumans: _getLogForHumans(),
+  logForHumansCompactFormat: process.env.LOG_FOR_HUMANS_FORMAT === 'compact',
 };
 
 export let pixApi = {

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -7,9 +7,15 @@ const nullDestination = { write() {} };
 
 let destination = pino.destination();
 
-if (config.logging.prettyPrint) {
+if (config.logging.logForHumans) {
+  const omitDay = 'HH:MM:ss';
   destination = pretty({
+    sync: true,
     colorize: true,
+    translateTime: omitDay,
+    ignore: 'pid,hostname',
+    messageFormat: config.logging.logForHumansCompactFormat ? messageFormatCompact : undefined,
+    hideObject: config.logging.logForHumansCompactFormat,
   });
 }
 
@@ -41,6 +47,49 @@ export const SCOPES = {
   REPLICATION: 'replication',
   RELEASE: 'release',
 };
+
+function messageFormatCompact(log, messageKey, _logLevel, { colors }) {
+  const message = log[messageKey];
+  const { err, req, res, responseTime } = log;
+
+  // compact log for errors
+  if (err) {
+    const stack = colors.red(err.stack);
+    return `${message}\n${stack}`;
+  }
+
+  // compact log for HTTP requests
+  if (req && res) {
+    const method = req.method?.toUpperCase();
+
+    const queries = req.metrics?.knexQueryCount ? `sql:${req.metrics.knexQueryCount}` : '';
+    const queriesTime = req.metrics?.knexTotalTimeSpent ? `sql-time:${req.metrics.knexTotalTimeSpent}` : '';
+
+    const statusCode = res.statusCode >= 400 ? colors.red(res.statusCode) : colors.greenBright(res.statusCode);
+    const request = colors.magentaBright([method, req.url].filter(Boolean).join(' '));
+    const details = colors.yellow([queries, queriesTime].filter(Boolean).join(' '));
+    const time = colors.gray(`(${responseTime}ms)`);
+
+    return [statusCode, request, details, time].filter(Boolean).join(' - ');
+  }
+
+  // compact log by default
+  const compactLog = omit(log, [
+    messageKey,
+    'id',
+    'level',
+    'time',
+    'pid',
+    'hostname',
+    'uri',
+    'address',
+    'event',
+    'started',
+    'created',
+  ]);
+  const details = !isEmpty(compactLog) ? colors.gray(JSON.stringify(compactLog)) : '';
+  return `${message} ${details}`;
+}
 
 logger.debug('DEBUG logs enabled');
 logger.trace('TRACE logs enabled');

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -1,28 +1,84 @@
-import _ from 'lodash';
+import { stdSerializers } from 'pino';
+
 import * as monitoringTools from '../monitoring-tools.js';
 import * as config from '../../config.js';
-import { logger } from '../logger.js';
+import { logger as loggerPino } from '../logger.js';
 
-function logObjectSerializer(obj) {
-  if (config.hapi.enableRequestMonitoring) {
-    const context = monitoringTools.getContext();
-    return {
-      ...obj,
-      route: context?.request?.route?.path,
-      user_id: _.get(context, 'request') ? monitoringTools.extractUserIdFromRequest(context.request) : '-',
-      metrics: _.get(context, 'metrics'),
-    };
-  } else {
-    return { ...obj };
-  }
+const serializersSym = Symbol.for('pino.serializers');
+
+function requestSerializer(req) {
+  const enhancedReq = {
+    ...req,
+    version: config.version,
+  };
+
+  if (!config.hapi.enableRequestMonitoring) return enhancedReq;
+
+  const context = monitoringTools.getContext();
+
+  return {
+    ...enhancedReq,
+    user_id: monitoringTools.extractUserIdFromRequest(context.request),
+    metrics: context?.metrics,
+    route: context?.request?.route?.path,
+  };
 }
 
-export { default as plugin } from 'hapi-pino';
+const plugin = {
+  name: 'hapi-pino',
+  register: async function (server, options) {
+    const serializers = {
+      req: stdSerializers.wrapRequestSerializer(requestSerializer),
+      res: stdSerializers.wrapResponseSerializer(stdSerializers.res),
+    };
+    const logger = options.instance;
+    logger[serializersSym] = Object.assign({}, serializers, logger[serializersSym]);
 
-export const options = {
-  serializers: {
-    req: logObjectSerializer,
+    server.ext('onPostStart', async function () {
+      logger.info(server.info, 'server started');
+    });
+
+    server.ext('onPostStop', async function () {
+      logger.info(server.info, 'server stopped');
+    });
+
+    server.events.on('log', function (event) {
+      logger.info({ tags: event.tags, data: event.data });
+    });
+
+    server.events.on('request', function (request, event) {
+      if (event.channel !== 'error') {
+        return;
+      }
+      if (event.error) {
+        logger.error(
+          {
+            tags: event.tags,
+            err: event.error,
+          },
+          'request error',
+        );
+      }
+    });
+
+    server.events.on('response', (request) => {
+      const info = request.info;
+
+      logger.info(
+        {
+          queryParams: request.query,
+          req: request,
+          res: request.raw.res,
+          responseTime: (info.completed !== undefined ? info.completed : info.responded) - info.received,
+        },
+        'request completed',
+      );
+    });
   },
-  instance: logger,
-  logQueryParams: true,
 };
+
+const options = {
+  instance: loggerPino,
+};
+
+export { options, plugin };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -29,7 +29,6 @@
         "countries-list": "^3.0.6",
         "fast-csv": "^5.0.5",
         "file-saver": "^2.0.5",
-        "hapi-pino": "^8.4.0",
         "joi": "^18.0.0",
         "js-crypto-random": "^1.0.4",
         "jsonapi-serializer": "^3.6.9",
@@ -207,7 +206,6 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
       "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
@@ -2663,7 +2661,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
       "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
-      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       }
@@ -2723,7 +2720,6 @@
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/cookie/-/cookie-12.0.1.tgz",
       "integrity": "sha512-TpykARUIgTBvgbsgtYe5CrM/7XBGms2/22JD3N6dzct6bG1vcOC6pH1JWIos1O5zvQnyDSJ2pnaFk+DToHkAng==",
-      "peer": true,
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@hapi/bounce": "^3.0.1",
@@ -2757,7 +2753,6 @@
       "version": "21.3.8",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.8.tgz",
       "integrity": "sha512-2YGNQZTnWKAWiexoLxvsSFFpJvFBJKhtRzARNxR6G1dHbDfL1WPQBXF00rmMRJLdo+oi7d+Ntgdno6V+z+js7w==",
-      "peer": true,
       "dependencies": {
         "@hapi/accept": "^6.0.1",
         "@hapi/ammo": "^6.0.1",
@@ -2801,7 +2796,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.0.tgz",
       "integrity": "sha512-5X+cl/Ozm0U9uPGGX1dSKhnhTQIf161bH/kkTN9OBVAZKFG+nrj8j/NMj6S1zBBZWmQrkVRNPfCUGrXzB4fCFQ==",
-      "peer": true,
       "dependencies": {
         "@hapi/ammo": "^6.0.1",
         "@hapi/boom": "^10.0.1",
@@ -3330,7 +3324,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3843,7 +3836,6 @@
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.1.13.tgz",
       "integrity": "sha512-cMC8bgTN63dj1Mv82iDeeLl6sa9kY0Pug8LSalxVEptRmyFVsVxGgu2/6Y3T+9aCYScxfS06EkA8SdzFMAwYTQ==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4223,7 +4215,6 @@
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.1.13.tgz",
       "integrity": "sha512-zNbA7muWsHuVg12GrTgN/j119rLePPq5M8dZgkKxUwdw8VmU3eUyBp1SihPEXJ2U0MGdZhNhFX7Y74g11u66sg==",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.2.0",
         "prosemirror-collab": "^1.3.0",
@@ -4538,18 +4529,12 @@
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
-    "node_modules/abstract-logging": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
-      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
-    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4572,7 +4557,6 @@
       "resolved": "https://registry.npmjs.org/adminjs/-/adminjs-7.8.13.tgz",
       "integrity": "sha512-xTmrU9K1VWoIPxHfJnfU8CeFj4f1bZFjyizBntVp0F9dVc8geEaDCOcRIiKbfzrvIk2/Yr5G6z0seLKa4hprIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adminjs/design-system": "^4.1.0",
         "@babel/core": "^7.23.9",
@@ -4739,28 +4723,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/args": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/args/-/args-5.0.3.tgz",
-      "integrity": "sha512-h6k/zfFgusnv3i5TU08KQkVKuCPBtL/PWQbWkHUxvJrZ2nAyeaUupneemcrgn1xmqxPQsPIzwkUhOpoqPDRZuA==",
-      "dependencies": {
-        "camelcase": "5.0.0",
-        "chalk": "2.4.2",
-        "leven": "2.1.0",
-        "mri": "1.1.4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/args/node_modules/camelcase": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4789,7 +4751,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
       "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -5083,7 +5044,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -6036,7 +5996,6 @@
       "integrity": "sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -6440,14 +6399,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -6570,11 +6521,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "node_modules/flatted": {
       "version": "3.3.1",
@@ -6977,165 +6923,6 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
-    "node_modules/hapi-pino": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.5.0.tgz",
-      "integrity": "sha512-p0phuePalD8965r6mboCBLIMWRO2vQAx+VSnXhTKxnF/4Sf+dk8Uze7109w9QfhlvGMqvBTEF6SxGStObBB/Lw==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "abstract-logging": "^2.0.0",
-        "pino": "^6.0.0",
-        "pino-pretty": "^4.0.0"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-    },
-    "node_modules/hapi-pino/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/hapi-pino/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/hapi-pino/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/joycon": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
-      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/pino": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.14.0.tgz",
-      "integrity": "sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==",
-      "dependencies": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "process-warning": "^1.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/pino-pretty": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.8.0.tgz",
-      "integrity": "sha512-mhQfHG4rw5ZFpWL44m0Utjo4GC2+HMfdNvxyA8lLw0sIqn6fCf7uQe6dPckUcW/obly+OQHD7B/MTso6LNizYw==",
-      "dependencies": {
-        "@hapi/bourne": "^2.0.0",
-        "args": "^5.0.1",
-        "chalk": "^4.0.0",
-        "dateformat": "^4.5.1",
-        "fast-safe-stringify": "^2.0.7",
-        "jmespath": "^0.15.0",
-        "joycon": "^2.2.5",
-        "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
-        "rfdc": "^1.3.0",
-        "split2": "^3.1.1",
-        "strip-json-comments": "^3.1.1"
-      },
-      "bin": {
-        "pino-pretty": "bin.js"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
-    "node_modules/hapi-pino/node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
-    },
-    "node_modules/hapi-pino/node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/hapi-pino/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -7296,7 +7083,6 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.6"
       }
@@ -7832,14 +7618,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/joi": {
       "version": "18.0.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.1.tgz",
@@ -8075,14 +7853,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -8421,14 +8191,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/mri": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
-      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -9706,7 +9468,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9827,7 +9588,6 @@
       "version": "1.19.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.19.4.tgz",
       "integrity": "sha512-RPmVXxUfOhyFdayHawjuZCxiROsm9L4FCUA6pWI+l7n2yCBsWy9VpdE1hpDHUS8Vad661YLY9AzqfjLhAKQ4iQ==",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9854,7 +9614,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9910,7 +9669,6 @@
       "version": "1.33.3",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.3.tgz",
       "integrity": "sha512-P4Ao/bc4OrU/2yLIf8dL4lJaEtjLR3QjIvQHgJYp2jUS7kYM4bSR6okbBjkqzOs/FwUon6UGjTLdKMnPL1MZqw==",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.16.0",
         "prosemirror-state": "^1.0.0",
@@ -10001,7 +9759,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10038,7 +9795,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -10314,7 +10070,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -10464,11 +10219,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -10508,7 +10258,6 @@
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
       "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -10660,7 +10409,6 @@
           "url": "https://opencollective.com/sequelize"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -11299,7 +11047,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11418,7 +11165,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -11641,7 +11387,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
       "integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",

--- a/api/package.json
+++ b/api/package.json
@@ -64,7 +64,6 @@
     "countries-list": "^3.0.6",
     "fast-csv": "^5.0.5",
     "file-saver": "^2.0.5",
-    "hapi-pino": "^8.4.0",
     "joi": "^18.0.0",
     "js-crypto-random": "^1.0.4",
     "jsonapi-serializer": "^3.6.9",

--- a/api/sample.env
+++ b/api/sample.env
@@ -154,12 +154,34 @@ AIRTABLE_EDITOR_BASE=
 # default: `undefined` (`false`)
 LOG_ENABLED=true
 
-# Enable or disable the logging of the API.
+# Set logging level of the API.
 #
 # presence: optional
 # type: String
 # default: "info"
 # LOG_LEVEL=debug
+
+# Log for humans
+#
+# Make log human-friendly:
+# - color logs
+# - display time of the day in HH:MM:SS format
+# - skip process id and hostname
+# - synchronous logs (decrease performance)
+# Do NOT use if logs are to be processed by a log processing pipeline
+#
+# Sample output: [8:27:12] INFO: Connected to server
+# presence: optional
+# type: String
+LOG_FOR_HUMANS=true
+
+# Logs for humans format
+#
+# "compact": Always display logs on a single line with key information.
+#
+# presence: optional
+# type: String
+# LOG_FOR_HUMANS_FORMAT=compact
 
 # Log operations metrics
 #
@@ -179,15 +201,6 @@ LOG_ENABLED=true
 # type: positive integer
 # default: 15
 # OPS_EVENT_EACH_SECONDS=1
-
-# Format ndjson-like log line into a more human friendly message.
-#
-# See https://github.com/pinojs/pino-pretty
-#
-# presence: optional
-# type: Boolean
-# default: `undefined` (`false`)
-# LOG_PRETTY_PRINT=true
 
 # Enables debug log level for a list of sections.
 # Sections must be given separated by commas.

--- a/api/tests/integration/infrastructure/plugins/pino_test.js
+++ b/api/tests/integration/infrastructure/plugins/pino_test.js
@@ -1,3 +1,5 @@
+import { Writable } from 'node:stream';
+
 import { beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import split from 'split2';
 import writeStream from 'flush-write-stream';
@@ -7,6 +9,7 @@ import { generateAuthorizationHeader, databaseBuilder } from '../../../test-help
 import * as pinoPlugin from '../../../../lib/infrastructure/plugins/pino.js';
 import * as monitoringTools from '../../../../lib/infrastructure/monitoring-tools.js';
 import * as security from '../../../../lib/infrastructure/security.js';
+import pino from 'pino';
 
 function sink(func) {
   const result = split(JSON.parse);
@@ -45,11 +48,19 @@ describe('Integration | Infrastructure | plugins | pino', function () {
   });
 
   async function registerWithPlugin(cb) {
+    const stream = new Writable({
+      write(chunk, encoding, ack) {
+        cb(JSON.parse(chunk.toString()));
+        ack();
+        return true;
+      },
+    });
+
     const pinoPluginWithLogger = {
       ...pinoPlugin,
       options: {
         ...pinoPlugin.options,
-        instance: undefined,
+        instance: pino(stream),
         level: 'info',
         stream: sink(cb),
       },


### PR DESCRIPTION
## :fallen_leaf: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Nous avons plusieurs versions de retard sur `hapi-pino` et on peut se passer de cette dépendance comme sur les autres api de pix (cf Pix-API et ChatPix).

## :chestnut: Proposition
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->
On reprend les mêmes fonctions de logging que sur Pix API et on supprime la dépendance à `hapi-pino`.

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS.

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
Vérifier les logs en local, avec et sans `LOGS_FOR_HUMAN` activé.
Vérifier les logs de la review app.
