### PR TITLE
[BUGFIX] Fermeture du panneau de création d’épreuves ou d’acquis (PIX-20498)

### DIFF
--- a/pix-editor/app/routes/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single.js
@@ -52,16 +52,17 @@ export default class SingleRoute extends Route {
 
   @action
   willTransition(transition) {
-    if (this.controllerFor('authenticated.competence.prototypes.single').edition) {
+    const controller = this.controllerFor(transition.from.name);
+    if (controller.edition) {
       if (confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
-        this.controllerFor('authenticated.competence.prototypes.single').send('cancelEdit');
+        controller.send('cancelEdit');
         return true;
       } else {
         transition.abort();
       }
     } else {
       if (transition.targetName === 'authenticated.competence.skills.index' || transition.targetName === 'authenticated.competence.quality.index') {
-        const challenge = this.controllerFor('authenticated.competence.prototypes.single').model;
+        const challenge = controller.model;
         if (!challenge.isWorkbench) {
           const skill = challenge.skill;
           if (skill) {
@@ -73,7 +74,7 @@ export default class SingleRoute extends Route {
           }
         }
       }
-      this.controllerFor('authenticated.competence.prototypes.single').edition = false;
+      controller.edition = false;
       return true;
     }
   }

--- a/pix-editor/app/routes/authenticated/competence/skills/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single.js
@@ -35,18 +35,17 @@ export default class SingleRoute extends Route {
 
   @action
   async willTransition(transition) {
-    if (this.controllerFor('authenticated.competence.skills.single').edition
+    const controller = this.controllerFor(transition.from.name);
+    if (controller.edition
       && !confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
       transition.abort();
     } else {
-      const modelSkillSingle = this.controllerFor('authenticated.competence.skills.single').model;
-
-      if (modelSkillSingle && modelSkillSingle.rollbackAttributes) {
-        // may not exist if it was a new skill
+      const modelSkillSingle = controller.model;
+      if (modelSkillSingle && !modelSkillSingle.isNew) {
         modelSkillSingle.rollbackAttributes();
       }
       if (transition.targetName === 'authenticated.competence.prototypes.index') {
-        const skill = this.controllerFor('authenticated.competence.skills.single').skill;
+        const skill = controller.skill;
         const prototype = this.currentData.getPrototype();
         if (prototype) {
           return this.router.transitionTo('authenticated.competence.prototypes.single', prototype);
@@ -54,8 +53,8 @@ export default class SingleRoute extends Route {
           const tube = skill.tube;
           return this.router.transitionTo('authenticated.competence.prototypes.list', tube.get('id'), skill.id);
         }
-      } else if (transition.targetName === 'authenticated.competence.quality.index' && this.controllerFor('authenticated.competence.skills.single').skill.productionPrototype) {
-        return this.router.transitionTo('authenticated.competence.quality.single', this.controllerFor('authenticated.competence.skills.single').skill);
+      } else if (transition.targetName === 'authenticated.competence.quality.index' && controller.skill.productionPrototype) {
+        return this.router.transitionTo('authenticated.competence.quality.single', controller.skill);
       }
 
       return true;

--- a/pix-editor/tests/acceptance/competence/skills/single-test.js
+++ b/pix-editor/tests/acceptance/competence/skills/single-test.js
@@ -3,6 +3,7 @@ import { click, currentURL, fillIn, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 import { waitForSelectToBeClosed } from '../../../helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from '../../../setup-application-rendering';
@@ -10,9 +11,11 @@ import { setupApplicationTest } from '../../../setup-application-rendering';
 module('Acceptance | skill | single', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  let skill1, competence1, tube1;
+  let skill1, competence1, tube1, originalWindowConfirm;
 
   hooks.beforeEach(function() {
+    originalWindowConfirm = window.confirm;
+
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
@@ -58,7 +61,14 @@ module('Acceptance | skill | single', function(hooks) {
     return authenticateSession();
   });
 
+  hooks.afterEach(function() {
+    window.confirm = originalWindowConfirm;
+  });
+
   test('close single', async function(assert) {
+    const confirmStub = sinon.stub(window, 'confirm');
+    confirmStub.returns(true);
+
     await visit(`/competence/${competence1.id}/skills/new/${tube1.id}/0?leftMaximized=true&view=workbench`);
     await click(find('.icon.window.close'));
 


### PR DESCRIPTION
## 🍂 Problème

Lorsqu’on démarre la création d’une épreuve ou d’un acquis, puis qu’on ferme le panneau de création, il n’y a pas de message de confirmation et l’entité n’est pas supprimée dans le store ember-data.

## 🌰 Proposition

Mettre le même comportement que pour l’édition : message de confirmation + suppression de l’entité.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Faire une nouvelle version d’acquis ou d’épreuve, puis cliquer sur la croix de fermeture du panneau de création, confirmer la navigation, et vérifier que la nouvelle version n’apparait pas dans la liste des versions.