### PR TITLE
[BUGFIX] Corrige les styles de la prévisualisation de markdown.

### DIFF
--- a/pix-editor/app/components/field/mde.gjs
+++ b/pix-editor/app/components/field/mde.gjs
@@ -35,7 +35,7 @@ export default class Mde extends Component {
         <MarkdownEditor @value={{@value}} @onChange={{@setValue}} />
       {{else}}
         <div data-test-markdow-to-html class="mde-preview">
-          <MarkdownToHtml @markdown={{@value}} @maximized={{this.maximized}} />
+          <MarkdownToHtml @strikethrough={{true}} @tables={{true}} @markdown={{@value}} @maximized={{this.maximized}} />
         </div>
       {{/if}}
     </div>

--- a/pix-editor/app/components/markdown-editor/markdown-editor.gjs
+++ b/pix-editor/app/components/markdown-editor/markdown-editor.gjs
@@ -40,6 +40,7 @@ export default class MarkdownEditor extends Component {
       spellChecker: false,
       nativeSpellcheck: false,
       status: false,
+      previewClass: 'mde-preview',
       toolbar,
     });
     this.easyMDE.codemirror.on('change', () => {

--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -1,4 +1,4 @@
-@use "global";
+@use 'global';
 
 // stylelint-disable color-no-hex, color-named
 .alternative {
@@ -22,7 +22,6 @@
   }
 }
 
-
 .challenge {
   display: flex;
   flex: 1 1 0;
@@ -43,13 +42,12 @@
     }
   }
 
-   .ui.icon.right {
+  .ui.icon.right {
     border: none;
     box-shadow: none;
   }
 
   .ui.cards > .card {
-
     .header .ui.button > .icon {
       margin-right: 0;
     }
@@ -80,7 +78,7 @@ img.clickable {
 .dropdown-content-challenge {
   & > .item {
     margin: 0;
-    padding: .7em 1.4em;
+    padding: 0.7em 1.4em;
     font-size: 16px !important;
     border-radius: 0;
 
@@ -94,7 +92,6 @@ img.clickable {
       background-color: global.$archived-background-color !important;
     }
   }
-
 }
 
 .challenge-header {
@@ -196,18 +193,9 @@ img.clickable {
       }
     }
 
-    .mde-preview {
-      height: 95px;
-      padding: 0.78571429em 1em;
-      overflow: scroll;
-      background-color: #f9f9f9;
-      border: 1px solid rgba(34, 36, 38, 0.15);
-      border-radius: 0.28571429rem;
-    }
-
     .field.disabled {
       textarea,
-      input[type="text"],
+      input[type='text'],
       .selection {
         background-color: #f9f9f9;
       }
@@ -233,7 +221,6 @@ img.clickable {
         flex-grow: 1;
         margin-bottom: 20px;
       }
-
     }
   }
 }
@@ -264,7 +251,6 @@ img.clickable {
   }
 
   .item {
-
     &.alternatives {
       color: #2185d0;
     }
@@ -290,7 +276,7 @@ img.clickable {
 }
 
 .file-remove i {
-  vertical-align: top
+  vertical-align: top;
 }
 
 .ui.form .field > label.file-upload {

--- a/pix-editor/app/styles/_mde.scss
+++ b/pix-editor/app/styles/_mde.scss
@@ -12,3 +12,175 @@
     }
   }
 }
