### PR TITLE
[TECH] Amélioration des warnings de migration Airtable

### DIFF
--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -14,7 +14,7 @@ export function logInfoWithCorrelationIds(data) {
     logger.info(
       {
         user_id: extractUserIdFromRequest(request),
-        request_id: `${_.get(request, 'info.id', '-')}`,
+        request_id: `${_.get(request, 'headers.x-request-id', '-')}`,
         ..._.get(data, 'metrics', {}),
       },
       _.get(data, 'message', '-'),
@@ -34,7 +34,7 @@ export function logErrorWithCorrelationIds(error) {
     logger.error(
       {
         user_id: extractUserIdFromRequest(request),
-        request_id: `${_.get(request, 'info.id', '-')}`,
+        request_id: `${_.get(request, 'headers.x-request-id', '-')}`,
       },
       error,
     );
@@ -51,6 +51,10 @@ export function getInContext(path, value) {
   const store = asyncLocalStorage.getStore();
   if (!store) return;
   return _.get(store, path, value);
+}
+
+export function getRequestId() {
+  return getInContext('request.headers.x-request-id', '-');
 }
 
 export function setInContext(path, value) {

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -47,7 +47,7 @@ export async function list() {
     translationRepository.listByModel(model),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareAreaDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareAreaDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -63,7 +63,7 @@ export async function listByFrameworkId(frameworkId) {
     translationRepository.listByModel(model),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareAreaDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareAreaDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -74,7 +74,7 @@ export async function getByAirtableId(areaAirtableId) {
 
   const [pgDto, translations] = await Promise.all([selectAreas().where('id', airtableDto.id).first(), translationRepository.listByEntity(model, airtableDto.id)]);
 
-  compareDtos(airtableDto, pgDto, compareAreaDtos);
+  compareDtos(airtableDto, pgDto, compareAreaDtos, TABLE_NAME);
 
   return toDomain(airtableDto, translations);
 }
@@ -108,16 +108,16 @@ export function toDomain(datasourceArea, translations = []) {
 
 function compareAreaDtos(airtableDto, pgDto) {
   const diff = [];
-  if (airtableDto.id !== pgDto.id) diff.push(`area airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
   if (airtableDto.code !== pgDto.code)
-    diff.push(`area airtable code "${airtableDto.code}" != postgres code "${pgDto.code}"`);
+    diff.push(`airtable code "${airtableDto.code}" != postgres code "${pgDto.code}"`);
   if (!areNullableValuesEqual(airtableDto.color, pgDto.color))
-    diff.push(`area airtable color "${airtableDto.color}" != postgres color "${pgDto.color}"`);
+    diff.push(`airtable color "${airtableDto.color}" != postgres color "${pgDto.color}"`);
   if (airtableDto.frameworkId !== pgDto.frameworkId)
-    diff.push(`area airtable frameworkId "${airtableDto.frameworkId}" != postgres frameworkId "${pgDto.frameworkId}"`);
+    diff.push(`airtable frameworkId "${airtableDto.frameworkId}" != postgres frameworkId "${pgDto.frameworkId}"`);
   if (!areArrayEquals(airtableDto.competenceIds, pgDto.competenceIds))
     diff.push(
-      `area airtable competenceIds "${airtableDto.competenceIds}" != postgres competenceIds "${pgDto.competenceIds}"`,
+      `airtable competenceIds "${airtableDto.competenceIds}" != postgres competenceIds "${pgDto.competenceIds}"`,
     );
   return diff;
 }

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -7,7 +7,7 @@ import { areNullableValuesEqual, compareDtos, compareDtosLists } from './migrati
 export async function get(id) {
   const [airtableDto, pgDto] = await Promise.all([attachmentDatasource.find(id), knex.select('*').from('attachments').where('id', id).first()]);
 
-  compareDtos(airtableDto, pgDto, compareAttachmentDtos);
+  compareDtos(airtableDto, pgDto, compareAttachmentDtos, 'attachments');
 
   if (!airtableDto) return null;
   return toDomain(airtableDto);
@@ -16,7 +16,7 @@ export async function get(id) {
 export async function list() {
   const [airtableDtos, pgDtos] = await Promise.all([attachmentDatasource.list(), knex.select('*').from('attachments').orderBy('id')]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareAttachmentDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareAttachmentDtos, 'attachments');
 
   return toDomainList(airtableDtos);
 }
@@ -24,7 +24,7 @@ export async function list() {
 export async function listByLocalizedChallengeIds(localizedChallengeIds) {
   const [airtableDtos, pgDtos] = await Promise.all([attachmentDatasource.filterByLocalizedChallengeIds(localizedChallengeIds), knex.select('*').from('attachments').whereIn('localizedChallengeId', localizedChallengeIds).orderBy('id')]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareAttachmentDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareAttachmentDtos, 'attachments');
 
   if (!airtableDtos) return [];
   return toDomainList(airtableDtos);
@@ -33,7 +33,7 @@ export async function listByLocalizedChallengeIds(localizedChallengeIds) {
 export async function listByLocalizedChallengeId(localizedChallengeId) {
   const [airtableDtos, pgDtos] = await Promise.all([attachmentDatasource.filterByLocalizedChallengeId(localizedChallengeId), knex.select('*').from('attachments').where('localizedChallengeId', localizedChallengeId).orderBy('id')]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareAttachmentDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareAttachmentDtos, 'attachments');
 
   if (!airtableDtos) return [];
   return toDomainList(airtableDtos);
@@ -142,24 +142,24 @@ export async function remove(attachmentId) {
 
 function compareAttachmentDtos(airtableDto, pgDto) {
   const diff = [];
-  if (airtableDto.id !== pgDto.id) diff.push(`attachment airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
   if (airtableDto.url !== pgDto.url)
-    diff.push(`attachment airtable url "${airtableDto.url}" != postgres url "${pgDto.url}"`);
+    diff.push(`airtable url "${airtableDto.url}" != postgres url "${pgDto.url}"`);
   if (airtableDto.size !== pgDto.size)
-    diff.push(`attachment airtable size "${airtableDto.size}" != postgres size "${pgDto.size}"`);
+    diff.push(`airtable size "${airtableDto.size}" != postgres size "${pgDto.size}"`);
   if (airtableDto.type !== pgDto.type)
-    diff.push(`attachment airtable type "${airtableDto.type}" != postgres type "${pgDto.type}"`);
+    diff.push(`airtable type "${airtableDto.type}" != postgres type "${pgDto.type}"`);
   if (!areNullableValuesEqual(airtableDto.mimeType, pgDto.mimeType))
-    diff.push(`attachment airtable mimeType "${airtableDto.mimeType}" != postgres mimeType "${pgDto.mimeType}"`);
+    diff.push(`airtable mimeType "${airtableDto.mimeType}" != postgres mimeType "${pgDto.mimeType}"`);
   if (airtableDto.filename !== pgDto.filename)
-    diff.push(`attachment airtable filename "${airtableDto.filename}" != postgres filename "${pgDto.filename}"`);
+    diff.push(`airtable filename "${airtableDto.filename}" != postgres filename "${pgDto.filename}"`);
   if (!areNullableValuesEqual(airtableDto.challengeId, pgDto.challengeId))
     diff.push(
-      `attachment airtable challengeId "${airtableDto.challengeId}" != postgres challengeId "${pgDto.challengeId}"`,
+      `airtable challengeId "${airtableDto.challengeId}" != postgres challengeId "${pgDto.challengeId}"`,
     );
   if (airtableDto.localizedChallengeId !== pgDto.localizedChallengeId)
     diff.push(
-      `attachment airtable localizedChallengeId "${airtableDto.localizedChallengeId}" != postgres localizedChallengeId "${pgDto.localizedChallengeId}"`,
+      `airtable localizedChallengeId "${airtableDto.localizedChallengeId}" != postgres localizedChallengeId "${pgDto.localizedChallengeId}"`,
     );
   return diff;
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -31,7 +31,7 @@ export async function get(id) {
     translationRepository.listByEntity(model, id),
   ]);
 
-  compareDtos(airtableDto, pgDto, compareChallengeDtos);
+  compareDtos(airtableDto, pgDto, compareChallengeDtos, 'challenges');
 
   if (!airtableDto) throw new NotFoundError('Épreuve introuvable');
 
@@ -51,7 +51,7 @@ export async function list() {
     localizedChallengeRepository.list(),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareChallengeDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareChallengeDtos, 'challenges');
 
   return toDomainList(airtableDtos, translations, localizedChallenges);
 }
@@ -66,7 +66,7 @@ export async function getMany(ids) {
     selectChallenges().whereIn('challenges.id', ids).orderBy('challenges.id'),
     loadTranslationsAndLocalizedChallengesForChallengeIds(ids),
   ]);
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos, 'challenges');
 
   if (!airtableDtos) return [];
   return toDomainList(airtableDtos, translations, localizedChallenges);
@@ -284,7 +284,7 @@ export async function update(challenge, transaction = knex) {
 
 export async function listBySkillId(skillId) {
   const [airtableDtos, pgDtos] = await Promise.all([challengeDatasource.filterBySkillId(skillId), selectChallenges().where('challenges.skillId', skillId).orderBy('id')]);
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos, 'challenges');
 
   if (!airtableDtos) return [];
   const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(airtableDtos);
@@ -300,7 +300,7 @@ export async function listActiveOrDraftByCompetenceId(competenceId) {
       .and.whereIn('challenges.status', [Challenge.STATUSES.PROPOSE, Challenge.STATUSES.VALIDE])
       .orderBy('id'),
   ]);
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos, 'challenges');
 
   if (!airtableDtos) return [];
   const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(airtableDtos);
@@ -316,7 +316,7 @@ export async function listPrototypesByCompetenceId(competenceId) {
       .andWhere('genealogy', Challenge.GENEALOGIES.PROTOTYPE)
       .orderBy('id'),
   ]);
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos, 'challenges');
 
   if (!airtableDtos) return [];
   const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(airtableDtos);
@@ -332,7 +332,7 @@ export async function listValidPrototypesBySkillIds(skillIds) {
       .andWhere('challenges.status', Challenge.STATUSES.VALIDE)
       .orderBy('challenges.id'),
   ]);
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareChallengeDtos, 'challenges');
 
   if (!airtableDtos) return [];
   const [translations, localizedChallenges] = await loadTranslationsAndLocalizedChallengesForChallenges(airtableDtos);
