### PR TITLE
[TECH] Remplacer les appels datasources par des appels repositories (PIX-20179)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -1,9 +1,8 @@
 import Joi from 'joi';
 import { logger } from '../../infrastructure/logger.js';
-import { challengeRepository } from '../../infrastructure/repositories/index.js';
+import { attachmentRepository, challengeRepository } from '../../infrastructure/repositories/index.js';
 import { challengeSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import * as securityPreHandlers from '../security-pre-handlers.js';
-import { attachmentDatasource } from '../../infrastructure/datasources/airtable/index.js';
 import { createChallengeTransformer } from '../../infrastructure/transformers/index.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
@@ -22,7 +21,7 @@ const challengeIdType = Joi.string()
 
 async function _refreshCache({ challenge }) {
   try {
-    const attachments = await attachmentDatasource.filterByLocalizedChallengeId(challenge.id);
+    const attachments = await attachmentRepository.listByLocalizedChallengeId(challenge.id);
     const transformChallenge = createChallengeTransformer({ attachments });
     const newChallenge = transformChallenge(challenge);
 

--- a/api/lib/domain/usecases/get-learning-content-for-replication.js
+++ b/api/lib/domain/usecases/get-learning-content-for-replication.js
@@ -1,4 +1,3 @@
-import { tutorialDatasource } from '../../infrastructure/datasources/airtable/index.js';
 import {
   areaRepository,
   attachmentRepository,
@@ -10,6 +9,7 @@ import {
   thematicRepository,
   translationRepository,
   tubeRepository,
+  tutorialRepository,
 } from '../../infrastructure/repositories/index.js';
 import {
   areaTransformer,
@@ -62,7 +62,7 @@ export async function getLearningContentForReplication() {
     skillRepository.list(),
     challengeRepository.list(),
     attachmentRepository.list(),
-    tutorialDatasource.list(),
+    tutorialRepository.list(),
     _getCoursesFromPGForReplication(),
     missionRepository.list(),
     translationRepository.list(),

--- a/api/lib/domain/usecases/update-challenge.js
+++ b/api/lib/domain/usecases/update-challenge.js
@@ -1,12 +1,11 @@
-import { challengeRepository } from '../../infrastructure/repositories/index.js';
+import { attachmentRepository, challengeRepository } from '../../infrastructure/repositories/index.js';
 import { normalizeNonBreakingSpace } from '../../infrastructure/utils/normalize-non-breaking-space.js';
-import { attachmentDatasource } from '../../infrastructure/datasources/airtable/index.js';
 import { createChallengeTransformer } from '../../infrastructure/transformers/index.js';
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import { logger } from '../../infrastructure/logger.js';
 
-export async function updateChallenge(challenge, dependencies = { challengeRepository, attachmentDatasource }) {
+export async function updateChallenge(challenge, dependencies = { challengeRepository, attachmentRepository }) {
   if (challenge.locales.includes('fr') || challenge.locales.includes('fr-fr')) {
     const fieldsToNormalize = ['instruction', 'proposals', 'alternativeInstruction'];
     for (const field of fieldsToNormalize) {
@@ -18,7 +17,7 @@ export async function updateChallenge(challenge, dependencies = { challengeRepos
   const updatedChallenge = await dependencies.challengeRepository.update(challenge);
 
   try {
-    const attachments = await dependencies.attachmentDatasource.filterByLocalizedChallengeId(updatedChallenge.id);
+    const attachments = await dependencies.attachmentRepository.listByLocalizedChallengeId(updatedChallenge.id);
     const transformChallenge = createChallengeTransformer({ attachments });
     const newChallenge = transformChallenge(updatedChallenge);
     await updatedRecordNotifier.notify({

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -34,6 +34,7 @@ export const skillDatasource = datasource.extend({
 
   sortableFields: {
     name: 'Nom',
+    version: 'Version',
   },
 
   fromAirTableObject(airtableRecord) {

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -20,6 +20,12 @@ export async function listByLocalizedChallengeIds(localizedChallengeIds) {
   return toDomainList(datasourceAttachments);
 }
 
+export async function listByLocalizedChallengeId(localizedChallengeId) {
+  const datasourceAttachments = await attachmentDatasource.filterByLocalizedChallengeId(localizedChallengeId);
+  if (!datasourceAttachments) return [];
+  return toDomainList(datasourceAttachments);
+}
+
 export async function createBatch(attachments) {
   return knex.transaction(async (transaction) => {
     if (!attachments || attachments.length === 0) return [];

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -4,7 +4,7 @@ import { fetchPage } from '../utils/knex-utils.js';
 import { Mission } from '../../domain/models/index.js';
 import * as missionTranslations from '../translations/mission.js';
 import { NotFoundError } from '../../domain/errors.js';
-import { translationRepository } from './index.js';
+import * as translationRepository from './translation-repository.js';
 
 const model = 'mission';
 

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -1,6 +1,6 @@
-import { attachmentDatasource, tutorialDatasource } from '../datasources/airtable/index.js';
 import {
   areaRepository,
+  attachmentRepository,
   challengeRepository,
   competenceRepository,
   frameworkRepository,
@@ -8,6 +8,7 @@ import {
   skillRepository,
   thematicRepository,
   tubeRepository,
+  tutorialRepository,
 } from './index.js';
 import {
   areaTransformer,
@@ -81,13 +82,13 @@ async function _getCurrentContent() {
   ] = await Promise.all([
     challengeRepository.list(),
     areaRepository.list(),
-    attachmentDatasource.list(),
+    attachmentRepository.list(),
     competenceRepository.list(),
     frameworkRepository.list(),
     skillRepository.list(),
     thematicRepository.list(),
     tubeRepository.list(),
-    tutorialDatasource.list(),
+    tutorialRepository.list(),
     getStaticCourses(),
     missionRepository.list(),
   ]);

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -145,13 +145,15 @@ export async function search(params) {
     `${params.filter.name}%`,
   ]);
   if (params.sort) {
-    params.sort.forEach(([field, direction]) => {
+    const orderBySqlAndParams = params.sort.map(([field, direction]) => {
       if (field === 'name') {
-        query = query.orderByRaw('(?? || ??) collate ??', ['tubes.name', 'skills.level', 'fr-x-icu']);
-      } else {
-        query = query.orderBy(field, direction);
+        return [`(?? || ??) collate ?? ${direction}`, ['tubes.name', 'skills.level', 'fr-x-icu']];
       }
+      return [`?? ${direction}`, [`skills.${field}`]];
     });
+    const orderBySql = orderBySqlAndParams.map(([sql]) => sql).join(', ');
+    const orderByParams = orderBySqlAndParams.flatMap(([, params]) => params);
+    query = query.orderByRaw(orderBySql, orderByParams);
   } else {
     query = query.orderBy('skills.id');
   }

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -40,6 +40,18 @@ export async function get(id) {
   return toDomain(airtableDto, translations, pgDto);
 }
 
+export async function getMany(ids) {
+  const [airtableDtos, pgDtos, translations] = await Promise.all([
+    skillDatasource.filter({ filter: { ids } }),
+    selectSkills().whereIn('skills.id', ids).orderBy('skills.id'),
+    translationRepository.listByEntities(model, ids),
+  ]);
+
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+
+  return toDomainList(airtableDtos, translations, pgDtos);
+}
+
 export async function getByAirtableId(id) {
   const airtableDto = await skillDatasource.find(id);
   if (!airtableDto) return null;

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -7,9 +7,9 @@ import {
   StaticCourseTag as StaticCourseTag_Read,
 } from '../../domain/readmodels/index.js';
 import { StaticCourse } from '../../domain/models/index.js';
-import { skillDatasource } from '../datasources/airtable/index.js';
 import * as challengeRepository from './challenge-repository.js';
-import { localizedChallengeRepository } from './index.js';
+import * as localizedChallengeRepository from './localized-challenge-repository.js';
+import * as skillRepository from './skill-repository.js';
 import _ from 'lodash';
 
 export async function findReadSummaries({ filter, page }) {
@@ -183,9 +183,7 @@ async function findChallengeSummaries(localizedChallengeIds, { baseUrl }) {
   });
 
   const skillIds = challenges.map(({ skillId }) => skillId);
-  const skillsFromAirtable = await skillDatasource.filter({
-    filter: { ids: skillIds },
-  });
+  const skillsFromAirtable = await skillRepository.getMany(skillIds);
 
   return localizedChallengeIds.map((localizedChallengeId, index) => {
     const localizedChallenge = localizedChallenges.find(({ id }) => id === localizedChallengeId);

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -172,6 +172,14 @@ export async function getMany(ids) {
   return airtableDtos.map(toDomain);
 }
 
+export async function list() {
+  const [airtableDtos, pgDtos] = await Promise.all([tutorialDatasource.list(), selectTutorials().orderBy('id')]);
+
+  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos);
+
+  return airtableDtos.map(toDomain);
+}
+
 async function _delete(ids) {
   const airtableIds = Object.entries(await tutorialDatasource.getAirtableIdsByIds(ids)).map(
     ([, airtableId]) => airtableId,

--- a/api/tests/acceptance/application/static-courses/get_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/get_static-course_test.js
@@ -3,7 +3,7 @@ import { databaseBuilder, generateAuthorizationHeader, airtableBuilder, domainBu
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | API | static courses | GET /api/static-courses/{id}', function () {
-  it('Return the static course', async function () {
+  it('returns the static course', async function () {
     // Given
     const server = await createServer();
     const user = databaseBuilder.factory.buildReadonlyUser();
@@ -32,9 +32,44 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
     databaseBuilder.factory.buildTube({ id: 'tube1', name: '@tube', thematicId: 'thematic1' });
-    const challenge1 = domainBuilder.buildChallenge({ id: 'challengeid1' });
-    const challenge2 = domainBuilder.buildChallenge({ id: 'challengeid2' });
-    databaseBuilder.factory.buildSkill({ id: challenge1.skillId, tubeId: 'tube1' });
+    const skill1 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid1',
+      name: '@skillid1',
+      hint_i18n: {},
+      tubeId: 'tube1',
+      level: 1,
+      name: '@tube1',
+      competenceId: 'competence1',
+      challengeIds: ['challengeid1'],
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+    });
+    const skill2 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid2',
+      name: '@skillid2',
+      hint_i18n: {},
+      tubeId: 'tube1',
+      level: 2,
+      name: '@tube2',
+      competenceId: 'competence1',
+      challengeIds: ['challengeid2'],
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+    });
+    databaseBuilder.factory.buildSkill(skill1);
+    databaseBuilder.factory.buildSkill(skill2);
+    const challenge1 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid1',
+      skillId: 'skillid1',
+      status: 'status for challengeid1',
+      locales: ['fr'],
+    });
+    const challenge2 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid2',
+      skillId: 'skillid2',
+      status: 'status for challengeid2',
+      locales: ['fr'],
+    });
 
     databaseBuilder.factory.buildChallenge(challenge1);
     databaseBuilder.factory.buildLocalizedChallenge({
@@ -53,28 +88,10 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
     databaseBuilder.factory.linkTagsTo({ staticCourseTagIds: [tagAId, tagBId], staticCourseId: 'courseid1' });
 
     await databaseBuilder.commit();
-    const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid1',
-      skillId: 'skillid1',
-      status: 'status for challengeid1',
-      locales: ['fr'],
-    });
-    const airtableSkill1 = airtableBuilder.factory.buildSkill({
-      id: 'skillid1',
-      name: '@skillid1',
-      hint_i18n: {},
-    });
-    const airtableChallenge2 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid2',
-      skillId: 'skillid2',
-      status: 'status for challengeid2',
-      locales: ['fr'],
-    });
-    const airtableSkill2 = airtableBuilder.factory.buildSkill({
-      id: 'skillid2',
-      name: '@skillid2',
-      hint_i18n: {},
-    });
+    const airtableChallenge1 = airtableBuilder.factory.buildChallenge(challenge1);
+    const airtableSkill1 = airtableBuilder.factory.buildSkill(skill1);
+    const airtableChallenge2 = airtableBuilder.factory.buildChallenge(challenge2);
+    const airtableSkill2 = airtableBuilder.factory.buildSkill(skill2);
     airtableBuilder.mockLists({
       challenges: [airtableChallenge1, airtableChallenge2],
       skills: [airtableSkill1, airtableSkill2],
@@ -138,7 +155,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
           attributes: {
             index: 0,
             instruction: 'instruction for challengeid1',
-            'skill-name': '@skillid1',
+            'skill-name': '@tube1',
             status: 'status for challengeid1',
             'preview-url': 'http://host.site/api/challenges/challengeid1/preview',
           },
@@ -149,7 +166,7 @@ describe('Acceptance | API | static courses | GET /api/static-courses/{id}', fun
           attributes: {
             index: 1,
             instruction: 'instruction for challengeid2',
-            'skill-name': '@skillid2',
+            'skill-name': '@tube2',
             status: 'status for challengeid2',
             'preview-url': 'http://host.site/api/challenges/challengeid2/preview',
           },

--- a/api/tests/acceptance/application/static-courses/post_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/post_static-course_test.js
@@ -23,12 +23,84 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
     databaseBuilder.factory.buildTube({ id: 'tube1', name: '@tube', thematicId: 'thematic1' });
-    const challenge2 = domainBuilder.buildChallenge({ id: 'challengeid2' });
-    databaseBuilder.factory.buildSkill({ id: challenge2.skillId, tubeId: 'tube1' });
+
+    const skill1 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid1',
+      name: '@tube1',
+      level: 1,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid1'],
+    });
+    const skill2 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid2',
+      name: '@tube2',
+      level: 2,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid2'],
+    });
+    const skill3 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid3',
+      name: '@tube3',
+      level: 3,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid3'],
+    });
+    const skill4 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid4',
+      name: '@tube4',
+      level: 4,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid4'],
+    });
+    const challenge1 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid1',
+      skillId: 'skillid1',
+      locales: ['fr'],
+      status: Challenge.STATUSES.VALIDE,
+    });
+    const challenge2 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid2',
+      skillId: 'skillid2',
+      locales: ['fr'],
+      status: Challenge.STATUSES.PROPOSE,
+    });
+    const challenge3 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid3',
+      skillId: 'skillid3',
+      locales: ['fr'],
+      status: Challenge.STATUSES.PROPOSE,
+    });
+    const challenge4 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid4',
+      skillId: 'skillid4',
+      locales: ['fr'],
+      status: Challenge.STATUSES.PROPOSE,
+    });
+    databaseBuilder.factory.buildSkill(skill1);
+    databaseBuilder.factory.buildSkill(skill2);
+    databaseBuilder.factory.buildSkill(skill3);
+    databaseBuilder.factory.buildSkill(skill4);
+    databaseBuilder.factory.buildChallenge(challenge1);
     databaseBuilder.factory.buildChallenge(challenge2);
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid1' }));
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid3' }));
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid4' }));
+    databaseBuilder.factory.buildChallenge(challenge3);
+    databaseBuilder.factory.buildChallenge(challenge4);
+
     databaseBuilder.factory.buildLocalizedChallenge({
       id: 'challengeid1',
       challengeId: 'challengeid1',
@@ -98,53 +170,13 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
     });
 
     await databaseBuilder.commit();
-    const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid1',
-      skillId: 'skillid1',
-      status: Challenge.STATUSES.VALIDE,
-      locales: ['fr'],
-    });
-    const airtableSkill1 = airtableBuilder.factory.buildSkill({
-      id: 'skillid1',
-      name: '@skillid1',
-      hint_i18n: {},
-    });
-    const airtableChallenge2 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid2',
-      skillId: 'skillid2',
-      status: Challenge.STATUSES.PROPOSE,
-      locales: ['fr'],
-    });
-    const airtableSkill2 = airtableBuilder.factory.buildSkill({
-      id: 'skillid2',
-      name: '@skillid2',
-      hint_i18n: {},
-    });
-    const airtableChallenge3 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid3',
-      skillId: 'skillid3',
-      status: Challenge.STATUSES.PROPOSE,
-      locales: ['fr'],
-    });
-    const airtableSkill3 = airtableBuilder.factory.buildSkill({
-      id: 'skillid3',
-      name: '@skillid3',
-      hint_i18n: {},
-    });
-    const airtableChallenge4 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid4',
-      skillId: 'skillid4',
-      status: Challenge.STATUSES.PROPOSE,
-      locales: ['fr'],
-    });
-    const airtableSkill4 = airtableBuilder.factory.buildSkill({
-      id: 'skillid4',
-      name: '@skillid4',
-      hint_i18n: {},
-    });
+    const airtableChallenge1 = airtableBuilder.factory.buildChallenge(challenge1);
+    const airtableSkill1 = airtableBuilder.factory.buildSkill(skill1);
+    const airtableChallenge3 = airtableBuilder.factory.buildChallenge(challenge3);
+    const airtableSkill3 = airtableBuilder.factory.buildSkill(skill3);
     airtableBuilder.mockLists({
-      challenges: [airtableChallenge1, airtableChallenge2, airtableChallenge3, airtableChallenge4],
-      skills: [airtableSkill1, airtableSkill2, airtableSkill3, airtableSkill4],
+      challenges: [airtableChallenge1, airtableChallenge3],
+      skills: [airtableSkill1, airtableSkill3],
     });
   });
 
