### PR TITLE
 [REFACTO] Renommer `Formulation à revoir` pour une épreuve (PIX-20718)

### DIFF
--- a/pix-editor/app/components/challenge-view/challenge-view.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view.gjs
@@ -158,7 +158,7 @@ export default class ChallengeViewProduction extends Component {
               <:label>Accès GAFAM requis</:label>
             </PixCheckbox>
             <PixCheckbox @checked={{@challenge.toRephrase}} disabled>
-              <:label>Formulation à revoir</:label>
+              <:label>Épreuve à revoir</:label>
             </PixCheckbox>
             <PixCheckbox @checked={{@challenge.isIncompatibleIpadCertif}} disabled>
               <:label>Incompatible iPad certif</:label>

--- a/pix-editor/app/components/field/quality.gjs
+++ b/pix-editor/app/components/field/quality.gjs
@@ -75,7 +75,7 @@ export default class Quality extends Component {
         />
         <Checkbox
           data-test-to-rephrase-challenge-id={{@challenge.id}}
-          @label="Formulation à revoir"
+          @label="Épreuve à revoir"
           @checked={{@challenge.toRephrase}}
           @disabled={{not @edition}}
         />

--- a/pix-editor/tests/acceptance/competence/skills/single-test.js
+++ b/pix-editor/tests/acceptance/competence/skills/single-test.js
@@ -206,7 +206,7 @@ module('Acceptance | skill | single', function (hooks) {
       await fillIn(descriptionInput, skillDescription);
       await clickByText('Épreuve de sensibilisation');
       await clickByText('Accès GAFAM requis');
-      await clickByText('Formulation à revoir');
+      await clickByText('Épreuve à revoir');
       await clickByText('Incompatible iPad certif');
       await clickByText('Sourds et malentendants');
       await click(await screen.findByRole('option', { name: 'RAS' }));
@@ -233,7 +233,7 @@ module('Acceptance | skill | single', function (hooks) {
       assert.strictEqual(screen.getByLabelText('Spoil').childNodes[3].textContent, 'Facilement Sp');
       assert.false(screen.getByRole('checkbox', { name: 'Épreuve de sensibilisation' }).checked);
       assert.false(screen.getByRole('checkbox', { name: 'Accès GAFAM requis' }).checked);
-      assert.false(screen.getByRole('checkbox', { name: 'Formulation à revoir' }).checked);
+      assert.false(screen.getByRole('checkbox', { name: 'Épreuve à revoir' }).checked);
       assert.false(screen.getByRole('checkbox', { name: 'Incompatible iPad certif' }).checked);
 
       assert.strictEqual(screen.getByLabelText('Responsive').childNodes[3].textContent, 'Non');

--- a/pix-editor/tests/acceptance/create-challenge-test.js
+++ b/pix-editor/tests/acceptance/create-challenge-test.js
@@ -105,7 +105,7 @@ module('Acceptance | Create-Challenge', function (hooks) {
     await selectFiles('[data-test-file-input-attachment] input', attachmentFile);
     await clickByText('Épreuve de sensibilisation');
     await clickByText('Accès GAFAM requis');
-    await clickByText('Formulation à revoir');
+    await clickByText('Épreuve à revoir');
     await clickByText('Incompatible iPad certif');
     await clickByText('Sans validation (Pix Junior)');
     await clickByText("Validation par l'embed (Pix Junior)");
@@ -145,7 +145,7 @@ module('Acceptance | Create-Challenge', function (hooks) {
     assert.strictEqual((await screen.getByLabelText('Géographie')).childNodes[3].textContent, 'Japon');
     assert.true(screen.getByRole('checkbox', { name: 'Épreuve de sensibilisation' }).checked);
     assert.true(screen.getByRole('checkbox', { name: 'Accès GAFAM requis' }).checked);
-    assert.true(screen.getByRole('checkbox', { name: 'Formulation à revoir' }).checked);
+    assert.true(screen.getByRole('checkbox', { name: 'Épreuve à revoir' }).checked);
     assert.true(screen.getByRole('checkbox', { name: 'Incompatible iPad certif' }).checked);
     assert.true(screen.getByRole('checkbox', { name: 'Sans validation (Pix Junior)' }).checked);
     assert.true(screen.getByRole('checkbox', { name: "Validation par l'embed (Pix Junior)" }).checked);

--- a/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
+++ b/pix-editor/tests/acceptance/modify-challenge/modify-challenge-test.js
@@ -136,7 +136,7 @@ module('Acceptance | Modify-Challenge', function (hooks) {
       );
       await clickByText('Épreuve de sensibilisation');
       await clickByText('Accès GAFAM requis');
-      await clickByText('Formulation à revoir');
+      await clickByText('Épreuve à revoir');
       await clickByText('Incompatible iPad certif');
       await clickByText('Sans validation (Pix Junior)');
       await clickByText("Validation par l'embed (Pix Junior)");
@@ -173,7 +173,7 @@ module('Acceptance | Modify-Challenge', function (hooks) {
       assert.strictEqual((await screen.getByLabelText('Géographie')).childNodes[3].textContent, 'Japon');
       assert.true(screen.getByRole('checkbox', { name: 'Épreuve de sensibilisation' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'Accès GAFAM requis' }).checked);
-      assert.true(screen.getByRole('checkbox', { name: 'Formulation à revoir' }).checked);
+      assert.true(screen.getByRole('checkbox', { name: 'Épreuve à revoir' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'Incompatible iPad certif' }).checked);
       assert.true(screen.getByRole('checkbox', { name: 'Sans validation (Pix Junior)' }).checked);
       assert.true(screen.getByRole('checkbox', { name: "Validation par l'embed (Pix Junior)" }).checked);
@@ -311,7 +311,7 @@ module('Acceptance | Modify-Challenge', function (hooks) {
       await clickByText("Validation par l'embed (Pix Junior)");
       await clickByText('Épreuve de sensibilisation');
       await clickByText('Accès GAFAM requis');
-      await clickByText('Formulation à revoir');
+      await clickByText('Épreuve à revoir');
       await clickByText('Incompatible iPad certif');
       await clickByText('Sourds et malentendants');
       await click(await screen.findByRole('option', { name: 'RAS' }));
@@ -474,7 +474,7 @@ module('Acceptance | Modify-Challenge', function (hooks) {
       await clickByText("Validation par l'embed (Pix Junior)");
       await clickByText('Épreuve de sensibilisation');
       await clickByText('Accès GAFAM requis');
-      await clickByText('Formulation à revoir');
+      await clickByText('Épreuve à revoir');
       await clickByText('Incompatible iPad certif');
 
       await clickByText('Sourds et malentendants');

--- a/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/challenge-view/challenge-view-test.gjs
@@ -89,7 +89,7 @@ module('Integration | Component | challenge-view | challenge-view', function (ho
     assert.dom(screen.getByLabelText('Sourds et malentendants')).hasValue('Ok');
     assert.dom(screen.getByLabelText('Épreuve de sensibilisation')).isChecked();
     assert.dom(screen.getByLabelText('Accès GAFAM requis')).isChecked();
-    assert.dom(screen.getByLabelText('Formulation à revoir')).isNotChecked();
+    assert.dom(screen.getByLabelText('Épreuve à revoir')).isNotChecked();
     assert.dom(screen.getByLabelText('Incompatible iPad certif')).isChecked();
     assert.dom(screen.getByLabelText('Champs contextualisés')).hasValue('contextualizedFields');
     assert.dom(screen.getByLabelText('Id')).hasValue('challengeProtoValidee');


### PR DESCRIPTION
## ❄️ Problème
`Formulation à revoir` est trop précis. C'est l'épreuve qu'il faut globalement revoir.

## 🛷 Proposition
Changer en `Épreuve à revoir`

## ☃️ Remarques
RAS

## 🧑‍🎄 Pour tester
Tests au vert.