### PR TITLE
[TECH] Afficher les logs des appels réseaux mirage dans le cadre des tests de PixEditor

### DIFF
--- a/pix-editor/tests/test-support/setup-mirage.js
+++ b/pix-editor/tests/test-support/setup-mirage.js
@@ -9,6 +9,7 @@ import makeServer from '../mirage/config';
 export function setupMirage(hooks) {
   hooks.beforeEach(function () {
     this.server = makeServer({ environment: 'test' });
+    this.server.logging = true;
   });
 
   hooks.afterEach(async function () {


### PR DESCRIPTION
## ❄️ Problème

Depuis le passage à mirage, y'a plus la case à cocher pour voir les logs Mirage dans la console du développeur (et c'est dommage car c'est bien pratique)

## 🛷 Proposition

Les remettre pour tout le temps

## ☃️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🧑‍🎄 Pour tester

lancer les tests et ouvrir la console du dev pour voir les logs mirage