+
+// stylelint-disable color-no-hex, color-named
+.mde-preview {
+  --background: #efefef;
+  --focus: #0096bfab;
+  --border: #dbdbdb;
+
+  box-sizing: border-box;
+  height: 95px;
+  padding: 0.78571429em 1em;
+  overflow: scroll;
+  color: #253858;
+  font-size: 14px;
+  line-height: 20px;
+  background-color: #f9f9f9;
+  border: 1px solid rgba(34, 36, 38, 0.15);
+  border-radius: 0.28571429rem;
+
+  ul {
+    margin-top: 1em;
+    margin-bottom: 1em;
+    padding-left: 2.5em;
+    list-style-type: disc;
+  }
+
+  ol {
+    margin-top: 1em;
+    margin-bottom: 1em;
+    padding-left: 2.5em;
+    list-style-type: decimal;
+  }
+
+  a {
+    color: #00e;
+  }
+
+  p {
+    margin: 0;
+    overflow-wrap: break-word;
+  }
+
+  h1 {
+    font-size: 1.8em;
+  }
+
+  h2 {
+    font-size: 1.4em;
+  }
+
+  h3 {
+    font-size: 1.2em;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-bottom: 12px;
+    color: #000;
+  }
+
+  strong {
+    color: #000;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  b,
+  strong,
+  th {
+    font-weight: 600;
+  }
+
+  q::before {
+    content: none;
+  }
+
+  q::after {
+    content: none;
+  }
+
+  blockquote {
+    margin: 1.5em 0;
+    padding: 0.5em 1em;
+    font-style: italic;
+    border-left: 4px solid var(--focus);
+  }
+
+  q {
+    margin: 1.5em 0;
+    padding: 0.5em 1em;
+    font-style: italic;
+    border-left: 4px solid var(--focus);
+  }
+
+  blockquote > footer {
+    font-style: normal;
+    border: 0;
+  }
+
+  blockquote cite {
+    font-style: normal;
+  }
+
+  mark {
+    padding: 0 2px;
+    color: #000;
+    background-color: #ff0;
+    border-radius: 2px;
+  }
+
+  code {
+    padding: 2.5px 5px;
+    color: #000;
+    font-size: 1em;
+    background: var(--background);
+    border-radius: 6px;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--border);
+  }
+
+  table {
+    width: 100%;
+    margin-bottom: 10px;
+    table-layout: fixed;
+    border: 1px solid #dbdbdb;
+    border-radius: 8px;
+    border-collapse: collapse;
+  }
+
+  table caption {
+    text-align: left;
+  }
+
+  td,
+  th {
+    padding: 6px;
+    text-align: left;
+    vertical-align: top;
+    overflow-wrap: break-word;
+    border-right: 1px solid var(--border);
+  }
+
+  thead {
+    border-bottom: 1px solid var(--border);
+  }
+
+  tfoot {
+    border-top: 1px solid var(--border);
+  }
+
+  tbody tr:nth-child(even) {
+    background-color: #efefef;
+  }
+
+  tbody tr:nth-child(even) button {
+    background-color: #f7f7f7;
+  }
+
+  tbody tr:nth-child(even) button:hover {
+    background-color: #fff;
+  }
+}

--- a/pix-editor/app/styles/components/markdown-editor/markdown-editor.scss
+++ b/pix-editor/app/styles/components/markdown-editor/markdown-editor.scss
@@ -1,1 +1,8 @@
 @use 'node_modules/easymde/dist/easymde.min.css';
+
+.EasyMDEContainer {
+    .mde-preview {
+        border-radius: 0;
+        height: 100%;
+    }
+}


### PR DESCRIPTION
## ❄️ Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Certains éléments ne sont pas stylisés dans la partie "preview" de l'éditeur de markdown.
Après analyse, on constate que le reset css supprime tous les styles.
C'est le cas également pour certains styles des champs dans la page qui affiche les détails d'une épreuve.

## 🛷 Proposition

On spéficie au composant MardownPreview les options tables et strikethrough afin de rendre correctement les tableaux et textes soulignés.
On extrait les surcharges de style de la classe `mde-preview` dans le fichier `mde.scss` et on y ajoute les styles manquants pour les listes et les liens.
On applique la classe `mde-preview` à l'éditeur de markdown.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## ☃️ Remarques

RAS

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

Se rendre sur une page d'épreuve et modifier le texte de la consigne en y ajoutant tous les éléments possibles.
Vérifier que la "preview" de l'éditeur affiche correctement ces éléments.
Enregistrer.
Vérifier que la page de détail de l'épreuve affiche correctement tous les éléments également.

<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
