### PR TITLE
[FEATURE] Filtrer la vue épreuves production avec le référentiel cadre (PIX-20508)

### DIFF
--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -10,7 +10,7 @@ export class CompetenceOverview {
     this.skillsCount = sumBy(thematicOverviews, ({ skillsCount }) => skillsCount);
   }
 
-  static buildForChallengesProduction({ competence, thematics, tubes, skills, challenges, locale }) {
+  static buildForChallengesProduction({ competence, thematics, tubes, skills, challenges, locale, localizedFrameworkTubes }) {
     let id = `${competence.id}:challenges-production`;
     if (locale) id += `:${locale}`;
     return new CompetenceOverview({
@@ -26,6 +26,7 @@ export class CompetenceOverview {
             skills,
             challenges,
             locale,
+            localizedFrameworkTubes,
           }),
         )
         .filter((thematicOverview) => !thematicOverview.isEmpty),
@@ -73,8 +74,9 @@ class ThematicOverview {
     return this.isEmpty ? 0 : sumBy(this.tubeOverviews, ({ skillsCount }) => skillsCount);
   }
 
-  static buildForChallengesProduction({ thematic, tubes, skills, challenges, locale }) {
+  static buildForChallengesProduction({ thematic, tubes, skills, challenges, locale, localizedFrameworkTubes }) {
     const tubesById = Object.fromEntries(tubes.map((tube) => [tube.id, tube]));
+    const localizedFrameworkTubesById = localizedFrameworkTubes ? Object.fromEntries(localizedFrameworkTubes.map((localizedFrameworkTube) => [localizedFrameworkTube.tubeId, localizedFrameworkTube])) : null;
 
     return new ThematicOverview({
       airtableId: thematic.airtableId,
@@ -88,6 +90,7 @@ class ThematicOverview {
             skills,
             challenges,
             locale,
+            localizedFrameworkTube: localizedFrameworkTubesById?.[tube.id],
           }),
         )
         .filter((tubeOverview) => !tubeOverview.isEmpty),
@@ -130,8 +133,9 @@ class TubeOverview {
     return this.isEmpty ? 0 : sumBy(this.skillOverviews, (skillOverview) => (skillOverview === null ? 0 : 1));
   }
 
-  static buildForChallengesProduction({ tube, skills, challenges, locale }) {
-    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
+  static buildForChallengesProduction({ tube, skills, challenges, locale, localizedFrameworkTube }) {
+    const localizedFrameworkSkills = localizedFrameworkTube ? skills.filter((skill) => skill.level <= localizedFrameworkTube.maxLevel) : skills;
+    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(localizedFrameworkSkills);
 
     return new TubeOverview({
       airtableId: tube.airtableId,

--- a/api/lib/domain/usecases/get-competence-challenges-production-overview.js
+++ b/api/lib/domain/usecases/get-competence-challenges-production-overview.js
@@ -1,6 +1,7 @@
 import {
   challengeRepository,
   competenceRepository,
+  localizedFrameworksTubesRepository,
   skillRepository,
   thematicRepository,
   tubeRepository,
@@ -21,6 +22,7 @@ export async function getCompetenceChallengesProductionOverview({ competenceId, 
     skillRepository.listActiveByCompetenceId(competenceId),
     challengeRepository.listActiveOrDraftByCompetenceId(competenceId),
   ]);
+  const localizedFrameworkTubes = locale ? await localizedFrameworksTubesRepository.filter({ competenceId, locale }) : null;
   return CompetenceOverview.buildForChallengesProduction({
     competence,
     thematics,
@@ -28,5 +30,6 @@ export async function getCompetenceChallengesProductionOverview({ competenceId, 
     skills,
     challenges,
     locale,
+    localizedFrameworkTubes,
   });
 }

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -449,8 +449,7 @@ describe('Acceptance | Route | competence-overviews', () => {
     });
 
     describe('with language filter set to english', () => {
-      it('should respond status 200 and overview of competence’s production, localized and primary english challenges', async () => {
-        // given
+      beforeEach(async () => {
         databaseBuilder.factory.buildLocalizedChallenge({
           id: 'recChallenge3_en',
           challengeId: 'recChallenge3',
@@ -470,7 +469,10 @@ describe('Acceptance | Route | competence-overviews', () => {
           locale: LOCALE.ENGLISH_SPOKEN,
         });
         await databaseBuilder.commit();
+      });
 
+      it('should respond status 200 and overview of competence’s production, localized and primary english challenges', async () => {
+        // given
         const server = await createServer();
 
         // when
@@ -600,6 +602,119 @@ describe('Acceptance | Route | competence-overviews', () => {
               ],
             },
           },
+        });
+      });
+
+      describe('with a defined localized framework', () => {
+        it('should respond status 200 and overview of competence’s production, filtered according to localized framework', async () => {
+          // given
+          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube1', locale: 'en', maxLevel: 3 });
+          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube2', locale: 'en', maxLevel: 8 });
+          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube4', locale: 'en', maxLevel: 0 });
+          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube5', locale: 'en', maxLevel: 6 });
+          await databaseBuilder.commit();
+
+          const server = await createServer();
+
+          // when
+          const response = await server.inject({
+            method: 'GET',
+            url: `/api/competences/${competenceId}/overviews/challenges-production?locale=en`,
+            headers: generateAuthorizationHeader(user),
+          });
+
+          // then
+          expect(response.statusCode).toBe(200);
+
+          expect(response.result).toEqual({
+            data: {
+              type: 'competence-overviews',
+              id: `${competenceId}:challenges-production:en`,
+              attributes: {
+                'airtable-id': 'recCompetence1',
+                name: '2.2 Mon super titre',
+                'tubes-count': 3,
+                'skills-count': 3,
+                'thematic-overviews': [
+                  {
+                    airtableId: 'recThematic2',
+                    name: 'Thématique 2',
+                    tubeOverviews: [
+                      {
+                        airtableId: 'recTube5',
+                        name: '@tube5',
+                        skillOverviews: [
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          {
+                            id: 'recSkill5',
+                            airtableId: 'recSkill5',
+                            name: '@tube56',
+                            prototypeId: 'recChallenge5',
+                            validatedChallengesCount: 0,
+                            proposedChallengesCount: 0,
+                            isPrototypeDeclinable: false,
+                          },
+                          null,
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    airtableId: 'recThematic1',
+                    name: 'Thématique 1',
+                    tubeOverviews: [
+                      {
+                        airtableId: 'recTube2',
+                        name: '@tube2',
+                        skillOverviews: [
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          null,
+                          {
+                            id: 'recSkill3',
+                            airtableId: 'recSkill3',
+                            name: '@tube27',
+                            prototypeId: 'recChallenge3',
+                            validatedChallengesCount: 1,
+                            proposedChallengesCount: 1,
+                            isPrototypeDeclinable: true,
+                          },
+                        ],
+                      },
+                      {
+                        airtableId: 'recTube1',
+                        name: '@tube1',
+                        skillOverviews: [
+                          null,
+                          null,
+                          {
+                            id: 'recSkill2',
+                            airtableId: 'recSkill2',
+                            name: '@tube13',
+                            prototypeId: 'recChallenge2',
+                            validatedChallengesCount: 0,
+                            proposedChallengesCount: 0,
+                            isPrototypeDeclinable: false,
+                          },
+                          null,
+                          null,
+                          null,
+                          null,
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          });
         });
       });
     });


### PR DESCRIPTION
## ❄️ Problème

Le référentiel cadre peut être défini mais ne filtre pas la vue épreuves production.

## 🛷 Proposition

Filtrer la vue épreuves production en fonction du référentiel cadre.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Définir un référentiel cadre sur différentes compétences/langues et vérifier qu’il s’applique bien sur le vue épreuves production.