@@ -397,80 +397,80 @@ function toDomain(challengeDto, challengeTranslations, localizedChallenges = [])
 
 function compareChallengeDtos(airtableDto, pgDto) {
   const diff = [];
-  if (airtableDto.id !== pgDto.id) diff.push(`challenge airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
   if (!areNullableValuesEqual(airtableDto.type, pgDto.type))
-    diff.push(`challenge airtable type "${airtableDto.type}" != postgres type "${pgDto.type}"`);
+    diff.push(`airtable type "${airtableDto.type}" != postgres type "${pgDto.type}"`);
   if (airtableDto.t1Status !== pgDto.t1Status)
-    diff.push(`challenge airtable t1Status "${airtableDto.t1Status}" != postgres t1Status "${pgDto.t1Status}"`);
+    diff.push(`airtable t1Status "${airtableDto.t1Status}" != postgres t1Status "${pgDto.t1Status}"`);
   if (airtableDto.t2Status !== pgDto.t2Status)
-    diff.push(`challenge airtable t2Status "${airtableDto.t2Status}" != postgres t2Status "${pgDto.t2Status}"`);
+    diff.push(`airtable t2Status "${airtableDto.t2Status}" != postgres t2Status "${pgDto.t2Status}"`);
   if (airtableDto.t3Status !== pgDto.t3Status)
-    diff.push(`challenge airtable t3Status "${airtableDto.t3Status}" != postgres t3Status "${pgDto.t3Status}"`);
+    diff.push(`airtable t3Status "${airtableDto.t3Status}" != postgres t3Status "${pgDto.t3Status}"`);
   if (!areNullableValuesEqual(airtableDto.status, pgDto.status))
-    diff.push(`challenge airtable status "${airtableDto.status}" != postgres status "${pgDto.status}"`);
+    diff.push(`airtable status "${airtableDto.status}" != postgres status "${pgDto.status}"`);
   if (!areNullableValuesEqual(airtableDto.skillId, pgDto.skillId))
-    diff.push(`challenge airtable skillId "${airtableDto.skillId}" != postgres skillId "${pgDto.skillId}"`);
+    diff.push(`airtable skillId "${airtableDto.skillId}" != postgres skillId "${pgDto.skillId}"`);
   if (!areNullableValuesEqual(airtableDto.embedHeight, pgDto.embedHeight))
     diff.push(
-      `challenge airtable embedHeight "${airtableDto.embedHeight}" != postgres embedHeight "${pgDto.embedHeight}"`,
+      `airtable embedHeight "${airtableDto.embedHeight}" != postgres embedHeight "${pgDto.embedHeight}"`,
     );
   if (!areNullableValuesEqual(airtableDto.timer, pgDto.timer))
-    diff.push(`challenge airtable timer "${airtableDto.timer}" != postgres timer "${pgDto.timer}"`);
+    diff.push(`airtable timer "${airtableDto.timer}" != postgres timer "${pgDto.timer}"`);
   if (!areNullableValuesEqual(airtableDto.competenceId, pgDto.competenceId))
     diff.push(
-      `challenge airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
+      `airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
     );
   if (!areNullableValuesEqual(airtableDto.format, pgDto.format))
-    diff.push(`challenge airtable format "${airtableDto.format}" != postgres format "${pgDto.format}"`);
+    diff.push(`airtable format "${airtableDto.format}" != postgres format "${pgDto.format}"`);
   if (airtableDto.autoReply !== pgDto.autoReply)
-    diff.push(`challenge airtable autoReply "${airtableDto.autoReply}" != postgres autoReply "${pgDto.autoReply}"`);
+    diff.push(`airtable autoReply "${airtableDto.autoReply}" != postgres autoReply "${pgDto.autoReply}"`);
   if (!areArrayEquals(airtableDto.locales, pgDto.locales))
     diff.push(`challenges airtable locales "${airtableDto.locales}" != postgres locales "${pgDto.locales}"`);
   if (!areNullableValuesEqual(airtableDto.genealogy, pgDto.genealogy))
-    diff.push(`challenge airtable genealogy "${airtableDto.genealogy}" != postgres genealogy "${pgDto.genealogy}"`);
+    diff.push(`airtable genealogy "${airtableDto.genealogy}" != postgres genealogy "${pgDto.genealogy}"`);
   if (!areNullableValuesEqual(airtableDto.pedagogy, pgDto.pedagogy))
-    diff.push(`challenge airtable pedagogy "${airtableDto.pedagogy}" != postgres pedagogy "${pgDto.pedagogy}"`);
+    diff.push(`airtable pedagogy "${airtableDto.pedagogy}" != postgres pedagogy "${pgDto.pedagogy}"`);
   if (!areArrayEquals(airtableDto.author, pgDto.author))
-    diff.push(`challenge airtable author "${airtableDto.author}" != postgres author "${pgDto.author}"`);
+    diff.push(`airtable author "${airtableDto.author}" != postgres author "${pgDto.author}"`);
   if (!areNullableValuesEqual(airtableDto.declinable, pgDto.declinable))
-    diff.push(`challenge airtable declinable "${airtableDto.declinable}" != postgres declinable "${pgDto.declinable}"`);
+    diff.push(`airtable declinable "${airtableDto.declinable}" != postgres declinable "${pgDto.declinable}"`);
   if (!areNullableValuesEqual(airtableDto.version, pgDto.version))
-    diff.push(`challenge airtable version "${airtableDto.version}" != postgres version "${pgDto.version}"`);
+    diff.push(`airtable version "${airtableDto.version}" != postgres version "${pgDto.version}"`);
   if (!areNullableValuesEqual(airtableDto.alternativeVersion, pgDto.alternativeVersion))
     diff.push(
-      `challenge airtable alternativeVersion "${airtableDto.alternativeVersion}" != postgres alternativeVersion "${pgDto.alternativeVersion}"`,
+      `airtable alternativeVersion "${airtableDto.alternativeVersion}" != postgres alternativeVersion "${pgDto.alternativeVersion}"`,
     );
   if (!areNullableValuesEqual(airtableDto.accessibility1, pgDto.accessibility1))
     diff.push(
-      `challenge airtable accessibility1 "${airtableDto.accessibility1}" != postgres accessibility1 "${pgDto.accessibility1}"`,
+      `airtable accessibility1 "${airtableDto.accessibility1}" != postgres accessibility1 "${pgDto.accessibility1}"`,
     );
   if (!areNullableValuesEqual(airtableDto.accessibility2, pgDto.accessibility2))
     diff.push(
-      `challenge airtable accessibility2 "${airtableDto.accessibility2}" != postgres accessibility2 "${pgDto.accessibility2}"`,
+      `airtable accessibility2 "${airtableDto.accessibility2}" != postgres accessibility2 "${pgDto.accessibility2}"`,
     );
   if (!areNullableValuesEqual(airtableDto.spoil, pgDto.spoil))
-    diff.push(`challenge airtable spoil "${airtableDto.spoil}" != postgres spoil "${pgDto.spoil}"`);
+    diff.push(`airtable spoil "${airtableDto.spoil}" != postgres spoil "${pgDto.spoil}"`);
   if (!areNullableValuesEqual(airtableDto.responsive, pgDto.responsive))
-    diff.push(`challenge airtable responsive "${airtableDto.responsive}" != postgres responsive "${pgDto.responsive}"`);
+    diff.push(`airtable responsive "${airtableDto.responsive}" != postgres responsive "${pgDto.responsive}"`);
   if (!areNullableValuesEqual(airtableDto.delta, pgDto.delta))
-    diff.push(`challenge airtable delta "${airtableDto.delta}" != postgres delta "${pgDto.delta}"`);
+    diff.push(`airtable delta "${airtableDto.delta}" != postgres delta "${pgDto.delta}"`);
   if (!areNullableValuesEqual(airtableDto.alpha, pgDto.alpha))
-    diff.push(`challenge airtable alpha "${airtableDto.alpha}" != postgres alpha "${pgDto.alpha}"`);
+    diff.push(`airtable alpha "${airtableDto.alpha}" != postgres alpha "${pgDto.alpha}"`);
   if (airtableDto.shuffled !== pgDto.shuffled)
-    diff.push(`challenge airtable shuffled "${airtableDto.shuffled}" != postgres shuffled "${pgDto.shuffled}"`);
+    diff.push(`airtable shuffled "${airtableDto.shuffled}" != postgres shuffled "${pgDto.shuffled}"`);
   if (!areArrayEquals(airtableDto.contextualizedFields, pgDto.contextualizedFields))
     diff.push(
-      `challenge airtable contextualizedFields "${airtableDto.contextualizedFields}" != postgres contextualizedFields "${pgDto.contextualizedFields}"`,
+      `airtable contextualizedFields "${airtableDto.contextualizedFields}" != postgres contextualizedFields "${pgDto.contextualizedFields}"`,
     );
   if (!areNullableDatesEqual(airtableDto.validatedAt, pgDto.validatedAt))
     diff.push(
-      `challenge airtable validatedAt "${airtableDto.validatedAt}" != postgres validatedAt "${pgDto.validatedAt}"`,
+      `airtable validatedAt "${airtableDto.validatedAt}" != postgres validatedAt "${pgDto.validatedAt}"`,
     );
   if (!areNullableDatesEqual(airtableDto.archivedAt, pgDto.archivedAt))
-    diff.push(`challenge airtable archivedAt "${airtableDto.archivedAt}" != postgres archivedAt "${pgDto.archivedAt}"`);
+    diff.push(`airtable archivedAt "${airtableDto.archivedAt}" != postgres archivedAt "${pgDto.archivedAt}"`);
   if (!areNullableDatesEqual(airtableDto.madeObsoleteAt, pgDto.madeObsoleteAt))
     diff.push(
-      `challenge airtable madeObsoleteAt "${airtableDto.madeObsoleteAt}" != postgres madeObsoleteAt "${pgDto.madeObsoleteAt}"`,
+      `airtable madeObsoleteAt "${airtableDto.madeObsoleteAt}" != postgres madeObsoleteAt "${pgDto.madeObsoleteAt}"`,
     );
   if (
     !areArrayEquals(airtableDto.files, pgDto.files, {
@@ -484,7 +484,7 @@ function compareChallengeDtos(airtableDto, pgDto) {
     })
   )
     diff.push(
-      `challenge airtable files "${JSON.stringify(airtableDto.files)}" != postgres files "${JSON.stringify(pgDto.files)}"`,
+      `airtable files "${JSON.stringify(airtableDto.files)}" != postgres files "${JSON.stringify(pgDto.files)}"`,
     );
 
   return diff;

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -22,7 +22,7 @@ export async function list() {
     translationRepository.listByModel(model),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareCompetenceDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareCompetenceDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -38,7 +38,7 @@ export async function getMany(ids) {
     translationRepository.listByEntities(model, ids),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareCompetenceDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareCompetenceDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -54,7 +54,7 @@ export async function get(id) {
     translationRepository.listByEntity(model, id),
   ]);
 
-  compareDtos(airtableDto, pgDto, compareCompetenceDtos);
+  compareDtos(airtableDto, pgDto, compareCompetenceDtos, TABLE_NAME);
 
   if (!airtableDto) return null;
 
@@ -67,7 +67,7 @@ export async function getByAirtableId(airtableId) {
 
   const [pgDto, translations] = await Promise.all([selectCompetences().where('competences.id', airtableDto.id).first(), translationRepository.listByEntity(model, airtableDto.id)]);
 
-  compareDtos(airtableDto, pgDto, compareCompetenceDtos);
+  compareDtos(airtableDto, pgDto, compareCompetenceDtos, TABLE_NAME);
 
   return toDomain(airtableDto, translations);
 }
@@ -142,24 +142,24 @@ function selectCompetences() {
 function compareCompetenceDtos(airtableCompetence, pgCompetence) {
   const diff = [];
   if (airtableCompetence.id !== pgCompetence.id)
-    diff.push(`competence airtable id "${airtableCompetence.id}" != postgres id "${pgCompetence.id}"`);
+    diff.push(`airtable id "${airtableCompetence.id}" != postgres id "${pgCompetence.id}"`);
   if (airtableCompetence.index !== pgCompetence.index)
-    diff.push(`competence airtable index "${airtableCompetence.index}" != postgres index "${pgCompetence.index}"`);
+    diff.push(`airtable index "${airtableCompetence.index}" != postgres index "${pgCompetence.index}"`);
   if (airtableCompetence.areaId !== pgCompetence.areaId)
-    diff.push(`competence airtable areaId "${airtableCompetence.areaId}" != postgres areaId "${pgCompetence.areaId}"`);
+    diff.push(`airtable areaId "${airtableCompetence.areaId}" != postgres areaId "${pgCompetence.areaId}"`);
   if (airtableCompetence.origin !== pgCompetence.origin)
-    diff.push(`competence airtable origin "${airtableCompetence.origin}" != postgres origin "${pgCompetence.origin}"`);
+    diff.push(`airtable origin "${airtableCompetence.origin}" != postgres origin "${pgCompetence.origin}"`);
   if (!areArrayEquals(airtableCompetence.thematicIds, pgCompetence.thematicIds))
     diff.push(
-      `competence airtable thematicIds "${airtableCompetence.thematicIds}" != postgres thematicIds "${pgCompetence.thematicIds}"`,
+      `airtable thematicIds "${airtableCompetence.thematicIds}" != postgres thematicIds "${pgCompetence.thematicIds}"`,
     );
   if (!areArrayEquals(airtableCompetence.tubeIds, pgCompetence.tubeIds))
     diff.push(
-      `competence airtable tubeIds "${airtableCompetence.tubeIds}" != postgres tubeIds "${pgCompetence.tubeIds}"`,
+      `airtable tubeIds "${airtableCompetence.tubeIds}" != postgres tubeIds "${pgCompetence.tubeIds}"`,
     );
   if (!areArrayEquals(airtableCompetence.skillIds, pgCompetence.skillIds))
     diff.push(
-      `competence airtable skillIds "${airtableCompetence.skillIds}" != postgres skillIds "${pgCompetence.skillIds}"`,
+      `airtable skillIds "${airtableCompetence.skillIds}" != postgres skillIds "${pgCompetence.skillIds}"`,
     );
   return diff;
 }

--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -23,7 +23,7 @@ export async function list() {
       .orderBy('createdAt'),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareFrameworkDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareFrameworkDtos, TABLE_NAME);
 
   return airtableDtos.map(toDomain);
 }
@@ -47,11 +47,11 @@ export async function create(framework) {
 function compareFrameworkDtos(airtableFramework, pgFramework) {
   const diff = [];
   if (airtableFramework.id !== pgFramework.id)
-    diff.push(`framework airtable id "${airtableFramework.id}" != postgres id "${pgFramework.id}"`);
+    diff.push(`airtable id "${airtableFramework.id}" != postgres id "${pgFramework.id}"`);
   if (airtableFramework.name !== pgFramework.name)
-    diff.push(`framework airtable name "${airtableFramework.name}" != postgres name "${pgFramework.name}"`);
+    diff.push(`airtable name "${airtableFramework.name}" != postgres name "${pgFramework.name}"`);
   if (!areArrayEquals(airtableFramework.areaIds, pgFramework.areaIds))
-    diff.push(`framework airtable areaIds "${airtableFramework.areaIds}" != postgres areaIds "${pgFramework.areaIds}"`);
+    diff.push(`airtable areaIds "${airtableFramework.areaIds}" != postgres areaIds "${pgFramework.areaIds}"`);
   return diff;
 }
 

--- a/api/lib/infrastructure/repositories/migration-from-airtable.js
+++ b/api/lib/infrastructure/repositories/migration-from-airtable.js
@@ -1,5 +1,6 @@
 import * as config from '../../config.js';
 import { child } from '../logger.js';
+import { getRequestId } from '../monitoring-tools.js';
 
 const logger = child('airtable:migration', { event: 'migration-from-airtable' });
 
@@ -7,55 +8,48 @@ const logger = child('airtable:migration', { event: 'migration-from-airtable' })
  * @param {object[]} airtableDtos
  * @param {object[]} pgDtos
  * @param {(object, object) => string[]} compareFunc
+ * @param {string} tableName
  */
-export function compareDtosLists(airtableDtos, pgDtos, compareFunc) {
-  if (airtableDtos.length !== pgDtos.length) {
-    logger.warn(
+export function compareDtosLists(airtableDtos, pgDtos, compareFunc, tableName) {
+  const airtableIds = new Set(airtableDtos.map((airtableDtos) => airtableDtos.id));
+  const pgIds = new Set(pgDtos.map((pgDtos) => pgDtos.id));
+
+  const airtableOnlyIds = airtableIds.values().filter((id) => !pgIds.has(id)).toArray();
+  const pgOnlyIds = airtableIds.values().filter((id) => !airtableIds.has(id)).toArray();
+
+  if (airtableOnlyIds.length !== 0 || pgOnlyIds.length !== 0) {
+    logDifference(
       {
+        tableName,
         airtableCount: airtableDtos.length,
         postgresCount: pgDtos.length,
+        airtableOnlyIds,
+        pgOnlyIds,
       },
-      'difference between airtable and postgres dtos count',
+      'difference between airtable and postgres dtos',
     );
-    if (config.migrationFromAirtable.throwOnPostgresDifference) {
-      console.error('difference between airtable and postgres dtos count', {
-        airtableCount: airtableDtos.length,
-        postgresCount: pgDtos.length,
-      });
-      throw new Error('difference between airtable and postgres dtos count');
-    }
     return;
   }
+
   const sortedAirtableDtos = airtableDtos.toSorted(byId);
   const sortedPgDtos = pgDtos.toSorted(byId);
-  sortedAirtableDtos.forEach((airtableDto, i) => compareDtos(airtableDto, sortedPgDtos[i], compareFunc));
+
+  sortedAirtableDtos.forEach((airtableDto, i) => compareDtos(airtableDto, sortedPgDtos[i], compareFunc, tableName));
 }
 
-export function compareDtos(airtableDto, pgDto, compareFunc) {
+export function compareDtos(airtableDto, pgDto, compareFunc, tableName) {
   if (airtableDto == null && pgDto == null) return;
   if (airtableDto == null && pgDto != null) {
-    logger.warn('airtable dto empty whereas postgres dto not empty');
-    if (config.migrationFromAirtable.throwOnPostgresDifference) {
-      console.error('airtable dto empty whereas postgres dto not empty');
-      throw new Error('airtable dto empty whereas postgres dto not empty');
-    }
+    logDifference({ tableName, entityId: pgDto.id }, 'airtable dto empty whereas postgres dto not empty');
     return;
   }
   if (airtableDto != null && pgDto == null) {
-    logger.warn('airtable dto not empty whereas postgres dto empty');
-    if (config.migrationFromAirtable.throwOnPostgresDifference) {
-      console.error('airtable dto not empty whereas postgres dto empty');
-      throw new Error('airtable dto not empty whereas postgres dto empty');
-    }
+    logDifference({ tableName, entityId: airtableDto.id }, 'airtable dto not empty whereas postgres dto empty');
     return;
   }
   const diff = compareFunc(airtableDto, pgDto);
   if (diff.length === 0) return;
-  logger.warn({ diff }, 'difference between airtable and postgres dtos');
-  if (config.migrationFromAirtable.throwOnPostgresDifference) {
-    console.error('difference between airtable and postgres dtos', diff);
-    throw new Error('difference between airtable and postgres dtos');
-  }
+  logDifference({ diff, tableName, entityId: airtableDto.id }, 'difference between airtable and postgres dtos');
 }
 
 export function areArrayEquals(array1, array2, { sortFn, compareFn = (value1, value2) => value1 === value2 } = {}) {
@@ -81,4 +75,13 @@ export function areNullableDatesEqual(date1, date2) {
 
 function byId(dto1, dto2) {
   return dto1.id < dto2.id ? -1 : +1;
+}
+
+function logDifference(data, msg) {
+  const request_id = getRequestId();
+  logger.warn({ request_id, ...data }, msg);
+  if (config.migrationFromAirtable.throwOnPostgresDifference) {
+    console.error(msg, data);
+    throw new Error(msg);
+  }
 }

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -27,7 +27,7 @@ export async function list() {
     translationRepository.listByModel(model),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations, pgDtos);
 }
@@ -43,7 +43,7 @@ export async function get(id) {
     translationRepository.listByEntity(model, id),
   ]);
 
-  compareDtos(airtableDto, pgDto, compareSkillDtos);
+  compareDtos(airtableDto, pgDto, compareSkillDtos, TABLE_NAME);
 
   if (!airtableDto) return null;
   return toDomain(airtableDto, translations, pgDto);
@@ -60,7 +60,7 @@ export async function getMany(ids) {
     translationRepository.listByEntities(model, ids),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations, pgDtos);
 }
@@ -71,7 +71,7 @@ export async function getByAirtableId(id) {
   const translations = await translationRepository.listByEntity(model, airtableDto.id);
   const pgDto = await selectSkills().where('skills.id', airtableDto.id).first();
 
-  compareDtos(airtableDto, pgDto, compareSkillDtos);
+  compareDtos(airtableDto, pgDto, compareSkillDtos, TABLE_NAME);
 
   return toDomain(airtableDto, translations, pgDto);
 }
@@ -91,14 +91,14 @@ export async function getManyByAirtableIds(ids) {
     )
     .orderBy('skills.id');
 
-  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareSkillDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations, pgDtos);
 }
 
 export async function listByTubeId(tubeId) {
   const [airtableDtos, pgDtos] = await Promise.all([skillDatasource.filterByTubeId(tubeId), selectSkills().where('skills.tubeId', tubeId)]);
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
   const translations = await translationRepository.listByEntities(
@@ -118,7 +118,7 @@ export async function listActiveByCompetenceId(competenceId) {
       .orderBy('skills.id'),
   ]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
 
@@ -133,7 +133,7 @@ export async function listActiveByCompetenceId(competenceId) {
 export async function listByCompetenceId(competenceId) {
   const [airtableDtos, pgDtos] = await Promise.all([skillDatasource.listByCompetenceId(competenceId), selectSkills().where('thematics.competenceId', competenceId).orderBy('skills.id')]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
 
@@ -177,7 +177,7 @@ export async function search(params) {
 
   const [airtableDtos, pgDtos] = await Promise.all([skillDatasource.search(params), query]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareSkillDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
 
@@ -340,42 +340,42 @@ export async function update(skill) {
 
 function compareSkillDtos(airtableDto, pgDto) {
   const diff = [];
-  if (airtableDto.id !== pgDto.id) diff.push(`skill airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
   if (!areNullableValuesEqual(airtableDto.status, pgDto.status))
-    diff.push(`skill airtable status "${airtableDto.status}" != postgres status "${pgDto.status}"`);
+    diff.push(`airtable status "${airtableDto.status}" != postgres status "${pgDto.status}"`);
   if (!areNullableValuesEqual(airtableDto.hintStatus, pgDto.hintStatus))
-    diff.push(`skill airtable hintStatus "${airtableDto.hintStatus}" != postgres hintStatus "${pgDto.hintStatus}"`);
+    diff.push(`airtable hintStatus "${airtableDto.hintStatus}" != postgres hintStatus "${pgDto.hintStatus}"`);
   if (!areNullableValuesEqual(airtableDto.descriptionStatus, pgDto.descriptionStatus))
     diff.push(
-      `skill airtable descriptionStatus "${airtableDto.descriptionStatus}" != postgres descriptionStatus "${pgDto.descriptionStatus}"`,
+      `airtable descriptionStatus "${airtableDto.descriptionStatus}" != postgres descriptionStatus "${pgDto.descriptionStatus}"`,
     );
   if (!areNullableValuesEqual(airtableDto.description, pgDto.description))
-    diff.push(`skill airtable description "${airtableDto.description}" != postgres description "${pgDto.description}"`);
+    diff.push(`airtable description "${airtableDto.description}" != postgres description "${pgDto.description}"`);
   if (!areNullableValuesEqual(airtableDto.level, pgDto.level))
-    diff.push(`skill airtable level "${airtableDto.level}" != postgres level "${pgDto.level}"`);
+    diff.push(`airtable level "${airtableDto.level}" != postgres level "${pgDto.level}"`);
   if (!areNullableValuesEqual(airtableDto.internationalisation, pgDto.internationalisation))
     diff.push(
-      `skill airtable internationalisation "${airtableDto.internationalisation}" != postgres internationalisation "${pgDto.internationalisation}"`,
+      `airtable internationalisation "${airtableDto.internationalisation}" != postgres internationalisation "${pgDto.internationalisation}"`,
     );
   if (!areNullableValuesEqual(airtableDto.version, pgDto.version))
-    diff.push(`skill airtable version "${airtableDto.version}" != postgres version "${pgDto.version}"`);
+    diff.push(`airtable version "${airtableDto.version}" != postgres version "${pgDto.version}"`);
   if (!areNullableValuesEqual(airtableDto.tubeId, pgDto.tubeId))
-    diff.push(`skill airtable tubeId "${airtableDto.tubeId}" != postgres tubeId "${pgDto.tubeId}"`);
+    diff.push(`airtable tubeId "${airtableDto.tubeId}" != postgres tubeId "${pgDto.tubeId}"`);
   if (airtableDto.name !== pgDto.name)
-    diff.push(`skill airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
+    diff.push(`airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
   if (!areNullableValuesEqual(airtableDto.competenceId, pgDto.competenceId))
     diff.push(
-      `skill airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
+      `airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
     );
   if (!areArrayEquals(airtableDto.tutorialIds, pgDto.tutorialIds))
-    diff.push(`skill airtable tutorialIds "${airtableDto.tutorialIds}" != postgres tutorialIds "${pgDto.tutorialIds}"`);
+    diff.push(`airtable tutorialIds "${airtableDto.tutorialIds}" != postgres tutorialIds "${pgDto.tutorialIds}"`);
   if (!areArrayEquals(airtableDto.learningMoreTutorialIds, pgDto.learningMoreTutorialIds))
     diff.push(
-      `skill airtable learningMoreTutorialIds "${airtableDto.learningMoreTutorialIds}" != postgres learningMoreTutorialIds "${pgDto.learningMoreTutorialIds}"`,
+      `airtable learningMoreTutorialIds "${airtableDto.learningMoreTutorialIds}" != postgres learningMoreTutorialIds "${pgDto.learningMoreTutorialIds}"`,
     );
   if (!areArrayEquals(airtableDto.challengeIds, pgDto.challengeIds))
     diff.push(
-      `skill airtable challengeIds "${airtableDto.challengeIds}" != postgres challengeIds "${pgDto.challengeIds}"`,
+      `airtable challengeIds "${airtableDto.challengeIds}" != postgres challengeIds "${pgDto.challengeIds}"`,
     );
   return diff;
 }

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -19,7 +19,7 @@ export async function getByAirtableId(tagId) {
 
   const pgDto = await knex.select('*').from(TABLE_NAME).where('id', airtableDto.id).first();
 
-  compareDtos(airtableDto, pgDto, compareTagDtos);
+  compareDtos(airtableDto, pgDto, compareTagDtos, TABLE_NAME);
 
   return toDomain(airtableDto);
 }
@@ -37,7 +37,7 @@ export async function getManyByAirtableIds(airtableIds) {
     )
     .orderBy('id');
 
-  compareDtosLists(airtableDtos, pgDtos, compareTagDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTagDtos, TABLE_NAME);
 
   return airtableDtos.map(toDomain);
 }
@@ -53,7 +53,7 @@ export async function searchByTitle(title) {
       .limit(4),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareTagDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTagDtos, TABLE_NAME);
 
   return airtableDtos.map(toDomain);
 }
