### PR TITLE
[BUGFIX] Impossible d'afficher épreuves traduites d'un acquis avec 2 protos (PIX-21584)

### DIFF
--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -83,11 +83,7 @@ export default class SkillModel extends Model {
   }
 
   get prototypes() {
-    const challenges = this.hasMany('challenges').value();
-
-    if (challenges === null) return [];
-
-    return challenges.filter((challenge) => challenge.isPrototype);
+    return this.challengesArray.filter((challenge) => challenge.isPrototype);
   }
 
   get sortedPrototypes() {
@@ -106,12 +102,8 @@ export default class SkillModel extends Model {
     return this.prototypes.find((prototype) => prototype.isValidated);
   }
 
-  get productionPrototypes() {
-    return this.prototypes.filter((prototype) => prototype.isValidated);
-  }
-
   get challengesArray() {
-    return this.hasMany('challenges').value() || [];
+    return this.hasMany('challenges').value() ?? this.hasMany('challengesProduction').value() ?? [];
   }
 
   get alternatives() {

--- a/pix-editor/tests/unit/models/skill-test.js
+++ b/pix-editor/tests/unit/models/skill-test.js
@@ -25,83 +25,133 @@ module('Unit | Model | skill', function (hooks) {
     locales: ['Franco Français'],
     status: 'validé',
   };
+
   hooks.beforeEach(function () {
     store = this.owner.lookup('service:store');
   });
 
-  test('it should return a map of unique language and alternatives', function (assert) {
-    // given
-    const skill = store.createRecord('skill', {
-      id: 'rec123456',
-      name: 'skillName',
-      challenges: [
-        store.createRecord('challenge', challenge1),
-        store.createRecord('challenge', challenge2),
-        store.createRecord('challenge', challenge3),
-        store.createRecord('challenge', challenge4),
-      ],
+  module('#languagesAndAlternativesCount', function () {
+    test('it should return a map of unique language and alternatives', function (assert) {
+      // given
+      const skill = store.createRecord('skill', {
+        id: 'rec123456',
+        name: 'skillName',
+        challenges: [
+          store.createRecord('challenge', challenge1),
+          store.createRecord('challenge', challenge2),
+          store.createRecord('challenge', challenge3),
+          store.createRecord('challenge', challenge4),
+        ],
+      });
+
+      // when
+      const languagesAndAlternativesCount = skill.languagesAndAlternativesCount;
+
+      // then
+      assert.strictEqual(languagesAndAlternativesCount.get('Anglais'), 2);
     });
-
-    // when
-    const languagesAndAlternativesCount = skill.languagesAndAlternativesCount;
-
-    // then
-    assert.strictEqual(languagesAndAlternativesCount.get('Anglais'), 2);
   });
 
-  test('it should return an array of unique language sorted', function (assert) {
-    // given
-    const skill = store.createRecord('skill', {
-      id: 'rec123456',
-      name: 'skillName',
-      challenges: [
-        store.createRecord('challenge', challenge1),
-        store.createRecord('challenge', challenge2),
-        store.createRecord('challenge', challenge3),
-        store.createRecord('challenge', challenge4),
-      ],
+  module('#languages', function () {
+    test('it should return an array of unique language sorted', function (assert) {
+      // given
+      const skill = store.createRecord('skill', {
+        id: 'rec123456',
+        name: 'skillName',
+        challenges: [
+          store.createRecord('challenge', challenge1),
+          store.createRecord('challenge', challenge2),
+          store.createRecord('challenge', challenge3),
+          store.createRecord('challenge', challenge4),
+        ],
+      });
+
+      // when
+      const languages = skill.languages;
+      const expected = ['Anglais', 'Franco Français', 'Francophone'];
+
+      // then
+      assert.deepEqual(languages, expected);
     });
-
-    // when
-    const languages = skill.languages;
-    const expected = ['Anglais', 'Franco Français', 'Francophone'];
-
-    // then
-    assert.deepEqual(languages, expected);
   });
 
-  test('it should clone skill with save method and adapterOptions', async function (assert) {
-    // given
-    const level = Symbol('level');
-    const storeStub = { createRecord: sinon.stub() };
-    const saveStub = sinon.stub();
-    storeStub.createRecord.returns({ save: saveStub });
+  module('#clone', function () {
+    test('it should clone skill with save method and adapterOptions', async function (assert) {
+      // given
+      const level = Symbol('level');
+      const storeStub = { createRecord: sinon.stub() };
+      const saveStub = sinon.stub();
+      storeStub.createRecord.returns({ save: saveStub });
 
-    const tube = store.createRecord('tube', { pixId: 'tubeId' });
-    const skill = store.createRecord('skill', {
-      id: 'rec_1',
-      pixId: 'pix_1',
-      status: 'actif',
-      competence: ['competenceId'],
-    });
+      const tube = store.createRecord('tube', { pixId: 'tubeId' });
+      const skill = store.createRecord('skill', {
+        id: 'rec_1',
+        pixId: 'pix_1',
+        status: 'actif',
+        competence: ['competenceId'],
+      });
 
-    skill.myStore = storeStub;
-    // when
-    await skill.clone({ tubeDestination: tube, level });
+      skill.myStore = storeStub;
+      // when
+      await skill.clone({ tubeDestination: tube, level });
 
-    // then
-    assert.ok(saveStub.calledOnce);
-    assert.ok(
-      saveStub.calledWith({
-        adapterOptions: {
-          clone: true,
-          body: {
-            skillIdToClone: 'pix_1',
-            tubeDestinationId: 'tubeId',
-            level,
+      // then
+      assert.ok(saveStub.calledOnce);
+      assert.ok(
+        saveStub.calledWith({
+          adapterOptions: {
+            clone: true,
+            body: {
+              skillIdToClone: 'pix_1',
+              tubeDestinationId: 'tubeId',
+              level,
+            },
           },
-        },
-      }),
-    );
+        }),
+      );
+    });
+  });
+
+  module('#productionPrototype', function () {
+    module('when challenges relationship is loaded', function () {
+      test('returns validated prototype', function (assert) {
+        // given
+        const skill = store.createRecord('skill', {
+          id: 'skill123',
+          name: 'skillName',
+          challenges: [
+            store.createRecord('challenge', { id: 'challenge1', genealogy: 'Prototype 1', status: 'proposé' }),
+            store.createRecord('challenge', { id: 'challenge2', genealogy: 'Décliné 1', status: 'proposé' }),
+            store.createRecord('challenge', { id: 'challenge3', genealogy: 'Prototype 1', status: 'validé' }),
+          ],
+        });
+
+        // when
+        const { productionPrototype } = skill;
+
+        // then
+        assert.strictEqual(productionPrototype?.id, 'challenge3');
+      });
+    });
+
+    module('when challengesProduction relationship is loaded', function () {
+      test('returns validated prototype', function (assert) {
+        // given
+        const skill = store.createRecord('skill', {
+          id: 'skill123',
+          name: 'skillName',
+          challengesProduction: [
+            store.createRecord('challenge', { id: 'challenge1', genealogy: 'Prototype 1', status: 'validé' }),
+            store.createRecord('challenge', { id: 'challenge2', genealogy: 'Décliné 1', status: 'validé' }),
+          ],
+        });
+
+        // when
+        const { productionPrototype } = skill;
+
+        // then
+        assert.strictEqual(productionPrototype?.id, 'challenge1');
+      });
+    });
   });
 });


### PR DESCRIPTION
## 🥀 Problème

On récupère le proto validé depuis la relation `challenges` du skill, qui n’est pas chargée.
C’est la relation `challengesProduction` qui est chargée.

## 🏹 Proposition

Récupérer le proto validé depuis la relation `challenges` ou à défaut depuis la relation `challengesProduction`.

## 💌 Remarques

Le bug ne se produit que pour les acquis dont les relations `challenges` et `challengesProduction` ne contiennent pas les mêmes challenges, donc ceux qui ont au moins 2 protos.

## ❤️‍🔥 Pour tester

Aller en V2 sur les épreuves traduites d'un acquis avec 2 prototypes, par exemple `@amandePistache3` en 1.1.