### PR TITLE
[BUGFIX] Lors d'un déplacement d'épreuves, on peut valider le déplacement alors que le bouton est disabled (PIX-20518)

### DIFF
--- a/pix-editor/app/components/pop-in/select-location.gjs
+++ b/pix-editor/app/components/pop-in/select-location.gjs
@@ -29,6 +29,7 @@ export default class PopinSelectLocation extends Component {
 
   @action
   onSubmit(...args) {
+    if (this.disableActionButton) return;
     this.args.onSubmit(...args);
     this.closeModal();
   }
@@ -63,8 +64,8 @@ export default class PopinSelectLocation extends Component {
           @isDisabled={{this.disableActionButton}}
           @type="submit"
           form="form-select-location"
+          @iconBefore="check"
         >
-          <i class="checkmark icon"></i>
           {{this.actionButtonTitle}}
         </PixButton>
       </:footer>

--- a/pix-editor/tests/integration/components/pop-in/select-location-test.gjs
+++ b/pix-editor/tests/integration/components/pop-in/select-location-test.gjs
@@ -303,6 +303,23 @@ module('Integration | Component | pop-in-select-location / form-select-location'
       assert.ok(onSubmitStub.calledWith(skill1_1_1_1_1));
       assert.true(closeModalStub.calledOnce);
     });
+
+    test('it should prevent submit when is disabled', async function(assert) {
+      // when
+      await click(screen.getByLabelText('Compétence'));
+      await click(await screen.findByRole('option', { name: '1.1 competence1_1_1' }));
+      await waitForSelectToBeClosed(screen);
+
+      await click(screen.getByLabelText('Sujet'));
+      await click(await screen.findByRole('option', { name: 'tube1_1_1_1' }));
+      await waitForSelectToBeClosed(screen);
+
+      await click(screen.getByRole('button', { name: 'Déplacer' }));
+      // then
+
+      assert.notOk(onSubmitStub.calledOnce);
+      assert.notOk(closeModalStub.calledOnce);
+    });
   });
 
   module('if variant is `skill`', function(hooks) {


### PR DESCRIPTION
## 🍂 Problème

Lors d'un déplacement d'épreuves, on peut valider le déplacement alors que le bouton est `disabled`

## 🌰 Proposition

Vérifier que l'état du bouton avant d’exécuter l'action onSubmit.

## 🍁 Remarques

RAS

## 🪵 Pour tester

Déplacer une épreuve d'acquis, sélectionner un sujet sans sélectionner d'acquis clicker sur déplacer et constaté qu'il ne se passe rien
