### PR TITLE
[BUGFIX] Warnings de comparaison sur les épreuves

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -75,7 +75,7 @@ export class Challenge {
     this.t1Status = t1Status;
     this.t2Status = t2Status;
     this.t3Status = t3Status;
-    this.timer = timer;
+    this.timer = timer === 0 ? undefined : timer;
     this.type = type;
     this.updatedAt = updatedAt;
     this.validatedAt = validatedAt;

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -58,11 +58,6 @@ export const challengeDatasource = datasource.extend({
       competenceId = airtableRecord.get('Compétences (via tube) (id persistant)')[0];
     }
 
-    let timer;
-    if (airtableRecord.get('Timer')) {
-      timer = parseInt(airtableRecord.get('Timer'));
-    }
-
     const filesIds = airtableRecord.get('files');
     const filesLocalizedChallengeIds = airtableRecord.get('filesLocalizedChallengeIds');
     const files =
@@ -84,7 +79,7 @@ export const challengeDatasource = datasource.extend({
       skillId: (airtableRecord.get('Acquix (id persistant)') || [])[0],
       embedUrl: airtableRecord.get('Embed URL'),
       embedHeight: airtableRecord.get('Embed height'),
-      timer,
+      timer: airtableRecord.get('Timer'),
       competenceId,
       format: airtableRecord.get('Format'),
       files,

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -393,7 +393,7 @@ function toDomain(challengeDto, challengeTranslations, localizedChallenges = [])
 function compareChallengeDtos(airtableDto, pgDto) {
   const diff = [];
   if (airtableDto.id !== pgDto.id) diff.push(`challenge airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
-  if (airtableDto.type !== pgDto.type)
+  if (!areNullableValuesEqual(airtableDto.type, pgDto.type))
     diff.push(`challenge airtable type "${airtableDto.type}" != postgres type "${pgDto.type}"`);
   if (airtableDto.t1Status !== pgDto.t1Status)
     diff.push(`challenge airtable t1Status "${airtableDto.t1Status}" != postgres t1Status "${pgDto.t1Status}"`);
@@ -411,7 +411,7 @@ function compareChallengeDtos(airtableDto, pgDto) {
     );
   if (!areNullableValuesEqual(airtableDto.timer, pgDto.timer))
     diff.push(`challenge airtable timer "${airtableDto.timer}" != postgres timer "${pgDto.timer}"`);
-  if (airtableDto.competenceId !== pgDto.competenceId)
+  if (!areNullableValuesEqual(airtableDto.competenceId, pgDto.competenceId))
     diff.push(
       `challenge airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
     );


### PR DESCRIPTION
## 🍂 Problème

On a des warnings de comparaison sur les champs timer, competenceId, et type des épreuves.

## 🌰 Proposition

Comparer competenceId et type comme nullable.
Considérer la valeur 0 comme indéfinie pour timer.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Faire un current content.