### PR TITLE
[FEATURE] Ne pas afficher le bouton de modification d'une épreuve traduite lorsqu'on n'a pas les droits (PIX-20451)

### DIFF
--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
@@ -11,9 +11,9 @@ import flagForLanguage from 'pixeditor/helpers/flag-for-language';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
 
 export default class LocalizedChallengeViewHeader extends Component {
+  @service access;
   @service multipanelManager;
   @service router;
-  @service access;
 
   @action
   closePanel() {
@@ -33,6 +33,10 @@ export default class LocalizedChallengeViewHeader extends Component {
 
   get localizedChallenge() {
     return this.args.challengeLocale.localizedChallengeValue;
+  }
+
+  get mayEditLocalized() {
+    return this.access.mayEditLocalized(this.localizedChallenge);
   }
 
   get toggleLocalizedChallengeStatusButtonState() {
@@ -130,37 +134,37 @@ export default class LocalizedChallengeViewHeader extends Component {
             {{/let}}
           </div>
           <div class="challenge-view-header-second__right-action">
-            {{#if @edition}}
-              <PixButton
-                @triggerAction={{@cancelEdit}}
-                @variant="secondary"
-                aria-label="Annuler l'édition"
-              >
-                Annuler
-              </PixButton>
-              <PixButton
-                @triggerAction={{@save}}
-              >
-                Enregistrer
-              </PixButton>
-            {{else}}
-              {{#if this.mayChangeStatus}}
-
-              <PixButton
-                @triggerAction={{@toggleStatus}}
-                @iconBefore={{this.toggleLocalizedChallengeStatusButtonState.icon}}
-              >
-                {{this.toggleLocalizedChallengeStatusButtonState.name}}
-              </PixButton>
+            {{#if this.mayEditLocalized}}
+              {{#if @edition}}
+                <PixButton
+                  @triggerAction={{@cancelEdit}}
+                  @variant="secondary"
+                  aria-label="Annuler l'édition"
+                >
+                  Annuler
+                </PixButton>
+                <PixButton
+                  @triggerAction={{@save}}
+                >
+                  Enregistrer
+                </PixButton>
+              {{else}}
+                {{#if this.mayChangeStatus}}
+                  <PixButton
+                    @triggerAction={{@toggleStatus}}
+                    @iconBefore={{this.toggleLocalizedChallengeStatusButtonState.icon}}
+                  >
+                    {{this.toggleLocalizedChallengeStatusButtonState.name}}
+                  </PixButton>
+                {{/if}}
+                <PixButton
+                  @triggerAction={{@edit}}
+                  @iconAfter="edit"
+                >
+                  Modifier
+                </PixButton>
               {{/if}}
-              <PixButton
-                @triggerAction={{@edit}}
-                @iconAfter="edit"
-              >
-                Modifier
-              </PixButton>
             {{/if}}
-
           </div>
         </div>
     </header>

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -96,6 +96,10 @@ export default class AccessService extends Service {
     return level >= EDITOR || (!production && !prototype && level === REPLICATOR);
   }
 
+  mayEditLocalized(localizedChallenge) {
+    return this.config.accessLevel >= EDITOR;
+  }
+
   mayDuplicate(challenge) {
     const level = this.config.accessLevel;
     const prototype = challenge.isPrototype;

--- a/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
@@ -1,4 +1,5 @@
 import { fillByLabel, render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import LocalizedChallengeView from 'pixeditor/components/localized-challenge-view/localized-challenge-view';
 import Challenge from 'pixeditor/models/challenge';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
@@ -6,7 +7,6 @@ import { module, test } from 'qunit';
 import { click, find } from '@ember/test-helpers';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 import sinon from 'sinon';
-import Service from '@ember/service';
 
 module('Integration | Component | localized-challenge-view | localized-challenge-view', function(hooks) {
   setupIntlRenderingTest(hooks);
@@ -54,15 +54,50 @@ module('Integration | Component | localized-challenge-view | localized-challenge
     });
   });
 
+  module('when user is not allowed to edit a challenge', function(hooks) {
+    let mayChangeLocalizedChallengeStatusStub, mayEditLocalizedStub;
+    hooks.beforeEach(function() {
+      mayEditLocalizedStub = sinon.stub().returns(false);
+      mayChangeLocalizedChallengeStatusStub = sinon.stub().returns(true);
+
+      class AccessService extends Service {
+        mayChangeLocalizedChallengeStatus = mayChangeLocalizedChallengeStatusStub;
+        mayEditLocalized = mayEditLocalizedStub;
+      }
+      this.owner.register('service:access', AccessService);
+    });
+
+    test('it should not display edit button', async function(assert) {
+      // given
+      // when
+      screen = await render(<template>
+        <LocalizedChallengeView
+          @challengeLocale={{challengeLocale}}
+          @localizedChallenge={{localizedChallenge}}
+          @competence={{competence}}
+          @overview={{'overview'}}
+          @skillId={{'skillId'}}
+          @edition={{edition}}
+        />
+      </template>,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Modifier' })).doesNotExist();
+    });
+  });
+
   module('when edition is false', function(hooks) {
-    let mayChangeLocalizedChallengeStatusStub;
+    let mayChangeLocalizedChallengeStatusStub, mayEditLocalizedStub;
     hooks.beforeEach(function() {
       edition = false;
       mayChangeLocalizedChallengeStatusStub = sinon.stub().returns(true);
       save = sinon.stub();
+      mayEditLocalizedStub = sinon.stub().returns(true);
 
       class AccessService extends Service {
         mayChangeLocalizedChallengeStatus = mayChangeLocalizedChallengeStatusStub;
+        mayEditLocalized = mayEditLocalizedStub;
       }
       this.owner.register('service:access', AccessService);
     });


### PR DESCRIPTION
## 🍂 Problème

En V2, en mode affichage d'une épreuve traduite, le bouton "Modifier" apparaît toujours

## 🌰 Proposition

Ne pas afficher le bouton "Modifier" si l'utilisateur n'a pas les droits

## 🍁 Remarques

RAS

## 🪵 Pour tester

CI au vert
