### PR TITLE
[FEATURE] Besoin de mettre en Qualité Validé les épreuves en prod à J+15 (PIX-21098)

### DIFF
--- a/api/scripts/update-validate-to-qualityOk-challenges.js
+++ b/api/scripts/update-validate-to-qualityOk-challenges.js
@@ -25,11 +25,21 @@ export class UpdateValidateToQualityOkChallenges extends Script {
 
     await knex.transaction(
       async (transaction) => {
-        const changedChallenges = await transaction
+        const challengesToUpdate = await transaction('challenges')
+          .select('challenges.*')
+          .join('skills', 'challenges.skillId', '=', 'skills.id')
+          .join('tubes', 'skills.tubeId', '=', 'tubes.id')
+          .join('thematics', 'tubes.thematicId', '=', 'thematics.id')
+          .join('competences', 'thematics.competenceId', '=', 'competences.id')
+          .join('areas', 'competences.areaId', '=', 'areas.id')
+          .join('frameworks', 'areas.frameworkId', '=', 'frameworks.id')
+          .where('frameworks.name', '<>', 'Pix 1D')
+          .where('challenges.status', 'validé')
+          .where('challenges.validatedAt', '<=', date);
+
+        const changedChallenges = await transaction('challenges')
           .update({ isQualityOk: true })
-          .from('challenges')
-          .where('status', 'validé')
-          .where('validatedAt', '<=', date);
+          .whereIn('id', challengesToUpdate.map((ch) => ch.id));
 
         if (options.dryRun) await transaction.rollback();
 

--- a/api/scripts/update-validate-to-qualityOk-challenges.js
+++ b/api/scripts/update-validate-to-qualityOk-challenges.js
@@ -1,0 +1,46 @@
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+import { knex } from '../db/knex-database-connection.js';
+
+export class UpdateValidateToQualityOkChallenges extends Script {
+  constructor() {
+    super({
+      description: 'Script de reprise des données des épreuves à statut validé à J+15',
+      permanent: true,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist any deletion made during the script.',
+          demandOption: false,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script updateValidateToQualityOkChallenges has started');
+    const date = new Date();
+    date.setDate(date.getDate() - 15);
+
+    await knex.transaction(
+      async (transaction) => {
+        const changedChallenges = await transaction
+          .update({ isQualityOk: true })
+          .from('challenges')
+          .where('status', 'validé')
+          .where('validatedAt', '<=', date);
+
+        if (options.dryRun) await transaction.rollback();
+
+        if (changedChallenges === 0) {
+          logger.info('No validated challenges status changed');
+        } else {
+          logger.info({ changedChallenges }, `${changedChallenges} challenges' status updated to 'Qualité validée'`);
+        }
+      },
+    );
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, UpdateValidateToQualityOkChallenges);

--- a/api/tests/integration/tooling/database-builder/build-group_test.js
+++ b/api/tests/integration/tooling/database-builder/build-group_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { databaseBuilder } from '../../../test-helper.js';
+import { databaseBuilder, knex } from '../../../test-helper.js';
 
 describe('Unit | Tooling | database Builder | buildGroup', function() {
   it('should build a challenge in group', async () => {
@@ -10,6 +10,8 @@ describe('Unit | Tooling | database Builder | buildGroup', function() {
     const result = databaseBuilder.factory.buildChallengeInGroup({ challenge });
     await databaseBuilder.commit();
 
+    const challengeCreated = await knex('challenges').select('*').where('id', challenge.id).first();
+
     // then
     expect(result.challenge).deep.equal({
       id: 'challenge1',
@@ -18,7 +20,7 @@ describe('Unit | Tooling | database Builder | buildGroup', function() {
       t2Status: false,
       t3Status: true,
       status: 'validé',
-      skillId: 'skill1',
+      skillId: challengeCreated.skillId,
       embedHeight: 500,
       timer: 1234,
       format: 'mots',
@@ -62,7 +64,7 @@ describe('Unit | Tooling | database Builder | buildGroup', function() {
       validatedAt: null,
     });
     expect(result.skill).deep.equal({
-      id: 'skill1',
+      id: result.skill.id,
       status: 'actif',
       hintStatus: 'Validé',
       descriptionStatus: 'Validé',
@@ -70,7 +72,7 @@ describe('Unit | Tooling | database Builder | buildGroup', function() {
       level: 5,
       internationalisation: 'Monde',
       version: 1,
-      tubeId: 'tube1',
+      tubeId: result.skill.tubeId,
       activatedAt: undefined,
       archivedAt: undefined,
       obsoletedAt: undefined,
@@ -80,37 +82,37 @@ describe('Unit | Tooling | database Builder | buildGroup', function() {
       learningMoreTutorialIds: [],
     });
     expect(result.tube).deep.equal({
-      id: 'tube1',
+      id: result.tube.id,
       name: '@tube',
       index: undefined,
-      thematicId: 'thematic1',
+      thematicId: result.tube.thematicId,
       createdAt: undefined,
       updatedAt: undefined,
     });
     expect(result.thematic).deep.equal({
-      id: 'thematic1',
+      id: result.thematic.id,
       index: undefined,
-      competenceId: 'competence1',
+      competenceId: result.thematic.competenceId,
       createdAt: undefined,
       updatedAt: undefined,
     });
     expect(result.competence).deep.equal({
-      id: 'competence1',
+      id: result.competence.id,
       index: '1.1',
-      areaId: 'area1',
+      areaId: result.competence.areaId,
       createdAt: undefined,
       updatedAt: undefined,
     });
     expect(result.area).deep.equal({
-      id: 'area1',
+      id: result.area.id,
       code: '1',
       color: undefined,
-      frameworkId: 'framework1',
+      frameworkId: result.area.frameworkId,
       createdAt: undefined,
       updatedAt: undefined,
     });
     expect(result.framework).deep.equal({
-      id: 'framework1',
+      id: result.framework.id,
       name: 'Pix',
       createdAt: undefined,
       updatedAt: undefined,

--- a/api/tests/scripts/update-validate-to-qualityOk-challenges_test.js
+++ b/api/tests/scripts/update-validate-to-qualityOk-challenges_test.js
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { databaseBuilder, domainBuilder, knex } from '../test-helper.js';
+import { UpdateValidateToQualityOkChallenges } from '../../scripts/update-validate-to-qualityOk-challenges.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+
+describe('Script | UpdateValidateToQualityOkChallenges', () => {
+  /** @type {UpdateValidateToQualityOkChallenges} */
+  let script;
+
+  beforeEach(() => {
+    script = new UpdateValidateToQualityOkChallenges();
+  });
+
+  describe('#handle', () => {
+    beforeEach(async () => {
+      const today = new Date();
+      const dayMinus15 = new Date();
+      dayMinus15.setDate(-15);
+
+      const challengeDataToUpdate = {
+        id: 'challengeId',
+        skillId: 'skillId1',
+        status: 'validé',
+        validatedAt: dayMinus15,
+        isQualityOk: false,
+      };
+      const localizedChallenge = {
+        id: challengeDataToUpdate.id,
+        challengeId: challengeDataToUpdate.id,
+        locale: 'fr',
+      };
+      databaseBuilder.factory.buildChallengeInGroup({ challenge: challengeDataToUpdate, localizedChallenge });
+      const challengeDataFromPix1D = {
+        id: 'challengeId_fromPix1D',
+        skillId: 'skillId2',
+        status: 'validé',
+        validatedAt: dayMinus15,
+        isQualityOk: false,
+      };
+      const localizedChallengeFromPix1D = {
+        id: challengeDataFromPix1D.id,
+        challengeId: challengeDataFromPix1D.id,
+        locale: 'fr',
+      };
+      databaseBuilder.factory.buildChallengeInGroup({ challenge: challengeDataFromPix1D, localizedChallenge: localizedChallengeFromPix1D, framework: { name: 'Pix 1D' } });
+
+      const challengeNotToUpdate = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId_notupdate1',
+        skillId: 'skillId1',
+        status: 'validé',
+        validatedAt: today,
+        isQualityOk: false,
+      });
+      databaseBuilder.factory.buildChallenge(challengeNotToUpdate);
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeNotToUpdate.id,
+        challengeId: challengeNotToUpdate.id,
+        locale: 'fr',
+      });
+
+      const challengeNotToUpdate2 = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId_notupdate2',
+        skillId: 'skillId1',
+        status: 'archivé',
+        validatedAt: dayMinus15,
+        isQualityOk: false,
+      });
+      databaseBuilder.factory.buildChallenge(challengeNotToUpdate2);
+      databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeNotToUpdate2.id,
+        challengeId: challengeNotToUpdate2.id,
+        locale: 'fr',
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('update only challenges with status validate and validateAt older than 15days ', async () => {
+      // given
+      const options = { dryRun: false };
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      const challengesNotToUpdate1 = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId_notupdate1' }).first();
+      const challengesNotToUpdate2 = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId_notupdate2' }).first();
+      const challengesToUpdate = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId' }).first();
+      const challengesFromPix1D = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId_fromPix1D' }).first();
+      expect(challengesToUpdate.isQualityOk).to.be.true;
+      expect(challengesNotToUpdate1.isQualityOk).to.be.false;
+      expect(challengesNotToUpdate2.isQualityOk).to.be.false;
+      expect(challengesFromPix1D.isQualityOk).to.be.false;
+    });
+
+    describe('when dryRun option is true', () => {
+      it('stops before deletion', async () => {
+        // given
+        const options = { dryRun: true };
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        const challengesNotToUpdate1 = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId_notupdate1' }).first();
+        const challengesNotToUpdate2 = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId_notupdate2' }).first();
+        const challengesToUpdate = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId' }).first();
+        const challengesFromPix1D = await knex.select('isQualityOk').from('challenges').where({ id: 'challengeId_fromPix1D' }).first();
+        expect(challengesToUpdate.isQualityOk).to.be.false;
+        expect(challengesNotToUpdate1.isQualityOk).to.be.false;
+        expect(challengesNotToUpdate2.isQualityOk).to.be.false;
+        expect(challengesFromPix1D.isQualityOk).to.be.false;
+      });
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
@@ -10,11 +10,13 @@ import { buildChallenge } from './build-challenge.js';
 import { buildLocalizedChallenge } from './build-localized-challenge.js';
 import { buildTranslation } from './build-translation.js';
 
-export function buildChallengeInGroup({ challenge, localizedChallenge, challengeTranslations, skill }) {
+export function buildChallengeInGroup({ challenge, localizedChallenge, challengeTranslations, skill, framework }) {
+  const randomId = generateRandomId();
+
   const chalengeDTO = buildChallengeDatasourceObject({
-    id: 'challenge1',
-    competenceId: 'competence1',
-    skillId: 'skill1',
+    id: `challenge${randomId}`,
+    competenceId: `competence${randomId}`,
+    skillId: `skill${randomId}`,
     ...challenge,
   });
 
@@ -47,7 +49,7 @@ export function buildChallengeInGroup({ challenge, localizedChallenge, challenge
   };
 
   const skillDTO = buildSkillDatasourceObject({
-    tubeId: 'tube1',
+    tubeId: `tube${randomId}`,
     createdAt: chalengeDTO.createdAt,
     ...skill,
     id: chalengeDTO.skillId,
@@ -60,11 +62,11 @@ export function buildChallengeInGroup({ challenge, localizedChallenge, challenge
   }));
 
   return {
-    framework: buildFramework({ id: 'framework1', name: 'Pix' }),
-    area: buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' }),
-    competence: buildCompetence({ id: chalengeDTO.competenceId, index: '1.1', areaId: 'area1' }),
-    thematic: buildThematic({ id: 'thematic1', competenceId: chalengeDTO.competenceId }),
-    tube: buildTube({ id: skillDTO.tubeId, name: '@tube', thematicId: 'thematic1' }),
+    framework: buildFramework({ id: `framework${randomId}`, name: 'Pix', ...framework }),
+    area: buildArea({ id: `area${randomId}`, code: '1', frameworkId: framework?.id ?? `framework${randomId}` }),
+    competence: buildCompetence({ id: chalengeDTO.competenceId, index: '1.1', areaId: `area${randomId}` }),
+    thematic: buildThematic({ id: `thematic${randomId}`, competenceId: chalengeDTO.competenceId }),
+    tube: buildTube({ id: skillDTO.tubeId, name: '@tube', thematicId: `thematic${randomId}` }),
     skill: buildSkill({ ...skillDTO, tutorialIds: [], learningMoreTutorialIds: [] }),
     challenge: buildChallenge(chalengeDTO),
     localizedChallenge: buildLocalizedChallenge(localizedChallengeDTO),
@@ -72,3 +74,6 @@ export function buildChallengeInGroup({ challenge, localizedChallenge, challenge
   };
 }
 
+function generateRandomId() {
+  return (Math.random() * 100).toFixed();
+}


### PR DESCRIPTION
## ❄️ Problème
Depuis qu'on peut afficher un statut "Validée qualité" après J+15 de mise en prod, il faut reprendre les données sur les épreuves en prod depuis plus de 15 jours.

## 🛷 Proposition
Créer un script qui va reprendre tous les challenges validés depuis plus de 15 jours et mettre la valeur du champ `isQualityOk` à `true`.

## ☃️ Remarques
Il faut le faire pour tous les référentiels sauf Pix Junior.

## 🧑‍🎄 Pour tester
Tests au vert.
Lancer le script `update-validate-to-qualityOk-challenges` et voir si les challenges validés ont bien la valeur isQualityOk à true. (Peut se voir aussi sur le front)