### PR TITLE
[FEATURE] Ignorer les accents dans la recherche d’acquis (PIX-20822)

### DIFF
--- a/api/db/migrations/20251217095015_create-collation-ignore-case-accents.js
+++ b/api/db/migrations/20251217095015_create-collation-ignore-case-accents.js
@@ -1,0 +1,15 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.raw('CREATE COLLATION IF NOT EXISTS "ignore-case-accents" (provider = icu, deterministic = false, locale = \'und-u-ks-level1\');');
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.raw('DROP COLLATION "ignore-case-accents";');
+}

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -2,7 +2,6 @@ import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
 import { knex } from '../../../db/knex-database-connection.js';
-import { escapeLikeWildcards } from './sql-utils.js';
 
 const TABLE_NAME = 'skills';
 const TUTORIALS_RELATION_TABLE_NAME = 'skills-tutorials';
@@ -76,10 +75,12 @@ export async function listByCompetenceId(competenceId) {
 }
 
 export async function search(params) {
-  let query = selectSkills().whereRaw("?? || coalesce(??::varchar, '') ilike ?", [
+  let query = selectSkills().whereRaw("left(?? || coalesce(??::varchar, ''), ?) = ? collate ??", [
     'tubes.name',
     'skills.level',
-    `${escapeLikeWildcards(params.filter.name)}%`,
+    params.filter.name.length,
+    params.filter.name,
+    'ignore-case-accents',
   ]).where('tubes.name', '<>', '@workbench');
   if (params.sort) {
     const orderBySqlAndParams = params.sort.map(([field, direction]) => {

--- a/api/tests/integration/infrastructure/repositories/skill-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/skill-repository_test.js
@@ -561,7 +561,7 @@ describe('Integration | Repository | skill-repository', () => {
 
         await databaseBuilder.commit();
 
-        const params = { filter: { name: '@skill' } };
+        const params = { filter: { name: '@sKîl' } };
 
         // when
         const results = await skillRepository.search(params);


### PR DESCRIPTION
## ❄️ Problème

À la recherche d’un acquis on ne souhaite pas tenir compte des accents (et continuer également de ne pas tenir compte de la casse).

## 🛷 Proposition

Créer une collation ignore-case-accents et l’utiliser pour la comparaison.

## ☃️ Remarques

On ne peut plus utiliser `LIKE` car il est incompatible avec les collations non déterministes.
Il sera compatible en Postgres v18.

## 🧑‍🎄 Pour tester

Créer un tube avec des accents dedans.
Faire des recherches avec ou sans accents et vérifier que les bons résultats remontent.