### PR TITLE
[TECH] Supprime ember-dayjs.

### DIFF
--- a/pix-editor/app/components/challenge-view/challenge-view-header.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view-header.gjs
@@ -6,7 +6,7 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import dayjs from 'ember-dayjs/helpers/dayjs-format';
+import formatDate from 'ember-intl/helpers/format-date';
 import flagForLanguage from 'pixeditor/helpers/flag-for-language';
 import Challenge from 'pixeditor/models/challenge';
 
@@ -87,7 +87,7 @@ export default class ChallengesViewHeader extends Component {
           <PixTag @color={{@statusColor}}>
             {{this.buildStatusText @challenge}}
           </PixTag>
-          <p>{{dayjs @challenge.updatedAt "DD/MM/YYYY" allow-empty=true}}</p>
+          <p>{{formatDate @challenge.updatedAt "DD/MM/YYYY" allow-empty=true}}</p>
         </div>
         <span class="challenge-view-header__dark-separator"></span>
         <div class="challenge-view-header-second__actions">

--- a/pix-editor/app/components/challenges-production/challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/challenges-production.gjs
@@ -11,7 +11,7 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjs from 'ember-dayjs/helpers/dayjs-format';
+import formatDate from 'ember-intl/helpers/format-date';
 import flagForLanguage from 'pixeditor/helpers/flag-for-language';
 import Challenge from 'pixeditor/models/challenge';
 
@@ -103,7 +103,7 @@ export default class ChallengesProduction extends Component {
                 Dernière MAJ
               </:header>
               <:cell>
-                {{dayjs challenge.updatedAt "DD/MM/YYYY" allow-empty=true}}
+                {{formatDate challenge.updatedAt "DD/MM/YYYY" allow-empty=true}}
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}}>

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -10,7 +10,7 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import dayjs from 'ember-dayjs/helpers/dayjs-format';
+import formatDate from 'ember-intl/helpers/format-date';
 import Challenge from 'pixeditor/models/challenge';
 
 import DropdownMenu from '../dropdown-menu';
