### PR TITLE
[TECH] Ecrit les notes et changelogs dans PG (PIX-20396).

### DIFF
--- a/api/db/migrations/20251117143150_create-notes-changelogs-tables.js
+++ b/api/db/migrations/20251117143150_create-notes-changelogs-tables.js
@@ -9,7 +9,7 @@ export async function up(knex) {
     table.string('author').notNullable();
     table.string('elementId').notNullable();
     table.string('elementType').nullable();
-    table.timestamp('createdAt');
+    table.timestamp('createdAt').notNullable().defaultTo(knex.fn.now());
   });
 
   await knex.schema.createTable('notes', function(table) {

--- a/api/db/migrations/20251117143150_create-notes-changelogs-tables.js
+++ b/api/db/migrations/20251117143150_create-notes-changelogs-tables.js
@@ -1,0 +1,32 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable('changelog_entries', function(table) {
+    table.string('id').primary().notNullable();
+    table.text('text').notNullable();
+    table.string('author').notNullable();
+    table.string('elementId').notNullable();
+    table.string('elementType').nullable();
+    table.timestamp('createdAt');
+  });
+
+  await knex.schema.createTable('notes', function(table) {
+    table.string('id').primary().notNullable();
+    table.string('status').nullable();
+    table.text('text').notNullable();
+    table.string('author').notNullable();
+    table.string('challengeId').notNullable();
+    table.timestamps(true, true, true);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable('changelog_entries');
+  await knex.schema.dropTable('notes');
+}

--- a/api/lib/domain/models/ChangelogEntry.js
+++ b/api/lib/domain/models/ChangelogEntry.js
@@ -24,9 +24,8 @@ export class ChangelogEntry {
     };
   }
 
-  constructor({ id, status, text, author, createdAt, elementId, elementType }) {
+  constructor({ id, text, author, createdAt, elementId, elementType }) {
     this.id = id;
-    this.status = status;
     this.text = text;
     this.author = author;
     this.createdAt = createdAt;

--- a/api/lib/infrastructure/repositories/changelog-entry-repository.js
+++ b/api/lib/infrastructure/repositories/changelog-entry-repository.js
@@ -10,14 +10,13 @@ function _airtableClient() {
 
 export async function listByElementId(elementId) {
   const airtableRecords = await _airtableClient().table(TABLE_NAME).select({
-    filterByFormula: `AND(Record_Id = "${elementId}", Statut != "archive", Changelog = "oui")`,
+    filterByFormula: `AND(Record_Id = "${elementId}", Changelog = "oui")`,
     sort: [{ field: 'Date', direction: 'asc' }],
   }).all();
 
   return airtableRecords.map((record) => {
     return new ChangelogEntry({
       id: record.id,
-      status: record.get('Statut'),
       text: record.get('Texte'),
       author: record.get('Auteur'),
       createdAt: record.get('Date'),
@@ -30,7 +29,6 @@ export async function listByElementId(elementId) {
 export async function create(changelogEntry) {
   const airtableRecordToCreate = {
     fields: {
-      Statut: changelogEntry.status,
       Texte: changelogEntry.text,
       Auteur: changelogEntry.author,
       Record_Id: changelogEntry.elementId,
@@ -42,7 +40,6 @@ export async function create(changelogEntry) {
 
   return new ChangelogEntry({
     id: records[0].id,
-    status: records[0].get('Statut'),
     text: records[0].get('Texte'),
     author: records[0].get('Auteur'),
     createdAt: records[0].get('Date'),

--- a/api/lib/infrastructure/repositories/changelog-entry-repository.js
+++ b/api/lib/infrastructure/repositories/changelog-entry-repository.js
@@ -1,15 +1,16 @@
 import Airtable from 'airtable';
 import * as config from '../../config.js';
 import { ChangelogEntry } from '../../domain/models/ChangelogEntry.js';
+import { knex } from '../../../db/knex-database-connection.js';
 
-const TABLE_NAME = 'Notes';
+const AIRTABLE_NAME = 'Notes';
 
 function _airtableClient() {
   return new Airtable({ apiKey: config.airtable.apiKey }).base(config.airtable.editorBase);
 }
 
 export async function listByElementId(elementId) {
-  const airtableRecords = await _airtableClient().table(TABLE_NAME).select({
+  const airtableRecords = await _airtableClient().table(AIRTABLE_NAME).select({
     filterByFormula: `AND(Record_Id = "${elementId}", Changelog = "oui")`,
     sort: [{ field: 'Date', direction: 'asc' }],
   }).all();
@@ -36,14 +37,22 @@ export async function create(changelogEntry) {
       Changelog: 'oui',
     },
   };
-  const records = await _airtableClient().table(TABLE_NAME).create([airtableRecordToCreate]);
+  const [record] = await _airtableClient().table(AIRTABLE_NAME).create([airtableRecordToCreate]);
+
+  await knex.insert({
+    id: record.id,
+    text: changelogEntry.text,
+    author: changelogEntry.author,
+    elementId: changelogEntry.elementId,
+    elementType: changelogEntry.elementType,
+  }).into('changelog_entries');
 
   return new ChangelogEntry({
-    id: records[0].id,
-    text: records[0].get('Texte'),
-    author: records[0].get('Auteur'),
-    createdAt: records[0].get('Date'),
-    elementId: records[0].get('Record_Id'),
-    elementType: records[0].get("Type d'élément"),
+    id: record.id,
+    text: record.get('Texte'),
+    author: record.get('Auteur'),
+    createdAt: record.get('Date'),
+    elementId: record.get('Record_Id'),
+    elementType: record.get("Type d'élément"),
   });
 }

--- a/api/lib/infrastructure/repositories/note-repository.js
+++ b/api/lib/infrastructure/repositories/note-repository.js
@@ -1,6 +1,7 @@
 import Airtable from 'airtable';
 import * as config from '../../config.js';
 import { Note } from '../../domain/models/Note.js';
+import { knex } from '../../../db/knex-database-connection.js';
 
 const TABLE_NAME = 'Notes';
 
@@ -37,15 +38,23 @@ export async function create(note) {
       Changelog: 'non',
     },
   };
-  const records = await _airtableClient().table(TABLE_NAME).create([airtableRecordToCreate]);
+  const [record] = await _airtableClient().table(TABLE_NAME).create([airtableRecordToCreate]);
+
+  await knex.insert({
+    id: record.id,
+    status: note.status,
+    text: note.text,
+    author: note.author,
+    challengeId: note.challengeId,
+  }).into('notes');
 
   return new Note({
-    id: records[0].id,
-    status: records[0].get('Statut'),
-    text: records[0].get('Texte'),
-    author: records[0].get('Auteur'),
-    createdAt: records[0].get('Date'),
-    challengeId: records[0].get('Record_Id'),
+    id: record.id,
+    status: record.get('Statut'),
+    text: record.get('Texte'),
+    author: record.get('Auteur'),
+    createdAt: record.get('Date'),
+    challengeId: record.get('Record_Id'),
   });
 }
 
@@ -57,11 +66,17 @@ export async function update(noteId, note) {
       Texte: note.text,
       Auteur: note.author,
       Record_Id: note.challengeId,
-      'Type d\'élément': 'épreuve',
-      Changelog: 'non',
     },
   };
   const [record] = await _airtableClient().table(TABLE_NAME).update([airtableRecordToUpdate]);
+
+  await knex('notes').update({
+    status: note.status,
+    text: note.text,
+    author: note.author,
+    challengeId: note.challengeId,
+    updatedAt: knex.fn.now(),
+  }).where('id', noteId);
 
   return new Note({
     id: record.id,

--- a/api/scripts/migration-from-airtable/copy-notes-from-airtable-to-pg.js
+++ b/api/scripts/migration-from-airtable/copy-notes-from-airtable-to-pg.js
@@ -1,0 +1,95 @@
+import Airtable from 'airtable';
+import { knex } from '../../db/knex-database-connection.js';
+import { ScriptRunner } from '../../lib/application/scripts/script-runner.js';
+import { Script } from '../../lib/application/scripts/script.js';
+import * as config from '../../lib/config.js';
+
+export class CopyNotesFromAirtableToPg extends Script {
+  constructor() {
+    super({
+      description: 'Copie des notes et entrées de changelog de Airtable vers Postgres',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist insert/updates made during the script.',
+          demandOption: false,
+          default: true,
+        },
+        chunkSize: {
+          type: 'number',
+          describe: 'size of inserted chunk',
+          demandOption: false,
+          default: 500,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    const airtableClient = new Airtable({ apiKey: config.airtable.apiKey }).base(config.airtable.editorBase);
+
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const airtableNotes = await airtableClient.table('Notes').select({}).all();
+    logger.info({ count: airtableNotes.length }, 'Loaded notes from airtable');
+
+    const notes = airtableNotes
+      .filter((record) => record.get('Changelog') === 'non')
+      .map((record) => ({
+        id: record.get('Record Id'),
+        status: record.get('Statut'),
+        text: record.get('Texte'),
+        author: record.get('Auteur'),
+        challengeId: record.get('Record_Id'),
+        createdAt: record.get('Date'),
+        updatedAt: knex.fn.now(),
+      }));
+
+    const postgresOnlyNoteIds = await knex
+      .pluck('id')
+      .from('notes')
+      .whereNotIn('id', knex.select('*').fromRaw('unnest(?::text[])', [notes.map((note) => note.id)]));
+    if (postgresOnlyNoteIds.length !== 0) {
+      logger.warn({ ids: postgresOnlyNoteIds }, 'Some notes are only in postgres');
+    }
+
+    const changelogEntries = airtableNotes
+      .filter((record) => record.get('Changelog') === 'oui')
+      .map((record) => ({
+        id: record.get('Record Id'),
+        text: record.get('Texte'),
+        author: record.get('Auteur'),
+        elementId: record.get('Record_Id'),
+        elementType: record.get("Type d'élément"),
+        createdAt: record.get('Date'),
+      }));
+
+    const postgresOnlyChangelogEntryIds = await knex
+      .pluck('id')
+      .from('changelog_entries')
+      .whereNotIn('id', knex.select('*').fromRaw('unnest(?::text[])', [changelogEntries.map((changelogEntry) => changelogEntry.id)]));
+    if (postgresOnlyChangelogEntryIds.length !== 0) {
+      logger.warn({ ids: postgresOnlyChangelogEntryIds }, 'Some changelog entries are only in postgres');
+    }
+    if (options.dryRun) return;
+
+    for (const chunk of chunks(notes, options.chunkSize)) {
+      await knex.insert(chunk).into('notes').onConflict('id').merge();
+    }
+    logger.info({ count: notes.length }, 'Inserted notes into postgres');
+
+    for (const chunk of chunks(changelogEntries, options.chunkSize)) {
+      await knex.insert(chunk).into('changelog_entries').onConflict('id').merge();
+    }
+    logger.info({ count: changelogEntries.length }, 'Inserted changelog entries into postgres');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, CopyNotesFromAirtableToPg);
+
+function* chunks(arr, size) {
+  for (let i = 0; i < arr.length; i += size) {
+    yield arr.slice(i, i + size);
+  }
+}

--- a/api/tests/acceptance/application/changelog-entries_test.js
+++ b/api/tests/acceptance/application/changelog-entries_test.js
@@ -2,7 +2,7 @@ import nock from 'nock';
 import { describe, it, expect } from 'vitest';
 import { ChangelogEntry } from '../../../lib/domain/models/index.js';
 import { createServer } from '../../../server.js';
-import { databaseBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../test-helper.js';
 import Airtable from 'airtable';
 
 const { Record: AirtableRecord } = Airtable;
@@ -92,6 +92,7 @@ describe('Acceptance | Routes | Notes', () => {
       expect(airtableScope.isDone()).toBe(true);
     });
   });
+
   describe('POST /changelog-entries', () => {
     it('returns 201 and created changelog entry', async function() {
       // given
@@ -160,6 +161,18 @@ describe('Acceptance | Routes | Notes', () => {
           },
         },
       });
+
+      await expect(knex.select('*').from('changelog_entries')).resolves.toStrictEqual([
+        {
+          id: 'changelog123',
+          text: 'Un texte',
+          author: 'NLE',
+          createdAt: expect.any(Date),
+          elementId: changelogEntry.elementId,
+          elementType: ChangelogEntry.ELEMENT_TYPES.ACQUIS,
+        },
+      ]);
+
       expect(airtableScope.isDone()).toBe(true);
     });
   });

--- a/api/tests/acceptance/application/changelog-entries_test.js
+++ b/api/tests/acceptance/application/changelog-entries_test.js
@@ -25,7 +25,6 @@ describe('Acceptance | Routes | Notes', () => {
             Changelog: 'oui',
             Date: new Date('2025-11-12T14:39:00Z'),
             Record_Id: challengeId,
-            Statut: ChangelogEntry.STATUSES.TERMINE,
             "Type d'élément": 'épreuve',
           },
         },
@@ -37,7 +36,6 @@ describe('Acceptance | Routes | Notes', () => {
             Changelog: 'oui',
             Date: new Date('2025-11-12T14:47:00Z'),
             Record_Id: challengeId,
-            Statut: ChangelogEntry.STATUSES.EN_COURS,
             "Type d'élément": 'épreuve',
           },
         },
@@ -46,7 +44,7 @@ describe('Acceptance | Routes | Notes', () => {
       const airtableScope = nock('https://api.airtable.com')
         .get('/v0/airtableEditorBaseValue/Notes')
         .query({
-          filterByFormula: `AND(Record_Id = "${challengeId}", Statut != "archive", Changelog = "oui")`,
+          filterByFormula: `AND(Record_Id = "${challengeId}", Changelog = "oui")`,
           sort: [{ field: 'Date', direction: 'asc' }],
         })
         .matchHeader('authorization', 'Bearer airtableApiKeyValue')
@@ -73,7 +71,6 @@ describe('Acceptance | Routes | Notes', () => {
               text: 'Un texte',
               author: 'NLE',
               'created-at': '2025-11-12T14:39:00.000Z',
-              status: ChangelogEntry.STATUSES.TERMINE,
               'element-id': challengeId,
               'element-type': ChangelogEntry.ELEMENT_TYPES.EPREUVE,
             },
@@ -85,7 +82,6 @@ describe('Acceptance | Routes | Notes', () => {
               text: 'Un autre texte',
               author: 'FOO',
               'created-at': '2025-11-12T14:47:00.000Z',
-              status: ChangelogEntry.STATUSES.EN_COURS,
               'element-id': challengeId,
               'element-type': ChangelogEntry.ELEMENT_TYPES.EPREUVE,
             },
@@ -104,7 +100,6 @@ describe('Acceptance | Routes | Notes', () => {
 
       const changelogEntry = new ChangelogEntry({
         id: 'changelog123',
-        status: ChangelogEntry.STATUSES.EN_COURS,
         text: 'Un texte',
         author: 'NLE',
         createdAt: new Date('2025-11-10T16:33:00Z'),
@@ -115,7 +110,6 @@ describe('Acceptance | Routes | Notes', () => {
       const airtableChangelogEntry = {
         id: changelogEntry.id,
         fields: {
-          Statut: changelogEntry.status,
           Texte: changelogEntry.text,
           Auteur: changelogEntry.author,
           Date: changelogEntry.createdAt,
@@ -142,7 +136,6 @@ describe('Acceptance | Routes | Notes', () => {
           data: {
             type: 'changelog-entries',
             attributes: {
-              status: changelogEntry.status,
               text: changelogEntry.text,
               author: changelogEntry.author,
               'element-id': 'skillAbc123',
@@ -162,7 +155,6 @@ describe('Acceptance | Routes | Notes', () => {
             text: 'Un texte',
             author: 'NLE',
             'created-at': changelogEntry.createdAt.toISOString(),
-            status: ChangelogEntry.STATUSES.EN_COURS,
             'element-id': changelogEntry.elementId,
             'element-type': ChangelogEntry.ELEMENT_TYPES.ACQUIS,
           },

--- a/api/tests/acceptance/application/notes_test.js
+++ b/api/tests/acceptance/application/notes_test.js
@@ -2,7 +2,7 @@ import nock from 'nock';
 import { describe, it, expect } from 'vitest';
 import { Note } from '../../../lib/domain/models/index.js';
 import { createServer } from '../../../server.js';
-import { databaseBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../test-helper.js';
 import Airtable from 'airtable';
 
 const { Record: AirtableRecord } = Airtable;
@@ -90,6 +90,7 @@ describe('Acceptance | Routes | Notes', () => {
       expect(airtableScope.isDone()).toBe(true);
     });
   });
+
   describe('POST /notes', () => {
     it('returns 201 and created note', async function() {
       // given
@@ -158,13 +159,37 @@ describe('Acceptance | Routes | Notes', () => {
           },
         },
       });
+
+      await expect(knex.select('*').from('notes')).resolves.toStrictEqual([
+        {
+          id: 'note123',
+          text: 'Un texte',
+          author: 'NLE',
+          status: Note.STATUSES.EN_COURS,
+          challengeId: 'challengeAbc123',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
       expect(airtableScope.isDone()).toBe(true);
     });
   });
+
   describe('PATCH /notes/:noteId', () => {
     it('returns 200 and updated note', async function() {
       // given
       const user = databaseBuilder.factory.buildAdminUser();
+
+      await knex.insert({
+        id: 'note123',
+        status: Note.STATUSES.EN_COURS,
+        text: 'Un texte',
+        author: 'NLE',
+        createdAt: new Date('2025-11-10T16:33:00Z'),
+        challengeId: 'challengeAbc123',
+      }).into('notes');
+
       await databaseBuilder.commit();
 
       const note = new Note({
@@ -179,8 +204,8 @@ describe('Acceptance | Routes | Notes', () => {
       const airtableNote = {
         id: note.id,
         fields: {
-          Statut: note.status,
-          Texte: note.text,
+          Statut: Note.STATUSES.TERMINE,
+          Texte: 'Un nouveau texte',
           Auteur: note.author,
           Date: note.createdAt,
           Record_Id: note.challengeId,
@@ -189,10 +214,9 @@ describe('Acceptance | Routes | Notes', () => {
         },
       };
       const expectedNoteBody = structuredClone(airtableNote);
-      delete expectedNoteBody.fields.Record_Id;
-      delete expectedNoteBody.fields.Auteur;
-      delete expectedNoteBody.fields.Texte;
+      delete expectedNoteBody.fields.Changelog;
       delete expectedNoteBody.fields.Date;
+      delete expectedNoteBody.fields['Type d\'élément'];
 
       const airtableScope = nock('https://api.airtable.com')
         .patch('/v0/airtableEditorBaseValue/Notes/?', { records: [expectedNoteBody] })
@@ -207,7 +231,13 @@ describe('Acceptance | Routes | Notes', () => {
         payload: {
           data: {
             type: 'notes',
-            attributes: { status: note.status },
+            attributes: {
+              status: Note.STATUSES.TERMINE,
+              text: 'Un nouveau texte',
+              author: note.author,
+              createdAt: note.createdAt,
+              challengeId: note.challengeId,
+            },
           },
         },
       });
@@ -219,13 +249,26 @@ describe('Acceptance | Routes | Notes', () => {
           type: 'notes',
           id: 'note123',
           attributes: {
-            text: 'Un texte',
+            text: 'Un nouveau texte',
             author: 'NLE',
             'created-at': note.createdAt.toISOString(),
-            status: Note.STATUSES.EN_COURS,
+            status: Note.STATUSES.TERMINE,
           },
         },
       });
+
+      await expect(knex.select('*').from('notes')).resolves.toStrictEqual([
+        {
+          id: 'note123',
+          text: 'Un nouveau texte',
+          author: 'NLE',
+          status: Note.STATUSES.TERMINE,
+          challengeId: 'challengeAbc123',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+
       expect(airtableScope.isDone()).toBe(true);
     });
   });


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Les notes et entrées de changelog ne sont écrites que dans Airtable alors qu'on souhaite s'en séparer.

## 🌰 Proposition

Ecrire en double d'Airtable les notes et entrées de changelog dans PG.
Ajouter un script de migration des Notes pour récupérer l'existant depuis Airtable.
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Sur la review app, créer des notes et des changelogs.
Lancer le script de migration des notes : 
`cd api && node ./scripts/migration-from-airtable/copy-notes-from-airtable-to-pg.js --dryRun=false`

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
