### PR TITLE
[FEATURE] Enregistrement de tutos Youtube (PIX-20899)

### DIFF
--- a/api/lib/domain/usecases/create-tutorial.js
+++ b/api/lib/domain/usecases/create-tutorial.js
@@ -1,6 +1,10 @@
+import { logger } from '../../infrastructure/logger.js';
 import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 export async function createTutorial(tutorial, dependencies = { tutorialRepository }) {
+  if (tutorial.isYoutubeVideoLink) {
+    tutorial.rewriteYoutubeVideoLink({ logger });
+  }
   const createdTutorial = await dependencies.tutorialRepository.create(tutorial);
   await updatePixApiReleaseCache.onTutorialCreated(createdTutorial);
   return createdTutorial;

--- a/api/lib/domain/usecases/update-tutorial.js
+++ b/api/lib/domain/usecases/update-tutorial.js
@@ -1,3 +1,4 @@
+import { logger } from '../../infrastructure/logger.js';
 import { NotFoundError } from '../errors.js';
 import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
@@ -7,6 +8,9 @@ export async function updateTutorial(tutorialData, dependencies = { tutorialRepo
     throw new NotFoundError('unknown tutorial id');
   }
   tutorial.update(tutorialData);
+  if (tutorial.isYoutubeVideoLink) {
+    tutorial.rewriteYoutubeVideoLink({ logger });
+  }
   const updatedTutorial = await dependencies.tutorialRepository.update(tutorial);
   await updatePixApiReleaseCache.onTutorialUpdated(updatedTutorial);
   return updatedTutorial;

--- a/api/tests/unit/domain/usecases/create-tutorial_test.js
+++ b/api/tests/unit/domain/usecases/create-tutorial_test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTutorial } from '../../../../lib/domain/usecases/index.js';
+import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
+import { Tutorial } from '../../../../lib/domain/models/index.js';
+
+describe('Unit | Domain | Use Cases | create-tutorial', () => {
+  const createdTutorial = Symbol('createdTutorial');
+  let tutorialRepository, dependencies, onTutorialCreated;
+
+  beforeEach(() => {
+    tutorialRepository = { create: vi.fn().mockResolvedValueOnce(createdTutorial) };
+    dependencies = { tutorialRepository };
+
+    onTutorialCreated = vi.spyOn(updatePixApiReleaseCache, 'onTutorialCreated').mockResolvedValueOnce();
+  });
+
+  it('saves the tutorial to database and notifies PixApi', async () => {
+    // given
+    const tutorial = new Tutorial({});
+
+    // when
+    const result = await createTutorial(tutorial, dependencies);
+
+    // then
+    expect(result).toBe(createdTutorial);
+    expect(tutorialRepository.create).toHaveBeenCalledExactlyOnceWith(tutorial);
+    expect(onTutorialCreated).toHaveBeenCalledExactlyOnceWith(createdTutorial);
+  });
+
+  describe('when tutorial has a Youtube video link', () => {
+    it('is saved with a app.pix.fr/youtube-video.html link', async () => {
+      // given
+      const tutorial = new Tutorial({ link: 'youtu.be/videoid' });
+
+      // when
+      const result = await createTutorial(tutorial, dependencies);
+
+      // then
+      expect(result).toBe(createdTutorial);
+      expect(tutorialRepository.create).toHaveBeenCalledExactlyOnceWith(new Tutorial({ link: 'https://app.pix.fr/youtube-video.html?v=videoid' }));
+      expect(onTutorialCreated).toHaveBeenCalledExactlyOnceWith(createdTutorial);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/update-tutorial_test.js
+++ b/api/tests/unit/domain/usecases/update-tutorial_test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { updateTutorial } from '../../../../lib/domain/usecases/index.js';
+import * as updatePixApiReleaseCache from '../../../../lib/domain/services/update-pix-api-release-cache.js';
+import { Tutorial } from '../../../../lib/domain/models/index.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | Domain | Use Cases | update-tutorial', () => {
+  const updatedTutorial = Symbol('updatedTutorial');
+  let tutorialRepository, dependencies, onTutorialUpdated;
+
+  beforeEach(() => {
+    tutorialRepository = { get: vi.fn(), update: vi.fn().mockResolvedValueOnce(updatedTutorial) };
+    dependencies = { tutorialRepository };
+
+    onTutorialUpdated = vi.spyOn(updatePixApiReleaseCache, 'onTutorialUpdated').mockResolvedValueOnce();
+  });
+
+  it('saves the tutorial to database and notifies PixApi', async () => {
+    // given
+    const existingTutorial = { update: vi.fn() };
+    tutorialRepository.get.mockResolvedValueOnce(existingTutorial);
+
+    const tutorial = new Tutorial({ airtableId: 'existingTutorial' });
+
+    // when
+    const result = await updateTutorial(tutorial, dependencies);
+
+    // then
+    expect(result).toBe(updatedTutorial);
+    expect(tutorialRepository.get).toHaveBeenCalledExactlyOnceWith('existingTutorial');
+    expect(existingTutorial.update).toHaveBeenCalledExactlyOnceWith(tutorial);
+    expect(tutorialRepository.update).toHaveBeenCalledExactlyOnceWith(existingTutorial);
+    expect(onTutorialUpdated).toHaveBeenCalledExactlyOnceWith(updatedTutorial);
+  });
+
+  describe('when tutorial does not exist', () => {
+    it('throws a NotFoundError', async () => {
+      tutorialRepository.get.mockResolvedValueOnce(null);
+      const tutorial = new Tutorial({ airtableId: 'unknownTutorial' });
+
+      // when
+      const result = updateTutorial(tutorial, dependencies);
+
+      await expect(result).rejects.toStrictEqual(new NotFoundError('unknown tutorial id'));
+    });
+  });
+
+  describe('when tutorial has a Youtube video link', () => {
+    it('migrates Youtube video link to app.pix.fr/youtube-video.html before saving', async () => {
+      // given
+      const existingTutorial = { update: vi.fn(), isYoutubeVideoLink: true, rewriteYoutubeVideoLink: vi.fn() };
+      tutorialRepository.get.mockResolvedValueOnce(existingTutorial);
+
+      const tutorial = new Tutorial({ airtableId: 'existingTutorial' });
+
+      // when
+      const result = await updateTutorial(tutorial, dependencies);
+
+      // then
+      expect(result).toBe(updatedTutorial);
+      expect(tutorialRepository.get).toHaveBeenCalledExactlyOnceWith('existingTutorial');
+      expect(existingTutorial.update).toHaveBeenCalledExactlyOnceWith(tutorial);
+      expect(existingTutorial.rewriteYoutubeVideoLink).toHaveBeenCalledExactlyOnceWith({ logger: expect.any(Object) });
+      expect(tutorialRepository.update).toHaveBeenCalledExactlyOnceWith(existingTutorial);
+      expect(onTutorialUpdated).toHaveBeenCalledExactlyOnceWith(updatedTutorial);
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Lorsqu’on enregistre un tutos avec un lien vers Youtube, on souhaite que ce lien soit réécris pour pointer sur app.pix.fr/youtube-video.html

## 🛷 Proposition

Réécrire les liens YT à l’enregistrement de tuto.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Créer ou modifier un tuto et vérifier que le lien se fait réécrire.