### PR TITLE
[TECH] Bump to vitest 4

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -3,7 +3,7 @@
 import { createServer } from './server.js';
 import { logger } from './lib/infrastructure/logger.js';
 import { queue as checkUrlQueue } from './lib/infrastructure/scheduled-jobs/check-urls-job.js';
-import * as releaseJob from './lib/infrastructure/scheduled-jobs/release-job.js';
+import { scheduleReleaseJobQueue } from './lib/infrastructure/scheduled-jobs/release-job.js';
 import * as exportExternalUrlListJob from './lib/infrastructure/scheduled-jobs/export-external-url-list-job.js';
 import * as cleanReleasesJob from './lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js';
 import { disconnect } from './db/knex-database-connection.js';
@@ -11,12 +11,14 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 
 validateEnvironmentVariables();
 
+let releaseJobQueue;
+
 async function start() {
   try {
     const server = await createServer();
     await server.start();
 
-    releaseJob.schedule();
+    releaseJobQueue = scheduleReleaseJobQueue();
     exportExternalUrlListJob.schedule();
     cleanReleasesJob.schedule();
 
@@ -32,7 +34,7 @@ async function exitOnSignal(signal) {
   try {
     await disconnect();
     await checkUrlQueue.close();
-    await releaseJob.queue.close();
+    await releaseJobQueue?.close();
     await cleanReleasesJob.queue.close();
     process.exit(0);
   } catch (err) {

--- a/api/lib/application/releases.js
+++ b/api/lib/application/releases.js
@@ -1,10 +1,10 @@
 import Boom from '@hapi/boom';
 import Joi from 'joi';
 import { releaseRepository } from '../infrastructure/repositories/index.js';
-import { queue as createReleaseQueue } from '../infrastructure/scheduled-jobs/release-job.js';
 import { promiseStreamer } from '../infrastructure/utils/promise-streamer.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
 import { SCOPES } from '../infrastructure/logger.js';
+import { createReleaseJobQueue } from '../infrastructure/scheduled-jobs/release-job.js';
 
 const releaseIdType = Joi.number().greater(-2147483648).less(2147483647).required();
 
@@ -32,7 +32,8 @@ export async function register(server) {
           },
         ],
         handler: async function () {
-          const job = await createReleaseQueue.add({ slackNotification: true });
+          const releaseJobQueue = createReleaseJobQueue();
+          const job = await releaseJobQueue.add({ slackNotification: true });
           const promise = async () => {
             const releaseId = await job.finished();
             return releaseRepository.getRelease(releaseId);
@@ -40,6 +41,7 @@ export async function register(server) {
           return promiseStreamer({
             promise: promise(),
             loggingScope: SCOPES.RELEASE,
+            onFinish: () => releaseJobQueue.close(),
           });
         },
       },

--- a/api/lib/infrastructure/scheduled-jobs/release-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job.js
@@ -4,16 +4,19 @@ import { logger } from '../logger.js';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
-export const queue = createQueue('create-release-queue');
 const cjsFile = __dirname + '/release-job-processor.cjs';
 const esmFile = __dirname + '/release-job-processor.js';
-if (process.env.NODE_ENV === 'test') {
-  import(esmFile).then((module) => {
-    queue.process(module.default);
-  });
-} else {
-  queue.process(cjsFile);
+
+export function createReleaseJobQueue() {
+  const queue = createQueue('create-release-queue');
+  if (process.env.NODE_ENV === 'test') {
+    import(esmFile).then((module) => {
+      queue.process(module.default);
+    });
+  } else {
+    queue.process(cjsFile);
+  }
+  return queue;
 }
 
 const releaseJobOptions = {
@@ -27,14 +30,15 @@ const releaseJobOptions = {
   },
 };
 
-export function schedule() {
-  if (!_isScheduledReleaseEnabled()) {
+export function scheduleReleaseJobQueue() {
+  const isScheduledReleaseEnabled = config.scheduledJobs.createReleaseTime && config.scheduledJobs.redisUrl;
+
+  if (!isScheduledReleaseEnabled) {
     logger.info('Scheduled release is not enabled - check `CREATE_RELEASE_TIME` and `REDIS_URL` variables');
     return;
   }
-  queue.add({}, releaseJobOptions);
-}
 
-function _isScheduledReleaseEnabled() {
-  return config.scheduledJobs.createReleaseTime && config.scheduledJobs.redisUrl;
+  const queue = createReleaseJobQueue();
+  queue.add({}, releaseJobOptions);
+  return queue;
 }

--- a/api/lib/infrastructure/utils/promise-streamer.js
+++ b/api/lib/infrastructure/utils/promise-streamer.js
@@ -19,7 +19,7 @@ function getWritableStream() {
   return writableStream;
 }
 
-export function promiseStreamer({ promise, writableStream = getWritableStream(), loggingScope }) {
+export function promiseStreamer({ promise, writableStream = getWritableStream(), loggingScope, onFinish }) {
   let logger = genericLogger;
   if (loggingScope) {
     logger = child('promisestream', { event: loggingScope });
@@ -29,9 +29,11 @@ export function promiseStreamer({ promise, writableStream = getWritableStream(),
   }, 1000);
   writableStream.on('error', (err) => {
     logger.error(`WritableStream error: ${err}`);
+    onFinish?.();
   });
   writableStream.on('finish', () => {
     logger.info('WritableStream close');
+    onFinish?.();
   });
   writableStream.on('pipe', () => {
     logger.info('WritableStream pipe');

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -63,7 +63,7 @@
         "parse-multipart-data": "^1.5.0",
         "prettier": "3.6.2",
         "split2": "^4.1.0",
-        "vitest": "^3.0.0",
+        "vitest": "^4.0.7",
         "yargs": "^18.0.0"
       },
       "engines": {
@@ -2357,6 +2357,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
@@ -2372,6 +2389,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
@@ -2385,6 +2419,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -3184,9 +3235,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -3509,180 +3560,286 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
-      "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
-      "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
-      "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
-      "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
-      "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
-      "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
-      "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
-      "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
       "cpu": [
-        "ppc64le"
+        "loong64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
-      "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
-      "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
-      "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
-      "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
-      "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
-      "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
-      "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4290,13 +4447,14 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/debug": {
@@ -4315,9 +4473,10 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.5",
@@ -4334,11 +4493,12 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
-      "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -4384,80 +4544,44 @@
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.1.tgz",
-      "integrity": "sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.7.tgz",
+      "integrity": "sha512-jGRG6HghnJDjljdjYIoVzX17S6uCVCBRFnsgdLGJ6CaxfPh8kzUKe/2n533y4O/aeZ/sIr7q7GbuEbeGDsWv4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.1",
-        "@vitest/utils": "3.2.1",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.0.7",
+        "@vitest/utils": "4.0.7",
+        "chai": "^6.0.1",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.1.tgz",
-      "integrity": "sha512-OXxMJnx1lkB+Vl65Re5BrsZEHc90s5NMjD23ZQ9NlU7f7nZiETGoX4NeKZSmsKjseuMq2uOYXdLOeoM0pJU+qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "3.2.1",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.1.tgz",
-      "integrity": "sha512-xBh1X2GPlOGBupp6E1RcUQWIxw0w/hRLd3XyBS6H+dMdKTAqHDNsIR2AnJwPA3yYe9DFy3VUKTe3VRTrAiQ01g==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.7.tgz",
+      "integrity": "sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.1.tgz",
-      "integrity": "sha512-kygXhNTu/wkMYbwYpS3z/9tBe0O8qpdBuC3dD/AW9sWa0LE/DAZEjnHtWA9sIad7lpD4nFW1yQ+zN7mEKNH3yA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.7.tgz",
+      "integrity": "sha512-orU1lsu4PxLEcDWfjVCNGIedOSF/YtZ+XMrd1PZb90E68khWCNzD8y1dtxtgd0hyBIQk8XggteKN/38VQLvzuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.1",
+        "@vitest/utils": "4.0.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4465,14 +4589,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.1.tgz",
-      "integrity": "sha512-5xko/ZpW2Yc65NVK9Gpfg2y4BFvcF+At7yRT5AHUpTg9JvZ4xZoyuRY4ASlmNcBZjMslV08VRLDrBOmUe2YX3g==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.7.tgz",
+      "integrity": "sha512-xJL+Nkw0OjaUXXQf13B8iKK5pI9QVtN9uOtzNHYuG/o/B7fIEg0DQ+xOe0/RcqwDEI15rud1k7y5xznBKGUXAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.0.7",
+        "magic-string": "^0.30.19",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4480,28 +4604,24 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.1.tgz",
-      "integrity": "sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.7.tgz",
+      "integrity": "sha512-FW4X8hzIEn4z+HublB4hBF/FhCVaXfIHm8sUfvlznrcy1MQG7VooBgZPMtVCGZtHi0yl3KESaXTqsKh16d8cFg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.1.tgz",
-      "integrity": "sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.7.tgz",
+      "integrity": "sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.1",
-        "loupe": "^3.1.3",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.0.7",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5156,15 +5276,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -5271,20 +5382,13 @@
       ]
     },
     "node_modules/chai": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.0.tgz",
+      "integrity": "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5298,16 +5402,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5698,16 +5792,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -6346,9 +6430,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
-      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -8027,13 +8111,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8051,12 +8128,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -8228,9 +8305,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -8238,6 +8315,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -9039,16 +9117,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pg": {
       "version": "8.11.5",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
@@ -9161,9 +9229,10 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9344,9 +9413,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -9362,10 +9431,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -10255,11 +10325,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10269,21 +10340,28 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
         "fsevents": "~2.3.2"
       }
     },
@@ -10690,10 +10768,11 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10832,6 +10911,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -11010,14 +11090,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11027,11 +11107,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -11042,9 +11125,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11059,30 +11142,10 @@
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.3.tgz",
       "integrity": "sha512-3fCHKAeqT+xNwBVESf6iDbDV0VNwZNmfrkx9c/6Gz5iB8piMfaO6s7FvoiTrj1hf1gVbfyLTnz1DooI6DhgINQ=="
     },
-    "node_modules/tinypool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
-      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11224,9 +11287,10 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -11382,551 +11446,39 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/vite": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
-      "integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
-      "dev": true,
-      "dependencies": {
-        "esbuild": "^0.20.1",
-        "postcss": "^8.4.38",
-        "rollup": "^4.13.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-node": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
-      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-node/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-node/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.1.tgz",
-      "integrity": "sha512-VZ40MBnlE1/V5uTgdqY3DmjUgZtIzsYq758JGlyQrv5syIsaYcabkfPkEuWML49Ph0D/SoqpVFd0dyVTr551oA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.7.tgz",
+      "integrity": "sha512-xQroKAadK503CrmbzCISvQUjeuvEZzv6U0wlnlVFOi5i3gnzfH4onyQ29f3lzpe0FresAiTAd3aqK0Bi/jLI8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.1",
-        "@vitest/mocker": "3.2.1",
-        "@vitest/pretty-format": "^3.2.1",
-        "@vitest/runner": "3.2.1",
-        "@vitest/snapshot": "3.2.1",
-        "@vitest/spy": "3.2.1",
-        "@vitest/utils": "3.2.1",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.0.7",
+        "@vitest/mocker": "4.0.7",
+        "@vitest/pretty-format": "4.0.7",
+        "@vitest/runner": "4.0.7",
+        "@vitest/snapshot": "4.0.7",
+        "@vitest/spy": "4.0.7",
+        "@vitest/utils": "4.0.7",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.19",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
+        "picomatch": "^4.0.3",
         "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.0",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.1",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -11934,9 +11486,11 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.1",
-        "@vitest/ui": "3.2.1",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.7",
+        "@vitest/browser-preview": "4.0.7",
+        "@vitest/browser-webdriverio": "4.0.7",
+        "@vitest/ui": "4.0.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -11950,7 +11504,13 @@
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
           "optional": true
         },
         "@vitest/ui": {
@@ -11964,10 +11524,428 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.7.tgz",
+      "integrity": "sha512-OsDwLS7WnpuNslOV6bJkXVYVV/6RSc4eeVxV7h9wxQPNxnjRvTTrIikfwCbMyl8XJmW6oOccBj2Q07YwZtQcCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.19"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11982,6 +11960,76 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11990,9 +12038,9 @@
       "license": "MIT"
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12000,6 +12048,96 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/void-elements": {

--- a/api/package.json
+++ b/api/package.json
@@ -98,7 +98,7 @@
     "parse-multipart-data": "^1.5.0",
     "prettier": "3.6.2",
     "split2": "^4.1.0",
-    "vitest": "^3.0.0",
+    "vitest": "^4.0.7",
     "yargs": "^18.0.0"
   }
 }

--- a/api/tests/acceptance/application/areas_test.js
+++ b/api/tests/acceptance/application/areas_test.js
@@ -240,10 +240,6 @@ describe('Acceptance | Route | areas', () => {
   });
 
   describe('POST /areas', () => {
-    afterEach(async () => {
-      await knex.delete().from('areas');
-    });
-
     describe('when user is NOT admin', () => {
       it('should respond with status 403', async () => {
         // given

--- a/api/tests/acceptance/application/attachments_test.js
+++ b/api/tests/acceptance/application/attachments_test.js
@@ -56,10 +56,6 @@ describe('Acceptance | Route | attachments', () => {
       };
     });
 
-    afterEach(async function () {
-      await knex('attachments').delete();
-    });
-
     context('when user is NOT editor', () => {
       it('should respond with status 403', async () => {
         // given

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
 import _ from 'lodash';
 import {
@@ -1385,12 +1385,6 @@ describe('Acceptance | Controller | challenges-controller', () => {
     beforeEach(async function () {
       user = databaseBuilder.factory.buildAdminUser();
       await databaseBuilder.commit();
-    });
-
-    afterEach(async function () {
-      await knex('translations').delete();
-      await knex('localized_challenges').delete();
-      await knex('challenges').delete();
     });
 
     it('should create a challenge', async () => {

--- a/api/tests/acceptance/application/competences/competences_test.js
+++ b/api/tests/acceptance/application/competences/competences_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
 import {
   airtableBuilder,
@@ -775,14 +775,6 @@ describe('Acceptance | Route | competences', () => {
         .reply(200);
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await knex('skills').delete();
-      await knex('tubes').delete();
-      await knex('thematics').delete();
-      await knex('competences').delete();
-      await knex('translations').delete();
     });
 
     describe('when payload is NOT valid', () => {

--- a/api/tests/acceptance/application/mission/get_mission_test.js
+++ b/api/tests/acceptance/application/mission/get_mission_test.js
@@ -1,14 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { Mission } from '../../../../lib/domain/models/index.js';
 
 describe('Acceptance | API | mission | GET /api/missions', function () {
-  afterEach(async function () {
-    await knex('missions').delete();
-    await knex('translations').delete();
-  });
-
   it('Should return an object of serialized missions', async function () {
     //given
     const user = databaseBuilder.factory.buildAdminUser();

--- a/api/tests/acceptance/application/mission/post_mission_test.js
+++ b/api/tests/acceptance/application/mission/post_mission_test.js
@@ -1,15 +1,10 @@
 import _ from 'lodash';
-import { afterEach, describe, describe as context, expect, it } from 'vitest';
+import { describe, describe as context, expect, it } from 'vitest';
 import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { Mission } from '../../../../lib/domain/models/index.js';
 
 describe('Acceptance | API | mission | POST /api/missions', function () {
-  afterEach(async function () {
-    await knex('missions').delete();
-    await knex('translations').delete();
-  });
-
   context('when user has rights to create a mission', function () {
     it('creates the mission and returns its id', async function () {
       // given

--- a/api/tests/acceptance/application/mission/put_mission_test.js
+++ b/api/tests/acceptance/application/mission/put_mission_test.js
@@ -1,15 +1,10 @@
 import _ from 'lodash';
-import { afterEach, describe, describe as context, expect, it } from 'vitest';
+import { describe, describe as context, expect, it } from 'vitest';
 import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { Mission } from '../../../../lib/domain/models/index.js';
 
 describe('Acceptance | API | mission | PATCH /api/missions/{id}', function () {
-  afterEach(async function () {
-    await knex('missions').delete();
-    await knex('translations').delete();
-  });
-
   context('when user has rights to update a mission', function () {
     it('updates the mission and returns its id', async function () {
       // given

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseString as parseCSVString } from 'fast-csv';
 import _ from 'lodash';
 import { Buffer } from 'node:buffer';
@@ -435,11 +435,6 @@ describe('Acceptance | Controller | phrase-controller', () => {
         { projectId: 'MY_AREA_1_PROJECT_ID', areaCode: 1, frameworkName: 'Pix' },
         { projectId: 'MY_AREA_2_PROJECT_ID', areaCode: 2, frameworkName: 'Pix' },
       ]);
-    });
-
-    afterEach(async () => {
-      await knex.delete().from('translations');
-      await knex.delete().from('localized_challenges');
     });
 
     it('should download the translations from phrase', async () => {

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
+import { beforeEach, describe, describe as context, expect, it, vi, afterEach } from 'vitest';
 import nock from 'nock';
 import {
   airtableBuilder,
@@ -1137,8 +1137,8 @@ describe('Acceptance | Controller | release-controller', () => {
       vi.spyOn(axios, 'post').mockResolvedValue();
     });
 
-    afterEach(function () {
-      return knex('releases').delete();
+    afterEach(async function () {
+      await knex('releases').delete();
     });
 
     context('nominal case', () => {

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
 import _ from 'lodash';
 
@@ -1307,12 +1307,6 @@ describe('Application | Route | Skills', () => {
         .reply(200);
     });
 
-    afterEach(async () => {
-      await knex('skills-tutorials').delete();
-      await knex('skills').delete();
-      await knex('translations').delete();
-    });
-
     it('should respond with status 201 and created skill', async () => {
       // given
       const server = await createServer();
@@ -2229,15 +2223,6 @@ describe('Application | Route | Skills', () => {
       vi.spyOn(idGenerator, 'generateNewId')
         .mockReturnValueOnce('clonedAcquisId')
         .mockReturnValueOnce('clonedChallengeId');
-    });
-
-    afterEach(async () => {
-      await knex('skills-tutorials').delete();
-      await knex('attachments').delete();
-      await knex('localized_challenges').delete();
-      await knex('challenges').delete();
-      await knex('skills').delete();
-      await knex('translations').delete();
     });
 
     it('should respond with status 302 with cloned skill redirection', async () => {

--- a/api/tests/acceptance/application/static-courses/post_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/post_static-course_test.js
@@ -190,8 +190,6 @@ describe('Acceptance | API | static courses | POST /api/static-courses', functio
 
   afterEach(async function () {
     vi.useRealTimers();
-    await knex('static_courses_tags_link').delete();
-    return knex('static_courses').delete();
   });
 
   it('creates and returns the static course', async function () {

--- a/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-deactivate_test.js
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  airtableBuilder,
-  databaseBuilder,
-  domainBuilder,
-  generateAuthorizationHeader,
-  knex,
-} from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deactivate', function () {
@@ -142,7 +136,6 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
 
   afterEach(function () {
     vi.useRealTimers();
-    return knex('static_courses').delete();
   });
 
   it('deactivates and returns the static course', async function () {

--- a/api/tests/acceptance/application/static-courses/put_static-course-reactivate_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course-reactivate_test.js
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  airtableBuilder,
-  databaseBuilder,
-  domainBuilder,
-  generateAuthorizationHeader,
-  knex,
-} from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deactivate', function () {
@@ -150,7 +144,6 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}/deact
 
   afterEach(function () {
     vi.useRealTimers();
-    return knex('static_courses').delete();
   });
 
   it('deactivates and returns the static course', async function () {

--- a/api/tests/acceptance/application/static-courses/put_static-course_test.js
+++ b/api/tests/acceptance/application/static-courses/put_static-course_test.js
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  airtableBuilder,
-  databaseBuilder,
-  domainBuilder,
-  generateAuthorizationHeader,
-  knex,
-} from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { LocalizedChallenge } from '../../../../lib/domain/models/index.js';
 
@@ -202,8 +196,6 @@ describe('Acceptance | API | static courses | PUT /api/static-courses/{id}', fun
 
   afterEach(async function () {
     vi.useRealTimers();
-    await knex('static_courses_tags_link').delete();
-    return knex('static_courses').delete();
   });
 
   it('updates and returns the static course', async function () {

--- a/api/tests/acceptance/application/thematics_test.js
+++ b/api/tests/acceptance/application/thematics_test.js
@@ -650,11 +650,6 @@ describe('Application | Route | Thematics', () => {
         vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce('thematic3');
       });
 
-      afterEach(async () => {
-        await knex('thematics').delete();
-        await knex('translations').delete();
-      });
-
       it('should respond with status 201 and created thematic', async () => {
         // given
         const server = await createServer();

--- a/api/tests/acceptance/application/translations_test.js
+++ b/api/tests/acceptance/application/translations_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import FormData from 'form-data';
 import { parseString as parseCSVString } from 'fast-csv';
 import _ from 'lodash';
@@ -628,10 +628,6 @@ describe('Acceptance | Controller | translations-controller', () => {
     });
   });
   describe('PATCH /translations.csv - import translations from a CSV file', () => {
-    afterEach(async () => {
-      await knex('translations').delete();
-    });
-
     it('should update the translations', async () => {
       // Given
       const user = databaseBuilder.factory.buildAdminUser();

--- a/api/tests/acceptance/application/tubes_test.js
+++ b/api/tests/acceptance/application/tubes_test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, describe as context, expect, it, afterEach, vi } from 'vitest';
+import { beforeEach, describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
 
 import {
@@ -720,11 +720,6 @@ describe('Application | Route | Tubes', () => {
           .reply(200, { records: [createdAirtableTube] });
 
         vi.spyOn(idGenerator, 'generateNewId').mockReturnValueOnce('tube3');
-      });
-
-      afterEach(async () => {
-        await knex('tubes').delete();
-        await knex('translations').delete();
       });
 
       it('should respond with status 201 and created thematic', async () => {

--- a/api/tests/acceptance/application/tutorials_test.js
+++ b/api/tests/acceptance/application/tutorials_test.js
@@ -26,11 +26,6 @@ describe('Application | Route | Tutorials', () => {
   describe('POST /api/tutorials', async () => {
     let airtableCreateTutorialScope;
 
-    afterEach(async () => {
-      await knex.delete().from('tutorials-tutorial_tags');
-      await knex.delete().from('tutorials');
-    });
-
     context('when user has not the right to do the operation', function () {
       it('should respond with status 403', async function () {
         // given

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -15,7 +15,6 @@ describe('Acceptance | Controller | whitelisted-urls', () => {
 
   afterEach(function () {
     vi.useRealTimers();
-    return knex('whitelisted_urls').del();
   });
 
   describe('GET /whitelisted-urls', () => {

--- a/api/tests/integration/domain/usecases/create-mission_test.js
+++ b/api/tests/integration/domain/usecases/create-mission_test.js
@@ -1,16 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { InvalidMissionContentError } from '../../../../lib/domain/errors.js';
 import { createMission } from '../../../../lib/domain/usecases/index.js';
-import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { airtableBuilder, databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import { Mission, Skill } from '../../../../lib/domain/models/index.js';
 import _ from 'lodash';
 
 describe('Integration | Usecases | create mission', function () {
-  afterEach(async function () {
-    await knex('missions').delete();
-    await knex('translations').delete();
-  });
-
   it('when mission is totally valid, should create mission without warnings', async () => {
     // given
     const mission = domainBuilder.buildMission({ status: Mission.status.EXPERIMENTAL });

--- a/api/tests/integration/infrastructure/airtable_test.js
+++ b/api/tests/integration/infrastructure/airtable_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import airtable from 'airtable';
 import { airtableBuilder } from '../../test-helper.js';
 import { findRecords } from '../../../lib/infrastructure/airtable.js';
@@ -12,10 +12,6 @@ function assertAirtableRecordToEqualExpectedJson(actualRecord, expectedRecordJso
 }
 
 describe('Integration | Infrastructure | airtable', () => {
-  afterEach(() => {
-    airtableBuilder.cleanAll();
-  });
-
   describe('#findRecords', () => {
     const tableName = 'Tests';
     const airtableRecordsJson = [

--- a/api/tests/integration/infrastructure/repositories/area-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/area-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
@@ -12,10 +12,6 @@ const AIRTABLE_NAME = 'Domaines';
 
 describe('Integration | Infrastructure | Repository | area-repository', () => {
   describe('#create', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('inserts area in airtable and postgres w/ its translations', async () => {
       // given
       const airtableId = 'rec123Abc';

--- a/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/attachment-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, describe as context, expect, it, vi, beforeEach } from 'vitest';
+import { describe, describe as context, expect, it, vi, beforeEach } from 'vitest';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as attachmentRepository from '../../../../lib/infrastructure/repositories/attachment-repository.js';
 import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
@@ -325,10 +325,6 @@ describe('Integration | Repository | attachment-repository', () => {
   });
 
   describe('#createBatch', () => {
-    afterEach(async () => {
-      await knex('attachments').delete();
-    });
-
     it('should create several attachments in airtable and the links to the localized challenge', async () => {
       // given
       const attachmentA = domainBuilder.buildAttachment({
@@ -496,10 +492,6 @@ describe('Integration | Repository | attachment-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(async () => {
-      await knex('attachments').delete();
-    });
-
     it('should create an attachment in airtable with relationship to airtable challenge and create the link to the localized challenge', async () => {
       // given
       const attachment = domainBuilder.buildAttachment({

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as airtableClient from '../../../../lib/infrastructure/airtable.js';
 import * as airtable from '../../../../lib/infrastructure/airtable.js';
@@ -2610,12 +2610,6 @@ describe('Integration | Repository | challenge-repository', () => {
   });
 
   describe('#createBatch', () => {
-    afterEach(async () => {
-      await knex('localized_challenges').delete();
-      await knex('challenges').delete();
-      await knex('translations').delete();
-    });
-
     it('should create several challenges in airtable and its localized challenges and translations in PG', async () => {
       // given
       const primaryLocalizedChallenge_challengeA = domainBuilder.buildLocalizedChallenge({
@@ -3213,11 +3207,6 @@ describe('Integration | Repository | challenge-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(async () => {
-      await knex.delete().from('localized_challenges');
-      await knex.delete().from('challenges');
-    });
-
     it('should create a challenge, its localized challenge primary and its translated attributes', async function () {
       // given
       const challengeToCreate_data = {

--- a/api/tests/integration/infrastructure/repositories/competence-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper';
@@ -457,10 +457,6 @@ describe('Integration | Repository | competence-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('inserts competence in airtable and postgres w/ its translations', async () => {
       // given
       const airtableId = 'rec123Abc';

--- a/api/tests/integration/infrastructure/repositories/framework-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/framework-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { create, list } from '../../../../lib/infrastructure/repositories/framework-repository.js';
@@ -12,10 +12,6 @@ const AIRTABLE_NAME = 'Referentiel';
 
 describe('Integration | Infrastructure | Repositories | Framework', () => {
   describe('#create', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('inserts framework in Airtable and Postgres', async () => {
       // given
       const id = 'rec123Abc456Def';

--- a/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-challenge-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe as context, describe, expect, it } from 'vitest';
+import { beforeEach, describe as context, describe, expect, it } from 'vitest';
 import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import { localizedChallengeRepository } from '../../../../lib/infrastructure/repositories/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
@@ -155,10 +155,6 @@ describe('Integration | Repository | localized-challenge-repository', function (
   });
 
   context('#create', function () {
-    afterEach(async () => {
-      await knex('localized_challenges').delete();
-    });
-
     it('should create a localized challenge', async function () {
       // when
       await localizedChallengeRepository.create({

--- a/api/tests/integration/infrastructure/repositories/mission-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/mission-repository_test.js
@@ -1,5 +1,5 @@
 import { omit } from 'lodash';
-import { afterEach, describe, describe as context, expect, expectTypeOf, it } from 'vitest';
+import { describe, describe as context, expect, expectTypeOf, it } from 'vitest';
 import { databaseBuilder, knex } from '../../../test-helper.js';
 import {
   findAllMissions,
@@ -11,11 +11,6 @@ import { Mission } from '../../../../lib/domain/models/index.js';
 import { NotFoundError } from '../../../../lib/domain/errors.js';
 
 describe('Integration | Repository | mission-repository', function () {
-  afterEach(async function () {
-    await knex('translations').delete();
-    await knex('missions').delete();
-  });
-
   describe('#get', function () {
     context('When mission does not exists', function () {
       it('should throw a NotFoundError', async function () {

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, describe as context, expect, it } from 'vitest';
+import { beforeEach, describe, describe as context, expect, it } from 'vitest';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import {
   create,
@@ -15,10 +15,6 @@ import {
 } from '../../../../lib/domain/models/release/index.js';
 
 describe('Integration | Repository | release-repository', function () {
-  afterEach(function () {
-    return knex('releases').delete();
-  });
-
   describe('#create', function () {
     it('should save current content as a new release', async function () {
       // Given

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as skillRepository from '../../../../lib/infrastructure/repositories/skill-repository.js';
@@ -1010,12 +1010,6 @@ describe('Integration | Repository | skill-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(async () => {
-      await knex('skills-tutorials').delete();
-      await knex('skills').delete();
-      await knex('translations').delete();
-    });
-
     it('should save new skill and translations', async () => {
       // given
       const skill = domainBuilder.buildSkill({

--- a/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/thematic-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as thematicRepository from '../../../../lib/infrastructure/repositories/thematic-repository.js';
@@ -306,11 +306,6 @@ describe('Integration | Repository | thematic-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(() => {
-      return knex('thematics').delete();
-      return knex('translations').delete();
-    });
-
     it('should save new thematic to Airtable and translations to DB', async () => {
       // given
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });

--- a/api/tests/integration/infrastructure/repositories/translation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translation-repository_test.js
@@ -4,10 +4,6 @@ import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import * as translationRepository from '../../../../lib/infrastructure/repositories/translation-repository.js';
 
 describe('Integration | Repository | translation-repository', function () {
-  afterEach(async function () {
-    await knex('translations').delete();
-  });
-
   context('#save', function () {
     it('should create or update translations', async () => {
       // given

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 import nock from 'nock';
 import { airtableBuilder, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
@@ -358,11 +358,6 @@ describe('Integration | Repository | tube-repository', () => {
   });
 
   describe('#create', () => {
-    afterEach(async () => {
-      await knex('tubes').delete();
-      await knex('translations').delete();
-    });
-
     it('should save new tube to Airtable and translations to DB', async () => {
       // given
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk1' });

--- a/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/whitelisted-url-repository_test.js
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder } from '../../../test-helper.js';
 import * as whitelistedUrlRepository from '../../../../lib/infrastructure/repositories/whitelisted-url-repository.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
 
@@ -212,10 +212,6 @@ describe('Integration | Repository | whitelisted-url-repository', () => {
     });
   });
   describe('#save', function () {
-    afterEach(function () {
-      return knex('whitelisted_urls').del();
-    });
-
     it('should update the whitelisted url', async function () {
       // given
       const adminUser1 = databaseBuilder.factory.buildUser({ name: 'Madame Admin 1', access: 'admin', trigram: 'MA1' });

--- a/api/tests/integration/scripts/migration-from-airtable/copy-areas-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-areas-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyAreasFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-areas-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyAreasFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads areas from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyAttachmentsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-attachments-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyAttachmentsFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads attachments from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false, chunkSize: 10 };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyChallengesFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg.js';
@@ -122,10 +122,6 @@ describe('Integration | Scripts | CopyChallengesFromAirtableToPg', () => {
       });
 
       await databaseBuilder.commit();
-    });
-
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
     });
 
     it('reads challenges from airtable and saves these to postgres', async () => {

--- a/api/tests/integration/scripts/migration-from-airtable/copy-competences-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-competences-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyCompetencesFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-competences-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyCompetencesFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads competences from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyFrameworksFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-frameworks-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyFrameworksFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads frameworks from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-skills-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-skills-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopySkillsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-skills-from-airtable-to-pg.js';
@@ -20,11 +20,6 @@ describe('Integration | Scripts | CopySkillsFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TUTORIALS_RELATION_TABLE_NAME);
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads skills from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyThematicsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-thematics-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyThematicsFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads thematics from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-tubes-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-tubes-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyTubesFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-tubes-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyTubesFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads tubes from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyTutorialTagsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-tutorial_tags-from-airtable-to-pg.js';
@@ -18,10 +18,6 @@ describe('Integration | Scripts | CopyTutorialTagsFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads tutorial tags from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/integration/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg_test.js
+++ b/api/tests/integration/scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg_test.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Airtable from 'airtable';
 
 import { CopyTutorialsFromAirtableToPg } from '../../../../scripts/migration-from-airtable/copy-tutorials-from-airtable-to-pg.js';
@@ -20,11 +20,6 @@ describe('Integration | Scripts | CopyTutorialsFromAirtableToPg', () => {
   });
 
   describe('#handle', () => {
-    afterEach(async () => {
-      await knex.delete().from(TAGS_RELATION_TABLE_NAME);
-      await knex.delete().from(TABLE_NAME);
-    });
-
     it('reads tutorials from airtable and saves these to postgres', async () => {
       // given
       const options = { dryRun: false };

--- a/api/tests/setup-tests.js
+++ b/api/tests/setup-tests.js
@@ -1,6 +1,6 @@
-import { afterEach, beforeAll, afterAll } from 'vitest';
 import { loadEnvFileIfExists } from '../lib/shared/load-env-file-if-exists.js';
 import { disconnect } from '../db/knex-database-connection.js';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { queues } from '../lib/infrastructure/scheduled-jobs/index.js';
 import { cache } from '../lib/infrastructure/cache.js';
 import { airtableBuilder, databaseBuilder } from './test-helper.js';

--- a/api/tests/setup-tests.js
+++ b/api/tests/setup-tests.js
@@ -1,10 +1,10 @@
 import { afterEach, beforeAll, afterAll } from 'vitest';
 import { loadEnvFileIfExists } from '../lib/shared/load-env-file-if-exists.js';
-import { airtableBuilder, databaseBuilder } from './test-helper.js';
-import { cache } from '../lib/infrastructure/cache.js';
-import nock from 'nock';
-import { queues } from '../lib/infrastructure/scheduled-jobs/create-queue.js';
 import { disconnect } from '../db/knex-database-connection.js';
+import { queues } from '../lib/infrastructure/scheduled-jobs/index.js';
+import { cache } from '../lib/infrastructure/cache.js';
+import { airtableBuilder, databaseBuilder } from './test-helper.js';
+import nock from 'nock';
 
 loadEnvFileIfExists();
 

--- a/api/tests/setup-tests.js
+++ b/api/tests/setup-tests.js
@@ -10,17 +10,16 @@ loadEnvFileIfExists();
 
 beforeAll(() => {
   nock.disableNetConnect();
-  vi.restoreAllMocks();
   vi.resetModules();
 });
 
 afterEach(async () => {
   airtableBuilder.cleanAll();
   await databaseBuilder.clean();
-  cache.flushAll();
   nock.cleanAll();
+  cache.flushAll();
   for (const queue of queues) {
-    await queue.obliterate({ force: true });
+    await queue.obliterate({ force: true }).catch(() => {});
   }
 });
 

--- a/api/tests/setup-tests.js
+++ b/api/tests/setup-tests.js
@@ -10,6 +10,8 @@ loadEnvFileIfExists();
 
 beforeAll(() => {
   nock.disableNetConnect();
+  vi.restoreAllMocks();
+  vi.resetModules();
 });
 
 afterEach(async () => {

--- a/api/tests/setup-tests.js
+++ b/api/tests/setup-tests.js
@@ -1,3 +1,27 @@
+import { afterEach, beforeAll, afterAll } from 'vitest';
 import { loadEnvFileIfExists } from '../lib/shared/load-env-file-if-exists.js';
+import { airtableBuilder, databaseBuilder } from './test-helper.js';
+import { cache } from '../lib/infrastructure/cache.js';
+import nock from 'nock';
+import { queues } from '../lib/infrastructure/scheduled-jobs/create-queue.js';
+import { disconnect } from '../db/knex-database-connection.js';
 
 loadEnvFileIfExists();
+
+beforeAll(() => {
+  nock.disableNetConnect();
+});
+
+afterEach(async () => {
+  airtableBuilder.cleanAll();
+  await databaseBuilder.clean();
+  cache.flushAll();
+  nock.cleanAll();
+  for (const queue of queues) {
+    await queue.obliterate({ force: true });
+  }
+});
+
+afterAll(async () => {
+  await disconnect();
+});

--- a/api/tests/setup-unit-tests.js
+++ b/api/tests/setup-unit-tests.js
@@ -1,0 +1,3 @@
+import { loadEnvFileIfExists } from '../lib/shared/load-env-file-if-exists.js';
+
+loadEnvFileIfExists();

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -11,7 +11,7 @@ export { streamToPromise, streamToPromiseArray } from '../lib/infrastructure/uti
 export { knex };
 
 // DatabaseBuilder
-export const databaseBuilder = new DatabaseBuilder({ knex });
+export const databaseBuilder = await DatabaseBuilder.create({ knex });
 
 // Hapi
 export const hFake = {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,26 +1,9 @@
-import { beforeEach, afterEach } from 'vitest';
 import * as infraErrors from '../lib/infrastructure/errors.js';
-import { cache } from '../lib/infrastructure/cache.js';
 import nock from 'nock';
 import { DatabaseBuilder } from './tooling/database-builder/database-builder.js';
 import { AirtableBuilder } from './tooling/airtable-builder/airtable-builder.js';
 import { knex } from '../db/knex-database-connection.js';
 import './tooling/vitest-custom-matchers/index.js';
-import { queues } from '../lib/infrastructure/scheduled-jobs/index.js';
-
-beforeEach(() => {
-  nock.disableNetConnect();
-});
-
-afterEach(async () => {
-  airtableBuilder.cleanAll();
-  await databaseBuilder.clean();
-  cache.flushAll();
-  nock.cleanAll();
-  for (const queue of queues) {
-    await queue.obliterate({ force: true });
-  }
-});
 
 export { streamToPromise, streamToPromiseArray } from '../lib/infrastructure/utils/stream-to-promise.js';
 

--- a/api/tests/tooling/database-builder/database-buffer.js
+++ b/api/tests/tooling/database-builder/database-buffer.js
@@ -1,21 +1,22 @@
 const INITIAL_ID = 100000;
-
-export const databaseBuffer = {
-  objectsToInsert: [],
-  tablesToDelete: [],
+const databaseBuffer = {
+  objectsToInsert: {},
   nextId: INITIAL_ID,
 
-  pushInsertable({ tableName, values, autoId = true }) {
-    if (!values.id && autoId) {
-      values = { ...values, id: this.nextId++ };
-    }
-    this.objectsToInsert.push({ tableName, values });
+  pushInsertable({ tableName, values }) {
+    if (!this.objectsToInsert[tableName]) this.objectsToInsert[tableName] = [];
+    this.objectsToInsert[tableName].push(values);
 
     return values;
   },
 
+  getNextId() {
+    return this.nextId++;
+  },
+
   purge() {
-    this.objectsToInsert = [];
-    this.tablesToDelete = [];
+    this.objectsToInsert = {};
   },
 };
+
+export { databaseBuffer };

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -1,68 +1,229 @@
-import { databaseBuffer } from './database-buffer.js';
-import * as factory from './factory/index.js';
-import { emptyAllTables, listTablesByDependencyOrderDesc } from '../../../db/knex-database-connection.js';
 import _ from 'lodash';
 
+import { databaseBuffer as defaultDatabaseBuffer } from './database-buffer.js';
+import * as factory from './factory/index.js';
+
+const READONLY_TABLES = ['knex_migrations', 'knex_migrations_lock'];
+const CHUNK_SIZE = 1000;
+
+/**
+ * @class DatabaseBuilder
+ * @property {Factory} factory
+ */
 export class DatabaseBuilder {
-  constructor({ knex }) {
+  #beforeEmptyDatabase;
+  #emptyFirst;
+  #databaseBuffer;
+
+  #isFirstCommit = true;
+
+  #tablesOrderedByDependency;
+  #insertPriority;
+  #deletePriority;
+  #dirtyTables = new Set();
+
+  constructor({ knex, emptyFirst = true, databaseBuffer = defaultDatabaseBuffer, beforeEmptyDatabase }) {
     this.knex = knex;
-    this.databaseBuffer = databaseBuffer;
-    this.tablesOrderedByDependencyWithDirtinessMap = [];
     this.factory = factory;
-    this.isFirstCommit = true;
+    this.#databaseBuffer = databaseBuffer;
+    this.#emptyFirst = emptyFirst;
+    this.#beforeEmptyDatabase = beforeEmptyDatabase;
+
+    this.#addListeners();
+  }
+
+  static async create({ knex, emptyFirst = true, beforeEmptyDatabase }) {
+    const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst, beforeEmptyDatabase });
+
+    try {
+      await databaseBuilder.#init();
+    } catch {
+      // Error thrown only with unit tests
+    }
+
+    return databaseBuilder;
   }
 
   async commit() {
-    if (this.isFirstCommit) {
-      this.isFirstCommit = false;
-      await emptyAllTables();
-      await this._initTablesOrderedByDependencyWithDirtinessMap();
+    await this.#init();
+
+    const orderedObjectsToInsert = Object.entries(this.#databaseBuffer.objectsToInsert).sort(
+      ([tableName1], [tableName2]) => this.#insertPriority.get(tableName1) - this.#insertPriority.get(tableName2),
+    );
+
+    try {
+      await this.knex.transaction(async (trx) => {
+        for (const [tableName, objectsToInsert] of orderedObjectsToInsert) {
+          for (const chunk of _.chunk(objectsToInsert, CHUNK_SIZE)) {
+            await trx.insert(chunk).into(tableName);
+          }
+          this.#dirtyTables.add(tableName);
+        }
+      });
+    } catch (err) {
+      console.error(`Erreur dans databaseBuilder.commit() : ${err}`);
+      this.#dirtyTables.clear();
+      throw err;
+    } finally {
+      this.#databaseBuffer.objectsToInsert = [];
     }
-    const trx = await this.knex.transaction();
-    for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
-      await trx(objectToInsert.tableName).insert(objectToInsert.values);
-      this._setTableAsDirty(objectToInsert.tableName);
-    }
-    this.databaseBuffer.objectsToInsert = [];
-    this.databaseBuffer.tablesToDelete = this._selectDirtyTables();
-    await trx.commit();
   }
 
   async clean() {
-    let rawQuery = '';
-    _.times(this.databaseBuffer.tablesToDelete.length, () => {
-      rawQuery += 'DELETE FROM ??;';
-    });
-    if (rawQuery !== '') {
-      await this.knex.raw(rawQuery, this.databaseBuffer.tablesToDelete);
-      this.databaseBuffer.purge();
-      this._purgeDirtiness();
+    if (this.#dirtyTables.size) {
+      await this.knex.raw(
+        Array.from(this.#dirtyTables)
+          .sort((tableName1, tableName2) => this.#deletePriority.get(tableName1) - this.#deletePriority.get(tableName2))
+          .map(deleteFrom)
+          .join('\n'),
+      );
+    }
+
+    this.#databaseBuffer.purge();
+    this.#dirtyTables.clear();
+  }
+
+  /**
+   * Database builder is used to create data:
+   *   - for automated tests;
+   *   - for manual tests (aka "seeds").
+   *
+   * To make tests and seeds easier to write, identifiers are defined in the file and passed to the database builder.
+   * (In a production environment, this never happens. The database is the only in charge of supplying an identifier
+   * using a sequence).
+   * Inserting elements in PGSQL when specifying their ID does not update the sequence for that id.
+   * It is hence important to update sequences to avoid conflict with hard coded identifier
+   * i.e. ERROR: duplicate key value violates unique constraint "pk_***"
+   */
+  async fixSequences() {
+    if (!this.#dirtyTables.size) return;
+
+    const dirtyTablesSequencesInfo = await this.#getDirtyTablesSequencesInfo();
+
+    for (const dirtyTablesSequence of dirtyTablesSequencesInfo) {
+      const { tableName, sequenceName } = dirtyTablesSequence;
+      const sequenceRestartAtNumber = (await this.#getTableMaxId(tableName)) + 1;
+      if (sequenceRestartAtNumber !== 0) {
+        await this.knex.raw(`ALTER SEQUENCE "${sequenceName}" RESTART WITH ${sequenceRestartAtNumber};`);
+      }
     }
   }
 
-  async _initTablesOrderedByDependencyWithDirtinessMap() {
-    const dependencyOrderedTables = await listTablesByDependencyOrderDesc();
-    this.tablesOrderedByDependencyWithDirtinessMap = _.map(dependencyOrderedTables, (table) => {
-      return {
-        table,
-        isDirty: false,
-      };
+  async #getDirtyTablesSequencesInfo() {
+    const database = this.knex.client.database();
+
+    const rawSequencesInfo = await this.knex
+      .from('information_schema.columns')
+      .select('table_name', 'column_default')
+      .whereRaw("column_default like 'nextval%'")
+      .where({ table_catalog: database, column_name: 'id' })
+      .whereIn('table_name', Array.from(this.#dirtyTables));
+
+    const sequencesInfo = rawSequencesInfo.map(({ table_name, column_default }) => ({
+      tableName: table_name,
+      sequenceName: column_default.replaceAll('"', '').slice("nextval('".length, -"'::regclass)".length),
+    }));
+    return sequencesInfo;
+  }
+
+  async #getTableMaxId(tableName) {
+    const { max } = await this.knex.from(tableName).max('id').first();
+    return max;
+  }
+
+  async #init() {
+    if (!this.#isFirstCommit) return;
+    await this.#loadTables();
+    if (this.#emptyFirst) {
+      await this.emptyDatabase();
+    }
+    this.#isFirstCommit = false;
+  }
+
+  async emptyDatabase() {
+    this.#beforeEmptyDatabase?.();
+
+    const sortedTableNames = this.#tablesOrderedByDependency.map(sanitizeTableName).join(',');
+    return this.knex.raw(`TRUNCATE ${sortedTableNames}`);
+  }
+
+  async #loadTables() {
+    // See this link : https://stackoverflow.com/questions/51279588/sort-tables-in-order-of-dependency-postgres
+    function _constructRawQuery(namespace) {
+      return `with recursive fk_tree as (
+      select t.oid as reloid,
+      t.relname as table_name,
+      s.nspname as schema_name,
+      null::name as referenced_table_name,
+      null::name as referenced_schema_name,
+      1 as level
+      from pg_class t
+      join pg_namespace s on s.oid = t.relnamespace
+      where relkind = 'r'
+      and not exists (select *
+      from pg_constraint
+      where contype = 'f'
+      and conrelid = t.oid)
+      and s.nspname = '${namespace}'
+      union all
+      select ref.oid,
+      ref.relname,
+      rs.nspname,
+      p.table_name,
+      p.schema_name,
+      p.level + 1
+      from pg_class ref
+      join pg_namespace rs on rs.oid = ref.relnamespace
+      join pg_constraint c on c.contype = 'f' and c.conrelid = ref.oid
+      join fk_tree p on p.reloid = c.confrelid
+      where ref.oid != p.reloid),
+      all_tables as (
+      select schema_name, table_name, level, row_number() over (partition by schema_name, table_name order by level desc) as
+      last_table_row from fk_tree )
+      select table_name
+      from all_tables at where last_table_row = 1 order by level DESC;`;
+    }
+
+    const publicResults = await this.knex.raw(_constructRawQuery('public'));
+
+    this.#tablesOrderedByDependency = [...publicResults.rows.map(({ table_name }) => table_name)].filter(
+      (tableName) => !READONLY_TABLES.includes(tableName),
+    );
+
+    this.#deletePriority = new Map(this.#tablesOrderedByDependency.map((tableName, index) => [tableName, index]));
+
+    this.#insertPriority = new Map(
+      this.#tablesOrderedByDependency.toReversed().map((tableName, index) => [tableName, index]),
+    );
+  }
+
+  #addListeners() {
+    this.knex?.on('query', (queryData) => {
+      if (queryData.method?.toLowerCase() === 'insert') {
+        const tableName = getTableNameFromInsertSqlQuery(queryData.sql);
+
+        if (!tableName || tableName === '') return;
+
+        this.#dirtyTables.add(tableName);
+      }
     });
   }
+}
 
-  _setTableAsDirty(table) {
-    const tableWithDirtiness = _.find(this.tablesOrderedByDependencyWithDirtinessMap, { table });
-    tableWithDirtiness.isDirty = true;
-  }
+function sanitizeTableName(tableName) {
+  return tableName
+    .split('.')
+    .map((name) => `"${name}"`)
+    .join('.');
+}
 
-  _selectDirtyTables() {
-    const dirtyTableObjects = _.filter(this.tablesOrderedByDependencyWithDirtinessMap, { isDirty: true });
-    return _.map(dirtyTableObjects, 'table');
-  }
+function deleteFrom(tableName) {
+  return `DELETE FROM ${sanitizeTableName(tableName)};`;
+}
 
-  _purgeDirtiness() {
-    _.each(this.tablesOrderedByDependencyWithDirtinessMap, (table) => {
-      table.isDirty = false;
-    });
-  }
+const TABLE_NAME_REGEXP = /(?<=insert into\s)(?<tableName>(".*"))(?=\s\(.*)/i;
+
+function getTableNameFromInsertSqlQuery(insertSqlQuery) {
+  const tableName = TABLE_NAME_REGEXP.exec(insertSqlQuery)?.groups?.tableName?.replaceAll('"', '');
+  return tableName;
 }

--- a/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/release-job_test.js
@@ -75,7 +75,9 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
       it('should not send a slack success notification if slack notification is is globally disabled', async function () {
         // given
-        vi.spyOn(config.notifications.slack, 'enable', 'get').mockReturnValue(false);
+        vi.spyOn(config.notifications, 'slack', 'get').mockReturnValue({
+          enable: false,
+        });
 
         // When
         await releaseJobProcessor({ data: { slackNotification: true } });
@@ -86,7 +88,10 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
       it('should not send a slack success notification if slack notification is locally disabled', async function () {
         // given
-        vi.spyOn(config.notifications.slack, 'enable', 'get').mockReturnValue(true);
+        vi.spyOn(config.notifications, 'slack', 'get').mockReturnValue({
+          webhookUrl: 'http://webook.url',
+          enable: true,
+        });
 
         // When
         await releaseJobProcessor({ data: { slackNotification: false } });
@@ -95,8 +100,12 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
         expect(learningContentNotification.notifyReleaseCreationSuccess).not.toHaveBeenCalled();
       });
 
-      it('should start the upload translation job to  phrase when is finished', async () => {
+      it('should start the upload translation job to phrase when is finished', async () => {
         // given
+        vi.spyOn(config.notifications, 'slack', 'get').mockReturnValue({
+          webhookUrl: 'http://webook.url',
+          enable: true,
+        });
         const uploadTranslationToPhraseStub = vi.spyOn(uploadTranslationToPhraseJob, 'start').mockResolvedValue();
 
         // when
@@ -117,6 +126,10 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
       it('should log the error', async () => {
         // given
+        vi.spyOn(config.notifications, 'slack', 'get').mockReturnValue({
+          webhookUrl: 'http://webook.url',
+          enable: true,
+        });
         const errorLogStub = vi.spyOn(logger, 'error');
 
         // when
@@ -145,7 +158,9 @@ describe('Unit | Infrastructure | scheduled-jobs | release-job', () => {
 
       it('should not send a slack failure notification if Slack notification is disabled', async function () {
         // given
-        vi.spyOn(config.notifications.slack, 'enable', 'get').mockReturnValue(false);
+        vi.spyOn(config.notifications, 'slack', 'get').mockReturnValue({
+          enable: false,
+        });
 
         // When
         await releaseJobProcessor({ data: {} });

--- a/api/tests/unit/infrastructure/utils/storage_test.js
+++ b/api/tests/unit/infrastructure/utils/storage_test.js
@@ -17,7 +17,6 @@ describe('Unit | Infrastructure | Storage', () => {
     });
 
     afterEach(() => {
-      vi.restoreAllMocks();
       vi.useRealTimers();
     });
 

--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -5,12 +5,10 @@ export default defineConfig({
     include: ['tests/**/*_test.js'],
     reporters: process.env.CI ? 'junit' : 'default',
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
-    restoreMocks: true,
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    mockReset: true,
+    pool: 'threads',
+    maxWorkers: 1,
+    isolate: false,
     setupFiles: ['tests/setup-tests.js'],
   },
 });

--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -2,13 +2,31 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*_test.js'],
     reporters: process.env.CI ? 'junit' : 'default',
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     restoreMocks: true,
     pool: 'threads',
-    maxWorkers: 1,
     isolate: false,
-    setupFiles: ['tests/setup-tests.js'],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'acc|int',
+          include: ['tests/acceptance/**/*_test.js', 'tests/integration/**/*_test.js', 'tests/scripts/**/*_test.js'],
+          setupFiles: ['tests/setup-tests.js'],
+          sequence: { groupOrder: 1 },
+          maxWorkers: 1,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['tests/unit/**/*_test.js'],
+          setupFiles: ['tests/setup-unit-tests.js'],
+          sequence: { groupOrder: 2, concurrent: true },
+        },
+      },
+    ],
   },
 });

--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*_test.js'],
-    reporters: process.env.CI ? 'junit' : 'dot',
+    reporters: process.env.CI ? 'junit' : 'default',
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
     restoreMocks: true,
     poolOptions: {

--- a/api/vitest.config.js
+++ b/api/vitest.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     include: ['tests/**/*_test.js'],
     reporters: process.env.CI ? 'junit' : 'default',
     outputFile: process.env.CI ? './test-results/report.xml' : undefined,
-    mockReset: true,
+    restoreMocks: true,
     pool: 'threads',
     maxWorkers: 1,
     isolate: false,


### PR DESCRIPTION
**Changement**
- Upgrade vers `vitest@4.0.7`
- Utilisation du `database-builder` de `pix-api` pour mieux clean la BDD entre chaque test
- Amélioration du setup-test pour nettoyer les ressources (Mock, BDD, cache, queues...) entre chaque test
- Suppression des `delete` de table manuels dans les tests

**Notes**
- Les tests d'acceptance/integ sont exécutés en séquence
- Les tests unitaires sont exécutés en parallèle

Il y a des erreurs `nock` qui apparaissents de temps en temps. Le problème semble être lié à la désactivation des appels HTTP par nock dans les jobs qui restent dans les queues BullMQ ouvertes.



