### PR TITLE
[TECH] Correction warning `legacy ember-template-compiler.js AMD bundle`

### DIFF
--- a/pix-editor/config/optional-features.json
+++ b/pix-editor/config/optional-features.json
@@ -2,5 +2,6 @@
   "application-template-wrapper": false,
   "default-async-observers": true,
   "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "template-only-glimmer-components": true,
+  "use-ember-modules": true
 }


### PR DESCRIPTION
## ❄️ Problème

On a un warning Ember :

```
Your app is using the legacy ember-template-compiler.js AMD bundle. This will be removed in ember-source 7.0.
```

## 🛷 Proposition

Corriger le warning.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Vérifier que l’appli fonctionne comme attendu.