### PR TITLE
[FEATURE] Changement de la valeur par défaut de maxLevel de localizedFrameworkTubes (PIX-20937)

### DIFF
--- a/pix-editor/app/components/v2/localized-framework.gjs
+++ b/pix-editor/app/components/v2/localized-framework.gjs
@@ -22,7 +22,7 @@ export default class LocalizedFramework extends Component {
 
   @action
   getMaxLevelLocalizedFrameworkTube(tubeId) {
-    return this.tubeMaxLevelById[tubeId] ?? 8;
+    return this.tubeMaxLevelById[tubeId] ?? 0;
   }
 
   @action


### PR DESCRIPTION
## ❄️ Problème

Le métier préfère que le maxLevel soit à 0 par défaut.

## 🛷 Proposition

Changer les valeur de base.

## ☃️ Remarques

RAS

## 🧑‍🎄 Pour tester

Aller dans une locale qui ne possède pas d'entité `localizedFrameworkTubes` et observer que la valeur est à 0.
Vérifier qu'il n'y a pas de régression sur des update ou autre trucs.