### PR TITLE
[REVERT] Config vitest

### DIFF
--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -6,7 +6,11 @@ export default defineConfig({
     reporters: process.env.CI ? 'junit' : 'dot',
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     restoreMocks: true,
-    maxWorkers: 1,
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
     setupFiles: ['tests/setup-tests.js'],
   },
 });


### PR DESCRIPTION
## 🍂 Problème

La config vitest doit revenir en arrière pour être compatible avec vitest v3.

## 🌰 Proposition

Remettre la config d’avant.

## 🍁 Remarques

N/A

## 🪵 Pour tester

N/A