@@ -229,7 +261,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
           attributes: {
             index: 0,
             instruction: 'instruction for challengeid3',
-            'skill-name': '@skillid3',
+            'skill-name': '@tube3',
             status: Challenge.STATUSES.PROPOSE,
             'preview-url': 'http://test.site/api/challenges/challengeid3/preview',
           },
@@ -240,7 +272,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
           attributes: {
             index: 1,
             instruction: 'instruction for challengeid1',
-            'skill-name': '@skillid1',
+            'skill-name': '@tube1',
             status: Challenge.STATUSES.VALIDE,
             'preview-url': 'http://test.site/api/challenges/challengeid1/preview',
           },
@@ -251,7 +283,7 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
           attributes: {
             index: 2,
             instruction: 'instruction for challengeid1 in nl',
-            'skill-name': '@skillid1',
+            'skill-name': '@tube1',
             status: Challenge.STATUSES.PROPOSE,
             'preview-url': 'http://test.site/api/challenges/challengeid1/preview?locale=nl',
           },

--- a/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
@@ -32,11 +32,63 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
     databaseBuilder.factory.buildTube({ id: 'tube1', name: '@tube', thematicId: 'thematic1' });
-    const challenge2 = domainBuilder.buildChallenge({ id: 'challengeid2' });
-    databaseBuilder.factory.buildSkill({ id: challenge2.skillId, tubeId: 'tube1' });
+    const skill2 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid2',
+      name: '@tube2',
+      level: 2,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid2'],
+    });
+    const skill3 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid3',
+      name: '@tube3',
+      level: 3,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid3'],
+    });
+    const skill4 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid4',
+      name: '@tube4',
+      level: 4,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid4'],
+    });
+    const challenge2 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid2',
+      skillId: 'skillid2',
+      status: 'status for challengeid2',
+      locales: ['fr'],
+    });
+    const challenge3 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid3',
+      skillId: 'skillid3',
+      status: 'status for challengeid3',
+      locales: ['fr'],
+    });
+    const challenge4 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid4',
+      skillId: 'skillid4',
+      status: 'status for challengeid4',
+      locales: ['fr'],
+    });
+    databaseBuilder.factory.buildSkill(skill2);
+    databaseBuilder.factory.buildSkill(skill3);
+    databaseBuilder.factory.buildSkill(skill4);
     databaseBuilder.factory.buildChallenge(challenge2);
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid3' }));
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid4' }));
+    databaseBuilder.factory.buildChallenge(challenge3);
+    databaseBuilder.factory.buildChallenge(challenge4);
 
     databaseBuilder.factory.buildLocalizedChallenge({
       id: 'challengeid2',
@@ -69,39 +121,13 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       value: 'instruction for challengeid4',
     });
     await databaseBuilder.commit();
