### PR TITLE
[TECH] Mettre à jour le plan des addons Scalingo

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -14,13 +14,13 @@
   },
   "addons": [
     {
-      "plan": "postgresql:postgresql-sandbox",
+      "plan": "postgresql:postgresql-starter-512",
       "options": {
         "version": "16.9"
       }
     },
     {
-      "plan": "redis:redis-sandbox",
+      "plan": "redis:redis-starter-256",
       "options": {
         "version": "7.2.11"
       }


### PR DESCRIPTION
## 🥀 Problème
Scalingo ne propose plus de plan sandbox depuis le début du mois et crée les addons sur les premiers plans payants. Cependant, nous recevons un email à chaque fois qu'une RA est créée pour nous avertir du changement de plan.  

## 🏹 Proposition
- Utiliser le plan starter-512 pour PG.
- Utiliser le plan starter-256 pour Redis.

## ❤️‍🔥 Pour tester
La review app se déploie.