### PR TITLE
[BUGFIX] Éviter d’envoyer null dans les booléens txStatus

### DIFF
--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -167,9 +167,9 @@ export default class ChallengeForm extends Component {
       this.args.challenge.autoReply = true;
       this.args.challenge.format = 'mots';
       this.args.challenge.proposals = null;
-      this.args.challenge.t1Status = null;
-      this.args.challenge.t2Status = null;
-      this.args.challenge.t3Status = null;
+      this.args.challenge.t1Status = false;
+      this.args.challenge.t2Status = false;
+      this.args.challenge.t3Status = false;
     }
 
     if (['QCU', 'QCM'].includes(value)) {


### PR DESCRIPTION
## 🍂 Problème

Quand on créé une épreuve avec modalité embed-auto, cela provoque une erreur 500.
C’est la valeur null mise dans les booléens txStatus.

## 🌰 Proposition

Mettre false dans les booléens.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Créer une épreuve avec modalité embed-auto.