-    const airtableChallenge2 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid2',
-      skillId: 'skillid2',
-      status: 'status for challengeid2',
-      locales: ['fr'],
-    });
-    const airtableSkill2 = airtableBuilder.factory.buildSkill({
-      id: 'skillid2',
-      name: '@skillid2',
-      hint_i18n: {},
-    });
-    const airtableChallenge3 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid3',
-      skillId: 'skillid3',
-      status: 'status for challengeid3',
-      locales: ['fr'],
-    });
-    const airtableSkill3 = airtableBuilder.factory.buildSkill({
-      id: 'skillid3',
-      name: '@skillid3',
-      hint_i18n: {},
-    });
-    const airtableChallenge4 = airtableBuilder.factory.buildChallenge({
-      id: 'challengeid4',
-      skillId: 'skillid4',
-      status: 'status for challengeid4',
-      locales: ['fr'],
-    });
-    const airtableSkill4 = airtableBuilder.factory.buildSkill({
-      id: 'skillid4',
-      name: '@skillid4',
-      hint_i18n: {},
-    });
+
+    const airtableSkill2 = airtableBuilder.factory.buildSkill(skill2);
+    const airtableSkill3 = airtableBuilder.factory.buildSkill(skill3);
+    const airtableSkill4 = airtableBuilder.factory.buildSkill(skill4);
+    const airtableChallenge2 = airtableBuilder.factory.buildChallenge(challenge2);
+    const airtableChallenge3 = airtableBuilder.factory.buildChallenge(challenge3);
+    const airtableChallenge4 = airtableBuilder.factory.buildChallenge(challenge4);
     airtableBuilder.mockLists({
       challenges: [airtableChallenge2, airtableChallenge3, airtableChallenge4],
       skills: [airtableSkill2, airtableSkill3, airtableSkill4],
@@ -178,7 +204,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           attributes: {
             index: 0,
             instruction: 'instruction for challengeid2',
-            'skill-name': '@skillid2',
+            'skill-name': '@tube2',
             status: 'status for challengeid2',
             'preview-url': 'http://test.site/api/challenges/challengeid2/preview',
           },
@@ -189,7 +215,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           attributes: {
             index: 1,
             instruction: 'instruction for challengeid3',
-            'skill-name': '@skillid3',
+            'skill-name': '@tube3',
             status: 'status for challengeid3',
             'preview-url': 'http://test.site/api/challenges/challengeid3/preview',
           },
@@ -200,7 +226,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           attributes: {
             index: 2,
             instruction: 'instruction for challengeid4',
-            'skill-name': '@skillid4',
+            'skill-name': '@tube4',
             status: 'status for challengeid4',
             'preview-url': 'http://test.site/api/challenges/challengeid4/preview',
           },

--- a/api/tests/acceptance/application/static-courses/put_static-course-reactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-reactivate_test.js
@@ -18,59 +18,12 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       toFake: ['Date'],
     });
 
