### PR TITLE
[BUGFIX] Passage à la vue épreuves lorsqu’une version acquis possède plusieurs versions de proto (PIX-19793)

### DIFF
--- a/pix-editor/app/routes/authenticated/competence/skills/single.js
+++ b/pix-editor/app/routes/authenticated/competence/skills/single.js
@@ -15,7 +15,12 @@ export default class SingleRoute extends Route {
   async afterModel(model) {
     await model.challenges;
     if (model.prototypes.length > 0) {
-      this.currentData.setPrototype(model.prototypes[0]);
+      this.currentData.setPrototype(
+        model.prototypes.find((prototype) => prototype.isValidated) ??
+          model.prototypes.reduce((prototype1, prototype2) =>
+            prototype1.version > prototype2.version ? prototype1 : prototype2,
+          ),
+      );
     }
     return model.pinRelationships();
   }


### PR DESCRIPTION
## ❄️ Problème

Quand on bascule d’une version d’acquis ayant plusieurs protos vers la vue épreuves, on arrive pas forcément sur le proto validé ou à défaut la dernière version de proto.

## 🛷 Proposition

Choisir le bon proto lorsqu’on bascule vers la vue épreuves.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Se placer sur [une version d’acquis avec plusieurs protos dont un validé](https://pix-lcms-review-pr1307.osc-fr1.scalingo.io/competence/competenceF0A0C1/skills/skillF0A0C1Th1Tu1S0Act?view=production), basculer sur la vue épreuves et vérifier qu’on arrive bien sur le proto validé.

Se placer sur [une version d’acquis avec plusieurs protos dont aucun validé](https://pix-lcms-review-pr1307.osc-fr1.scalingo.io/competence/competenceF0A0C1/skills/skillF0A0C1Th1Tu1S0EnCons?view=workbench), basculer sur la vue épreuves et vérifier qu’on arrive bien sur la dernière version de proto.