### PR TITLE
[TECH] Met à jour nock en version 15.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -57,7 +57,7 @@
         "flush-write-stream": "^2.0.0",
         "form-data": "^4.0.4",
         "globals": "^16.0.0",
-        "nock": "^14.0.0-beta.5",
+        "nock": "^15.0.0",
         "nodemon": "^3.0.0",
         "papaparse": "^5.5.2",
         "parse-multipart-data": "^1.5.0",
@@ -3258,6 +3258,24 @@
         "win32"
       ]
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.8.tgz",
+      "integrity": "sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3267,6 +3285,31 @@
       "dependencies": {
         "eslint-scope": "5.1.1"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -7291,6 +7334,13 @@
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "license": "MIT"
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8082,17 +8132,17 @@
       "license": "MIT"
     },
     "node_modules/nock": {
-      "version": "14.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.5.tgz",
-      "integrity": "sha512-u255tf4DYvyErTlPZA9uTfXghiZZy+NflUOFONPVKZ5tP0yaHwKig28zyFOLhu8y5YcCRC+V5vDk4HHileh2iw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-15.0.0.tgz",
+      "integrity": "sha512-EoAVk4Y8Yv4JUQz62sv8zmv+DoBblD/pht/q7aW/td1WietaFWrivzhMGGCLmx2qjpLcOrbyammedW8IRUU5TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
+        "@mswjs/interceptors": "^0.39.5",
+        "json-stringify-safe": "^5.0.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">=18.20.0 <20 || >=20.12.1"
       }
     },
     "node_modules/node-cache": {
@@ -8354,6 +8404,13 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/p-limit": {
@@ -8954,16 +9011,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
@@ -10259,6 +10306,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/api/package.json
+++ b/api/package.json
@@ -91,7 +91,7 @@
     "flush-write-stream": "^2.0.0",
     "form-data": "^4.0.4",
     "globals": "^16.0.0",
-    "nock": "14.0.0-beta.5",
+    "nock": "^15.0.0",
     "nodemon": "^3.0.0",
     "papaparse": "^5.5.2",
     "parse-multipart-data": "^1.5.0",

--- a/api/tests/acceptance/application/attachments_test.js
+++ b/api/tests/acceptance/application/attachments_test.js
@@ -603,7 +603,7 @@ describe('Acceptance | Route | attachments', () => {
         .delete('/v0/airtableBaseValue/Attachments')
         .query({ 'records[]': 'recAttachmentId' })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
-        .reply(204, {
+        .reply(200, {
           records: [
             {
               id: 'recAttachmentId',


### PR DESCRIPTION
## 🍂 Problème

On utilise une version beta de nock.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🌰 Proposition

On passe à la version 15.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->
Il a fallu modifier un test dans lequel le mock d'un appel Airtable était configuré pour retourner 204 (le DELETE /attachments).
Cela posait problème car désormais, en cas de 204 (qui signifie NO CONTENT), nock n'envoie pas de réponse. Or, dans le cas d'une suppression côté Airtable, le client airtable essaie de lire une réponse qui du coup est `undefined`. Le code du client n'exécute alors jamais la callback `done` et le test échouait en timeout.
On a donc modifié le mock pour retourner un code 200, ce qui correspond au comportement réel d'Airtable.

## 🪵 Pour tester

Une CI verte

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
