### PR TITLE
[FEATURE] Recevoir les traductions des épreuves etc. via les webhooks Phrase (PIX-20914)

### DIFF
--- a/api/lib/application/phrase.js
+++ b/api/lib/application/phrase.js
@@ -1,5 +1,9 @@
 import * as securityPreHandlers from './security-pre-handlers.js';
 import { downloadTranslationFromPhrase, uploadTranslationToPhrase } from '../domain/usecases/index.js';
+import { child } from '../infrastructure/logger.js';
+import * as config from '../config.js';
+
+const logger = child('application:phrase', { event: 'phrase' });
 
 export async function register(server) {
   server.route([
@@ -25,7 +29,99 @@ export async function register(server) {
         },
       },
     },
+    {
+      method: 'POST',
+      path: '/api/phrase/webhook',
+      config: {
+        auth: false,
+        payload: { parse: false },
+        pre: [{ method: checkPhraseappSignature }, { method: validatePhraseWebhookRequest }],
+        handler: async function(request, h) {
+          logger.info({ payload: request.payload }, 'Phrase webhook called');
+          return h.response();
+        },
+        tags: [
+          'api',
+          'phrase',
+          'webhook',
+        ],
+      },
+    },
   ]);
 }
 
 export const name = 'phrase-api';
+
+export async function checkPhraseappSignature(request, h) {
+  const xPhraseappSignature = request.headers['x-phraseapp-signature'];
+  if (!xPhraseappSignature) {
+    logger.warn('Phrase webhook call missing signature');
+    return h.response().code(401).takeover();
+  };
+
+  const signature = Buffer.from(xPhraseappSignature, 'base64');
+  const key = await getPhraseWebhookSecretKey();
+
+  if (!await crypto.subtle.verify('HMAC', key, signature, request.payload)) {
+    logger.warn('Phrase webhook call bad signature');
+    return h.response().code(400).takeover();
+  }
+
+  request.payload = JSON.parse(request.payload.toString());
+
+  return h.response(true);
+}
+
+let phraseWebhookSecretKey;
+
+/**
+ * @returns {Promise<CryptoKey>}
+ */
+async function getPhraseWebhookSecretKey() {
+  if (phraseWebhookSecretKey) return phraseWebhookSecretKey.promise;
+
+  phraseWebhookSecretKey = Promise.withResolvers();
+
+  try {
+    phraseWebhookSecretKey.resolve(
+      await crypto.subtle.importKey(
+        'raw',
+        new TextEncoder().encode(config.phrase.webhookSecret),
+        { name: 'HMAC', hash: { name: 'SHA-256' } },
+        false,
+        ['verify'],
+      ),
+    );
+  } catch (err) {
+    phraseWebhookSecretKey.reject(new Error('error while importing phrase webhook secret', { cause: err }));
+  }
+
+  return phraseWebhookSecretKey.promise;
+}
+
+const TEST_EVENT = 'test:event';
+const TRANSLATIONS_EVENTS = ['translations:create', 'translations:udpate'];
+
+function validatePhraseWebhookRequest(request, h) {
+  if (request.payload.event === TEST_EVENT) {
+    logger.info('received test event from phrase webhook');
+    return h.response().takeover();
+  }
+
+  if (!TRANSLATIONS_EVENTS.includes(request.payload.event)) {
+    logger.warn({ event: request.payload.event }, 'received unexpected event from phrase webhook');
+    return h.response().code(400).takeover();
+  }
+
+  if (request.payload.branch != null) {
+    logger.warn({ branch: request.payload.branch }, 'received translations event on branch');
+    return h.response().code(400).takeover();
+  }
+
+  if (!config.phrase.projects.some((project) => project.projectId === request.payload.project.id)) {
+    logger.warn({ project: request.payload.project }, 'received translations event on unexpected project');
+    return h.response().code(400).takeover();
+  }
+
+  return h.response(true);
+}

--- a/api/lib/application/phrase.js
+++ b/api/lib/application/phrase.js
@@ -1,7 +1,8 @@
 import * as securityPreHandlers from './security-pre-handlers.js';
-import { downloadTranslationFromPhrase, uploadTranslationToPhrase } from '../domain/usecases/index.js';
+import { downloadTranslationFromPhrase, importTranslations, uploadTranslationToPhrase } from '../domain/usecases/index.js';
 import { child } from '../infrastructure/logger.js';
 import * as config from '../config.js';
