### PR TITLE
[TECH] Met à jour ember-source en v6.

### DIFF
--- a/pix-editor/app/adapters/application.js
+++ b/pix-editor/app/adapters/application.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 
 const FIND_GROUP_SIZE = 200;

--- a/pix-editor/app/authenticators/custom.js
+++ b/pix-editor/app/authenticators/custom.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Base from 'ember-simple-auth/authenticators/base';
 
 export default class CustomAuthenticator extends Base {

--- a/pix-editor/app/components/alternatives.js
+++ b/pix-editor/app/components/alternatives.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/components/buttons/copy-link.gjs
+++ b/pix-editor/app/components/buttons/copy-link.gjs
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import CopyButton from 'ember-cli-clipboard/components/copy-button';
 

--- a/pix-editor/app/components/competence/competence-actions.gjs
+++ b/pix-editor/app/components/competence/competence-actions.gjs
@@ -2,7 +2,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { eq, or } from 'ember-truth-helpers';
 

--- a/pix-editor/app/components/competence/competence-footer.js
+++ b/pix-editor/app/components/competence/competence-footer.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CompetenceFooter extends Component {

--- a/pix-editor/app/components/competence/competence-grid-thematic.js
+++ b/pix-editor/app/components/competence/competence-grid-thematic.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CompetenceCompetenceGridThematicComponent extends Component {

--- a/pix-editor/app/components/competence/competence-header.gjs
+++ b/pix-editor/app/components/competence/competence-header.gjs
@@ -1,6 +1,6 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { LinkTo } from '@ember/routing';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class CompetenceHeader extends Component {

--- a/pix-editor/app/components/competence/grid/grid-cell.js
+++ b/pix-editor/app/components/competence/grid/grid-cell.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class GridCell extends Component {

--- a/pix-editor/app/components/field/files.js
+++ b/pix-editor/app/components/field/files.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Files extends Component {

--- a/pix-editor/app/components/field/toggle-field.js
+++ b/pix-editor/app/components/field/toggle-field.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class FieldToggleFieldComponent extends Component {

--- a/pix-editor/app/components/field/tutorials.gjs
+++ b/pix-editor/app/components/field/tutorials.gjs
@@ -3,7 +3,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';

--- a/pix-editor/app/components/form/challenge.js
+++ b/pix-editor/app/components/form/challenge.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/components/form/mission.js
+++ b/pix-editor/app/components/form/mission.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/components/form/select-location.gjs
+++ b/pix-editor/app/components/form/select-location.gjs
@@ -1,7 +1,7 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { and, or } from 'ember-truth-helpers';

--- a/pix-editor/app/components/form/static-course.js
+++ b/pix-editor/app/components/form/static-course.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/components/form/tutorial.gjs
+++ b/pix-editor/app/components/form/tutorial.gjs
@@ -5,7 +5,7 @@ import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';

--- a/pix-editor/app/components/form/whitelisted-url.js
+++ b/pix-editor/app/components/form/whitelisted-url.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/components/list/alternatives.js
+++ b/pix-editor/app/components/list/alternatives.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SortedList from './sorted';
 

--- a/pix-editor/app/components/list/archive.js
+++ b/pix-editor/app/components/list/archive.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SortedList from './sorted';
 

--- a/pix-editor/app/components/list/prototypes.js
+++ b/pix-editor/app/components/list/prototypes.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SortedList from './sorted';
 

--- a/pix-editor/app/components/list/skills.js
+++ b/pix-editor/app/components/list/skills.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SortedList from './sorted';
 

--- a/pix-editor/app/components/list/workbench.js
+++ b/pix-editor/app/components/list/workbench.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SortedList from './sorted';
 

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -4,7 +4,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';

--- a/pix-editor/app/components/pop-in/challenge-log.gjs
+++ b/pix-editor/app/components/pop-in/challenge-log.gjs
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/pix-editor/app/components/pop-in/changelog.js
+++ b/pix-editor/app/components/pop-in/changelog.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/components/sidebar/export.js
+++ b/pix-editor/app/components/sidebar/export.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class SidebarExportComponent extends Component {

--- a/pix-editor/app/components/sidebar/main.js
+++ b/pix-editor/app/components/sidebar/main.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'pixeditor/config/environment';
 

--- a/pix-editor/app/components/sidebar/navigation.gjs
+++ b/pix-editor/app/components/sidebar/navigation.gjs
@@ -4,7 +4,7 @@ import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';

--- a/pix-editor/app/components/sidebar/search.gjs
+++ b/pix-editor/app/components/sidebar/search.gjs
@@ -1,6 +1,6 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { uniqBy } from 'lodash';

--- a/pix-editor/app/components/v2/field/files.gjs
+++ b/pix-editor/app/components/v2/field/files.gjs
@@ -4,7 +4,7 @@ import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { concat, fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import fileQueue from 'ember-file-upload/helpers/file-queue';
 import { or } from 'ember-truth-helpers';

--- a/pix-editor/app/components/v2/field/toggle-field.gjs
+++ b/pix-editor/app/components/v2/field/toggle-field.gjs
@@ -3,7 +3,7 @@ import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class FieldToggleFieldComponent extends Component {

--- a/pix-editor/app/controllers/application.js
+++ b/pix-editor/app/controllers/application.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
   @service session;

--- a/pix-editor/app/controllers/authenticated.js
+++ b/pix-editor/app/controllers/authenticated.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import ENV from 'pixeditor/config/environment';

--- a/pix-editor/app/controllers/authenticated/area-management/new.js
+++ b/pix-editor/app/controllers/authenticated/area-management/new.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 export default class AreaManagementNewController extends Controller {

--- a/pix-editor/app/controllers/authenticated/competence-management/new.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/new.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 export default class CompetenceManagementNewController extends Controller {

--- a/pix-editor/app/controllers/authenticated/competence-management/single.js
+++ b/pix-editor/app/controllers/authenticated/competence-management/single.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence.js
+++ b/pix-editor/app/controllers/authenticated/competence.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/list.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/list.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListController extends Controller {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import yaml from 'js-yaml';

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class AlternativesController extends Controller {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single/alternatives/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence/skills/list.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/list.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceHistoryListController extends Controller {
   @controller('authenticated.competence')

--- a/pix-editor/app/controllers/authenticated/competence/skills/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 import Skill from './single';

--- a/pix-editor/app/controllers/authenticated/competence/skills/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence/skills/single/archive.js
+++ b/pix-editor/app/controllers/authenticated/competence/skills/single/archive.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class CompetenceSkillsSingleArchiveController extends Controller {

--- a/pix-editor/app/controllers/authenticated/competence/themes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/themes/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 import CompetenceThemesSingleController from './single';

--- a/pix-editor/app/controllers/authenticated/competence/themes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/themes/single.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/competence/tubes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/new.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 import Tube from './single';

--- a/pix-editor/app/controllers/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/tubes/single.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/missions/list.js
+++ b/pix-editor/app/controllers/authenticated/missions/list.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import MissionSummary from '../../../models/mission-summary';

--- a/pix-editor/app/controllers/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/controllers/authenticated/missions/mission/edit.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionEditController extends Controller {
   @service router;

--- a/pix-editor/app/controllers/authenticated/missions/new.js
+++ b/pix-editor/app/controllers/authenticated/missions/new.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionController extends Controller {
   @service router;

--- a/pix-editor/app/controllers/authenticated/static-courses/list.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/list.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class StaticCoursesController extends Controller {

--- a/pix-editor/app/controllers/authenticated/static-courses/new.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/new.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NewStaticCourseController extends Controller {
   @service store;

--- a/pix-editor/app/controllers/authenticated/static-courses/static-course/details.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/static-course/details.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class StaticCoursesController extends Controller {

--- a/pix-editor/app/controllers/authenticated/static-courses/static-course/edit.js
+++ b/pix-editor/app/controllers/authenticated/static-courses/static-course/edit.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import sortBy from 'lodash/sortBy';
 
 export default class EditStaticCourseController extends Controller {

--- a/pix-editor/app/controllers/authenticated/synchronize-translations.js
+++ b/pix-editor/app/controllers/authenticated/synchronize-translations.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SynchronizeTranslationsController extends Controller {
   @service notifications;

--- a/pix-editor/app/controllers/authenticated/target-profile.js
+++ b/pix-editor/app/controllers/authenticated/target-profile.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/list.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class WhitelistedUrlsController extends Controller {

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/new.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/new.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NewWhitelistedUrlController extends Controller {
   @service store;

--- a/pix-editor/app/controllers/authenticated/whitelisted-urls/whitelisted-url/edit.js
+++ b/pix-editor/app/controllers/authenticated/whitelisted-urls/whitelisted-url/edit.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class EditWhitelistedUrlController extends Controller {
   @service store;

--- a/pix-editor/app/controllers/login.js
+++ b/pix-editor/app/controllers/login.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginController extends Controller {
   @service session;

--- a/pix-editor/app/deprecation-workflow.js
+++ b/pix-editor/app/deprecation-workflow.js
@@ -3,8 +3,36 @@ import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 setupDeprecationWorkflow({
   workflow: [
     {
-      handler: 'error', // this deprecation is only on EmberTable package
-      matchId: 'template-action',
+      handler: 'silence',
+      matchId: 'importing-inject-from-ember-service',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--is-destroying-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--is-destroyed-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import-destroy-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import--register-destructor-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'deprecate-import-onerror-from-ember',
+    },
+    {
+      handler: 'silence',
+      matchId: 'warp-drive.deprecate-tracking-package',
+    },
+    {
+      handler: 'silence',
+      matchId: 'warp-drive:deprecate-legacy-request-methods',
     },
   ],
 });

--- a/pix-editor/app/deprecation-workflow.js
+++ b/pix-editor/app/deprecation-workflow.js
@@ -3,7 +3,7 @@ import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 setupDeprecationWorkflow({
   workflow: [
     {
-      handler: 'warn', // this deprecation is only on EmberTable package
+      handler: 'error', // this deprecation is only on EmberTable package
       matchId: 'template-action',
     },
   ],

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { tracked } from '@glimmer/tracking';
 import _ from 'lodash';

--- a/pix-editor/app/models/changelog-entry.js
+++ b/pix-editor/app/models/changelog-entry.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Model, { attr } from '@ember-data/model';
 
 export default class ChangelogEntryModel extends Model {

--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { tracked } from '@glimmer/tracking';
 

--- a/pix-editor/app/routes/application.js
+++ b/pix-editor/app/routes/application.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service session;

--- a/pix-editor/app/routes/authenticated.js
+++ b/pix-editor/app/routes/authenticated.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
   @service config;

--- a/pix-editor/app/routes/authenticated/area-management/new.js
+++ b/pix-editor/app/routes/authenticated/area-management/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AreaManagementNewRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/competence-management/new.js
+++ b/pix-editor/app/routes/authenticated/competence-management/new.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceManagementNewRoute extends Route {
   templateName = 'authenticated/competence-management/single';

--- a/pix-editor/app/routes/authenticated/competence-management/single.js
+++ b/pix-editor/app/routes/authenticated/competence-management/single.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceManagementSingleRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/competence.js
+++ b/pix-editor/app/routes/authenticated/competence.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/competence/index.js
+++ b/pix-editor/app/routes/authenticated/competence/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceIndexRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/competence/prototypes.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PrototypesRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/list.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/list.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/new.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import PrototypeRoute from './single';
 

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SingleRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/new.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class NewRoute extends Route {
   templateName = 'authenticated/competence/prototypes/single';

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SingleRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/competence/quality.js
+++ b/pix-editor/app/routes/authenticated/competence/quality.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class QualityRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/competence/quality/single.js
+++ b/pix-editor/app/routes/authenticated/competence/quality/single.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SkillRoute from '../skills/single';
 

--- a/pix-editor/app/routes/authenticated/competence/skills/list.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceSkillsListRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/competence/skills/new.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/new.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import SingleRoute from './single';
 

--- a/pix-editor/app/routes/authenticated/competence/skills/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SingleRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/competence/skills/single/archive/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single/archive/single.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceSkillsSingleArchiveSingleRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/competence/themes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/themes/new.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import CompetenceThemesSingleRoute from './single';
 

--- a/pix-editor/app/routes/authenticated/competence/themes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/themes/single.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceThemesSingleRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/competence/tubes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/tubes/new.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Tube from './single';
 

--- a/pix-editor/app/routes/authenticated/competence/tubes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/tubes/single.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SingleRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/missions/list.js
+++ b/pix-editor/app/routes/authenticated/missions/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionsRoute extends Route {
   queryParams = {

--- a/pix-editor/app/routes/authenticated/missions/mission.js
+++ b/pix-editor/app/routes/authenticated/missions/mission.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/missions/mission/details.js
+++ b/pix-editor/app/routes/authenticated/missions/mission/details.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionDetailsRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/missions/mission/edit.js
+++ b/pix-editor/app/routes/authenticated/missions/mission/edit.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionNewRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/missions/new.js
+++ b/pix-editor/app/routes/authenticated/missions/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MissionNewRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/skill.js
+++ b/pix-editor/app/routes/authenticated/skill.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SkillRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/static-courses.js
+++ b/pix-editor/app/routes/authenticated/static-courses.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StaticCoursesRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/static-courses/list.js
+++ b/pix-editor/app/routes/authenticated/static-courses/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StaticCoursesRoute extends Route {
   queryParams = {

--- a/pix-editor/app/routes/authenticated/static-courses/new.js
+++ b/pix-editor/app/routes/authenticated/static-courses/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StaticCourseNewRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/static-courses/static-course.js
+++ b/pix-editor/app/routes/authenticated/static-courses/static-course.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StaticCourseRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/static-courses/static-course/details.js
+++ b/pix-editor/app/routes/authenticated/static-courses/static-course/details.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StaticCoursesRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/static-courses/static-course/edit.js
+++ b/pix-editor/app/routes/authenticated/static-courses/static-course/edit.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StaticCoursesRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/statistics.js
+++ b/pix-editor/app/routes/authenticated/statistics.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class StatisticsRoute extends Route {
   @service currentData;

--- a/pix-editor/app/routes/authenticated/v2.js
+++ b/pix-editor/app/routes/authenticated/v2.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class V2Route extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/v2/challenge.js
+++ b/pix-editor/app/routes/authenticated/v2/challenge.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/v2/competence-overview.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CompetenceOverviewRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/v2/competence-overview/challenges.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview/challenges.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ChallengesRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LocalizedChallengesRoute extends Route {
   @service router;

--- a/pix-editor/app/routes/authenticated/v2/localized-challenge.js
+++ b/pix-editor/app/routes/authenticated/v2/localized-challenge.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ChallengeRoute extends Route {

--- a/pix-editor/app/routes/authenticated/whitelisted-urls.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class WhitelistedUrlsRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/list.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class WhitelistedUrlsRoute extends Route {
   queryParams = {

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/new.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/new.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class WhitelistedUrlNewRoute extends Route {
   @service access;

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class WhitelistedUrlRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url/edit.js
+++ b/pix-editor/app/routes/authenticated/whitelisted-urls/whitelisted-url/edit.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class EditWhitelistedUrlRoute extends Route {
   @service store;

--- a/pix-editor/app/routes/login.js
+++ b/pix-editor/app/routes/login.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class LoginRoute extends Route {
   @service session;

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 const READ_PIX_ONLY = 0;
 const READ_ONLY = 1;

--- a/pix-editor/app/services/config.js
+++ b/pix-editor/app/services/config.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 

--- a/pix-editor/app/services/confirm.js
+++ b/pix-editor/app/services/confirm.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ConfirmService extends Service {
   target = null;

--- a/pix-editor/app/services/paginated-query.js
+++ b/pix-editor/app/services/paginated-query.js
@@ -1,5 +1,5 @@
 import { A } from '@ember/array';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class PaginatedQueryService extends Service {

--- a/pix-editor/app/services/phrase.js
+++ b/pix-editor/app/services/phrase.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class PhraseService extends Service {
   @service session;

--- a/pix-editor/app/services/storage.js
+++ b/pix-editor/app/services/storage.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import * as Sentry from '@sentry/ember';
 
 export default class StorageService extends Service {

--- a/pix-editor/app/services/version-manager.js
+++ b/pix-editor/app/services/version-manager.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 const V2_STORAGE_KEY = 'v2';

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -67,7 +67,7 @@
         "ember-simple-auth": "^8.0.0",
         "ember-sortable": "^5.0.0",
         "ember-source": "^5.11.0",
-        "ember-table": "^5.0.4",
+        "ember-table": "^6.0.0-10",
         "ember-template-imports": "^4.2.0",
         "ember-template-lint": "^7.0.0",
         "ember-test-selectors": "^7.0.0",
@@ -27341,9 +27341,9 @@
       }
     },
     "node_modules/ember-table": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/ember-table/-/ember-table-5.0.6.tgz",
-      "integrity": "sha512-nEt5YXsqId2z0n1ooqCyiKjIi33bOqtxtUqrwRZbdWXTVMiI4BSEFXNbhnWyjfISgLBdLENvTApRTUyxo2vLcg==",
+      "version": "6.0.0-10",
+      "resolved": "https://registry.npmjs.org/ember-table/-/ember-table-6.0.0-10.tgz",
+      "integrity": "sha512-DFJWRwomnWKcQIRu3znW0GvHHq0/+rC9/ud8/Pa7wSR2vEBf5kMG0QmaJR8uW5RF4msyFptlyuIZC36GItD7bg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -27355,14 +27355,14 @@
         "@babel/plugin-proposal-optional-chaining": "^7.12.13",
         "@html-next/vertical-collection": "^4.0.0",
         "css-element-queries": "^0.4.0",
-        "ember-classy-page-object": "^0.8.0-beta.2",
+        "ember-classy-page-object": "^0.8.0",
         "ember-cli-babel": "^7.12.0",
         "ember-cli-htmlbars": "^6.0.0",
         "ember-cli-node-assets": "^0.2.2",
         "ember-cli-version-checker": "^5.1.2",
         "ember-compatibility-helpers": "^1.2.6",
         "ember-raf-scheduler": "^0.3.0",
-        "ember-test-selectors": "^6.0.0",
+        "ember-test-selectors": "^7.1.0",
         "hammerjs": "^2.0.8"
       },
       "engines": {
@@ -27770,21 +27770,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-table/node_modules/ember-test-selectors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-6.0.0.tgz",
-      "integrity": "sha512-PgYcI9PeNvtKaF0QncxfbS68olMYM1idwuI8v/WxsjOGqUx5bmsu6V17vy/d9hX4mwmjgsBhEghrVasGSuaIgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "ember-cli-babel": "^7.26.4",
-        "ember-cli-version-checker": "^5.1.2"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16.*"
       }
     },
     "node_modules/ember-table/node_modules/find-babel-config": {

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -57,7 +57,6 @@
         "ember-eslint-parser": "^0.5.3",
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^9.5.0",
-        "ember-inflector": "^4.0.3",
         "ember-intl": "^7.3.1",
         "ember-lifeline": "7.0.0",
         "ember-load-initializers": "^3.0.0",
@@ -66,7 +65,7 @@
         "ember-resolver": "^13.0.0",
         "ember-simple-auth": "^8.0.0",
         "ember-sortable": "^5.0.0",
-        "ember-source": "^5.11.0",
+        "ember-source": "^6.8.2",
         "ember-table": "^6.0.0-10",
         "ember-template-imports": "^4.2.0",
         "ember-template-lint": "^7.0.0",
@@ -7498,55 +7497,77 @@
       }
     },
     "node_modules/@glimmer/compiler": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.92.4.tgz",
-      "integrity": "sha512-xoR8F6fsgFqWbPbCfSgJuJ95vaLnXw0SgDCwyl/KMeeaSxpHwJbr8+BfiUl+7ko2A+HzrY5dPXXnGr4ZM+CUXw==",
+      "version": "0.94.11",
+      "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.94.11.tgz",
+      "integrity": "sha512-t9eyLZIFsiwAib8Zyfu67yBep5Vn2bd5DScIE2hharPE/OKKI7cpQYi6BzQhSGYEBVU82ITd/2TLvJ1K8eIahA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/syntax": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/vm": "0.92.3",
-        "@glimmer/wire-format": "0.92.3"
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/syntax": "0.95.0",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/wire-format": "0.94.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@glimmer/compiler/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/compiler/node_modules/@glimmer/syntax": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.92.3.tgz",
-      "integrity": "sha512-7wPKQmULyXCYf0KvbPmfrs/skPISH2QGR9atCnmDWnHyLv5SSZVLm1P0Ctrpta6+Ci3uGQb7hGk0IjsLEavcYQ==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.95.0.tgz",
+      "integrity": "sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/wire-format": "0.92.3",
-        "@handlebars/parser": "~2.0.0",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/wire-format": "0.94.8",
+        "@handlebars/parser": "~2.2.0",
         "simple-html-tokenizer": "^0.5.11"
       }
     },
     "node_modules/@glimmer/compiler/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/compiler/node_modules/@handlebars/parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.2.1.tgz",
+      "integrity": "sha512-D76vKOZFEGA9v6g0rZTYTQDUXNopCblW1Zeas3EEVrbdeh8gWrCEO9/goocKmcgtqAwv1Md76p58UQp7HeFTEw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18 || ^20 || ^22 || >=24"
+      }
+    },
+    "node_modules/@glimmer/compiler/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/component": {
@@ -8295,71 +8316,39 @@
         "rsvp": "^4.8.4"
       }
     },
-    "node_modules/@glimmer/debug": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/debug/-/debug-0.92.4.tgz",
-      "integrity": "sha512-waTBOdtp92MC3h/51mYbc4GRumO+Tsa5jbXLoewqALjE1S8bMu9qgkG7Cx635x3/XpjsD9xceMqagBvYhuI6tA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/vm": "0.92.3"
-      }
-    },
-    "node_modules/@glimmer/debug/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
-      }
-    },
-    "node_modules/@glimmer/debug/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
-      }
-    },
     "node_modules/@glimmer/destroyable": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/destroyable/-/destroyable-0.92.3.tgz",
-      "integrity": "sha512-vQ+mzT9Vkf+JueY7L5XbZqK0WyEVTKv0HOLrw/zDw9F5Szn3F/8Ea/qbAClo3QK3oZeg+ulFTa/61rdjSFYHGA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/destroyable/-/destroyable-0.94.8.tgz",
+      "integrity": "sha512-IWNz34Q5IYnh20M/3xVv9jIdCATQyaO+8sdUSyUqiz1bAblW5vTXUNXn3uFzGF+CnP6ZSgPxHN/c1sNMAh+lAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/@glimmer/destroyable/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
-    "node_modules/@glimmer/destroyable/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+    "node_modules/@glimmer/destroyable/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/di": {
@@ -8370,24 +8359,38 @@
       "license": "MIT"
     },
     "node_modules/@glimmer/encoder": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/encoder/-/encoder-0.92.3.tgz",
-      "integrity": "sha512-DJ8DB33LxODjzCWRrxozHUaRqVyZj4p8jDLG42aCNmWo3smxrsjshcaVUwDmib24DW+dzR7kMc39ObMqT5zK0w==",
+      "version": "0.93.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/encoder/-/encoder-0.93.8.tgz",
+      "integrity": "sha512-G7ZbC+T+rn7UliG8Y3cn7SIACh7K5HgCxgFhJxU15HtmTUObs52mVR1SyhUBsbs86JHlCqaGguKE1WqP1jt+2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/vm": "0.92.3"
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/vm": "0.94.8"
       }
     },
     "node_modules/@glimmer/encoder/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
+      }
+    },
+    "node_modules/@glimmer/encoder/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/env": {
@@ -8398,9 +8401,9 @@
       "license": "MIT"
     },
     "node_modules/@glimmer/global-context": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.3.tgz",
-      "integrity": "sha512-tvlK5pt6oSe3furJ1KsO9vG/KmF9S98HLrcR48XbfwXlkuxvUeS94cdQId4GCN5naeX4OC4xm6eEjZWdc2s+jw==",
+      "version": "0.93.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.93.4.tgz",
+      "integrity": "sha512-Yw9xkDReAcC5oS/hY3PjGrFKRygYFA4pdO7tvuxReoVOyUtjoBOAwHJUileiElERDdMWIMfoLema8Td1mqkjhA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8415,301 +8418,338 @@
       }
     },
     "node_modules/@glimmer/manager": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/manager/-/manager-0.92.4.tgz",
-      "integrity": "sha512-YMoarZT/+Ft2YSd+Wuu5McVsdP9y6jeAdVQGYFpno3NlL3TXYbl7ELtK7OGxFLjzQE01BdiUZZRvcY+a/s9+CQ==",
+      "version": "0.94.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/manager/-/manager-0.94.10.tgz",
+      "integrity": "sha512-Hqi92t6vtVg4nSRGWTvCJ+0Vg3iF1tiTG9RLzuUtZac7DIAzuQAxjhGbtu82miT+liCqU+MFmB3nkfNH0Zz74g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/debug": "0.92.4",
-        "@glimmer/destroyable": "0.92.3",
-        "@glimmer/env": "0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/reference": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/validator": "0.92.3",
-        "@glimmer/vm": "0.92.3"
+        "@glimmer/destroyable": "0.94.8",
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/reference": "0.94.9",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/validator": "0.95.0",
+        "@glimmer/vm": "0.94.8"
       }
     },
     "node_modules/@glimmer/manager/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/manager/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/@glimmer/manager/node_modules/@glimmer/validator": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
-      "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.95.0.tgz",
+      "integrity": "sha512-xF3K5voKeRqhONztfMHDd2wHDYD6UUI9pFPd+RMGtW6DXYv31G0zUm2pGsOwQ9dyNeE6khaXy7e3FtNjDrSmvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/manager/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/node": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.92.4.tgz",
-      "integrity": "sha512-a5GME7HQJZFJPQDdSetQI6jjKXXQi0Vdr3WuUrYwhienVTV5LG0uClbFE2yYWC7TX97YDHpRrNk1CC258rujkQ==",
+      "version": "0.94.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.94.10.tgz",
+      "integrity": "sha512-8kw6K+RoKhjfprMO059M7x5yRZRK7WGLzD2056/G+65wV7gnJVDuh4qQirekaagjtskz6OdRBVWrSmrbICWtzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/runtime": "0.92.4",
-        "@glimmer/util": "0.92.3",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/runtime": "0.94.11",
+        "@glimmer/util": "0.94.8",
         "@simple-dom/document": "^1.4.0"
       }
     },
     "node_modules/@glimmer/node/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/node/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/node/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/opcode-compiler": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/opcode-compiler/-/opcode-compiler-0.92.4.tgz",
-      "integrity": "sha512-WnZSBwxNqW/PPD/zfxEg6BVR5tHwTm8fp76piix8BNCQ6CuzVn6HUJ5SlvBsOwyoRCmzt/pkKmBJn+I675KG4w==",
+      "version": "0.94.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/opcode-compiler/-/opcode-compiler-0.94.10.tgz",
+      "integrity": "sha512-KYsaODjkgtpUzMR1chyI0IRcvo4ewnjW8Dy+5833+OIG7rx6INl7HvKtooLzjHv+uJOZ74fd/s/0XfaY6eNEww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/debug": "0.92.4",
-        "@glimmer/encoder": "0.92.3",
-        "@glimmer/env": "0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/manager": "0.92.4",
-        "@glimmer/reference": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/vm": "0.92.3",
-        "@glimmer/wire-format": "0.92.3"
+        "@glimmer/encoder": "0.93.8",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/manager": "0.94.10",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/vm": "0.94.8",
+        "@glimmer/wire-format": "0.94.8"
       }
     },
     "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/opcode-compiler/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/owner": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/owner/-/owner-0.92.3.tgz",
-      "integrity": "sha512-ZxmXIUCy6DOobhGDhA6kMpaXZS7HAucEgIl/qcjV9crlzGOO8H4j+n2x6nA/8zpuqvO0gYaBzqdNdu+7EgOEmw==",
+      "version": "0.93.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/owner/-/owner-0.93.4.tgz",
+      "integrity": "sha512-xoclaVdCF4JH/yx8dHplCj6XFAa7ggwc7cyeOthRvTNGsp/J/CNKHT6NEkdERBYqy6tvg5GoONvWFdm8Wd5Uig==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/util": "0.92.3"
-      }
-    },
-    "node_modules/@glimmer/owner/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
-      }
-    },
-    "node_modules/@glimmer/owner/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
-      }
+      "license": "MIT"
     },
     "node_modules/@glimmer/program": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/program/-/program-0.92.4.tgz",
-      "integrity": "sha512-fkquujQ11lsGCWl/+XpZW2E7bjHj/g6/Ht292A7pSoANBD8Bz/gPYiPM+XuMwes9MApEsTEMjV4EXlyk2/Cirg==",
+      "version": "0.94.10",
+      "resolved": "https://registry.npmjs.org/@glimmer/program/-/program-0.94.10.tgz",
+      "integrity": "sha512-a5rpsvBwrcAn0boV4ONy+dHr8tWSTvLAPTR1T1KxF0OBHRVciCAfBPRFemVO6Q3H117At9ifn3uoevtQ6H0M+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/encoder": "0.92.3",
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/manager": "0.92.4",
-        "@glimmer/opcode-compiler": "0.92.4",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/vm": "0.92.3",
-        "@glimmer/wire-format": "0.92.3"
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/manager": "0.94.10",
+        "@glimmer/opcode-compiler": "0.94.10",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/vm": "0.94.8",
+        "@glimmer/wire-format": "0.94.8"
       }
     },
     "node_modules/@glimmer/program/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/program/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/program/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/reference": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.92.3.tgz",
-      "integrity": "sha512-Ud4LE689mEXL6BJnJx0ZPt2dt/A540C+TAnBFXHpcAjROz5gT337RN+tgajwudEUqpufExhcPSMGzs1pvWYCJg==",
+      "version": "0.94.9",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.94.9.tgz",
+      "integrity": "sha512-qlgTYxgEOpgxuyb13u2qwqhibpfktlk08F+nfwuNxtuhodsItBi3YxjFMPrVP0zOjTnhUObR8OYtMsD5WFOddA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/validator": "0.92.3"
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/validator": "0.95.0"
       }
     },
     "node_modules/@glimmer/reference/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/reference/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/@glimmer/reference/node_modules/@glimmer/validator": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
-      "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.95.0.tgz",
+      "integrity": "sha512-xF3K5voKeRqhONztfMHDd2wHDYD6UUI9pFPd+RMGtW6DXYv31G0zUm2pGsOwQ9dyNeE6khaXy7e3FtNjDrSmvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/reference/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/runtime": {
-      "version": "0.92.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.92.4.tgz",
-      "integrity": "sha512-ISqM/8hVh+fY/gnLAAPKfts4CvnJBOyCYAXgGccIlzzQrSVLaz0NoRiWTLGj5B/3xyPbqLwYPDvlTsOjYtvPoA==",
+      "version": "0.94.11",
+      "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.94.11.tgz",
+      "integrity": "sha512-96PqfxnkEW8k8dMydDmaXgijD7yvtIfjMkHoJ7ljUmE1icZ7jj6f+UIZ0LThpXMzkKaBe1xEapjr91Ldsvmqbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/destroyable": "0.92.3",
-        "@glimmer/env": "0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/manager": "0.92.4",
-        "@glimmer/owner": "0.92.3",
-        "@glimmer/program": "0.92.4",
-        "@glimmer/reference": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/validator": "0.92.3",
-        "@glimmer/vm": "0.92.3",
-        "@glimmer/wire-format": "0.92.3"
+        "@glimmer/destroyable": "0.94.8",
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/manager": "0.94.10",
+        "@glimmer/owner": "0.93.4",
+        "@glimmer/program": "0.94.10",
+        "@glimmer/reference": "0.94.9",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/validator": "0.95.0",
+        "@glimmer/vm": "0.94.8"
       }
     },
     "node_modules/@glimmer/runtime/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/@glimmer/runtime/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/@glimmer/runtime/node_modules/@glimmer/validator": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
-      "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.95.0.tgz",
+      "integrity": "sha512-xF3K5voKeRqhONztfMHDd2wHDYD6UUI9pFPd+RMGtW6DXYv31G0zUm2pGsOwQ9dyNeE6khaXy7e3FtNjDrSmvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/@glimmer/runtime/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/syntax": {
@@ -8763,27 +8803,26 @@
       "license": "MIT"
     },
     "node_modules/@glimmer/vm": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/vm/-/vm-0.92.3.tgz",
-      "integrity": "sha512-DNMQz7nn2zRwKO1irVZ4alg1lH+VInwR3vkWVgobUs0yh7OoHVGXKMd5uxzIksqJEUw1XOX9Qgu/GYZB1PiH3w==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm/-/vm-0.94.8.tgz",
+      "integrity": "sha512-0E8BVNRE/1qlK9OQRUmGlQXwWmoco7vL3yIyLZpTWhbv22C1zEcM826wQT3ioaoUQSlvRsKKH6IEEUal2d3wxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/@glimmer/vm-babel-plugins": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.92.3.tgz",
-      "integrity": "sha512-VpkKsHc3oiq9ruiwT7sN4RuOIc5n10PCeWX7tYSNZ85S1bETcAFn0XbyNjI+G3uFshQGEK0T8Fn3+/8VTNIQIg==",
+      "version": "0.93.5",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.93.5.tgz",
+      "integrity": "sha512-xwVRgDjuadOB9qV1jyTKBrUgE/cpmixD/wIYnFf4+hNJRD39urteKRPw98xJSAt7Bw/6y5B8zsgwFS18Nknlrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/@glimmer/vm-babel-plugins/node_modules/babel-plugin-debug-macros": {
@@ -8813,56 +8852,61 @@
       }
     },
     "node_modules/@glimmer/vm/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
-    "node_modules/@glimmer/vm/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+    "node_modules/@glimmer/vm/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@glimmer/wire-format": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.92.3.tgz",
-      "integrity": "sha512-gFz81Q9+V7Xs0X8mSq6y8qacHm0dPaGJo2/Bfcsdow1hLOKNgTCLr4XeDBhRML8f6I6Gk9ugH4QDxyIOXOpC4w==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.94.8.tgz",
+      "integrity": "sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/@glimmer/wire-format/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
-    "node_modules/@glimmer/wire-format/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+    "node_modules/@glimmer/wire-format/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@handlebars/parser": {
@@ -21583,16 +21627,6 @@
         "@glimmer/interfaces": "0.94.6"
       }
     },
-    "node_modules/ember-eslint-parser/node_modules/@glimmer/wire-format": {
-      "version": "0.94.8",
-      "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.94.8.tgz",
-      "integrity": "sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@glimmer/interfaces": "0.94.6"
-      }
-    },
     "node_modules/ember-eslint-parser/node_modules/@handlebars/parser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.2.1.tgz",
@@ -24067,715 +24101,15 @@
       }
     },
     "node_modules/ember-inflector": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-4.0.3.tgz",
-      "integrity": "sha512-E+NnmzybMRWn1JyEfDxY7arjOTJLIcGjcXnUxizgjD4TlvO1s3O65blZt+Xq2C2AFSPeqHLC6PXd6XHYM8BxdQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ember-inflector/-/ember-inflector-5.0.2.tgz",
+      "integrity": "sha512-aoPaT7B3pbUHSi4ulf02iRaMMvPteuDBO8jA1SLLOl/JwnO2YI5F/MhNPaolxp8DWwAd/P6MNN+wD5bLwmiUIA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.11"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "^3.16.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/@babel/runtime": {
-      "version": "7.12.18",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/async-disk-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "2.1.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/async-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/async-disk-cache/node_modules/rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/babel-plugin-debug-macros": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
-      "integrity": "sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/babel-plugin-debug-macros/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/babel-plugin-module-resolver": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-babel-transpiler": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.1.tgz",
-      "integrity": "sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/polyfill": "^7.11.5",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "broccoli-persistent-filter": "^2.2.1",
-        "clone": "^2.1.2",
-        "hash-for-dep": "^1.4.7",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.9",
-        "json-stable-stringify": "^1.0.1",
-        "rsvp": "^4.8.4",
-        "workerpool": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-funnel/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-funnel/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-merge-trees": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-persistent-filter/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^1.1.1"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-plugin/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/broccoli-source": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
-      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/ember-cli-babel": {
-      "version": "7.26.11",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
-      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/helper-compilation-targets": "^7.12.0",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-decorators": "^7.13.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-runtime": "^7.13.9",
-        "@babel/plugin-transform-typescript": "^7.13.0",
-        "@babel/polyfill": "^7.11.5",
-        "@babel/preset-env": "^7.16.5",
-        "@babel/runtime": "7.12.18",
-        "amd-name-resolver": "^1.3.1",
-        "babel-plugin-debug-macros": "^0.3.4",
-        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-module-resolver": "^3.2.0",
-        "broccoli-babel-transpiler": "^7.8.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-source": "^2.1.2",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^4.1.0",
-        "ensure-posix-path": "^1.0.2",
-        "fixturify-project": "^1.10.0",
-        "resolve-package-path": "^3.1.0",
-        "rimraf": "^3.0.1",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/ember-cli-babel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/ember-cli-version-checker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-package-path": "^2.0.0",
-        "semver": "^6.3.0",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.13.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/find-babel-config": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.2.tgz",
-      "integrity": "sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json5": "^1.0.2",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/fixturify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
-      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/fs-extra": "^5.0.5",
-        "@types/minimatch": "^3.0.3",
-        "@types/rimraf": "^2.0.2",
-        "fs-extra": "^7.0.1",
-        "matcher-collection": "^2.0.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/fixturify-project": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
-      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fixturify": "^1.2.0",
-        "tmp": "^0.0.33"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-inflector/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ember-inflector/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/sync-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/sync-disk-cache/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/walk-sync/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-inflector/node_modules/workerpool": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-3.1.2.tgz",
-      "integrity": "sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.3.4",
-        "object-assign": "4.1.1",
-        "rsvp": "^4.8.4"
+        "@embroider/addon-shim": "^1.8.7",
+        "decorator-transforms": "^2.0.0"
       }
     },
     "node_modules/ember-intl": {
@@ -27213,39 +26547,38 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-5.12.0.tgz",
-      "integrity": "sha512-2MWlJmQEeeiIk9p5CDMuvD470YPi7/4wXgU41ftbWc9svwF+0usoe4PLoLC0T/jV6YX+3SY5tumQfxLSLoFhmQ==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-6.8.2.tgz",
+      "integrity": "sha512-z2ukdKj+97fmo6DqIajKcPFVFwxEIiHzcENmDQVMGlPUR9O7jtENOST7RS3xAiHdCdFoYKRuf7+g2GvNW/7hLw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
-        "@glimmer/compiler": "0.92.4",
-        "@glimmer/destroyable": "0.92.3",
-        "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/manager": "0.92.4",
-        "@glimmer/node": "0.92.4",
-        "@glimmer/opcode-compiler": "0.92.4",
-        "@glimmer/owner": "0.92.3",
-        "@glimmer/program": "0.92.4",
-        "@glimmer/reference": "0.92.3",
-        "@glimmer/runtime": "0.92.4",
-        "@glimmer/syntax": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/validator": "0.92.3",
-        "@glimmer/vm": "0.92.3",
-        "@glimmer/vm-babel-plugins": "0.92.3",
+        "@embroider/addon-shim": "^1.9.0",
+        "@glimmer/compiler": "0.94.11",
+        "@glimmer/destroyable": "0.94.8",
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/manager": "0.94.10",
+        "@glimmer/node": "0.94.10",
+        "@glimmer/opcode-compiler": "0.94.10",
+        "@glimmer/owner": "0.93.4",
+        "@glimmer/program": "0.94.10",
+        "@glimmer/reference": "0.94.9",
+        "@glimmer/runtime": "0.94.11",
+        "@glimmer/syntax": "0.95.0",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/validator": "0.95.0",
+        "@glimmer/vm": "0.94.8",
+        "@glimmer/vm-babel-plugins": "0.93.5",
         "@simple-dom/interface": "^1.4.0",
         "backburner.js": "^2.8.0",
         "broccoli-file-creator": "^2.1.1",
         "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "chalk": "^4.0.0",
-        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
@@ -27266,55 +26599,63 @@
         "node": ">= 18.*"
       },
       "peerDependencies": {
-        "@glimmer/component": "^1.1.2"
+        "@glimmer/component": ">= 1.1.2"
       }
     },
     "node_modules/ember-source/node_modules/@glimmer/interfaces": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
