### PR TITLE
[TECH] Synchronise la version de node de la CI avec le reste du repo.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - restore_cache:
           name: Restore npm cache
           keys:
-            - v9-e2e-npm-{{ checksum "~/pix-editor/cachekey" }}
+            - v10-e2e-npm-{{ checksum "~/pix-editor/cachekey" }}
 
       - run:
           name: Install Pix Editor
@@ -176,7 +176,7 @@ jobs:
 
       - save_cache:
           name: Save npm cache
-          key: v9-e2e-npm-{{ checksum "~/pix-editor/cachekey" }}
+          key: v10-e2e-npm-{{ checksum "~/pix-editor/cachekey" }}
           paths:
             - ~/.npm
             - ~/.cache/ms-playwright

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
     parameters:
       node-version:
         # renovate datasource=node-version depName=node
-        default: 22.16.0
+        default: 22.20.0
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
@@ -18,7 +18,7 @@ executors:
     parameters:
       node-version:
         # renovate datasource=node-version depName=node
-        default: 22.16.0
+        default: 22.20.0
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>
@@ -32,7 +32,7 @@ executors:
     parameters:
       node-version:
         # renovate datasource=node-version depName=node
-        default: 22.16.0
+        default: 22.20.0
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers
@@ -43,7 +43,7 @@ executors:
     parameters:
       node-version:
         # renovate datasource=node-version depName=node
-        default: 22.16.0
+        default: 22.20.0
         type: string
     docker:
       - image: cimg/node:<<parameters.node-version>>-browsers


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Pour une raison encore inconnue, notre configuration de CircleCI n'a pas suivi les montées de version de node.
Cela entraine des warnings dans les jobs de la CI et pourrait masquer des soucis liées à la version réellement utilisée.

## 🌰 Proposition

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

On force la version de node des exécuteurs de CircleCI à la version utilisée ailleurs, soit la v22.20.0.

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

On pourrait surement passer à Node v24 qui est désormais en Active LTS.

## 🪵 Pour tester

Des jobs verts, sans warnings.
L'application se déploie correctement sur Scalingo.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
