### PR TITLE
[FEATURE] Trier les prototypes par statut puis version (PIX-20800)

### DIFF
--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { tracked } from '@glimmer/tracking';
+import Challenge from 'pixeditor/models/challenge';
 
 export default class SkillModel extends Model {
   _pinnedRelationships = {};
@@ -81,7 +82,15 @@ export default class SkillModel extends Model {
   }
 
   get sortedPrototypes() {
-    return this.prototypes.sort((a, b) => a.version < b.version);
+    const statusesOrder = [
+      Challenge.STATUSES.VALIDE,
+      Challenge.STATUSES.PROPOSE,
+      Challenge.STATUSES.ARCHIVE,
+      Challenge.STATUSES.PERIME,
+    ];
+    return this.prototypes
+      .sort((a, b) => b.version - a.version)
+      .sort((a, b) => statusesOrder.indexOf(a.status) - statusesOrder.indexOf(b.status));
   }
 
   get productionPrototype() {


### PR DESCRIPTION
## ❄️ Problème

Il faudrait trier les versions de proto avec, affiché de haut en bas : 
 - Les statuts : validé > proposé > archivé > périmé
 - Les numéros de version du plus grand au plus petit, pour avoir les versions les plus récentes en premier.

## 🛷 Proposition

Corriger le tri existant qui était buggé.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Vérifier l’ordre de tri sur [@amandePistache3](https://pix-lcms-review-pr1332.osc-fr1.scalingo.io/competence/competenceF0A0C0/prototypes/list/tubeF0A0C0Th1Tu1/skillF0A0C0Th1Tu1S2EnCons?view=workbench).