### PR TITLE
[FEATURE] Permettre de mettre en prod/pause des épreuves traduites (PIX-19749)

### DIFF
--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
@@ -8,10 +8,12 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import flagForLanguage from 'pixeditor/helpers/flag-for-language';
+import LocalizedChallenge from 'pixeditor/models/localized-challenge';
 
 export default class LocalizedChallengeViewHeader extends Component {
   @service multipanelManager;
   @service router;
+  @service access;
 
   @action
   closePanel() {
@@ -26,11 +28,27 @@ export default class LocalizedChallengeViewHeader extends Component {
 
   @action
   async copyLocalizedChallengePreviewUrl() {
-    await navigator.clipboard.writeText(this.args.challengeLocale.url);
+    await navigator.clipboard.writeText(this.args.challengeLocale.localizedPreviewUrl);
+  }
+
+  @action
+  async toggleLocalizedChallengeStatus() {
+    await navigator.clipboard.writeText(this.args.challengeLocale.localizedPreviewUrl);
   }
 
   get localizedChallenge() {
     return this.args.challengeLocale.localizedChallengeValue;
+  }
+
+  get toggleLocalizedChallengeStatusButtonState() {
+    if (this.localizedChallenge.status === LocalizedChallenge.STATUSES.PAUSE) {
+      return { name: 'Mettre en prod', icon: 'playCircle' };
+    }
+    return { name: 'Mettre en pause', icon: 'pauseCircle' };
+  }
+
+  get mayChangeStatus() {
+    return this.access.mayChangeLocalizedChallengeStatus(this.localizedChallenge);
   }
 
   <template>
@@ -88,7 +106,7 @@ export default class LocalizedChallengeViewHeader extends Component {
                   <PixIcon @name="eye" />
                 </a>
               </:triggerElement>
-              <:tooltip>Prévisualiser l'épreuve <span class="sr-only">{{@localizedChallenge.id}}</span></:tooltip>
+              <:tooltip>Prévisualiser l'épreuve <span class="sr-only">{{this.localizedChallenge.id}}</span></:tooltip>
             </PixTooltip>
             <PixTooltip
               @id='copy-url-challenge-tooltip'
@@ -103,7 +121,7 @@ export default class LocalizedChallengeViewHeader extends Component {
                   @triggerAction={{this.copyLocalizedChallengePreviewUrl}}
                 />
               </:triggerElement>
-              <:tooltip>Copier le lien de l'épreuve <span class="sr-only">{{@localizedChallenge.id}}</span></:tooltip>
+              <:tooltip>Copier le lien de l'épreuve <span class="sr-only">{{this.localizedChallenge.id}}</span></:tooltip>
             </PixTooltip>
             {{#let (@challengeLocale.getTranslationsUrl @competence) as |translationsUrl|}}
               {{#if translationsUrl}}
@@ -131,6 +149,15 @@ export default class LocalizedChallengeViewHeader extends Component {
                 Enregistrer
               </PixButton>
             {{else}}
+              {{#if this.mayChangeStatus}}
+
+              <PixButton
+                @triggerAction={{@toggleStatus}}
+                @iconBefore={{this.toggleLocalizedChallengeStatusButtonState.icon}}
+              >
+                {{this.toggleLocalizedChallengeStatusButtonState.name}}
+              </PixButton>
+              {{/if}}
               <PixButton
                 @triggerAction={{@edit}}
                 @iconAfter="edit"

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 
 import PopInImage from '../pop-in/image';
+import PopInConfirm from '../pop-in/confirm';
 import Files from '../v2/field/files';
 import Illustration from '../v2/field/illustration';
 import FieldToggleFieldComponent from '../v2/field/toggle-field';
@@ -31,6 +32,7 @@ export default class LocalizedChallenge extends Component {
   @tracked isPopInIllustrationDisplayed = false;
   @tracked urlsToConsult = this.args.localizedChallenge.urlsToConsult?.join('\n');
   @tracked attachmentBasename = '';
+  @tracked displayConfirm = false;
 
   @tracked urlsToConsultTextareaHeigh = this.args.localizedChallenge.urlsToConsult?.length ?? 2;
 
@@ -78,6 +80,16 @@ export default class LocalizedChallenge extends Component {
 
   get shouldDisplayIllustration() {
     return !!this.primaryChallenge.illustration;
+  }
+
+  get confirmTitle() {
+    return this.args.localizedChallenge.isInProduction ? 'Mise en pause' : 'Mise en prod';
+  }
+
+  get confirmContent() {
+    return this.args.localizedChallenge.isInProduction
+      ? 'Êtes-vous sûr de vouloir mettre en pause cette épreuve ?'
+      : 'Êtes-vous sûr de vouloir mettre en prod cette épreuve ?';
   }
 
   @action
@@ -241,6 +253,28 @@ export default class LocalizedChallenge extends Component {
     }
   }
 
+  @action
+  async confirmApprove() {
+    this.args.localizedChallenge.status = this.args.localizedChallenge.isInProduction ? 'proposé' : 'validé';
+    try {
+      this.loader.start('Enregistrement');
+      await this.args.localizedChallenge.save();
+      this.notify.message('Statut modifié avec succès !');
+    } catch (error) {
+      console.error(error);
+      Sentry.captureException(error);
+      this.notify.error(this.args.localizedChallenge.isInProduction ? 'Erreur de la mise en prod de l\'épreuve localisée' : 'Erreur de la mise en pause de l\'épreuve localisée');
+    } finally {
+      this.loader.stop();
+      this.displayConfirm = false;
+    }
+  }
+
+  @action
+  confirmDeny() {
+    this.displayConfirm = false;
+  }
+
   async _handleIllustration() {
     const illustration = this.args.localizedChallenge.illustration;
     if (illustration && illustration.isNew) {
@@ -302,6 +336,11 @@ export default class LocalizedChallenge extends Component {
   }
 
   @action
+  displayConfirmPopIn() {
+    this.displayConfirm = true;
+  }
+
+  @action
   updateBasename(e) {
     this.attachmentBasename = e.target.value;
   }
@@ -317,6 +356,7 @@ export default class LocalizedChallenge extends Component {
       @edit={{@edit}}
       @save={{this.save}}
       @cancelEdit={{this.cancelEdit}}
+      @toggleStatus={{this.displayConfirmPopIn}}
     />
     <div class="challenge-view">
       <div class="challenge-view-editable-fields">
@@ -419,6 +459,13 @@ export default class LocalizedChallenge extends Component {
         @showModal={{this.isPopInIllustrationDisplayed}}
       />
       {{/if}}
+      <PopInConfirm
+        @title={{this.confirmTitle}}
+        @content={{this.confirmContent}}
+        @onApprove={{this.confirmApprove}}
+        @onDeny={{this.confirmDeny}}
+        @showModal={{this.displayConfirm}}
+      />
     </div>
   </template>
 }

--- a/pix-editor/app/components/pop-in/confirm.hbs
+++ b/pix-editor/app/components/pop-in/confirm.hbs
@@ -15,11 +15,6 @@
     >
       Annuler
     </PixButton>
-    <PixButton
-      @triggerAction={{@onApprove}}
-      data-testid='popin-confirm-button'
-    >
-      Oui
-    </PixButton>
+    <PixButton @triggerAction={{@onApprove}} data-testid='popin-confirm-button'>Oui</PixButton>
   </:footer>
 </PixModal>

--- a/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
@@ -3,19 +3,29 @@ import LocalizedChallengeView from 'pixeditor/components/localized-challenge-vie
 import Challenge from 'pixeditor/models/challenge';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
 import { module, test } from 'qunit';
+import { click, find } from '@ember/test-helpers';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Integration | Component | localized-challenge-view | localized-challenge-view', function(hooks) {
   setupIntlRenderingTest(hooks);
-  let screen, store, challenge, competence, challengeLocale, localizedChallenge, edition;
+  let screen, store, challenge, competence, challengeLocale, localizedChallenge, edition, loader, save, notifyMessageStub, notifyErrorStub;
 
   hooks.beforeEach(async function() {
     store = this.owner.lookup('service:store');
+    loader = this.owner.lookup('service:loader');
+    const notify = this.owner.lookup('service:notify');
+    sinon.stub(loader, 'start');
+    sinon.stub(loader, 'stop');
+    notifyMessageStub = sinon.stub(notify, 'message');
+    notifyErrorStub = sinon.stub(notify, 'error');
     const attachment = store.createRecord('attachment', { id: 'attachmentId', type: 'attachment', url: 'data:,', filename: 'attachment-name' });
     const illustration = store.createRecord('attachment', { id: 'illustrationId', type: 'illustration' });
     competence = store.createRecord('competence', {
       id: 'competenceId',
       code: '1.1',
+      source: 'Pix',
     });
     challenge
       = store.createRecord('challenge', {
@@ -25,11 +35,13 @@ module('Integration | Component | localized-challenge-view | localized-challenge
         status: Challenge.STATUSES.VALIDE,
         embedURL: 'https://mon-site.fr/my-link.html',
         geography: 'FR',
+        preview: 'previewURL',
         attachments: [attachment, illustration],
       });
     localizedChallenge
       = store.createRecord('localized-challenge', {
         id: 'localizedChallengeId',
+        challenge,
         locale: 'en',
         embedURL: `${challenge.embedURL}?lang=en`,
         status: LocalizedChallenge.STATUSES.PLAY,
@@ -43,8 +55,216 @@ module('Integration | Component | localized-challenge-view | localized-challenge
   });
 
   module('when edition is false', function(hooks) {
+    let mayChangeLocalizedChallengeStatusStub;
     hooks.beforeEach(function() {
       edition = false;
+      mayChangeLocalizedChallengeStatusStub = sinon.stub().returns(true);
+      save = sinon.stub();
+
+      class AccessService extends Service {
+        mayChangeLocalizedChallengeStatus = mayChangeLocalizedChallengeStatusStub;
+      }
+      this.owner.register('service:access', AccessService);
+    });
+    test('it should not display toggle status button when mayChangeStatus return `false`', async function(assert) {
+      // given
+      mayChangeLocalizedChallengeStatusStub.returns(false);
+
+      // when
+      screen = await render(<template>
+        <LocalizedChallengeView
+          @challengeLocale={{challengeLocale}}
+          @localizedChallenge={{localizedChallenge}}
+          @competence={{competence}}
+          @overview={{'overview'}}
+          @skillId={{'skillId'}}
+          @edition={{edition}}
+        />
+      </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Mettre en pause' })).doesNotExist();
+    });
+
+    module('when status is play', function() {
+      test('it should change status to pause', async function(assert) {
+        // given
+        localizedChallenge.save = save;
+        // when
+        screen = await render(<template>
+          <LocalizedChallengeView
+            @challengeLocale={{challengeLocale}}
+            @localizedChallenge={{localizedChallenge}}
+            @competence={{competence}}
+            @overview={{'overview'}}
+            @skillId={{'skillId'}}
+            @edition={{edition}}
+          />
+        </template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Mettre en pause' }));
+        await click(await screen.findByRole('button', { name: 'Oui' }));
+
+        // then
+        assert.strictEqual(localizedChallenge.status, LocalizedChallenge.STATUSES.PAUSE);
+        assert.ok(notifyMessageStub.calledOnce);
+        assert.ok(notifyMessageStub.calledWith('Statut modifié avec succès !'));
+        assert.notOk(notifyErrorStub.calledOnce);
+        assert.ok(loader.start.calledOnce);
+        assert.ok(loader.stop.calledOnce);
+      });
+
+      test('it should notify on modification\'s failure', async function(assert) {
+        localizedChallenge.save = save.rejects();
+        // when
+        screen = await render(<template>
+          <LocalizedChallengeView
+            @challengeLocale={{challengeLocale}}
+            @localizedChallenge={{localizedChallenge}}
+            @competence={{competence}}
+            @overview={{'overview'}}
+            @skillId={{'skillId'}}
+            @edition={{edition}}
+          />
+        </template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Mettre en pause' }));
+        await click(await screen.findByRole('button', { name: 'Oui' }));
+
+        // then
+        assert.strictEqual(localizedChallenge.status, LocalizedChallenge.STATUSES.PAUSE);
+        assert.ok(notifyMessageStub.notCalled);
+        assert.ok(notifyErrorStub.calledOnce);
+        assert.ok(notifyErrorStub.calledWith('Erreur de la mise en pause de l\'épreuve localisée'));
+        assert.ok(loader.start.calledOnce);
+        assert.ok(loader.stop.calledOnce);
+      });
+    });
+
+    module('when status is pause', function(hooks) {
+      hooks.beforeEach(function() {
+        localizedChallenge.status = LocalizedChallenge.STATUSES.PAUSE;
+      });
+
+      test('it should change status to play', async function(assert) {
+        // given
+        mayChangeLocalizedChallengeStatusStub.returns(true);
+
+        localizedChallenge.save = save;
+        // when
+        screen = await render(<template>
+          <LocalizedChallengeView
+            @challengeLocale={{challengeLocale}}
+            @localizedChallenge={{localizedChallenge}}
+            @competence={{competence}}
+            @overview={{'overview'}}
+            @skillId={{'skillId'}}
+            @edition={{edition}}
+          />
+        </template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Mettre en prod' }));
+        await click(await screen.findByRole('button', { name: 'Oui' }));
+
+        // then
+        assert.strictEqual(localizedChallenge.status, LocalizedChallenge.STATUSES.PLAY);
+        assert.ok(notifyMessageStub.calledOnce);
+        assert.ok(notifyMessageStub.calledWith('Statut modifié avec succès !'));
+        assert.notOk(notifyErrorStub.calledOnce);
+        assert.ok(loader.start.calledOnce);
+        assert.ok(loader.stop.calledOnce);
+      });
+
+      test('it should notify on modification\'s failure', async function(assert) {
+        localizedChallenge.save = save.rejects();
+        // when
+        screen = await render(<template>
+          <LocalizedChallengeView
+            @challengeLocale={{challengeLocale}}
+            @localizedChallenge={{localizedChallenge}}
+            @competence={{competence}}
+            @overview={{'overview'}}
+            @skillId={{'skillId'}}
+            @edition={{edition}}
+          />
+        </template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Mettre en prod' }));
+        await click(await screen.findByRole('button', { name: 'Oui' }));
+
+        // then
+        assert.ok(notifyMessageStub.notCalled);
+        assert.ok(notifyErrorStub.calledOnce);
+        assert.ok(notifyErrorStub.calledWith('Erreur de la mise en prod de l\'épreuve localisée'));
+        assert.ok(loader.start.calledOnce);
+        assert.ok(loader.stop.calledOnce);
+      });
+    });
+
+    test('it should fail during change status', async function(assert) {
+      // given
+      mayChangeLocalizedChallengeStatusStub.returns(true);
+
+      localizedChallenge.save = save;
+      // when
+      screen = await render(<template>
+        <LocalizedChallengeView
+          @challengeLocale={{challengeLocale}}
+          @localizedChallenge={{localizedChallenge}}
+          @competence={{competence}}
+          @overview={{'overview'}}
+          @skillId={{'skillId'}}
+          @edition={{edition}}
+        />
+      </template>,
+      );
+
+      await click(screen.getByRole('button', { name: 'Mettre en pause' }));
+      await click(await screen.findByRole('button', { name: 'Oui' }));
+
+      // then
+      assert.strictEqual(localizedChallenge.status, LocalizedChallenge.STATUSES.PAUSE);
+      assert.ok(notifyMessageStub.calledOnce);
+      assert.ok(notifyMessageStub.calledWith('Statut modifié avec succès !'));
+      assert.notOk(notifyErrorStub.calledOnce);
+      assert.ok(loader.start.calledOnce);
+      assert.ok(loader.stop.calledOnce);
+    });
+
+    test('it should display action buttons', async function(assert) {
+      // given
+      const clipboardStub = sinon.stub().resolves();
+
+      Object.defineProperty(navigator, 'clipboard', {
+        writable: true,
+        value: { writeText: clipboardStub },
+      });
+      clipboardStub.withArgs('http://localhost:4300/previewURL?locale=en');
+
+      // when
+      screen = await render(<template>
+        <LocalizedChallengeView
+          @challengeLocale={{challengeLocale}}
+          @localizedChallenge={{localizedChallenge}}
+          @competence={{competence}}
+          @overview={{'overview'}}
+          @skillId={{'skillId'}}
+          @edition={{edition}}
+        />
+      </template>,
+      );
+
+      await click(screen.getByRole('button', { name: 'Copier le lien de l\'épreuve' }));
+
+      // then
+      assert.ok(screen.getByRole('link', { name: 'Prévisualiser l\'épreuve' }).getAttribute('href').endsWith('/previewURL?locale=en'), 'href ends with /previewURL?locale=en');
+      assert.dom(screen.getByRole('link', { name: 'traduction de l\'épreuve de version Proto' })).hasAttribute('href', '/api/challenges/challengeProtoValidee/translations/en/framework-name/Pix/area-code/1');
+      assert.ok(clipboardStub.calledOnce);
     });
 
     test('it should display readonly form', async function(assert) {


### PR DESCRIPTION
## 🍂 Problème

Nous ne pouvons pas modifier le status d'une épreuve traduite en mode V2

## 🌰 Proposition

Permettre de mettre en prod/pause des épreuves traduites

## 🍁 Remarques

RAS

## 🪵 Pour tester

Se rendre sur sur une épreuve traduite et modifier son status.
Vérifier que le bouton n'est accessible seulement si on est admin.