@@ -100,7 +100,7 @@ export default class LocalizedChallengesProduction extends Component {
                 Dernière MAJ
               </:header>
               <:cell>
-                {{dayjs challengeLocale.primaryUpdatedAt "DD/MM/YYYY" allow-empty=true}}
+                {{formatDate challengeLocale.primaryUpdatedAt "DD/MM/YYYY" allow-empty=true}}
               </:cell>
             </PixTableColumn>
             <PixTableColumn @context={{context}}>

--- a/pix-editor/app/templates/authenticated/missions/list.hbs
+++ b/pix-editor/app/templates/authenticated/missions/list.hbs
@@ -59,7 +59,7 @@
               {{mission.name}}
             </td>
             <td>{{mission.competence}}</td>
-            <td>{{dayjs-format mission.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
+            <td>{{format-date mission.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
             <td>
               <PixTag @color="{{mission.statusColor}}">
                 {{mission.displayableStatus}}

--- a/pix-editor/app/templates/authenticated/missions/mission/details.hbs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.hbs
@@ -58,7 +58,7 @@
           <span class="bold">URL de la documentation de la mission : </span>
           <a href={{ this.model.mission.documentationUrl }} target="_blank">{{this.model.mission.documentationUrl}} </a>
         </li>
-        <li><span class="bold">Crée le : </span>{{dayjs-format this.model.mission.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
+        <li><span class="bold">Crée le : </span>{{format-date this.model.mission.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
       </ul>
     </Card>
   </section>

--- a/pix-editor/app/templates/authenticated/static-courses/list.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.hbs
@@ -101,7 +101,7 @@
               {{/each}}
             </td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{staticCourseSummary.challengeCount}}</td>
-            <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{dayjs-format staticCourseSummary.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
+            <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>{{format-date staticCourseSummary.createdAt "DD/MM/YYYY" allow-empty=true}}</td>
             <td {{on "click" (fn this.goToStaticCourseDetails staticCourseSummary.id)}}>
               <PixTag @color="{{if staticCourseSummary.isActive "green" "grey"}}">
                 {{if staticCourseSummary.isActive "Actif" "Inactif"}}

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.hbs
@@ -46,8 +46,8 @@
             (Motif: {{this.model.staticCourse.deactivationReason}})
           {{/if}}
         </li>
-        <li><span class="bold">Crée le : </span>{{dayjs-format this.model.staticCourse.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
-        <li><span class="bold">Dernière modification : </span>{{dayjs-format this.model.staticCourse.updatedAt "DD/MM/YYYY" allow-empty=true}}</li>
+        <li><span class="bold">Crée le : </span>{{format-date this.model.staticCourse.createdAt "DD/MM/YYYY" allow-empty=true}}</li>
+        <li><span class="bold">Dernière modification : </span>{{format-date this.model.staticCourse.updatedAt "DD/MM/YYYY" allow-empty=true}}</li>
       </ul>
       <div class="static-course-details__card-information--actions">
         <PixButton

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -54,7 +54,6 @@
         "ember-cli-showdown": "^9.0.0",
         "ember-concurrency": "^5.0.0",
         "ember-data": "^5.3.8",
-        "ember-dayjs": "^0.12.1",
         "ember-eslint-parser": "^0.5.3",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^9.5.0",
@@ -16258,13 +16257,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -21525,24 +21517,6 @@
         "qunit": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ember-dayjs": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/ember-dayjs/-/ember-dayjs-0.12.4.tgz",
-      "integrity": "sha512-Avslpo+hNGBPcYYiIVMk4l+erChT7YWfeEghpBx0Q9wVN3HHpu2h2nI0r5ckeOea4OM3IL8oUBiQcO9NsHm5Qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.8.9",
-        "@embroider/macros": "^1.16.1",
-        "dayjs": "^1.11.11"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/ember-eslint-parser": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -68,7 +68,6 @@
     "ember-cli-showdown": "^9.0.0",
     "ember-concurrency": "^5.0.0",
     "ember-data": "^5.3.8",
-    "ember-dayjs": "^0.12.1",
     "ember-eslint-parser": "^0.5.3",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^9.5.0",


### PR DESCRIPTION
## 🍂 Problème

La librairie `ember-dayjs` est peu utilisée, peu maintenue et cause plusieurs soucis.
- Elle bloque l'utilisation de Vite comme bundler car encore en Ember Addon v1
- `ember-dayjs` charge toutes les locales dans le bundle ce qui augmente sa taille significativement.

Beaucoup des fonctions utilitaires de `dayjs` sont nativement incluses dans les `Date` Javascript ou `Intl.DateTimeFormat` ([doc mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat))

## 🌰 Proposition

`ember-intl` propose des formateurs pré-configurés avec la locale utilisateur et qui utilisent [le standard `Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).

**Doc:** https://ember-intl.github.io/ember-intl/docs/helpers/introduction

**Remplacer les helpers `ember-dayjs` par ceux de `ember-intl`**

```diff
-import dayjsFormat from 'ember-dayjs/helpers/dayjs-format';
+import formatDate from 'ember-intl/helpers/format-date';

-{{dayjs-format @campaign.createdAt "DD/MM/YYYY"}}
+{{format-date @campaign.createdAt}}
```

**Suppression des lib `dayjs` et `ember-dayjs`, réduction de la taille du bundle :**

## 🍁 Remarques

RAS


## 🪵 Pour tester

- Les tests passent
- Vérifier les affichages de date : 
  - en-tête d'une épreuve (date de création)
  - date de mise à jour d'une épreuve en production
  - date de mise à jour d'une épreuve primary
  - date de création d'une mission (Pix Junior)
  - date de création d'une mission dans la liste des missions (Pix Junior)
  - date de création et de mise à jour d'un test statique
  - date de création et de mise à jour d'un test statique dans la liste
