### PR TITLE
[BUGFIX] Création d’un nouveau proto dans un acquis à tort

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
@@ -9,6 +9,7 @@ export default class NewController extends Prototype {
   creation = true;
   queryParams = ['from', 'fromSkill'];
   @tracked from = '';
+  @tracked fromSkill = '';
   @service currentData;
   @service loader;
   @service router;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/new.js
@@ -53,6 +53,7 @@ export default class NewRoute extends PrototypeRoute {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.from = '';
+      controller.fromSkill = '';
     }
   }
 }


### PR DESCRIPTION
## 🍂 Problème

Si on créé un proto dans un acquis vide, ensuite quand on créé un proto dans l’atelier celui-ci est rattaché à l’acquis à tort.
C’est le query param `fromSkill` qui n’est pas bien réinitialisé.

## 🌰 Proposition

Réinitialiser correctement le query param `fromSkill`.

## 🍁 Remarques

N/A

## 🪵 Pour tester

- Créer un proto dans un acquis vide (en utilisant le bouton "Nouvelle version" dans l’acquis)
- Créer un autre proto directement dans l’atelier (en utilisant le bouton "Nouveau prototype")