-    const airtableSkills = [
-      airtableBuilder.factory.buildSkill({
-        id: 'skillid2',
-        airtableId: 'airtableskillid2',
-        name: '@skillid2',
-        hint_i18n: {},
-      }),
-      airtableBuilder.factory.buildSkill({
-        id: 'skillid3',
-        airtableId: 'airtableskillid3',
-        name: '@skillid3',
-        hint_i18n: {},
-      }),
-      airtableBuilder.factory.buildSkill({
-        id: 'skillid4',
-        airtableId: 'airtableskillid4',
-        name: '@skillid4',
-        hint_i18n: {},
-      }),
-    ];
-
-    const airtableChallenges = [
-      airtableBuilder.factory.buildChallenge({
-        id: 'challengeid2',
-        skillId: airtableSkills[0].fields['id persistant'],
-        status: 'status for challengeid2',
-        locales: ['fr'],
-      }),
-      airtableBuilder.factory.buildChallenge({
-        id: 'challengeid3',
-        skillId: airtableSkills[1].fields['id persistant'],
-        status: 'status for challengeid3',
-        locales: ['fr'],
-      }),
-      airtableBuilder.factory.buildChallenge({
-        id: 'challengeid4',
-        skillId: airtableSkills[2].fields['id persistant'],
-        status: 'status for challengeid4',
-        locales: ['fr'],
-      }),
-    ];
-
-    airtableBuilder.mockLists({
-      skills: airtableSkills,
-      challenges: airtableChallenges,
-    });
-
     user = databaseBuilder.factory.buildAdminUser();
     databaseBuilder.factory.buildStaticCourse({
       id: staticCourseId,
       name: 'some name',
       description: 'some description',
-      challengeIds: airtableChallenges.map((challenge) => challenge.fields['id persistant']).join(','),
+      challengeIds: 'challengeid2,challengeid3,challengeid4',
       isActive: false,
       deactivationReason: 'because',
       createdAt: new Date('2020-01-01T00:00:10Z'),
@@ -81,11 +34,63 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
     databaseBuilder.factory.buildTube({ id: 'tube1', name: '@tube', thematicId: 'thematic1' });
-    const challenge2 = domainBuilder.buildChallenge({ id: 'challengeid2' });
-    databaseBuilder.factory.buildSkill({ id: challenge2.skillId, tubeId: 'tube1' });
+    const skill2 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid2',
+      name: '@tube2',
+      level: 2,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid2'],
+    });
+    const skill3 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid3',
+      name: '@tube3',
+      level: 3,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid3'],
+    });
+    const skill4 = domainBuilder.buildSkillDatasourceObject({
+      id: 'skillid4',
+      name: '@tube4',
+      level: 4,
+      hint_i18n: {},
+      tubeId: 'tube1',
+      competenceId: 'competence1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      challengeIds: ['challengeid4'],
+    });
+    const challenge2 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid2',
+      skillId: 'skillid2',
+      status: 'status for challengeid2',
+      locales: ['fr'],
+    });
+    const challenge3 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid3',
+      skillId: 'skillid3',
+      status: 'status for challengeid3',
+      locales: ['fr'],
+    });
+    const challenge4 = domainBuilder.buildChallengeDatasourceObject({
+      id: 'challengeid4',
+      skillId: 'skillid4',
+      status: 'status for challengeid4',
+      locales: ['fr'],
+    });
+    databaseBuilder.factory.buildSkill(skill2);
+    databaseBuilder.factory.buildSkill(skill3);
+    databaseBuilder.factory.buildSkill(skill4);
     databaseBuilder.factory.buildChallenge(challenge2);
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid3' }));
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid4' }));
+    databaseBuilder.factory.buildChallenge(challenge3);
+    databaseBuilder.factory.buildChallenge(challenge4);
 
     databaseBuilder.factory.buildLocalizedChallenge({
       id: 'challengeid2',
@@ -118,6 +123,23 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
       value: 'instruction for challengeid4',
     });
     await databaseBuilder.commit();
