### PR TITLE
[BUGFIX] Problème d’affichage dans la vue acquis en construction (PIX-20519)

### DIFF
--- a/pix-editor/app/components/competence/competence-grid-thematic.js
+++ b/pix-editor/app/components/competence/competence-grid-thematic.js
@@ -16,7 +16,7 @@ export default class CompetenceCompetenceGridThematicComponent extends Component
 
   get tubes() {
     const thematic = this.args.thematic;
-    if (this.args.view === 'workbench') {
+    if (this.args.view === 'workbench' || this.args.view === 'draft') {
       return thematic.tubes;
     }
     return thematic.productionTubes;


### PR DESCRIPTION
## 🍂 Problème

La vue acquis en construction n'affiche pas les tubes n’ayant aucun acquis en production.

## 🌰 Proposition

Afficher tous les tubes sur la vue acquis en construction.

## 🍁 Remarques

N/A

## 🪵 Pour tester

Aller sur la vue acquis en construction et vérifier qu’au moins un tube avec aucun acquis en production s’affiche.