### PR TITLE
[FEATURE] Moulinette URLs KO : analyser tutos liés à au moins un acquis non périmé (PIX-20836)

### DIFF
--- a/api/lib/domain/models/release/Release.js
+++ b/api/lib/domain/models/release/Release.js
@@ -30,19 +30,6 @@ export class Release {
     const skill = findSkillForChallenge(challenge, this.content);
     return skill?.name ?? null;
   }
-
-  findCompetenceNamesForTutorial(tutorial) {
-    const skills = findSkillsUsingTutorial(tutorial, this.content);
-    const rawCompetenceNames = skills.map((skill) =>
-      skill ? findCompetenceForSkill(skill, this.content)?.name_i18n.fr : null,
-    );
-    return _.uniq(_.compact(rawCompetenceNames));
-  }
-
-  findSkillNamesForTutorial(tutorial) {
-    const skills = findSkillsUsingTutorial(tutorial, this.content);
-    return skills.map((s) => s.name);
-  }
 }
 
 function findCompetenceForChallenge(challenge, content) {
@@ -54,26 +41,13 @@ function findCompetenceForChallenge(challenge, content) {
 function findTubeForChallenge(challenge, content) {
   const skill = findSkillForChallenge(challenge, content);
   if (!skill) return null;
-  const tube = content.tubes.find(({ id }) => skill.tubeId === id);
-  if (!tube) return null;
-  return tube;
+  return content.tubes.find(({ id }) => skill.tubeId === id) ?? null;
 }
 
 function findSkillForChallenge(challenge, content) {
-  const skill = content.skills.find(({ id }) => challenge.skillId === id);
-  if (!skill) return null;
-  return skill;
+  return content.skills.find(({ id }) => challenge.skillId === id) ?? null;
 }
 
 function findCompetenceForSkill(skill, content) {
-  const tube = content.tubes.find(({ id }) => skill.tubeId === id);
-  if (!tube) return null;
-  const competence = content.competences.find(({ id }) => tube.competenceId === id);
-  return competence ?? null;
-}
-
-function findSkillsUsingTutorial(tutorial, content) {
-  return content.skills.filter((skill) => {
-    return skill.tutorialIds.includes(tutorial.id) || skill.learningMoreTutorialIds.includes(tutorial.id);
-  });
+  return content.competences.find(({ id }) => skill.competenceId === id) ?? null;
 }

--- a/api/lib/domain/models/release/SkillForRelease.js
+++ b/api/lib/domain/models/release/SkillForRelease.js
@@ -42,6 +42,10 @@ export class SkillForRelease {
     return Skill.INTERNATIONALISATIONS;
   }
 
+  get isPerime() {
+    return this.status === Skill.STATUSES.PERIME;
+  }
+
   canExportForTranslation() {
     return this.status === SkillForRelease.STATUSES.ACTIF;
   }

--- a/api/lib/domain/usecases/validate-urls-from-release.js
+++ b/api/lib/domain/usecases/validate-urls-from-release.js
@@ -47,17 +47,26 @@ function findUrlsFromChallenges(challenges, release, localizedChallengesById, Ur
   });
 }
 