@@ -61,7 +61,7 @@ export async function searchByTitle(title) {
 export async function findByTitle(title) {
   const [airtableDto, pgDto] = await Promise.all([tagDatasource.findByTitle(title), knex.select('*').from(TABLE_NAME).where(knex.raw('LOWER(??)', 'title'), title.toLowerCase()).first()]);
 
-  compareDtos(airtableDto, pgDto, compareTagDtos);
+  compareDtos(airtableDto, pgDto, compareTagDtos, TABLE_NAME);
 
   if (!airtableDto) return null;
 
@@ -70,9 +70,9 @@ export async function findByTitle(title) {
 
 function compareTagDtos(airtableTag, pgTag) {
   const diff = [];
-  if (airtableTag.id !== pgTag.id) diff.push(`tag airtable id "${airtableTag.id}" != postgres id "${pgTag.id}"`);
+  if (airtableTag.id !== pgTag.id) diff.push(`airtable id "${airtableTag.id}" != postgres id "${pgTag.id}"`);
   if (airtableTag.title !== pgTag.title)
-    diff.push(`tag airtable title "${airtableTag.title}" != postgres title "${pgTag.title}"`);
+    diff.push(`airtable title "${airtableTag.title}" != postgres title "${pgTag.title}"`);
   return diff;
 }
 

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -21,7 +21,7 @@ export async function list() {
     translationRepository.listByModel(model),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -32,7 +32,7 @@ export async function getByAirtableId(airtableId) {
 
   const [pgDto, translations] = await Promise.all([selectThematics().where('id', airtableDto.id).first(), translationRepository.listByEntity(model, airtableDto.id)]);
 
-  compareDtos(airtableDto, pgDto, compareThematicDtos);
+  compareDtos(airtableDto, pgDto, compareThematicDtos, TABLE_NAME);
 
   return toDomain(airtableDto, translations);
 }
@@ -48,7 +48,7 @@ export async function getMany(ids) {
     translationRepository.listByEntities(model, ids),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -61,7 +61,7 @@ export async function getManyByAirtableIds(airtableIds) {
   const ids = airtableDtos.map(({ id }) => id);
   const [pgDtos, translations] = await Promise.all([selectThematics().whereIn('id', ids).orderBy('id'), translationRepository.listByEntities(model, ids)]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -70,7 +70,7 @@ export async function listByCompetenceId(competenceId) {
   const [airtableDtos, pgDtos] = await Promise.all([thematicDatasource.listByCompetenceId(competenceId), selectThematics().where('competenceId', competenceId).orderBy('id')]);
   if (!airtableDtos) return [];
 
-  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos, TABLE_NAME);
 
   const translations = await translationRepository.listByEntities(
     model,
@@ -87,7 +87,7 @@ export async function listByCompetenceAirtableId(competenceAirtableId) {
   const ids = airtableDtos.map(({ id }) => id);
   const [pgDtos, translations] = await Promise.all([selectThematics().whereIn('id', ids).orderBy('id'), translationRepository.listByEntities(model, ids)]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareThematicDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -150,15 +150,15 @@ function selectThematics(knexConn = knex) {
 function compareThematicDtos(airtableThematic, pgThematic) {
   const diff = [];
   if (airtableThematic.id !== pgThematic.id)
-    diff.push(`thematic airtable id "${airtableThematic.id}" != postgres id "${pgThematic.id}"`);
+    diff.push(`airtable id "${airtableThematic.id}" != postgres id "${pgThematic.id}"`);
   if (!areNullableValuesEqual(airtableThematic.index, pgThematic.index))
-    diff.push(`thematic airtable index "${airtableThematic.index}" != postgres index "${pgThematic.index}"`);
+    diff.push(`airtable index "${airtableThematic.index}" != postgres index "${pgThematic.index}"`);
   if (airtableThematic.competenceId !== pgThematic.competenceId)
     diff.push(
-      `thematic airtable competenceId "${airtableThematic.competenceId}" != postgres competenceId "${pgThematic.competenceId}"`,
+      `airtable competenceId "${airtableThematic.competenceId}" != postgres competenceId "${pgThematic.competenceId}"`,
     );
   if (!areArrayEquals(airtableThematic.tubeIds, pgThematic.tubeIds))
-    diff.push(`thematic airtable tubeIds "${airtableThematic.tubeIds}" != postgres tubeIds "${pgThematic.tubeIds}"`);
+    diff.push(`airtable tubeIds "${airtableThematic.tubeIds}" != postgres tubeIds "${pgThematic.tubeIds}"`);
   return diff;
 }
 

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -21,7 +21,7 @@ export async function list() {
     translationRepository.listByModel(model),
   ]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareTubeDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTubeDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -37,7 +37,7 @@ export async function get(id) {
     translationRepository.listByEntity(model, id),
   ]);
 
-  compareDtos(airtableDto, pgDto, compareTubeDtos);
+  compareDtos(airtableDto, pgDto, compareTubeDtos, TABLE_NAME);
 
   if (!airtableDto) return null;
 
@@ -47,7 +47,7 @@ export async function get(id) {
 export async function listByCompetenceId(competenceId) {
   const [airtableDtos, pgDtos] = await Promise.all([tubeDatasource.listByCompetenceId(competenceId), selectTubes().where('thematics.competenceId', competenceId).orderBy('tubes.id')]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareTubeDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTubeDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
 
@@ -65,7 +65,7 @@ export async function getByAirtableId(airtableId) {
 
   const [pgDto, translations] = await Promise.all([selectTubes().where('tubes.id', airtableDto.id).first(), translationRepository.listByEntity(model, airtableDto.id)]);
 
-  compareDtos(airtableDto, pgDto, compareTubeDtos);
+  compareDtos(airtableDto, pgDto, compareTubeDtos, TABLE_NAME);
 
   return toDomain(airtableDto, translations);
 }
@@ -80,7 +80,7 @@ export async function getManyByAirtableIds(airtableIds) {
 
   const [pgDtos, translations] = await Promise.all([selectTubes().whereIn('tubes.id', ids).orderBy('tubes.id'), translationRepository.listByEntities(model, ids)]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareTubeDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTubeDtos, TABLE_NAME);
 
   return toDomainList(airtableDtos, translations);
 }
@@ -145,19 +145,19 @@ function selectTubes() {
 
 function compareTubeDtos(airtableDto, pgDto) {
   const diff = [];
-  if (airtableDto.id !== pgDto.id) diff.push(`tube airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
+  if (airtableDto.id !== pgDto.id) diff.push(`airtable id "${airtableDto.id}" != postgres id "${pgDto.id}"`);
   if (airtableDto.name !== pgDto.name)
-    diff.push(`tube airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
+    diff.push(`airtable name "${airtableDto.name}" != postgres name "${pgDto.name}"`);
   if (!areNullableValuesEqual(airtableDto.index, pgDto.index))
-    diff.push(`tube airtable index "${airtableDto.index}" != postgres index "${pgDto.index}"`);
+    diff.push(`airtable index "${airtableDto.index}" != postgres index "${pgDto.index}"`);
   if (airtableDto.thematicId !== pgDto.thematicId)
-    diff.push(`tube airtable thematicId "${airtableDto.thematicId}" != postgres thematicId "${pgDto.thematicId}"`);
+    diff.push(`airtable thematicId "${airtableDto.thematicId}" != postgres thematicId "${pgDto.thematicId}"`);
   if (airtableDto.competenceId !== pgDto.competenceId)
     diff.push(
-      `tube airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
+      `airtable competenceId "${airtableDto.competenceId}" != postgres competenceId "${pgDto.competenceId}"`,
     );
   if (!areArrayEquals(airtableDto.skillIds, pgDto.skillIds))
-    diff.push(`tube airtable skillIds "${airtableDto.skillIds}" != postgres skillIds "${pgDto.skillIds}"`);
+    diff.push(`airtable skillIds "${airtableDto.skillIds}" != postgres skillIds "${pgDto.skillIds}"`);
   return diff;
 }
 

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -94,7 +94,7 @@ export async function getByAirtableId(airtableId) {
 
   const pgDto = await selectTutorials().where('id', airtableDto.id).first();
 
-  compareDtos(airtableDto, pgDto, compareTutorialDtos);
+  compareDtos(airtableDto, pgDto, compareTutorialDtos, TABLE_NAME);
 
   return toDomain(airtableDto);
 }
@@ -111,7 +111,7 @@ export async function getManyByAirtableIds(airtableIds) {
     )
     .orderBy('id');
 
-  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos, TABLE_NAME);
 
   return airtableDtos.map(toDomain);
 }
@@ -125,7 +125,7 @@ export async function searchByTitle(title) {
       .limit(100),
   ]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
   return airtableDtos.map(toDomain);
@@ -140,7 +140,7 @@ export async function searchBySource(source) {
       .limit(4),
   ]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
   return airtableDtos.map(toDomain);
@@ -162,7 +162,7 @@ export async function searchByTagTitles(tagTitles) {
 
   const [airtableDtos, pgDtos] = await Promise.all([tutorialDatasource.searchByTagTitles(tagTitles), tutorialsQuery]);
 
-  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos);
+  compareDtosLists(airtableDtos ?? [], pgDtos, compareTutorialDtos, TABLE_NAME);
 
   if (!airtableDtos) return [];
   return airtableDtos.map(toDomain);
@@ -171,7 +171,7 @@ export async function searchByTagTitles(tagTitles) {
 export async function getMany(ids) {
   const [airtableDtos, pgDtos] = await Promise.all([tutorialDatasource.filter({ filter: { ids } }), selectTutorials().whereIn('id', ids).orderBy('id')]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos, TABLE_NAME);
 
   return airtableDtos.map(toDomain);
 }
@@ -179,7 +179,7 @@ export async function getMany(ids) {
 export async function list() {
   const [airtableDtos, pgDtos] = await Promise.all([tutorialDatasource.list(), selectTutorials().orderBy('id')]);
 
-  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos);
+  compareDtosLists(airtableDtos, pgDtos, compareTutorialDtos, TABLE_NAME);
 
   return airtableDtos.map(toDomain);
 }
@@ -213,29 +213,29 @@ function selectTutorials() {
 function compareTutorialDtos(airtableTutorial, pgTutorial) {
   const diff = [];
   if (airtableTutorial.id !== pgTutorial.id)
-    diff.push(`tutorial airtable id "${airtableTutorial.id}" != postgres id "${pgTutorial.id}"`);
+    diff.push(`airtable id "${airtableTutorial.id}" != postgres id "${pgTutorial.id}"`);
   if (airtableTutorial.title !== pgTutorial.title)
-    diff.push(`tutorial airtable title "${airtableTutorial.title}" != postgres title "${pgTutorial.title}"`);
+    diff.push(`airtable title "${airtableTutorial.title}" != postgres title "${pgTutorial.title}"`);
   if (airtableTutorial.duration !== pgTutorial.duration)
     diff.push(
-      `tutorial airtable duration "${airtableTutorial.duration}" != postgres duration "${pgTutorial.duration}"`,
+      `airtable duration "${airtableTutorial.duration}" != postgres duration "${pgTutorial.duration}"`,
     );
   if (airtableTutorial.source !== pgTutorial.source)
-    diff.push(`tutorial airtable source "${airtableTutorial.source}" != postgres source "${pgTutorial.source}"`);
+    diff.push(`airtable source "${airtableTutorial.source}" != postgres source "${pgTutorial.source}"`);
   if (airtableTutorial.format !== pgTutorial.format)
-    diff.push(`tutorial airtable format "${airtableTutorial.format}" != postgres format "${pgTutorial.format}"`);
+    diff.push(`airtable format "${airtableTutorial.format}" != postgres format "${pgTutorial.format}"`);
   if (airtableTutorial.link !== pgTutorial.link)
-    diff.push(`tutorial airtable link "${airtableTutorial.link}" != postgres link "${pgTutorial.link}"`);
+    diff.push(`airtable link "${airtableTutorial.link}" != postgres link "${pgTutorial.link}"`);
   if (!areNullableValuesEqual(airtableTutorial.license, pgTutorial.license))
-    diff.push(`tutorial airtable license "${airtableTutorial.license}" != postgres license "${pgTutorial.license}"`);
+    diff.push(`airtable license "${airtableTutorial.license}" != postgres license "${pgTutorial.license}"`);
   if (!areNullableValuesEqual(airtableTutorial.level, pgTutorial.level))
-    diff.push(`tutorial airtable level "${airtableTutorial.level}" != postgres level "${pgTutorial.level}"`);
+    diff.push(`airtable level "${airtableTutorial.level}" != postgres level "${pgTutorial.level}"`);
   if (airtableTutorial.crush !== pgTutorial.crush)
-    diff.push(`tutorial airtable crush "${airtableTutorial.crush}" != postgres crush "${pgTutorial.crush}"`);
+    diff.push(`airtable crush "${airtableTutorial.crush}" != postgres crush "${pgTutorial.crush}"`);
   if (!areNullableValuesEqual(airtableTutorial.locale, pgTutorial.locale))
-    diff.push(`tutorial airtable locale "${airtableTutorial.locale}" != postgres locale "${pgTutorial.locale}"`);
+    diff.push(`airtable locale "${airtableTutorial.locale}" != postgres locale "${pgTutorial.locale}"`);
   if (!areArrayEquals(airtableTutorial.tagIds, pgTutorial.tagIds))
-    diff.push(`tutorial airtable tagIds "${airtableTutorial.tagIds}" != postgres tagIds "${pgTutorial.tagIds}"`);
+    diff.push(`airtable tagIds "${airtableTutorial.tagIds}" != postgres tagIds "${pgTutorial.tagIds}"`);
   return diff;
 }
 


### PR DESCRIPTION
## 🍂 Problème

Les warnings de migration Airtable sont parfois difficile à interpréter.

## 🌰 Proposition

Ajouter le nom de la table et le request_id aux warnings.
Comparer les results sets par identifiants et faire un seul warnings en cas de différence.

## 🍁 Remarques


N/A

## 🪵 Pour tester

N/A