### PR TITLE
[TECH] Ajout d'un script pour créer des entité localizedFrameworkTubes (PIX-20981)

### DIFF
--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -21,7 +21,7 @@ export async function upsert(request, h) {
   });
   localizeFrameworkTube.validate();
 
-  const createdLocalizedFrameworkTubes = await localizedFrameworksTubesRepository.save(localizeFrameworkTube);
+  const createdLocalizedFrameworkTubes = await localizedFrameworksTubesRepository.save([localizeFrameworkTube]);
   return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(createdLocalizedFrameworkTubes)).created();
 }
 

--- a/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
+++ b/api/lib/application/localized-framework-tubes/localized-framework-tubes-controller.js
@@ -21,8 +21,9 @@ export async function upsert(request, h) {
   });
   localizeFrameworkTube.validate();
 
-  const createdLocalizedFrameworkTubes = await localizedFrameworksTubesRepository.save([localizeFrameworkTube]);
-  return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(createdLocalizedFrameworkTubes)).created();
+  const [createdLocalizedFrameworkTube] = await localizedFrameworksTubesRepository.save([localizeFrameworkTube]);
+
+  return h.response(localizedFrameworkTubesSerializer.serializeLocalizedFrameworkTubes(createdLocalizedFrameworkTube)).created();
 }
 
 export async function remove(request, h) {

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -39,8 +39,8 @@ export async function list() {
   return toDomainList(dtos, translations);
 }
 
-export async function listByFrameworkId(frameworkId) {
-  const [dtos, translations] = await Promise.all([selectAreas().where('frameworkId', frameworkId).orderBy('code'), translationRepository.listByModel(model)]);
+export async function listByFrameworkId(frameworkId, { transaction: knexConn } = {}) {
+  const [dtos, translations] = await Promise.all([selectAreas(knexConn).where('frameworkId', frameworkId).orderBy('code'), translationRepository.listByModel(model, { knexConn })]);
 
   return toDomainList(dtos, translations);
 }

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -12,17 +12,25 @@ export async function filter({ competenceId, locale }) {
   return localizedFrameworkTubesDtos.map(_toDomain);
 }
 
-export async function save(localizedFrameworkTube) {
-  const [insertedLocalizedFrameworkTubes] = await knex('localized_framework_tubes')
-    .insert({
+export async function save(localizedFrameworkTubes, { transaction: knexConn = knex, onConflict = 'merge' } = {}) {
+  let query = knexConn('localized_framework_tubes')
+    .insert(localizedFrameworkTubes.map((localizedFrameworkTube) => ({
       id: localizedFrameworkTube.id,
       tubeId: localizedFrameworkTube.tubeId,
       maxLevel: localizedFrameworkTube.maxLevel,
       locale: localizedFrameworkTube.locale,
-    })
-    .onConflict('id')
-    .merge()
-    .returning('*');
+    })))
+    .onConflict('id');
+
+  if (onConflict === 'merge') {
+    query = query.merge();
+  } else {
+    query = query.ignore();
+  }
+
+  query = query.returning('*');
+
+  const [insertedLocalizedFrameworkTubes] = await query;
 
   return _toDomain(insertedLocalizedFrameworkTubes);
 }

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -9,7 +9,8 @@ export async function filter({ competenceId, locale }) {
     .join('localized_framework_tubes', 'localized_framework_tubes.tubeId', 'tubes.id')
     .where('thematics.competenceId', competenceId)
     .where('localized_framework_tubes.locale', locale);
-  return localizedFrameworkTubesDtos.map(_toDomain);
+
+  return toDomainList(localizedFrameworkTubesDtos);
 }
 
 export async function save(localizedFrameworkTubes, { transaction: knexConn = knex, onConflict = 'merge' } = {}) {
@@ -31,17 +32,18 @@ export async function save(localizedFrameworkTubes, { transaction: knexConn = kn
   query = query.returning('*');
 
   const insertedLocalizedFrameworkTubes = await query;
-  return _toDomainList(insertedLocalizedFrameworkTubes);
+
+  return toDomainList(insertedLocalizedFrameworkTubes);
 }
 
 export async function remove(id) {
   return knex.delete().from('localized_framework_tubes').where('id', id);
 }
 
-function _toDomain(dto) {
+function toDomain(dto) {
   return new LocalizedFrameworkTubes(dto);
 }
 
-function _toDomainList(dtos) {
-  return dtos.map((dto) => _toDomain(dto));
+function toDomainList(dtos) {
+  return dtos.map((dto) => toDomain(dto));
 }

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -30,9 +30,8 @@ export async function save(localizedFrameworkTubes, { transaction: knexConn = kn
 
   query = query.returning('*');
 
-  const [insertedLocalizedFrameworkTubes] = await query;
-
-  return _toDomain(insertedLocalizedFrameworkTubes);
+  const insertedLocalizedFrameworkTubes = await query;
+  return _toDomainList(insertedLocalizedFrameworkTubes);
 }
 
 export async function remove(id) {
@@ -41,4 +40,8 @@ export async function remove(id) {
 
 function _toDomain(dto) {
   return new LocalizedFrameworkTubes(dto);
+}
+
+function _toDomainList(dtos) {
+  return dtos.map((dto) => _toDomain(dto));
 }

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -22,7 +22,7 @@ export async function get(id) {
   return toDomain(dto, translations);
 }
 
-export async function listByCompetenceId(competenceId, { transaction: knexConn }) {
+export async function listByCompetenceId(competenceId, { transaction: knexConn = knex } = {}) {
   const dtos = await selectTubes(knexConn).where('thematics.competenceId', competenceId).orderBy('tubes.id');
 
   if (dtos.length === 0) return [];

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -8,8 +8,8 @@ import { knex } from '../../../db/knex-database-connection.js';
 const model = 'tube';
 const TABLE_NAME = 'tubes';
 
-export async function list() {
-  const [dtos, translations] = await Promise.all([selectTubes().orderBy(`${TABLE_NAME}.id`), translationRepository.listByModel(model)]);
+export async function list({ transaction: knexConn } = {}) {
+  const [dtos, translations] = await Promise.all([selectTubes(knexConn).orderBy(`${TABLE_NAME}.id`), translationRepository.listByModel(model, { knexConn })]);
 
   return toDomainList(dtos, translations);
 }
@@ -22,14 +22,15 @@ export async function get(id) {
   return toDomain(dto, translations);
 }
 
-export async function listByCompetenceId(competenceId) {
-  const dtos = await selectTubes().where('thematics.competenceId', competenceId).orderBy('tubes.id');
+export async function listByCompetenceId(competenceId, { transaction: knexConn }) {
+  const dtos = await selectTubes(knexConn).where('thematics.competenceId', competenceId).orderBy('tubes.id');
 
   if (dtos.length === 0) return [];
 
   const translations = await translationRepository.listByEntities(
     model,
     dtos.map(({ id }) => id),
+    { knexConn },
   );
 
   return toDomainList(dtos, translations);

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -22,7 +22,7 @@ export async function get(id) {
   return toDomain(dto, translations);
 }
 
-export async function listByCompetenceId(competenceId, { transaction: knexConn = knex } = {}) {
+export async function listByCompetenceId(competenceId, { transaction: knexConn } = {}) {
   const dtos = await selectTubes(knexConn).where('thematics.competenceId', competenceId).orderBy('tubes.id');
 
   if (dtos.length === 0) return [];

--- a/api/scripts/create-localized-framework.js
+++ b/api/scripts/create-localized-framework.js
@@ -1,0 +1,75 @@
+import { areaRepository, localizedFrameworksTubesRepository, tubeRepository } from '../lib/infrastructure/repositories/index.js';
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+import { LocalizedFrameworkTubes } from '../lib/domain/models/LocalizedFrameworkTubes.js';
+import { knex } from '../db/knex-database-connection.js';
+
+export class CreateLocalizedFrameworks extends Script {
+  constructor() {
+    super({
+      description: 'Script de création des entités localized frameworks',
+      permanent: true,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not perform any creation.',
+          demandOption: true,
+          default: true,
+        },
+        locales: {
+          type: 'array',
+          describe: 'Locale to create (space separated)',
+          demandOption: true,
+        },
+        frameworkIds: {
+          type: 'array',
+          describe: 'Framework ID to create (space separated)',
+          demandOption: false,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun, locales: options.locales, frameworkIds: options.frameworkIds }, 'Script options');
+
+    await knex.transaction(async (transaction) => {
+      let tubes;
+      if (options.frameworkIds) {
+        const frameworksTubes = await Promise.all(options.frameworkIds.map((frameworkId) => loadFrameworkTubes(frameworkId, transaction)));
+        tubes = frameworksTubes.flat();
+      } else {
+        tubes = await tubeRepository.list({ transaction });
+      }
+
+      const tubesWithoutWorkbench = tubes.filter((tube) => !tube.isWorkbench);
+
+      if (tubesWithoutWorkbench.length === 0) {
+        logger.info('No localized framework to create');
+        return;
+      }
+      logger.info({ count: tubesWithoutWorkbench.length }, 'Tubes were found');
+
+      for (const locale of options.locales) {
+        const localizedFrameworkTubes = tubesWithoutWorkbench.map((tube) => new LocalizedFrameworkTubes({ tubeId: tube.id, locale, maxLevel: 8 }));
+
+        await localizedFrameworksTubesRepository.save(localizedFrameworkTubes, { transaction, onConflict: 'ignore' });
+
+        logger.info({ locale, count: localizedFrameworkTubes.length }, 'Localized framework tubes were created for locale');
+      }
+
+      if (options.dryRun) {
+        logger.info('Dry run, will rollback modifications');
+        await transaction.rollback();
+      }
+    });
+  }
+}
+
+async function loadFrameworkTubes(frameworkId, transaction) {
+  const areas = await areaRepository.listByFrameworkId(frameworkId, { transaction });
+  const areasTubes = await Promise.all(areas.flatMap((area) => area.competenceIds.map((competenceId) => tubeRepository.listByCompetenceId(competenceId, { transaction }))));
+  return areasTubes.flat();
+}
+
+await ScriptRunner.execute(import.meta.url, CreateLocalizedFrameworks);

--- a/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
@@ -62,17 +62,21 @@ describe('Acceptance | API | localized_framework_tubes | POST /api/localized-fra
     const { id: localizedFrameworkTubesId } = await knex('localized_framework_tubes').select('id').first();
 
     expect(response.statusCode).to.equal(201);
-    expect(response.result).to.deep.equal({
-      data: {
-        type: 'localized-framework-tubes',
-        id: localizedFrameworkTubesId.toString(),
-        attributes: {
-          'tube-id': 'tubeId',
-          'max-level': 2,
-          locale: 'nl',
-        },
+    expect(response.result).toStrictEqual(
+      {
+        data: [
+          {
+            type: 'localized-framework-tubes',
+            id: localizedFrameworkTubesId.toString(),
+            attributes: {
+              'tube-id': 'tubeId',
+              'max-level': 2,
+              locale: 'nl',
+            },
+          },
+        ],
       },
-    });
+    );
   });
 
   it('Should return bad request', async function() {

--- a/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
+++ b/api/tests/acceptance/application/localized-framework-tubes/post_localized-framework-tubes_test.js
@@ -62,21 +62,17 @@ describe('Acceptance | API | localized_framework_tubes | POST /api/localized-fra
     const { id: localizedFrameworkTubesId } = await knex('localized_framework_tubes').select('id').first();
 
     expect(response.statusCode).to.equal(201);
-    expect(response.result).toStrictEqual(
-      {
-        data: [
-          {
-            type: 'localized-framework-tubes',
-            id: localizedFrameworkTubesId.toString(),
-            attributes: {
-              'tube-id': 'tubeId',
-              'max-level': 2,
-              locale: 'nl',
-            },
-          },
-        ],
+    expect(response.result).to.deep.equal({
+      data: {
+        type: 'localized-framework-tubes',
+        id: localizedFrameworkTubesId.toString(),
+        attributes: {
+          'tube-id': 'tubeId',
+          'max-level': 2,
+          locale: 'nl',
+        },
       },
-    );
+    });
   });
 
   it('Should return bad request', async function() {

--- a/api/tests/integration/infrastructure/repositories/localized-framework-tubes-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/localized-framework-tubes-repository_test.js
@@ -10,6 +10,6 @@ describe('Integration | Repository | localized-framework-tubes-repository', func
       tubeId: 'unknown',
     };
 
-    await expect(localizedFrameworksTubesRepository.save(localizedFrameworkTubesDTO)).rejects.to.contain({ constraint: 'localized_framework_tubes_tubeid_foreign' });
+    await expect(localizedFrameworksTubesRepository.save([localizedFrameworkTubesDTO])).rejects.to.contain({ constraint: 'localized_framework_tubes_tubeid_foreign' });
   });
 });

--- a/api/tests/scripts/create-localized-framework_test.js
+++ b/api/tests/scripts/create-localized-framework_test.js
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { databaseBuilder, knex } from '../test-helper.js';
+import { CreateLocalizedFrameworks } from '../../scripts/create-localized-framework.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+
+describe('Script | CreateLocalizedFramework', () => {
+  /** @type {CreateLocalizedFrameworks} */
+  let script;
+
+  beforeEach(() => {
+    script = new CreateLocalizedFrameworks();
+  });
+
+  describe('#handle', () => {
+    beforeEach(async () => {
+      const tube = {
+        id: 'tube1',
+        name: '@test',
+        index: 1,
+        competenceId: 'competence1',
+        thematicId: 'thematic1',
+        skillAirtableIds: ['skill1', 'skill2'],
+        skillIds: ['skill1', 'skill2'],
+      };
+
+      const otherTube = {
+        id: 'tube2',
+        name: '@test2',
+        index: 2,
+        competenceId: 'competence2',
+        thematicId: 'thematic2',
+        skillAirtableIds: ['skill3', 'skill4'],
+        skillIds: ['skill3', 'skill4'],
+      };
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: tube.competenceId, index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: tube.thematicId, competenceId: tube.competenceId });
+      databaseBuilder.factory.buildTube(tube);
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk2', name: 'Fmk 2' });
+      databaseBuilder.factory.buildArea({ id: 'area2', code: '2', frameworkId: 'recFmk2' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence2', index: '2.2', areaId: 'area2' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic2', competenceId: 'competence2' });
+      databaseBuilder.factory.buildTube(otherTube);
+
+      await databaseBuilder.commit();
+    });
+
+    it('creates localizedFrameworkTubes for a given framework, and given locale', async () => {
+      // given
+      const options = {
+        dryRun: false,
+        locales: ['fr'],
+        frameworkIds: ['recFmk1'],
+      };
+
+      // when
+      await script.handle({ options, logger });
+      const localizedFrameworkTubeId = await knex.pluck('id').from('localized_framework_tubes').where('tubeId', 'tube1');
+      // then
+      await expect(knex.select('*').from('localized_framework_tubes').orderBy('id')).resolves.toStrictEqual([
+        {
+          id: localizedFrameworkTubeId[0],
+          tubeId: 'tube1',
+          maxLevel: 8,
+          locale: 'fr',
+        },
+      ]);
+    });
+
+    it('creates localizedFrameworkTubes for 2 given locales and no framework', async () => {
+      // given
+      const options = {
+        dryRun: false,
+        locales: ['fr', 'nl'],
+      };
+
+      // when
+      await script.handle({ options, logger });
+      const localizedFrameworkTubeIds = await knex.pluck('id').from('localized_framework_tubes');
+      // then
+      await expect(knex.select('*').from('localized_framework_tubes').orderBy('id')).resolves.toStrictEqual([
+        {
+          id: localizedFrameworkTubeIds[0],
+          tubeId: 'tube1',
+          maxLevel: 8,
+          locale: 'fr',
+        },
+        {
+          id: localizedFrameworkTubeIds[1],
+          tubeId: 'tube2',
+          maxLevel: 8,
+          locale: 'fr',
+        },
+        {
+          id: localizedFrameworkTubeIds[2],
+          tubeId: 'tube1',
+          maxLevel: 8,
+          locale: 'nl',
+        },
+        {
+          id: localizedFrameworkTubeIds[3],
+          tubeId: 'tube2',
+          maxLevel: 8,
+          locale: 'nl',
+        },
+      ]);
+    });
+
+    describe('when dryRun option is true', () => {
+      it('stops before creation', async () => {
+        // given
+        const options = {
+          dryRun: true,
+          locales: ['fr'],
+          frameworkIds: ['recFmk1'],
+        };
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        await expect(knex.select('*').from('localized_framework_tubes').orderBy('id')).resolves.toStrictEqual([]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

On a besoin de créer des entités localizedFrameworkTubes avec la propriété `maxLevel` à 8 ou 0 pour selont la locale et le framework.

## 🛷 Proposition

Créer un script qui nous facilite la vie ! 

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

Lancer la commande 

`scalingo -a pix-lcms-review-pr1354 run "node api/scripts/create-localized-framework.js --locales='fr-FR' --frameworkIds='Pix'"`
 => pas de localizeFramework à créer

`scalingo -a pix-lcms-review-pr1354 run "node api/scripts/create-localized-framework.js --locales='fr-FR' --frameworkIds='frameworkFundefined'"`
 => un certains nombre à créer si la locale est présente il est possible d'en mettre une fake pour créer de la data

Il faut ensuite le run avec l'option `--dryRun=false`

et vérifier dans la table `localized_framework_tybes` que les entités on bien été créer avec la bonne local et le maxLevel à 8.