-function findUrlsFromTutorials(tutorials, release, UrlUtils) {
-  return tutorials.map((tutorial) => {
-    return {
-      id: [
-        release.findCompetenceNamesForTutorial(tutorial).join(' '),
-        release.findSkillNamesForTutorial(tutorial).join(' '),
-        tutorial.id,
-      ].join(';'),
-      url: UrlUtils.findUrlsInText(tutorial.link)[0],
-    };
-  });
+function findUrlsFromTutorials(release, UrlUtils) {
+  const notObsoleteSkills = release.content.skills.filter((skill) => !skill.isPerime);
+  const accessibleTutorialIds = new Set(
+    notObsoleteSkills.flatMap((skill) => [...skill.tutorialIds, ...skill.learningMoreTutorialIds]),
+  );
+  return release.content.tutorials
+    .filter((tutorial) => accessibleTutorialIds.has(tutorial.id))
+    .map((tutorial) => {
+      const skills = notObsoleteSkills.filter((skill) => skill.tutorialIds.includes(tutorial.id) || skill.learningMoreTutorialIds.includes(tutorial.id));
+      const competenceIds = new Set(skills.flatMap((skill) => skill.competenceId));
+      const competences = release.content.competences.filter((competence) => competenceIds.has(competence.id));
+      return {
+        id: [
+          competences.map((competence) => competence.name_i18n.fr).join(' '),
+          skills.map((skill) => skill.name).join(' '),
+          tutorial.id,
+        ].join(';'),
+        url: UrlUtils.findUrlsInText(tutorial.link)[0],
+      };
+    });
 }
 
 function keepAndFormatKOUrls(analyzedLines) {
@@ -93,8 +102,7 @@ async function checkAndUploadKOUrlsFromChallenges(
 }
 
 async function checkAndUploadKOUrlsFromTutorials(release, { urlRepository, UrlUtils }, whitelistedUrls) {
-  const tutorials = release.content.tutorials;
-  const urlList = findUrlsFromTutorials(tutorials, release, UrlUtils);
+  const urlList = findUrlsFromTutorials(release, UrlUtils);
   const finalUrlList = urlList.filter(
     ({ url }) => !whitelistedUrls.some((whitelistedUrl) => whitelistedUrl.matches(url)),
   );

--- a/api/tests/unit/domain/models/Release_test.js
+++ b/api/tests/unit/domain/models/Release_test.js
@@ -36,7 +36,7 @@ describe('Unit | Domain | Release', () => {
   });
 
   describe('#findOriginForChallenge', () => {
-    let challengeWithNoSkill, challengeWithNoTube, challengeWithNoCompetence, challengeWithNoOrigin, challengeOk;
+    let challengeWithNoSkill, challengeWithNoCompetence, challengeWithNoOrigin, challengeOk;
     let release;
 
     beforeEach(() => {
@@ -50,46 +50,24 @@ describe('Unit | Domain | Release', () => {
         origin: null,
         name_i18n: { fr: 'competence no origin name' },
       });
-      const tube = domainBuilder.buildTubeForRelease({
-        id: 'tubeId1',
-        competenceId: competence.id,
-      });
-      const tubeNoCompetence = domainBuilder.buildTubeForRelease({
-        id: 'tubeNoCompetenceId',
-        competenceId: 'competenceUnknown',
-      });
-      const tubeNoOrigin = domainBuilder.buildTubeForRelease({
-        id: 'tubeNoOriginId',
-        competenceId: competenceNoOrigin.id,
-      });
       const skill = domainBuilder.buildSkillForRelease({
         id: 'skillId1',
-        tubeId: tube.id,
+        competenceId: competence.id,
         name: '@mySkill1',
-      });
-      const skillNoTube = domainBuilder.buildSkillForRelease({
-        id: 'skillNoTubeId',
-        tubeId: 'tubeUnknown',
-        name: '@mySkill2',
       });
       const skillNoCompetence = domainBuilder.buildSkillForRelease({
         id: 'skillNoCompetenceId',
-        tubeId: tubeNoCompetence.id,
+        competenceId: 'competenceUnknown',
         name: '@mySkill3',
       });
       const skillNoOrigin = domainBuilder.buildSkillForRelease({
         id: 'skillNoOriginId',
-        tubeId: tubeNoOrigin.id,
+        competenceId: competenceNoOrigin.id,
         name: '@mySkill4',
       });
       challengeWithNoSkill = domainBuilder.buildChallengeForRelease({
         id: 'challengeIdWithNoSkill',
         skillId: 'skillUnknown',
-        status: ChallengeForRelease.STATUSES.VALIDE,
-      });
-      challengeWithNoTube = domainBuilder.buildChallengeForRelease({
-        id: 'challengeIdWithNoTube',
-        skillId: skillNoTube.id,
         status: ChallengeForRelease.STATUSES.VALIDE,
       });
       challengeWithNoCompetence = domainBuilder.buildChallengeForRelease({
@@ -109,20 +87,13 @@ describe('Unit | Domain | Release', () => {
       });
       release = domainBuilder.buildDomainRelease.withContent({
         competencesFromRelease: [competence, competenceNoOrigin],
-        tubesFromRelease: [
-          tube,
-          tubeNoCompetence,
-          tubeNoOrigin,
-        ],
         skillsFromRelease: [
           skill,
-          skillNoTube,
           skillNoCompetence,
           skillNoOrigin,
         ],
         challengesFromRelease: [
           challengeWithNoSkill,
-          challengeWithNoTube,
           challengeWithNoCompetence,
           challengeWithNoOrigin,
           challengeOk,
@@ -133,14 +104,6 @@ describe('Unit | Domain | Release', () => {
     it('should return null when no skill found for challenge', () => {
       // when
       const origin = release.findOriginForChallenge(challengeWithNoSkill);
-
-      // then
-      expect(origin).toStrictEqual(null);
-    });
-
-    it('should return null when no tube found for challenge', () => {
-      // when
-      const origin = release.findOriginForChallenge(challengeWithNoTube);
 
       // then
       expect(origin).toStrictEqual(null);
@@ -172,7 +135,7 @@ describe('Unit | Domain | Release', () => {
   });
 
   describe('#findCompetenceNameForChallenge', () => {
-    let challengeWithNoSkill, challengeWithNoTube, challengeWithNoCompetence, challengeOk;
+    let challengeWithNoSkill, challengeWithNoCompetence, challengeOk;
     let release;
 
     beforeEach(() => {
@@ -181,37 +144,19 @@ describe('Unit | Domain | Release', () => {
         origin: 'competenceOrigin',
         name_i18n: { fr: 'competence name' },
       });
-      const tube = domainBuilder.buildTubeForRelease({
-        id: 'tubeId1',
-        competenceId: competence.id,
-      });
-      const tubeNoCompetence = domainBuilder.buildTubeForRelease({
-        id: 'tubeNoCompetenceId',
-        competenceId: 'competenceUnknown',
-      });
       const skill = domainBuilder.buildSkillForRelease({
         id: 'skillId1',
-        tubeId: tube.id,
+        competenceId: competence.id,
         name: '@mySkill1',
-      });
-      const skillNoTube = domainBuilder.buildSkillForRelease({
-        id: 'skillNoTubeId',
-        tubeId: 'tubeUnknown',
-        name: '@mySkill2',
       });
       const skillNoCompetence = domainBuilder.buildSkillForRelease({
         id: 'skillNoCompetenceId',
-        tubeId: tubeNoCompetence.id,
+        competenceId: 'competenceUnknown',
         name: '@mySkill3',
       });
       challengeWithNoSkill = domainBuilder.buildChallengeForRelease({
         id: 'challengeIdWithNoSkill',
         skillId: 'skillUnknown',
-        status: ChallengeForRelease.STATUSES.VALIDE,
-      });
-      challengeWithNoTube = domainBuilder.buildChallengeForRelease({
-        id: 'challengeIdWithNoTube',
-        skillId: skillNoTube.id,
         status: ChallengeForRelease.STATUSES.VALIDE,
       });
       challengeWithNoCompetence = domainBuilder.buildChallengeForRelease({
@@ -226,15 +171,9 @@ describe('Unit | Domain | Release', () => {
       });
       release = domainBuilder.buildDomainRelease.withContent({
         competencesFromRelease: [competence],
-        tubesFromRelease: [tube, tubeNoCompetence],
-        skillsFromRelease: [
-          skill,
-          skillNoTube,
-          skillNoCompetence,
-        ],
+        skillsFromRelease: [skill, skillNoCompetence],
         challengesFromRelease: [
           challengeWithNoSkill,
-          challengeWithNoTube,
           challengeWithNoCompetence,
           challengeOk,
         ],
@@ -244,14 +183,6 @@ describe('Unit | Domain | Release', () => {
     it('should return null when no skill found for challenge', () => {
       // when
       const competenceName = release.findCompetenceNameForChallenge(challengeWithNoSkill);
-
-      // then
-      expect(competenceName).toStrictEqual(null);
-    });
-
-    it('should return null when no tube found for challenge', () => {
-      // when
-      const competenceName = release.findCompetenceNameForChallenge(challengeWithNoTube);
 
       // then
       expect(competenceName).toStrictEqual(null);
@@ -383,133 +314,6 @@ describe('Unit | Domain | Release', () => {
 
       // then
       expect(skillName).toStrictEqual('@mySkill1');
-    });
-  });
-
-  describe('#findCompetenceNamesForTutorial', () => {
-    let tutorialInSeveralCompetences, tutorialWithNoCompetence, tutorialWithNoSkill;
-    let release;
-
-    beforeEach(() => {
-      const competence1 = domainBuilder.buildCompetenceForRelease({
-        id: 'competenceId1',
-        name_i18n: { fr: 'competence1 name' },
-      });
-      const competence2 = domainBuilder.buildCompetenceForRelease({
-        id: 'competenceId2',
-        name_i18n: { fr: 'competence2 name' },
-      });
-      const tube1 = domainBuilder.buildTubeForRelease({
-        id: 'tubeId1',
-        competenceId: competence1.id,
-      });
-      const tube2 = domainBuilder.buildTubeForRelease({
-        id: 'tubeId2',
-        competenceId: competence2.id,
-      });
-      const skill1 = domainBuilder.buildSkillForRelease({
-        id: 'skillId1',
-        tubeId: tube1.id,
-        name: '@mySkill1',
-        tutorialIds: ['tutorialInSeveralCompetences'],
-        learningMoreTutorialIds: [],
-      });
-      const skill2 = domainBuilder.buildSkillForRelease({
-        id: 'skillId2',
-        tubeId: tube2.id,
-        name: '@mySkill2',
-        tutorialIds: [],
-        learningMoreTutorialIds: ['tutorialInSeveralCompetences'],
-      });
-      const skillNoTube = domainBuilder.buildSkillForRelease({
-        id: 'skillNoTubeId',
-        tubeId: 'tubeUnknown',
-        name: '@mySkill3',
-        tutorialIds: ['tutorialWithNoCompetence'],
-      });
-      tutorialInSeveralCompetences = domainBuilder.buildTutorialForRelease({ id: 'tutorialInSeveralCompetences' });
-      tutorialWithNoCompetence = domainBuilder.buildTutorialForRelease({ id: 'tutorialWithNoCompetence' });
-      tutorialWithNoSkill = domainBuilder.buildTutorialForRelease({ id: 'tutorialWithNoSkill' });
-      release = domainBuilder.buildDomainRelease.withContent({
-        competencesFromRelease: [competence1, competence2],
-        tubesFromRelease: [tube1, tube2],
-        skillsFromRelease: [
-          skill1,
-          skill2,
-          skillNoTube,
-        ],
-        tutorialsFromRelease: [
-          tutorialInSeveralCompetences,
-          tutorialWithNoCompetence,
-          tutorialWithNoSkill,
-        ],
-      });
-    });
-
-    it('should return empty array when tutorial linked to none', () => {
-      // when
-      const competenceNames = release.findCompetenceNamesForTutorial(tutorialWithNoSkill);
-
-      // then
-      expect(competenceNames).toStrictEqual([]);
-    });
-
-    it('should return empty array when tutorial linked to skill in no competence', () => {
-      // when
-      const competenceNames = release.findCompetenceNamesForTutorial(tutorialWithNoCompetence);
-
-      // then
-      expect(competenceNames).toStrictEqual([]);
-    });
-
-    it('should return competence names of competences to which tutorial is linked', () => {
-      // when
-      const competenceNames = release.findCompetenceNamesForTutorial(tutorialInSeveralCompetences);
-
-      // then
-      expect(competenceNames).toStrictEqual(['competence1 name', 'competence2 name']);
-    });
-  });
-
-  describe('#findSkillNamesForTutorial', () => {
-    let tutorialInSeveralCompetences, tutorialWithNoSkill;
-    let release;
-
-    beforeEach(() => {
-      const skill1 = domainBuilder.buildSkillForRelease({
-        id: 'skillId1',
-        name: '@mySkill1',
-        tutorialIds: ['tutorialInSeveralCompetences'],
-        learningMoreTutorialIds: [],
-      });
-      const skill2 = domainBuilder.buildSkillForRelease({
-        id: 'skillId2',
-        name: '@mySkill2',
-        tutorialIds: [],
-        learningMoreTutorialIds: ['tutorialInSeveralCompetences'],
-      });
-      tutorialInSeveralCompetences = domainBuilder.buildTutorialForRelease({ id: 'tutorialInSeveralCompetences' });
-      tutorialWithNoSkill = domainBuilder.buildTutorialForRelease({ id: 'tutorialWithNoSkill' });
-      release = domainBuilder.buildDomainRelease.withContent({
-        skillsFromRelease: [skill1, skill2],
-        tutorialsFromRelease: [tutorialInSeveralCompetences, tutorialWithNoSkill],
-      });
-    });
-
-    it('should return empty array when tutorial linked to none', () => {
-      // when
-      const skillNames = release.findSkillNamesForTutorial(tutorialWithNoSkill);
-
-      // then
-      expect(skillNames).toStrictEqual([]);
-    });
-
-    it('should return skill names of skills to which tutorial is linked', () => {
-      // when
-      const skillNames = release.findSkillNamesForTutorial(tutorialInSeveralCompetences);
-
-      // then
-      expect(skillNames).toStrictEqual(['@mySkill1', '@mySkill2']);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/export-external-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/export-external-urls-from-release_test.js
@@ -33,16 +33,19 @@ describe('Unit | Domain | Usecases | Export external urls from release', functio
       const pixSkill1 = domainBuilder.buildSkillForRelease({
         id: 'skill1',
         tubeId: 'tube1',
+        competenceId: 'competence1',
         name: '@mySkill1',
       });
       const pixSkill2 = domainBuilder.buildSkillForRelease({
         id: 'skill2',
         tubeId: 'tube1',
+        competenceId: 'competence1',
         name: '@mySkill2',
       });
       const wonderlandSkill1 = domainBuilder.buildSkillForRelease({
         id: 'skill23',
         tubeId: 'tube2',
+        competenceId: 'competence2',
         name: '@mySkill23',
       });
       const pixChallenge1Skill1 = domainBuilder.buildChallengeForRelease({

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
-import { ChallengeForRelease } from '../../../../lib/domain/models/release/index.js';
+import { ChallengeForRelease, SkillForRelease } from '../../../../lib/domain/models/release/index.js';
 import { validateUrlsFromRelease } from '../../../../lib/domain/usecases/index.js';
 import * as UrlUtils from '../../../../lib/infrastructure/utils/url-utils.js';
 import { WhitelistedUrl } from '../../../../lib/domain/models/index.js';
@@ -67,6 +67,11 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         origin: 'Pix',
         name_i18n: { fr: 'competence 1.1' },
       });
+      const pixCompetence2 = domainBuilder.buildCompetenceForRelease({
+        id: 'competence3',
+        origin: 'Pix',
+        name_i18n: { fr: 'competence 1.3' },
+      });
       const wonderlandCompetence = domainBuilder.buildCompetenceForRelease({
         id: 'competence2',
         origin: 'wonderland',
@@ -76,6 +81,10 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         id: 'tube1',
         competenceId: 'competence1',
       });
+      const pixTube2 = domainBuilder.buildTubeForRelease({
+        id: 'tube3',
+        competenceId: 'competence3',
+      });
       const wonderlandTube = domainBuilder.buildTubeForRelease({
         id: 'tube2',
         competenceId: 'competence2',
@@ -83,6 +92,7 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       const pixSkill1 = domainBuilder.buildSkillForRelease({
         id: 'skill1',
         tubeId: 'tube1',
+        competenceId: 'competence1',
         name: '@mySkill1',
         tutorialIds: ['tutorial1', 'tutorial3'],
         learningMoreTutorialIds: [],
@@ -90,13 +100,24 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       const pixSkill2 = domainBuilder.buildSkillForRelease({
         id: 'skill2',
         tubeId: 'tube1',
+        competenceId: 'competence1',
         name: '@mySkill2',
         tutorialIds: [],
         learningMoreTutorialIds: [],
       });
+      const obsoletePixSkill = domainBuilder.buildSkillForRelease({
+        id: 'skill3',
+        tubeId: 'tube3',
+        competenceId: 'competence3',
+        name: '@mySkill3',
+        tutorialIds: ['tutorial1', 'tutorial4'],
+        learningMoreTutorialIds: ['tutorial5'],
+        status: SkillForRelease.STATUSES.PERIME,
+      });
       const wonderlandSkill1 = domainBuilder.buildSkillForRelease({
         id: 'skill23',
         tubeId: 'tube2',
+        competenceId: 'competence2',
         name: '@mySkill23',
         tutorialIds: [],
         learningMoreTutorialIds: ['tutorial2'],
@@ -105,6 +126,8 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         domainBuilder.buildTutorialForRelease({ id: 'tutorial1', link: 'https://tuto1.net/' }),
         domainBuilder.buildTutorialForRelease({ id: 'tutorial2', link: 'www.tuto2.net/' }),
         domainBuilder.buildTutorialForRelease({ id: 'tutorial3', link: 'https://tuto3.net/' }),
+        domainBuilder.buildTutorialForRelease({ id: 'tutorial4', link: 'https://tuto4.net/' }),
+        domainBuilder.buildTutorialForRelease({ id: 'tutorial5', link: 'https://tuto5.net/' }),
       ];
       const pixChallenge1Skill1 = domainBuilder.buildChallengeForRelease({
         id: 'challenge1',
@@ -165,11 +188,20 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         locales: ['nl'],
       });
       const latestRelease = domainBuilder.buildDomainRelease.withContent({
-        competencesFromRelease: [pixCompetence, wonderlandCompetence],
-        tubesFromRelease: [pixTube, wonderlandTube],
+        competencesFromRelease: [
+          pixCompetence,
+          pixCompetence2,
+          wonderlandCompetence,
+        ],
+        tubesFromRelease: [
+          pixTube,
+          pixTube2,
+          wonderlandTube,
+        ],
         skillsFromRelease: [
           pixSkill1,
           pixSkill2,
+          obsoletePixSkill,
           wonderlandSkill1,
         ],
         challengesFromRelease: [

--- a/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
+++ b/api/tests/unit/domain/usecases/validate-urls-from-release_test.js
@@ -77,21 +77,8 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
         origin: 'wonderland',
         name_i18n: { fr: 'competence 4.5' },
       });
-      const pixTube = domainBuilder.buildTubeForRelease({
-        id: 'tube1',
-        competenceId: 'competence1',
-      });
-      const pixTube2 = domainBuilder.buildTubeForRelease({
-        id: 'tube3',
-        competenceId: 'competence3',
-      });
-      const wonderlandTube = domainBuilder.buildTubeForRelease({
-        id: 'tube2',
-        competenceId: 'competence2',
-      });
       const pixSkill1 = domainBuilder.buildSkillForRelease({
         id: 'skill1',
-        tubeId: 'tube1',
         competenceId: 'competence1',
         name: '@mySkill1',
         tutorialIds: ['tutorial1', 'tutorial3'],
@@ -99,7 +86,6 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       });
       const pixSkill2 = domainBuilder.buildSkillForRelease({
         id: 'skill2',
-        tubeId: 'tube1',
         competenceId: 'competence1',
         name: '@mySkill2',
         tutorialIds: [],
@@ -107,7 +93,6 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       });
       const obsoletePixSkill = domainBuilder.buildSkillForRelease({
         id: 'skill3',
-        tubeId: 'tube3',
         competenceId: 'competence3',
         name: '@mySkill3',
         tutorialIds: ['tutorial1', 'tutorial4'],
@@ -116,7 +101,6 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
       });
       const wonderlandSkill1 = domainBuilder.buildSkillForRelease({
         id: 'skill23',
-        tubeId: 'tube2',
         competenceId: 'competence2',
         name: '@mySkill23',
         tutorialIds: [],
@@ -192,11 +176,6 @@ describe('Unit | Domain | Usecases | Validate urls from release', function() {
           pixCompetence,
           pixCompetence2,
           wonderlandCompetence,
-        ],
-        tubesFromRelease: [
-          pixTube,
-          pixTube2,
-          wonderlandTube,
         ],
         skillsFromRelease: [
           pixSkill1,


### PR DESCRIPTION
## ❄️ Problème

Dans la moulinette des URLs KO, parmi les tutos, il faudrait uniquement tenir compte des tutos liés à des acquis à l'état “en construction” / “actif” / “archivé”.

Il ne faudrait pas tenir compte des tutos qui sont liés uniquement à des acquis “périmé” ou lié à aucun acquis.

## 🛷 Proposition

Filtrer les tutos analysés.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

C’est compliqué.