### PR TITLE
[FEATURE] Cacher les valeurs des champs ayant le type "secret" dans le back-office (PIX-21074)

### DIFF
--- a/pix-editor/app/components/admin/entity-cell.gjs
+++ b/pix-editor/app/components/admin/entity-cell.gjs
@@ -1,0 +1,80 @@
+import Component from '@glimmer/component';
+import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { fn } from '@ember/helper';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class AdminEntityCell extends Component {
+  @tracked isDisplayed = false;
+
+  get value() {
+    return this.args.row.properties[this.args.field.key];
+  }
+
+  get optionLabel() {
+    return this.args.field?.options.find((option) => option.value === this.value)?.label;
+  }
+
+  get isEnum() {
+    return this.args.field.type === 'enum';
+  }
+
+  get isSecret() {
+    return this.args.field.type === 'secret';
+  }
+
+  get secretFieldVisibilityClass() {
+    return this.isDisplayed ? '' : 'secret-container__secret--blurred';
+  }
+
+  get secretFieldToggleIcon() {
+    return this.isDisplayed ? 'eyeOff' : 'eye';
+  }
+
+  get secretFieldToggleAriaLabel() {
+    return this.isDisplayed
+      ? `Cacher le secret "${this.args.field.label}" de l'entité "${this.args.row.id}"`
+      : `Afficher le secret "${this.args.field.label}" de l'entité "${this.args.row.id}"`;
+  }
+
+  get redactedValue() {
+    return '*'.repeat(this.value.length);
+  }
+
+  @action
+  toggleFieldVisibility() {
+    this.isDisplayed = !this.isDisplayed;
+  }
+
+  <template>
+    {{#if this.isEnum}}
+      <PixTag>
+        {{this.optionLabel}}
+      </PixTag>
+    {{else if this.isSecret}}
+      <span class="secret-container">
+        <span class="secret-container__secret {{this.secretFieldVisibilityClass}}" aria-live="polite">
+          {{#if this.isDisplayed}}
+            {{this.value}}
+          {{else}}
+            <span aria-hidden="true">
+              {{this.redactedValue}}
+            </span>
+            <span class="sr-only">
+              Valeur cachée
+            </span>
+          {{/if}}
+        </span>
+        <PixIconButton
+          @ariaLabel="{{this.secretFieldToggleAriaLabel}}"
+          @iconName="{{this.secretFieldToggleIcon}}"
+          @triggerAction={{this.toggleFieldVisibility}}
+          @size="small"
+        />
+      </span>
+    {{else}}
+      {{this.value}}
+    {{/if}}
+  </template>
+}

--- a/pix-editor/app/components/admin/entity-list.gjs
+++ b/pix-editor/app/components/admin/entity-list.gjs
@@ -1,21 +1,12 @@
 import Component from '@glimmer/component';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
-import { fn } from '@ember/helper';
-import { eq, or } from 'ember-truth-helpers';
+
+import AdminEntityCell from './entity-cell';
 
 export default class AdminEntityList extends Component {
   get lowercaseEntityName() {
     return this.args.schema.label.toLowerCase();
-  }
-
-  getKeyValue(row, key) {
-    return row.properties[key];
-  }
-
-  getEnumLabel(row, field) {
-    return field.options.find((option) => option.value === row.properties[field.key])?.label;
   }
 
   getColumnType(field) {
@@ -40,13 +31,7 @@ export default class AdminEntityList extends Component {
               {{field.label}}
             </:header>
             <:cell>
-              {{#if (eq field.type "enum")}}
-                <PixTag>
-                  {{this.getEnumLabel row field}}
-                </PixTag>
-              {{else}}
-                {{this.getKeyValue row field.key}}
-              {{/if}}
+              <AdminEntityCell @row={{row}} @field={{field}} />
             </:cell>
           </PixTableColumn>
         {{/each}}

--- a/pix-editor/app/styles/components/admin.scss
+++ b/pix-editor/app/styles/components/admin.scss
@@ -33,4 +33,28 @@
   .pagination {
     margin-top: 1rem;
   }
+
+  .secret-container {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    &__secret {
+      font-family: monospace;
+      transition: filter 0.15s ease;
+
+      * {
+        font-family: monospace;
+      }
+
+      &--blurred {
+        filter: blur(6px);
+        cursor: not-allowed;
+        background: rgb(0 0 0 / 0.15);
+        border-radius: 100px;
+        color: transparent;
+        user-select: none;
+      }
+    }
+  }
 }

--- a/pix-editor/tests/integration/components/admin/entity-cell.gjs
+++ b/pix-editor/tests/integration/components/admin/entity-cell.gjs
@@ -1,0 +1,80 @@
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import { module, test } from 'qunit';
+
+import AdminEntityCell from 'pixeditor/components/admin/entity-cell';
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | admin | entity-cell', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let screen;
+
+  module('when field\'s type is "enum"', function () {
+    test("it should display the value's corresponding label", async function (assert) {
+      // given
+      const field = {
+        type: 'enum',
+        key: 'flavour',
+        options: [
+          { value: 123, label: 'Chocolat' },
+          { value: 456, label: 'Fraise' },
+        ],
+      };
+      const row = { properties: { flavour: 456 } };
+
+      // when
+      screen = await render(<template><AdminEntityCell @row={{row}} @field={{field}} /></template>);
+
+      // then
+      assert.dom(await screen.queryByText('Chocolat')).doesNotExist();
+      assert.dom(await screen.queryByText('456')).doesNotExist();
+      assert.dom(await screen.queryByText('flavour')).doesNotExist();
+      assert.dom(await screen.getByText('Fraise')).exists();
+    });
+  });
+
+  module('when field\'s type is "secret"', function () {
+    test('it should initially hide the value', async function (assert) {
+      // given
+      const field = {
+        type: 'secret',
+        key: 'flavour',
+        label: 'Goût',
+      };
+      const row = { id: 1, properties: { flavour: 'Chocolat' } };
+
+      // when
+      screen = await render(<template><AdminEntityCell @row={{row}} @field={{field}} /></template>);
+
+      // then
+      assert.dom(await screen.queryByText('Chocolat')).doesNotExist();
+      assert.dom(await screen.getByText('Valeur cachée')).exists();
+
+      await clickByName('Afficher le secret "Goût" de l\'entité "1"');
+      assert.dom(await screen.getByText('Chocolat')).exists();
+      assert.dom(await screen.queryByText('Valeur cachée')).doesNotExist();
+
+      await clickByName('Cacher le secret "Goût" de l\'entité "1"');
+      assert.dom(await screen.queryByText('Chocolat')).doesNotExist();
+      assert.dom(await screen.getByText('Valeur cachée')).exists();
+    });
+  });
+
+  module("when field's type is anything else", function () {
+    test('it should display the raw value', async function (assert) {
+      // given
+      const field = {
+        type: 'string',
+        key: 'flavour',
+      };
+      const row = { properties: { flavour: 'Chocolat' } };
+
+      // when
+      screen = await render(<template><AdminEntityCell @row={{row}} @field={{field}} /></template>);
+
+      // then
+      assert.dom(await screen.queryByText('flavour')).doesNotExist();
+      assert.dom(await screen.getByText('Chocolat')).exists();
+    });
+  });
+});


### PR DESCRIPTION
## ❄️ Problème

Dans le nouveau back-office d'administration, les champs de type `secret` ne sont pas encore pris en compte, et sont affichés comme les champs de type `string`.

## 🛷 Proposition

Cacher, par défaut, la valeur des champs de type `secret`.

## 🧐 Remarques

L'idéal serait de ne pas du tout y avoir accès, et de seulement pouvoir les re-générer, mais cela fera l'objet d'une autre PR dans un futur plus ou moins éloigné.

## 🧑‍🎄 Pour tester

- Se rendre sur la page d'administration.
- Afficher la liste des utilisateurs.
- Constater que les clés d'API sont cachées par défaut.
- Cliquer sur le bouton "👁️" à côté d'une valeur cachée.
- Constater que la valeur s'est affichée.
- Cliquer à nouveau sur le bouton.
- Constater que la valeur est à nouveau cachée.
