### PR TITLE
[FEATURE] Filtrer la vue épreuves production avec le cadre de traduction (PIX-20937)

### DIFF
--- a/api/lib/domain/readmodels/CompetenceOverview.js
+++ b/api/lib/domain/readmodels/CompetenceOverview.js
@@ -134,13 +134,14 @@ class TubeOverview {
   }
 
   static buildForChallengesProduction({ tube, skills, challenges, locale, localizedFrameworkTube }) {
-    const localizedFrameworkSkills = localizedFrameworkTube ? skills.filter((skill) => skill.level <= localizedFrameworkTube.maxLevel) : skills;
-    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(localizedFrameworkSkills);
+    const tubeSkills = skills.filter((skill) => skill.tubeId === tube.id);
+    const localizedFrameworkSkills = TubeOverview.getLocalizedFrameworkSkills({ skills: tubeSkills, locale, localizedFrameworkTube });
+    const skillsByLevel = arrangeSkillsByLevel(localizedFrameworkSkills);
 
     return new TubeOverview({
       airtableId: tube.airtableId,
       name: tube.name,
-      skillOverviews: skillsByTubeIdAndLevel[tube.id]?.map((skills) =>
+      skillOverviews: skillsByLevel?.map((skills) =>
         SkillOverview.buildForChallengesProduction({
           skill: skills?.[0],
           challenges,
@@ -150,13 +151,20 @@ class TubeOverview {
     });
   }
 
+  static getLocalizedFrameworkSkills({ skills, locale, localizedFrameworkTube }) {
+    if (!locale) return skills;
+    if (!localizedFrameworkTube) return [];
+    return skills.filter((skill) => skill.level <= localizedFrameworkTube.maxLevel);
+  }
+
   static buildForChallengesWorkbench({ tube, skills, challenges }) {
-    const skillsByTubeIdAndLevel = arrangeSkillsByTubeIdAndLevel(skills);
+    const tubeSkills = skills.filter((skill) => skill.tubeId === tube.id);
+    const skillsByLevel = arrangeSkillsByLevel(tubeSkills);
 
     return new TubeOverview({
       airtableId: tube.airtableId,
       name: tube.name,
-      skillOverviews: skillsByTubeIdAndLevel[tube.id]?.map((skills) =>
+      skillOverviews: skillsByLevel?.map((skills) =>
         SkillOverview.buildForChallengesWorkbench({ skills, challenges }),
       ),
     });
@@ -240,20 +248,19 @@ function byIndex({ index: index1 }, { index: index2 }) {
   return index1 - index2;
 }
 
-function arrangeSkillsByTubeIdAndLevel(skills) {
-  const skillsByTubeIdAndLevel = {};
+function arrangeSkillsByLevel(skills) {
+  if (skills.length === 0) return null;
 
-  for (const skill of skills) {
-    if (!skillsByTubeIdAndLevel[skill.tubeId]) {
-      skillsByTubeIdAndLevel[skill.tubeId] = new Array(7).fill(null);
-    }
-    if (!skillsByTubeIdAndLevel[skill.tubeId][skill.level - 1]) {
-      skillsByTubeIdAndLevel[skill.tubeId][skill.level - 1] = [];
-    }
-    skillsByTubeIdAndLevel[skill.tubeId][skill.level - 1].push(skill);
-  }
+  const skillsByLevel = new Array(7).fill(null);
 
-  return skillsByTubeIdAndLevel;
+  skills.forEach((skill) => {
+    if (!skillsByLevel[skill.level - 1]) {
+      skillsByLevel[skill.level - 1] = [];
+    }
+    skillsByLevel[skill.level - 1].push(skill);
+  });
+
+  return skillsByLevel;
 }
 
 function isProductionPrototypeOf(skill) {

--- a/api/tests/acceptance/application/competences/overviews_test.js
+++ b/api/tests/acceptance/application/competences/overviews_test.js
@@ -160,6 +160,15 @@ describe('Acceptance | Route | competence-overviews', () => {
 
       skills.forEach(databaseBuilder.factory.buildSkill);
 
+      const localizedFrameworkTubes = [
+        { tubeId: 'recTube1', maxLevel: 3, locale: 'en' },
+        { tubeId: 'recTube2', maxLevel: 8, locale: 'en' },
+        { tubeId: 'recTube3', maxLevel: 8, locale: 'en' },
+        { tubeId: 'recTube4', maxLevel: 8, locale: 'en' },
+        { tubeId: 'recTube6', maxLevel: 8, locale: 'en' },
+      ];
+      localizedFrameworkTubes.forEach(databaseBuilder.factory.buildLocalizedFrameworkTubes);
+
       const challenges = [
         {
           id: 'recChallenge1',
@@ -492,8 +501,8 @@ describe('Acceptance | Route | competence-overviews', () => {
             attributes: {
               'airtable-id': 'recCompetence1',
               name: '2.2 Mon super titre',
-              'tubes-count': 4,
-              'skills-count': 5,
+              'tubes-count': 3,
+              'skills-count': 3,
               'thematic-overviews': [
                 {
                   airtableId: 'recThematic2',
@@ -517,27 +526,6 @@ describe('Acceptance | Route | competence-overviews', () => {
                         null,
                         null,
                         null,
-                        null,
-                      ],
-                    },
-                    {
-                      airtableId: 'recTube5',
-                      name: '@tube5',
-                      skillOverviews: [
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        {
-                          id: 'recSkill5',
-                          airtableId: 'recSkill5',
-                          name: '@tube56',
-                          prototypeId: 'recChallenge5',
-                          validatedChallengesCount: 0,
-                          proposedChallengesCount: 0,
-                          isPrototypeDeclinable: false,
-                        },
                         null,
                       ],
                     },
@@ -583,15 +571,7 @@ describe('Acceptance | Route | competence-overviews', () => {
                           proposedChallengesCount: 0,
                           isPrototypeDeclinable: false,
                         },
-                        {
-                          id: 'recSkill1',
-                          airtableId: 'recSkill1',
-                          name: '@tube14',
-                          prototypeId: 'recChallenge1',
-                          validatedChallengesCount: 1,
-                          proposedChallengesCount: 0,
-                          isPrototypeDeclinable: true,
-                        },
+                        null,
                         null,
                         null,
                         null,
@@ -602,119 +582,6 @@ describe('Acceptance | Route | competence-overviews', () => {
               ],
             },
           },
-        });
-      });
-
-      describe('with a defined localized framework', () => {
-        it('should respond status 200 and overview of competence’s production, filtered according to localized framework', async () => {
-          // given
-          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube1', locale: 'en', maxLevel: 3 });
-          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube2', locale: 'en', maxLevel: 8 });
-          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube4', locale: 'en', maxLevel: 0 });
-          databaseBuilder.factory.buildLocalizedFrameworkTubes({ tubeId: 'recTube5', locale: 'en', maxLevel: 6 });
-          await databaseBuilder.commit();
-
-          const server = await createServer();
-
-          // when
-          const response = await server.inject({
-            method: 'GET',
-            url: `/api/competences/${competenceId}/overviews/challenges-production?locale=en`,
-            headers: generateAuthorizationHeader(user),
-          });
-
-          // then
-          expect(response.statusCode).toBe(200);
-
-          expect(response.result).toEqual({
-            data: {
-              type: 'competence-overviews',
-              id: `${competenceId}:challenges-production:en`,
-              attributes: {
-                'airtable-id': 'recCompetence1',
-                name: '2.2 Mon super titre',
-                'tubes-count': 3,
-                'skills-count': 3,
-                'thematic-overviews': [
-                  {
-                    airtableId: 'recThematic2',
-                    name: 'Thématique 2',
-                    tubeOverviews: [
-                      {
-                        airtableId: 'recTube5',
-                        name: '@tube5',
-                        skillOverviews: [
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          {
-                            id: 'recSkill5',
-                            airtableId: 'recSkill5',
-                            name: '@tube56',
-                            prototypeId: 'recChallenge5',
-                            validatedChallengesCount: 0,
-                            proposedChallengesCount: 0,
-                            isPrototypeDeclinable: false,
-                          },
-                          null,
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    airtableId: 'recThematic1',
-                    name: 'Thématique 1',
-                    tubeOverviews: [
-                      {
-                        airtableId: 'recTube2',
-                        name: '@tube2',
-                        skillOverviews: [
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          null,
-                          {
-                            id: 'recSkill3',
-                            airtableId: 'recSkill3',
-                            name: '@tube27',
-                            prototypeId: 'recChallenge3',
-                            validatedChallengesCount: 1,
-                            proposedChallengesCount: 1,
-                            isPrototypeDeclinable: true,
-                          },
-                        ],
-                      },
-                      {
-                        airtableId: 'recTube1',
-                        name: '@tube1',
-                        skillOverviews: [
-                          null,
-                          null,
-                          {
-                            id: 'recSkill2',
-                            airtableId: 'recSkill2',
-                            name: '@tube13',
-                            prototypeId: 'recChallenge2',
-                            validatedChallengesCount: 0,
-                            proposedChallengesCount: 0,
-                            isPrototypeDeclinable: false,
-                          },
-                          null,
-                          null,
-                          null,
-                          null,
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            },
-          });
         });
       });
     });


### PR DESCRIPTION
## ❄️ Problème

La vue épreuves production n’est pas filtrée avec les nouvelles règles des cadres de traduction (niveau par défaut à 0).

## 🛷 Proposition

Filtrer selon les nouvelles règles.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Vérifier que rien ne s’affiche sur les vue épreuves production quand on sélectionne une langue à moins de créer un cadre de traduction.