### PR TITLE
[BUGFIX] Warnings sur la double lecture des épreuves

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -147,7 +147,7 @@ export const challengeDatasource = datasource.extend({
         archived_at: model.archivedAt,
         made_obsolete_at: model.madeObsoleteAt,
         shuffled: model.shuffled,
-        contextualizedFields: model.contextualizedFields,
+        contextualizedFields: model.contextualizedFields ?? [],
       },
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -160,6 +160,7 @@ export const challengeDatasource = datasource.extend({
     const options = {
       fields: this.usedFields,
       filterByFormula: `FIND(${stringValue(params.filter.search)}, LOWER(CONCATENATE({Embed URL})))`,
+      sort: [{ field: 'updated_at', direction: 'desc' }],
     };
     if (params.filter.ids && params.filter.ids.length > 0) {
       options.filterByFormula =

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -72,7 +72,7 @@ export async function filter(params = {}) {
       .whereIn('challenges.id', params.filter.ids)
       .orWhereILike('localized_challenges.embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`)
       .limit(params.page?.size)
-      .orderBy('id'),
+      .orderBy('updatedAt', 'desc'),
   ]);
 
   compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -687,6 +687,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
           maxRecords: 100,
           filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
+          sort: [{ field: 'updated_at', direction: 'desc' }],
         })
         .reply(200, {
           records: [],
@@ -715,6 +716,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
           filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
           maxRecords: 20,
+          sort: [{ field: 'updated_at', direction: 'desc' }],
         })
         .reply(200, {
           records: [],

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -240,6 +240,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
+        sort: [{ field: 'updated_at', direction: 'desc' }],
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');
@@ -264,6 +265,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'OR(FIND("query term", LOWER(CONCATENATE({Embed URL}))), "challengeId1" = {id persistant})',
+        sort: [{ field: 'updated_at', direction: 'desc' }],
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');


### PR DESCRIPTION
## 🍂 Problème

On a 2 types de warnings sur la double lecture des épreuves :
 - les résultats de la recherche ne sont pas les mêmes à cause de l’ordre de tri
 - le champ `contextualizedFields` n’a pas la même valeur quand il est enregistré vide

## 🌰 Proposition

Fixer l’ordre de tri de la recherche.
Mettre une valeur par défaut tableau vide pour `contextualizedFields`.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Faire des recherches et vérifier qu’il n’y a pas de warnings.
Modifier puis enregistrer une épreuve avec rien de sélectionné dans "Champ contextualisé", rafraichir la page et vérifier qu’il n’y a pas de warning.
