### PR TITLE
[BUGFIX] Evite de crash quand on log en dehors du contexte d'une requête.

### DIFF
--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -18,7 +18,7 @@ function requestSerializer(req) {
 
   return {
     ...enhancedReq,
-    user_id: monitoringTools.extractUserIdFromRequest(context.request),
+    user_id: monitoringTools.extractUserIdFromRequest(context?.request),
     metrics: context?.metrics,
     route: context?.request?.route?.path,
   };


### PR DESCRIPTION
## :fallen_leaf: Problème
<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On observe des crashs quand on essaie de logger. En regardant le soucis, il s'agit de la request qui est undefined.

## :chestnut: Proposition

On s'assure de gérer le cas d'une request undefined.
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## :jack_o_lantern: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->
RAS

## :wood: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