-      "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.94.6.tgz",
+      "integrity": "sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
+        "@simple-dom/interface": "^1.4.0",
+        "type-fest": "^4.35.0"
       }
     },
     "node_modules/ember-source/node_modules/@glimmer/syntax": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.92.3.tgz",
-      "integrity": "sha512-7wPKQmULyXCYf0KvbPmfrs/skPISH2QGR9atCnmDWnHyLv5SSZVLm1P0Ctrpta6+Ci3uGQb7hGk0IjsLEavcYQ==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.95.0.tgz",
+      "integrity": "sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3",
-        "@glimmer/wire-format": "0.92.3",
-        "@handlebars/parser": "~2.0.0",
+        "@glimmer/interfaces": "0.94.6",
+        "@glimmer/util": "0.94.8",
+        "@glimmer/wire-format": "0.94.8",
+        "@handlebars/parser": "~2.2.0",
         "simple-html-tokenizer": "^0.5.11"
       }
     },
     "node_modules/ember-source/node_modules/@glimmer/util": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
-      "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "version": "0.94.8",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.94.8.tgz",
+      "integrity": "sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.92.3"
+        "@glimmer/interfaces": "0.94.6"
       }
     },
     "node_modules/ember-source/node_modules/@glimmer/validator": {
-      "version": "0.92.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
-      "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.95.0.tgz",
+      "integrity": "sha512-xF3K5voKeRqhONztfMHDd2wHDYD6UUI9pFPd+RMGtW6DXYv31G0zUm2pGsOwQ9dyNeE6khaXy7e3FtNjDrSmvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.92.3",
-        "@glimmer/interfaces": "0.92.3",
-        "@glimmer/util": "0.92.3"
+        "@glimmer/global-context": "0.93.4",
+        "@glimmer/interfaces": "0.94.6"
+      }
+    },
+    "node_modules/ember-source/node_modules/@handlebars/parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@handlebars/parser/-/parser-2.2.1.tgz",
+      "integrity": "sha512-D76vKOZFEGA9v6g0rZTYTQDUXNopCblW1Zeas3EEVrbdeh8gWrCEO9/goocKmcgtqAwv1Md76p58UQp7HeFTEw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18 || ^20 || ^22 || >=24"
       }
     },
     "node_modules/ember-source/node_modules/inflection": {
@@ -27338,6 +26679,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ember-source/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ember-table": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -81,7 +81,7 @@
     "ember-simple-auth": "^8.0.0",
     "ember-sortable": "^5.0.0",
     "ember-source": "^5.11.0",
-    "ember-table": "^5.0.4",
+    "ember-table": "^6.0.0-10",
     "ember-template-imports": "^4.2.0",
     "ember-template-lint": "^7.0.0",
     "ember-test-selectors": "^7.0.0",

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -71,7 +71,6 @@
     "ember-eslint-parser": "^0.5.3",
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^9.5.0",
-    "ember-inflector": "^4.0.3",
     "ember-intl": "^7.3.1",
     "ember-lifeline": "7.0.0",
     "ember-load-initializers": "^3.0.0",
@@ -80,7 +79,7 @@
     "ember-resolver": "^13.0.0",
     "ember-simple-auth": "^8.0.0",
     "ember-sortable": "^5.0.0",
-    "ember-source": "^5.11.0",
+    "ember-source": "^6.8.2",
     "ember-table": "^6.0.0-10",
     "ember-template-imports": "^4.2.0",
     "ember-template-lint": "^7.0.0",
@@ -117,7 +116,7 @@
   "overrides": {
     "ember-cli-page-object": ">= 2.1.0",
     "ember-dayjs": {
-      "ember-source": "^5.11.0"
+      "ember-source": "^6.8.2"
     }
   },
   "engines": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -113,12 +113,6 @@
     "tracked-built-ins": "^4.0.0",
     "webpack": "^5.88.1"
   },
-  "overrides": {
-    "ember-cli-page-object": ">= 2.1.0",
-    "ember-dayjs": {
-      "ember-source": "^6.8.2"
-    }
-  },
   "engines": {
     "node": "^24.11.0"
   },


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

On souhaite profiter des dernières évolutions de Ember mais nous sommes en retard dans la version de `ember-source`.

## 🌰 Proposition

Monter de version `ember-table` puis monter de version `ember-source`.
On ignore les nouvelles dépréciations d'Ember.
On en profite pour exécuter le codemod lié à la dépréciation sur l'import des services (`npx ember-codemod-remove-inject-as-service`)
<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

On en profite pour supprimer les overrides de dépendances qui ne sont plus utiles.

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->

Faire une passe de non-reg sur l'application.