### PR TITLE
[BUGFIX] Calcule la Pix Value avec la même précision qu'Airtable.

### DIFF
--- a/api/lib/domain/services/compute-pix-values-by-skill.js
+++ b/api/lib/domain/services/compute-pix-values-by-skill.js
@@ -18,7 +18,7 @@ export function computePixValuesBySkill(skills) {
   activeSkills.forEach(({ id, competenceId, level }) => {
     pixValuesBySkill[id] = Math.min(
       MAX_PIX_VALUE_PER_SKILL,
-      (LEVELS_PER_SKILL_COUNT / skillsByCompetenceAndLevel[competenceId][level].length).toFixed(3),
+      LEVELS_PER_SKILL_COUNT / skillsByCompetenceAndLevel[competenceId][level].length,
     );
   });
   return pixValuesBySkill;

--- a/api/tests/unit/domain/services/compute-pix-values-by-skill_test.js
+++ b/api/tests/unit/domain/services/compute-pix-values-by-skill_test.js
@@ -88,9 +88,9 @@ describe('Unit | Domain | Services | compute-pix-values-by-skill', function () {
 
         // then
         expect(pixValuesBySkill).toStrictEqual({
-          skill1: 2.667,
-          skill2: 2.667,
-          skill3: 2.667,
+          skill1: 2.6666666666666665,
+          skill2: 2.6666666666666665,
+          skill3: 2.6666666666666665,
         });
       });
     });
@@ -133,9 +133,9 @@ describe('Unit | Domain | Services | compute-pix-values-by-skill', function () {
 
       // then
       expect(pixValuesBySkill).toStrictEqual({
-        skill1: 2.667,
-        skill2: 2.667,
-        skill3: 2.667,
+        skill1: 2.6666666666666665,
+        skill2: 2.6666666666666665,
+        skill3: 2.6666666666666665,
         skill4: 4,
         skill5: 4,
         skill6: 4,


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On observe des avertissements lors de la création d'une release car le calcul en JS de la Pix Value arrondi au millième près la valeur alors qu'aucun arrondi n'est fait par Airtable.

## 🌰 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On supprime l'arrondi au milième.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

RAS

## 🪵 Pour tester

Faire une release en ayant au moins 3 acquis validé pour le même niveau et la même compétence (pour avoir un nombre à virgule comme Pix Value).
Vérifier qu'aucun avertissement n'est levé.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
