### PR TITLE
[FEATURE] Permettre le CRUD d'un localizedFrameworkTube (PIX-20505).

### DIFF
--- a/api/db/migrations/20251124095012_add_tubeId_foreignkey.js
+++ b/api/db/migrations/20251124095012_add_tubeId_foreignkey.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'localized_framework_tubes';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('tubeId').notNullable().references('tubes.id').alter();
+    table.index('tubeId');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down() {
+  // on ne veut pas down
+}

--- a/api/lib/application/localized-framework-tubes/index.js
+++ b/api/lib/application/localized-framework-tubes/index.js
@@ -1,0 +1,13 @@
+import * as localizedFrameworkTubesController from './localized-framework-tubes-controller.js';
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/localized-framework-tubes',
+      config: { handler: localizedFrameworkTubesController.findAll },
+    },
+  ]);
+}
+
+export const name = 'localized-framework-tubes-api';

--- a/api/lib/application/localized-framework-tubes/index.js
+++ b/api/lib/application/localized-framework-tubes/index.js
@@ -12,8 +12,27 @@ export async function register(server) {
       method: 'POST',
       path: '/api/localized-framework-tubes',
       config: {
-        handler: localizedFrameworkTubesController.create,
+        handler: localizedFrameworkTubesController.upsert,
         validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'tube-id': Joi.string().required(),
+                'max-level': Joi.number().required(),
+                locale: Joi.string().required(),
+              },
+            },
+          }),
+        },
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/api/localized-framework-tubes/{id}',
+      config: {
+        handler: localizedFrameworkTubesController.upsert,
+        validate: {
+          params: Joi.object({ id: Joi.string().required() }),
           payload: Joi.object({
             data: {
               attributes: {

--- a/api/lib/application/localized-framework-tubes/index.js
+++ b/api/lib/application/localized-framework-tubes/index.js
@@ -1,4 +1,5 @@
 import * as localizedFrameworkTubesController from './localized-framework-tubes-controller.js';
+import Joi from 'joi';
 
 export async function register(server) {
   server.route([
@@ -6,6 +7,24 @@ export async function register(server) {
       method: 'GET',
       path: '/api/localized-framework-tubes',
       config: { handler: localizedFrameworkTubesController.findAll },
+    },
+    {
+      method: 'POST',
+      path: '/api/localized-framework-tubes',
+      config: {
+        handler: localizedFrameworkTubesController.create,
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'tube-id': Joi.string().required(),
+                'max-level': Joi.number().required(),
+                locale: Joi.string().required(),
+              },
+            },
+          }),
+        },
+      },
     },
   ]);
 }

--- a/api/lib/application/localized-framework-tubes/index.js
+++ b/api/lib/application/localized-framework-tubes/index.js
@@ -45,6 +45,11 @@ export async function register(server) {
         },
       },
     },
+    {
+      method: 'DELETE',
+      path: '/api/localized-framework-tubes/{id}',
+      config: { handler: localizedFrameworkTubesController.remove },
+    },
   ]);
 }
 

--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -5,3 +5,11 @@ export async function findAll(request, h) {
   const localizedFrameworksTubes = await localizedFrameworksTubesRepository.findAll();
   return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(localizedFrameworksTubes));
 }
+
+export async function create(request, h) {
+  const localizeFrameworkTube = localizedFrameworkTubesSerializer.deserializeLocalizedFrameworkTubes(request?.payload?.data?.attributes);
+  localizeFrameworkTube.validate();
+
+  const createdLocalizedFrameworkTubes = await localizedFrameworksTubesRepository.save(localizeFrameworkTube);
+  return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(createdLocalizedFrameworkTubes)).created();
+}

--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -19,3 +19,9 @@ export async function upsert(request, h) {
   const createdLocalizedFrameworkTubes = await localizedFrameworksTubesRepository.save(localizeFrameworkTube);
   return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(createdLocalizedFrameworkTubes)).created();
 }
+
+export async function remove(request, h) {
+  const id = request?.params?.id;
+  await localizedFrameworksTubesRepository.remove(id);
+  return h.response().code(204);
+}

--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -1,0 +1,7 @@
+import { localizedFrameworksTubesRepository } from '../../infrastructure/repositories/index.js';
+import { localizedFrameworkTubesSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
+
+export async function findAll(request, h) {
+  const localizedFrameworksTubes = await localizedFrameworksTubesRepository.findAll();
+  return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(localizedFrameworksTubes));
+}

