### PR TITLE
[BUGFIX] Impossible d'importer des fichiers PSD/XCF dans les PJ des épreuves sous windows (PIX-19477)

### DIFF
--- a/pix-editor/app/components/form/challenge.gjs
+++ b/pix-editor/app/components/form/challenge.gjs
@@ -15,7 +15,7 @@ import Files from 'pixeditor/components/field/files';
 import Input from 'pixeditor/components/field/input';
 import Quality from 'pixeditor/components/field/quality';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
-import mime from 'mime';
+import getMimeType from 'pixeditor/helpers/get-mime-type';
 
 export default class ChallengeForm extends Component {
   <template>
@@ -498,7 +498,7 @@ export default class ChallengeForm extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: mime.getType(file.name),
+      mimeType: file.type ? file.type : getMimeType(file.name),
       file,
       type: 'illustration',
     };
@@ -512,7 +512,7 @@ export default class ChallengeForm extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: mime.getType(file.name),
+      mimeType: file.type ? file.type : getMimeType(file.name),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/components/form/challenge.gjs
+++ b/pix-editor/app/components/form/challenge.gjs
@@ -15,6 +15,7 @@ import Files from 'pixeditor/components/field/files';
 import Input from 'pixeditor/components/field/input';
 import Quality from 'pixeditor/components/field/quality';
 import PixMultiSelect from '@1024pix/pix-ui/components/pix-multi-select';
+import mime from 'mime';
 
 export default class ChallengeForm extends Component {
   <template>
@@ -497,7 +498,7 @@ export default class ChallengeForm extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type,
+      mimeType: mime.getType(file.name),
       file,
       type: 'illustration',
     };
@@ -511,7 +512,7 @@ export default class ChallengeForm extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type,
+      mimeType: mime.getType(file.name),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -8,6 +8,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
+import mime from 'mime';
 
 import PopInImage from '../pop-in/image';
 import PopInConfirm from '../pop-in/confirm';
@@ -176,7 +177,7 @@ export default class LocalizedChallenge extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type,
+      mimeType: mime.getType(file.name),
       file,
       type: 'illustration',
       alt,
@@ -242,7 +243,7 @@ export default class LocalizedChallenge extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type,
+      mimeType: mime.getType(file.name),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -8,7 +8,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
-import mime from 'mime';
+import getMimeType from 'pixeditor/helpers/get-mime-type';
 
 import PopInImage from '../pop-in/image';
 import PopInConfirm from '../pop-in/confirm';
@@ -177,7 +177,7 @@ export default class LocalizedChallenge extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: mime.getType(file.name),
+      mimeType: file.type ? file.type : getMimeType(file.name),
       file,
       type: 'illustration',
       alt,
@@ -243,7 +243,7 @@ export default class LocalizedChallenge extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: mime.getType(file.name),
+      mimeType: file.type ? file.type : getMimeType(file.name),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
-import mime from 'mime';
+import getMimeType from 'pixeditor/helpers/get-mime-type';
 
 export default class LocalizedController extends Controller {
   @service router;
@@ -260,7 +260,7 @@ export default class LocalizedController extends Controller {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: mime.getType(file.name),
+      mimeType: file.type ? file.type : getMimeType(file.name),
       file,
       type: 'illustration',
       alt,
@@ -290,7 +290,7 @@ export default class LocalizedController extends Controller {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: mime.getType(file.name),
+      mimeType: file.type ? file.type : getMimeType(file.name),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
+import mime from 'mime';
 
 export default class LocalizedController extends Controller {
   @service router;
@@ -259,7 +260,7 @@ export default class LocalizedController extends Controller {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type,
+      mimeType: mime.getType(file.name),
       file,
       type: 'illustration',
       alt,
@@ -289,7 +290,7 @@ export default class LocalizedController extends Controller {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type,
+      mimeType: mime.getType(file.name),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/helpers/get-mime-type.js
+++ b/pix-editor/app/helpers/get-mime-type.js
@@ -1,0 +1,12 @@
+import { Mime } from 'mime/lite';
+
+import standardTypes from 'mime/types/standard.js';
+import otherTypes from 'mime/types/other.js';
+
+const mime = new Mime(standardTypes, otherTypes, {
+  'image/x-xcf': ['xcf'],
+});
+
+export default function getMimeType(pathOrExtension) {
+  return mime.getType(pathOrExtension);
+}

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -86,6 +86,7 @@
         "jspdf-autotable": "^5.0.0",
         "loader.js": "^4.7.0",
         "lodash": "^4.17.21",
+        "mime": "^4.1.0",
         "miragejs": "^0.1.47",
         "morgan": "^1.10.0",
         "npm-run-all2": "^8.0.0",
@@ -32696,16 +32697,19 @@
       }
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {
@@ -36916,6 +36920,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/serialize-javascript": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -100,6 +100,7 @@
     "jspdf-autotable": "^5.0.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.21",
+    "mime": "^4.1.0",
     "miragejs": "^0.1.47",
     "morgan": "^1.10.0",
     "npm-run-all2": "^8.0.0",


### PR DESCRIPTION
## ❄️ Problème

Sur certains systèmes, notamment Windows, PixEditor n’arrive pas à déterminer le type MIME des PJs/illustrations, empêchant ainsi leur ajout.
Le type MIME est déterminé en utilisant [la propriété `type` du `File`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/type) de la PJ/illustration, mais MDN recommande de ne pas se reposer sur cette propriété :

> Client configuration (for instance, the Windows Registry) may result in unexpected values even for common types. Developers are advised not to rely on this property as a sole validation scheme.

## 🛷 Proposition

Utiliser la librairie [mime](https://www.npmjs.com/package/mime) en fallback pour déterminer le type MIME et lui ajouter le support du type xcf.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Sur la RA, ajouter une PJ de type PSD sur Windows.