### PR TITLE
[BUGFIX] Liens vers les tutos youtube cassés

### DIFF
--- a/pix-editor/.template-lintrc.mjs
+++ b/pix-editor/.template-lintrc.mjs
@@ -6,6 +6,7 @@ export default {
     'no-inline-styles': false,
     'style-concatenation': false,
     'no-potential-path-strings': false,
+    'link-rel-noopener': false,
   },
   overrides: [
     {

--- a/pix-editor/app/components/challenge-view/challenge-view-header.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view-header.gjs
@@ -104,7 +104,6 @@ export default class ChallengesViewHeader extends Component {
                 class="challenge-view-header-action__preview"
                 href="{{this.getChallengePreviewUrl @challenge}}"
                 target="_blank"
-                rel="noopener noreferrer"
                 aria-labelledby="preview-challenge-tooltip"
               >
                 <PixIcon @name="eye" />

--- a/pix-editor/app/components/challenges-production/challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/challenges-production.gjs
@@ -157,7 +157,6 @@ export default class ChallengesProduction extends Component {
                 <a
                   href="{{this.getChallengePreviewUrl challenge}}"
                   target="_blank"
-                  rel="noopener noreferrer"
                   aria-label="Prévisualiser l'épreuve {{challenge.id}}"
                 >
                   <PixIcon @name="eye" />

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -156,7 +156,7 @@ export default class LocalizedChallengesProduction extends Component {
                     <span class="title">Source</span>
                     <ul aria-label="source">
                       <li class="localized-menu-action__item">
-                        <a href="{{challengeLocale.primaryPreviewUrl}}" target="_blank" rel="noopener noreferrer">
+                        <a href="{{challengeLocale.primaryPreviewUrl}}" target="_blank">
                           <PixIcon @name="eye" aria-hidden="true" />
                           Prévisualiser
                           <span class="sr-only">l'épreuve {{challengeLocale.challenge.id}}</span>
@@ -169,7 +169,7 @@ export default class LocalizedChallengesProduction extends Component {
                       <span class="title">Traduction</span>
                       <ul aria-label="traduction">
                         <li class="localized-menu-action__item">
-                          <a href="{{challengeLocale.localizedPreviewUrl}}" target="_blank" rel="noopener noreferrer">
+                          <a href="{{challengeLocale.localizedPreviewUrl}}" target="_blank">
                             <PixIcon @name="eye" aria-hidden="true" />
                             Prévisualiser
                             <span class="sr-only">l'épreuve {{challengeLocale.localizedChallenge.id}}</span>
@@ -195,7 +195,7 @@ export default class LocalizedChallengesProduction extends Component {
                       class="ui button item"
                       href={{translationsUrl}}
                       target="_blank"
-                      rel="noopener noreferrer"
+                      referrerpolicy="strict-origin"
                       aria-label={{concat "traduction de l'épreuve de version " challengeLocale.alternativeVersion}}
                     >
                       <svg

--- a/pix-editor/app/components/field/files.gjs
+++ b/pix-editor/app/components/field/files.gjs
@@ -15,7 +15,7 @@ export default class Files extends Component {
       {{/if}}
       {{#if @value.length}}
         {{#each @value as |file|}}
-          <a href={{file.url}} download={{file.filename}} target="_blank" rel="noopener noreferrer"><i
+          <a href={{file.url}} download={{file.filename}} target="_blank" referrerpolicy="strict-origin"><i
               class="file icon"
             ></i>
             {{file.filename}}</a>

--- a/pix-editor/app/components/field/tutorials.gjs
+++ b/pix-editor/app/components/field/tutorials.gjs
@@ -163,7 +163,7 @@ export default class Tutorials extends Component {
                       class="ui right floated button tutorial-link"
                       href={{tutorial.link}}
                       target="_blank"
-                      rel="noreferrer noopener"
+                      referrerpolicy="strict-origin"
                     >
                       <PixIcon @name="openNew" />
                     </a>

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
@@ -100,7 +100,6 @@ export default class LocalizedChallengeViewHeader extends Component {
                 class="challenge-view-header-action__preview"
                 href="{{@challengeLocale.localizedPreviewUrl}}"
                 target="_blank"
-                rel="noopener noreferrer"
                 aria-labelledby="preview-challenge-tooltip"
               >
                 <PixIcon @name="eye" />
@@ -124,7 +123,7 @@ export default class LocalizedChallengeViewHeader extends Component {
                 class="phrase-link"
                 href={{translationsUrl}}
                 target="_blank"
-                rel="noopener noreferrer"
+                referrerpolicy="strict-origin"
                 aria-label={{concat "traduction de l'épreuve de version " @challengeLocale.alternativeVersion}}
               >
                 <svg

--- a/pix-editor/app/components/v2/field/files.gjs
+++ b/pix-editor/app/components/v2/field/files.gjs
@@ -38,7 +38,7 @@ export default class Files extends Component {
               href={{file.url}}
               download={{file.filename}}
               target="_blank"
-              rel="noopener noreferrer"
+              referrerpolicy="strict-origin"
               class="files-field--download"
             >
               <PixIcon @name="infoUser" @plainIcon={{true}} @ariaHidden={{true}} />

--- a/pix-editor/app/templates/authenticated/competence/prototypes/localized.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/localized.gjs
@@ -59,7 +59,7 @@ import Image from 'pixeditor/components/pop-in/image';
           Annuler
         </button>
       {{else}}
-        <a class="ui button item" href={{@controller.previewUrl}} target="_blank" rel="noopener noreferrer">
+        <a class="ui button item" href={{@controller.previewUrl}} target="_blank">
           <i class="eye icon"></i>
           Prévisualiser
         </a>
@@ -68,7 +68,7 @@ import Image from 'pixeditor/components/pop-in/image';
           <i class="globe icon"></i>
           Version originale
         </LinkTo>
-        <a class="ui button item" href={{@controller.translationsUrl}} target="_blank" rel="noopener noreferrer">
+        <a class="ui button item" href={{@controller.translationsUrl}} target="_blank" referrerpolicy="strict-origin">
           <i class="language icon"></i>
           Traductions
         </a>

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
@@ -138,7 +138,7 @@ import SelectLocation from 'pixeditor/components/pop-in/select-location';
           Annuler
         </button>
       {{else}}
-        <a class="ui button item" href={{@controller.absolutePreviewUrl}} target="_blank" rel="noopener noreferrer">
+        <a class="ui button item" href={{@controller.absolutePreviewUrl}} target="_blank">
           <i class="eye icon"></i>
           Prévisualiser
         </a>

--- a/pix-editor/app/templates/authenticated/competence/skills/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/skills/single.gjs
@@ -97,7 +97,7 @@ import ConfirmLog from 'pixeditor/components/pop-in/confirm-log';
         </button>
       {{else}}
         {{#if @controller.skill.productionPrototype}}
-          <a class="ui button item" href={{@controller.previewPrototypeUrl}} target="_blank" rel="noopener noreferrer">
+          <a class="ui button item" href={{@controller.previewPrototypeUrl}} target="_blank">
             <i class="eye icon"></i>
             Prévisualiser
           </a>

--- a/pix-editor/app/templates/authenticated/missions/mission/details.gjs
+++ b/pix-editor/app/templates/authenticated/missions/mission/details.gjs
@@ -55,7 +55,7 @@ import formatDate from 'ember-intl/helpers/format-date';
             <a
               href={{@controller.model.mission.introductionMediaUrl}}
               target="_blank"
-              rel="noopener noreferrer"
+              referrerpolicy="strict-origin"
             >{{@controller.model.mission.introductionMediaUrl}}</a>
           </li>
           <li>
@@ -71,7 +71,7 @@ import formatDate from 'ember-intl/helpers/format-date';
             <a
               href={{@controller.model.mission.documentationUrl}}
               target="_blank"
-              rel="noopener noreferrer"
+              referrerpolicy="strict-origin"
             >{{@controller.model.mission.documentationUrl}} </a>
           </li>
           <li><span class="bold">Crée le : </span>{{formatDate

--- a/pix-editor/app/templates/authenticated/static-courses/list.gjs
+++ b/pix-editor/app/templates/authenticated/static-courses/list.gjs
@@ -159,7 +159,6 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
                       <a
                         href="{{staticCourseSummary.previewURL}}"
                         target="_blank"
-                        rel="noopener noreferrer"
                         aria-describedby="open-static-course-link-tooltip"
                         class="{{if staticCourseSummary.isActive '' 'disabled-link-with-icon'}}"
                       >

--- a/pix-editor/app/templates/authenticated/static-courses/static-course/details.gjs
+++ b/pix-editor/app/templates/authenticated/static-courses/static-course/details.gjs
@@ -86,7 +86,6 @@ import { on } from '@ember/modifier';
           <PixButtonLink
             @href={{if @controller.model.staticCourse.isActive @controller.model.staticCourse.previewURL "#"}}
             target={{if @controller.model.staticCourse.isActive "_blank" "_self"}}
-            rel="noopener noreferrer"
             @backgroundColor="transparent-light"
             @isBorderVisible={{true}}
             class="pix-button-link-with-icon"
@@ -149,7 +148,7 @@ import { on } from '@ember/modifier';
                     {{/if}}
                   </td>
                   <td>
-                    <a href="{{challengeSummary.previewUrl}}" target="_blank" rel="noopener noreferrer">
+                    <a href="{{challengeSummary.previewUrl}}" target="_blank">
                       <PixIcon @name="eye" @plainIcon={{true}} />
                     </a>
                   </td>


### PR DESCRIPTION
## ❄️ Problème

Les liens vers les tutos youtube via youtube-nocookie.com sont cassés (comme sur PixApp).

## 🛷 Proposition

Remplacer l’attribut `rel="noreferrer"` par l’attribut `referrerpolicy="strict-origin"`

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Aller sur[ un acquis avec un tuto youtube](https://pix-lcms-review-pr1315.osc-fr1.scalingo.io/competence/competenceF0A0C0/skills/skillF0A0C0Th1Tu0S0Act?leftMaximized=true&view=production) et cliquer sur le lien.