### PR TITLE
[BUGFIX] Impossible de dupliquer une épreuve (PIX-20552)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence.js
+++ b/pix-editor/app/controllers/authenticated/competence.js
@@ -148,7 +148,7 @@ export default class CompetenceController extends Controller {
 
   @action
   copyChallenge(challenge) {
-    this.router.transitionTo('authenticated.competence.prototypes.new', this.competence, { queryParams: { from: challenge.id } });
+    this.router.transitionTo('authenticated.competence.prototypes.new', this.competence, { queryParams: { from: challenge.id, leftMaximized: true, view: 'workbench' } });
   }
 
   @action

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single.js
@@ -52,7 +52,11 @@ export default class SingleRoute extends Route {
 
   @action
   willTransition(transition) {
-    const controller = this.controllerFor(transition.from.name);
+    const controller = this.controllerFor(
+      transition.from.name === 'authenticated.competence.prototypes.new'
+        ? 'authenticated.competence.prototypes.new'
+        : 'authenticated.competence.prototypes.single',
+    );
     if (controller.edition) {
       if (confirm('Êtes-vous sûr de vouloir abandonner la modification en cours ?')) {
         controller.send('cancelEdit');


### PR DESCRIPTION
## 🍂 Problème

Il y a une popup de confirmation et si on fait OK il ne se passe rien.

## 🌰 Proposition

Corriger les transitions depuis le prototype.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Aller sur un proto, et cliquer sur Dupliquer, on doit atterir sur l’édition d’une nouvelle épreuve.