+import * as translationSerializer from '../infrastructure/serializers/phrase/translation-serializer.js';
 
 const logger = child('application:phrase', { event: 'phrase' });
 
@@ -37,7 +38,8 @@ export async function register(server) {
         payload: { parse: false },
         pre: [{ method: checkPhraseappSignature }, { method: validatePhraseWebhookRequest }],
         handler: async function(request, h) {
-          logger.info({ payload: request.payload }, 'Phrase webhook called');
+          const translation = translationSerializer.deserialize(request.payload);
+          await importTranslations([translation]);
           return h.response();
         },
         tags: [
@@ -100,7 +102,7 @@ async function getPhraseWebhookSecretKey() {
 }
 
 const TEST_EVENT = 'test:event';
-const TRANSLATIONS_EVENTS = ['translations:create', 'translations:udpate'];
+const TRANSLATIONS_EVENTS = ['translations:create', 'translations:update'];
 
 function validatePhraseWebhookRequest(request, h) {
   if (request.payload.event === TEST_EVENT) {

--- a/api/lib/application/translations.js
+++ b/api/lib/application/translations.js
@@ -1,13 +1,14 @@
 import { PassThrough } from 'node:stream';
 import fs from 'node:fs';
 import Boom from '@hapi/boom';
-import { exportTranslations } from '../domain/usecases/export-translations.js';
-import { importTranslations, InvalidFileError } from '../domain/usecases/import-translations.js';
+import Joi from 'joi';
+
+import { exportTranslations, importTranslations } from '../domain/usecases/index.js';
 import { logger } from '../infrastructure/logger.js';
 import { releaseRepository, localizedChallengeRepository } from '../infrastructure/repositories/index.js';
 import * as config from '../config.js';
 import * as securityPreHandlers from './security-pre-handlers.js';
-import Joi from 'joi';
+import { parseTranslationsCsvStream, InvalidFileError } from '../domain/services/parse-translations-csv-stream.js';
 
 export async function register(server) {
   server.route([
@@ -54,7 +55,8 @@ export async function importTranslationsHandler(request, h) {
   }
   try {
     const stream = fs.createReadStream(request.payload.file.path);
-    await importTranslations(stream);
+    const translations = await parseTranslationsCsvStream(stream);
+    await importTranslations(translations);
   } catch (error) {
     if (error instanceof InvalidFileError) {
       logger.error(error);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -149,6 +149,7 @@ export const phrase = {
       projectId: process.env.PHRASE_PIX_NR_PROJECT_ID,
     },
   ].filter(({ projectId }) => projectId),
+  webhookSecret: process.env.PHRASE_WEBHOOK_SECRET,
 };
 
 export const importTranslationsFileMaxSize = process.env.IMPORT_TRANSLATIONS_FILE_MAX_SIZE || 2097152;
@@ -202,4 +203,5 @@ if (process.env.NODE_ENV === 'test') {
 
   phrase.apiKey = 'MY_PHRASE_ACCESS_TOKEN';
   phrase.projects = [{ projectId: 'MY_PHRASE_PROJECT_ID', frameworkName: 'Pix' }];
+  phrase.webhookSecret = 'le secret de phrase';
 }

--- a/api/lib/domain/services/parse-translations-csv-stream.js
+++ b/api/lib/domain/services/parse-translations-csv-stream.js
@@ -1,0 +1,41 @@
+import { parseStream } from 'fast-csv';
+
+import { Translation } from '../models/index.js';
+
+export class InvalidFileError extends Error {}
+
+export async function parseTranslationsCsvStream(csvStream) {
+  return new Promise((resolve, reject) => {
+    const translations = [];
+    let locale;
+    parseStream(csvStream, {
+      headers: (headers) => {
+        if (headers[0] !== 'key_name') throw new InvalidFileError('Expected first column to be key_name');
+        locale = headers[1];
+        try {
+          new Intl.Locale(locale);
+        } catch {
+          throw new InvalidFileError('Expected second column to be a valid locale');
+        }
+        return [
+          'key',
+          'value',
+          ...Array(headers.length - 2),
+        ];
+      },
+      objectMode: true,
+      strictColumnHandling: true,
+    })
+      .validate((data) => data.key && data.value)
+      .on('error', reject)
+      .on('data-invalid', (invalidData) => {
+        reject(new InvalidFileError(`Invalid data: ${JSON.stringify(invalidData)}`));
+      })
+      .on('data', (row) => {
+        translations.push(new Translation({ ...row, locale }));
+      })
+      .on('end', () => {
+        resolve(translations);
+      });
+  });
+}

--- a/api/lib/domain/usecases/download-translation-from-phrase.js
+++ b/api/lib/domain/usecases/download-translation-from-phrase.js
@@ -1,8 +1,10 @@
+import { Readable } from 'node:stream';
 import { Configuration, LocalesApi } from 'phrase-js';
+
 import * as config from '../../config.js';
 import { logger } from '../../infrastructure/logger.js';
 import { importTranslations } from './import-translations.js';
-import { Readable } from 'node:stream';
+import { parseTranslationsCsvStream } from '../services/parse-translations-csv-stream.js';
 
 export async function downloadTranslationFromPhrase(phraseApi = { Configuration, LocalesApi }) {
   const { apiKey, projects } = config.phrase;
@@ -30,7 +32,10 @@ export async function downloadTranslationFromPhrase(phraseApi = { Configuration,
           id: phraseLocale.id,
           fileFormat: 'csv',
         });
-        await importTranslations(Readable.fromWeb(csvFile.stream()));
+
+        const translations = await parseTranslationsCsvStream(Readable.fromWeb(csvFile.stream()));
+
+        await importTranslations(translations);
       }
     } catch (e) {
       const text = (await e.text?.()) ?? e;

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -1,58 +1,26 @@
-import { localizedChallengeRepository, translationRepository } from '../../infrastructure/repositories/index.js';
-import { LocalizedChallenge, Translation } from '../models/index.js';
-import { parseStream } from 'fast-csv';
 import fp from 'lodash/fp.js';
 
-export class InvalidFileError extends Error {}
+import { knex } from '../../../db/knex-database-connection.js';
+import { localizedChallengeRepository, translationRepository } from '../../infrastructure/repositories/index.js';
+import { LocalizedChallenge } from '../models/index.js';
 
-export function importTranslations(csvStream, dependencies = { translationRepository, localizedChallengeRepository }) {
-  return new Promise((resolve, reject) => {
-    const translations = [];
-    let locale;
-    parseStream(csvStream, {
-      headers: (headers) => {
-        if (headers[0] !== 'key_name') throw new InvalidFileError('Expected first column to be key_name');
-        locale = headers[1];
-        try {
-          new Intl.Locale(locale);
-        } catch {
-          throw new InvalidFileError('Expected second column to be a valid locale');
-        }
-        return [
-          'key',
-          'value',
-          ...Array(headers.length - 2),
-        ];
-      },
-      objectMode: true,
-      strictColumnHandling: true,
-    })
-      .validate((data) => data.key && data.value)
-      .on('error', reject)
-      .on('data-invalid', (invalidData) => {
-        reject(new InvalidFileError(`Invalid data: ${JSON.stringify(invalidData)}`));
-      })
-      .on('data', (row) => {
-        translations.push(new Translation({ ...row, locale }));
-      })
-      .on('end', async () => {
-        const challengesLocales = extractChallengesLocales(translations);
-        await dependencies.localizedChallengeRepository.create({ localizedChallenges: challengesLocales });
+export async function importTranslations(translations, dependencies = { translationRepository, localizedChallengeRepository }) {
+  return knex.transaction(async (transaction) => {
+    if (translations.length === 0) return;
 
-        await dependencies.translationRepository.save({
-          translations,
-          shouldDuplicateToAirtable: false,
-        });
+    await dependencies.translationRepository.save({ translations, transaction });
 
-        resolve();
-      });
+    const localizedChallenges = extractLocalizedChallengesFromTranslations(translations);
+    if (localizedChallenges.length === 0) return;
+
+    await dependencies.localizedChallengeRepository.create({ localizedChallenges, transaction });
   });
 }
 
-const extractChallengesLocales = fp.flow(
+const extractLocalizedChallengesFromTranslations = fp.flow(
   fp.filter((translation) => {
     return translation.key.startsWith('challenge.');
   }),
+  fp.uniqBy(({ key, locale }) => `${key.slice(0, key.lastIndexOf('.'))}:${locale}`),
   fp.map(LocalizedChallenge.buildAlternativeFromTranslation),
-  fp.uniqBy(({ challengeId, locale }) => `${challengeId}:${locale}`),
 );

--- a/api/lib/infrastructure/serializers/phrase/translation-serializer.js
+++ b/api/lib/infrastructure/serializers/phrase/translation-serializer.js
@@ -1,0 +1,5 @@
+import { Translation } from '../../../domain/models/index.js';
+
+export function deserialize(payload) {
+  return new Translation({ key: payload.translation.key.name, locale: payload.translation.locale.code, value: payload.translation.content });
+}

--- a/api/sample.env
+++ b/api/sample.env
@@ -541,6 +541,13 @@ EXPORT_EXTERNAL_URLS_LIST_SPREADSHEET_ID=
 # default: none
 # PHRASE_PIX_NR_PROJECT_ID=xxxxx
 
+# The Phrase webhook secret
+#
+# presence: optional
+# type: String
+# default: none
+# PHRASE_WEBHOOK_SECRET=xxxxx
+
 # =================
 # UPLOAD TRANSLATION TO PHRASE JOB
 # =================

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -765,7 +765,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
     });
 
     describe('when event is translations:create', () => {
-      it.fails('saves the translation in database', async () => {
+      it('saves the translation in database', async () => {
         const payload = {
           event: 'translations:create',
           project: { id: config.phrase.projects[0].projectId },
@@ -805,7 +805,67 @@ describe('Acceptance | Controller | phrase-controller', () => {
         databaseBuilder.factory.buildFramework({ id: 'framework1', name: 'Pix' });
         databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' });
         databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+        await databaseBuilder.commit();
 
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+
+        await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([{ key: 'area.area1.title', locale: 'en', value: 'area1’s english title' }, { key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' }]);
+      });
+    });
+
+    describe('when event is translations:update', () => {
+      it('saves the translation in database', async () => {
+        const payload = {
+          event: 'translations:update',
+          project: { id: config.phrase.projects[0].projectId },
+          branch: null,
+          translation: {
+            id: 'translationId',
+            content: 'area1’s english title',
+            unverified: false,
+            excluded: false,
+            plural_suffix: '',
+            created_at: '2025-12-22T21:30:39Z',
+            updated_at: '2025-12-22T21:30:39Z',
+            placeholders: [],
+            state: 'translated',
+            linked_translation: null,
+            key: {
+              id: 'keyId',
+              name: 'area.area1.title',
+              plural: false,
+              use_ordinal_rules: false,
+              data_type: 'string',
+              tags: ['tag-1', 'tag-2'],
+              description: '',
+            },
+            locale: {
+              id: 'localeId',
+              name: 'en',
+              code: 'en',
+            },
+          },
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'framework1', name: 'Pix' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'en', value: 'area1’s english former title' });
         await databaseBuilder.commit();
 
         const server = await createServer();

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -625,4 +625,218 @@ describe('Acceptance | Controller | phrase-controller', () => {
       ]);
     });
   });
+
+  describe('POST /phrase/webhook', () => {
+    describe('when x-phraseapp-signature header is missing', () => {
+      it('returns a 401 status code', async () => {
+        // given
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+        });
+
+        // then
+        expect(response.statusCode).toBe(401);
+      });
+    });
+
+    describe('when x-phraseapp-signature does not match payload', () => {
+      it('returns a 400 status code', async () => {
+        // given
+        const payload = { event: 'test:event' };
+        const serializedPayload = JSON.stringify(payload);
+        const wrongSignature = Buffer.from('wrong signature').toString('base64');
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': wrongSignature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when event is test:event', () => {
+      it('returns a 204 status code', async () => {
+        // given
+        const payload = { event: 'test:event' };
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+      });
+    });
+
+    describe('when event is none of test:event, translations:create or translations:update', () => {
+      it('returns a 400 status code', async () => {
+        const payload = { event: 'unknown:event' };
+
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when branch is not null', () => {
+      it('returns a 400 status code', async () => {
+        const payload = {
+          event: 'translations:create',
+          branch: { id: 'branchId' },
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when project id does not match config', () => {
+      it('returns a 400 status code', async () => {
+        const payload = {
+          event: 'translations:create',
+          branch: null,
+          project: { id: 'NOT_MY_PHRASE_PROJECT_ID' },
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when event is translations:create', () => {
+      it.fails('saves the translation in database', async () => {
+        const payload = {
+          event: 'translations:create',
+          project: { id: config.phrase.projects[0].projectId },
+          branch: null,
+          translation: {
+            id: 'translationId',
+            content: 'area1’s english title',
+            unverified: false,
+            excluded: false,
+            plural_suffix: '',
+            created_at: '2025-12-22T21:30:39Z',
+            updated_at: '2025-12-22T21:30:39Z',
+            placeholders: [],
+            state: 'translated',
+            linked_translation: null,
+            key: {
+              id: 'keyId',
+              name: 'area.area1.title',
+              plural: false,
+              use_ordinal_rules: false,
+              data_type: 'string',
+              tags: ['tag-1', 'tag-2'],
+              description: '',
+            },
+            locale: {
+              id: 'localeId',
+              name: 'en',
+              code: 'en',
+            },
+          },
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'framework1', name: 'Pix' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+
+        await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([{ key: 'area.area1.title', locale: 'en', value: 'area1’s english title' }, { key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' }]);
+      });
+    });
+  });
 });
+
+async function generatePhraseAppSignature(payload) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(config.phrase.webhookSecret),
+    { name: 'HMAC', hash: { name: 'SHA-256' } },
+    false,
+    ['sign'],
+  );
+  const data = encoder.encode(payload);
+
+  return Buffer.from(await crypto.subtle.sign('HMAC', key, data)).toString('base64');
+}

--- a/api/tests/unit/domain/services/parse-translations-csv-stream_test.js
+++ b/api/tests/unit/domain/services/parse-translations-csv-stream_test.js
@@ -1,0 +1,70 @@
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { Translation } from '../../../../lib/domain/models/index.js';
+import { parseTranslationsCsvStream, InvalidFileError } from '../../../../lib/domain/services/parse-translations-csv-stream.js';
+
+describe('Unit | Domain | Services | parse-translations-csv-stream', function() {
+  let csvStream;
+
+  beforeEach(() => {
+    csvStream = new PassThrough();
+  });
+
+  it('should parse translations from CSV', async () => {
+    // given
+    csvStream.write('key_name,nl,comment\nchallenge.id.key,Hallo,\nchallenge.id.key2,Hallo2,\nchallenge.id2.key,Hallo3,\narea.area1.title,Harea,');
+    csvStream.end();
+
+    // when
+    const translations = await parseTranslationsCsvStream(csvStream);
+
+    // then
+    expect(translations).toStrictEqual([
+      new Translation({
+        key: 'challenge.id.key',
+        locale: 'nl',
+        value: 'Hallo',
+      }),
+      new Translation({
+        key: 'challenge.id.key2',
+        locale: 'nl',
+        value: 'Hallo2',
+      }),
+      new Translation({
+        key: 'challenge.id2.key',
+        locale: 'nl',
+        value: 'Hallo3',
+      }),
+      new Translation({
+        key: 'area.area1.title',
+        locale: 'nl',
+        value: 'Harea',
+      }),
+    ]);
+  });
+
+  it("should return an error when the CSV doesn't have key_name as first column", async () => {
+    // given
+    csvStream.write('one invalid header,nl,comment\navalue,anotherone,');
+    csvStream.end();
+
+    // when
+    const result = parseTranslationsCsvStream(csvStream);
+
+    // then
+    await expect(result).rejects.toThrow(new InvalidFileError('Expected first column to be key_name'));
+  });
+
+  it("should return an error when the CSV doesn't have a valid locale as second column", async () => {
+    // given
+    csvStream.write('key_name,invalid_locale,comment\navalue,anotherone,');
+    csvStream.end();
+
+    // when
+    const result = parseTranslationsCsvStream(csvStream);
+
+    // then
+    await expect(result).rejects.toThrow(new InvalidFileError('Expected second column to be a valid locale'));
+  });
+});

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -1,135 +1,72 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { LocalizedChallenge, Translation } from '../../../../lib/domain/models/index.js';
-import { importTranslations, InvalidFileError } from '../../../../lib/domain/usecases/index.js';
-import { PassThrough } from 'node:stream';
+import { domainBuilder } from '../../../test-helper.js';
 
-describe('Unit | Domain | Usecases | import-translations', function() {
-  let csvStream;
-  let localizedChallengeRepository;
-  let translationRepository;
+import { importTranslations } from '../../../../lib/domain/usecases/index.js';
+import { LocalizedChallenge } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Use Cases | import-translations', () => {
+  let localizedChallengeRepository, translationRepository;
 
   beforeEach(() => {
-    csvStream = new PassThrough();
     localizedChallengeRepository = { create: vi.fn() };
     translationRepository = { save: vi.fn() };
   });
 
-  it('should write in database translation from CSV', async () => {
-    // when
-    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
-    csvStream.write('key_name,nl,comment\nsome.key,Hallo,');
-    csvStream.end();
+  describe('when given translations array is empty', () => {
+    it('does nothing', async () => {
+      // given
+      const translations = [];
 
-    // then
-    await promise;
+      // when
+      await importTranslations(translations, { localizedChallengeRepository, translationRepository });
 
-    expect(translationRepository.save).toHaveBeenCalledOnce();
-    expect(translationRepository.save).toHaveBeenCalledWith({
-      translations: [
-        new Translation({
-          key: 'some.key',
-          locale: 'nl',
-          value: 'Hallo',
-        }),
-      ],
-      shouldDuplicateToAirtable: false,
+      // then
+      expect(localizedChallengeRepository.create).not.toHaveBeenCalled();
+      expect(translationRepository.save).not.toHaveBeenCalled();
     });
   });
 
-  it("should return an error when the CSV doesn't have key_name as first column", async () => {
-    // when
-    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
-    csvStream.write('one invalid header,nl,comment\navalue,anotherone,');
-    csvStream.end();
+  describe('when there is no challenge translations', () => {
+    it('save only translations to DB', async () => {
+      // given
+      const translations = [domainBuilder.buildTranslation({ key: 'area.area123.title', locale: 'nl', value: 'area123 title nl' }), domainBuilder.buildTranslation({ key: 'competence.competence456.name', locale: 'es', value: 'competence456 name es' })];
 
-    // then
-    await expect(promise).rejects.toThrow(new InvalidFileError('Expected first column to be key_name'));
-    expect(translationRepository.save).not.toHaveBeenCalled();
-  });
+      // when
+      await importTranslations(translations, { localizedChallengeRepository, translationRepository });
 
-  it("should return an error when the CSV doesn't have a valid locale as second column", async () => {
-    // when
-    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
-    csvStream.write('key_name,invalid_locale,comment\navalue,anotherone,');
-    csvStream.end();
-
-    // then
-    await expect(promise).rejects.toThrow(new InvalidFileError('Expected second column to be a valid locale'));
-    expect(translationRepository.save).not.toHaveBeenCalled();
-  });
-
-  it('should create a localized challenge when a new locale is added', async () => {
-    // when
-    const promise = importTranslations(csvStream, { localizedChallengeRepository, translationRepository });
-    csvStream.write(
-      'key_name,nl,comment\nchallenge.id.key,Hallo,\nchallenge.id.key2,Hallo2,\nchallenge.id2.key,Hallo3,',
-    );
-    csvStream.end();
-
-    // then
-    await promise;
-
-    expect(translationRepository.save).toHaveBeenCalledOnce();
-    expect(translationRepository.save).toHaveBeenCalledWith({
-      translations: [
-        new Translation({
-          key: 'challenge.id.key',
-          locale: 'nl',
-          value: 'Hallo',
-        }),
-        new Translation({
-          key: 'challenge.id.key2',
-          locale: 'nl',
-          value: 'Hallo2',
-        }),
-        new Translation({
-          key: 'challenge.id2.key',
-          locale: 'nl',
-          value: 'Hallo3',
-        }),
-      ],
-      shouldDuplicateToAirtable: false,
+      // then
+      expect(localizedChallengeRepository.create).not.toHaveBeenCalled();
+      expect(translationRepository.save).toHaveBeenCalledExactlyOnceWith({ translations, transaction: expect.any(Function) });
     });
-    expect(localizedChallengeRepository.create).toHaveBeenCalledOnce();
-    expect(localizedChallengeRepository.create).toHaveBeenCalledWith({
-      localizedChallenges: [
-        new LocalizedChallenge({
-          id: null,
-          challengeId: 'id',
-          locale: 'nl',
-          status: LocalizedChallenge.STATUSES.PAUSE,
-          embedUrl: null,
-          fileIds: [],
-          geography: 'AA',
-          urlsToConsult: null,
-          requireGafamWebsiteAccess: false,
-          isIncompatibleIpadCertif: false,
-          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
-          isAwarenessChallenge: false,
-          toRephrase: false,
-          hasEmbedInternalValidation: false,
-          noValidationNeeded: false,
-          validatedAt: null,
-        }),
-        new LocalizedChallenge({
-          id: null,
-          challengeId: 'id2',
-          locale: 'nl',
-          status: LocalizedChallenge.STATUSES.PAUSE,
-          embedUrl: null,
-          fileIds: [],
-          geography: 'AA',
-          urlsToConsult: null,
-          requireGafamWebsiteAccess: false,
-          isIncompatibleIpadCertif: false,
-          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
-          isAwarenessChallenge: false,
-          toRephrase: false,
-          hasEmbedInternalValidation: false,
-          noValidationNeeded: false,
-          validatedAt: null,
-        }),
-      ],
+  });
+
+  describe('when there are challenge translations', () => {
+    it('save translations and localizedChallenges to DB', async () => {
+      // given
+      const translations = [
+        domainBuilder.buildTranslation({ key: 'area.area123.title', locale: 'nl', value: 'area123 title nl' }),
+        domainBuilder.buildTranslation({ key: 'competence.competence456.name', locale: 'es', value: 'competence456 name es' }),
+        domainBuilder.buildTranslation({ key: 'challenge.challenge789.instruction', locale: 'nl', value: 'challenge789 instruction nl' }),
+        domainBuilder.buildTranslation({ key: 'challenge.challenge789.solution', locale: 'nl', value: 'challenge789 solution nl' }),
+        domainBuilder.buildTranslation({ key: 'challenge.challenge789.instruction', locale: 'es', value: 'challenge789 instruction es' }),
+        domainBuilder.buildTranslation({ key: 'challenge.challenge789.solution', locale: 'es', value: 'challenge789 solution es' }),
+        domainBuilder.buildTranslation({ key: 'challenge.challenge321.instruction', locale: 'nl', value: 'challenge321 instruction nl' }),
+        domainBuilder.buildTranslation({ key: 'challenge.challenge321.solution', locale: 'nl', value: 'challenge321 solution nl' }),
+      ];
+
+      // when
+      await importTranslations(translations, { localizedChallengeRepository, translationRepository });
+
+      // then
+      expect(localizedChallengeRepository.create).toHaveBeenCalledExactlyOnceWith({
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({ challengeId: 'challenge789', locale: 'nl', id: null, embedUrl: null, status: LocalizedChallenge.STATUSES.PAUSE, urlsToConsult: null }),
+          domainBuilder.buildLocalizedChallenge({ challengeId: 'challenge789', locale: 'es', id: null, embedUrl: null, status: LocalizedChallenge.STATUSES.PAUSE, urlsToConsult: null }),
+          domainBuilder.buildLocalizedChallenge({ challengeId: 'challenge321', locale: 'nl', id: null, embedUrl: null, status: LocalizedChallenge.STATUSES.PAUSE, urlsToConsult: null }),
+        ],
+        transaction: expect.any(Function),
+      });
+      expect(translationRepository.save).toHaveBeenCalledExactlyOnceWith({ translations, transaction: expect.any(Function) });
     });
   });
 });


### PR DESCRIPTION
## ❄️ Problème

Phrase met à disposition des webhooks permettant d’écouter des évènements et notamment :

- Traduction créé pour une clé
- Traduction modifiée pour une clé

## 🛷 Proposition

On souhaite écouter ces événements afin de ne plus avoir à utiliser le bouton “Récupérer les traductions”.

## ☃️ Remarques

[Documentation des webhooks phrase](https://support.phrase.com/hc/en-us/articles/5784125630620-Webhooks-Strings).

## 🧑‍🎄 Pour tester

Créer ou mettre à jour une traduction sur le projet "Referentiel - integration - Domaine 1".

Vérifier que la traduction arrive bien en BdD sur la RA.