### PR TITLE
[BUGFIX] Permettre aux éditeurs d'attribuer le statut "validé qualité" (PIX-21669)

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -117,6 +117,10 @@ export default class SingleController extends Controller {
     return this.challenge.isPrototype && !this.challenge.isWorkbench;
   }
 
+  get mayHaveDifferentChallengeVersions() {
+    return this.challenge.isPrototype && !this.challenge.isWorkbench;
+  }
+
   get shouldDisplayStatusActionsMenu() {
     return this.mayValidate || this.mayArchive || this.mayObsolete || this.mayValidateQuality;
   }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -117,6 +117,10 @@ export default class SingleController extends Controller {
     return this.challenge.isPrototype && !this.challenge.isWorkbench;
   }
 
+  get shouldDisplayStatusActionsMenu() {
+    return this.mayValidate || this.mayArchive || this.mayObsolete || this.mayValidateQuality;
+  }
+
   get level() {
     const challenge = this.challenge;
     if (challenge.skillLevel) {

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
@@ -39,7 +39,7 @@ import SelectLocation from 'pixeditor/components/pop-in/select-location';
             title="Afficher les différentes versions d'épreuves"
           ><i class="clone icon"></i>&nbsp;v{{@controller.challenge.version}}</button>
         {{/if}}
-        {{#if (or @controller.mayValidate @controller.mayArchive @controller.mayObsolete)}}
+        {{#if @controller.shouldDisplayStatusActionsMenu}}
           <div class="challenge-status-actions" id={{@controller.challengeStatusActionsId}}>
             <PixIconButton
               @ariaLabel={{@controller.challengeStatusActionsLabel}}

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
@@ -1,8 +1,5 @@
 import ChallengeHeader from 'pixeditor/components/competence/prototypes/challenge-header';
 import { on } from '@ember/modifier';
-import and from 'ember-truth-helpers/helpers/and';
-import not from 'ember-truth-helpers/helpers/not';
-import or from 'ember-truth-helpers/helpers/or';
 import PixIconButton from '@1024pix/pix-ui/components/pix-icon-button';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
@@ -31,7 +28,7 @@ import SelectLocation from 'pixeditor/components/pop-in/select-location';
           ></i></button>
       {{/if}}
       {{#unless @controller.edition}}
-        {{#if (and @controller.challenge.isPrototype (not @controller.challenge.isWorkbench))}}
+        {{#if @controller.mayHaveDifferentChallengeVersions}}
           <button
             class="ui button icon item"
             {{on "click" @controller.showVersions}}

--- a/pix-editor/tests/acceptance/challenge/validate-quality-challenge/validate-quality-alternative-test.js
+++ b/pix-editor/tests/acceptance/challenge/validate-quality-challenge/validate-quality-alternative-test.js
@@ -1,9 +1,9 @@
-import { clickByText, visit } from '@1024pix/ember-testing-library';
+import { visit } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
-import { log, module, test } from 'qunit';
+import { module, test } from 'qunit';
 import Challenge from 'pixeditor/models/challenge.js';
 import Skill from 'pixeditor/models/skill.js';
 import sinon from 'sinon';
@@ -27,7 +27,7 @@ module('Acceptance | Validate-quality-challenge', function (hooks) {
     messageStub = sinon.stub(notifyServiceStub, 'message');
 
     this.server.create('config', 'default');
-    this.server.create('user', { trigram: 'ABC' });
+    this.server.create('user', { trigram: 'ABC', access: 'editor' });
 
     prototype = this.server.create('challenge', {
       id: 'challengeId1',

--- a/pix-editor/tests/acceptance/challenge/validate-quality-challenge/validate-quality-prototype-test.js
+++ b/pix-editor/tests/acceptance/challenge/validate-quality-challenge/validate-quality-prototype-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Validate-quality-challenge', function (hooks) {
     messageStub = sinon.stub(notifyServiceStub, 'message');
 
     this.server.create('config', 'default');
-    this.server.create('user', { trigram: 'ABC' });
+    this.server.create('user', { trigram: 'ABC', access: 'editor' });
 
     prototype = this.server.create('challenge', {
       id: 'challengeId1',


### PR DESCRIPTION
## 🥀 Problème

Les éditeurs (`access: 'editor'`) ne peuvent pas attribuer le statut "validé qualité" sur les épreuves.
Il y a eu un oubli sur une des conditions qui permet d'afficher le menu de modification de statut d'une épreuve (⚡️).

## 🏹 Proposition

Corriger la condition.

## 💌 Remarques

- Conversion des conditions dans le `template.gjs` en getters dans le `controller`.

## ❤️‍🔥 Pour tester

- Se connecter en tant qu'éditeur.
- Se rendre sur une épreuve validée.
- Constater que le bouton de modification du statut d'une épreuve est présent (éclair ⚡️).
- Cliquer dessus.
- Constater que le bouton d'attribution du statut "validé qualité" est présent.