### PR TITLE
[BUGFIX] Différence de tri dans la recherche d’épreuves

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -155,10 +155,7 @@ export const challengeDatasource = datasource.extend({
     const options = {
       fields: this.usedFields,
       filterByFormula: `FIND(${stringValue(params.filter.search)}, LOWER(CONCATENATE({Embed URL})))`,
-      sort: [
-        { field: 'updated_at', direction: 'desc' },
-        { field: 'id persistant', direction: 'asc' },
-      ],
+      sort: [{ field: 'id persistant', direction: 'asc' }],
     };
     if (params.filter.ids && params.filter.ids.length > 0) {
       options.filterByFormula =

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -77,10 +77,7 @@ export async function filter(params = {}) {
           .whereILike('embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`),
       )
       .limit(params.page?.size)
-      .orderBy([
-        { column: 'updatedAt', order: 'desc' },
-        { column: 'challenges.id', order: 'asc' },
-      ]),
+      .orderBy('challenges.id'),
   ]);
 
   compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -68,7 +68,7 @@ export async function list() {
 
 export async function search({ entity, fields, search, limit }) {
   const query = knex('translations')
-    .pluck('key')
+    .pluck('entityId')
     .distinct()
     .whereILike('value', `%${escapeLikeWildcards(search)}%`)
     .andWhere(function () {
@@ -76,17 +76,11 @@ export async function search({ entity, fields, search, limit }) {
         this.orWhereLike('key', `${entity}.%.${field}`);
       }
     })
-    .orderBy('key');
+    .orderBy('entityId');
 
   if (limit) query.limit(limit);
 
-  const keys = await query;
-
-  return _.sortedUniq(
-    keys.map((key) => {
-      return key.split('.')[1];
-    }),
-  );
+  return query;
 }
 
 export async function checkIfTableExistInAirtable() {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -687,10 +687,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
           maxRecords: 100,
           filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
-          sort: [
-            { field: 'updated_at', direction: 'desc' },
-            { field: 'id persistant', direction: 'asc' },
-          ],
+          sort: [{ field: 'id persistant', direction: 'asc' }],
         })
         .reply(200, {
           records: [],
@@ -719,10 +716,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           },
           filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
           maxRecords: 20,
-          sort: [
-            { field: 'updated_at', direction: 'desc' },
-            { field: 'id persistant', direction: 'asc' },
-          ],
+          sort: [{ field: 'id persistant', direction: 'asc' }],
         })
         .reply(200, {
           records: [],

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -240,10 +240,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
-        sort: [
-          { field: 'updated_at', direction: 'desc' },
-          { field: 'id persistant', direction: 'asc' },
-        ],
+        sort: [{ field: 'id persistant', direction: 'asc' }],
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');
@@ -268,10 +265,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(airtable.findRecords).toHaveBeenCalledWith('Epreuves', {
         fields: challengeDatasource.usedFields,
         filterByFormula: 'OR(FIND("query term", LOWER(CONCATENATE({Embed URL}))), "challengeId1" = {id persistant})',
-        sort: [
-          { field: 'updated_at', direction: 'desc' },
-          { field: 'id persistant', direction: 'asc' },
-        ],
+        sort: [{ field: 'id persistant', direction: 'asc' }],
       });
       expect(challenges.length).to.equal(1);
       expect(challenges[0].id).to.equal('recChallenge');


### PR DESCRIPTION
## 🍂 Problème

Le tri par date de màj n’est pas cohérent entre PG et Airtable car la date de màj de PG peut changée sans que celle de Airtable change quand on ne modifie que des champs traduisibles.

## 🌰 Proposition

Trier uniquement sur l’identifiant.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Vérifier que la recherche d’épreuves n’est pas cassée.