### PR TITLE
[BUGFIX] Rafraichissement de l’overview de la compétence (PIX-20517)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ executors:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
       - image: redis:7.2.11-alpine
-    resource_class: medium
+    resource_class: medium+
 
 jobs:
   pix-editor-test:

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -41,7 +41,9 @@ export default class SingleController extends Controller {
   @tracked urlsToConsult = '';
 
   deletedFiles = [];
+
   @controller('authenticated.competence') parentController;
+  @controller('authenticated.competence.prototypes') overviewController;
 
   get challengeStatusActionsId() {
     return `challenge-${this.challenge.id}-status-actions`;
@@ -408,6 +410,7 @@ export default class SingleController extends Controller {
         const prototype = this.challenge;
         await this._setSkill(prototype, skill);
         await this._handleChangelog(prototype, changelog);
+        await this.overviewController.send('refreshModel');
       } catch (error) {
         Sentry.captureException(error);
         this._message(this.intl.t('challenge.move.error'));
@@ -426,21 +429,16 @@ export default class SingleController extends Controller {
     const prototypeVersion = skill.getNextPrototypeVersion();
     const challenges = prototype.alternatives;
     challenges.push(prototype);
-    const updateChallenges = challenges.reduce((current, challenge) => {
+    await Promise.all(challenges.map(async(challenge) => {
       challenge.skill = skill;
       challenge.version = prototypeVersion;
-      current.push(challenge.save()
-        .then(() => {
-          if (challenge.isPrototype) {
-            this._message(this.intl.t('challenge.move.success-prototype-message'));
-          } else {
-            this._message(this.intl.t('challenge.move.success-alternative-message', { number: challenge.alternativeVersion }));
-          }
-        }),
-      );
-      return current;
-    }, []);
-    await Promise.all(updateChallenges);
+      await challenge.save();
+      if (challenge.isPrototype) {
+        this._message(this.intl.t('challenge.move.success-prototype-message'));
+      } else {
+        this._message(this.intl.t('challenge.move.success-alternative-message', { number: challenge.alternativeVersion }));
+      }
+    }));
   }
 
   @action

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -286,6 +286,8 @@ export default class SingleController extends Controller {
           await this._handleChangelog(challenge, changelog);
           await this._checkSkillValidation(challenge);
           await this._validateAlternatives(challenge);
+          const skill = await challenge.skill;
+          await skill.hasMany('challengesProduction').reload();
           this._message('Mise en production réussie');
           this.parentController.send('selectView', 'production', true);
           this.router.refresh('authenticated.competence.prototypes');

--- a/pix-editor/ember-cli-build.js
+++ b/pix-editor/ember-cli-build.js
@@ -46,6 +46,7 @@ module.exports = function(defaults) {
   const { Webpack } = require('@embroider/webpack');
 
   return require('@embroider/compat').compatBuild(app, Webpack, {
+    staticEmberSource: true,
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
     staticModifiers: true,


### PR DESCRIPTION
## 🍂 Problème

Suite à certaines modifications, certaines données ne sont pas correctement rafraichies, cf "Pour tester".

## 🌰 Proposition

Rafraichir les données impactées suite aux modifications.

## 🍁 Remarques

N/A

## 🪵 Pour tester

### Cas 1 : Mise en production d’un proto

 - Etape 0 : Se mettre en vue V2
 - Etape 1 : Avoir une version d’acquis avec un proto validé et un proto proposé (ce doit être la même version d’acquis)
 - Etape 2 : Visiter l’acquis en vue épreuves production (dans la liste des épreuves on a le proto validé)
 - Etape 3 : Valider le proto proposé (et aussi ses déclis si proposé)
 - Etape 4 : Retourner sur l’acquis en vue épreuves production

=> Le proto qui vient d’être validé doit apparaître dans la liste des épreuves (avec ses déclis si il en a).

### Cas 2 : Déplacement d’épreuve

 - Se mettre en vue épreuves atelier
 - Déplacer une épreuve proposée vers un nouvel acquis, de niveau différent par exemple (créer l’acquis au préalable si nécessiare).

=> Vérifier que la grille de la vue épreuves atelier se met à jour pour refléter la nouvelle situation.