### PR TITLE
[FEATURE] Script de migration des tutos Youtube vers app.pix.fr/youtube-video.html (PIX-20898)

### DIFF
--- a/api/lib/domain/models/Tutorial.js
+++ b/api/lib/domain/models/Tutorial.js
@@ -1,3 +1,13 @@
+const YOUTUBE_DOMAINS = [
+  { pattern: /^(https:\/\/)?(www\.)?youtube-nocookie\.com\//, getVideoId: (url) => url.pathname.replace(/^\/embed\//, '') },
+  { pattern: /^(https:\/\/)?(www\.)?youtube\.com\/watch/, getVideoId: (url) => url.searchParams.get('v') },
+  { pattern: /^(https:\/\/)?youtu\.be\//, getVideoId: (url) => url.pathname.replace(/^\//, '') },
+];
+
+const HAS_PROTOCOL_PATTERN = /^https:\/\//i;
+
+const PIX_YOUTUBE_URL = 'https://app.pix.fr/youtube-video.html';
+
 export class Tutorial {
   constructor({
     id,
@@ -79,5 +89,42 @@ export class Tutorial {
     this.crush = tutorial.crush;
     this.locale = tutorial.locale;
     this.tagAirtableIds = tutorial.tagAirtableIds;
+  }
+
+  get isYoutubeVideoLink() {
+    return YOUTUBE_DOMAINS.some((youtubeDomain) => youtubeDomain.pattern.test(this.link));
+  }
+
+  rewriteYoutubeVideoLink({ logger }) {
+    const youtubeDomain = YOUTUBE_DOMAINS.find((youtubeDomain) => youtubeDomain.pattern.test(this.link));
+    if (youtubeDomain == null) {
+      logger.warn({ tutorialId: this.id, link: this.link }, 'Trying to rewrite a link that is not a Youtube video');
+      return;
+    }
+
+    const oldLink = new URL(HAS_PROTOCOL_PATTERN.test(this.link) ? this.link : `https://${this.link}`);
+    const videoId = youtubeDomain.getVideoId(oldLink);
+
+    if (videoId == null) {
+      logger.warn({ tutorialId: this.id, link: oldLink }, 'Could not rewrite tutorial link');
+      return;
+    }
+
+    const newLink = new URL(PIX_YOUTUBE_URL);
+    newLink.searchParams.set('v', videoId);
+
+    if (oldLink.searchParams.has('start')) {
+      newLink.searchParams.set('start', oldLink.searchParams.get('start'));
+    } else if (oldLink.searchParams.has('t')) {
+      newLink.searchParams.set('start', oldLink.searchParams.get('t'));
+    }
+
+    if (oldLink.searchParams.has('end')) {
+      newLink.searchParams.set('end', oldLink.searchParams.get('end'));
+    }
+
+    logger.info({ tutorialId: this.id, oldLink, newLink }, 'Rewritten tutorial link');
+
+    this.link = newLink.href;
   }
 }

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -42,46 +42,52 @@ export async function create(tutorial) {
   });
 }
 
-export async function update(tutorial) {
-  return knex.transaction(async (transaction) => {
-    await transaction(TABLE_NAME)
-      .update({
-        title: tutorial.title,
-        duration: tutorial.duration,
-        source: tutorial.source,
-        format: tutorial.format,
-        link: tutorial.link,
-        license: tutorial.license,
-        level: tutorial.level,
-        crush: tutorial.crush,
-        locale: tutorial.locale,
-        updatedAt: transaction.fn.now(),
-      })
-      .where('id', tutorial.id);
+export async function update(tutorial, { transaction } = {}) {
+  if (transaction) {
+    return doUpdate(tutorial, transaction);
+  } else {
+    return knex.transaction(async(transaction) => doUpdate(tutorial, transaction));
+  }
+}
 
+async function doUpdate(tutorial, transaction) {
+  await transaction(TABLE_NAME)
+    .update({
+      title: tutorial.title,
+      duration: tutorial.duration,
+      source: tutorial.source,
+      format: tutorial.format,
+      link: tutorial.link,
+      license: tutorial.license,
+      level: tutorial.level,
+      crush: tutorial.crush,
+      locale: tutorial.locale,
+      updatedAt: transaction.fn.now(),
+    })
+    .where('id', tutorial.id);
+
+  await transaction
+    .delete()
+    .from(TAGS_RELATION_TABLE_NAME)
+    .where('tutorialId', tutorial.id)
+    .whereNotIn('tutorialTagId', tutorial.tagAirtableIds);
+  if (tutorial.tagAirtableIds.length !== 0) {
     await transaction
-      .delete()
-      .from(TAGS_RELATION_TABLE_NAME)
-      .where('tutorialId', tutorial.id)
-      .whereNotIn('tutorialTagId', tutorial.tagAirtableIds);
-    if (tutorial.tagAirtableIds.length !== 0) {
-      await transaction
-        .insert(
-          tutorial.tagAirtableIds.map((tutorialTagId) => ({
-            tutorialId: tutorial.id,
-            tutorialTagId,
-            updatedAt: transaction.fn.now(),
-          })),
-        )
-        .into(TAGS_RELATION_TABLE_NAME)
-        .onConflict(['tutorialId', 'tutorialTagId'])
-        .merge({ updatedAt: transaction.fn.now() });
-    }
+      .insert(
+        tutorial.tagAirtableIds.map((tutorialTagId) => ({
+          tutorialId: tutorial.id,
+          tutorialTagId,
+          updatedAt: transaction.fn.now(),
+        })),
+      )
+      .into(TAGS_RELATION_TABLE_NAME)
+      .onConflict(['tutorialId', 'tutorialTagId'])
+      .merge({ updatedAt: transaction.fn.now() });
+  }
 
-    const dto = await selectTutorials(transaction).where('tutorials.id', tutorial.id).first();
+  const dto = await selectTutorials(transaction).where('tutorials.id', tutorial.id).first();
 
-    return toDomain(dto);
-  });
+  return toDomain(dto);
 }
 
 export async function get(id) {
@@ -136,8 +142,11 @@ export async function getMany(ids) {
   return dtos.map(toDomain);
 }
 
-export async function list() {
-  const dtos = await selectTutorials().orderBy('id');
+export async function list({ transaction, forUpdate = false } = {}) {
+  const query = selectTutorials(transaction).orderBy('id');
+  if (forUpdate) query.forUpdate();
+
+  const dtos = await query;
 
   return dtos.map(toDomain);
 }

--- a/api/scripts/migrate-youtube-tutorials.js
+++ b/api/scripts/migrate-youtube-tutorials.js
@@ -1,0 +1,48 @@
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+import { knex } from '../db/knex-database-connection.js';
+import { tutorialRepository } from '../lib/infrastructure/repositories/index.js';
+
+export class MigrateYoutubeTutorials extends Script {
+  constructor() {
+    super({
+      description: 'Script de migration des tutoriels Youtube vers l’URL https://app.pix.fr/youtube-video.html',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not perform any migration.',
+          demandOption: true,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    await knex.transaction(async (transaction) => {
+      const tutorials = await tutorialRepository.list({ transaction, forUpdate: true });
+
+      const youtubeVideoTutorials = tutorials.filter((tutorial) => tutorial.isYoutubeVideoLink);
+
+      if (tutorials.length === 0) {
+        logger.info('No Youtube video tutorials found');
+        return;
+      }
+      logger.info({ count: youtubeVideoTutorials.length }, 'Youtube video tutorials found');
+
+      youtubeVideoTutorials.forEach((tutorial) => tutorial.rewriteYoutubeVideoLink({ logger }));
+
+      await Promise.all(youtubeVideoTutorials.map((tutorial) => tutorialRepository.update(tutorial, { transaction })));
+
+      if (options.dryRun) {
+        logger.info('Dry run, rolling back modifications');
+        await transaction.rollback();
+      }
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, MigrateYoutubeTutorials);

--- a/api/tests/scripts/migrate-youtube-tutorials_test.js
+++ b/api/tests/scripts/migrate-youtube-tutorials_test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { databaseBuilder, domainBuilder, knex } from '../test-helper.js';
+import { MigrateYoutubeTutorials } from '../../scripts/migrate-youtube-tutorials.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+
+describe('Script | MigrateYoutubeTutorials', () => {
+  /** @type {MigrateYoutubeTutorials} */
+  let script;
+
+  beforeEach(() => {
+    script = new MigrateYoutubeTutorials();
+  });
+
+  describe('#handle', () => {
+    beforeEach(async () => {
+      const tutorials = [
+        { id: 'tuto', link: 'https://test.youtube.com/watch?v=nop', tagIds: [] },
+        { id: 'youtube', link: 'https://youtu.be/youtube2videoId?t=123', tagIds: [] },
+        { id: 'youtubecom', link: 'www.youtube.com/watch?v=youtubecomvideoId&start=333&end=666', tagIds: [] },
+        { id: 'youtubenocookie', link: 'https://www.youtube-nocookie.com/embed/youtubenocookievideoId?start=123', tagIds: [] },
+      ];
+
+      tutorials.map(domainBuilder.buildTutorialDatasourceObject).forEach(databaseBuilder.factory.buildTutorial);
+
+      await databaseBuilder.commit();
+    });
+
+    it('migrates youtube tutorials to PixApp’s Youtube page', async () => {
+      // given
+      const options = { dryRun: false };
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      await expect(knex.select('id', 'link').from('tutorials').orderBy('id')).resolves.toStrictEqual([
+        { id: 'tuto', link: 'https://test.youtube.com/watch?v=nop' },
+        { id: 'youtube', link: 'https://app.pix.fr/youtube-video.html?v=youtube2videoId&start=123' },
+        { id: 'youtubecom', link: 'https://app.pix.fr/youtube-video.html?v=youtubecomvideoId&start=333&end=666' },
+        { id: 'youtubenocookie', link: 'https://app.pix.fr/youtube-video.html?v=youtubenocookievideoId&start=123' },
+      ]);
+    });
+
+    describe('when dryRun option is true', () => {
+      it('rollbacks modifications', async () => {
+        // given
+        const options = { dryRun: true };
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        await expect(knex.select('id', 'link').from('tutorials').orderBy('id')).resolves.toStrictEqual([
+          { id: 'tuto', link: 'https://test.youtube.com/watch?v=nop' },
+          { id: 'youtube', link: 'https://youtu.be/youtube2videoId?t=123' },
+          { id: 'youtubecom', link: 'www.youtube.com/watch?v=youtubecomvideoId&start=333&end=666' },
+          { id: 'youtubenocookie', link: 'https://www.youtube-nocookie.com/embed/youtubenocookievideoId?start=123' },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/models/Tutorial_test.js
+++ b/api/tests/unit/domain/models/Tutorial_test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Tutorial } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Tutorial', () => {
+  describe('#get isYoutubeVideoLink', () => {
+    it('is true when tutorial’s link references a Youtube video', () => {
+      // given
+      const youtubeVideoLinks = [
+        'https://youtu.be/youtubecom1videoId',
+        'https://youtu.be/youtubecom2videoId?t=123',
+        'https://www.youtube.com/watch?v=youtubecom1videoId',
+        'youtube.com/watch?v=youtubecom2videoId&t=666s',
+        'https://youtube.com/watch?v=youtubecom3videoId&start=333',
+        'www.youtube.com/watch?v=youtubecom4videoId&start=333&end=666',
+        'https://www.youtube-nocookie.com/embed/youtubenocookie1videoId',
+        'https://www.youtube-nocookie.com/embed/youtubenocookie3videoId?start=123',
+        'https://www.youtube-nocookie.com/embed/youtubenocookie3videoId?start=123&end=456',
+      ];
+
+      // when
+      const tutorials = youtubeVideoLinks.map((link) => new Tutorial({ link }));
+
+      // then
+      tutorials.forEach((tutorial) => expect(tutorial).toHaveProperty('isYoutubeVideoLink', true));
+    });
+
+    it('is false when tutorial’s link doesn’t reference a Youtube video', () => {
+      // given
+      const nonYoutubeVideoLinks = [
+        'https://test.youtube.com/watch?v=nop',
+        'https://example.com/embed/pouet',
+        'https://app.pix.fr/youtube-video.html?v=test&start=123',
+      ];
+
+      // when
+      const tutorials = nonYoutubeVideoLinks.map((link) => new Tutorial({ link }));
+
+      // then
+      tutorials.forEach((tutorial) => expect(tutorial).toHaveProperty('isYoutubeVideoLink', false));
+    });
+  });
+
+  describe('#rewriteYoutubeVideoLink', () => {
+    it('rewrites Youtube video links when possible', () => {
+      // given
+      const links = [
+        { given: 'https://test.youtube.com/watch?v=nop', expected: 'https://test.youtube.com/watch?v=nop' },
+        { given: 'https://example.com/embed/pouet', expected: 'https://example.com/embed/pouet' },
+        { given: 'https://youtu.be/youtubecom1videoId', expected: 'https://app.pix.fr/youtube-video.html?v=youtubecom1videoId' },
+        { given: 'https://youtu.be/youtubecom2videoId?t=123', expected: 'https://app.pix.fr/youtube-video.html?v=youtubecom2videoId&start=123' },
+        { given: 'https://www.youtube.com/watch?v=youtubecom1videoId', expected: 'https://app.pix.fr/youtube-video.html?v=youtubecom1videoId' },
+        { given: 'https://www.youtube.com/watch?t=789', expected: 'https://www.youtube.com/watch?t=789' },
+        { given: 'youtube.com/watch?v=youtubecom2videoId&t=666s', expected: 'https://app.pix.fr/youtube-video.html?v=youtubecom2videoId&start=666s' },
+        { given: 'https://youtube.com/watch?v=youtubecom3videoId&start=333', expected: 'https://app.pix.fr/youtube-video.html?v=youtubecom3videoId&start=333' },
+        { given: 'www.youtube.com/watch?v=youtubecom4videoId&start=333&end=666', expected: 'https://app.pix.fr/youtube-video.html?v=youtubecom4videoId&start=333&end=666' },
+        { given: 'https://www.youtube-nocookie.com/embed/youtubenocookie1videoId', expected: 'https://app.pix.fr/youtube-video.html?v=youtubenocookie1videoId' },
+        { given: 'https://www.youtube-nocookie.com/embed/youtubenocookie3videoId?start=123', expected: 'https://app.pix.fr/youtube-video.html?v=youtubenocookie3videoId&start=123' },
+        { given: 'https://www.youtube-nocookie.com/embed/youtubenocookie3videoId?start=123&end=456', expected: 'https://app.pix.fr/youtube-video.html?v=youtubenocookie3videoId&start=123&end=456' },
+      ];
+
+      const tutorials = links.map((link) => new Tutorial({ link: link.given }));
+
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      // when
+      tutorials.forEach((tutorial) => tutorial.rewriteYoutubeVideoLink({ logger }));
+
+      // then
+      tutorials.forEach((tutorial, index) => expect(tutorial).toHaveProperty('link', links[index].expected));
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

On veut que la visualisation des tutos Youtube passe par la page app.pix.fr/youtube-video.html
Il faut migrer les tutos Youtube existants.

## 🛷 Proposition

Écrire un script de migration.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

À tester fonctionnellement en prod en dry run.