### PR TITLE
[BUGFIX] Répare le tri des résultats de recherche d'acquis dans PG.

### DIFF
--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -135,7 +135,7 @@ export async function search(params) {
   if (params.sort) {
     params.sort.forEach(([field, direction]) => {
       if (field === 'name') {
-        query = query.orderByRaw('?? collate ??, ??', ['tubes.name', 'fr-x-icu', 'skills.level']);
+        query = query.orderByRaw('(?? || ??) collate ??', ['tubes.name', 'skills.level', 'fr-x-icu']);
       } else {
         query = query.orderBy(field, direction);
       }


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->
L'ordre de tri des résultats de recherche d'acquis n'est pas le même pour PG et Airtable.

## 🌰 Proposition

Il faut prendre en compte le niveau dans le tri.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## 🪵 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
