### PR TITLE
[BUGFIX] Rechargement épreuves lors de la sélection d’un acquis (PIX-17285)

### DIFF
--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -104,7 +104,7 @@ export default class ChallengeModel extends Model {
     const challengeLocale = this.challengeLocales.find((challengeLocale) => {
       return challengeLocale.locale === canonicalLocale;
     });
-    await challengeLocale.localizedChallenge;
+    await challengeLocale.belongsTo('localizedChallenge').reload();
     return challengeLocale;
   }
 


### PR DESCRIPTION
## ❄️ Problème

Lorsqu’on sélectionne un acquis (notamment après avoir recharger les traductions), la liste des épreuves traduites ne sont pas rechargées si elle a déjà été chargée une fois.

## 🛷 Proposition

Recharger la liste des épreuves traduites à chaque fois qu’on sélectionne un acquis.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

En v2, en ayant sélectionné une langue sur la vue épreuves production, vérifier dans le panneau network que la requête de chargement est faite à chaque fois qu’on sélectionne un acquis.