### PR TITLE
[BUGFIX] Différences de résultats de recherche d’épreuves

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -155,7 +155,10 @@ export const challengeDatasource = datasource.extend({
     const options = {
       fields: this.usedFields,
       filterByFormula: `FIND(${stringValue(params.filter.search)}, LOWER(CONCATENATE({Embed URL})))`,
-      sort: [{ field: 'updated_at', direction: 'desc' }],
+      sort: [
+        { field: 'updated_at', direction: 'desc' },
+        { field: 'id persistant', direction: 'asc' },
+      ],
     };
     if (params.filter.ids && params.filter.ids.length > 0) {
       options.filterByFormula =

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -68,11 +68,19 @@ export async function filter(params = {}) {
   const [airtableDtos, pgDtos] = await Promise.all([
     challengeDatasource.search(params),
     selectChallenges()
-      .join('localized_challenges', 'localized_challenges.id', 'challenges.id')
       .whereIn('challenges.id', params.filter.ids)
-      .orWhereILike('localized_challenges.embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`)
+      .orWhereIn(
+        'challenges.id',
+        knex
+          .select('challengeId')
+          .from('localized_challenges')
+          .whereILike('embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`),
+      )
       .limit(params.page?.size)
-      .orderBy('updatedAt', 'desc'),
+      .orderBy([
+        { column: 'updatedAt', order: 'desc' },
+        { column: 'challenges.id', order: 'asc' },
+      ]),
   ]);
 
   compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -69,6 +69,7 @@ export async function list() {
 export async function search({ entity, fields, search, limit }) {
   const query = knex('translations')
     .pluck('key')
+    .distinct()
     .whereILike('value', `%${escapeLikeWildcards(search)}%`)
     .andWhere(function () {
       for (const field of fields) {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -687,7 +687,10 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
           maxRecords: 100,
           filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
-          sort: [{ field: 'updated_at', direction: 'desc' }],
+          sort: [
+            { field: 'updated_at', direction: 'desc' },
+            { field: 'id persistant', direction: 'asc' },
+          ],
         })
         .reply(200, {
           records: [],
@@ -716,7 +719,10 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
           filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
           maxRecords: 20,
-          sort: [{ field: 'updated_at', direction: 'desc' }],
+          sort: [
+            { field: 'updated_at', direction: 'desc' },
+            { field: 'id persistant', direction: 'asc' },
+          ],
         })
         .reply(200, {
           records: [],

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -240,7 +240,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
-        sort: [{ field: 'updated_at', direction: 'desc' }],
+        sort: [
+          { field: 'updated_at', direction: 'desc' },
+          { field: 'id persistant', direction: 'asc' },
+        ],
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');
@@ -265,7 +268,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'OR(FIND("query term", LOWER(CONCATENATE({Embed URL}))), "challengeId1" = {id persistant})',
-        sort: [{ field: 'updated_at', direction: 'desc' }],
+        sort: [
+          { field: 'updated_at', direction: 'desc' },
+          { field: 'id persistant', direction: 'asc' },
+        ],
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');


### PR DESCRIPTION
## 🍂 Problème

Les résultats de la recherche d’épreuves ne sont pas les mêmes entre Postgres et Airtable.

## 🌰 Proposition

Stabiliser l’ordre de tri des 2 côtés.
Éviter les doublons côté PG.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Faire des recherches d’épreuves.