### PR TITLE
[FEATURE] Ajouter le référentiel Pix+Edu à Phrase pour pouvoir le traduire en fr-be et en (PIX-21585)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -148,6 +148,10 @@ export const phrase = {
       frameworkName: 'Numérique Responsable',
       projectId: process.env.PHRASE_PIX_NR_PROJECT_ID,
     },
+    {
+      frameworkName: 'Edu',
+      projectId: process.env.PHRASE_PIX_EDU_PROJECT_ID,
+    },
   ].filter(({ projectId }) => projectId),
   webhookSecret: process.env.PHRASE_WEBHOOK_SECRET,
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -541,6 +541,14 @@ EXPORT_EXTERNAL_URLS_LIST_SPREADSHEET_ID=
 # default: none
 # PHRASE_PIX_NR_PROJECT_ID=xxxxx
 
+# The Project ID used to upload and download translations for Pix+Edu framework
+# Get it on Project Settings -> API
+#
+# presence: optional
+# type: String
+# default: none
+# PHRASE_PIX_EDU_PROJECT_ID=xxxxx
+
 # The Phrase webhook secret
 #
 # presence: optional


### PR DESCRIPTION
## 🥀 Problème
Il y a besoin de traduire le référentiel Pix+Edu en fr-BE et en. Ce n'est pas encore inclus dans Phrase.

## 🏹 Proposition
1 - Créer le projet dans Phrase
2 - Ajouter le référentiel concerné dans la config phrase sur Pix Editor.

## 💌 Remarques
RAS

## ❤️‍🔥 Pour tester
Tests au vert ? 