### PR TITLE
[FEATURE] Recherche d’épreuves traduites (PIX-20098)

### DIFF
--- a/pix-editor/app/adapters/search-result.js
+++ b/pix-editor/app/adapters/search-result.js
@@ -1,0 +1,7 @@
+import ApplicationAdapter from './application';
+
+export default class SearchResultAdapter extends ApplicationAdapter {
+  pathForType() {
+    return 'search';
+  }
+}

--- a/pix-editor/app/components/sidebar/search.gjs
+++ b/pix-editor/app/components/sidebar/search.gjs
@@ -12,83 +12,10 @@ export default class SidebarSearch extends Component {
   @service router;
   @tracked searchResults = [];
 
-  statusToIcon = {
-    validated: '🟢',
-    suggested: '🔵',
-    archived: '⬜️',
-    deleted: '🔴',
-    '': '❓',
-  };
-
   get searchResultOptions() {
-    return this.searchResults.map((result) => {
-      if (!result.isSkill) {
-        return {
-          value: result.transition.model,
-          label: result.title,
-        };
-      }
-
-      const icon = this.statusToIcon[result.statusCSS];
-      return {
-        value: result.transition.model,
-        label: `${icon} ${result.title}${result.version ? ` v${result.version}` : ''}`,
-      };
-    });
-  }
-
-  async searchSkillsByName(skillName) {
-    const skills = await this.store.query('skill', {
-      filter: { name: skillName },
-      page: { limit: 20 },
-      sort: 'name,-version',
-    });
-    return skills.map((skill) => ({
-      isSkill: true,
-      title: skill.name,
-      status: skill.status,
-      statusCSS: skill.statusCSS,
-      version: skill.version,
-      transition: {
-        route: 'authenticated.skill',
-        model: skill.pixId,
-      },
-    }));
-  }
-
-  async searchChallengesById(challengeId) {
-    const challenges = await this.store.query('challenge', { filter: { ids: [challengeId] } });
-    return challenges.map((challenge) => ({
-      title: challenge.id,
-      transition: {
-        route: 'authenticated.challenge',
-        model: challenge.id,
-      },
-    }));
-  }
-
-  async searchLocalizedChallengesById(localizedChallengeId) {
-    const results = await this.store.query('localized-challenge', { filter: { ids: [localizedChallengeId] } });
-    return results.map((result) => ({
-      title: result.id,
-      transition: {
-        route: 'authenticated.challenge',
-        model: result.id,
-      },
-    }));
-  }
-
-  async searchChallengesByText(text) {
-    const challenges = await this.store.query('challenge', {
-      filter: { search: text.toLowerCase() },
-      page: { size: 20 },
-    });
-    return challenges.map((challenge) => ({
-      title: challenge.instruction.substr(0, 100),
-      transition: {
-        route: 'authenticated.challenge',
-        model: challenge.id,
-      },
+    return this.searchResults.map((result) => ({
+      value: result.transition,
+      label: `${result.statusIcon} ${result.title}${result.version ? ` v${result.version}` : ''}`,
     }));
   }
 
@@ -97,31 +24,20 @@ export default class SidebarSearch extends Component {
     query = query.trim();
     if (query.length === 0) {
       this.searchResults = [];
-    } else if (query.startsWith('@')) {
-      this.searchResults = await this.searchSkillsByName(query);
-    } else if (query.startsWith('rec') || query.startsWith('challenge')) {
-      const challenges = await this.searchChallengesById(query);
-      const localizedChallenges = await this.searchLocalizedChallengesById(query);
-      this.searchResults = uniqBy([...challenges, ...localizedChallenges], 'id');
-    } else {
-      this.searchResults = await this.searchChallengesByText(query);
+      return this.searchResults;
     }
+    this.searchResults = await this.store.query('search-result', {
+      filter: {
+        name: query,
+      },
+    });
     return this.searchResults;
   }
 
   @action
-  linkTo({ transition }) {
-    const router = this.router;
+  transitionTo(transition) {
     this.args.close();
-    router.transitionTo(transition.route, transition.model);
-  }
-
-  @action
-  linkToModelId(modelId) {
-    const model = this.searchResults.find((result) => result.transition.model === modelId);
-    if (!model) return;
-    this.args.close();
-    this.router.transitionTo(model.transition.route, model.transition.model);
+    this.router.transitionTo(...transition);
   }
 
   <template>
@@ -132,7 +48,7 @@ export default class SidebarSearch extends Component {
       @placeholder="Acquix ou recordId"
       @options={{this.searchResultOptions}}
       @onSearch={{this.getSearchResults}}
-      @onChange={{this.linkToModelId}}
+      @onChange={{this.transitionTo}}
       @iconName="search"
       @value=""
       @hideDefaultOption={{true}}

--- a/pix-editor/app/models/search-result.js
+++ b/pix-editor/app/models/search-result.js
@@ -1,0 +1,42 @@
+import Model, { attr } from '@ember-data/model';
+
+const skillStatusIcon = {
+  actif: '🟢',
+  'en construction': '🔵',
+  archivé: '⬜️',
+  périmé: '🔴',
+  '': '❓',
+};
+
+const challengeStatusIcon = {
+  validé: '🟢',
+  proposé: '🔵',
+  archivé: '⬜️',
+  périmé: '🔴',
+  '': '❓',
+};
+
+export default class SearchResult extends Model {
+  @attr type;
+  @attr status;
+  @attr title;
+  @attr locale;
+  @attr isPrimary;
+  @attr version;
+
+  get #routeForType() {
+    if (this.type === 'skill') return 'authenticated.skill';
+    if (this.type === 'challenge') return 'authenticated.challenge';
+    throw new TypeError(`unknown search result type "${this.type}"`);
+  }
+
+  get transition() {
+    return [this.#routeForType, this.id];
+  }
+
+  get statusIcon() {
+    if (this.type === 'skill') return skillStatusIcon[this.status];
+    if (this.type === 'challenge') return challengeStatusIcon[this.status];
+    throw new TypeError(`unknown search result type "${this.type}"`);
+  }
+}

--- a/pix-editor/app/routes/authenticated/challenge.js
+++ b/pix-editor/app/routes/authenticated/challenge.js
@@ -22,11 +22,13 @@ export default class ChallengeRoute extends Route {
     try {
       const challenge = await localizedChallenge.challenge;
       const skill = await challenge.get('skill');
-      await skill.challenges; // in order to load model.relatedPrototype later on
+      await skill.challenges; // in order to use model.relatedPrototype later on
       const tube = await skill.tube;
       const competence = await tube.competence;
-      if (challenge.get('isPrototype') && localizedChallenge.isPrimaryChallenge) {
-        if (this.versionManager.isV2 && challenge.get('isValidated')) {
+      const prototype = challenge.get('isPrototype') ? challenge : challenge.get('relatedPrototype');
+
+      if (this.versionManager.isV2 && prototype?.get('isValidated')) {
+        if (localizedChallenge.isPrimaryChallenge) {
           return this.router.transitionTo(
             'authenticated.v2.challenge',
             competence.get('id'),
@@ -34,7 +36,20 @@ export default class ChallengeRoute extends Route {
             skill.get('id'),
             challenge.get('id'),
           );
-        } else {
+        }
+
+        return this.router.transitionTo(
+          'authenticated.v2.localized-challenge',
+          competence.get('id'),
+          'challenges-production',
+          skill.get('id'),
+          localizedChallenge.id,
+          { queryParams: { locale: localizedChallenge.locale } },
+        );
+      }
+
+      if (challenge.get('isPrototype')) {
+        if (localizedChallenge.isPrimaryChallenge) {
           return this.router.transitionTo(
             'authenticated.competence.prototypes.single',
             competence.get('id'),
@@ -42,41 +57,32 @@ export default class ChallengeRoute extends Route {
             { queryParams: { view: challenge.get('isValidated') ? 'production' : 'workbench' } },
           );
         }
-      } else if (challenge.get('isPrototype')) {
+
         return this.router.transitionTo(
           'authenticated.competence.prototypes.localized',
           competence.get('id'),
           challenge.get('id'),
           localizedChallenge.get('id'),
         );
-      } else if (localizedChallenge.isPrimaryChallenge) {
-        const prototype = challenge.get('relatedPrototype');
-        if (this.versionManager.isV2 && prototype.get('isValidated')) {
-          return this.router.transitionTo(
-            'authenticated.v2.challenge',
-            competence.get('id'),
-            'challenges-production',
-            skill.get('id'),
-            challenge.get('id'),
-          );
-        } else {
-          return this.router.transitionTo(
-            'authenticated.competence.prototypes.single.alternatives.single',
-            competence.get('id'),
-            prototype.get('id'),
-            challenge.get('id'),
-            { queryParams: { view: prototype.get('isValidated') ? 'production' : 'workbench' } },
-          );
-        }
-      } else {
+      }
+
+      if (localizedChallenge.isPrimaryChallenge) {
         return this.router.transitionTo(
-          'authenticated.competence.prototypes.single.alternatives.localized',
+          'authenticated.competence.prototypes.single.alternatives.single',
           competence.get('id'),
-          challenge.get('relatedPrototype').get('id'),
+          prototype.get('id'),
           challenge.get('id'),
-          localizedChallenge.get('id'),
+          { queryParams: { view: prototype.get('isValidated') ? 'production' : 'workbench' } },
         );
       }
+
+      return this.router.transitionTo(
+        'authenticated.competence.prototypes.single.alternatives.localized',
+        competence.get('id'),
+        prototype.get('id'),
+        challenge.get('id'),
+        localizedChallenge.get('id'),
+      );
     } catch {
       this.router.transitionTo('authenticated');
     }

--- a/pix-editor/testem.js
+++ b/pix-editor/testem.js
@@ -10,7 +10,7 @@ const config = {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.CI ? '--no-sandbox' : null,
+        process?.env.CI ? '--no-sandbox' : null,
         '--headless',
         '--disable-gpu',
         '--disable-dev-shm-usage',

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -17,9 +17,9 @@ module('Acceptance | Search', function (hooks) {
     const prototype = this.server.create('challenge', {
       id: 'recChallenge1',
       instruction: 'test',
-      airtableId: 'REC_RECHERCHE1',
+      airtableId: 'recChallenge1',
     });
-    this.server.create('challenge', { id: 'challengeChallenge1', airtableId: 'REC_RECHERCHE2' });
+    this.server.create('challenge', { id: 'challengeChallenge1', airtableId: 'challengeChallenge1' });
     this.server.create('localized-challenge', { id: 'challengeChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', {
       id: 'challengeLocalizedChallenge1',
@@ -32,19 +32,19 @@ module('Acceptance | Search', function (hooks) {
       challengeIds: [],
       status: 'archivé',
       version: 2,
-      pixId: 'skill2',
+      pixId: 'recSkill2',
     });
     const skill = this.server.create('skill', {
       id: 'recSkill1',
       name: '@skill1',
       challengeIds: ['recChallenge1', 'challengeChallenge1'],
-      pixId: 'skill1',
+      pixId: 'recSkill1',
       version: 1,
     });
     const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill2', 'recSkill1'] });
     const competence = this.server.create('competence', {
       id: 'recCompetence1.1',
-      pixId: 'pixId recCompetence1.1',
+      pixId: 'recCompetence1.1',
       rawTubeIds: ['recTube1'],
     });
     this.server.create('competence-overview', {
@@ -88,36 +88,38 @@ module('Acceptance | Search', function (hooks) {
     return authenticateSession();
   });
 
-  test('search a challenge by rec id', async function (assert) {
+  test('search a challenge', async function (assert) {
     // given
+    this.server.create('search-result', {
+      id: 'recChallenge1',
+      title: 'Le challenge avec l’ID recChallenge1',
+      type: 'challenge',
+      status: 'validé',
+      locale: 'fr',
+      'is-primary': true,
+    });
     const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1?view=production';
 
     // when
     const screen = await visit('/');
     await clickByText('Rechercher un acquis ou une épreuve...');
     await fillByLabel('Rechercher...', '  recChallenge1  ');
-    await click(await screen.findByRole('option', { name: 'recChallenge1' }));
+    await click(await screen.findByRole('option', { name: '🟢 Le challenge avec l’ID recChallenge1' }));
 
     // then
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by challenge id', async function (assert) {
+  test('search a localized challenge', async function (assert) {
     // given
-    const expectedUrl = '/competence/recCompetence1.1/prototypes/challengeChallenge1?view=production';
-
-    // when
-    const screen = await visit('/');
-    await clickByText('Rechercher un acquis ou une épreuve...');
-    await fillByLabel('Rechercher...', '  challengeChallenge1  ');
-    await click(await screen.findByRole('option', { name: 'challengeChallenge1' }));
-
-    // then
-    assert.strictEqual(currentURL(), expectedUrl);
-  });
-
-  test('search a challenge by localized challenge id', async function (assert) {
-    // given
+    this.server.create('search-result', {
+      id: 'challengeLocalizedChallenge1',
+      title: 'The challenge with ID challengeLocalizedChallenge1',
+      type: 'challenge',
+      status: 'proposé',
+      locale: 'en',
+      'is-primary': false,
+    });
     const expectedUrl =
       '/competence/recCompetence1.1/prototypes/challengeChallenge1/localized/challengeLocalizedChallenge1?view=production';
 
@@ -125,28 +127,21 @@ module('Acceptance | Search', function (hooks) {
     const screen = await visit('/');
     await clickByText('Rechercher un acquis ou une épreuve...');
     await fillByLabel('Rechercher...', '  challengeLocalizedChallenge1  ');
-    await click(await screen.findByRole('option', { name: 'challengeLocalizedChallenge1' }));
+    await click(await screen.findByRole('option', { name: '🔵 The challenge with ID challengeLocalizedChallenge1' }));
 
     // then
     assert.strictEqual(currentURL(), expectedUrl);
   });
 
-  test('search a challenge by text', async function (assert) {
+  test('search a skill', async function (assert) {
     // given
-    const expectedUrl = '/competence/recCompetence1.1/prototypes/recChallenge1?view=production';
-
-    // when
-    const screen = await visit('/');
-    await clickByText('Rechercher un acquis ou une épreuve...');
-    await fillByLabel('Rechercher...', 'test');
-    await click(await screen.findByRole('option', { name: 'test' }));
-
-    // then
-    assert.strictEqual(currentURL(), expectedUrl);
-  });
-
-  test('search a skill by name - starting with @', async function (assert) {
-    // given
+    this.server.create('search-result', {
+      id: 'recSkill1',
+      title: '@skill1',
+      type: 'skill',
+      status: 'actif',
+      version: 1,
+    });
     const expectedUrl = '/competence/recCompetence1.1/skills/recSkill1?view=production';
 
     // when

--- a/pix-editor/tests/acceptance/search-test.js
+++ b/pix-editor/tests/acceptance/search-test.js
@@ -19,11 +19,21 @@ module('Acceptance | Search', function (hooks) {
       instruction: 'test',
       airtableId: 'recChallenge1',
     });
-    this.server.create('challenge', { id: 'challengeChallenge1', airtableId: 'challengeChallenge1' });
+    this.server.create('challenge', {
+      id: 'challengeChallenge1',
+      airtableId: 'challengeChallenge1',
+      locales: ['fr'],
+    });
     this.server.create('localized-challenge', { id: 'challengeChallenge1', challengeId: 'challengeChallenge1' });
     this.server.create('localized-challenge', {
       id: 'challengeLocalizedChallenge1',
       challengeId: 'challengeChallenge1',
+      locale: 'en',
+    });
+    this.server.create('challenge-locale', {
+      locale: 'en',
+      challengeId: 'challengeChallenge1',
+      localizedChallengeId: 'challengeLocalizedChallenge1',
     });
     this.server.create('localized-challenge', { id: 'recChallenge1', challengeId: 'recChallenge1' });
     this.server.create('skill', {
@@ -38,6 +48,7 @@ module('Acceptance | Search', function (hooks) {
       id: 'recSkill1',
       name: '@skill1',
       challengeIds: ['recChallenge1', 'challengeChallenge1'],
+      challengesProductionIds: ['recChallenge1', 'challengeChallenge1'],
       pixId: 'recSkill1',
       version: 1,
     });
@@ -63,8 +74,39 @@ module('Acceptance | Search', function (hooks) {
                   name: skill.name,
                   prototypeId: prototype.id,
                   isPrototypeDeclinable: true,
-                  proposedChallengesCount: 1,
-                  validatedChallengesCount: 0,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    this.server.create('competence-overview', {
+      id: `${competence.pixId}:challenges-production:en`,
+      thematicOverviews: [
+        {
+          id: 'pas de thématique',
+          name: "on m'a oublié :(",
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 1,
                 },
                 null,
                 null,
@@ -152,5 +194,57 @@ module('Acceptance | Search', function (hooks) {
 
     // then
     assert.strictEqual(currentURL(), expectedUrl);
+  });
+
+  module('when v2 is enabled', function (hooks) {
+    hooks.beforeEach(function () {
+      window.localStorage.setItem('v2', 'true');
+    });
+
+    test('search a challenge', async function (assert) {
+      // given
+      this.server.create('search-result', {
+        id: 'recChallenge1',
+        title: 'Le challenge avec test dans la consigne',
+        type: 'challenge',
+        status: 'périmé',
+        locale: 'fr',
+        'is-primary': true,
+      });
+      const expectedUrl =
+        '/v2/competences/recCompetence1.1/challenges-production/skills/recSkill1/challenges/recChallenge1';
+
+      // when
+      const screen = await visit('/');
+      await clickByText('Rechercher un acquis ou une épreuve...');
+      await fillByLabel('Rechercher...', 'test');
+      await click(await screen.findByRole('option', { name: '🔴 Le challenge avec test dans la consigne' }));
+
+      // then
+      assert.strictEqual(currentURL(), expectedUrl);
+    });
+
+    test('search a localized challenge', async function (assert) {
+      // given
+      this.server.create('search-result', {
+        id: 'challengeLocalizedChallenge1',
+        title: 'The challenge with ID challengeLocalizedChallenge1',
+        type: 'challenge',
+        status: 'validé',
+        locale: 'en',
+        'is-primary': false,
+      });
+      const expectedUrl =
+        '/v2/competences/recCompetence1.1/challenges-production/skills/recSkill1/localized-challenges/challengeLocalizedChallenge1?locale=en';
+
+      // when
+      const screen = await visit('/');
+      await clickByText('Rechercher un acquis ou une épreuve...');
+      await fillByLabel('Rechercher...', '  challengeLocalizedChallenge1  ');
+      await click(await screen.findByRole('option', { name: '🟢 The challenge with ID challengeLocalizedChallenge1' }));
+
+      // then
+      assert.strictEqual(currentURL(), expectedUrl);
+    });
   });
 });

--- a/pix-editor/tests/mirage/factories.js
+++ b/pix-editor/tests/mirage/factories.js
@@ -9,6 +9,7 @@ import competence from './factories/competence';
 import framework from './factories/framework';
 import localizedChallenge from './factories/localized-challenge';
 import note from './factories/note';
+import searchResult from './factories/search-result';
 import skill from './factories/skill';
 import tag from './factories/tag';
 import theme from './factories/theme';
@@ -26,6 +27,7 @@ export default {
   framework,
   localizedChallenge,
   note,
+  searchResult,
   skill,
   tag,
   theme,

--- a/pix-editor/tests/mirage/factories/search-result.js
+++ b/pix-editor/tests/mirage/factories/search-result.js
@@ -1,0 +1,3 @@
+import { Factory } from 'miragejs';
+
+export default Factory.extend({});

--- a/pix-editor/tests/mirage/models.js
+++ b/pix-editor/tests/mirage/models.js
@@ -19,6 +19,7 @@ import localizedFrameworkTube from './models/localized-framework-tube';
 import missionSummary from './models/mission-summary';
 import mission from './models/mission';
 import note from './models/note';
+import searchResult from './models/search-result';
 import skill from './models/skill';
 import staticCourseSummary from './models/static-course-summary';
 import staticCourseTag from './models/static-course-tag';
@@ -50,6 +51,7 @@ export default {
   missionSummary,
   mission,
   note,
+  searchResult,
   skill,
   staticCourseSummary,
   staticCourseTag,

--- a/pix-editor/tests/mirage/models/search-result.js
+++ b/pix-editor/tests/mirage/models/search-result.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -486,6 +486,8 @@ export default function routes() {
   this.post('/phrase/download', function () {
     return { ok: 'cool' };
   });
+
+  this.get('/search', (schema) => schema.searchResults.all());
 }
 /* eslint-enable ember/no-get */
 

--- a/pix-editor/tests/unit/routes/challenge-test.js
+++ b/pix-editor/tests/unit/routes/challenge-test.js
@@ -47,6 +47,7 @@ module('Unit | Route | challenge', function (hooks) {
     secondaryLocalizedPrototype = store.createRecord('localized-challenge', {
       id: `${prototypeId}nl`,
       challenge: prototype,
+      locale: 'nl',
     });
     alternative = store.createRecord('challenge', {
       id: alternativeId,
@@ -61,6 +62,7 @@ module('Unit | Route | challenge', function (hooks) {
     secondaryLocalizedAlternative = store.createRecord('localized-challenge', {
       id: `${alternativeId}nl`,
       challenge: alternative,
+      locale: 'nl',
     });
   });
 
@@ -118,7 +120,7 @@ module('Unit | Route | challenge', function (hooks) {
         });
 
         module('when navigating to prototype’s secondary', function () {
-          test('redirects to v1 localized challenge', async function (assert) {
+          test('redirects to v2 localized challenge', async function (assert) {
             // given
             const model = secondaryLocalizedPrototype;
 
@@ -128,17 +130,19 @@ module('Unit | Route | challenge', function (hooks) {
             // then
             sinon.assert.calledOnceWithExactly(
               route.router.transitionTo,
-              'authenticated.competence.prototypes.localized',
+              'authenticated.v2.localized-challenge',
               competenceId,
-              prototypeId,
+              'challenges-production',
+              skillId,
               secondaryLocalizedPrototype.get('id'),
+              { queryParams: { locale: 'nl' } },
             );
             assert.ok(true);
           });
         });
 
         module('when navigating to alternative’s secondary', function () {
-          test('redirects to v1 localized challenge', async function (assert) {
+          test('redirects to v2 localized challenge', async function (assert) {
             // given
             const model = secondaryLocalizedAlternative;
 
@@ -148,11 +152,12 @@ module('Unit | Route | challenge', function (hooks) {
             // then
             sinon.assert.calledOnceWithExactly(
               route.router.transitionTo,
-              'authenticated.competence.prototypes.single.alternatives.localized',
+              'authenticated.v2.localized-challenge',
               competenceId,
-              prototypeId,
-              alternativeId,
+              'challenges-production',
+              skillId,
               secondaryLocalizedAlternative.get('id'),
+              { queryParams: { locale: 'nl' } },
             );
             assert.ok(true);
           });


### PR DESCRIPTION
## ❄️ Problème

On ne peut pas accéder à une épreuve traduite en v2 depuis la recherche.

## 🛷 Proposition

Intégrer le nouveau endpoint de recherche et implémenter la redirection vers une épreuve traduite en v2.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Faire des recherches dans tous les sens.