### PR TITLE
[BUGFIX] Ne pas sauvegarder d'autres entités que le localized challenge quand on met en prod/en pause une épreuve (PIX-20581).

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -162,8 +162,16 @@ export default class LocalizedController extends Controller {
 
   @action async confirmApprove() {
     this.localizedChallenge.status = this.localizedChallenge.isInProduction ? 'proposé' : 'validé';
-    await this.save();
-    this.displayConfirm = false;
+    try {
+      await this._saveChallenge(this.localizedChallenge);
+    } catch (error) {
+      console.error(error);
+      Sentry.captureException(error);
+      this.notify.error('Erreur lors de la mise à jour de l\'épreuve');
+    } finally {
+      this.loader.stop();
+      this.displayConfirm = false;
+    }
   }
 
   @action confirmDeny() {


### PR DESCRIPTION
## 🍂 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Quand on met en pause ou en prod une épreuve localisée, on sauvegarde toutes les entitées même celles qui n'ont pas changées (comme les attachments par exemple).

## 🌰 Proposition

Ne pas appeler la fonction `save` qui sauvegarde tous les modèles mais appeler directement la sauvegarde du challenge.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🍁 Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🪵 Pour tester

Se rendre sur une épreuve localisée, qui possède au moins une pièce jointe.
Mettre en prod ou en pause l'épreuve.
Vérifier que dans la console réseau, 1 seul appel à été fait, pour sauvegarder le localized challenge.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
