### PR TITLE
[FEATURE] Ajout d'un popin de confirmation lors de l'édition d'un challenge (PIX-20467)

### DIFF
--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
@@ -144,14 +144,14 @@ export default class LocalizedChallengeViewHeader extends Component {
                   Annuler
                 </PixButton>
                 <PixButton
-                  @triggerAction={{@save}}
+                  @triggerAction={{@openSaveConfirmPopin}}
                 >
                   Enregistrer
                 </PixButton>
               {{else}}
                 {{#if this.mayChangeStatus}}
                   <PixButton
-                    @triggerAction={{@toggleStatus}}
+                    @triggerAction={{@openProductionStatusConfirmPopin}}
                     @iconBefore={{this.toggleLocalizedChallengeStatusButtonState.icon}}
                   >
                     {{this.toggleLocalizedChallengeStatusButtonState.name}}

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -33,6 +33,9 @@ export default class LocalizedChallenge extends Component {
   @tracked urlsToConsult = this.args.localizedChallenge.urlsToConsult?.join('\n');
   @tracked attachmentBasename = '';
   @tracked displayConfirm = false;
+  @tracked confirmTitle = '';
+  @tracked confirmContent = '';
+  @tracked confirmApprove;
 
   @tracked urlsToConsultTextareaHeigh = this.args.localizedChallenge.urlsToConsult?.length ?? 2;
 
@@ -82,14 +85,23 @@ export default class LocalizedChallenge extends Component {
     return !!this.primaryChallenge.illustration;
   }
 
-  get confirmTitle() {
-    return this.args.localizedChallenge.isInProduction ? 'Mise en pause' : 'Mise en prod';
+  @action
+  async openSaveConfirmPopin(confirmPopinType) {
+    this.confirmTitle = 'Enregistrer les modifications';
+    this.confirmContent = 'Êtes vous sûr de vouloir enregistrer ?';
+    this.confirmApprove = this.save;
+    this.displayConfirm = true;
   }
 
-  get confirmContent() {
-    return this.args.localizedChallenge.isInProduction
+  @action
+  async openProductionStatusConfirmPopin() {
+    this.confirmTitle = this.args.localizedChallenge.isInProduction ? 'Mise en pause' : 'Mise en prod';
+    this.confirmContent = this.args.localizedChallenge.isInProduction
       ? 'Êtes-vous sûr de vouloir mettre en pause cette épreuve ?'
       : 'Êtes-vous sûr de vouloir mettre en prod cette épreuve ?';
+
+    this.confirmApprove = this.updateStatusProduction;
+    this.displayConfirm = true;
   }
 
   @action
@@ -222,6 +234,7 @@ export default class LocalizedChallenge extends Component {
       this.notify.error('Erreur lors de la mise à jour de l\'épreuve');
     } finally {
       this.loader.stop();
+      this.displayConfirm = false;
     }
   }
 
@@ -254,7 +267,7 @@ export default class LocalizedChallenge extends Component {
   }
 
   @action
-  async confirmApprove() {
+  async updateStatusProduction() {
     this.args.localizedChallenge.status = this.args.localizedChallenge.isInProduction ? 'proposé' : 'validé';
     try {
       this.loader.start('Enregistrement');
@@ -336,11 +349,6 @@ export default class LocalizedChallenge extends Component {
   }
 
   @action
-  displayConfirmPopIn() {
-    this.displayConfirm = true;
-  }
-
-  @action
   updateBasename(e) {
     this.attachmentBasename = e.target.value;
   }
@@ -354,9 +362,10 @@ export default class LocalizedChallenge extends Component {
       @skillId={{@skillId}}
       @edition={{@edition}}
       @edit={{@edit}}
+      @openSaveConfirmPopin={{this.openSaveConfirmPopin}}
+      @openProductionStatusConfirmPopin={{this.openProductionStatusConfirmPopin}}
       @save={{this.save}}
       @cancelEdit={{this.cancelEdit}}
-      @toggleStatus={{this.displayConfirmPopIn}}
     />
     <div class="challenge-view">
       <div class="challenge-view-editable-fields">

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -86,7 +86,7 @@ export default class LocalizedChallenge extends Component {
   }
 
   @action
-  async openSaveConfirmPopin(confirmPopinType) {
+  async openSaveConfirmPopin() {
     this.confirmTitle = 'Enregistrer les modifications';
     this.confirmContent = 'Êtes vous sûr de vouloir enregistrer ?';
     this.confirmApprove = this.save;
@@ -215,9 +215,9 @@ export default class LocalizedChallenge extends Component {
 
   @action
   async save() {
+    this.displayConfirm = false;
     try {
       this.loader.start('Enregistrement...');
-
       await this._handleIllustration();
       await this._handlePiecesJointes(this.localizedChallenge);
       await this._saveFiles();
@@ -234,7 +234,6 @@ export default class LocalizedChallenge extends Component {
       this.notify.error('Erreur lors de la mise à jour de l\'épreuve');
     } finally {
       this.loader.stop();
-      this.displayConfirm = false;
     }
   }
 
@@ -268,6 +267,7 @@ export default class LocalizedChallenge extends Component {
 
   @action
   async updateStatusProduction() {
+    this.displayConfirm = false;
     this.args.localizedChallenge.status = this.args.localizedChallenge.isInProduction ? 'proposé' : 'validé';
     try {
       this.loader.start('Enregistrement');
@@ -279,7 +279,6 @@ export default class LocalizedChallenge extends Component {
       this.notify.error(this.args.localizedChallenge.isInProduction ? 'Erreur de la mise en prod de l\'épreuve localisée' : 'Erreur de la mise en pause de l\'épreuve localisée');
     } finally {
       this.loader.stop();
-      this.displayConfirm = false;
     }
   }
 

--- a/pix-editor/tests/acceptance/v2/modify-localized-challenge/modify-localized-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/v2/modify-localized-challenge/modify-localized-challenge-attachment-test.js
@@ -1,4 +1,4 @@
-import { clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { clickByText, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -133,6 +133,9 @@ module('Acceptance | V2 | Modify-Localized-Challenge-Attachment', function(hooks
     await selectFiles(screen.getByLabelText('Ajouter un fichier...'), file2);
     await clickByText('Enregistrer');
 
+    const dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
+
     const attachments = await store.peekAll('attachment');
 
     // then
@@ -158,6 +161,9 @@ module('Acceptance | V2 | Modify-Localized-Challenge-Attachment', function(hooks
     await clickByText('Supprimer la pièce jointe attachmentName1');
 
     await clickByText('Enregistrer');
+
+    const dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
 
     const attachments = await store.peekAll('attachment');
 
@@ -197,10 +203,13 @@ module('Acceptance | V2 | Modify-Localized-Challenge-Attachment', function(hooks
       localizedChallengeId: 'localizedChallengeIdProto',
     });
     // when
-    await visit(`/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges/localizedChallengeIdProto?locale=nl`);
+    const screen = await visit(`/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges/localizedChallengeIdProto?locale=nl`);
     await clickByText('Modifier');
     await fillByLabel('Nom :', 'newName');
     await clickByText('Enregistrer');
+
+    const dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
 
     // then
     const attachment = await store.findRecord('attachment', 'attachmentId1');

--- a/pix-editor/tests/acceptance/v2/modify-localized-challenge/modify-localized-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/v2/modify-localized-challenge/modify-localized-challenge-illustration-test.js
@@ -1,4 +1,5 @@
-import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { clickByText, visit, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { selectFiles } from 'ember-file-upload/test-support';
@@ -121,6 +122,9 @@ module('Acceptance | V2 | Modify-Localized-Challenge-Illustration', function(hoo
     await selectFiles(screen.getByLabelText('Choisir une image'), file);
     await clickByText('Enregistrer');
 
+    const dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
+
     const attachments = await store.peekAll('attachment');
 
     // then
@@ -147,9 +151,15 @@ module('Acceptance | V2 | Modify-Localized-Challenge-Illustration', function(hoo
     await clickByText('Enregistrer');
 
     // replace illustrationA with illustrationB
+    let dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
+
     await clickByText('Modifier');
     await selectFiles(screen.getByLabelText('Choisir une image'), illustrationB);
     await clickByText('Enregistrer');
+
+    dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
 
     const attachments = store.peekAll('attachment').slice();
 
@@ -165,12 +175,14 @@ module('Acceptance | V2 | Modify-Localized-Challenge-Illustration', function(hoo
     this.server.create('attachment', { id: 'recAttachment1', type: 'illustration', challengeId: 'challengeIdProto', localizedChallengeId: 'localizedChallengeIdProto' });
 
     // when
-    await visit(`/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges/localizedChallengeIdProto?locale=nl`);
+    const screen = await visit(`/v2/competences/recCompetence1/challenges-production/skills/${skillId}/localized-challenges/localizedChallengeIdProto?locale=nl`);
 
     await clickByText('Modifier');
     await clickByText('Supprimer l\'image');
-
     await clickByText('Enregistrer');
+
+    const dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
 
     const attachments = await store.peekAll('attachment');
 

--- a/pix-editor/tests/acceptance/v2/modify-localized-challenge/modify-localized-challenge-test.js
+++ b/pix-editor/tests/acceptance/v2/modify-localized-challenge/modify-localized-challenge-test.js
@@ -1,4 +1,4 @@
-import { clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { clickByText, fillByLabel, visit, within } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -162,6 +162,9 @@ module('Acceptance | v2 | Modify-Localized-Challenge', function(hooks) {
     await click(await screen.findByRole('option', { name: 'Japon' }));
     await waitForSelectToBeClosed(screen);
     await clickByText('Enregistrer');
+
+    const dialog = screen.getByLabelText('Enregistrer les modifications');
+    await click(within(dialog).getByText('Oui'));
 
     // then
     const localizedChallenge = await store.peekRecord('localized-challenge', 'localizedChallengeIdProto');


### PR DESCRIPTION
# 🍂 Problème
Lors de la modification d'un challenge on ne demande pas à l'utilisateur si il est sur de son action.

# 🌰 Proposition
Ajouter une popin de confirmation

# 🍁 Remarques
Il y a encore un bug visuel au moment du reset des info dans la popin

# 🪵 Pour tester
Modifier un localized challenge et observer que le boutton qui change le satut PLAY/PAUSE et le boutton save possèdent bien une popin de confirmation mais aussi que ca fonctionne :)
