### PR TITLE
[FEATURE] Permettre l’édition des acquis archivés (PIX-20823)

### DIFF
--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -33,7 +33,7 @@ export default class AccessService extends Service {
   }
 
   mayEditSkill(skill) {
-    return this.mayEditSkills() && skill.isLive;
+    return this.mayEditSkills() && !skill.isObsolete;
   }
 
   mayMoveTube(tube) {


### PR DESCRIPTION
## ❄️ Problème

Dans PixEditor, on ne peut modifier un acquis que s’il est “en construction” ou “validé”. 

Si un acquis vient d'être archivé et qu’un tuto est KO on ne peut pas le retirer. Cela est gênant car il continue d'être proposé au sein de campagnes d'évaluation. On ne peut pas périmer l’acquis sans impacter de nombreuses campagnes.

## 🛷 Proposition

Il faudrait permettre de modifier également les acquis “archivé”.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Essayer d’éditer un acquis archivé.