### PR TITLE
[FEATURE] Ajout de la page pour editer le maxLevel des localizedFrameworkTube (PIX-20506)

### DIFF
--- a/api/lib/application/localized-framework-tubes/index.js
+++ b/api/lib/application/localized-framework-tubes/index.js
@@ -6,7 +6,7 @@ export async function register(server) {
     {
       method: 'GET',
       path: '/api/localized-framework-tubes',
-      config: { handler: localizedFrameworkTubesController.findAll },
+      config: { handler: localizedFrameworkTubesController.filter },
     },
     {
       method: 'POST',

--- a/api/lib/application/localized-framework-tubes/index.js
+++ b/api/lib/application/localized-framework-tubes/index.js
@@ -16,6 +16,7 @@ export async function register(server) {
         validate: {
           payload: Joi.object({
             data: {
+              type: 'localized-framework-tubes',
               attributes: {
                 'tube-id': Joi.string().required(),
                 'max-level': Joi.number().required(),
@@ -27,7 +28,7 @@ export async function register(server) {
       },
     },
     {
-      method: 'PUT',
+      method: 'PATCH',
       path: '/api/localized-framework-tubes/{id}',
       config: {
         handler: localizedFrameworkTubesController.upsert,
@@ -35,6 +36,8 @@ export async function register(server) {
           params: Joi.object({ id: Joi.string().required() }),
           payload: Joi.object({
             data: {
+              id: Joi.number().required(),
+              type: 'localized-framework-tubes',
               attributes: {
                 'tube-id': Joi.string().required(),
                 'max-level': Joi.number().required(),

--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -1,8 +1,13 @@
 import { localizedFrameworksTubesRepository } from '../../infrastructure/repositories/index.js';
 import { localizedFrameworkTubesSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
+import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 
-export async function findAll(request, h) {
-  const localizedFrameworksTubes = await localizedFrameworksTubesRepository.findAll();
+export async function filter(request, h) {
+  const params = extractParameters(request.query);
+  const competenceId = params.filter.competenceId;
+  const locale = params.filter.locale;
+
+  const localizedFrameworksTubes = await localizedFrameworksTubesRepository.filter({ competenceId, locale });
   return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(localizedFrameworksTubes));
 }
 

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -1,8 +1,14 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { LocalizedFrameworkTubes } from '../../domain/models/index.js';
 
-export async function findAll() {
-  const localizedFrameworkTubesDtos = await knex('localized_framework_tubes').select('*');
+export async function filter({ competenceId, locale }) {
+  const localizedFrameworkTubesDtos = await knex
+    .select('localized_framework_tubes.*')
+    .from('thematics')
+    .join('tubes', 'tubes.thematicId', 'thematics.id')
+    .join('localized_framework_tubes', 'localized_framework_tubes.tubeId', 'tubes.id')
+    .where('thematics.competenceId', competenceId)
+    .where('localized_framework_tubes.locale', locale);
   return localizedFrameworkTubesDtos.map(_toDomain);
 }
 

--- a/api/tests/acceptance/application/localized-framework-tubes/get_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/get_localized-framework-tubes_test.js
@@ -3,7 +3,7 @@ import { databaseBuilder, generateAuthorizationHeader } from '../../../test-help
 import { createServer } from '../../../../server.js';
 
 describe('Acceptance | API | localized_framework_tubes | GET /api/localized-framework-tubes', function() {
-  it('Should return serialized localizedFrameworkTubes', async function() {
+  it('Should return serialized localizedFrameworkTubes filtered by competenceId and local', async function() {
     // given
     const user = databaseBuilder.factory.buildAdminUser();
     const { id: frameworkId } = databaseBuilder.factory.buildFramework({
@@ -44,7 +44,7 @@ describe('Acceptance | API | localized_framework_tubes | GET /api/localized-fram
     const server = await createServer();
     const response = await server.inject({
       method: 'GET',
-      url: '/api/localized-framework-tubes',
+      url: '/api/localized-framework-tubes?filter[competenceId]=competenceId&filter[locale]=bz',
       headers: generateAuthorizationHeader(user),
     });
 

--- a/api/tests/acceptance/application/localized-framework-tubes/patch_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/patch_localized-framework-tubes_test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { databaseBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 
-describe('Acceptance | API | localized_framework_tubes | PUT /api/localized-framework-tubes', function() {
+describe('Acceptance | API | localized_framework_tubes | PATCH /api/localized-framework-tubes', function() {
   let user, tubeId, localizedFrameworkTubeId;
 
   beforeEach(async function() {
@@ -50,6 +50,8 @@ describe('Acceptance | API | localized_framework_tubes | PUT /api/localized-fram
     // given
     const payload = {
       data: {
+        id: localizedFrameworkTubeId,
+        type: 'localized-framework-tubes',
         attributes: {
           'tube-id': tubeId,
           'max-level': 2,
@@ -61,7 +63,7 @@ describe('Acceptance | API | localized_framework_tubes | PUT /api/localized-fram
     // when
     const server = await createServer();
     const response = await server.inject({
-      method: 'PUT',
+      method: 'PATCH',
       url: `/api/localized-framework-tubes/${localizedFrameworkTubeId}`,
       headers: generateAuthorizationHeader(user),
       payload,

--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -1,4 +1,5 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import { concat, hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
@@ -11,12 +12,17 @@ import { htmlSafe } from '@ember/template';
 import CompetenceOverviewSkill from './competence-overview-skill';
 
 export default class CompetenceOverview extends Component {
+  @service access;
   @service phrase;
   @service router;
   @service notifications;
   @service multipanelManager;
 
   @tracked selectedSkillId = null;
+
+  get isAdmin() {
+    return this.access.isAdmin();
+  }
 
   @action
   async fetchTranslations() {
@@ -63,30 +69,37 @@ export default class CompetenceOverview extends Component {
         </ul>
         <div class="competence-overview-actions__buttons">
           {{#if @locale}}
+            {{#if this.isAdmin}}
+                <PixButtonLink
+                  class="competence-overview-actions__fetch"
+                  @route="authenticated.v2.localized-framework"
+                  @variant="secondary"
+                >Cadre de traduction</PixButtonLink>
+              {{/if}}
+              <PixButton
+                class="competence-overview-actions__fetch"
+                @size="small"
+                @isBorderVisible={{true}}
+                @variant="secondary"
+                @loadingColor="grey"
+                @triggerAction={{this.fetchTranslations}}
+              >
+                Récupérer les traductions
+              </PixButton>
+            {{/if}}
             <PixButton
-              class="competence-overview-actions__fetch"
+              class="competence-overview-actions__refresh"
+              @iconBefore="refresh"
               @size="small"
               @isBorderVisible={{true}}
               @variant="secondary"
-              @loadingColor="grey"
-              @triggerAction={{this.fetchTranslations}}
+              @triggerAction={{this.refresh}}
             >
-              Récupérer les traductions
+              Actualiser
             </PixButton>
-          {{/if}}
-          <PixButton
-            class="competence-overview-actions__refresh"
-            @iconBefore="refresh"
-            @size="small"
-            @isBorderVisible={{true}}
-            @variant="secondary"
-            @triggerAction={{this.refresh}}
-          >
-            Actualiser
-          </PixButton>
+          </div>
         </div>
-      </div>
-      <div class="competence-overview-grid">
+        <div class="competence-overview-grid">
         {{#each @competenceOverview.thematicOverviews as |thematicOverview|}}
           <div class="thematic" style={{this.thematicStyle thematicOverview}}>
             <h3>{{thematicOverview.name}}</h3>

--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -70,36 +70,36 @@ export default class CompetenceOverview extends Component {
         <div class="competence-overview-actions__buttons">
           {{#if @locale}}
             {{#if this.isAdmin}}
-                <PixButtonLink
-                  class="competence-overview-actions__fetch"
-                  @route="authenticated.v2.localized-framework"
-                  @variant="secondary"
-                >Cadre de traduction</PixButtonLink>
-              {{/if}}
-              <PixButton
+              <PixButtonLink
                 class="competence-overview-actions__fetch"
-                @size="small"
-                @isBorderVisible={{true}}
+                @route="authenticated.v2.localized-framework"
                 @variant="secondary"
-                @loadingColor="grey"
-                @triggerAction={{this.fetchTranslations}}
-              >
-                Récupérer les traductions
-              </PixButton>
+              >Cadre de traduction</PixButtonLink>
             {{/if}}
             <PixButton
-              class="competence-overview-actions__refresh"
-              @iconBefore="refresh"
+              class="competence-overview-actions__fetch"
               @size="small"
               @isBorderVisible={{true}}
               @variant="secondary"
-              @triggerAction={{this.refresh}}
+              @loadingColor="grey"
+              @triggerAction={{this.fetchTranslations}}
             >
-              Actualiser
+              Récupérer les traductions
             </PixButton>
-          </div>
+          {{/if}}
+          <PixButton
+            class="competence-overview-actions__refresh"
+            @iconBefore="refresh"
+            @size="small"
+            @isBorderVisible={{true}}
+            @variant="secondary"
+            @triggerAction={{this.refresh}}
+          >
+            Actualiser
+          </PixButton>
         </div>
-        <div class="competence-overview-grid">
+      </div>
+      <div class="competence-overview-grid">
         {{#each @competenceOverview.thematicOverviews as |thematicOverview|}}
           <div class="thematic" style={{this.thematicStyle thematicOverview}}>
             <h3>{{thematicOverview.name}}</h3>

--- a/pix-editor/app/components/v2/field/localized-framework-tube.gjs
+++ b/pix-editor/app/components/v2/field/localized-framework-tube.gjs
@@ -1,0 +1,42 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+
+export default class LocalizedFrameworkTube extends Component {
+  @service store;
+  @service router;
+  @tracked validationStatus = 'default';
+
+  @tracked errorMessage = 'la valeur doit être comprise entre 0 et 8';
+
+  @action
+  updateMaxLevel(e) {
+    const maxLevel = parseInt(e.target.value, 10);
+    if (0 <= maxLevel && maxLevel <= 8 && !Number.isNaN(maxLevel)) {
+      this.args.updateMaxLevel(this.args.tube.id, maxLevel);
+      this.args.inputStateList[this.args.index] = '';
+      this.validationStatus = 'default';
+    } else {
+      this.args.inputStateList[this.args.index] = 'error';
+      this.validationStatus = 'error';
+    }
+  }
+
+  <template>
+    <PixInput
+      max=8
+      min=0
+      type="number"
+      @screenReaderOnly={{true}}
+      @validationStatus={{this.validationStatus}}
+      @errorMessage={{this.errorMessage}}
+      @value={{@value}}
+      {{on "change" this.updateMaxLevel}}
+    >
+      <:label>Modifier le niveau max du tube {{@tube.name}}</:label>
+    </PixInput>
+  </template>
+}

--- a/pix-editor/app/components/v2/field/localized-framework-tube.gjs
+++ b/pix-editor/app/components/v2/field/localized-framework-tube.gjs
@@ -15,14 +15,14 @@ export default class LocalizedFrameworkTube extends Component {
   @action
   updateMaxLevel(e) {
     const maxLevel = parseInt(e.target.value, 10);
-    if (0 <= maxLevel && maxLevel <= 8 && !Number.isNaN(maxLevel)) {
-      this.args.updateMaxLevel(this.args.tube.id, maxLevel);
-      this.args.inputStateList[this.args.index] = '';
-      this.validationStatus = 'default';
-    } else {
+    if (Number.isNaN(maxLevel) || 0 > maxLevel || maxLevel > 8) {
       this.args.inputStateList[this.args.index] = 'error';
       this.validationStatus = 'error';
+      return;
     }
+    this.args.updateMaxLevel(this.args.tube.id, maxLevel);
+    this.args.inputStateList[this.args.index] = '';
+    this.validationStatus = 'default';
   }
 
   <template>

--- a/pix-editor/app/components/v2/field/localized-framework-tube.gjs
+++ b/pix-editor/app/components/v2/field/localized-framework-tube.gjs
@@ -27,8 +27,8 @@ export default class LocalizedFrameworkTube extends Component {
 
   <template>
     <PixInput
-      max=8
-      min=0
+      max="8"
+      min="0"
       type="number"
       @screenReaderOnly={{true}}
       @validationStatus={{this.validationStatus}}

--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -44,6 +44,11 @@ export default class LocalizedFramework extends Component {
   }
 
   @action
+  undo() {
+    this.router.transitionTo('authenticated.v2.competence-overview', this.args.competence.id, 'challenges-production');
+  }
+
+  @action
   updateMaxLevel(tubeId, value) {
     this.tubeMaxLevelById[tubeId] = value;
   }
@@ -61,6 +66,16 @@ export default class LocalizedFramework extends Component {
           @triggerAction={{this.save}}
         >
           Enregistrer
+        </PixButton>
+        <PixButton
+          class="competence-overview-actions__fetch"
+          @size="small"
+          @isBorderVisible={{true}}
+          @variant="secondary"
+          @loadingColor="grey"
+          @triggerAction={{this.undo}}
+        >
+          Annuler
         </PixButton>
       </div>
       <div class="competence-overview-grid">

--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -50,7 +50,7 @@ export default class LocalizedFramework extends Component {
   }
 
   @action
-  undo() {
+  cancel() {
     this.router.transitionTo('authenticated.v2.competence-overview', this.args.competence.id, 'challenges-production');
   }
 
@@ -79,7 +79,7 @@ export default class LocalizedFramework extends Component {
           @isBorderVisible={{true}}
           @variant="secondary"
           @loadingColor="grey"
-          @triggerAction={{this.undo}}
+          @triggerAction={{this.cancel}}
         >
           Annuler
         </PixButton>

--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -1,0 +1,77 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { concat, fn } from '@ember/helper';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { service } from '@ember/service';
+
+export default class LocalizedFramework extends Component {
+  @service store;
+  @service router;
+
+  @tracked tubeMaxLevelById = Object.fromEntries(this.args.localizedFrameworkTubes.map(({ tubeId, maxLevel }) => [tubeId, maxLevel]));
+
+  @action
+  getMaxLevelLocalizedFrameworkTube(tubeId) {
+    return this.tubeMaxLevelById[tubeId] ?? 8;
+  }
+
+  @action
+  async save() {
+    const localizedFrameworkTubesToSave = [];
+    for (const tubeId in this.tubeMaxLevelById) {
+      const existingLocalizedFrameworkTube = this.args.localizedFrameworkTubes.find((localizedFrameworkTube) => localizedFrameworkTube.tubeId === tubeId);
+      if (existingLocalizedFrameworkTube) {
+        existingLocalizedFrameworkTube.maxLevel = this.tubeMaxLevelById[tubeId];
+        localizedFrameworkTubesToSave.push(existingLocalizedFrameworkTube);
+      } else {
+        localizedFrameworkTubesToSave.push(this.store.createRecord('localized-framework-tube', {
+          locale: this.args.locale,
+          tubeId,
+          maxLevel: this.tubeMaxLevelById[tubeId],
+        }));
+      }
+    }
+    await Promise.all(localizedFrameworkTubesToSave.map((localizedFramework) => localizedFramework.save()));
+    this.router.transitionTo('authenticated.v2.competence-overview', this.args.competence.id, 'challenges-production');
+  }
+
+  @action
+  updateMaxLevel(tubeId, e) {
+    this.tubeMaxLevelById[tubeId] = Number(e.target.value);
+  }
+
+  <template>
+    <div class="competence-overview localized-framework-tube">
+      <div class="competence-overview-actions">
+        <PixButton
+          class="competence-overview-actions__fetch"
+          @size="small"
+          @isBorderVisible={{true}}
+          @variant="secondary"
+          @loadingColor="grey"
+          @triggerAction={{this.save}}
+        >
+          Enregistrer
+        </PixButton>
+      </div>
+      <div class="competence-overview-grid">
+      {{#each @competence.sortedThemes as |theme|}}
+        <div class="thematic" style={{concat "--tubes-count: " theme.tubes.length ";"}}>
+          <h3>{{theme.name}}</h3>
+          {{#each theme.tubes as |tube|}}
+          <div class="tube">
+            <h4>{{tube.name}}</h4>
+            <PixInput max=8 min=0 type="number" @screenReaderOnly={{true}} @value={{this.getMaxLevelLocalizedFrameworkTube tube.id}} {{on "change" (fn this.updateMaxLevel tube.id)}}>
+              <:label>Modifier le niveau max du tube {{tube.name}}</:label>
+            </PixInput>
+          </div>
+          {{/each}}
+        </div>
+      {{/each}}
+      </div>
+    </div>
+  </template>
+}

--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -11,7 +11,9 @@ export default class LocalizedFramework extends Component {
   @service store;
   @service router;
 
-  @tracked tubeMaxLevelById = Object.fromEntries(this.args.localizedFrameworkTubes.map(({ tubeId, maxLevel }) => [tubeId, maxLevel]));
+  @tracked tubeMaxLevelById = Object.fromEntries(
+    this.args.localizedFrameworkTubes.map(({ tubeId, maxLevel }) => [tubeId, maxLevel]),
+  );
   @tracked inputStateList = trackedArray([]);
 
   get isInvalidForm() {
@@ -27,16 +29,20 @@ export default class LocalizedFramework extends Component {
   async save() {
     const localizedFrameworkTubesToSave = [];
     for (const tubeId in this.tubeMaxLevelById) {
-      const existingLocalizedFrameworkTube = this.args.localizedFrameworkTubes.find((localizedFrameworkTube) => localizedFrameworkTube.tubeId === tubeId);
+      const existingLocalizedFrameworkTube = this.args.localizedFrameworkTubes.find(
+        (localizedFrameworkTube) => localizedFrameworkTube.tubeId === tubeId,
+      );
       if (existingLocalizedFrameworkTube) {
         existingLocalizedFrameworkTube.maxLevel = this.tubeMaxLevelById[tubeId];
         localizedFrameworkTubesToSave.push(existingLocalizedFrameworkTube);
       } else {
-        localizedFrameworkTubesToSave.push(this.store.createRecord('localized-framework-tube', {
-          locale: this.args.locale,
-          tubeId,
-          maxLevel: this.tubeMaxLevelById[tubeId],
-        }));
+        localizedFrameworkTubesToSave.push(
+          this.store.createRecord('localized-framework-tube', {
+            locale: this.args.locale,
+            tubeId,
+            maxLevel: this.tubeMaxLevelById[tubeId],
+          }),
+        );
       }
     }
     await Promise.all(localizedFrameworkTubesToSave.map((localizedFramework) => localizedFramework.save()));
@@ -79,23 +85,23 @@ export default class LocalizedFramework extends Component {
         </PixButton>
       </div>
       <div class="competence-overview-grid">
-      {{#each @competence.sortedThemes as |theme|}}
-        <div class="thematic" style={{concat "--tubes-count: " theme.tubes.length ";"}}>
-          <h3>{{theme.name}}</h3>
-          {{#each theme.tubes as |tube index|}}
-          <div class="tube">
-            <h4>{{tube.name}}</h4>
-            <LocalizedFrameworkTube
-              @tube={{tube}}
-              @index={{index}}
-              @updateMaxLevel={{this.updateMaxLevel}}
-              @inputStateList={{this.inputStateList}}
-              @value={{this.getMaxLevelLocalizedFrameworkTube tube.id}}
-            />
+        {{#each @competence.sortedThemes as |theme|}}
+          <div class="thematic" style={{concat "--tubes-count: " theme.tubes.length ";"}}>
+            <h3>{{theme.name}}</h3>
+            {{#each theme.tubes as |tube index|}}
+              <div class="tube">
+                <h4>{{tube.name}}</h4>
+                <LocalizedFrameworkTube
+                  @tube={{tube}}
+                  @index={{index}}
+                  @updateMaxLevel={{this.updateMaxLevel}}
+                  @inputStateList={{this.inputStateList}}
+                  @value={{this.getMaxLevelLocalizedFrameworkTube tube.id}}
+                />
+              </div>
+            {{/each}}
           </div>
-          {{/each}}
-        </div>
-      {{/each}}
+        {{/each}}
       </div>
     </div>
   </template>

--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -1,17 +1,22 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixInput from '@1024pix/pix-ui/components/pix-input';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { concat, fn } from '@ember/helper';
 import { tracked } from '@glimmer/tracking';
-import { on } from '@ember/modifier';
+import { trackedArray } from '@ember/reactive/collections';
 import { service } from '@ember/service';
+import LocalizedFrameworkTube from './field/localized-framework-tube';
 
 export default class LocalizedFramework extends Component {
   @service store;
   @service router;
 
   @tracked tubeMaxLevelById = Object.fromEntries(this.args.localizedFrameworkTubes.map(({ tubeId, maxLevel }) => [tubeId, maxLevel]));
+  @tracked inputStateList = trackedArray([]);
+
+  get isInvalidForm() {
+    return this.inputStateList.some((state) => state === 'error');
+  }
 
   @action
   getMaxLevelLocalizedFrameworkTube(tubeId) {
@@ -39,8 +44,8 @@ export default class LocalizedFramework extends Component {
   }
 
   @action
-  updateMaxLevel(tubeId, e) {
-    this.tubeMaxLevelById[tubeId] = Number(e.target.value);
+  updateMaxLevel(tubeId, value) {
+    this.tubeMaxLevelById[tubeId] = value;
   }
 
   <template>
@@ -52,6 +57,7 @@ export default class LocalizedFramework extends Component {
           @isBorderVisible={{true}}
           @variant="secondary"
           @loadingColor="grey"
+          @isDisabled={{this.isInvalidForm}}
           @triggerAction={{this.save}}
         >
           Enregistrer
@@ -61,12 +67,16 @@ export default class LocalizedFramework extends Component {
       {{#each @competence.sortedThemes as |theme|}}
         <div class="thematic" style={{concat "--tubes-count: " theme.tubes.length ";"}}>
           <h3>{{theme.name}}</h3>
-          {{#each theme.tubes as |tube|}}
+          {{#each theme.tubes as |tube index|}}
           <div class="tube">
             <h4>{{tube.name}}</h4>
-            <PixInput max=8 min=0 type="number" @screenReaderOnly={{true}} @value={{this.getMaxLevelLocalizedFrameworkTube tube.id}} {{on "change" (fn this.updateMaxLevel tube.id)}}>
-              <:label>Modifier le niveau max du tube {{tube.name}}</:label>
-            </PixInput>
+            <LocalizedFrameworkTube
+              @tube={{tube}}
+              @index={{index}}
+              @updateMaxLevel={{this.updateMaxLevel}}
+              @inputStateList={{this.inputStateList}}
+              @value={{this.getMaxLevelLocalizedFrameworkTube tube.id}}
+            />
           </div>
           {{/each}}
         </div>

--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -61,12 +61,12 @@ export default class LocalizedFramework extends Component {
 
   <template>
     <div class="competence-overview localized-framework-tube">
-      <div class="competence-overview-actions">
+      <div class="localized-framework-tube-actions">
         <PixButton
           class="competence-overview-actions__fetch"
           @size="small"
           @isBorderVisible={{true}}
-          @variant="secondary"
+          @variant="primary"
           @loadingColor="grey"
           @isDisabled={{this.isInvalidForm}}
           @triggerAction={{this.save}}

--- a/pix-editor/app/models/localized-framework-tube.js
+++ b/pix-editor/app/models/localized-framework-tube.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class LocalizedFrameworkTube extends Model {
+  @attr tubeId;
+  @attr locale;
+  @attr maxLevel;
+}

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -18,6 +18,7 @@ Router.map(function () {
       this.route('localized-challenge', {
         path: '/:overview/skills/:skill_id/localized-challenges/:localized_challenge_id',
       });
+      this.route('localized-framework');
     });
     this.route('competence', { path: '/competence/:competence_id' }, function () {
       this.route('prototypes', function () {

--- a/pix-editor/app/routes/authenticated/v2.js
+++ b/pix-editor/app/routes/authenticated/v2.js
@@ -26,7 +26,7 @@ export default class V2Route extends Route {
       }
       return;
     }
-    const view = extractViewFromTransition(transition);
+    const view = extractV1ViewFromTransition(transition);
     this.router.transitionTo('authenticated.competence.prototypes', competence_id, {
       queryParams: { languageFilter: locale, view },
     });
@@ -36,11 +36,12 @@ export default class V2Route extends Route {
 // L'information sur la vue est au niveau de la route enfant
 // On peut trouver cette info dans la transition
 // On parcourt tous les RouteInfo dans la transition jusqu'à trouver celui de la route qui contient la vue
-function extractViewFromTransition(transition) {
+function extractV1ViewFromTransition(transition) {
   if (!transition?.from) {
     return 'production';
   }
   const routeInfoOfCompetenceOverview = transition.from.find((item) => item.params.overview);
+  if (!routeInfoOfCompetenceOverview) return 'production';
   const [, view] = routeInfoOfCompetenceOverview.params.overview.split('-');
   return view;
 }

--- a/pix-editor/app/routes/authenticated/v2/localized-framework.js
+++ b/pix-editor/app/routes/authenticated/v2/localized-framework.js
@@ -5,7 +5,13 @@ export default class CompetenceOverviewRoute extends Route {
   @service router;
   @service store;
 
-  async model(params) {
+  async beforeModel() {
+    const { competence, locale } = this.modelFor('authenticated.v2');
+
+    if (!locale) this.router.transitionTo('authenticated.v2.competence-overview', competence.id, 'challenges-production');
+  }
+
+  async model() {
     const { competence, locale } = this.modelFor('authenticated.v2');
     const themes = await competence.rawThemes;
     await Promise.all(themes.map((theme) => theme.rawTubes));

--- a/pix-editor/app/routes/authenticated/v2/localized-framework.js
+++ b/pix-editor/app/routes/authenticated/v2/localized-framework.js
@@ -8,14 +8,17 @@ export default class CompetenceOverviewRoute extends Route {
   async beforeModel() {
     const { competence, locale } = this.modelFor('authenticated.v2');
 
-    if (!locale) this.router.transitionTo('authenticated.v2.competence-overview', competence.id, 'challenges-production');
+    if (!locale)
+      this.router.transitionTo('authenticated.v2.competence-overview', competence.id, 'challenges-production');
   }
 
   async model() {
     const { competence, locale } = this.modelFor('authenticated.v2');
     const themes = await competence.rawThemes;
     await Promise.all(themes.map((theme) => theme.rawTubes));
-    const localizedFrameworkTubes = await this.store.query('localized-framework-tube', { filter: { competenceId: competence.id, locale } });
+    const localizedFrameworkTubes = await this.store.query('localized-framework-tube', {
+      filter: { competenceId: competence.id, locale },
+    });
     return { localizedFrameworkTubes, competence, locale };
   }
 }

--- a/pix-editor/app/routes/authenticated/v2/localized-framework.js
+++ b/pix-editor/app/routes/authenticated/v2/localized-framework.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class CompetenceOverviewRoute extends Route {
+export default class LocalizedFrameworkRoute extends Route {
   @service router;
   @service store;
 

--- a/pix-editor/app/routes/authenticated/v2/localized-framework.js
+++ b/pix-editor/app/routes/authenticated/v2/localized-framework.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class CompetenceOverviewRoute extends Route {
+  @service router;
+  @service store;
+
+  async model(params) {
+    const { competence, locale } = this.modelFor('authenticated.v2');
+    const themes = await competence.rawThemes;
+    await Promise.all(themes.map((theme) => theme.rawTubes));
+    const localizedFrameworkTubes = await this.store.query('localized-framework-tube', { filter: { competenceId: competence.id, locale } });
+    return { localizedFrameworkTubes, competence, locale };
+  }
+}

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -61,3 +61,4 @@
 @use 'components/v2/field/files';
 @use 'components/v2/field/illustration';
 @use 'components/v2/field/toggle-field';
+@use 'components/v2/localized-framework-tube';

--- a/pix-editor/app/styles/components/v2/localized-framework-tube.scss
+++ b/pix-editor/app/styles/components/v2/localized-framework-tube.scss
@@ -1,5 +1,17 @@
+@use 'pix-design-tokens/shadows' as *;
+
 .localized-framework-tube {
   .pix-input {
     grid-column: span 7;
+  }
+
+  &-actions {
+    display: flex;
+    align-items: stretch;
+    background: white;
+    padding: 0 var(--pix-spacing-6x);
+    @extend %pix-shadow-sm;
+    border-radius: 8px;
+    gap: var(--pix-spacing-6x);
   }
 }

--- a/pix-editor/app/styles/components/v2/localized-framework-tube.scss
+++ b/pix-editor/app/styles/components/v2/localized-framework-tube.scss
@@ -1,0 +1,5 @@
+.localized-framework-tube {
+  .pix-input {
+    grid-column: span 7;
+  }
+}

--- a/pix-editor/app/templates/authenticated/v2/localized-framework.gjs
+++ b/pix-editor/app/templates/authenticated/v2/localized-framework.gjs
@@ -1,0 +1,9 @@
+import LocalizedFramework from 'pixeditor/components/v2/localized-framework';
+
+<template>
+  <LocalizedFramework
+    @competence={{@controller.model.competence}}
+    @localizedFrameworkTubes={{@controller.model.localizedFrameworkTubes}}
+    @locale={{@controller.model.locale}}
+  />
+</template>

--- a/pix-editor/app/templates/authenticated/v2/localized-framework.hbs
+++ b/pix-editor/app/templates/authenticated/v2/localized-framework.hbs
@@ -1,0 +1,5 @@
+<V2::LocalizedFramework
+  @competence={{this.model.competence}}
+  @localizedFrameworkTubes={{this.model.localizedFrameworkTubes}}
+  @locale={{this.model.locale}}
+/>

--- a/pix-editor/app/templates/authenticated/v2/localized-framework.hbs
+++ b/pix-editor/app/templates/authenticated/v2/localized-framework.hbs
@@ -1,5 +1,0 @@
-<V2::LocalizedFramework
-  @competence={{this.model.competence}}
-  @localizedFrameworkTubes={{this.model.localizedFrameworkTubes}}
-  @locale={{this.model.locale}}
-/>

--- a/pix-editor/mirage/config.js
+++ b/pix-editor/mirage/config.js
@@ -46,6 +46,10 @@ function routes() {
     return skill.challengesProduction;
   });
 
+  this.get('/localized-framework-tubes');
+  this.post('/localized-framework-tubes');
+  this.patch('/localized-framework-tubes/:id');
+
   this.get('/frameworks');
   this.post('/frameworks');
 

--- a/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
+++ b/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
@@ -1,0 +1,152 @@
+import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from '../../../setup-application-rendering';
+
+module('Acceptance | v2 | Localized-framework', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  let store;
+
+  hooks.beforeEach(function() {
+    store = this.owner.lookup('service:store');
+    window.localStorage.setItem('v2', 'true');
+
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    const prototype1 = this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+    this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+
+    const prototype2 = this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId2', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+    this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+
+    const prototype3 = this.server.create('challenge', { id: 'recChallenge3', airtableId: 'airtableId3', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+    this.server.create('localized-challenge', { id: 'recChallenge3', challengeId: 'recChallenge3', locale: 'fr' });
+    this.server.create('localized-challenge', { id: 'recChallenge3NL', challengeId: 'recChallenge3', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+
+    const skill1 = this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'], level: 1 });
+    const skill2 = this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 2 });
+    const skill3 = this.server.create('skill', { id: 'recSkill3', challengeIds: ['recChallenge3'], level: 3 });
+
+    const tube = this.server.create('tube', {
+      id: 'recTube1',
+      rawSkillIds: [
+        'recSkill1',
+        'recSkill2',
+        'recSkill3',
+      ],
+      name: '@tubeName',
+    });
+    const thematic = this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+    const competence = this.server.create('competence', {
+      id: 'competence1-1',
+      pixId: 'pixId-competence1.1',
+      rawThemeIds: ['recTheme1'],
+      rawTubeIds: ['recTube1'],
+    });
+    this.server.create('area', {
+      id: 'recArea1',
+      name: '1. Information et données',
+      code: '1',
+      competenceIds: ['competence1-1'],
+    });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+
+    this.server.create('competence-overview', {
+      id: `${competence.pixId}:challenges-production:nl`,
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill1.id,
+                  name: skill1.name,
+                  prototypeId: prototype1.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 1,
+                },
+                {
+                  id: skill2.id,
+                  name: skill2.name,
+                  prototypeId: prototype2.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 1,
+                },
+                {
+                  id: skill3.id,
+                  name: skill3.name,
+                  prototypeId: prototype3.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    return authenticateSession();
+  });
+
+  test('should navigate to localized framework editor', async function(assert) {
+    // when
+    const screen = await visit('/v2/competences/competence1-1/challenges-production?locale=nl');
+    await click(await screen.findByRole('link', { name: 'Cadre de traduction' }));
+
+    // then
+    assert.strictEqual(currentURL(), '/v2/competences/competence1-1/localized-framework?locale=nl');
+  });
+
+  test('it should create localized framework tubes', async function(assert) {
+    // given
+    const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
+
+    const localizedFrameworkTubesBeforeSave = await store.peekAll('localized-framework-tube');
+    assert.strictEqual(localizedFrameworkTubesBeforeSave.length, 0);
+
+    await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 5);
+    await clickByText('Enregistrer');
+
+    const localizedFrameworkTubes = await store.peekAll('localized-framework-tube');
+    const createdLocalizedFrameworkTube = localizedFrameworkTubes[0];
+
+    assert.strictEqual(localizedFrameworkTubes.length, 1);
+    assert.strictEqual(createdLocalizedFrameworkTube.maxLevel, 5);
+    assert.strictEqual(createdLocalizedFrameworkTube.locale, 'nl');
+    assert.strictEqual(createdLocalizedFrameworkTube.tubeId, 'recTube1');
+    assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
+  });
+
+  test('it should update localized framework tubes', async function(assert) {
+    // given
+    this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
+    const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
+
+    await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 5);
+    await clickByText('Enregistrer');
+
+    const localizedFrameworkTube = await store.peekRecord('localized-framework-tube', 'lft-1');
+
+    assert.strictEqual(localizedFrameworkTube.maxLevel, 5);
+    assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
+  });
+});

--- a/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
+++ b/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
@@ -236,7 +236,7 @@ module('Acceptance | v2 | Localized-framework', function (hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production');
   });
 
-  test('user can exit without save modifications', async function (assert) {
+  test('user can exit without saving modifications', async function (assert) {
     // given
     this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
     const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
@@ -248,5 +248,18 @@ module('Acceptance | v2 | Localized-framework', function (hooks) {
 
     assert.strictEqual(localizedFrameworkTube.maxLevel, 2);
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
+  });
+
+
+  test('it should redirect to overview V1 when user click on versionToggle', async function (assert) {
+    // given
+    this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
+    const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
+
+    await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 5);
+
+    await clickByText('V1')
+
+    assert.strictEqual(currentURL(), '/competence/competence1-1/prototypes?languageFilter=nl&view=production');
   });
 });

--- a/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
+++ b/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
@@ -250,7 +250,6 @@ module('Acceptance | v2 | Localized-framework', function (hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
   });
 
-
   test('it should redirect to overview V1 when user click on versionToggle', async function (assert) {
     // given
     this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
@@ -258,7 +257,7 @@ module('Acceptance | v2 | Localized-framework', function (hooks) {
 
     await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 5);
 
-    await clickByText('V1')
+    await clickByText('V1');
 
     assert.strictEqual(currentURL(), '/competence/competence1-1/prototypes?languageFilter=nl&view=production');
   });

--- a/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
+++ b/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
@@ -59,6 +59,52 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
     this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
 
     this.server.create('competence-overview', {
+      id: `${competence.pixId}:challenges-production`,
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill1.id,
+                  name: skill1.name,
+                  prototypeId: prototype1.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 1,
+                },
+                {
+                  id: skill2.id,
+                  name: skill2.name,
+                  prototypeId: prototype2.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 1,
+                },
+                {
+                  id: skill3.id,
+                  name: skill3.name,
+                  prototypeId: prototype3.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 2,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    this.server.create('competence-overview', {
       id: `${competence.pixId}:challenges-production:nl`,
       thematicOverviews: [
         {
@@ -148,5 +194,16 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
 
     assert.strictEqual(localizedFrameworkTube.maxLevel, 5);
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
+  });
+
+  test('it should redirect to challenges-production when user choose source language', async function(assert) {
+    // given
+    this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
+    const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
+
+    await click(screen.getByRole('button', { name: 'Choix de la langue' }));
+    await clickByText('Langue source');
+
+    assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production');
   });
 });

--- a/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
+++ b/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
@@ -6,29 +6,62 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from '../../../setup-application-rendering';
 
-module('Acceptance | v2 | Localized-framework', function(hooks) {
+module('Acceptance | v2 | Localized-framework', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
     window.localStorage.setItem('v2', 'true');
 
     this.server.create('config', 'default');
     this.server.create('user', { trigram: 'ABC' });
 
-    const prototype1 = this.server.create('challenge', { id: 'recChallenge1', airtableId: 'airtableId1', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+    const prototype1 = this.server.create('challenge', {
+      id: 'recChallenge1',
+      airtableId: 'airtableId1',
+      embedURL: 'https://mon-site.fr/my-link.html?lang=fr',
+      genealogy: 'Prototype 1',
+      version: 1,
+    });
     this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1', locale: 'fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge1NL', challengeId: 'recChallenge1', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+    this.server.create('localized-challenge', {
+      id: 'recChallenge1NL',
+      challengeId: 'recChallenge1',
+      locale: 'nl',
+      defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl',
+    });
 
-    const prototype2 = this.server.create('challenge', { id: 'recChallenge2', airtableId: 'airtableId2', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+    const prototype2 = this.server.create('challenge', {
+      id: 'recChallenge2',
+      airtableId: 'airtableId2',
+      embedURL: 'https://mon-site.fr/my-link.html?lang=fr',
+      genealogy: 'Prototype 1',
+      version: 1,
+    });
     this.server.create('localized-challenge', { id: 'recChallenge2', challengeId: 'recChallenge2', locale: 'fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge2NL', challengeId: 'recChallenge2', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+    this.server.create('localized-challenge', {
+      id: 'recChallenge2NL',
+      challengeId: 'recChallenge2',
+      locale: 'nl',
+      defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl',
+    });
 
-    const prototype3 = this.server.create('challenge', { id: 'recChallenge3', airtableId: 'airtableId3', embedURL: 'https://mon-site.fr/my-link.html?lang=fr', genealogy: 'Prototype 1', version: 1 });
+    const prototype3 = this.server.create('challenge', {
+      id: 'recChallenge3',
+      airtableId: 'airtableId3',
+      embedURL: 'https://mon-site.fr/my-link.html?lang=fr',
+      genealogy: 'Prototype 1',
+      version: 1,
+    });
     this.server.create('localized-challenge', { id: 'recChallenge3', challengeId: 'recChallenge3', locale: 'fr' });
-    this.server.create('localized-challenge', { id: 'recChallenge3NL', challengeId: 'recChallenge3', locale: 'nl', defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl' });
+    this.server.create('localized-challenge', {
+      id: 'recChallenge3NL',
+      challengeId: 'recChallenge3',
+      locale: 'nl',
+      defaultEmbedURL: 'https://mon-site.fr/my-link.html?lang=nl',
+    });
 
     const skill1 = this.server.create('skill', { id: 'recSkill1', challengeIds: ['recChallenge1'], level: 1 });
     const skill2 = this.server.create('skill', { id: 'recSkill2', challengeIds: ['recChallenge2'], level: 2 });
@@ -36,11 +69,7 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
 
     const tube = this.server.create('tube', {
       id: 'recTube1',
-      rawSkillIds: [
-        'recSkill1',
-        'recSkill2',
-        'recSkill3',
-      ],
+      rawSkillIds: ['recSkill1', 'recSkill2', 'recSkill3'],
       name: '@tubeName',
     });
     const thematic = this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
@@ -153,7 +182,7 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
     return authenticateSession();
   });
 
-  test('should navigate to localized framework editor', async function(assert) {
+  test('should navigate to localized framework editor', async function (assert) {
     // when
     const screen = await visit('/v2/competences/competence1-1/challenges-production?locale=nl');
     await click(await screen.findByRole('link', { name: 'Cadre de traduction' }));
@@ -162,7 +191,7 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/localized-framework?locale=nl');
   });
 
-  test('it should create localized framework tubes', async function(assert) {
+  test('it should create localized framework tubes', async function (assert) {
     // given
     const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
 
@@ -182,7 +211,7 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
   });
 
-  test('it should update localized framework tubes', async function(assert) {
+  test('it should update localized framework tubes', async function (assert) {
     // given
     this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
     const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
@@ -196,7 +225,7 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
   });
 
-  test('it should redirect to challenges-production when user choose source language', async function(assert) {
+  test('it should redirect to challenges-production when user choose source language', async function (assert) {
     // given
     this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
     const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
@@ -207,7 +236,7 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production');
   });
 
-  test('user can exit without save modifications', async function(assert) {
+  test('user can exit without save modifications', async function (assert) {
     // given
     this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
     const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');

--- a/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
+++ b/pix-editor/tests/acceptance/v2/localized-framework/localized-framework-test.js
@@ -206,4 +206,18 @@ module('Acceptance | v2 | Localized-framework', function(hooks) {
 
     assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production');
   });
+
+  test('user can exit without save modifications', async function(assert) {
+    // given
+    this.server.create('localized-framework-tube', { id: 'lft-1', maxLevel: 2, tubeId: 'recTube1', locale: 'nl' });
+    const screen = await visit('/v2/competences/competence1-1/localized-framework?locale=nl');
+
+    await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 5);
+    await click(screen.getByRole('button', { name: 'Annuler' }));
+
+    const localizedFrameworkTube = await store.peekRecord('localized-framework-tube', 'lft-1');
+
+    assert.strictEqual(localizedFrameworkTube.maxLevel, 2);
+    assert.strictEqual(currentURL(), '/v2/competences/competence1-1/challenges-production?locale=nl');
+  });
 });

--- a/pix-editor/tests/integration/components/competence-overview/competence-overview-test.gjs
+++ b/pix-editor/tests/integration/components/competence-overview/competence-overview-test.gjs
@@ -1,0 +1,97 @@
+import { render } from '@1024pix/ember-testing-library';
+import { module, test } from 'qunit';
+
+import CompetenceOverview from '../../../../components/competence-overview/competence-overview';
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Integration | Component | competence-overview | competence-overview', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let screen, competenceOverview;
+
+  hooks.beforeEach(function() {
+    competenceOverview = {
+      id: 'competence1:challenges-production:nl',
+      name: '1.1 ma compétence',
+      airtableId: 'recCompetence1',
+      thematicOverviews: [
+        {
+          id: 'thematic1',
+          name: 'thematic name',
+          tubeOverviews: [
+            {
+              id: 'tube1',
+              name: '@tube',
+              skillOverviews: [
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  });
+
+  module('when user is admin', function(hooks) {
+    hooks.beforeEach(function() {
+      const isAdminStub = sinon.stub().returns(true);
+      class Access extends Service {
+        isAdmin = isAdminStub;
+      }
+      this.owner.register('service:access', Access);
+    });
+
+    test('it should display localized framework link if locale is defined', async function(assert) {
+      // given
+      const locale = 'nl';
+
+      // when
+      screen = await render(<template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}}/></template>);
+
+      // then
+      const link = screen.getByText('Cadre de traduction');
+      assert.dom(link).exists();
+    });
+
+    test('it should hide localized framework link if locale is undefined', async function(assert) {
+      // given
+      const locale = undefined;
+
+      // when
+      screen = await render(<template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}}/></template>);
+
+      // then
+      const link = await screen.queryByText('Cadre de traduction');
+      assert.dom(link).doesNotExist();
+    });
+  });
+  module('when user not admin', function(hooks) {
+    hooks.beforeEach(function() {
+      const isAdminStub = sinon.stub().returns(false);
+      class Access extends Service {
+        isAdmin = isAdminStub;
+      }
+      this.owner.register('service:access', Access);
+    });
+
+    test('it should hide localized framework link ', async function(assert) {
+      // given
+      const locale = 'nl';
+
+      // when
+      screen = await render(<template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}}/></template>);
+
+      // then
+      const link = await screen.queryByText('Cadre de traduction');
+      assert.dom(link).doesNotExist();
+    });
+  });
+});

--- a/pix-editor/tests/integration/components/competence-overview/competence-overview-test.gjs
+++ b/pix-editor/tests/integration/components/competence-overview/competence-overview-test.gjs
@@ -6,12 +6,12 @@ import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Integration | Component | competence-overview | competence-overview', function(hooks) {
+module('Integration | Component | competence-overview | competence-overview', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let screen, competenceOverview;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     competenceOverview = {
       id: 'competence1:challenges-production:nl',
       name: '1.1 ma compétence',
@@ -24,15 +24,7 @@ module('Integration | Component | competence-overview | competence-overview', fu
             {
               id: 'tube1',
               name: '@tube',
-              skillOverviews: [
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-              ],
+              skillOverviews: [null, null, null, null, null, null, null],
             },
           ],
         },
@@ -40,8 +32,8 @@ module('Integration | Component | competence-overview | competence-overview', fu
     };
   });
 
-  module('when user is admin', function(hooks) {
-    hooks.beforeEach(function() {
+  module('when user is admin', function (hooks) {
+    hooks.beforeEach(function () {
       const isAdminStub = sinon.stub().returns(true);
       class Access extends Service {
         isAdmin = isAdminStub;
@@ -49,32 +41,36 @@ module('Integration | Component | competence-overview | competence-overview', fu
       this.owner.register('service:access', Access);
     });
 
-    test('it should display localized framework link if locale is defined', async function(assert) {
+    test('it should display localized framework link if locale is defined', async function (assert) {
       // given
       const locale = 'nl';
 
       // when
-      screen = await render(<template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}}/></template>);
+      screen = await render(
+        <template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}} /></template>,
+      );
 
       // then
       const link = screen.getByText('Cadre de traduction');
       assert.dom(link).exists();
     });
 
-    test('it should hide localized framework link if locale is undefined', async function(assert) {
+    test('it should hide localized framework link if locale is undefined', async function (assert) {
       // given
       const locale = undefined;
 
       // when
-      screen = await render(<template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}}/></template>);
+      screen = await render(
+        <template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}} /></template>,
+      );
 
       // then
       const link = await screen.queryByText('Cadre de traduction');
       assert.dom(link).doesNotExist();
     });
   });
-  module('when user not admin', function(hooks) {
-    hooks.beforeEach(function() {
+  module('when user not admin', function (hooks) {
+    hooks.beforeEach(function () {
       const isAdminStub = sinon.stub().returns(false);
       class Access extends Service {
         isAdmin = isAdminStub;
@@ -82,12 +78,14 @@ module('Integration | Component | competence-overview | competence-overview', fu
       this.owner.register('service:access', Access);
     });
 
-    test('it should hide localized framework link ', async function(assert) {
+    test('it should hide localized framework link ', async function (assert) {
       // given
       const locale = 'nl';
 
       // when
-      screen = await render(<template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}}/></template>);
+      screen = await render(
+        <template><CompetenceOverview @competenceOverview={{competenceOverview}} @locale={{locale}} /></template>,
+      );
 
       // then
       const link = await screen.queryByText('Cadre de traduction');

--- a/pix-editor/tests/integration/components/v2/localized-framework-test.gjs
+++ b/pix-editor/tests/integration/components/v2/localized-framework-test.gjs
@@ -5,11 +5,11 @@ import { module, test } from 'qunit';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 import { fillIn } from '@ember/test-helpers';
 
-module('Integration | Component | v2/localized-framework', function(hooks) {
+module('Integration | Component | v2/localized-framework', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   let screen;
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     const tubeId = 'tubeId1';
     const competence = {
       id: 'competenceId1',
@@ -30,18 +30,18 @@ module('Integration | Component | v2/localized-framework', function(hooks) {
 
     // when
     screen = await render(
-    <template>
-      <LocalizedFramework
-        @competence={{competence}}
-        @locale={{locale}}
-        @localizedFrameworkTubes={{localizedFrameworkTubes}}
-      />
-    </template>,
+      <template>
+        <LocalizedFramework
+          @competence={{competence}}
+          @locale={{locale}}
+          @localizedFrameworkTubes={{localizedFrameworkTubes}}
+        />
+      </template>,
     );
   });
 
-  module('it should warn', function() {
-    test('if max-level is out of range', async function(assert) {
+  module('it should warn', function () {
+    test('if max-level is out of range', async function (assert) {
       // when
       await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), '30');
 
@@ -49,7 +49,7 @@ module('Integration | Component | v2/localized-framework', function(hooks) {
       assert.dom(screen.getByText('la valeur doit être comprise entre 0 et 8')).exists();
     });
 
-    test('if max-level is not a number', async function(assert) {
+    test('if max-level is not a number', async function (assert) {
       // when
       await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 'george');
 
@@ -58,7 +58,7 @@ module('Integration | Component | v2/localized-framework', function(hooks) {
     });
   });
 
-  test('save action should be disabled if form is not valid', async function(assert) {
+  test('save action should be disabled if form is not valid', async function (assert) {
     // when
     await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 'george');
 

--- a/pix-editor/tests/integration/components/v2/localized-framework-test.gjs
+++ b/pix-editor/tests/integration/components/v2/localized-framework-test.gjs
@@ -1,0 +1,68 @@
+import { render } from '@1024pix/ember-testing-library';
+import LocalizedFramework from 'pixeditor/components/v2/localized-framework';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+import { fillIn } from '@ember/test-helpers';
+
+module('Integration | Component | v2/localized-framework', function(hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let screen;
+  hooks.beforeEach(async function() {
+    const tubeId = 'tubeId1';
+    const competence = {
+      id: 'competenceId1',
+      sortedThemes: [
+        {
+          name: 'ma thematique',
+          tubes: [
+            {
+              id: tubeId,
+              name: '@tubeName',
+            },
+          ],
+        },
+      ],
+    };
+    const locale = 'nl';
+    const localizedFrameworkTubes = [];
+
+    // when
+    screen = await render(
+    <template>
+      <LocalizedFramework
+        @competence={{competence}}
+        @locale={{locale}}
+        @localizedFrameworkTubes={{localizedFrameworkTubes}}
+      />
+    </template>,
+    );
+  });
+
+  module('it should warn', function() {
+    test('if max-level is out of range', async function(assert) {
+      // when
+      await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), '30');
+
+      // then
+      assert.dom(screen.getByText('la valeur doit être comprise entre 0 et 8')).exists();
+    });
+
+    test('if max-level is not a number', async function(assert) {
+      // when
+      await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 'george');
+
+      // then
+      assert.dom(screen.getByText('la valeur doit être comprise entre 0 et 8')).exists();
+    });
+  });
+
+  test('save action should be disabled if form is not valid', async function(assert) {
+    // when
+    await fillIn(screen.getByLabelText('Modifier le niveau max du tube @tubeName'), 'george');
+
+    // then
+    assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).hasAttribute('aria-disabled', 'true');
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Les utilisateurs ont besoin de choisir les niveaux disponibles par langue. Entre deux langue il est possible que le niveau ne soit pas le même.

## 🛷 Proposition

Ajouter au niveau de chaque sujets une propriété  `maxLevel` qui permet de choisir par langue le niveau de difficulté possible.

## ☃️ Remarques

Pour la langue source il n'y à pas cette notions.

## 🧑‍🎄 Pour tester

- Aller sur https://pix-lcms-review-pr1301.osc-fr1.scalingo.io/v2/competences/competenceF0A0C0/challenges-production?locale=en
- cliquer sur Cadre de traduction
- Essayer de modifier / sauvegarder / annuler / Changer de langue pour voir si tout se passe bien :)