### PR TITLE
[FEATURE] Ajout de 2 nouveaux types pédagogies pour les épreuves (PIX-20824)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -118,6 +118,8 @@ export class Challenge {
       E_PREUVE: 'e-preuve',
       Q_SAVOIR: 'q-savoir',
       Q_SITUATION: 'q-situation',
+      E_RECHINFO: 'e-rechinfo',
+      E_SIMULATION: 'e-simulation',
     };
   }
 

--- a/pix-editor/app/components/form/challenge.gjs
+++ b/pix-editor/app/components/form/challenge.gjs
@@ -321,6 +321,8 @@ export default class ChallengeForm extends Component {
       { label: 'e-preuve', value: 'e-preuve' },
       { label: 'q-savoir', value: 'q-savoir' },
       { label: 'q-situation', value: 'q-situation' },
+      { label: 'e-rechinfo', value: 'e-rechinfo' },
+      { label: 'e-simulation', value: 'e-simulation' },
     ],
     declinable: [
       { label: 'facilement', value: 'facilement' },


### PR DESCRIPTION
## ❄️ Problème
Le métier a besoin de distinguer 2 nouveaux types pédagogiques `e-rechinfo` et `e-simulation`

## 🛷 Proposition
Ajouter ces 2 nouveaux types dans le back et le front

## ☃️ Remarques
Les seeds sont si bien faites qu'il n'y a pas besoin de retravailler dessus :)
Pas besoin de faire de la reprise de données.

## 🧑‍🎄 Pour tester
Allez en v1 dans la modification d'une épreuve, et constater qu'on peut choisir ces deux nouveaux `types pédagogiques` et qu'ils persistent à l'enregistrement. Tests au vert ✅ 