--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -6,8 +6,14 @@ export async function findAll(request, h) {
   return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(localizedFrameworksTubes));
 }
 
-export async function create(request, h) {
-  const localizeFrameworkTube = localizedFrameworkTubesSerializer.deserializeLocalizedFrameworkTubes(request?.payload?.data?.attributes);
+export async function upsert(request, h) {
+  const attributes = request?.payload?.data?.attributes;
+  const id = request?.params?.id;
+
+  const localizeFrameworkTube = localizedFrameworkTubesSerializer.deserializeLocalizedFrameworkTubes({
+    id,
+    ...attributes,
+  });
   localizeFrameworkTube.validate();
 
   const createdLocalizedFrameworkTubes = await localizedFrameworksTubesRepository.save(localizeFrameworkTube);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -91,3 +91,9 @@ export class CloneSkillError extends DomainError {
 }
 
 export class ForbiddenError extends DomainError {}
+
+export class InvalidLocalizedFrameworkTubesError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}

--- a/api/lib/domain/models/LocalizedFrameworkTubes.js
+++ b/api/lib/domain/models/LocalizedFrameworkTubes.js
@@ -1,8 +1,16 @@
+import { InvalidLocalizedFrameworkTubesError } from '../errors.js';
+
 export class LocalizedFrameworkTubes {
   constructor({ id, tubeId, maxLevel, locale }) {
     this.id = id;
     this.tubeId = tubeId;
     this.maxLevel = maxLevel;
     this.locale = locale;
+  }
+
+  validate() {
+    if (this.maxLevel < 0 || this.maxLevel > 8) {
+      throw new InvalidLocalizedFrameworkTubesError('MaxLevel out of range');
+    }
   }
 }

--- a/api/lib/domain/models/LocalizedFrameworkTubes.js
+++ b/api/lib/domain/models/LocalizedFrameworkTubes.js
@@ -1,0 +1,8 @@
+export class LocalizedFrameworkTubes {
+  constructor({ id, tubeId, maxLevel, locale }) {
+    this.id = id;
+    this.tubeId = tubeId;
+    this.maxLevel = maxLevel;
+    this.locale = locale;
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -5,6 +5,7 @@ export * from './ChangelogEntry.js';
 export * from './Competence.js';
 export * from './Framework.js';
 export * from './LocalizedChallenge.js';
+export * from './LocalizedFrameworkTubes.js';
 export * from './Mission.js';
 export * from './Note.js';
 export * from './Skill.js';

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -5,6 +5,7 @@ export * as competenceRepository from './competence-repository.js';
 export * as fileStorageTokenRepository from './file-storage-token-repository.js';
 export * as frameworkRepository from './framework-repository.js';
 export * as localizedChallengeRepository from './localized-challenge-repository.js';
+export * as localizedFrameworksTubesRepository from './localized-framework-tubes-repository.js';
 export * as missionRepository from './mission-repository.js';
 export * as releaseRepository from './release-repository.js';
 export * as skillRepository from './skill-repository.js';

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -6,6 +6,21 @@ export async function findAll() {
   return localizedFrameworkTubesDtos.map(_toDomain);
 }
 
+export async function save(localizedFrameworkTube) {
+  const [insertedLocalizedFrameworkTubes] = await knex('localized_framework_tubes')
+    .insert({
+      id: localizedFrameworkTube.id,
+      tubeId: localizedFrameworkTube.tubeId,
+      maxLevel: localizedFrameworkTube.maxLevel,
+      locale: localizedFrameworkTube.locale,
+    })
+    .onConflict('id')
+    .merge()
+    .returning('*');
+
+  return _toDomain(insertedLocalizedFrameworkTubes);
+}
+
 function _toDomain(dto) {
   return new LocalizedFrameworkTubes(dto);
 }

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -1,0 +1,11 @@
+import { knex } from '../../../db/knex-database-connection.js';
+import { LocalizedFrameworkTubes } from '../../domain/models/index.js';
+
+export async function findAll() {
+  const localizedFrameworkTubesDtos = await knex('localized_framework_tubes').select('*');
+  return localizedFrameworkTubesDtos.map(_toDomain);
+}
+
+function _toDomain(dto) {
+  return new LocalizedFrameworkTubes(dto);
+}

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -21,6 +21,10 @@ export async function save(localizedFrameworkTube) {
   return _toDomain(insertedLocalizedFrameworkTubes);
 }
 
+export async function remove(id) {
+  return knex.delete().from('localized_framework_tubes').where('id', id);
+}
+
 function _toDomain(dto) {
   return new LocalizedFrameworkTubes(dto);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/index.js
+++ b/api/lib/infrastructure/serializers/jsonapi/index.js
@@ -7,6 +7,7 @@ export * as configSerializer from './config-serializer.js';
 export * as errorSerializer from './error-serializer.js';
 export * as frameworkSerializer from './framework-serializer.js';
 export * as localizedChallengeSerializer from './localized-challenge-serializer.js';
+export * as localizedFrameworkTubesSerializer from './localized-framework-tubes-serializer.js';
 export * as missionSerializer from './mission-serializer.js';
 export * as skillSerializer from './skill-serializer.js';
 export * as staticCourseSerializer from './static-course-serializer.js';

--- a/api/lib/infrastructure/serializers/jsonapi/localized-framework-tubes-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-framework-tubes-serializer.js
@@ -1,4 +1,5 @@
 import JsonapiSerializer from 'jsonapi-serializer';
+import { LocalizedFrameworkTubes } from '../../../domain/models/index.js';
 
 const { Serializer } = JsonapiSerializer;
 
@@ -10,4 +11,13 @@ export function serializeLocalizedFrameworkTubes(domainObject) {
       'locale',
     ],
   }).serialize(domainObject);
+}
+
+export function deserializeLocalizedFrameworkTubes(attributes) {
+  return new LocalizedFrameworkTubes({
+    id: attributes.id,
+    tubeId: attributes['tube-id'],
+    maxLevel: attributes['max-level'],
+    locale: attributes.locale,
+  });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/localized-framework-tubes-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/localized-framework-tubes-serializer.js
@@ -1,0 +1,13 @@
+import JsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = JsonapiSerializer;
+
+export function serializeLocalizedFrameworkTubes(domainObject) {
+  return new Serializer('localized-framework-tubes', {
+    attributes: [
+      'tubeId',
+      'maxLevel',
+      'locale',
+    ],
+  }).serialize(domainObject);
+}

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -97,6 +97,14 @@ function _mapToInfrastructureError(error) {
     };
   }
 
+  if (error instanceof DomainErrors.InvalidLocalizedFrameworkTubesError) {
+    const infraError = new InfraErrors.BadRequestError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
+
   const infraError = new InfraErrors.InfrastructureError(error.message);
   return {
     infraErrors: [infraError],

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -10,6 +10,7 @@ import * as frameworksRoute from './application/frameworks.js';
 import * as healthcheckRoute from './application/healthcheck/index.js';
 import * as heapdumpRoute from './application/heapdump.js';
 import * as localizedChallengesRoute from './application/localized-challenges.js';
+import * as localizedFrameworkTubesRoute from './application/localized-framework-tubes/index.js';
 import * as missionsRoute from './application/missions/index.js';
 import * as notesRoute from './application/notes.js';
 import * as phraseRoute from './application/phrase.js';
@@ -39,6 +40,7 @@ export const routes = [
   heapdumpRoute,
   healthcheckRoute,
   localizedChallengesRoute,
+  localizedFrameworkTubesRoute,
   missionsRoute,
   notesRoute,
   phraseRoute,

--- a/api/tests/acceptance/application/localized-framework-tubes/delete_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/delete_localized-framework-tubes_test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | API | localized_framework_tubes | DELETE /api/localized-framework-tubes', function() {
+  let user, tubeId, localizedFrameworkTubeId;
+
+  beforeEach(async function() {
+    user = databaseBuilder.factory.buildAdminUser();
+    const { id: frameworkId } = databaseBuilder.factory.buildFramework({
+      id: 'frameworkId',
+      name: 'framework',
+    });
+    const { id: areaId } = databaseBuilder.factory.buildArea({
+      id: 'areaId',
+      code: '1.1',
+      color: 'blue',
+      frameworkId,
+    });
+    const { id: competenceId } = databaseBuilder.factory.buildCompetence({
+      id: 'competenceId',
+      index: 1,
+      areaId,
+    });
+    const { id: thematicId } = databaseBuilder.factory.buildThematic({
+      id: 'thematicId',
+      index: 1,
+      competenceId,
+    });
+    const tube = databaseBuilder.factory.buildTube({
+      id: 'tubeId',
+      name: 'tubeName',
+      index: 1,
+      thematicId,
+    });
+    tubeId = tube.id;
+
+    const localizedFrameworkTube = databaseBuilder.factory.buildLocalizedFrameworkTubes({
+      tubeId,
+      maxLevel: 8,
+      locale: 'nl',
+    });
+
+    localizedFrameworkTubeId = localizedFrameworkTube.id;
+
+    await databaseBuilder.commit();
+  });
+
+  it('should delete localizedFrameworkTube', async function() {
+    // when
+    const server = await createServer();
+    const response = await server.inject({
+      method: 'DELETE',
+      url: `/api/localized-framework-tubes/${localizedFrameworkTubeId}`,
+      headers: generateAuthorizationHeader(user),
+    });
+
+    // then
+    const localizedFrameworkTube = await knex('localized_framework_tubes').select().first();
+
+    expect(response.statusCode).to.equal(204);
+    expect(localizedFrameworkTube).to.be.undefined;
+  });
+});

--- a/api/tests/acceptance/application/localized-framework-tubes/get_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/get_localized-framework-tubes_test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | API | localized_framework_tubes | GET /api/localized-framework-tubes', function() {
+  it('Should return serialized localizedFrameworkTubes', async function() {
+    // given
+    const user = databaseBuilder.factory.buildAdminUser();
+    const { id: frameworkId } = databaseBuilder.factory.buildFramework({
+      id: 'frameworkId',
+      name: 'framework',
+    });
+    const { id: areaId } = databaseBuilder.factory.buildArea({
+      id: 'areaId',
+      code: '1.1',
+      color: 'blue',
+      frameworkId,
+    });
+    const { id: competenceId } = databaseBuilder.factory.buildCompetence({
+      id: 'competenceId',
+      index: 1,
+      areaId,
+    });
+    const { id: thematicId } = databaseBuilder.factory.buildThematic({
+      id: 'thematicId',
+      index: 1,
+      competenceId,
+    });
+    const { id: tubeId } = databaseBuilder.factory.buildTube({
+      id: 'tubeId',
+      name: 'tubeName',
+      index: 1,
+      thematicId,
+    });
+
+    const localizedFrameworkTubes = databaseBuilder.factory.buildLocalizedFrameworkTubes({
+      tubeId,
+      maxLevel: 5,
+      locale: 'bz',
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const server = await createServer();
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/localized-framework-tubes',
+      headers: generateAuthorizationHeader(user),
+    });
+
+    // then
+    expect(response.result).to.deep.equal({
+      data: [
+        {
+          type: 'localized-framework-tubes',
+          id: localizedFrameworkTubes.id.toString(),
+          attributes: {
+            'tube-id': 'tubeId',
+            'max-level': 5,
+            locale: 'bz',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
@@ -1,39 +1,106 @@
-import { describe, expect, it } from 'vitest';
-import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
-describe('Acceptance | API | localized_framework_tubes | GET /api/localized-framework-tubes', function() {
-  it('Should return an object of serialized localizedFrameworkTubes', async function() {
-    // given
-    const user = databaseBuilder.factory.buildAdminUser();
-    const localizedFrameworkTubes = databaseBuilder.factory.buildLocalizedFrameworkTubes({
-      tubeId: 'tubeId1',
-      maxLevel: 5,
-      locale: 'bz',
+describe('Acceptance | API | localized_framework_tubes | POST /api/localized-framework-tubes', function() {
+  let user, tubeId;
+
+  beforeEach(async function() {
+    user = databaseBuilder.factory.buildAdminUser();
+    const { id: frameworkId } = databaseBuilder.factory.buildFramework({
+      id: 'frameworkId',
+      name: 'framework',
     });
+    const { id: areaId } = databaseBuilder.factory.buildArea({
+      id: 'areaId',
+      code: '1.1',
+      color: 'blue',
+      frameworkId,
+    });
+    const { id: competenceId } = databaseBuilder.factory.buildCompetence({
+      id: 'competenceId',
+      index: 1,
+      areaId,
+    });
+    const { id: thematicId } = databaseBuilder.factory.buildThematic({
+      id: 'thematicId',
+      index: 1,
+      competenceId,
+    });
+    const tube = databaseBuilder.factory.buildTube({
+      id: 'tubeId',
+      name: 'tubeName',
+      index: 1,
+      thematicId,
+    });
+    tubeId = tube.id;
     await databaseBuilder.commit();
+  });
+
+  it('should create a localizedFrameworkTube', async function() {
+    // given
+    const payload = {
+      data: {
+        attributes: {
+          'tube-id': tubeId,
+          'max-level': 2,
+          locale: 'nl',
+        },
+      },
+    };
 
     // when
     const server = await createServer();
     const response = await server.inject({
-      method: 'GET',
+      method: 'POST',
       url: '/api/localized-framework-tubes',
       headers: generateAuthorizationHeader(user),
+      payload,
     });
 
     // then
+    const { id: localizedFrameworkTubesId } = await knex('localized_framework_tubes').select('id').first();
+
+    expect(response.statusCode).to.equal(201);
     expect(response.result).to.deep.equal({
-      data: [
-        {
-          type: 'localized-framework-tubes',
-          id: localizedFrameworkTubes.id.toString(),
-          attributes: {
-            'tube-id': 'tubeId1',
-            'max-level': 5,
-            locale: 'bz',
-          },
+      data: {
+        type: 'localized-framework-tubes',
+        id: localizedFrameworkTubesId.toString(),
+        attributes: {
+          'tube-id': 'tubeId',
+          'max-level': 2,
+          locale: 'nl',
         },
-      ],
+      },
     });
+  });
+
+  it('Should return bad request', async function() {
+    // given
+    const payload = {
+      data: {
+        attributes: {
+          'tube-id': tubeId,
+          'max-level': 10,
+          locale: 'nl',
+        },
+      },
+    };
+
+    // when
+    const server = await createServer();
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/localized-framework-tubes',
+      headers: generateAuthorizationHeader(user),
+      payload,
+    });
+
+    // then
+    const localizedFrameworkTube = await knex('localized_framework_tubes').select('id').first();
+
+    expect(localizedFrameworkTube).to.be.undefined;
+    expect(response.statusCode).to.equal(400);
+    expect(response.payload).to.equal('{"errors":[{"status":"400","title":"Bad Request","detail":"MaxLevel out of range"}]}');
   });
 });

--- a/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | API | localized_framework_tubes | GET /api/localized-framework-tubes', function() {
+  it('Should return an object of serialized localizedFrameworkTubes', async function() {
+    // given
+    const user = databaseBuilder.factory.buildAdminUser();
+    const localizedFrameworkTubes = databaseBuilder.factory.buildLocalizedFrameworkTubes({
+      tubeId: 'tubeId1',
+      maxLevel: 5,
+      locale: 'bz',
+    });
+    await databaseBuilder.commit();
+
+    // when
+    const server = await createServer();
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/localized-framework-tubes',
+      headers: generateAuthorizationHeader(user),
+    });
+
+    // then
+    expect(response.result).to.deep.equal({
+      data: [
+        {
+          type: 'localized-framework-tubes',
+          id: localizedFrameworkTubes.id.toString(),
+          attributes: {
+            'tube-id': 'tubeId1',
+            'max-level': 5,
+            locale: 'bz',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/api/tests/acceptance/application/localized-framework-tubes/put_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/put_localized-framework-tubes_test.js
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | API | localized_framework_tubes | PUT /api/localized-framework-tubes', function() {
+  let user, tubeId, localizedFrameworkTubeId;
+
+  beforeEach(async function() {
+    user = databaseBuilder.factory.buildAdminUser();
+    const { id: frameworkId } = databaseBuilder.factory.buildFramework({
+      id: 'frameworkId',
+      name: 'framework',
+    });
+    const { id: areaId } = databaseBuilder.factory.buildArea({
+      id: 'areaId',
+      code: '1.1',
+      color: 'blue',
+      frameworkId,
+    });
+    const { id: competenceId } = databaseBuilder.factory.buildCompetence({
+      id: 'competenceId',
+      index: 1,
+      areaId,
+    });
+    const { id: thematicId } = databaseBuilder.factory.buildThematic({
+      id: 'thematicId',
+      index: 1,
+      competenceId,
+    });
+    const tube = databaseBuilder.factory.buildTube({
+      id: 'tubeId',
+      name: 'tubeName',
+      index: 1,
+      thematicId,
+    });
+    tubeId = tube.id;
+
+    const localizedFrameworkTube = databaseBuilder.factory.buildLocalizedFrameworkTubes({
+      tubeId,
+      maxLevel: 8,
+      locale: 'nl',
+    });
+
+    localizedFrameworkTubeId = localizedFrameworkTube.id;
+
+    await databaseBuilder.commit();
+  });
+
+  it('should update the localizedFrameworkTube', async function() {
+    // given
+    const payload = {
+      data: {
+        attributes: {
+          'tube-id': tubeId,
+          'max-level': 2,
+          locale: 'nl',
+        },
+      },
+    };
+
+    // when
+    const server = await createServer();
+    const response = await server.inject({
+      method: 'PUT',
+      url: `/api/localized-framework-tubes/${localizedFrameworkTubeId}`,
+      headers: generateAuthorizationHeader(user),
+      payload,
+    });
+
+    // then
+    const localizedFrameworkTube = await knex('localized_framework_tubes').select().first();
+
+    expect(response.statusCode).to.equal(201);
+    expect(localizedFrameworkTube).to.deep.equal({
+      id: localizedFrameworkTubeId,
+      maxLevel: 2,
+      tubeId,
+      locale: 'nl',
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/localized-framework-tubes-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-framework-tubes-repository_test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { localizedFrameworksTubesRepository } from '../../../../lib/infrastructure/repositories/index.js';
+
+describe('Integration | Repository | localized-framework-tubes-repository', function() {
+  it('should return an error if tube does not exists', async () => {
+    // given
+    const localizedFrameworkTubesDTO = {
+      locale: 'nl',
+      maxLevel: 2,
+      tubeId: 'unknown',
+    };
+
+    await expect(localizedFrameworksTubesRepository.save(localizedFrameworkTubesDTO)).rejects.to.contain({ constraint: 'localized_framework_tubes_tubeid_foreign' });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-localized-framework-tubes.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-framework-tubes.js
@@ -1,0 +1,22 @@
+import { databaseBuffer } from '../database-buffer.js';
+
+export function buildLocalizedFrameworkTubes(
+  {
+    id = databaseBuffer.nextId++,
+    tubeId = '',
+    maxLevel = 5,
+    locale = 'bz',
+  } = {},
+) {
+  const values = {
+    id,
+    tubeId,
+    maxLevel,
+    locale,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'localized_framework_tubes',
+    values,
+  });
+}

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -5,6 +5,7 @@ export * from './build-changelog-entry.js';
 export * from './build-competence.js';
 export * from './build-framework.js';
 export * from './build-localized-challenge.js';
+export * from './build-localized-framework-tubes.js';
 export * from './build-mission.js';
 export * from './build-note.js';
 export * from './build-release.js';

--- a/api/tests/unit/domain/models/LocalizedFrameworkTubes_test.js
+++ b/api/tests/unit/domain/models/LocalizedFrameworkTubes_test.js
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { LocalizedFrameworkTubes } from '../../../../lib/domain/models/index.js';
+import { catchErr } from '../../../test-helper.js';
+import { InvalidLocalizedFrameworkTubesError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | Domain | LocalizedFrameworkTubes', () => {
+  describe('when max-level is out of range (0-8)', () => {
+    test('should return an exception', async function() {
+      const localizedFrameworkTubes = new LocalizedFrameworkTubes({
+        maxLevel: 9,
+        locale: 'locale',
+        tubeId: 'tubeId',
+      });
+      const error = await catchErr(localizedFrameworkTubes.validate, localizedFrameworkTubes)();
+
+      expect(error).to.be.instanceOf(InvalidLocalizedFrameworkTubesError);
+      expect(error.message).to.be.equal('MaxLevel out of range');
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -184,6 +184,19 @@ describe('Unit | Infrastructure | ErrorManager', function() {
               },
             ],
           });
+        } else if (domainErrorName === 'InvalidLocalizedFrameworkTubesError') {
+          const errorInstance = new domainErrorClass('mon message');
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(400);
+          expect(responseForError.source).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Bad Request',
+                detail: 'mon message',
+              },
+            ],
+          });
         } else {
           expect(true, `Conversion for ${domainErrorName} not tested`).to.be.false;
         }


### PR DESCRIPTION
## 🍂 Problème

Nous avons besoin de créer, supprimer, modifier un `localizedFrameworkTube`.

## 🌰 Proposition
Créer les route permettant afin de créer, supprimer, modifier un `localizedFrameworkTube`.

## 🍁 Remarques

RAS

## 🪵 Pour tester
les tests au vert
appeler les routes de l'api avec les bon payload/params 
