### PR TITLE
[TECH] Ajoute la taille de tranche comme option au script de migration des attachments.

### DIFF
--- a/api/scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg.js
@@ -15,6 +15,12 @@ export class CopyAttachmentsFromAirtableToPg extends Script {
           demandOption: false,
           default: true,
         },
+        chunkSize: {
+          type: 'number',
+          describe: 'size of inserted chunk',
+          demandOption: false,
+          default: 500,
+        },
       },
     });
   }
@@ -51,9 +57,17 @@ export class CopyAttachmentsFromAirtableToPg extends Script {
       );
     logger.info({ count: deletedCount }, 'Deleted attachments into postgres');
 
-    await knex.insert(attachments).into('attachments').onConflict('id').merge();
+    for (const chunk of chunks(attachments, options.chunkSize)) {
+      await knex.insert(chunk).into('attachments').onConflict('id').merge();
+    }
     logger.info({ count: attachments.length }, 'Inserted attachments into postgres');
   }
 }
 
 await ScriptRunner.execute(import.meta.url, CopyAttachmentsFromAirtableToPg);
+
+function* chunks(arr, size) {
+  for (let i = 0; i < arr.length; i += size) {
+    yield arr.slice(i, i + size);
+  }
+}

--- a/api/tests/integration/scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg_test.js
@@ -24,7 +24,7 @@ describe('Integration | Scripts | CopyAttachmentsFromAirtableToPg', () => {
 
     it('reads attachments from airtable and saves these to postgres', async () => {
       // given
-      const options = { dryRun: false };
+      const options = { dryRun: false, chunkSize: 10 };
 
       const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
         new Airtable.Record(AIRTABLE_NAME, 'rec123Abc', {
@@ -136,7 +136,7 @@ describe('Integration | Scripts | CopyAttachmentsFromAirtableToPg', () => {
     describe('when dryRun is true', () => {
       it('reads attachments from airtable and stops', async () => {
         // given
-        const options = { dryRun: true };
+        const options = { dryRun: true, chunkSize: 10 };
 
         const findRecords = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([
           new Airtable.Record(AIRTABLE_NAME, 'rec123Abc', {


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Le nombre d'attachments présents en production ne permet pas de migrer en une seule requête.

## 🌰 Proposition

On ajoute une option au script de migration pour permettre de définir une taille de tranche et ainsi découper l'insertion des attachments dans la base de données PG en plusieurs requêtes.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Exécuter les commandes suivantes :
```
cd api
node scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg.js --dryRun=false --chunkSize=10
```

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
