### PR TITLE
[BUGFIX] Warnings sur la double lecture des épreuves

### DIFF
--- a/api/db/seeds/data/challenges.js
+++ b/api/db/seeds/data/challenges.js
@@ -688,7 +688,7 @@ export async function copyChallengesFromAirtable({ airtableClient, databaseBuild
       madeObsoleteAt: record.get('made_obsolete_at'),
       createdAt: record.get('created_at'),
       shuffled: record.get('shuffled') ?? false,
-      contextualizedFields: record.get('contextualizedFields'),
+      contextualizedFields: record.get('contextualizedFields') ?? [],
     });
   });
 }

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -111,7 +111,7 @@ export const challengeDatasource = datasource.extend({
       madeObsoleteAt: airtableRecord.get('made_obsolete_at'),
       createdAt: airtableRecord.get('created_at'),
       shuffled: airtableRecord.get('shuffled') ?? false,
-      contextualizedFields: airtableRecord.get('contextualizedFields'),
+      contextualizedFields: airtableRecord.get('contextualizedFields') ?? [],
     };
   },
 
@@ -147,7 +147,7 @@ export const challengeDatasource = datasource.extend({
         archived_at: model.archivedAt,
         made_obsolete_at: model.madeObsoleteAt,
         shuffled: model.shuffled,
-        contextualizedFields: model.contextualizedFields ?? [],
+        contextualizedFields: model.contextualizedFields,
       },
     };
     if (model.airtableId) {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -360,9 +360,9 @@ function selectChallenges() {
       ),
     )
     .from('challenges')
-    .join('skills', 'skills.id', 'challenges.skillId')
-    .join('tubes', 'tubes.id', 'skills.tubeId')
-    .join('thematics', 'thematics.id', 'tubes.thematicId');
+    .leftOuterJoin('skills', 'skills.id', 'challenges.skillId')
+    .leftOuterJoin('tubes', 'tubes.id', 'skills.tubeId')
+    .leftOuterJoin('thematics', 'thematics.id', 'tubes.thematicId');
 }
 
 function toDomainList(challengeDtos, translations, localizedChallenges) {

--- a/api/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-challenges-from-airtable-to-pg.js
@@ -99,7 +99,7 @@ export class CopyChallengesFromAirtableToPg extends Script {
       madeObsoleteAt: record.get('made_obsolete_at'),
       createdAt: record.get('created_at'),
       shuffled: record.get('shuffled') ?? false,
-      contextualizedFields: record.get('contextualizedFields'),
+      contextualizedFields: record.get('contextualizedFields') ?? [],
     }));
 
     const postgresOnlyIds = await knex

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -360,7 +360,7 @@ async function mockCurrentContent() {
   databaseBuilder.factory.buildTube(expectedCurrentContent.tubes[0]);
   expectedCurrentContent.tutorials.forEach(databaseBuilder.factory.buildTutorial);
   databaseBuilder.factory.buildSkill(expectedCurrentContent.skills[0]);
-  databaseBuilder.factory.buildChallenge(expectedCurrentContent.challenges[0]);
+  databaseBuilder.factory.buildChallenge({ ...expectedCurrentContent.challenges[0], contextualizedFields: [] });
 
   databaseBuilder.factory.buildStaticCourse({
     id: 'recCourse0',
@@ -880,12 +880,17 @@ async function mockContentForRelease() {
     });
   }
 
-  databaseBuilder.factory.buildChallenge({ ...expectedCurrentContent.challenges[0], version: 8 });
+  databaseBuilder.factory.buildChallenge({
+    ...expectedCurrentContent.challenges[0],
+    version: 8,
+    contextualizedFields: [],
+  });
   databaseBuilder.factory.buildChallenge({
     ...expectedCurrentContent.challenges[1],
     accessibility1: ChallengeForRelease.ACCESSIBILITY1.KO,
     accessibility2: ChallengeForRelease.ACCESSIBILITY2.KO,
     version: 8,
+    contextualizedFields: [],
   });
 
   for (const challenge of expectedCurrentContent.challenges) {

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -758,6 +758,7 @@ function _mockRichAirtableContent() {
     alpha: 2.2,
     updatedAt: new Date(),
     shuffled: false,
+    contextualizedFields: [],
   };
   databaseBuilder.factory.buildChallenge(challenge121211);
   const airtableChallenge121211 = airtableBuilder.factory.buildChallenge(challenge121211);
@@ -796,6 +797,7 @@ function _mockRichAirtableContent() {
     alpha: 456,
     updatedAt: new Date(),
     shuffled: true,
+    contextualizedFields: [],
   };
   databaseBuilder.factory.buildChallenge(challenge121212);
   const airtableChallenge121212 = airtableBuilder.factory.buildChallenge(challenge121212);
@@ -835,6 +837,7 @@ function _mockRichAirtableContent() {
     alpha: 200,
     updatedAt: new Date(),
     shuffled: false,
+    contextualizedFields: [],
   };
   databaseBuilder.factory.buildChallenge(challenge211111);
   const airtableChallenge211111 = airtableBuilder.factory.buildChallenge(challenge211111);
@@ -873,6 +876,7 @@ function _mockRichAirtableContent() {
     alpha: 200,
     updatedAt: new Date(),
     shuffled: false,
+    contextualizedFields: [],
   };
   databaseBuilder.factory.buildChallenge(challenge211112);
   const airtableChallenge211112 = airtableBuilder.factory.buildChallenge(challenge211112);
@@ -911,6 +915,7 @@ function _mockRichAirtableContent() {
     alpha: 200,
     updatedAt: new Date(),
     shuffled: false,
+    contextualizedFields: [],
   };
   databaseBuilder.factory.buildChallenge(challenge211113);
   const airtableChallenge211113 = airtableBuilder.factory.buildChallenge(challenge211113);


### PR DESCRIPTION
## 🍂 Problème

On a des warnings sur la double lecture des épreuves :
 - le champ `contextualizedFields` n’a pas la même valeur quand il est enregistré vide
 - postgres remonte moins de challenges en release

## 🌰 Proposition

Mettre une valeur par défaut tableau vide pour `contextualizedFields`.
Faire des outers joins pour remonter tous les challenges en release.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Modifier puis enregistrer une épreuve avec rien de sélectionné dans "Champ contextualisé", rafraichir la page et vérifier qu’il n’y a pas de warning.
