### PR TITLE
[BUGFIX] @workbench dans la recherche d'acquis

### DIFF
--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -116,7 +116,7 @@ export const skillDatasource = datasource.extend({
   },
 
   async search(params) {
-    const filterByFormula = `FIND(${stringValue(params.filter.name.toLowerCase())}, LOWER(Nom))`;
+    const filterByFormula = `AND(FIND(${stringValue(params.filter.name.toLowerCase())}, LOWER(Nom)), Nom != "@workbench")`;
 
     let sort = params.sort
       ?.filter(([field]) => this.sortableFields[field])

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -150,7 +150,7 @@ export async function search(params) {
     'tubes.name',
     'skills.level',
     `${escapeLikeWildcards(params.filter.name)}%`,
-  ]);
+  ]).where('tubes.name', '<>', '@workbench');
   if (params.sort) {
     const orderBySqlAndParams = params.sort.map(([field, direction]) => {
       if (field === 'name') {

--- a/api/tests/acceptance/application/skills/index_test.js
+++ b/api/tests/acceptance/application/skills/index_test.js
@@ -805,7 +805,7 @@ describe('Application | Route | Skills', () => {
         airtableSkillsScope = nock('https://api.airtable.com')
           .get('/v0/airtableBaseValue/Acquis')
           .query({
-            filterByFormula: 'FIND("@skil", LOWER(Nom))',
+            filterByFormula: 'AND(FIND("@skil", LOWER(Nom)), Nom != "@workbench")',
             fields: { '': skillDatasource.usedFields },
             sort: [{ field: 'Nom', direction: 'asc' }],
             maxRecords: 10,

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -619,7 +619,7 @@ describe('Integration | Repository | skill-repository', () => {
         // then
         expect(results).toEqual([]);
         expect(findRecordsSpy).toHaveBeenCalledWith(skillDatasource.tableName, {
-          filterByFormula: 'FIND("@notfound", LOWER(Nom))',
+          filterByFormula: 'AND(FIND("@notfound", LOWER(Nom)), Nom != "@workbench")',
           fields: skillDatasource.usedFields,
           sort: [{ field: 'Nom', direction: 'asc' }, { field: 'Version', direction: 'desc' }],
           maxRecords: 10,
@@ -738,7 +738,7 @@ describe('Integration | Repository | skill-repository', () => {
         // then
         expect(results).toStrictEqual(skills.map(domainBuilder.buildSkill));
         expect(findRecordsSpy).toHaveBeenCalledWith(skillDatasource.tableName, {
-          filterByFormula: 'FIND("@skill", LOWER(Nom))',
+          filterByFormula: 'AND(FIND("@skill", LOWER(Nom)), Nom != "@workbench")',
           fields: skillDatasource.usedFields,
           sort: [{ field: skillDatasource.sortField, direction: 'asc' }],
         });


### PR DESCRIPTION
## 🍂 Problème

Les acquis `@workbench` apparaissent dans les résultats de recherche d'acquis.

## 🌰 Proposition

Filtrer les acquis `@workbench`.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Vérifier que les acquis `@workbench` n'apparaissent plus dans les résultats de recherche.