### PR TITLE
[BUGFIX] Problème d'affichage des URLs externes à consulter (PIX-21189).

### DIFF
--- a/pix-editor/app/components/field/input.gjs
+++ b/pix-editor/app/components/field/input.gjs
@@ -8,7 +8,7 @@ import { on } from '@ember/modifier';
 export default class Input extends Component {
   <template>
     <div class={{concat "field" (if @edition "" " disabled")}} ...attributes>
-      <p>{{@title}}</p>
+      <p id="title-{{@id}}">{{@title}}</p>
       <div class="ui input">
         {{#if @label}}
           <label class="label-input" for={{@id}}>{{@label}} : </label>
@@ -16,6 +16,7 @@ export default class Input extends Component {
         <Input0
           id={{@id}}
           @value={{@value}}
+          aria-labelledby={{this.ariaLabeledBy}}
           placeholder={{@placeholder}}
           readonly={{not @edition}}
           {{on "change" this.change}}
@@ -23,6 +24,8 @@ export default class Input extends Component {
       </div>
     </div>
   </template>
+
+  ariaLabeledBy = this.args.title && !this.args.label ? `title-${this.args.id}` : false;
 
   @action
   change(evt) {

--- a/pix-editor/app/components/form/challenge.gjs
+++ b/pix-editor/app/components/form/challenge.gjs
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import Mde from 'pixeditor/components/field/mde';
 import { fn } from '@ember/helper';
+import { guidFor } from '@ember/object/internals';
 import ToggleField from 'pixeditor/components/field/toggle-field';
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import not from 'ember-truth-helpers/helpers/not';
@@ -100,7 +101,7 @@ export default class ChallengeForm extends Component {
         @edition={{@edition}}
         @helpContent={{this.helpAnswers}}
         data-test-answers-field
-        @id="challenge-solution"
+        @id={{this.solutionsFieldId}}
       />
       {{#if (and @challenge.isTextBased (not this.isAutoReply))}}
         <div id="toleranceField" data-test-tolerence-fields class="field {{if @edition '' 'disabled'}}">
@@ -137,7 +138,7 @@ export default class ChallengeForm extends Component {
           @value={{@challenge.solutionToDisplay}}
           @edition={{@edition}}
           data-test-solution-to-display-field
-          @id="challenge-solution-to-display"
+          @id={{this.solutionToDisplayFieldId}}
         />
       </ToggleField>
 
@@ -159,7 +160,7 @@ export default class ChallengeForm extends Component {
           @change={{@setUrlsToConsult}}
           @helpContent={{this.helpUrlsToConsult}}
           data-test-urls-to-consult-field
-          @id="urls-to-consult-to-display"
+          @id={{this.urlToConsultFieldId}}
         />
       </ToggleField>
       {{#if @invalidUrlsToConsult}}
@@ -183,7 +184,7 @@ export default class ChallengeForm extends Component {
           @value={{@challenge.illustrationAlt}}
           @title="Texte alternatif"
           @edition={{@edition}}
-          @id="challenge-illustration-alt"
+          @id={{this.illustrationAltFieldId}}
         />
       {{/if}}
       <Files
@@ -200,7 +201,7 @@ export default class ChallengeForm extends Component {
         @value={{@challenge.embedURL}}
         @edition={{@edition}}
         @label="URL"
-        @id="challenge-embed-url"
+        @id={{this.embedUrlFieldId}}
         @change={{@checkEmbedURL}}
       />
       {{#if @invalidEmbedURL}}
@@ -209,8 +210,8 @@ export default class ChallengeForm extends Component {
           {{@invalidEmbedURL}}
         </p>
       {{/if}}
-      <Input @value={{@challenge.embedHeight}} @edition={{@edition}} @label="Hauteur" @id="challenge-embed-height" />
-      <Input @value={{@challenge.embedTitle}} @edition={{@edition}} @label="Titre" @id="challenge-embed-title" />
+      <Input @value={{@challenge.embedHeight}} @edition={{@edition}} @label="Hauteur" @id={{this.embedHeightFieldId}} />
+      <Input @value={{@challenge.embedTitle}} @edition={{@edition}} @label="Titre" @id={{this.embedTitleFieldId}} />
       {{#if @challenge.isPrototype}}
         <div class="fields--selectors">
           <div class="field">
@@ -269,7 +270,7 @@ export default class ChallengeForm extends Component {
           </div>
           <div class="field">
             <PixSelect
-              @id="challenge-select-geography"
+              @id={{this.geographyFieldId}}
               @placeholder="Géographie"
               @onChange={{fn (mut @challenge.geography)}}
               @value={{this.challengeGeographyValue}}
@@ -298,10 +299,20 @@ export default class ChallengeForm extends Component {
         {{/if}}
       </div>
       {{#unless @edition}}
-        <Input @value={{@challenge.id}} @title="Id" @edition={{false}} />
+        <Input @id={{this.idFieldId}} @value={{@challenge.id}} @title="Id" @edition={{false}} />
       {{/unless}}
     </form>
   </template>
+
+  solutionsFieldId = `solutionsFieldId-${guidFor(this)}`;
+  solutionToDisplayFieldId = `solutionToDisplayFieldId-${guidFor(this)}`;
+  urlToConsultFieldId = `urlToConsultFieldId-${guidFor(this)}`;
+  illustrationAltFieldId = `illustrationAltFieldId-${guidFor(this)}`;
+  embedUrlFieldId = `embedUrlFieldId-${guidFor(this)}`;
+  embedHeightFieldId = `embedHeightFieldId-${guidFor(this)}`;
+  embedTitleFieldId = `embedTitleFieldId-${guidFor(this)}`;
+  geographyFieldId = `geographyFieldId-${guidFor(this)}`;
+  idFieldId = `idFieldId-${guidFor(this)}`;
 
   @service config;
   @service confirm;

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -18,7 +18,7 @@ import FieldToggleFieldComponent from '../v2/field/toggle-field';
 import LocalizedChallengeViewHeader from './localized-challenge-view-header';
 
 export default class LocalizedChallenge extends Component {
-  textareaId = `textareaId-${guidFor()}`;
+  textareaId = `textareaId-${guidFor(this)}`;
 
   @service countries;
   @service loader;

--- a/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/single/alternatives/single.js
@@ -16,9 +16,11 @@ export default class SingleRoute extends Route {
     await model?.attachments;
   }
 
-  setupController(controller) {
+  setupController(controller, model) {
     super.setupController(...arguments);
     controller.edition = false;
+    controller.urlsToConsult = model.urlsToConsult?.join('\n') ?? '';
+    controller.invalidUrlsToConsult = '';
   }
 
   @action

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
@@ -99,7 +99,7 @@ import SelectLocation from 'pixeditor/components/pop-in/select-location';
       {{/unless}}
     </:default>
   </ChallengeHeader>
-  <div class="challenge">
+  <div class="challenge" data-testid="panel-{{@controller.elementClass}}">
     <div class="challenge-data {{@controller.elementClass}}" {{scrollTop @controller.edition}}>
       <Challenge
         @challenge={{@controller.challenge}}

--- a/pix-editor/tests/acceptance/competence/prototypes/single/alternative/single-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/single/alternative/single-test.js
@@ -1,0 +1,135 @@
+import { visit, within } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
+
+module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.create('config', {
+      id: 'pix-editor-global-config',
+      localeToLanguageMap: {
+        fr: 'Francophone',
+      },
+    });
+    this.server.create('user', { trigram: 'ABC' });
+
+    const prototype = this.server.create('challenge', {
+      id: 'challenge1',
+      version: 1,
+      status: 'validé',
+      genealogy: 'Prototype 1',
+    });
+    this.server.create('challenge', {
+      id: 'challenge1-1',
+      status: 'validé',
+      genealogy: 'Décliné 1',
+      version: 1,
+      alternativeVersion: 1,
+      instruction: 'Ma consigne',
+      alternativeInstruction: 'Ma consigne alternative',
+      type: 'QCU',
+      autoReply: false,
+      proposals: 'Mes propositions',
+      solution: 'Ma solution',
+      solutionToDisplay: 'Ma solution à afficher',
+      embedURL: 'https://mon-embed-url.pop',
+      embedHeight: 500,
+      embedTitle: 'Titre de mon embed',
+      urlsToConsult: ['https://test-aleternative.pop'],
+      locales: ['fr'],
+      geography: 'BR',
+      validatedAt: '2021-10-02T14:00:00.000Z',
+      updatedAt: '2021-10-02T14:00:00.000Z',
+    });
+    const skill = this.server.create('skill', {
+      id: 'recSkill1',
+      name: '@sujet1',
+      challengeIds: ['challenge1', 'challenge1-1'],
+      level: 1,
+    });
+
+    const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
+    const thematic = this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
+    const competence = this.server.create('competence', {
+      id: 'recCompetence1.1',
+      pixId: 'pixId recCompetence1.1',
+      rawThemeIds: ['recTheme1'],
+      rawTubeIds: ['recTube1'],
+    });
+    this.server.create('competence-overview', {
+      id: `${competence.pixId}:challenges-production`,
+      thematicOverviews: [
+        {
+          id: thematic.id,
+          name: thematic.name,
+          tubeOverviews: [
+            {
+              id: tube.id,
+              name: tube.name,
+              skillOverviews: [
+                {
+                  id: skill.id,
+                  name: skill.name,
+                  prototypeId: prototype.id,
+                  isPrototypeDeclinable: true,
+                  proposedChallengesCount: 0,
+                  validatedChallengesCount: 2,
+                },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    this.server.create('area', {
+      id: 'recArea1',
+      name: '1. Information et données',
+      code: '1',
+      competenceIds: ['recCompetence1.1'],
+    });
+    this.server.create('framework', { id: 'recFramework1', name: 'Pix', areaIds: ['recArea1'] });
+    return authenticateSession();
+  });
+
+  test('it should display the alternative challenge', async function (assert) {
+    // when
+    const screen = await visit('/');
+    await click(screen.getByRole('button', { name: '1. Information et données' }));
+    await click(screen.getByRole('link', { name: 'Code Title' }));
+
+    await click(screen.getByRole('link', { name: '@sujet1 2' }));
+    await click(screen.getByRole('button', { name: 'Déclinaisons >>' }));
+    await click(screen.getByRole('cell', { name: 'Ma consigne' }));
+
+    // then
+    const alternativePanel = within(screen.getByTestId('panel-alternative-challenge'));
+
+    assert.dom(alternativePanel.getByText('Ma consigne')).exists();
+    assert.dom(screen.getByText('Ma consigne alternative')).exists();
+    assert.dom(screen.getByText('Mes propositions')).exists();
+
+    assert.dom(alternativePanel.getByLabelText('Réponses')).hasValue('Ma solution');
+    assert.dom(screen.getByLabelText('Bonne réponse à afficher')).hasValue('Ma solution à afficher');
+    assert
+      .dom(screen.getByLabelText("URLs externes nécessaires à la résolution de l'épreuve"))
+      .hasValue('https://test-aleternative.pop');
+    assert.dom(alternativePanel.getByLabelText('URL :')).hasValue('https://mon-embed-url.pop');
+    assert.dom(alternativePanel.getByLabelText('Hauteur :')).hasValue('500');
+    assert.dom(alternativePanel.getByLabelText('Titre :')).hasValue('Titre de mon embed');
+    assert.strictEqual(alternativePanel.getByLabelText('Langue(s)').textContent.trim(), 'Francophone');
+    assert.strictEqual(alternativePanel.getByLabelText('Géographie').textContent.trim(), 'Brésil');
+    assert.dom(alternativePanel.getByLabelText('Id')).hasValue('challenge1-1');
+  });
+});


### PR DESCRIPTION
## 🥀 Problème

Lors de la consultation d’une déclinaison, certaines fois le champ URLs externes ne s’affiche par alors qu’il est renseigné, d’autres fois il apparaît vide.

## 🏹 Proposition

La valeur du champ est rempli au niveau de la route pour un proto. Copier cette logique pour les déclinaisons.

## 💌 Remarques
Je ne sais plus pourquoi on ajoute cette valeur au niveau de la route et pas directement sur le controller., mais il doit surement y avoir une raison.

## ❤️‍🔥 Pour tester

Ajouter des `URLs externes nécessaires à la résolution de l'épreuve` à une déclinaison, recharger la page et vérifier que le champ est toujours rempli.