### PR TITLE
[BUGFIX] Résultats de recherche d’épreuves différents PG/Airtable

### DIFF
--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -59,32 +59,30 @@ export async function getMany(ids) {
 }
 
 export async function filter(params = {}) {
-  params.filter.ids = await translationRepository.search({
+  let ids = await translationRepository.search({
     entity: model,
     fields: ['instruction', 'proposals'],
     search: params.filter.search,
     limit: params.page?.size,
   });
-  const [airtableDtos, pgDtos] = await Promise.all([
-    challengeDatasource.search(params),
-    selectChallenges()
-      .whereIn('challenges.id', params.filter.ids)
-      .orWhereIn(
-        'challenges.id',
-        knex
-          .select('challengeId')
-          .from('localized_challenges')
-          .whereILike('embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`),
-      )
-      .limit(params.page?.size)
-      .orderBy('challenges.id'),
-  ]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);
+  ids = await knex
+    .pluck('challenges.id')
+    .from('challenges')
+    .whereIn('challenges.id', ids)
+    .orWhereIn(
+      'challenges.id',
+      knex
+        .select('challengeId')
+        .from('localized_challenges')
+        .whereILike('embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`),
+    )
+    .limit(params.page?.size)
+    .orderBy('challenges.updatedAt', 'desc');
 
-  if (!airtableDtos) return [];
-  const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(airtableDtos);
-  return toDomainList(airtableDtos, translations, localizedChallenges);
+  if (ids.length === 0) return [];
+
+  return getMany(ids);
 }
 
 export async function create(challenge) {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -677,50 +677,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
       });
     });
 
-    it('should search challenges', async () => {
-      // Given
-      const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
-        .query({
-          fields: {
-            '': challengeAirtableFields,
-          },
-          maxRecords: 100,
-          filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
-          sort: [{ field: 'id persistant', direction: 'asc' }],
-        })
-        .reply(200, {
-          records: [],
-        });
-      const server = await createServer();
-
-      // When
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/challenges?filter[search]=query term',
-        headers: generateAuthorizationHeader(user),
-      });
-
-      // Then
-      expect(airtableCall.isDone()).to.be.true;
-      expect(response.statusCode).to.equal(200);
-      expect(response.result).to.deep.equal({ data: [] });
-    });
-
     it('should search challenges with limit', async () => {
-      const airtableCall = nock('https://api.airtable.com')
-        .get('/v0/airtableBaseValue/Epreuves')
-        .query({
-          fields: {
-            '': challengeAirtableFields,
-          },
-          filterByFormula: 'FIND("query term", LOWER(CONCATENATE({Embed URL})))',
-          maxRecords: 20,
-          sort: [{ field: 'id persistant', direction: 'asc' }],
-        })
-        .reply(200, {
-          records: [],
-        });
       const server = await createServer();
 
       // When
@@ -731,7 +688,6 @@ describe('Acceptance | Controller | challenges-controller', () => {
       });
 
       // Then
-      expect(airtableCall.isDone()).to.be.true;
       expect(response.statusCode).to.equal(200);
       expect(response.result).to.deep.equal({ data: [] });
     });

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -459,10 +459,7 @@ describe('Integration | Repository | challenge-repository', () => {
         await databaseBuilder.commit();
         vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
           if (tableName !== 'Epreuves') expect.unreachable('Airtable tableName should be Epreuves');
-          if (
-            options?.filterByFormula !==
-            'OR(FIND("toto", LOWER(CONCATENATE({Embed URL}))), "challengeA_id" = {id persistant},"challengeB_id" = {id persistant})'
-          )
+          if (options?.filterByFormula !== 'OR("challengeB_id" = {id persistant},"challengeA_id" = {id persistant})')
             expect.unreachable('Wrong filterByFormula');
           return [
             {
@@ -802,7 +799,7 @@ describe('Integration | Repository | challenge-repository', () => {
         await databaseBuilder.commit();
         vi.spyOn(airtableClient, 'findRecords').mockImplementation((tableName, options) => {
           if (tableName !== 'Epreuves') expect.unreachable('Airtable tableName should be Epreuves');
-          if (options?.filterByFormula !== 'FIND("toto", LOWER(CONCATENATE({Embed URL})))')
+          if (options?.filterByFormula !== 'OR("challengeA_id" = {id persistant})')
             expect.unreachable('Wrong filterByFormula');
           return [
             {


### PR DESCRIPTION
## 🍂 Problème

Il n’est pas possible d’obtenir les mêmes résultats en faisant la recherche dans Airtable et dans PG.

## 🌰 Proposition

Utiliser uniquement PG pour définir les résultats de recherche, et lire ensuite les résultats dans PG et Airtable.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Vérifier que la recherche d’épreuves fonctionne toujours.