### PR TITLE
[BUGFIX] Une déclinaison "validée" passe automatiquement au statut "validé qualité" (PIX-21562)

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -18,7 +18,7 @@ export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
   [LOCALE.ENGLISH_SPOKEN]: 'Anglais',
   [LOCALE.SPANISH_SPOKEN]: 'Espagnol',
   [LOCALE.FRENCH_FRANCE]: 'Franco Français',
-  [LOCALE.FRENCH_BELGIUM]: 'Français (Belgique)',
+  [LOCALE.FRENCH_BELGIUM]: 'Franco Belge',
   [LOCALE.FRENCH_SPOKEN]: 'Francophone',
   [LOCALE.ITALIAN_SPOKEN]: 'Italien',
   [LOCALE.DUTCH_SPOKEN]: 'Néerlandais',

--- a/pix-editor/app/components/competence-header.gjs
+++ b/pix-editor/app/components/competence-header.gjs
@@ -43,7 +43,7 @@ export default class CompetenceHeader extends Component {
       value: 'fr-fr',
     },
     {
-      label: 'Français (Belgique)',
+      label: 'Franco Belge',
       value: 'fr-BE',
     },
     {

--- a/pix-editor/app/components/competence/competence-header.gjs
+++ b/pix-editor/app/components/competence/competence-header.gjs
@@ -47,7 +47,7 @@ export default class CompetenceHeader extends Component {
       value: 'fr-fr',
     },
     {
-      label: 'Français (Belgique)',
+      label: 'Franco Belge',
       value: 'fr-BE',
     },
     {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -305,7 +305,16 @@ export default class ChallengeModel extends Model {
   }
 
   async duplicate() {
-    const ignoredFields = ['skill', 'author', 'airtableId', 'updatedAt', 'archivedAt', 'madeObsoleteAt', 'validatedAt'];
+    const ignoredFields = [
+      'skill',
+      'author',
+      'airtableId',
+      'updatedAt',
+      'archivedAt',
+      'madeObsoleteAt',
+      'validatedAt',
+      'isQualityOk',
+    ];
     if (this.isPrototype) {
       ignoredFields.push('version');
     } else {
@@ -322,7 +331,15 @@ export default class ChallengeModel extends Model {
   }
 
   async copyForDifferentSkill() {
-    const ignoredFields = ['skill', 'airtableId', 'updatedAt', 'archivedAt', 'madeObsoleteAt', 'validatedAt'];
+    const ignoredFields = [
+      'skill',
+      'airtableId',
+      'updatedAt',
+      'archivedAt',
+      'madeObsoleteAt',
+      'validatedAt',
+      'isQualityOk',
+    ];
     const data = this._getJSON(ignoredFields);
     data.status = 'proposé';
 

--- a/pix-editor/tests/unit/models/challenge-test.js
+++ b/pix-editor/tests/unit/models/challenge-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import sinon from 'sinon';
 
 module('Unit | Model | challenge', function (hooks) {
   setupTest(hooks);
@@ -121,7 +120,6 @@ module('Unit | Model | challenge', function (hooks) {
       toRephrase: true,
       hasEmbedInternalValidation: true,
       noValidationNeeded: true,
-      isQualityOk: true,
     };
   });
 
@@ -211,6 +209,7 @@ module('Unit | Model | challenge', function (hooks) {
         'champ hasEmbedInternalValidation',
       );
       assert.strictEqual(clonedChallenge.noValidationNeeded, prototype.noValidationNeeded, 'champ noValidationNeeded');
+      assert.strictEqual(clonedChallenge.isQualityOk, undefined, 'champ isQualityOk');
     });
 
     test('it should duplicate challenge to create new alternative version', async function (assert) {
@@ -302,6 +301,7 @@ module('Unit | Model | challenge', function (hooks) {
         alternative.noValidationNeeded,
         'champ noValidationNeeded',
       );
+      assert.strictEqual(clonedChallenge.isQualityOk, undefined, 'champ isQualityOk');
     });
 
     test('it should clone the attachments', async function (assert) {
@@ -343,6 +343,7 @@ module('Unit | Model | challenge', function (hooks) {
       assert.strictEqual(clonedChallenge.constructor.modelName, 'challenge');
       assert.strictEqual(clonedChallenge.airtableId, undefined);
       assert.strictEqual(clonedChallenge.status, 'proposé');
+      assert.strictEqual(clonedChallenge.isQualityOk, undefined);
       assert.notOk(skill);
     });
 


### PR DESCRIPTION
## 🥀 Problème

La propriété `isQualityOk` est recopiée à tort quand on créé une décli.

On veut "Franco Belge" à la place de "Français (Belgique)".

## 🏹 Proposition

Ne pas la recopier.

Mettre "Franco Belge" à la place de "Français (Belgique)".

## 💌 Remarques

Le bug était présent aussi sur la fonctionnalité "Dupliquer".

Une fois la MEP terminée, vérifier sur metabase si il y a des épreuves concernées :

```sql
SELECT COUNT(*) FROM challenges WHERE status = 'proposé' AND "isQualityOk";
```

Si c’est le cas, envoyer une requête de rattrapage aux captains.

## ❤️‍🔥 Pour tester

Créer une décli à partir d’un proto validé qualité, valider la décli, elle ne doit pas passer à validé qualité.
Créer un proto en dupliquant un proto validé qualité, valider ce le nouveau proto, il ne doit pas passer à validé qualité.