### PR TITLE
[BUGFIX] Impossible de vider les champs facultatifs d’un acquis (PIX-21046)

### DIFF
--- a/api/lib/application/skills/index.js
+++ b/api/lib/application/skills/index.js
@@ -93,10 +93,10 @@ export async function register(server) {
             data: Joi.object({
               type: Joi.string().required().equal('skills'),
               attributes: Joi.object({
-                description: Joi.string().allow(null),
+                description: Joi.string().empty('').allow(null).default(null),
                 'description-status': Joi.string().allow(null),
-                clue: Joi.string().allow(null),
-                'clue-en': Joi.string().allow(null),
+                clue: Joi.string().empty('').allow(null),
+                'clue-en': Joi.string().empty('').allow(null),
                 'clue-status': Joi.string().empty('').allow(null),
                 i18n: Joi.string().allow(null),
                 status: Joi.string().allow(null),


### PR DESCRIPTION
## ❄️ Problème

Sur un acquis, si on essaie de vider l’un des champs suivants et d’enregistrer, on a une erreur 400 :

 - Indice fr ou en
 - Description

Autre problème détecté en même temps : impossible de vider le champ description, il garde son ancienne valeur.

## 🛷 Proposition

Autoriser les valeurs vides pour les champs facultatifs dans la validation des payloads.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Modifier un acquis et essayer de vider les champs facultatifs.