### PR TITLE
[BUGFIX] Ajout puis suppression d’une illustration sans sauvegarder (PIX-20516)

### DIFF
--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { eq } from 'ember-truth-helpers';
+import { htmlSafe } from '@ember/template';
 
 import CompetenceOverviewSkill from './competence-overview-skill';
 
@@ -37,6 +38,10 @@ export default class CompetenceOverview extends Component {
   @action
   async updateSelectedSkillId(id) {
     this.selectedSkillId = id;
+  }
+
+  thematicStyle(thematicOverview) {
+    return htmlSafe(`--tubes-count: ${thematicOverview.tubeOverviews.length};`);
   }
 
   <template>
@@ -77,7 +82,7 @@ export default class CompetenceOverview extends Component {
         </div>
         <div class="competence-overview-grid">
         {{#each @competenceOverview.thematicOverviews as |thematicOverview|}}
-          <div class="thematic" style={{concat "--tubes-count: " thematicOverview.tubeOverviews.length ";"}}>
+          <div class="thematic" style={{(this.thematicStyle thematicOverview)}}>
             <h3>{{thematicOverview.name}}</h3>
             {{#each thematicOverview.tubeOverviews as |tubeOverview|}}
             <div class="tube">

--- a/pix-editor/app/components/list/notes.gjs
+++ b/pix-editor/app/components/list/notes.gjs
@@ -23,7 +23,7 @@ export default class NoteList extends SortedList {
   }
 
 <template>
-  <PixTable @data={{this.list}} @caption={{this.caption}} @onRowClick={{this.selectRow}}>
+  <PixTable @data={{this.list}} @caption={{@caption}} @onRowClick={{this.selectRow}}>
     <:columns as |row context|>
       <PixTableColumn @context={{context}} data-test-note>
         <:header>Date</:header>
@@ -31,10 +31,10 @@ export default class NoteList extends SortedList {
       </PixTableColumn>
 
       {{#if this.displayAuthor}}
-          <PixTableColumn @context={{context}} class="author-note">
-              <:header>Auteur</:header>
-              <:cell>{{row.author}}</:cell>
-          </PixTableColumn>
+        <PixTableColumn @context={{context}} class="author-note">
+          <:header>Auteur</:header>
+          <:cell>{{row.author}}</:cell>
+        </PixTableColumn>
       {{/if}}
 
       <PixTableColumn @context={{context}}>
@@ -43,10 +43,10 @@ export default class NoteList extends SortedList {
       </PixTableColumn>
 
       {{#if this.displayStatus}}
-          <PixTableColumn @context={{context}} class="status-note">
-              <:header>Statut</:header>
-              <:cell>{{row.status}}</:cell>
-          </PixTableColumn>
+        <PixTableColumn @context={{context}} class="status-note">
+          <:header>Statut</:header>
+          <:cell>{{row.status}}</:cell>
+        </PixTableColumn>
       {{/if}}
     </:columns>
   </PixTable>

--- a/pix-editor/app/components/pop-in/challenge-log.gjs
+++ b/pix-editor/app/components/pop-in/challenge-log.gjs
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { on } from '@ember/modifier';
+import { concat } from '@ember/helper';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
@@ -146,7 +147,12 @@ export default class PopinChallengeLog extends Component {
           </div>
 
           <div id="tabpanel1" role="tabpanel" tabindex="0" aria-labelledby="tab1" class="{{if (eq this.currentTabId 'tab1') "" "hidden"}}" data-tab="notes">
-            <ListNotes @list={{this.ownNotes}} @displayAuthor={{false}} @show={{this.showOwnNote}} />
+            <ListNotes
+              @list={{this.ownNotes}}
+              @displayAuthor={{false}}
+              @show={{this.showOwnNote}}
+              @caption={{concat "Mes notes sur l’épreuve de " this.args.challenge.skillName}}
+            />
             <div class="ui text menu note-menu">
               <PixButton @triggerAction={{this.addNote}} @variant="tertiary" @size="small" @iconBefore="add">
                 Nouvelle note
@@ -154,10 +160,19 @@ export default class PopinChallengeLog extends Component {
             </div>
           </div>
           <div id="tabpanel2" role="tabpanel" tabindex="0" aria-labelledby="tab2" class="{{if (eq this.currentTabId 'tab2') "" "hidden"}}" data-tab="notes">
-            <ListNotes @list={{this.notes}} @show={{this.showNote}} />
+            <ListNotes
+              @list={{this.notes}}
+              @show={{this.showNote}}
+              @caption={{concat "Toutes les notes sur l’épreuve de " this.args.challenge.skillName}}
+            />
           </div>
           <div id="tabpanel3" role="tabpanel" tabindex="0" aria-labelledby="tab3" class="{{if (eq this.currentTabId 'tab3') "" "hidden"}}" data-tab="notes">
-            <ListNotes @list={{this.changelogEntries}} @displayStatus={{false}} @show={{this.showChangelogEntry}} />
+            <ListNotes
+              @list={{this.changelogEntries}}
+              @displayStatus={{false}}
+              @show={{this.showChangelogEntry}}
+              @caption={{concat "Changelog de l’épreuve de " this.args.challenge.skillName}}
+            />
           </div>
         {{else}}
           <FormNote

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -446,10 +446,10 @@ export default class SingleController extends Controller {
     await this.challenge.attachments;
     const removedFile = this.challenge.illustration;
     if (removedFile) {
-      removedFile.deleteRecord();
-      if (removedFile.id) {
+      if (!removedFile.isNew) {
         this.deletedFiles.push(removedFile);
       }
+      removedFile.deleteRecord();
     }
   }
 


### PR DESCRIPTION
## ❄️ Problème

Quand on ajoute une nouvelle illustration sur une épreuve puis qu’on la remplace/supprime sans avoir enregistrer, ça plante.

## 🛷 Proposition

Changement de l’ordre d’exécution pour éviter d’utiliser des getters sur un record ember data déjà supprimé.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

 - Ajouter une nouvelle illustration sur une épreuve (sans sauvegarder)
 - Cliquer sur la croix pour la supprimer
 - Vérifier dans la console du navigateur qu’il n’y a pas d’erreur

Non régression :
 - Ajouter une nouvelle illustration sur une épreuve puis sauvegarder
 - Supprimer l’illustration puis sauvegarder
 - Vérifier qu’il y a bien une requête DELETE pour l’attachment