+
+    const airtableSkills = [
+      airtableBuilder.factory.buildSkill(skill2),
+      airtableBuilder.factory.buildSkill(skill3),
+      airtableBuilder.factory.buildSkill(skill4),
+    ];
+
+    const airtableChallenges = [
+      airtableBuilder.factory.buildChallenge(challenge2),
+      airtableBuilder.factory.buildChallenge(challenge3),
+      airtableBuilder.factory.buildChallenge(challenge4),
+    ];
+
+    airtableBuilder.mockLists({
+      skills: airtableSkills,
+      challenges: airtableChallenges,
+    });
   });
 
   afterEach(function () {
@@ -180,7 +202,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           attributes: {
             index: 0,
             instruction: 'instruction for challengeid2',
-            'skill-name': '@skillid2',
+            'skill-name': '@tube2',
             status: 'status for challengeid2',
             'preview-url': 'http://test.site/api/challenges/challengeid2/preview',
           },
@@ -191,7 +213,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           attributes: {
             index: 1,
             instruction: 'instruction for challengeid3',
-            'skill-name': '@skillid3',
+            'skill-name': '@tube3',
             status: 'status for challengeid3',
             'preview-url': 'http://test.site/api/challenges/challengeid3/preview',
           },
@@ -202,7 +224,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
           attributes: {
             index: 2,
             instruction: 'instruction for challengeid4',
-            'skill-name': '@skillid4',
+            'skill-name': '@tube4',
             status: 'status for challengeid4',
             'preview-url': 'http://test.site/api/challenges/challengeid4/preview',
           },

--- a/api/tests/acceptance/application/static-courses/put_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course_test.js
@@ -44,12 +44,58 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
     databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
     databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
     databaseBuilder.factory.buildTube({ id: 'tube1', name: '@tube', thematicId: 'thematic1' });
-    const challenge2 = domainBuilder.buildChallenge({ id: 'challengeid2' });
-    databaseBuilder.factory.buildSkill({ id: challenge2.skillId, tubeId: 'tube1' });
+    const challenge1 = domainBuilder.buildChallengeDatasourceObject({ id: 'challengeid1', skillId: 'skillid1' });
+    const challenge2 = domainBuilder.buildChallengeDatasourceObject({ id: 'challengeid2', skillId: 'skillid2' });
+    const challenge3 = domainBuilder.buildChallengeDatasourceObject({ id: 'challengeid3', skillId: 'skillid3' });
+    const challenge4 = domainBuilder.buildChallengeDatasourceObject({ id: 'challengeid4', skillId: 'skillid4' });
+    const skill1 = domainBuilder.buildSkillDatasourceObject({
+      id: challenge1.skillId,
+      tubeId: 'tube1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      competenceId: 'competence1',
+      challengeIds: ['challengeid1'],
+      level: 1,
+      name: '@tube1',
+    });
+    const skill2 = domainBuilder.buildSkillDatasourceObject({
+      id: challenge2.skillId,
+      tubeId: 'tube1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      competenceId: 'competence1',
+      challengeIds: ['challengeid2'],
+      level: 2,
+      name: '@tube2',
+    });
+    const skill3 = domainBuilder.buildSkillDatasourceObject({
+      id: challenge3.skillId,
+      tubeId: 'tube1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      competenceId: 'competence1',
+      challengeIds: ['challengeid3'],
+      level: 3,
+      name: '@tube3',
+    });
+    const skill4 = domainBuilder.buildSkillDatasourceObject({
+      id: challenge4.skillId,
+      tubeId: 'tube1',
+      tutorialIds: [],
+      learningMoreTutorialIds: [],
+      competenceId: 'competence1',
+      challengeIds: ['challengeid4'],
+      level: 4,
+      name: '@tube4',
+    });
+    databaseBuilder.factory.buildSkill(skill1);
+    databaseBuilder.factory.buildSkill(skill2);
+    databaseBuilder.factory.buildSkill(skill3);
+    databaseBuilder.factory.buildSkill(skill4);
+    databaseBuilder.factory.buildChallenge(challenge1);
     databaseBuilder.factory.buildChallenge(challenge2);
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid1' }));
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid3' }));
-    databaseBuilder.factory.buildChallenge(domainBuilder.buildChallenge({ id: 'challengeid4' }));
+    databaseBuilder.factory.buildChallenge(challenge3);
+    databaseBuilder.factory.buildChallenge(challenge4);
     databaseBuilder.factory.buildLocalizedChallenge({
       id: 'challengeid2',
       challengeId: 'challengeid2',
@@ -121,6 +167,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       staticCourseTagIds: [123, 456, 159],
       staticCourseId: activeCourseId,
     });
+
     await databaseBuilder.commit();
     const airtableChallenge1 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid1',
@@ -128,44 +175,28 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
       status: 'status for challengeid1',
       locales: ['fr'],
     });
