### PR TITLE
[BUGFIX] Trier les acquis dans le même ordre que Airtable dans la recherche

### DIFF
--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -134,10 +134,14 @@ export async function search(params) {
   ]);
   if (params.sort) {
     params.sort.forEach(([field, direction]) => {
-      query = query.orderBy(field, direction);
+      if (field === 'name') {
+        query = query.orderByRaw('?? collate ??', ['name', 'fr-x-icu']);
+      } else {
+        query = query.orderBy(field, direction);
+      }
     });
   } else {
-    query = query.orderByRaw('?? collate ??', ['skills.id', 'fr-x-icu']);
+    query = query.orderBy('skills.id');
   }
   if (params.page?.limit) {
     query = query.limit(params.page?.limit);


### PR DESCRIPTION
## 🍂 Problème

Quand on fait une recherche d’acquis, l’ordre des résultats n’est pas le même entre Airtable et Postgres.

## 🌰 Proposition

Changer l’ordre de tri de Postgres pour concorder avec Airtable.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Faire une recherche d’acquis et vérifier qu’il n’y a pas de logs de warning.