### PR TITLE
[FEATURE] Permettre aux éditeurs de déplacer des épreuves à l'état "proposé" (PIX-20689)

### DIFF
--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -149,7 +149,7 @@ export default class AccessService extends Service {
   }
 
   mayMove(challenge) {
-    return this.isAdmin() && challenge.isPrototype && challenge.isDraft;
+    return this.isEditor() && challenge.isPrototype && challenge.isDraft;
   }
 
   mayAccessStaticCourses() {


### PR DESCRIPTION
## ❄️ Problème

Aujourd’hui, seuls les admins peuvent déplacer des épreuves à l'état “proposé”.

## 🛷 Proposition

Permettre aux éditeurs de déplacer des épreuves à l'état "proposé"

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Se connecter en tant qu’éditeur et vérifier qu’il est possible de déplacer un proto proposé.