-    const airtableSkill1 = airtableBuilder.factory.buildSkill({
-      id: 'skillid1',
-      name: '@skillid1',
-      hint_i18n: {},
-    });
+    const airtableSkill1 = airtableBuilder.factory.buildSkill(skill1);
     const airtableChallenge2 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid2',
       skillId: 'skillid2',
       status: 'status for challengeid2',
       locales: ['fr'],
     });
-    const airtableSkill2 = airtableBuilder.factory.buildSkill({
-      id: 'skillid2',
-      name: '@skillid2',
-      hint_i18n: {},
-    });
+    const airtableSkill2 = airtableBuilder.factory.buildSkill(skill2);
     const airtableChallenge3 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid3',
       skillId: 'skillid3',
       status: 'status for challengeid3',
       locales: ['fr'],
     });
-    const airtableSkill3 = airtableBuilder.factory.buildSkill({
-      id: 'skillid3',
-      name: '@skillid3',
-      hint_i18n: {},
-    });
+    const airtableSkill3 = airtableBuilder.factory.buildSkill(skill3);
     const airtableChallenge4 = airtableBuilder.factory.buildChallenge({
       id: 'challengeid4',
       skillId: 'skillid4',
       status: 'status for challengeid4',
       locales: ['fr'],
     });
-    const airtableSkill4 = airtableBuilder.factory.buildSkill({
-      id: 'skillid4',
-      name: '@skillid4',
-      hint_i18n: {},
-    });
+    const airtableSkill4 = airtableBuilder.factory.buildSkill(skill4);
     // TODO replace by nock to assert airtable query parameters
     airtableBuilder.mockLists({
       challenges: [airtableChallenge1, airtableChallenge2, airtableChallenge3, airtableChallenge4],
@@ -256,7 +287,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
           attributes: {
             index: 0,
             instruction: 'instruction for challengeid3',
-            'skill-name': '@skillid3',
+            'skill-name': '@tube3',
             status: 'status for challengeid3',
             'preview-url': 'http://host.site/api/challenges/challengeid3/preview',
           },
@@ -267,7 +298,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
           attributes: {
             index: 1,
             instruction: 'instruction for challengeid1',
-            'skill-name': '@skillid1',
+            'skill-name': '@tube1',
             status: 'status for challengeid1',
             'preview-url': 'http://host.site/api/challenges/challengeid1/preview',
           },
@@ -278,7 +309,7 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
           attributes: {
             index: 2,
             instruction: 'instruction for challengeidnl1',
-            'skill-name': '@skillid1',
+            'skill-name': '@tube1',
             status: 'status for challengeid1',
             'preview-url': 'http://host.site/api/challenges/challengeid1/preview?locale=nl',
           },

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -599,7 +599,10 @@ describe('Integration | Repository | skill-repository', () => {
       it('should return corresponding skills', async () => {
         const params = {
           filter: { name: '@NotFound' },
-          sort: [['name', 'asc']],
+          sort: [
+            ['name', 'asc'],
+            ['version', 'desc'],
+          ],
           page: { limit: 10 },
         };
         const findRecordsSpy = vi.spyOn(airtable, 'findRecords').mockResolvedValueOnce([]);
@@ -612,7 +615,10 @@ describe('Integration | Repository | skill-repository', () => {
         expect(findRecordsSpy).toHaveBeenCalledWith(skillDatasource.tableName, {
           filterByFormula: 'FIND("@notfound", LOWER(Nom))',
           fields: skillDatasource.usedFields,
-          sort: [{ field: 'Nom', direction: 'asc' }],
+          sort: [
+            { field: 'Nom', direction: 'asc' },
+            { field: 'Version', direction: 'desc' },
+          ],
           maxRecords: 10,
         });
       });

--- a/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/static-course-repository_test.js
@@ -5,10 +5,10 @@ import {
   get,
   getRead,
 } from '../../../../lib/infrastructure/repositories/static-course-repository.js';
-import { skillDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import {
   challengeRepository,
   localizedChallengeRepository,
+  skillRepository,
 } from '../../../../lib/infrastructure/repositories/index.js';
 
 describe('Integration | Repository | static-course-repository', function () {
@@ -449,10 +449,12 @@ describe('Integration | Repository | static-course-repository', function () {
         .spyOn(localizedChallengeRepository, 'getMany')
         .mockResolvedValue(localizedChallenges);
       const stubFilterChallengeRepository = vi.spyOn(challengeRepository, 'filter').mockResolvedValue(challenges);
-      const stubFilterSkillDatasource = vi.spyOn(skillDatasource, 'filter').mockResolvedValue([
-        { id: 'skillA', name: '@skillA' },
-        { id: 'skillB', name: '@skillB' },
-      ]);
+      const stubFilterSkillRepository = vi
+        .spyOn(skillRepository, 'getMany')
+        .mockResolvedValue([
+          domainBuilder.buildSkill({ id: 'skillA', name: '@skillA' }),
+          domainBuilder.buildSkill({ id: 'skillB', name: '@skillB' }),
+        ]);
       await databaseBuilder.commit();
 
       //when
@@ -497,7 +499,7 @@ describe('Integration | Repository | static-course-repository', function () {
         }),
       );
       expect(stubFilterChallengeRepository).toHaveBeenCalledWith({ filter: { ids: ['challengeA', 'challengeB'] } });
-      expect(stubFilterSkillDatasource).toHaveBeenCalledWith({ filter: { ids: ['skillA', 'skillB'] } });
+      expect(stubFilterSkillRepository).toHaveBeenCalledWith(['skillA', 'skillB']);
       expect(stubLocalizedChallengeRepository).toHaveBeenCalledWith({ ids: ['challengeA', 'challengeB'] });
     });
   });

--- a/api/tests/unit/domain/usecases/update-challenge_test.js
+++ b/api/tests/unit/domain/usecases/update-challenge_test.js
@@ -2,17 +2,16 @@ import { describe, it, vi, expect, beforeEach } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 
 import { updateChallenge } from '../../../../lib/domain/usecases/update-challenge.js';
-import { challengeRepository } from '../../../../lib/infrastructure/repositories/index.js';
+import { attachmentRepository, challengeRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import * as updatedRecordNotifier from '../../../../lib/infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../../../lib/infrastructure/pix-api-client.js';
-import { attachmentDatasource } from '../../../../lib/infrastructure/datasources/airtable/index.js';
 import _ from 'lodash';
 
 describe('Unit | Domain | Usecases | update challenge', function () {
   beforeEach(() => {
     vi.spyOn(challengeRepository, 'update');
     vi.spyOn(updatedRecordNotifier, 'notify');
-    vi.spyOn(attachmentDatasource, 'filterByLocalizedChallengeId');
+    vi.spyOn(attachmentRepository, 'listByLocalizedChallengeId');
   });
 
   describe('when challenge id is unknown', () => {
@@ -49,7 +48,7 @@ describe('Unit | Domain | Usecases | update challenge', function () {
       updatedAt: '2025-10-04',
     });
 
-    attachmentDatasource.filterByLocalizedChallengeId.mockResolvedValueOnce([]);
+    attachmentRepository.listByLocalizedChallengeId.mockResolvedValueOnce([]);
     challengeRepository.update.mockResolvedValueOnce(updatedChallenge);
     updatedRecordNotifier.notify.mockResolvedValueOnce();
 
@@ -75,12 +74,12 @@ describe('Unit | Domain | Usecases | update challenge', function () {
     const expectedChallengeFOrRelease = _.omit(challengeUpdates, fieldToOmitForChallengeRelease);
 
     // when
-    const result = await updateChallenge(challengeUpdates, { challengeRepository, attachmentDatasource });
+    const result = await updateChallenge(challengeUpdates, { challengeRepository, attachmentRepository });
 
     // then
     expect(result).toBe(updatedChallenge);
     expect(challengeRepository.update).toHaveBeenCalledWith(challengeUpdates);
-    expect(attachmentDatasource.filterByLocalizedChallengeId).toHaveBeenCalledWith('updatedChallengeId');
+    expect(attachmentRepository.listByLocalizedChallengeId).toHaveBeenCalledWith('updatedChallengeId');
     expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
       model: 'challenges',
       pixApiClient,
@@ -105,11 +104,11 @@ describe('Unit | Domain | Usecases | update challenge', function () {
         alternativeInstruction: 'Et donc ; voilà',
       });
 
-      attachmentDatasource.filterByLocalizedChallengeId.mockResolvedValueOnce([]);
+      attachmentRepository.listByLocalizedChallengeId.mockResolvedValueOnce([]);
       challengeRepository.update.mockResolvedValueOnce(challenge);
       updatedRecordNotifier.notify.mockResolvedValueOnce();
 
-      await updateChallenge(challenge, { challengeRepository, attachmentDatasource });
+      await updateChallenge(challenge, { challengeRepository, attachmentRepository });
 
       expect(challengeRepository.update).toHaveBeenCalledOnce();
       expect(challengeRepository.update).toHaveBeenCalledWith({
@@ -157,17 +156,17 @@ describe('Unit | Domain | Usecases | update challenge', function () {
       ];
       const expectedChallengeFOrRelease = _.omit(challengeUpdates, fieldToOmitForChallengeRelease);
 
-      attachmentDatasource.filterByLocalizedChallengeId.mockResolvedValueOnce([]);
+      attachmentRepository.listByLocalizedChallengeId.mockResolvedValueOnce([]);
       challengeRepository.update.mockResolvedValueOnce(updatedChallenge);
       updatedRecordNotifier.notify.mockRejectedValueOnce(new Error());
 
       // when
-      const result = await updateChallenge(challengeUpdates, { challengeRepository, attachmentDatasource });
+      const result = await updateChallenge(challengeUpdates, { challengeRepository, attachmentRepository });
 
       // then
       expect(result).toBe(updatedChallenge);
       expect(challengeRepository.update).toHaveBeenCalledWith(challengeUpdates);
-      expect(attachmentDatasource.filterByLocalizedChallengeId).toHaveBeenCalledWith('updatedChallengeId');
+      expect(attachmentRepository.listByLocalizedChallengeId).toHaveBeenCalledWith('updatedChallengeId');
       expect(updatedRecordNotifier.notify).toHaveBeenCalledWith({
         model: 'challenges',
         pixApiClient,

--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -6,11 +6,7 @@ export default defineConfig({
     reporters: process.env.CI ? 'junit' : 'dot',
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     restoreMocks: true,
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    maxWorkers: 1,
     setupFiles: ['tests/setup-tests.js'],
   },
 });

--- a/pix-editor/app/components/sidebar/search.gjs
+++ b/pix-editor/app/components/sidebar/search.gjs
@@ -44,7 +44,7 @@ export default class SidebarSearch extends Component {
         name: skillName,
       },
       page: { limit: 20 },
-      sort: 'name',
+      sort: 'name,-version',
     });
     return skills.map((skill) => ({
       isSkill: true,

--- a/pix-editor/tests/unit/component/sidebar/search-test.js
+++ b/pix-editor/tests/unit/component/sidebar/search-test.js
@@ -28,7 +28,7 @@ module('Unit | Component | sidebar/search', function(hooks) {
           name: '\\\'"\t coucou \\\'"\t',
         },
         page: { limit: 20 },
-        sort: 'name',
+        sort: 'name,-version',
       }));
     });
   });


### PR DESCRIPTION
## 🍂 Problème

Il y a des appels à des datasources Airtable en dehors des repositories.

## 🌰 Proposition

Remplacer ces appels par des appels aux repositories.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Tests au vert.