### PR TITLE
[FEATURE] Reprendre les déclis anglaises pour les transformer en localized rattachés à leur proto français (PIX-21563)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -434,6 +434,11 @@ export class Challenge {
     if (this.isPrimary) return this.validatedAt;
     return localizedChallenge.validatedAt;
   }
+
+  obsolete() {
+    this.status = Challenge.STATUSES.PERIME;
+    this.madeObsoleteAt = new Date();
+  }
 }
 
 function findCorrespondingLocalizedChallenge(localizedChallenges, challengeLocale) {

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -7,6 +7,9 @@ export class Challenge {
   #primaryStatus;
   #translations;
 
+  /** @type {LocalizedChallenge[]} */
+  localizedChallenges;
+
   constructor({
     accessibility1,
     accessibility2,

--- a/api/lib/domain/models/LocalizedChallenge.js
+++ b/api/lib/domain/models/LocalizedChallenge.js
@@ -135,12 +135,13 @@ export class LocalizedChallenge {
     });
   }
 
-  clone({ id, challengeId, status, attachments }) {
+  clone({ id, challengeId, status, attachments, validatedAt = null }) {
     const clonedAttachments = [];
     const clonedLocalizedChallenge = new LocalizedChallenge({
       id,
       challengeId,
       status,
+      validatedAt,
       locale: this.locale,
       embedUrl: this.embedUrl,
       fileIds: [],
@@ -153,7 +154,6 @@ export class LocalizedChallenge {
       toRephrase: this.toRephrase,
       hasEmbedInternalValidation: this.hasEmbedInternalValidation,
       noValidationNeeded: this.noValidationNeeded,
-      validatedAt: null,
     });
     for (const attachmentId of this.fileIds) {
       const attachmentToClone = attachments.find((attachment) => attachment.id === attachmentId);

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -68,6 +68,10 @@ function selectAreas(knexConn = knex) {
     .from(TABLE_NAME);
 }
 
+/**
+ * @param {object[]} dtos
+ * @param {object[]} translations
+ */
 function toDomainList(dtos, translations) {
   const translationsByAreaId = Object.groupBy(translations, (translation) => translation.entityId);
   return dtos.map((dto) => toDomain(dto, translationsByAreaId[dto.id]));

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -31,10 +31,10 @@ export async function listByLocalizedChallengeId(localizedChallengeId) {
   return toDomainList(dtos);
 }
 
-export async function createBatch(attachments) {
+export async function createBatch(attachments, transaction = knex) {
   if (!attachments || attachments.length === 0) return [];
 
-  const dtos = await knex
+  const dtos = await transaction
     .insert(
       attachments.map((attachment) => ({
         id: idGenerator.generateNewId('attachment'),

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -90,6 +90,9 @@ export async function remove(attachmentId) {
   await knex.delete().from('attachments').where('id', attachmentId);
 }
 
+/**
+ * @param {object[]} dtos
+ */
 function toDomainList(dtos) {
   return dtos.map(toDomain);
 }

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -352,6 +352,12 @@ function selectChallenges(knexConn = knex) {
     .leftOuterJoin('thematics', 'thematics.id', 'tubes.thematicId');
 }
 
+/**
+ *
+ * @param {object[]} dtos
+ * @param {object[]} translations
+ * @param {object[]} localizedChallenges
+ */
 function toDomainList(dtos, translations, localizedChallenges) {
   const translationsByChallengeId = Object.groupBy(translations, (translation) => translation.entityId);
   const localizedChallengesByChallengeId = Object.groupBy(

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -8,19 +8,19 @@ const model = 'competence';
 const TABLE_NAME = 'competences';
 
 export async function list() {
-  const [dtos, translations] = await Promise.all([selectCompetences().orderBy('competences.index'), translationRepository.listByModel(model)]);
+  const [dtos, translations] = await Promise.all([_selectCompetences().orderBy('competences.index'), translationRepository.listByModel(model)]);
 
   return toDomainList(dtos, translations);
 }
 
 export async function getMany(ids) {
-  const [dtos, translations] = await Promise.all([selectCompetences().whereIn('competences.id', ids).orderBy('competences.index'), translationRepository.listByEntities(model, ids)]);
+  const [dtos, translations] = await Promise.all([_selectCompetences().whereIn('competences.id', ids).orderBy('competences.index'), translationRepository.listByEntities(model, ids)]);
 
   return toDomainList(dtos, translations);
 }
 
 export async function get(id) {
-  const [dto, translations] = await Promise.all([selectCompetences().where('competences.id', id).first(), translationRepository.listByEntity(model, id)]);
+  const [dto, translations] = await Promise.all([_selectCompetences().where('competences.id', id).first(), translationRepository.listByEntity(model, id)]);
 
   if (!dto) return null;
 
@@ -43,7 +43,7 @@ export async function create(competence) {
       translationRepository.save({ translations, transaction }),
     ]);
 
-    const dto = await selectCompetences(transaction).where('competences.id', competence.id).first();
+    const dto = await _selectCompetences(transaction).where('competences.id', competence.id).first();
 
     return toDomain(dto, translations);
   });
@@ -64,7 +64,7 @@ export async function update(competence) {
   });
 }
 
-function selectCompetences(knexConn = knex) {
+export function _selectCompetences(knexConn = knex) {
   return knexConn
     .select(
       'competences.*',

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -99,6 +99,10 @@ export function _selectCompetences(knexConn = knex) {
     .join('frameworks', 'frameworks.id', 'areas.frameworkId');
 }
 
+/**
+ * @param {object[]} dtos
+ * @param {object[]} translations
+ */
 function toDomainList(dtos, translations) {
   const translationsByCompetenceId = Object.groupBy(translations, (translation) => translation.entityId);
   return dtos.map((datasourceCompetence) =>

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -44,6 +44,9 @@ function toDomain(dto) {
   return new LocalizedFrameworkTubes(dto);
 }
 
+/**
+ * @param {object[]} dtos
+ */
 function toDomainList(dtos) {
   return dtos.map((dto) => toDomain(dto));
 }

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -88,6 +88,10 @@ function _toDomain(mission, translations) {
   });
 }
 
+/**
+ * @param {object[]} missions
+ * @param {object[]} translations
+ */
 function _toDomainList(missions, translations) {
   const translationsByMissionId = _.groupBy(translations, 'entityId');
   return missions.map((mission) => _toDomain(mission, translationsByMissionId[mission.id]));

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -266,6 +266,10 @@ export async function update(skill) {
   });
 }
 
+/**
+ * @param {object[]} dtos
+ * @param {object[]} translations
+ */
 function toDomainList(dtos, translations) {
   const translationsBySkillId = Object.groupBy(translations, (translation) => translation.entityId);
   return dtos.map((dto) => toDomain(dto, translationsBySkillId[dto.id]));

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -101,6 +101,10 @@ function selectThematics(knexConn = knex) {
     .from(TABLE_NAME);
 }
 
+/**
+ * @param {object[]} dtos
+ * @param {object[]} translations
+ */
 function toDomainList(dtos, translations) {
   const translationsByThematicId = Object.groupBy(translations, (translation) => translation.entityId);
   return _.orderBy(

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -110,6 +110,10 @@ function selectTubes(knexConn = knex) {
     .join('thematics', 'thematics.id', `${TABLE_NAME}.thematicId`);
 }
 
+/**
+ * @param {object[]} dtos
+ * @param {object[]} translations
+ */
 function toDomainList(dtos, translations) {
   const translationsByTubeId = Object.groupBy(translations, (translation) => translation.entityId);
   return dtos.map((dto) => toDomain(dto, translationsByTubeId[dto.id]));

--- a/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
@@ -32,6 +32,9 @@ export async function find(id) {
   return toDomain(whitelistedUrlDto);
 }
 
+/**
+ * @param {object[]} whitelistedUrlDtos
+ */
 function toDomainList(whitelistedUrlDtos) {
   return whitelistedUrlDtos.map(toDomain);
 }

--- a/api/lib/infrastructure/repositories/whitelisted-url-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-repository.js
@@ -43,6 +43,9 @@ export async function save(whitelistedUrl) {
   return id;
 }
 
+/**
+ * @param {object[]} whitelistedUrlDtos
+ */
 function toDomainList(whitelistedUrlDtos) {
   return whitelistedUrlDtos.map(toDomain);
 }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -111,13 +111,12 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           await attachmentRepository.createBatch(clonedAttachments, transaction);
           await translationRepository.save({ translations, transaction });
           await challengeRepository.update(legacyEnglishChallenge, transaction);
-
-          if (options.dryRun) {
-            logger.info('Dry run is enabled, not persisting changes');
-            await transaction.rollback();
-          } else {
-            await transaction.commit();
-          }
+        }
+        if (options.dryRun) {
+          logger.info('Dry run is enabled, not persisting changes');
+          await transaction.rollback();
+        } else {
+          await transaction.commit();
         }
         logger.info({
           skillId: activeSkill.id,

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -18,7 +18,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
   constructor() {
     super({
       description: 'Script de transformation des épreuves anglaises sous forme de décli en épreuves traduites rattachées à leur équivalent primary français',
-      permanent: true,
+      permanent: false,
       options: {
         dryRun: {
           type: 'boolean',
@@ -94,7 +94,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
             skillId: activeSkill.id,
             clonedEnglishLocalizedId: clonedLocalizedChallenge.id,
             frenchChallengeId: frenchChallenge.id,
-          });
+          }, 'Binding cloned english localized challenge to french challenge');
 
           // on clone les clés de trads
           const translations = extractFromChallenge(legacyEnglishChallenge);
@@ -112,18 +112,20 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           await translationRepository.save({ translations, transaction });
           await challengeRepository.update(legacyEnglishChallenge, transaction);
         }
+
         if (options.dryRun) {
           logger.info('Dry run is enabled, not persisting changes');
           await transaction.rollback();
         } else {
           await transaction.commit();
         }
+
         logger.info({
           skillId: activeSkill.id,
           obsoletedEnglishChallengesCount: legacyEnglishChallenges.length,
           clonedTranslationsCount,
           clonedAttachmentsCount,
-        });
+        }, `Finished processing skill ${skill.name}`);
         processedEnglishChallengesCount += legacyEnglishChallenges.length;
       });
     }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -35,3 +35,8 @@ export async function listActiveFrenchChallengesBySkillId(skillId) {
   const validatedChallenges = challenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE);
   return validatedChallenges.filter((challenge) => challenge.locale === 'fr');
 }
+
+export function assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(legacyEnglishChallenges, activeFrenchChallenges) {
+  if (legacyEnglishChallenges.length <= activeFrenchChallenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE).length) return;
+  throw new Error('Not enough active french challenges for each english challenge');
+}

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -2,12 +2,16 @@ import { Script } from '../lib/application/scripts/script.js';
 import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
 
 import {
+  attachmentRepository,
   challengeRepository,
   competenceRepository,
   frameworkRepository,
+  localizedChallengeRepository,
   skillRepository,
+  translationRepository,
 } from '../lib/infrastructure/repositories/index.js';
-import { Challenge } from '../lib/domain/models/index.js';
+import { Challenge, LocalizedChallenge } from '../lib/domain/models/index.js';
+import { extractFromChallenge } from '../lib/infrastructure/translations/challenge.js';
 
 export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
   constructor() {
@@ -48,14 +52,36 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
         }, 'Not enough active french challenges without english localized for each english challenge');
         continue;
       }
+
       // On veut dupliquer les localized anglais et changer le challengeId pour que celui-ci corresponde au challenge ayant un primary français et id += id-en
       for (const legacyEnglishChallenge of legacyEnglishChallenges) {
+        const frenchChallenge = activeFrenchChallenges.pop();
         const [localizedToClone] = legacyEnglishChallenge.localizedChallenges;
+        const localizedAttachments = await attachmentRepository.listByLocalizedChallengeId(localizedToClone.id);
+
         // on clone le legacy localized et ses attachments
-        // si challenge anglais === rpoposé ? localized.status = 'pause', si challenge anglais === validé ? localized.status = 'play'
         // on met les bons ids
+        // si challenge anglais === rpoposé ? localized.status = 'pause', si challenge anglais === validé ? localized.status = 'play'
+        const { clonedAttachments, clonedLocalizedChallenge } = localizedToClone.clone({
+          id: `${localizedToClone.id}-EN`,
+          challengeId: frenchChallenge.id,
+          status: legacyEnglishChallenge.status === Challenge.STATUSES.VALIDE ? LocalizedChallenge.STATUSES.PLAY : LocalizedChallenge.STATUSES.PAUSE,
+          attachments: localizedAttachments,
+          validatedAt: localizedToClone.validatedAt,
+        });
+
         // on clone les clés de trads
+        const translations = extractFromChallenge(legacyEnglishChallenge);
+        for (const translation of translations) {
+          translation.key = translation.key.replace(legacyEnglishChallenge.id, frenchChallenge.id);
+        }
+
         // On périme le challenge anglais
+
+        // on persiste tout
+        await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge] });
+        await attachmentRepository.createBatch(clonedAttachments);
+        await translationRepository.save({ translations });
       }
     }
   }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -77,11 +77,13 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
         }
 
         // On périme le challenge anglais
+        legacyEnglishChallenge.obsolete();
 
         // on persiste tout
         await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge] });
         await attachmentRepository.createBatch(clonedAttachments);
         await translationRepository.save({ translations });
+        await challengeRepository.update(legacyEnglishChallenge);
       }
     }
   }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -80,10 +80,14 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
         legacyEnglishChallenge.obsolete();
 
         // on persiste tout
-        await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge] });
-        await attachmentRepository.createBatch(clonedAttachments);
-        await translationRepository.save({ translations });
-        await challengeRepository.update(legacyEnglishChallenge);
+        if (options.dryRun) {
+          logger.info('Dry run, stopping before deletion');
+        } else {
+          await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge] });
+          await attachmentRepository.createBatch(clonedAttachments);
+          await translationRepository.save({ translations });
+          await challengeRepository.update(legacyEnglishChallenge);
+        }
       }
     }
   }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -164,7 +164,10 @@ export async function listActiveSkillsByFrameworkName(frameworkName) {
 
 export async function listLegacyEnglishChallengesBySkillId(skillId) {
   const challenges = await challengeRepository.listBySkillId(skillId);
-  const decliChallenges = challenges.filter((challenge) => challenge.genealogy !== Challenge.GENEALOGIES.PROTOTYPE);
+  const validatedPrototype = challenges.find((challenge) => challenge.genealogy === Challenge.GENEALOGIES.PROTOTYPE && challenge.status === Challenge.STATUSES.VALIDE);
+  if (!validatedPrototype) return [];
+  const prototypeVersion = validatedPrototype.version;
+  const decliChallenges = challenges.filter((challenge) => challenge.genealogy !== Challenge.GENEALOGIES.PROTOTYPE && challenge.version === prototypeVersion);
   const validatedAndProposedChallenges = decliChallenges.filter((decli) => decli.status === Challenge.STATUSES.VALIDE || decli.status === Challenge.STATUSES.PROPOSE);
   return validatedAndProposedChallenges.filter((decliChallenge) => decliChallenge.locale === 'en');
 }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -25,6 +25,11 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           demandOption: true,
           default: true,
         },
+        frameworkName: {
+          type: 'string',
+          describe: 'Framework name (not ID)',
+          demandOption: true,
+        },
       },
     });
   }
@@ -32,12 +37,25 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
   async handle({ options, logger }) {
     logger.info({ dryRun: options.dryRun }, 'Script bindEnglishChallengesToFrenchPrimaryEquivalent has started');
 
+    let processedEnglishChallengesCount = 0;
+    let skippedSkillsCount = 0;
+
     // lister les acquis actifs par nom de référentiel
     const activeSkills = await listActiveSkillsByFrameworkName(options.frameworkName);
 
     // pour chaque acquis, lister les challenges anglais legacy validés ou proposés
     for (const activeSkill of activeSkills) {
       const legacyEnglishChallenges = await listLegacyEnglishChallengesBySkillId(activeSkill.id);
+      if (legacyEnglishChallenges.length === 0) {
+        logger.info(`Ignored skill ${activeSkill.name} - ${activeSkill.id}`);
+        continue;
+      }
+
+      logger.info(`Now processing ${activeSkill.name} - ${activeSkill.id}`);
+
+      // compteurs
+      let clonedTranslationsCount = 0;
+      let clonedAttachmentsCount = 0;
 
       // pour chaque acquis, lister les challenges français validés.
       const skillChallenges = await challengeRepository.listBySkillId(activeSkill.id);
@@ -50,6 +68,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           activeFrenchChallengeIds: activeFrenchChallenges.map(({ id }) => id),
           legacyEnglishChallengeIds: legacyEnglishChallenges.map(({ id }) => id),
         }, 'Not enough active french challenges without english localized for each english challenge');
+        skippedSkillsCount++;
         continue;
       }
 
@@ -69,11 +88,18 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           attachments: localizedAttachments,
           validatedAt: localizedToClone.validatedAt,
         });
+        clonedAttachmentsCount += clonedAttachments.length;
+        logger.info({
+          skillId: activeSkill.id,
+          clonedEnglishLocalizedId: clonedLocalizedChallenge.id,
+          frenchChallengeId: frenchChallenge.id,
+        });
 
         // on clone les clés de trads
         const translations = extractFromChallenge(legacyEnglishChallenge);
         for (const translation of translations) {
           translation.key = translation.key.replace(legacyEnglishChallenge.id, frenchChallenge.id);
+          clonedTranslationsCount++;
         }
 
         // On périme le challenge anglais
@@ -81,7 +107,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
 
         // on persiste tout
         if (options.dryRun) {
-          logger.info('Dry run, stopping before deletion');
+          logger.info('Dry run is enabled, not persisting changes');
         } else {
           await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge] });
           await attachmentRepository.createBatch(clonedAttachments);
@@ -89,7 +115,20 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           await challengeRepository.update(legacyEnglishChallenge);
         }
       }
+
+      logger.info({
+        skillId: activeSkill.id,
+        obsoletedEnglishChallengesCount: legacyEnglishChallenges.length,
+        clonedTranslationsCount,
+        clonedAttachmentsCount,
+      });
+      processedEnglishChallengesCount += legacyEnglishChallenges.length;
     }
+
+    logger.info({
+      processedEnglishChallengesCount,
+      skippedSkillsCount,
+    }, 'DONE');
   }
 }
 

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -1,5 +1,10 @@
-import { challengeRepository, competenceRepository, frameworkRepository, skillRepository } from '../lib/infrastructure/repositories/index.js';
-import { Challenge, Skill } from '../lib/domain/models/index.js';
+import {
+  challengeRepository,
+  competenceRepository,
+  frameworkRepository,
+  skillRepository,
+} from '../lib/infrastructure/repositories/index.js';
+import { Challenge } from '../lib/domain/models/index.js';
 
 export async function listActiveSkillsByFrameworkName(frameworkName) {
   const frameworks = await frameworkRepository.list();
@@ -22,6 +27,11 @@ export async function listLegacyEnglishChallengesBySkillId(skillId) {
   const challenges = await challengeRepository.listBySkillId(skillId);
   const decliChallenges = challenges.filter((challenge) => challenge.genealogy !== Challenge.GENEALOGIES.PROTOTYPE);
   const validatedAndProposedChallenges = decliChallenges.filter((decli) => decli.status === Challenge.STATUSES.VALIDE || decli.status === Challenge.STATUSES.PROPOSE);
-  // Existe-t-il des prototypes en english, ou ne sont-ce que des déclis ?
   return validatedAndProposedChallenges.filter((decliChallenge) => decliChallenge.locale === 'en');
+}
+
+export async function listActiveFrenchChallengesBySkillId(skillId) {
+  const challenges = await challengeRepository.listBySkillId(skillId);
+  const validatedChallenges = challenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE);
+  return validatedChallenges.filter((challenge) => challenge.locale === 'fr');
 }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -40,6 +40,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
 
     let processedEnglishChallengesCount = 0;
     let skippedSkillsCount = 0;
+    let ignoredSkillsCount = 0;
 
     // lister les acquis actifs par nom de référentiel
     const activeSkills = await listActiveSkillsByFrameworkName(options.frameworkName);
@@ -49,6 +50,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
       const legacyEnglishChallenges = await listLegacyEnglishChallengesBySkillId(activeSkill.id);
       if (legacyEnglishChallenges.length === 0) {
         logger.info(`Ignored skill ${activeSkill.name} - ${activeSkill.id}`);
+        ignoredSkillsCount++;
         continue;
       }
       await knex.transaction(async (transaction) => {
@@ -139,6 +141,7 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
 
     logger.info({
       processedEnglishChallengesCount,
+      ignoredSkillsCount,
       skippedSkillsCount,
     }, 'DONE');
   }

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -113,20 +113,27 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
           await challengeRepository.update(legacyEnglishChallenge, transaction);
         }
 
+        logger.info({
+          skillId: activeSkill.id,
+          obsoletedEnglishChallengesCount: legacyEnglishChallenges.length,
+          clonedTranslationsCount,
+          clonedAttachmentsCount,
+        }, `Finished processing skill ${activeSkill.name}`);
+
+        processedEnglishChallengesCount += legacyEnglishChallenges.length;
+
         if (options.dryRun) {
           logger.info('Dry run is enabled, not persisting changes');
           await transaction.rollback();
         } else {
           await transaction.commit();
         }
-
-        logger.info({
+      }).catch((error) => {
+        logger.error({
           skillId: activeSkill.id,
-          obsoletedEnglishChallengesCount: legacyEnglishChallenges.length,
-          clonedTranslationsCount,
-          clonedAttachmentsCount,
-        }, `Finished processing skill ${skill.name}`);
-        processedEnglishChallengesCount += legacyEnglishChallenges.length;
+          err: error,
+        }, `Error in transaction while processing skill ${activeSkill.name}`);
+        skippedSkillsCount++;
       });
     }
 

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -17,3 +17,11 @@ export async function listActiveSkillsByFrameworkName(frameworkName) {
 
   return activeSkills;
 }
+
+export async function listLegacyEnglishChallengesBySkillId(skillId) {
+  const challenges = await challengeRepository.listBySkillId(skillId);
+  const decliChallenges = challenges.filter((challenge) => challenge.genealogy !== Challenge.GENEALOGIES.PROTOTYPE);
+  const validatedAndProposedChallenges = decliChallenges.filter((decli) => decli.status === Challenge.STATUSES.VALIDE || decli.status === Challenge.STATUSES.PROPOSE);
+  // Existe-t-il des prototypes en english, ou ne sont-ce que des déclis ?
+  return validatedAndProposedChallenges.filter((decliChallenge) => decliChallenge.locale === 'en');
+}

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -1,0 +1,19 @@
+import { challengeRepository, competenceRepository, frameworkRepository, skillRepository } from '../lib/infrastructure/repositories/index.js';
+import { Challenge, Skill } from '../lib/domain/models/index.js';
+
+export async function listActiveSkillsByFrameworkName(frameworkName) {
+  const frameworks = await frameworkRepository.list();
+  if (!frameworks.find(({ name }) => name === frameworkName)) throw new Error('framework with this given name does not exist');
+
+  const activeSkills = [];
+
+  const competences = await competenceRepository._selectCompetences().where('frameworks.name', '=', frameworkName);
+  for (const competence of competences) {
+    const competenceActiveSkills = await skillRepository.listActiveByCompetenceId(competence.id);
+    activeSkills.push(...competenceActiveSkills);
+  }
+
+  console.log(activeSkills);
+
+  return activeSkills;
+}

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -12,6 +12,7 @@ import {
 } from '../lib/infrastructure/repositories/index.js';
 import { Challenge, LocalizedChallenge } from '../lib/domain/models/index.js';
 import { extractFromChallenge } from '../lib/infrastructure/translations/challenge.js';
+import { knex } from '../db/knex-database-connection.js';
 
 export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
   constructor() {
@@ -50,79 +51,82 @@ export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
         logger.info(`Ignored skill ${activeSkill.name} - ${activeSkill.id}`);
         continue;
       }
+      await knex.transaction(async (transaction) => {
+        logger.info(`Now processing ${activeSkill.name} - ${activeSkill.id}`);
 
-      logger.info(`Now processing ${activeSkill.name} - ${activeSkill.id}`);
+        // compteurs
+        let clonedTranslationsCount = 0;
+        let clonedAttachmentsCount = 0;
 
-      // compteurs
-      let clonedTranslationsCount = 0;
-      let clonedAttachmentsCount = 0;
+        // pour chaque acquis, lister les challenges français validés.
+        const skillChallenges = await challengeRepository.listBySkillId(activeSkill.id);
+        const activeFrenchChallenges = skillChallenges.filter(byActiveFrenchChallenges);
 
-      // pour chaque acquis, lister les challenges français validés.
-      const skillChallenges = await challengeRepository.listBySkillId(activeSkill.id);
-      const activeFrenchChallenges = skillChallenges.filter(byActiveFrenchChallenges);
+        // On vérifie qu'il y a suffisamment de challenges français validés pour le nbre de challenges anglais.
+        if (legacyEnglishChallenges.length > activeFrenchChallenges.length) {
+          logger.error({
+            skillId: activeSkill.id,
+            activeFrenchChallengeIds: activeFrenchChallenges.map(({ id }) => id),
+            legacyEnglishChallengeIds: legacyEnglishChallenges.map(({ id }) => id),
+          }, 'Not enough active french challenges without english localized for each english challenge');
+          skippedSkillsCount++;
+          return;
+        }
 
-      // On vérifie qu'il y a suffisamment de challenges français validés pour le nbre de challenges anglais.
-      if (legacyEnglishChallenges.length > activeFrenchChallenges.length) {
-        logger.error({
-          skillId: activeSkill.id,
-          activeFrenchChallengeIds: activeFrenchChallenges.map(({ id }) => id),
-          legacyEnglishChallengeIds: legacyEnglishChallenges.map(({ id }) => id),
-        }, 'Not enough active french challenges without english localized for each english challenge');
-        skippedSkillsCount++;
-        continue;
-      }
+        // On veut dupliquer les localized anglais et changer le challengeId pour que celui-ci corresponde au challenge ayant un primary français et id += id-en
+        for (const legacyEnglishChallenge of legacyEnglishChallenges) {
+          const frenchChallenge = activeFrenchChallenges.pop();
+          const [localizedToClone] = legacyEnglishChallenge.localizedChallenges;
+          const localizedAttachments = await attachmentRepository.listByLocalizedChallengeId(localizedToClone.id);
 
-      // On veut dupliquer les localized anglais et changer le challengeId pour que celui-ci corresponde au challenge ayant un primary français et id += id-en
-      for (const legacyEnglishChallenge of legacyEnglishChallenges) {
-        const frenchChallenge = activeFrenchChallenges.pop();
-        const [localizedToClone] = legacyEnglishChallenge.localizedChallenges;
-        const localizedAttachments = await attachmentRepository.listByLocalizedChallengeId(localizedToClone.id);
+          // on clone le legacy localized et ses attachments
+          // on met les bons ids
+          // si challenge anglais === rpoposé ? localized.status = 'pause', si challenge anglais === validé ? localized.status = 'play'
+          const { clonedAttachments, clonedLocalizedChallenge } = localizedToClone.clone({
+            id: `${localizedToClone.id}-EN`,
+            challengeId: frenchChallenge.id,
+            status: legacyEnglishChallenge.status === Challenge.STATUSES.VALIDE ? LocalizedChallenge.STATUSES.PLAY : LocalizedChallenge.STATUSES.PAUSE,
+            attachments: localizedAttachments,
+            validatedAt: localizedToClone.validatedAt,
+          });
+          clonedAttachmentsCount += clonedAttachments.length;
+          logger.info({
+            skillId: activeSkill.id,
+            clonedEnglishLocalizedId: clonedLocalizedChallenge.id,
+            frenchChallengeId: frenchChallenge.id,
+          });
 
-        // on clone le legacy localized et ses attachments
-        // on met les bons ids
-        // si challenge anglais === rpoposé ? localized.status = 'pause', si challenge anglais === validé ? localized.status = 'play'
-        const { clonedAttachments, clonedLocalizedChallenge } = localizedToClone.clone({
-          id: `${localizedToClone.id}-EN`,
-          challengeId: frenchChallenge.id,
-          status: legacyEnglishChallenge.status === Challenge.STATUSES.VALIDE ? LocalizedChallenge.STATUSES.PLAY : LocalizedChallenge.STATUSES.PAUSE,
-          attachments: localizedAttachments,
-          validatedAt: localizedToClone.validatedAt,
-        });
-        clonedAttachmentsCount += clonedAttachments.length;
+          // on clone les clés de trads
+          const translations = extractFromChallenge(legacyEnglishChallenge);
+          for (const translation of translations) {
+            translation.key = translation.key.replace(legacyEnglishChallenge.id, frenchChallenge.id);
+            clonedTranslationsCount++;
+          }
+
+          // On périme le challenge anglais
+          legacyEnglishChallenge.obsolete();
+
+          // on persiste tout
+          await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge], transaction });
+          await attachmentRepository.createBatch(clonedAttachments, transaction);
+          await translationRepository.save({ translations, transaction });
+          await challengeRepository.update(legacyEnglishChallenge, transaction);
+
+          if (options.dryRun) {
+            logger.info('Dry run is enabled, not persisting changes');
+            await transaction.rollback();
+          } else {
+            await transaction.commit();
+          }
+        }
         logger.info({
           skillId: activeSkill.id,
-          clonedEnglishLocalizedId: clonedLocalizedChallenge.id,
-          frenchChallengeId: frenchChallenge.id,
+          obsoletedEnglishChallengesCount: legacyEnglishChallenges.length,
+          clonedTranslationsCount,
+          clonedAttachmentsCount,
         });
-
-        // on clone les clés de trads
-        const translations = extractFromChallenge(legacyEnglishChallenge);
-        for (const translation of translations) {
-          translation.key = translation.key.replace(legacyEnglishChallenge.id, frenchChallenge.id);
-          clonedTranslationsCount++;
-        }
-
-        // On périme le challenge anglais
-        legacyEnglishChallenge.obsolete();
-
-        // on persiste tout
-        if (options.dryRun) {
-          logger.info('Dry run is enabled, not persisting changes');
-        } else {
-          await localizedChallengeRepository.create({ localizedChallenges: [clonedLocalizedChallenge] });
-          await attachmentRepository.createBatch(clonedAttachments);
-          await translationRepository.save({ translations });
-          await challengeRepository.update(legacyEnglishChallenge);
-        }
-      }
-
-      logger.info({
-        skillId: activeSkill.id,
-        obsoletedEnglishChallengesCount: legacyEnglishChallenges.length,
-        clonedTranslationsCount,
-        clonedAttachmentsCount,
+        processedEnglishChallengesCount += legacyEnglishChallenges.length;
       });
-      processedEnglishChallengesCount += legacyEnglishChallenges.length;
     }
 
     logger.info({

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -1,3 +1,6 @@
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+
 import {
   challengeRepository,
   competenceRepository,
@@ -5,6 +8,58 @@ import {
   skillRepository,
 } from '../lib/infrastructure/repositories/index.js';
 import { Challenge } from '../lib/domain/models/index.js';
+
+export class BindEnglishChallengesToFrenchPrimaryEquivalent extends Script {
+  constructor() {
+    super({
+      description: 'Script de transformation des épreuves anglaises sous forme de décli en épreuves traduites rattachées à leur équivalent primary français',
+      permanent: true,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not persist any deletion made during the script.',
+          demandOption: true,
+          default: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun }, 'Script bindEnglishChallengesToFrenchPrimaryEquivalent has started');
+
+    // lister les acquis actifs par nom de référentiel
+    const activeSkills = await listActiveSkillsByFrameworkName(options.frameworkName);
+
+    // pour chaque acquis, lister les challenges anglais legacy validés ou proposés
+    for (const activeSkill of activeSkills) {
+      const legacyEnglishChallenges = await listLegacyEnglishChallengesBySkillId(activeSkill.id);
+
+      // pour chaque acquis, lister les challenges français validés.
+      const skillChallenges = await challengeRepository.listBySkillId(activeSkill.id);
+      const activeFrenchChallenges = skillChallenges.filter(byActiveFrenchChallenges);
+
+      // On vérifie qu'il y a suffisamment de challenges français validés pour le nbre de challenges anglais.
+      if (legacyEnglishChallenges.length > activeFrenchChallenges.length) {
+        logger.error({
+          skillId: activeSkill.id,
+          activeFrenchChallengeIds: activeFrenchChallenges.map(({ id }) => id),
+          legacyEnglishChallengeIds: legacyEnglishChallenges.map(({ id }) => id),
+        }, 'Not enough active french challenges without english localized for each english challenge');
+        continue;
+      }
+      // On veut dupliquer les localized anglais et changer le challengeId pour que celui-ci corresponde au challenge ayant un primary français et id += id-en
+      for (const legacyEnglishChallenge of legacyEnglishChallenges) {
+        const [localizedToClone] = legacyEnglishChallenge.localizedChallenges;
+        // on clone le legacy localized et ses attachments
+        // si challenge anglais === rpoposé ? localized.status = 'pause', si challenge anglais === validé ? localized.status = 'play'
+        // on met les bons ids
+        // on clone les clés de trads
+        // On périme le challenge anglais
+      }
+    }
+  }
+}
 
 export async function listActiveSkillsByFrameworkName(frameworkName) {
   const frameworks = await frameworkRepository.list();
@@ -18,8 +73,6 @@ export async function listActiveSkillsByFrameworkName(frameworkName) {
     activeSkills.push(...competenceActiveSkills);
   }
 
-  console.log(activeSkills);
-
   return activeSkills;
 }
 
@@ -30,25 +83,8 @@ export async function listLegacyEnglishChallengesBySkillId(skillId) {
   return validatedAndProposedChallenges.filter((decliChallenge) => decliChallenge.locale === 'en');
 }
 
-export async function listActiveFrenchChallengesBySkillId(skillId) {
-  const challenges = await challengeRepository.listBySkillId(skillId);
-  const validatedChallenges = challenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE);
-  return validatedChallenges.filter((challenge) => challenge.locale === 'fr');
+export function byActiveFrenchChallenges(challenge) {
+  return challenge.status === Challenge.STATUSES.VALIDE && challenge.locale === 'fr' && !challenge.localizedChallenges.map((localized) => localized.locale).includes('en');
 }
 
-export function assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(legacyEnglishChallenges, frenchChallenges) {
-  const skillId = legacyEnglishChallenges[0]?.skillId ?? frenchChallenges?.[0]?.skillId;
-
-  const validatedChallenges = frenchChallenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE);
-  if (legacyEnglishChallenges.length > validatedChallenges.length) {
-    throw new Error(`Not enough active french challenges (${validatedChallenges.length}) for each english challenge (${legacyEnglishChallenges.length}) in skill ${skillId}`);
-  }
-
-  const notEnglishChallenges = validatedChallenges.filter((challenge) => {
-    const locales = challenge.localizedChallenges.map((localized) => localized.locale);
-    return !locales.includes('en');
-  });
-  if (legacyEnglishChallenges.length > notEnglishChallenges.length) {
-    throw new Error(`Not enough active french challenges without english localized (${notEnglishChallenges.length}) for each english challenge (${legacyEnglishChallenges.length}) in skill ${skillId}`);
-  };
-}
+await ScriptRunner.execute(import.meta.url, BindEnglishChallengesToFrenchPrimaryEquivalent);

--- a/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
+++ b/api/scripts/bind-english-challenges-to-french-primary-equivalent.js
@@ -36,7 +36,19 @@ export async function listActiveFrenchChallengesBySkillId(skillId) {
   return validatedChallenges.filter((challenge) => challenge.locale === 'fr');
 }
 
-export function assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(legacyEnglishChallenges, activeFrenchChallenges) {
-  if (legacyEnglishChallenges.length <= activeFrenchChallenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE).length) return;
-  throw new Error('Not enough active french challenges for each english challenge');
+export function assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(legacyEnglishChallenges, frenchChallenges) {
+  const skillId = legacyEnglishChallenges[0]?.skillId ?? frenchChallenges?.[0]?.skillId;
+
+  const validatedChallenges = frenchChallenges.filter((challenge) => challenge.status === Challenge.STATUSES.VALIDE);
+  if (legacyEnglishChallenges.length > validatedChallenges.length) {
+    throw new Error(`Not enough active french challenges (${validatedChallenges.length}) for each english challenge (${legacyEnglishChallenges.length}) in skill ${skillId}`);
+  }
+
+  const notEnglishChallenges = validatedChallenges.filter((challenge) => {
+    const locales = challenge.localizedChallenges.map((localized) => localized.locale);
+    return !locales.includes('en');
+  });
+  if (legacyEnglishChallenges.length > notEnglishChallenges.length) {
+    throw new Error(`Not enough active french challenges without english localized (${notEnglishChallenges.length}) for each english challenge (${legacyEnglishChallenges.length}) in skill ${skillId}`);
+  };
 }

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -373,6 +373,31 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         localizedChallenge: { embedUrl: 'https://pix.fr' },
       });
 
+      const validatedFrenchChallenge = databaseBuilder.factory.buildChallenge({
+        id: 'validatedFrenchChallenge',
+        skillId: skill.id,
+        genealogy: Challenge.GENEALOGIES.DECLINAISON,
+        status: Challenge.STATUSES.VALIDE,
+        locales: ['fr'],
+        isQualityOk: true,
+      });
+      const validatedFrenchChallengeLocalized = databaseBuilder.factory.buildLocalizedChallenge({
+        id: validatedFrenchChallenge.id,
+        challengeId: validatedFrenchChallenge.id,
+        locale: 'fr',
+        embedUrl: 'https://pix.org/fr-FTR',
+        urlsToConsult: ['https://pix.fr'],
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        geography: 'FR',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+        validatedAt: new Date(),
+      });
+
       const validatedEnglishChallenge1 = databaseBuilder.factory.buildChallenge({
         id: 'validatedEnglishChallenge1',
         skillId: skill.id,
@@ -413,6 +438,46 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         localizedChallengeId: validatedEnglishChallenge1.id,
       });
 
+      const validatedEnglishChallenge2 = databaseBuilder.factory.buildChallenge({
+        id: 'validatedEnglishChallenge2',
+        skillId: skill.id,
+        genealogy: Challenge.GENEALOGIES.DECLINAISON,
+        status: Challenge.STATUSES.VALIDE,
+        locales: ['en'],
+        isQualityOk: true,
+      });
+      const englishLegacyLocalized2 = databaseBuilder.factory.buildLocalizedChallenge({
+        id: validatedEnglishChallenge2.id,
+        challengeId: validatedEnglishChallenge2.id,
+        locale: 'en',
+        embedUrl: 'https://pix.org/en-UK',
+        urlsToConsult: ['https://pix.fr'],
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        geography: 'UK',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+        validatedAt: new Date(),
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.validatedEnglishChallenge2.instruction',
+        locale: 'en',
+        value: 'EN instructions',
+      });
+      const englishLegacyAttachment2 = databaseBuilder.factory.buildAttachment({
+        id: 'attachmentEn2',
+        url: 'https://',
+        size: 3,
+        type: Attachment.TYPES.ILLUSTRATION,
+        filename: 'test.jpg',
+        mimeType: 'image/jpeg',
+        challengeId: validatedEnglishChallenge2.id,
+        localizedChallengeId: validatedEnglishChallenge2.id,
+      });
+
       await databaseBuilder.commit();
 
       const errorLoggerSpy = vi.spyOn(logger, 'error');
@@ -424,23 +489,48 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         logger,
       });
 
-      const frenchChallenge = await challengeRepository.get(challenge.id);
-      const localizedChallenges = frenchChallenge.localizedChallenges;
-      const englishLocalized = localizedChallenges.find(({ locale }) => locale === 'en');
-      const attachments = await attachmentRepository.listByLocalizedChallengeId(englishLocalized.id);
-      const translations = await translationRepository.listByEntity('challenge', frenchChallenge.id);
+      const frenchChallenges = await challengeRepository.getMany([challenge.id, 'validatedFrenchChallenge']);
+      const localizedChallenges = frenchChallenges.flatMap((challenge) => challenge.localizedChallenges);
+      const [englishLocalized1, englishLocalized2] = localizedChallenges.filter(({ locale }) => locale === 'en');
+
+      const englishLocalized1Attachments = await attachmentRepository.listByLocalizedChallengeId(englishLocalized1.id);
+      const englishLocalized2Attachments = await attachmentRepository.listByLocalizedChallengeId(englishLocalized2.id);
+
+      const translations = await translationRepository.listByEntities('challenge', frenchChallenges.map((challenge) => challenge.id));
       const englishTranslations = translations.filter(({ locale }) => locale === 'en');
 
-      const legacyEnglishChallenge = await challengeRepository.get(validatedEnglishChallenge1.id);
+      const legacyEnglishChallenge = await challengeRepository.getMany([validatedEnglishChallenge1.id, validatedEnglishChallenge2.id]);
 
       // then
-      expect(localizedChallenges.length).toEqual(2);
-      expect(englishLocalized).toStrictEqual(domainBuilder.buildLocalizedChallenge({
+      expect(localizedChallenges.length).toEqual(4);
+
+      expect(englishLocalized1).toStrictEqual(
+        domainBuilder.buildLocalizedChallenge({
+          id: `${validatedEnglishChallenge2.id}-EN`,
+          challengeId: challenge.id,
+          locale: 'en',
+          status: LocalizedChallenge.STATUSES.PLAY,
+          fileIds: [englishLocalized1Attachments[0].id],
+          embedUrl: englishLegacyLocalized.embedUrl,
+          primaryEmbedUrl: localizedChallenge.embedUrl,
+          urlsToConsult: englishLegacyLocalized.urlsToConsult,
+          requireGafamWebsiteAccess: englishLegacyLocalized.requireGafamWebsiteAccess,
+          isIncompatibleIpadCertif: englishLegacyLocalized.isIncompatibleIpadCertif,
+          deafAndHardOfHearing: englishLegacyLocalized.deafAndHardOfHearing,
+          isAwarenessChallenge: englishLegacyLocalized.isAwarenessChallenge,
+          toRephrase: englishLegacyLocalized.toRephrase,
+          geography: englishLegacyLocalized.geography,
+          hasEmbedInternalValidation: englishLegacyLocalized.hasEmbedInternalValidation,
+          noValidationNeeded: englishLegacyLocalized.noValidationNeeded,
+          validatedAt: englishLegacyLocalized.validatedAt,
+        }));
+
+      expect(englishLocalized2).toStrictEqual(domainBuilder.buildLocalizedChallenge({
         id: `${validatedEnglishChallenge1.id}-EN`,
-        challengeId: frenchChallenge.id,
+        challengeId: validatedFrenchChallenge.id,
         locale: 'en',
         status: LocalizedChallenge.STATUSES.PLAY,
-        fileIds: attachments.map(({ id }) => id),
+        fileIds: [englishLocalized2Attachments[0].id],
         embedUrl: englishLegacyLocalized.embedUrl,
         primaryEmbedUrl: localizedChallenge.embedUrl,
         urlsToConsult: englishLegacyLocalized.urlsToConsult,
@@ -453,8 +543,9 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         hasEmbedInternalValidation: englishLegacyLocalized.hasEmbedInternalValidation,
         noValidationNeeded: englishLegacyLocalized.noValidationNeeded,
         validatedAt: englishLegacyLocalized.validatedAt,
-      }));
-      expect(attachments).toStrictEqual([
+      },
+      ));
+      expect(englishLocalized2Attachments).toStrictEqual([
         domainBuilder.buildAttachment({
           id: expect.any(String),
           url: englishLegacyAttachment.url,
@@ -462,24 +553,59 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           type: englishLegacyAttachment.type,
           filename: englishLegacyAttachment.filename,
           mimeType: englishLegacyAttachment.mimeType,
-          challengeId: frenchChallenge.id,
-          localizedChallengeId: englishLocalized.id,
+          challengeId: frenchChallenges[1].id,
+          localizedChallengeId: englishLocalized2.id,
+        }),
+      ]);
+      expect(englishLocalized1Attachments).toStrictEqual([
+        domainBuilder.buildAttachment({
+          id: expect.any(String),
+          url: englishLegacyAttachment.url,
+          size: englishLegacyAttachment.size,
+          type: englishLegacyAttachment.type,
+          filename: englishLegacyAttachment.filename,
+          mimeType: englishLegacyAttachment.mimeType,
+          challengeId: frenchChallenges[0].id,
+          localizedChallengeId: englishLocalized1.id,
         }),
       ]);
       expect(englishTranslations).toStrictEqual([
         domainBuilder.buildTranslation({
-          key: `challenge.${frenchChallenge.id}.instruction`,
+          key: `challenge.${frenchChallenges[0].id}.instruction`,
+          locale: 'en',
+          value: 'EN instructions',
+        }),
+        domainBuilder.buildTranslation({
+          key: `challenge.${frenchChallenges[1].id}.instruction`,
           locale: 'en',
           value: 'EN instructions',
         }),
       ]);
-      expect(legacyEnglishChallenge.status).toStrictEqual(Challenge.STATUSES.PERIME);
+      expect(legacyEnglishChallenge[0].status).toStrictEqual(Challenge.STATUSES.PERIME);
+      expect(legacyEnglishChallenge[1].status).toStrictEqual(Challenge.STATUSES.PERIME);
       expect(errorLoggerSpy).not.toHaveBeenCalled();
       expect(infoLoggerSpy).toHaveBeenNthCalledWith(1, { dryRun: false }, 'Script bindEnglishChallengesToFrenchPrimaryEquivalent has started');
       expect(infoLoggerSpy).toHaveBeenNthCalledWith(2, `Now processing ${tube.name}${skill.level} - ${skill.id}`);
-      expect(infoLoggerSpy).toHaveBeenNthCalledWith(3, { skillId: skill.id, clonedEnglishLocalizedId: englishLocalized.id, frenchChallengeId: frenchChallenge.id });
-      expect(infoLoggerSpy).toHaveBeenNthCalledWith(4, { skillId: skill.id, obsoletedEnglishChallengesCount: 1, clonedTranslationsCount: 1, clonedAttachmentsCount: 1 });
-      expect(infoLoggerSpy).toHaveBeenNthCalledWith(5, { processedEnglishChallengesCount: 1, skippedSkillsCount: 0 }, 'DONE');
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(3, {
+        skillId: skill.id,
+        clonedEnglishLocalizedId: englishLocalized2.id,
+        frenchChallengeId: frenchChallenges[1].id,
+      });
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(4, {
+        skillId: skill.id,
+        clonedEnglishLocalizedId: englishLocalized1.id,
+        frenchChallengeId: frenchChallenges[0].id,
+      });
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(5, {
+        skillId: skill.id,
+        obsoletedEnglishChallengesCount: 2,
+        clonedTranslationsCount: 2,
+        clonedAttachmentsCount: 2,
+      });
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(6, {
+        processedEnglishChallengesCount: 2,
+        skippedSkillsCount: 0,
+      }, 'DONE');
     });
 
     describe('when framework name does not exist', () => {

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -355,6 +355,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
     beforeEach(async () => {
       await databaseBuilder.commit();
     });
+
     it('binds english challenges to french primary equivalent', async () => {
       // given
       const options = { dryRun: false, frameworkName: 'Pix' };
@@ -381,7 +382,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         locales: ['fr'],
         isQualityOk: true,
       });
-      const validatedFrenchChallengeLocalized = databaseBuilder.factory.buildLocalizedChallenge({
+      databaseBuilder.factory.buildLocalizedChallenge({
         id: validatedFrenchChallenge.id,
         challengeId: validatedFrenchChallenge.id,
         locale: 'fr',
@@ -446,7 +447,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         locales: ['en'],
         isQualityOk: true,
       });
-      const englishLegacyLocalized2 = databaseBuilder.factory.buildLocalizedChallenge({
+      databaseBuilder.factory.buildLocalizedChallenge({
         id: validatedEnglishChallenge2.id,
         challengeId: validatedEnglishChallenge2.id,
         locale: 'en',
@@ -467,7 +468,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         locale: 'en',
         value: 'EN instructions',
       });
-      const englishLegacyAttachment2 = databaseBuilder.factory.buildAttachment({
+      databaseBuilder.factory.buildAttachment({
         id: 'attachmentEn2',
         url: 'https://',
         size: 3,
@@ -590,18 +591,18 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         skillId: skill.id,
         clonedEnglishLocalizedId: englishLocalized2.id,
         frenchChallengeId: frenchChallenges[1].id,
-      });
+      }, 'Binding cloned english localized challenge to french challenge');
       expect(infoLoggerSpy).toHaveBeenNthCalledWith(4, {
         skillId: skill.id,
         clonedEnglishLocalizedId: englishLocalized1.id,
         frenchChallengeId: frenchChallenges[0].id,
-      });
+      }, 'Binding cloned english localized challenge to french challenge');
       expect(infoLoggerSpy).toHaveBeenNthCalledWith(5, {
         skillId: skill.id,
         obsoletedEnglishChallengesCount: 2,
         clonedTranslationsCount: 2,
         clonedAttachmentsCount: 2,
-      });
+      }, 'Finished processing skill activePixTube6');
       expect(infoLoggerSpy).toHaveBeenNthCalledWith(6, {
         processedEnglishChallengesCount: 2,
         skippedSkillsCount: 0,

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -9,7 +9,11 @@ import {
 } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
 import { logger } from '../../lib/infrastructure/logger.js';
 import { Attachment, Challenge, LocalizedChallenge, Skill } from '../../lib/domain/models/index.js';
-import { attachmentRepository, challengeRepository, translationRepository } from '../../lib/infrastructure/repositories/index.js';
+import {
+  attachmentRepository,
+  challengeRepository,
+  translationRepository,
+} from '../../lib/infrastructure/repositories/index.js';
 
 describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
   /** @type {BindEnglishChallengesToFrenchPrimaryEquivalent} */
@@ -317,7 +321,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         expect(filterResult).toBeFalsy();
       });
 
-      it('should return an validated french challenge without any english localized', () => {
+      it('should return a validated french challenge without any english localized', () => {
         // given
         const frenchChallengeWithoutEnglishLocalized = domainBuilder.buildChallenge({
           id: 'challengeFrId1',
@@ -426,6 +430,8 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
       const translations = await translationRepository.listByEntity('challenge', frenchChallenge.id);
       const englishTranslations = translations.filter(({ locale }) => locale === 'en');
 
+      const legacyEnglishChallenge = await challengeRepository.get(validatedEnglishChallenge1.id);
+
       // then
       expect(errorLoggerSpy).not.toHaveBeenCalled();
       expect(localizedChallenges.length).toEqual(2);
@@ -467,6 +473,8 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           value: 'EN instructions',
         }),
       ]);
+
+      expect(legacyEnglishChallenge.status).toStrictEqual(Challenge.STATUSES.PERIME);
     });
 
     describe('when framework name does not exist', () => {

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -871,6 +871,9 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         });
 
         // then
+        const frenchChallenge = await challengeRepository.get(challenge.id);
+        expect(frenchChallenge.localizedChallenges.length).toBe(1);
+        expect(frenchChallenge.localizedChallenges.every((localized) => localized.locale === 'fr')).toBe(true);
         expect(errorLoggerSpy).toHaveBeenCalledExactlyOnceWith({
           skillId: skill.id,
           activeFrenchChallengeIds: [challenge.id],

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -12,6 +12,7 @@ import { Attachment, Challenge, LocalizedChallenge, Skill } from '../../lib/doma
 import {
   attachmentRepository,
   challengeRepository,
+  localizedChallengeRepository,
   translationRepository,
 } from '../../lib/infrastructure/repositories/index.js';
 
@@ -618,6 +619,87 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           options,
           logger,
         })).rejects.toThrow(new Error('framework with this given name does not exist'));
+      });
+    });
+
+    describe('when an error occurs in the transaction', () => {
+      it('should rollback all changes and skip the problematic skill', async () => {
+        // given
+        const options = { dryRun: false, frameworkName: 'Pix' };
+        const { skill } = databaseBuilder.factory.buildChallengeInGroup({
+          framework: { name: 'Pix' },
+          tube: { name: 'activePixTube' },
+          skill: {
+            status: Skill.STATUSES.ACTIF,
+            level: 6,
+          },
+          challenge: {
+            genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+            status: Challenge.STATUSES.VALIDE,
+            locales: ['fr'],
+          },
+        });
+
+        const validatedFrenchChallenge = databaseBuilder.factory.buildChallenge({
+          id: 'validatedFrenchChallenge',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['fr'],
+          isQualityOk: true,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedFrenchChallenge.id,
+          challengeId: validatedFrenchChallenge.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedFrenchChallenge.instruction',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+
+        const validatedEnglishChallenge2 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedEnglishChallenge2',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['en'],
+          isQualityOk: false,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedEnglishChallenge2.id,
+          challengeId: validatedEnglishChallenge2.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedFrenchChallenge.instruction',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+
+        await databaseBuilder.commit();
+
+        const errorLoggerSpy = vi.spyOn(logger, 'error');
+        const infoLoggerSpy = vi.spyOn(logger, 'info');
+        const saveLocalizedChallengeSpy = vi.spyOn(localizedChallengeRepository, 'create').mockRejectedValue(new Error('The database disappeared 🪄'));
+
+        // when
+        await script.handle({
+          options,
+          logger,
+        });
+
+        // then
+        expect(saveLocalizedChallengeSpy).toHaveBeenCalledOnce();
+        expect(errorLoggerSpy).toHaveBeenCalledExactlyOnceWith({
+          skillId: skill.id,
+          err: expect.any(Error),
+        }, 'Error in transaction while processing skill activePixTube6');
+        expect(infoLoggerSpy).toHaveBeenCalledWith({
+          processedEnglishChallengesCount: 0,
+          skippedSkillsCount: 1,
+        }, 'DONE');
       });
     });
 

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -8,7 +8,8 @@ import {
   listLegacyEnglishChallengesBySkillId,
 } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
 import { logger } from '../../lib/infrastructure/logger.js';
-import { Challenge, LocalizedChallenge, Skill } from '../../lib/domain/models/index.js';
+import { Attachment, Challenge, LocalizedChallenge, Skill } from '../../lib/domain/models/index.js';
+import { attachmentRepository, challengeRepository, translationRepository } from '../../lib/infrastructure/repositories/index.js';
 
 describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
   /** @type {BindEnglishChallengesToFrenchPrimaryEquivalent} */
@@ -350,6 +351,123 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
     beforeEach(async () => {
       await databaseBuilder.commit();
     });
+    it('binds english challenges to french primary equivalent', async () => {
+      // given
+      const options = { dryRun: false, frameworkName: 'Pix' };
+      const { skill, challenge, localizedChallenge } = databaseBuilder.factory.buildChallengeInGroup({
+        framework: { name: 'Pix' },
+        tube: { name: 'activePixTube' },
+        skill: {
+          status: Skill.STATUSES.ACTIF,
+          level: 6,
+        },
+        challenge: {
+          genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['fr'],
+        },
+        localizedChallenge: { embedUrl: 'https://pix.fr' },
+      });
+
+      const validatedEnglishChallenge1 = databaseBuilder.factory.buildChallenge({
+        id: 'validatedEnglishChallenge1',
+        skillId: skill.id,
+        genealogy: Challenge.GENEALOGIES.DECLINAISON,
+        status: Challenge.STATUSES.VALIDE,
+        locales: ['en'],
+        isQualityOk: true,
+      });
+      const englishLegacyLocalized = databaseBuilder.factory.buildLocalizedChallenge({
+        id: validatedEnglishChallenge1.id,
+        challengeId: validatedEnglishChallenge1.id,
+        locale: 'en',
+        embedUrl: 'https://pix.org/en-UK',
+        urlsToConsult: ['https://pix.fr'],
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        geography: 'UK',
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+        validatedAt: new Date(),
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: 'challenge.validatedEnglishChallenge1.instruction',
+        locale: 'en',
+        value: 'EN instructions',
+      });
+      const englishLegacyAttachment = databaseBuilder.factory.buildAttachment({
+        id: 'attachmentEn',
+        url: 'https://',
+        size: 3,
+        type: Attachment.TYPES.ILLUSTRATION,
+        filename: 'test.jpg',
+        mimeType: 'image/jpeg',
+        challengeId: validatedEnglishChallenge1.id,
+        localizedChallengeId: validatedEnglishChallenge1.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const errorLoggerSpy = vi.spyOn(logger, 'error');
+
+      // when
+      await script.handle({
+        options,
+        logger,
+      });
+
+      const frenchChallenge = await challengeRepository.get(challenge.id);
+      const localizedChallenges = frenchChallenge.localizedChallenges;
+      const englishLocalized = localizedChallenges.find(({ locale }) => locale === 'en');
+      const attachments = await attachmentRepository.listByLocalizedChallengeId(englishLocalized.id);
+      const translations = await translationRepository.listByEntity('challenge', frenchChallenge.id);
+      const englishTranslations = translations.filter(({ locale }) => locale === 'en');
+
+      // then
+      expect(errorLoggerSpy).not.toHaveBeenCalled();
+      expect(localizedChallenges.length).toEqual(2);
+      expect(englishLocalized).toStrictEqual(domainBuilder.buildLocalizedChallenge({
+        id: `${validatedEnglishChallenge1.id}-EN`,
+        challengeId: frenchChallenge.id,
+        locale: 'en',
+        status: LocalizedChallenge.STATUSES.PLAY,
+        fileIds: attachments.map(({ id }) => id),
+        embedUrl: englishLegacyLocalized.embedUrl,
+        primaryEmbedUrl: localizedChallenge.embedUrl,
+        urlsToConsult: englishLegacyLocalized.urlsToConsult,
+        requireGafamWebsiteAccess: englishLegacyLocalized.requireGafamWebsiteAccess,
+        isIncompatibleIpadCertif: englishLegacyLocalized.isIncompatibleIpadCertif,
+        deafAndHardOfHearing: englishLegacyLocalized.deafAndHardOfHearing,
+        isAwarenessChallenge: englishLegacyLocalized.isAwarenessChallenge,
+        toRephrase: englishLegacyLocalized.toRephrase,
+        geography: englishLegacyLocalized.geography,
+        hasEmbedInternalValidation: englishLegacyLocalized.hasEmbedInternalValidation,
+        noValidationNeeded: englishLegacyLocalized.noValidationNeeded,
+        validatedAt: englishLegacyLocalized.validatedAt,
+      }));
+      expect(attachments).toStrictEqual([
+        domainBuilder.buildAttachment({
+          id: expect.any(String),
+          url: englishLegacyAttachment.url,
+          size: englishLegacyAttachment.size,
+          type: englishLegacyAttachment.type,
+          filename: englishLegacyAttachment.filename,
+          mimeType: englishLegacyAttachment.mimeType,
+          challengeId: frenchChallenge.id,
+          localizedChallengeId: englishLocalized.id,
+        }),
+      ]);
+      expect(englishTranslations).toStrictEqual([
+        domainBuilder.buildTranslation({
+          key: `challenge.${frenchChallenge.id}.instruction`,
+          locale: 'en',
+          value: 'EN instructions',
+        }),
+      ]);
+    });
 
     describe('when framework name does not exist', () => {
       it('should throw an error', async () => {
@@ -395,7 +513,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'en',
         });
         databaseBuilder.factory.buildTranslation({
-          key: 'challenge.validatedEnglishChallenge1.instructions',
+          key: 'challenge.validatedEnglishChallenge1.instruction',
           locale: 'en',
           value: 'EN instructions',
         });
@@ -414,7 +532,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'en',
         });
         databaseBuilder.factory.buildTranslation({
-          key: 'challenge.validatedEnglishChallenge2.instructions',
+          key: 'challenge.validatedEnglishChallenge2.instruction',
           locale: 'en',
           value: 'EN instructions',
         });
@@ -436,17 +554,6 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           legacyEnglishChallengeIds: [validatedEnglishChallenge1.id, validatedEnglishChallenge2.id],
         }, 'Not enough active french challenges without english localized for each english challenge');
       });
-    });
-
-    it('binds english challenges to french primary equivalent', async () => {
-      // given
-      const options = { dryRun: false };
-
-      // when
-      await script.handle({ options, logger });
-
-      // then
-      expect(true).toBe(false);
     });
 
     describe('when dryRun option is true', () => {

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -1,10 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { databaseBuilder, domainBuilder } from '../test-helper.js';
 import {
-  assertEachLegacyEnglishChallengeHasActiveFrenchChallenge,
   BindEnglishChallengesToFrenchPrimaryEquivalent,
-  listActiveFrenchChallengesBySkillId,
+  byActiveFrenchChallenges,
   listActiveSkillsByFrameworkName,
   listLegacyEnglishChallengesBySkillId,
 } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
@@ -15,15 +14,15 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
   /** @type {BindEnglishChallengesToFrenchPrimaryEquivalent} */
   let script;
 
-  // beforeEach(() => {
-  //   script = new BindEnglishChallengesToFrenchPrimaryEquivalent();
-  // });
+  beforeEach(() => {
+    script = new BindEnglishChallengesToFrenchPrimaryEquivalent();
+  });
 
   describe('Unit', () => {
     describe('listActiveSkillsByFrameworkName', () => {
       it('should retrieve all active skills', async () => {
         // given
-        const { tube, skill } = databaseBuilder.factory.buildChallengeInGroup({
+        const { tube } = databaseBuilder.factory.buildChallengeInGroup({
           framework: { name: 'Pix' },
           tube: { name: 'activePixTube' },
           skill: {
@@ -244,22 +243,146 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
       });
     });
 
-    describe('listActiveFrenchChallengesBySkillId', () => {
-      it('should retrieve all active french challenges for a given skill id', async () => {
-        const { skill, challenge } = databaseBuilder.factory.buildChallengeInGroup({
+    describe('byActiveFrenchChallenges', () => {
+      it('should not return a non active challenge', () => {
+        // given
+        const outdatedFrenchChallenge = domainBuilder.buildChallenge({
+          id: 'outdatedFrenchChallenge',
+          locales: ['fr'],
+          status: Challenge.STATUSES.PERIME,
+          localizedChallenges: [
+            domainBuilder.buildLocalizedChallenge({
+              id: 'outdatedFrenchChallenge-FR',
+              challengeId: 'outdatedFrenchChallenge',
+              locale: 'fr',
+            }),
+          ],
+        });
+
+        // when
+        const filterResult = byActiveFrenchChallenges(outdatedFrenchChallenge);
+
+        // then
+        expect(filterResult).toBeFalsy();
+      });
+
+      it('should not return a non french challenge', () => {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'englishChallenge',
+            locales: ['en'],
+            status: Challenge.STATUSES.VALIDE,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'nlChallenge',
+            locales: ['nl'],
+            status: Challenge.STATUSES.VALIDE,
+          }),
+        ];
+
+        // when
+        const filterResult = challenges.filter(byActiveFrenchChallenges);
+
+        // then
+        expect(filterResult).toHaveLength(0);
+      });
+
+      it('should not return an french challenge with an english localized', () => {
+        // given
+        const frenchChallengeWithEnglishLocalized = domainBuilder.buildChallenge({
+          id: 'challengeFrId1',
+          locales: ['fr', 'nl'],
+          status: Challenge.STATUSES.VALIDE,
+          localizedChallenges: [
+            domainBuilder.buildLocalizedChallenge({
+              id: 'challengeFrId1',
+              challengeId: 'challengeFrId1',
+              locale: 'fr',
+            }),
+            domainBuilder.buildLocalizedChallenge({
+              id: 'challengeFrId1-EN',
+              challengeId: 'challengeFrId1',
+              locale: 'en',
+              status: LocalizedChallenge.STATUSES.PLAY,
+            }),
+          ],
+        });
+
+        // when
+        const filterResult = byActiveFrenchChallenges(frenchChallengeWithEnglishLocalized);
+
+        // then
+        expect(filterResult).toBeFalsy();
+      });
+
+      it('should return an validated french challenge without any english localized', () => {
+        // given
+        const frenchChallengeWithoutEnglishLocalized = domainBuilder.buildChallenge({
+          id: 'challengeFrId1',
+          locales: ['fr', 'nl'],
+          status: Challenge.STATUSES.VALIDE,
+          localizedChallenges: [
+            domainBuilder.buildLocalizedChallenge({
+              id: 'challengeFrId1',
+              challengeId: 'challengeFrId1',
+              locale: 'fr',
+            }),
+            domainBuilder.buildLocalizedChallenge({
+              id: 'challengeFrId1-NL',
+              challengeId: 'challengeFrId1',
+              locale: 'nl',
+              status: LocalizedChallenge.STATUSES.PLAY,
+            }),
+          ],
+        });
+
+        // when
+        const filterResult = byActiveFrenchChallenges(frenchChallengeWithoutEnglishLocalized);
+
+        // then
+        expect(filterResult).toBeTruthy();
+      });
+    });
+  });
+
+  describe('#handle', () => {
+    beforeEach(async () => {
+      await databaseBuilder.commit();
+    });
+
+    describe('when framework name does not exist', () => {
+      it('should throw an error', async () => {
+        // given
+        const options = { dryRun: false, frameworkName: 'Pix' };
+        // then
+        await expect(script.handle({
+          options,
+          logger,
+        })).rejects.toThrow(new Error('framework with this given name does not exist'));
+      });
+    });
+
+    describe('when there aren\'t enough french challenges for every english challenge for a skill', () => {
+      it('should log an error and skip that skill', async () => {
+        // given
+        const options = { dryRun: false, frameworkName: 'Pix' };
+        const { challenge, skill } = databaseBuilder.factory.buildChallengeInGroup({
           framework: { name: 'Pix' },
+          tube: { name: 'activePixTube' },
           skill: {
             status: Skill.STATUSES.ACTIF,
-            name: '@activeSkill1',
+            level: 6,
           },
           challenge: {
             genealogy: Challenge.GENEALOGIES.PROTOTYPE,
             status: Challenge.STATUSES.VALIDE,
+            locales: ['fr'],
           },
         });
 
         const validatedEnglishChallenge1 = databaseBuilder.factory.buildChallenge({
-          id: 'validatedChallengeId1',
+          id: 'validatedEnglishChallenge1',
           skillId: skill.id,
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
           status: Challenge.STATUSES.VALIDE,
@@ -272,363 +395,47 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'en',
         });
         databaseBuilder.factory.buildTranslation({
-          key: 'challenge.validatedChallengeId1.instructions',
+          key: 'challenge.validatedEnglishChallenge1.instructions',
           locale: 'en',
           value: 'EN instructions',
         });
 
-        const validatedFrenchChallenge2 = databaseBuilder.factory.buildChallenge({
-          id: 'validatedChallengeId2',
+        const validatedEnglishChallenge2 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedEnglishChallenge2',
           skillId: skill.id,
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
           status: Challenge.STATUSES.VALIDE,
-          locales: ['fr'],
+          locales: ['en'],
           isQualityOk: false,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
-          id: validatedFrenchChallenge2.id,
-          challengeId: validatedFrenchChallenge2.id,
-          locale: 'fr',
+          id: validatedEnglishChallenge2.id,
+          challengeId: validatedEnglishChallenge2.id,
+          locale: 'en',
         });
         databaseBuilder.factory.buildTranslation({
-          key: 'challenge.validatedChallengeId2.instructions',
-          locale: 'fr',
-          value: 'FR instructions',
-        });
-        const proposedFrenchChallenge3 = databaseBuilder.factory.buildChallenge({
-          id: 'proposedChallengeId3',
-          skillId: skill.id,
-          genealogy: Challenge.GENEALOGIES.DECLINAISON,
-          status: Challenge.STATUSES.PROPOSE,
-          locales: ['fr'],
-        });
-        databaseBuilder.factory.buildLocalizedChallenge({
-          id: proposedFrenchChallenge3.id,
-          challengeId: proposedFrenchChallenge3.id,
-          locale: 'fr',
-        });
-        databaseBuilder.factory.buildTranslation({
-          key: 'challenge.proposedChallengeId3.instructions',
-          locale: 'fr',
-          value: 'FR instructions',
-        });
-        const archivedFrenchChallenge4 = databaseBuilder.factory.buildChallenge({
-          id: 'archivedChallengeId4',
-          skillId: skill.id,
-          genealogy: Challenge.GENEALOGIES.DECLINAISON,
-          status: Challenge.STATUSES.ARCHIVE,
-          locales: ['fr'],
-        });
-        databaseBuilder.factory.buildLocalizedChallenge({
-          id: archivedFrenchChallenge4.id,
-          challengeId: archivedFrenchChallenge4.id,
-          locale: 'fr',
-        });
-        databaseBuilder.factory.buildTranslation({
-          key: 'challenge.archivedChallengeId4.instructions',
-          locale: 'fr',
-          value: 'FR instructions',
-        });
-        const proposedChallenge5 = databaseBuilder.factory.buildChallenge({
-          id: 'proposedChallengeId5',
-          skillId: skill.id,
-          genealogy: Challenge.GENEALOGIES.DECLINAISON,
-          status: Challenge.STATUSES.PROPOSE,
-          locales: ['fr'],
-        });
-        databaseBuilder.factory.buildLocalizedChallenge({
-          id: proposedChallenge5.id,
-          challengeId: proposedChallenge5.id,
-          locale: 'fr',
-        });
-        databaseBuilder.factory.buildTranslation({
-          key: 'challenge.proposedChallengeId5.instructions',
-          locale: 'fr',
-          value: 'FR instructions',
-        });
-        const validatedNLChallenge6 = databaseBuilder.factory.buildChallenge({
-          id: 'validatedChallengeId6',
-          skillId: skill.id,
-          genealogy: Challenge.GENEALOGIES.DECLINAISON,
-          status: Challenge.STATUSES.VALIDE,
-          locales: ['nl'],
-        });
-        databaseBuilder.factory.buildLocalizedChallenge({
-          id: validatedNLChallenge6.id,
-          challengeId: validatedNLChallenge6.id,
-          locale: 'nl',
-        });
-        databaseBuilder.factory.buildTranslation({
-          key: 'challenge.validatedChallengeId6.instructions',
-          locale: 'nl',
-          value: 'NL instructions',
+          key: 'challenge.validatedEnglishChallenge2.instructions',
+          locale: 'en',
+          value: 'EN instructions',
         });
 
         await databaseBuilder.commit();
 
+        const errorLoggerSpy = vi.spyOn(logger, 'error');
+
         // when
-        const activeFrenchChallenges = await listActiveFrenchChallengesBySkillId(skill.id);
+        await script.handle({
+          options,
+          logger,
+        });
 
         // then
-        expect(activeFrenchChallenges).toHaveLength(2);
-        expect(activeFrenchChallenges.map((challenge) => challenge.id)).toStrictEqual([challenge.id, 'validatedChallengeId2']);
-        expect(activeFrenchChallenges.every((challenge) => challenge.status === Challenge.STATUSES.VALIDE)).toBe(true);
-        expect(activeFrenchChallenges.every((challenge) => challenge.locales.includes('fr') && challenge.locales.length === 1)).toBe(true);
+        expect(errorLoggerSpy).toHaveBeenCalledExactlyOnceWith({
+          skillId: skill.id,
+          activeFrenchChallengeIds: [challenge.id],
+          legacyEnglishChallengeIds: [validatedEnglishChallenge1.id, validatedEnglishChallenge2.id],
+        }, 'Not enough active french challenges without english localized for each english challenge');
       });
-    });
-
-    describe('assertEachLegacyEnglishChallengeHasActiveFrenchChallenge', () => {
-      describe('when there are enough french challenges to accomodate every english challenge', () => {
-        describe('exactly the same amount of french and english challenges', () => {
-          it('should not throw', async () => {
-            // given
-            const frenchChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId1',
-                locales: ['fr'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId2',
-                locales: ['fr', 'nl'],
-                status: Challenge.STATUSES.VALIDE,
-                localizedChallenges: [
-                  domainBuilder.buildLocalizedChallenge({
-                    id: 'challengeFrId2',
-                    challengeId: 'challengeFrId2',
-                    locale: 'fr',
-                  }),
-                  domainBuilder.buildLocalizedChallenge({
-                    id: 'challengeFrId2-NL',
-                    challengeId: 'challengeFrId2',
-                    locale: 'nl',
-                    status: LocalizedChallenge.STATUSES.PLAY,
-                  }),
-                ],
-              }),
-            ];
-            const englishChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeEnId1',
-                locales: ['en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeEnId2',
-                locales: ['en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-            ];
-
-            // then
-            expect(assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toBeUndefined();
-          });
-        });
-
-        describe('less english challenges than validated french challenges', () => {
-          it('should not throw', async () => {
-            // given
-            const frenchChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId1',
-                locales: ['fr'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId2',
-                locales: ['fr'],
-                status: Challenge.STATUSES.PROPOSE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId3',
-                locales: ['fr'],
-                status: Challenge.STATUSES.PERIME,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId4',
-                locales: ['fr'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrEnId5',
-                locales: ['fr', 'en'],
-                status: Challenge.STATUSES.VALIDE,
-                localizedChallenges: [
-                  domainBuilder.buildLocalizedChallenge({
-                    id: 'challengeFrEnId5',
-                    challengeId: 'challengeFrEnId5',
-                    locale: 'fr',
-                  }),
-                  domainBuilder.buildLocalizedChallenge({
-                    id: 'challengeFrEnId5-EN',
-                    challengeId: 'challengeFrEnId5',
-                    locale: 'en',
-                    status: LocalizedChallenge.STATUSES.PLAY,
-                  }),
-                ],
-              }),
-            ];
-            const englishChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeEnId1',
-                locales: ['en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-            ];
-
-            // then
-            expect(assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toBeUndefined();
-          });
-        });
-
-        describe('when there already are english localized but enough validated french challenges without english localized', () => {
-          it('should not throw', () => {
-            // given
-            const frenchChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId1',
-                locales: ['fr'],
-                status: Challenge.STATUSES.VALIDE,
-
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId2',
-                locales: ['fr'],
-                status: Challenge.STATUSES.PROPOSE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId3',
-                locales: ['fr'],
-                status: Challenge.STATUSES.PERIME,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrEnId4',
-                locales: ['fr', 'en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-            ];
-            const englishChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeEnId1',
-                locales: ['en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-            ];
-
-            // then
-            expect(assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toBeUndefined();
-          });
-        });
-      });
-
-      describe('when there aren\'t enough french challenges for every english challenge', () => {
-        it('should throw', async () => {
-          // given
-          const frenchChallenges = [
-            domainBuilder.buildChallenge({
-              id: 'challengeFrId1',
-              locales: ['fr'],
-              status: Challenge.STATUSES.VALIDE,
-            }),
-            domainBuilder.buildChallenge({
-              id: 'challengeFrId2',
-              locales: ['fr'],
-              status: Challenge.STATUSES.PROPOSE,
-            }),
-            domainBuilder.buildChallenge({
-              id: 'challengeFrId3',
-              locales: ['fr'],
-              status: Challenge.STATUSES.PERIME,
-            }),
-            domainBuilder.buildChallenge({
-              id: 'challengeFrId3',
-              locales: ['fr'],
-              status: Challenge.STATUSES.ARCHIVE,
-            }),
-          ];
-          const englishChallenges = [
-            domainBuilder.buildChallenge({
-              id: 'challengeEnId1',
-              locales: ['en'],
-              status: Challenge.STATUSES.VALIDE,
-            }),
-            domainBuilder.buildChallenge({
-              id: 'challengeEnId2',
-              locales: ['en'],
-              status: Challenge.STATUSES.VALIDE,
-            }),
-          ];
-
-          // then
-          expect(
-            () => assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges),
-          ).toThrowError('Not enough active french challenges (1) for each english challenge (2) in skill recSkillId');
-        });
-
-        describe('when there already are english localized but not enough validated french challenges without english localized', () => {
-          it('should throw', () => {
-            // given
-            const frenchChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId1',
-                locales: ['fr'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId2',
-                locales: ['fr'],
-                status: Challenge.STATUSES.PROPOSE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrId3',
-                locales: ['fr'],
-                status: Challenge.STATUSES.PERIME,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeFrEnId4',
-                locales: ['fr', 'en'],
-                status: Challenge.STATUSES.VALIDE,
-                localizedChallenges: [
-                  domainBuilder.buildLocalizedChallenge({
-                    id: 'challengeFrEnId4',
-                    challengeId: 'challengeFrEnId4',
-                    locale: 'fr',
-                  }),
-                  domainBuilder.buildLocalizedChallenge({
-                    id: 'challengeFrEnId4-EN',
-                    challengeId: 'challengeFrEnId4',
-                    locale: 'en',
-                    status: LocalizedChallenge.STATUSES.PLAY,
-                  }),
-                ],
-              }),
-            ];
-            const englishChallenges = [
-              domainBuilder.buildChallenge({
-                id: 'challengeEnId1',
-                locales: ['en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-              domainBuilder.buildChallenge({
-                id: 'challengeEnId2',
-                locales: ['en'],
-                status: Challenge.STATUSES.VALIDE,
-              }),
-            ];
-
-            // then
-            expect(
-              () => assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges),
-            ).toThrowError('Not enough active french challenges without english localized (1) for each english challenge (2) in skill recSkillId');
-          });
-        });
-      });
-    });
-  });
-
-  describe('#handle', () => {
-    beforeEach(async () => {
-      await databaseBuilder.commit();
     });
 
     it('binds english challenges to french primary equivalent', async () => {

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { databaseBuilder } from '../test-helper.js';
+import { BindEnglishChallengesToFrenchPrimaryEquivalent, listActiveSkillsByFrameworkName } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+import { Skill } from '../../lib/domain/models/Skill.js';
+import { Challenge } from '../../lib/domain/models/Challenge.js';
+
+describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
+  /** @type {BindEnglishChallengesToFrenchPrimaryEquivalent} */
+  let script;
+
+  beforeEach(() => {
+    script = new BindEnglishChallengesToFrenchPrimaryEquivalent();
+  });
+
+  describe('Unit', () => {
+    describe('listActiveSkillsByFrameworkName', () => {
+      it('should retrieve all active skills', async () => {
+        // given
+        const { tube, skill } = databaseBuilder.factory.buildChallengeInGroup({
+          framework: { name: 'Pix' },
+          tube: { name: 'activePixTube' },
+          skill: {
+            status: Skill.STATUSES.ACTIF,
+            level: 6,
+          },
+        });
+
+        databaseBuilder.factory.buildSkill({
+          id: 'activeSkill5',
+          tubeId: tube.id,
+          status: Skill.STATUSES.ACTIF,
+          level: 3,
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'proposedSkill2',
+          tubeId: tube.id,
+          status: Skill.STATUSES.EN_CONSTRUCTION,
+          name: '@proposedSkill2',
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'archivedSkill3',
+          tubeId: tube.id,
+          status: Skill.STATUSES.ARCHIVE,
+          name: '@archivedSkill3',
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'obsoleteSkill4',
+          tubeId: tube.id,
+          status: Skill.STATUSES.PERIME,
+          name: '@obsoleteSkill4',
+        });
+
+        const { tube: tube2 } = databaseBuilder.factory.buildChallengeInGroup({
+          framework: { name: 'Girafe' },
+          tube: { name: 'activeTube' },
+          skill: {
+            status: Skill.STATUSES.ACTIF,
+            level: 2,
+          },
+        });
+
+        databaseBuilder.factory.buildSkill({
+          id: 'activeSkill5_2',
+          tubeId: tube2.id,
+          status: Skill.STATUSES.ACTIF,
+          name: '@activeSkill5_2',
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'proposedSkill2_2',
+          tubeId: tube2.id,
+          status: Skill.STATUSES.EN_CONSTRUCTION,
+          name: '@proposedSkill2_2',
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'archivedSkill3_2',
+          tubeId: tube2.id,
+          status: Skill.STATUSES.ARCHIVE,
+          name: '@archivedSkill3_2',
+        });
+        databaseBuilder.factory.buildSkill({
+          id: 'outdatedSkill4_2',
+          tubeId: tube2.id,
+          status: Skill.STATUSES.PERIME,
+          name: '@outdatedSkill4_2',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const activeSkills = await listActiveSkillsByFrameworkName('Pix');
+
+        // then
+        expect(activeSkills).toHaveLength(2);
+        expect(activeSkills.map((skill) => skill.name)).toStrictEqual(['activePixTube3', 'activePixTube6']);
+        expect(activeSkills.every((skill) => skill.status === Skill.STATUSES.ACTIF)).toBe(true);
+      });
+
+      describe('when framework name does not exist', () => {
+        it('should throw an error', async () => {
+          // then
+          await expect(listActiveSkillsByFrameworkName('')).rejects.toThrow(new Error('framework with this given name does not exist'));
+        });
+      });
+    });
+  });
+
+  describe('#handle', () => {
+    beforeEach(async () => {
+      await databaseBuilder.commit();
+    });
+
+    it('binds english challenges to french primary equivalent', async () => {
+      // given
+      const options = { dryRun: false };
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(true).toBe(false);
+    });
+
+    describe('when dryRun option is true', () => {
+      it('stops before deletion', async () => {
+        // given
+        const options = { dryRun: true };
+
+        // when
+        await script.handle({ options, logger });
+
+        // then
+        expect(true).toBe(false);
+      });
+    });
+  });
+});

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -567,13 +567,81 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
     describe('when dryRun option is true', () => {
       it('stops before deletion', async () => {
         // given
-        const options = { dryRun: true };
+        const options = { dryRun: true, frameworkName: 'Pix' };
+        const { skill, challenge } = databaseBuilder.factory.buildChallengeInGroup({
+          framework: { name: 'Pix' },
+          tube: { name: 'activePixTube' },
+          skill: {
+            status: Skill.STATUSES.ACTIF,
+            level: 6,
+          },
+          challenge: {
+            genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+            status: Challenge.STATUSES.VALIDE,
+            locales: ['fr'],
+          },
+          localizedChallenge: { embedUrl: 'https://pix.fr' },
+        });
+
+        const validatedEnglishChallenge1 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedEnglishChallenge1',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['en'],
+          isQualityOk: true,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedEnglishChallenge1.id,
+          challengeId: validatedEnglishChallenge1.id,
+          locale: 'en',
+          embedUrl: 'https://pix.org/en-UK',
+          urlsToConsult: ['https://pix.fr'],
+          requireGafamWebsiteAccess: true,
+          isIncompatibleIpadCertif: true,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+          isAwarenessChallenge: true,
+          toRephrase: true,
+          geography: 'UK',
+          hasEmbedInternalValidation: false,
+          noValidationNeeded: false,
+          validatedAt: new Date(),
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedEnglishChallenge1.instruction',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+
+        await databaseBuilder.commit();
+
+        const errorLoggerSpy = vi.spyOn(logger, 'error');
 
         // when
-        await script.handle({ options, logger });
+        await script.handle({
+          options,
+          logger,
+        });
+
+        const frenchChallenge = await challengeRepository.get(challenge.id);
+        const localizedChallenges = frenchChallenge.localizedChallenges;
+        const englishLocalized = localizedChallenges.find(({ locale }) => locale === 'en');
+        const attachments = await attachmentRepository.list();
+        const newEnglishAttachments = attachments.filter((attachment) => attachment.localizedChallengeId.endsWith('-EN'));
+        const translations = await translationRepository.listByEntity('challenge', frenchChallenge.id);
+        const englishTranslations = translations.filter(({ locale }) => locale === 'en');
+
+        const legacyEnglishChallenge = await challengeRepository.get(validatedEnglishChallenge1.id);
 
         // then
-        expect(true).toBe(false);
+        expect(errorLoggerSpy).not.toHaveBeenCalled();
+        expect(localizedChallenges.length).toEqual(1);
+        expect(englishLocalized).toBeUndefined();
+        expect(newEnglishAttachments).toHaveLength(0);
+        expect(englishTranslations).toHaveLength(0);
+
+        expect(legacyEnglishChallenge.status).not.toStrictEqual(Challenge.STATUSES.PERIME);
+        expect(legacyEnglishChallenge.localizedChallenges[0].status).not.toStrictEqual(LocalizedChallenge.STATUSES.PAUSE);
       });
     });
   });

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { databaseBuilder } from '../test-helper.js';
+import { databaseBuilder, domainBuilder } from '../test-helper.js';
 import {
+  assertEachLegacyEnglishChallengeHasActiveFrenchChallenge,
   BindEnglishChallengesToFrenchPrimaryEquivalent,
   listActiveFrenchChallengesBySkillId,
   listActiveSkillsByFrameworkName,
@@ -373,6 +374,119 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         expect(activeFrenchChallenges.map((challenge) => challenge.id)).toStrictEqual([challenge.id, 'validatedChallengeId2']);
         expect(activeFrenchChallenges.every((challenge) => challenge.status === Challenge.STATUSES.VALIDE)).toBe(true);
         expect(activeFrenchChallenges.every((challenge) => challenge.locales.includes('fr') && challenge.locales.length === 1)).toBe(true);
+      });
+    });
+
+    describe('assertEachLegacyEnglishChallengeHasActiveFrenchChallenge', () => {
+      describe('when there are enough french challenges to accomodate every english challenge', () => {
+        describe('exactly the same amount of french and english challenges', () => {
+          it('should not throw', async () => {
+            // given
+            const frenchChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId1',
+                locales: ['fr'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId2',
+                locales: ['fr'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+            ];
+            const englishChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeEnId1',
+                locales: ['en'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeEnId2',
+                locales: ['en'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+            ];
+
+            // then
+            expect(assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toBeUndefined();
+          });
+        });
+
+        describe('less english challenges than validated french challenges', () => {
+          it('should not throw', async () => {
+            // given
+            const frenchChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId1',
+                locales: ['fr'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId2',
+                locales: ['fr'],
+                status: Challenge.STATUSES.PROPOSE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId3',
+                locales: ['fr'],
+                status: Challenge.STATUSES.PERIME,
+              }),
+            ];
+            const englishChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeEnId1',
+                locales: ['en'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+            ];
+
+            // then
+            expect(assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toBeUndefined();
+          });
+        });
+      });
+
+      describe('when there aren\'t enough french challenges for every english challenge', () => {
+        it('should throw', async () => {
+          // given
+          const frenchChallenges = [
+            domainBuilder.buildChallenge({
+              id: 'challengeFrId1',
+              locales: ['fr'],
+              status: Challenge.STATUSES.VALIDE,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'challengeFrId2',
+              locales: ['fr'],
+              status: Challenge.STATUSES.PROPOSE,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'challengeFrId3',
+              locales: ['fr'],
+              status: Challenge.STATUSES.PERIME,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'challengeFrId3',
+              locales: ['fr'],
+              status: Challenge.STATUSES.ARCHIVE,
+            }),
+          ];
+          const englishChallenges = [
+            domainBuilder.buildChallenge({
+              id: 'challengeEnId1',
+              locales: ['en'],
+              status: Challenge.STATUSES.VALIDE,
+            }),
+            domainBuilder.buildChallenge({
+              id: 'challengeEnId2',
+              locales: ['en'],
+              status: Challenge.STATUSES.VALIDE,
+            }),
+          ];
+
+          // then
+          expect(() => assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toThrowError('Not enough active french challenges for each english challenge');
+        });
       });
     });
   });

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -127,7 +127,86 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           challenge: {
             genealogy: Challenge.GENEALOGIES.PROTOTYPE,
             status: Challenge.STATUSES.VALIDE,
+            version: 2,
           },
+        });
+
+        const oldVersionObsoletePrototype = databaseBuilder.factory.buildChallenge({
+          id: 'oldVersionObsoletePrototype',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+          status: Challenge.STATUSES.PERIME,
+          version: 1,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: oldVersionObsoletePrototype.id,
+          challengeId: oldVersionObsoletePrototype.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.oldVersionObsoletePrototype.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+
+        const oldVersionObsoleteDecli = databaseBuilder.factory.buildChallenge({
+          id: 'oldVersionObsoleteDecli',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.PERIME,
+          version: 1,
+          locales: ['en'],
+          isQualityOk: true,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: oldVersionObsoleteDecli.id,
+          challengeId: oldVersionObsoleteDecli.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.oldVersionObsoleteDecli.instructions',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+
+        const newVersionProposedPrototype = databaseBuilder.factory.buildChallenge({
+          id: 'newVersionProposedPrototype',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+          status: Challenge.STATUSES.PROPOSE,
+          version: 3,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: newVersionProposedPrototype.id,
+          challengeId: newVersionProposedPrototype.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.newVersionProposedPrototype.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+
+        const newVersionProposedDecli = databaseBuilder.factory.buildChallenge({
+          id: 'newVersionProposedDecli',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.PROPOSE,
+          version: 3,
+          locales: ['en'],
+          isQualityOk: true,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: newVersionProposedDecli.id,
+          challengeId: newVersionProposedDecli.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.newVersionProposedDecli.instructions',
+          locale: 'en',
+          value: 'EN instructions',
         });
 
         const validatedChallenge1 = databaseBuilder.factory.buildChallenge({
@@ -137,6 +216,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: ['en'],
           isQualityOk: true,
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedChallenge1.id,
@@ -156,6 +236,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: ['en'],
           isQualityOk: false,
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedChallenge2.id,
@@ -167,12 +248,14 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'en',
           value: 'EN instructions',
         });
+
         const proposedChallenge3 = databaseBuilder.factory.buildChallenge({
           id: 'proposedChallengeId3',
           skillId: skill.id,
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
           status: Challenge.STATUSES.PROPOSE,
           locales: ['en'],
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: proposedChallenge3.id,
@@ -184,12 +267,14 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'en',
           value: 'EN instructions',
         });
+
         const archivedChallenge4 = databaseBuilder.factory.buildChallenge({
           id: 'archivedChallengeId4',
           skillId: skill.id,
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
           status: Challenge.STATUSES.ARCHIVE,
           locales: ['en'],
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: archivedChallenge4.id,
@@ -201,12 +286,14 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'en',
           value: 'EN instructions',
         });
+
         const proposedChallenge5 = databaseBuilder.factory.buildChallenge({
           id: 'proposedChallengeId5',
           skillId: skill.id,
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
           status: Challenge.STATUSES.PROPOSE,
           locales: ['fr'],
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: proposedChallenge5.id,
@@ -218,12 +305,14 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           locale: 'fr',
           value: 'FR instructions',
         });
+
         const validatedChallenge6 = databaseBuilder.factory.buildChallenge({
           id: 'validatedChallengeId6',
           skillId: skill.id,
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
           status: Challenge.STATUSES.VALIDE,
           locales: ['fr'],
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedChallenge6.id,
@@ -371,6 +460,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           genealogy: Challenge.GENEALOGIES.PROTOTYPE,
           status: Challenge.STATUSES.VALIDE,
           locales: ['fr'],
+          version: 2,
         },
         localizedChallenge: { embedUrl: 'https://pix.fr' },
       });
@@ -382,6 +472,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         status: Challenge.STATUSES.VALIDE,
         locales: ['fr'],
         isQualityOk: true,
+        version: 2,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: validatedFrenchChallenge.id,
@@ -407,6 +498,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         status: Challenge.STATUSES.VALIDE,
         locales: ['en'],
         isQualityOk: true,
+        version: 2,
       });
       const englishLegacyLocalized = databaseBuilder.factory.buildLocalizedChallenge({
         id: validatedEnglishChallenge1.id,
@@ -447,6 +539,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         status: Challenge.STATUSES.VALIDE,
         locales: ['en'],
         isQualityOk: true,
+        version: 2,
       });
       databaseBuilder.factory.buildLocalizedChallenge({
         id: validatedEnglishChallenge2.id,
@@ -638,6 +731,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
             genealogy: Challenge.GENEALOGIES.PROTOTYPE,
             status: Challenge.STATUSES.VALIDE,
             locales: ['fr'],
+            version: 2,
           },
         });
 
@@ -648,6 +742,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: ['fr'],
           isQualityOk: true,
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedFrenchChallenge.id,
@@ -667,6 +762,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: ['en'],
           isQualityOk: false,
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedEnglishChallenge2.id,
@@ -720,6 +816,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
             genealogy: Challenge.GENEALOGIES.PROTOTYPE,
             status: Challenge.STATUSES.VALIDE,
             locales: ['fr'],
+            version: 2,
           },
         });
 
@@ -730,6 +827,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: ['en'],
           isQualityOk: true,
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedEnglishChallenge1.id,
@@ -749,6 +847,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           status: Challenge.STATUSES.VALIDE,
           locales: ['en'],
           isQualityOk: false,
+          version: 2,
         });
         databaseBuilder.factory.buildLocalizedChallenge({
           id: validatedEnglishChallenge2.id,

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -1,18 +1,21 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { databaseBuilder } from '../test-helper.js';
-import { BindEnglishChallengesToFrenchPrimaryEquivalent, listActiveSkillsByFrameworkName } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
+import {
+  BindEnglishChallengesToFrenchPrimaryEquivalent,
+  listActiveSkillsByFrameworkName,
+  listLegacyEnglishChallengesBySkillId,
+} from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
 import { logger } from '../../lib/infrastructure/logger.js';
-import { Skill } from '../../lib/domain/models/Skill.js';
-import { Challenge } from '../../lib/domain/models/Challenge.js';
+import { Challenge, Skill } from '../../lib/domain/models/index.js';
 
 describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
   /** @type {BindEnglishChallengesToFrenchPrimaryEquivalent} */
   let script;
 
-  beforeEach(() => {
-    script = new BindEnglishChallengesToFrenchPrimaryEquivalent();
-  });
+  // beforeEach(() => {
+  //   script = new BindEnglishChallengesToFrenchPrimaryEquivalent();
+  // });
 
   describe('Unit', () => {
     describe('listActiveSkillsByFrameworkName', () => {
@@ -102,6 +105,140 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           // then
           await expect(listActiveSkillsByFrameworkName('')).rejects.toThrow(new Error('framework with this given name does not exist'));
         });
+      });
+    });
+
+    describe('listLegacyEnglishChallengesBySkillId', () => {
+      it('should retrieve all legacy english challenges for the given skill id', async () => {
+        // given
+        const { skill } = databaseBuilder.factory.buildChallengeInGroup({
+          framework: { name: 'Pix' },
+          skill: {
+            status: Skill.STATUSES.ACTIF,
+            name: '@activeSkill1',
+          },
+          challenge: {
+            genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+            status: Challenge.STATUSES.VALIDE,
+          },
+        });
+
+        const validatedChallenge1 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedChallengeId1',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['en'],
+          isQualityOk: true,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedChallenge1.id,
+          challengeId: validatedChallenge1.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedChallengeId1.instructions',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+
+        const validatedChallenge2 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedChallengeId2',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['en'],
+          isQualityOk: false,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedChallenge2.id,
+          challengeId: validatedChallenge2.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedChallengeId2.instructions',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+        const proposedChallenge3 = databaseBuilder.factory.buildChallenge({
+          id: 'proposedChallengeId3',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.PROPOSE,
+          locales: ['en'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: proposedChallenge3.id,
+          challengeId: proposedChallenge3.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.proposedChallengeId3.instructions',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+        const archivedChallenge4 = databaseBuilder.factory.buildChallenge({
+          id: 'archivedChallengeId4',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.ARCHIVE,
+          locales: ['en'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: archivedChallenge4.id,
+          challengeId: archivedChallenge4.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.archivedChallengeId4.instructions',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+        const proposedChallenge5 = databaseBuilder.factory.buildChallenge({
+          id: 'proposedChallengeId5',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.PROPOSE,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: proposedChallenge5.id,
+          challengeId: proposedChallenge5.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.proposedChallengeId5.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+        const validatedChallenge6 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedChallengeId6',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedChallenge6.id,
+          challengeId: validatedChallenge6.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedChallengeId6.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const legacyChallenges = await listLegacyEnglishChallengesBySkillId(skill.id);
+
+        // then
+        expect(legacyChallenges).toHaveLength(3);
+        expect(legacyChallenges.some((legacyChallenge) => legacyChallenge.id === 'validatedChallengeId1')).toBe(true);
+        expect(legacyChallenges.every((challenge) => challenge.isPrimary)).toBe(true);
+        expect(legacyChallenges.every((challenge) => challenge.locales.includes('en') && challenge.locales.length === 1)).toBe(true);
       });
     });
   });

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -607,6 +607,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
       expect(infoLoggerSpy).toHaveBeenNthCalledWith(6, {
         processedEnglishChallengesCount: 2,
         skippedSkillsCount: 0,
+        ignoredSkillsCount: 0,
       }, 'DONE');
     });
 
@@ -698,6 +699,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         }, 'Error in transaction while processing skill activePixTube6');
         expect(infoLoggerSpy).toHaveBeenCalledWith({
           processedEnglishChallengesCount: 0,
+          ignoredSkillsCount: 0,
           skippedSkillsCount: 1,
         }, 'DONE');
       });

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -9,7 +9,7 @@ import {
   listLegacyEnglishChallengesBySkillId,
 } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
 import { logger } from '../../lib/infrastructure/logger.js';
-import { Challenge, Skill } from '../../lib/domain/models/index.js';
+import { Challenge, LocalizedChallenge, Skill } from '../../lib/domain/models/index.js';
 
 describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
   /** @type {BindEnglishChallengesToFrenchPrimaryEquivalent} */
@@ -390,8 +390,21 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
               }),
               domainBuilder.buildChallenge({
                 id: 'challengeFrId2',
-                locales: ['fr'],
+                locales: ['fr', 'nl'],
                 status: Challenge.STATUSES.VALIDE,
+                localizedChallenges: [
+                  domainBuilder.buildLocalizedChallenge({
+                    id: 'challengeFrId2',
+                    challengeId: 'challengeFrId2',
+                    locale: 'fr',
+                  }),
+                  domainBuilder.buildLocalizedChallenge({
+                    id: 'challengeFrId2-NL',
+                    challengeId: 'challengeFrId2',
+                    locale: 'nl',
+                    status: LocalizedChallenge.STATUSES.PLAY,
+                  }),
+                ],
               }),
             ];
             const englishChallenges = [
@@ -430,6 +443,68 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
                 id: 'challengeFrId3',
                 locales: ['fr'],
                 status: Challenge.STATUSES.PERIME,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId4',
+                locales: ['fr'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrEnId5',
+                locales: ['fr', 'en'],
+                status: Challenge.STATUSES.VALIDE,
+                localizedChallenges: [
+                  domainBuilder.buildLocalizedChallenge({
+                    id: 'challengeFrEnId5',
+                    challengeId: 'challengeFrEnId5',
+                    locale: 'fr',
+                  }),
+                  domainBuilder.buildLocalizedChallenge({
+                    id: 'challengeFrEnId5-EN',
+                    challengeId: 'challengeFrEnId5',
+                    locale: 'en',
+                    status: LocalizedChallenge.STATUSES.PLAY,
+                  }),
+                ],
+              }),
+            ];
+            const englishChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeEnId1',
+                locales: ['en'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+            ];
+
+            // then
+            expect(assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toBeUndefined();
+          });
+        });
+
+        describe('when there already are english localized but enough validated french challenges without english localized', () => {
+          it('should not throw', () => {
+            // given
+            const frenchChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId1',
+                locales: ['fr'],
+                status: Challenge.STATUSES.VALIDE,
+
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId2',
+                locales: ['fr'],
+                status: Challenge.STATUSES.PROPOSE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId3',
+                locales: ['fr'],
+                status: Challenge.STATUSES.PERIME,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrEnId4',
+                locales: ['fr', 'en'],
+                status: Challenge.STATUSES.VALIDE,
               }),
             ];
             const englishChallenges = [
@@ -485,7 +560,67 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           ];
 
           // then
-          expect(() => assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges)).toThrowError('Not enough active french challenges for each english challenge');
+          expect(
+            () => assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges),
+          ).toThrowError('Not enough active french challenges (1) for each english challenge (2) in skill recSkillId');
+        });
+
+        describe('when there already are english localized but not enough validated french challenges without english localized', () => {
+          it('should throw', () => {
+            // given
+            const frenchChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId1',
+                locales: ['fr'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId2',
+                locales: ['fr'],
+                status: Challenge.STATUSES.PROPOSE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrId3',
+                locales: ['fr'],
+                status: Challenge.STATUSES.PERIME,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeFrEnId4',
+                locales: ['fr', 'en'],
+                status: Challenge.STATUSES.VALIDE,
+                localizedChallenges: [
+                  domainBuilder.buildLocalizedChallenge({
+                    id: 'challengeFrEnId4',
+                    challengeId: 'challengeFrEnId4',
+                    locale: 'fr',
+                  }),
+                  domainBuilder.buildLocalizedChallenge({
+                    id: 'challengeFrEnId4-EN',
+                    challengeId: 'challengeFrEnId4',
+                    locale: 'en',
+                    status: LocalizedChallenge.STATUSES.PLAY,
+                  }),
+                ],
+              }),
+            ];
+            const englishChallenges = [
+              domainBuilder.buildChallenge({
+                id: 'challengeEnId1',
+                locales: ['en'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+              domainBuilder.buildChallenge({
+                id: 'challengeEnId2',
+                locales: ['en'],
+                status: Challenge.STATUSES.VALIDE,
+              }),
+            ];
+
+            // then
+            expect(
+              () => assertEachLegacyEnglishChallengeHasActiveFrenchChallenge(englishChallenges, frenchChallenges),
+            ).toThrowError('Not enough active french challenges without english localized (1) for each english challenge (2) in skill recSkillId');
+          });
         });
       });
     });

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { databaseBuilder } from '../test-helper.js';
 import {
   BindEnglishChallengesToFrenchPrimaryEquivalent,
+  listActiveFrenchChallengesBySkillId,
   listActiveSkillsByFrameworkName,
   listLegacyEnglishChallengesBySkillId,
 } from '../../scripts/bind-english-challenges-to-french-primary-equivalent.js';
@@ -239,6 +240,139 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
         expect(legacyChallenges.some((legacyChallenge) => legacyChallenge.id === 'validatedChallengeId1')).toBe(true);
         expect(legacyChallenges.every((challenge) => challenge.isPrimary)).toBe(true);
         expect(legacyChallenges.every((challenge) => challenge.locales.includes('en') && challenge.locales.length === 1)).toBe(true);
+      });
+    });
+
+    describe('listActiveFrenchChallengesBySkillId', () => {
+      it('should retrieve all active french challenges for a given skill id', async () => {
+        const { skill, challenge } = databaseBuilder.factory.buildChallengeInGroup({
+          framework: { name: 'Pix' },
+          skill: {
+            status: Skill.STATUSES.ACTIF,
+            name: '@activeSkill1',
+          },
+          challenge: {
+            genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+            status: Challenge.STATUSES.VALIDE,
+          },
+        });
+
+        const validatedEnglishChallenge1 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedChallengeId1',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['en'],
+          isQualityOk: true,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedEnglishChallenge1.id,
+          challengeId: validatedEnglishChallenge1.id,
+          locale: 'en',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedChallengeId1.instructions',
+          locale: 'en',
+          value: 'EN instructions',
+        });
+
+        const validatedFrenchChallenge2 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedChallengeId2',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['fr'],
+          isQualityOk: false,
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedFrenchChallenge2.id,
+          challengeId: validatedFrenchChallenge2.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedChallengeId2.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+        const proposedFrenchChallenge3 = databaseBuilder.factory.buildChallenge({
+          id: 'proposedChallengeId3',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.PROPOSE,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: proposedFrenchChallenge3.id,
+          challengeId: proposedFrenchChallenge3.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.proposedChallengeId3.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+        const archivedFrenchChallenge4 = databaseBuilder.factory.buildChallenge({
+          id: 'archivedChallengeId4',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.ARCHIVE,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: archivedFrenchChallenge4.id,
+          challengeId: archivedFrenchChallenge4.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.archivedChallengeId4.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+        const proposedChallenge5 = databaseBuilder.factory.buildChallenge({
+          id: 'proposedChallengeId5',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.PROPOSE,
+          locales: ['fr'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: proposedChallenge5.id,
+          challengeId: proposedChallenge5.id,
+          locale: 'fr',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.proposedChallengeId5.instructions',
+          locale: 'fr',
+          value: 'FR instructions',
+        });
+        const validatedNLChallenge6 = databaseBuilder.factory.buildChallenge({
+          id: 'validatedChallengeId6',
+          skillId: skill.id,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          status: Challenge.STATUSES.VALIDE,
+          locales: ['nl'],
+        });
+        databaseBuilder.factory.buildLocalizedChallenge({
+          id: validatedNLChallenge6.id,
+          challengeId: validatedNLChallenge6.id,
+          locale: 'nl',
+        });
+        databaseBuilder.factory.buildTranslation({
+          key: 'challenge.validatedChallengeId6.instructions',
+          locale: 'nl',
+          value: 'NL instructions',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const activeFrenchChallenges = await listActiveFrenchChallengesBySkillId(skill.id);
+
+        // then
+        expect(activeFrenchChallenges).toHaveLength(2);
+        expect(activeFrenchChallenges.map((challenge) => challenge.id)).toStrictEqual([challenge.id, 'validatedChallengeId2']);
+        expect(activeFrenchChallenges.every((challenge) => challenge.status === Challenge.STATUSES.VALIDE)).toBe(true);
+        expect(activeFrenchChallenges.every((challenge) => challenge.locales.includes('fr') && challenge.locales.length === 1)).toBe(true);
       });
     });
   });

--- a/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
+++ b/api/tests/scripts/bind-english-challenges-to-french-primary-equivalent_test.js
@@ -358,7 +358,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
     it('binds english challenges to french primary equivalent', async () => {
       // given
       const options = { dryRun: false, frameworkName: 'Pix' };
-      const { skill, challenge, localizedChallenge } = databaseBuilder.factory.buildChallengeInGroup({
+      const { skill, challenge, localizedChallenge, tube } = databaseBuilder.factory.buildChallengeInGroup({
         framework: { name: 'Pix' },
         tube: { name: 'activePixTube' },
         skill: {
@@ -416,6 +416,7 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
       await databaseBuilder.commit();
 
       const errorLoggerSpy = vi.spyOn(logger, 'error');
+      const infoLoggerSpy = vi.spyOn(logger, 'info');
 
       // when
       await script.handle({
@@ -433,7 +434,6 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
       const legacyEnglishChallenge = await challengeRepository.get(validatedEnglishChallenge1.id);
 
       // then
-      expect(errorLoggerSpy).not.toHaveBeenCalled();
       expect(localizedChallenges.length).toEqual(2);
       expect(englishLocalized).toStrictEqual(domainBuilder.buildLocalizedChallenge({
         id: `${validatedEnglishChallenge1.id}-EN`,
@@ -473,8 +473,13 @@ describe('Script | BindEnglishChallengesToFrenchPrimaryEquivalent', () => {
           value: 'EN instructions',
         }),
       ]);
-
       expect(legacyEnglishChallenge.status).toStrictEqual(Challenge.STATUSES.PERIME);
+      expect(errorLoggerSpy).not.toHaveBeenCalled();
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(1, { dryRun: false }, 'Script bindEnglishChallengesToFrenchPrimaryEquivalent has started');
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(2, `Now processing ${tube.name}${skill.level} - ${skill.id}`);
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(3, { skillId: skill.id, clonedEnglishLocalizedId: englishLocalized.id, frenchChallengeId: frenchChallenge.id });
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(4, { skillId: skill.id, obsoletedEnglishChallengesCount: 1, clonedTranslationsCount: 1, clonedAttachmentsCount: 1 });
+      expect(infoLoggerSpy).toHaveBeenNthCalledWith(5, { processedEnglishChallengesCount: 1, skippedSkillsCount: 0 }, 'DONE');
     });
 
     describe('when framework name does not exist', () => {

--- a/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
@@ -10,7 +10,7 @@ import { buildChallenge } from './build-challenge.js';
 import { buildLocalizedChallenge } from './build-localized-challenge.js';
 import { buildTranslation } from './build-translation.js';
 
-export function buildChallengeInGroup({ challenge, localizedChallenge, challengeTranslations, skill, framework }) {
+export function buildChallengeInGroup({ challenge, localizedChallenge, challengeTranslations, skill, framework, tube }) {
   const randomId = generateRandomId();
 
   const chalengeDTO = buildChallengeDatasourceObject({
@@ -66,7 +66,7 @@ export function buildChallengeInGroup({ challenge, localizedChallenge, challenge
     area: buildArea({ id: `area${randomId}`, code: '1', frameworkId: framework?.id ?? `framework${randomId}` }),
     competence: buildCompetence({ id: chalengeDTO.competenceId, index: '1.1', areaId: `area${randomId}` }),
     thematic: buildThematic({ id: `thematic${randomId}`, competenceId: chalengeDTO.competenceId }),
-    tube: buildTube({ id: skillDTO.tubeId, name: '@tube', thematicId: `thematic${randomId}` }),
+    tube: buildTube({ id: skillDTO.tubeId, name: '@tube', thematicId: `thematic${randomId}`, ...tube }),
     skill: buildSkill({ ...skillDTO, tutorialIds: [], learningMoreTutorialIds: [] }),
     challenge: buildChallenge(chalengeDTO),
     localizedChallenge: buildLocalizedChallenge(localizedChallengeDTO),

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -1017,4 +1017,18 @@ describe('Unit | Domain | Challenge', () => {
       ]);
     });
   });
+
+  describe('obsolete', () => {
+    it('obsoletes a challenge', () => {
+      // given
+      const challenge = domainBuilder.buildChallenge({ status: Challenge.STATUSES.PROPOSE });
+
+      // when
+      challenge.obsolete();
+
+      // then
+      expect(challenge.status).toStrictEqual(Challenge.STATUSES.PERIME);
+      expect(challenge.madeObsoleteAt).toBeInstanceOf(Date);
+    });
+  });
 });

--- a/api/tests/unit/domain/models/LocalizedChallenge_test.js
+++ b/api/tests/unit/domain/models/LocalizedChallenge_test.js
@@ -325,6 +325,49 @@ describe('Unit | Domain | LocalizedChallenge', () => {
         }),
       ]);
     });
+
+    describe('when validatedAt is filled', function() {
+      it('should return a localized challenge with the given validatedAt', function() {
+        // given
+        const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+          id: 'oldLocId',
+          challengeId: 'oldLocId',
+          embedUrl: 'https://example.com/embed.html',
+          fileIds: [],
+          locale: 'fr',
+          status: LocalizedChallenge.STATUSES.PAUSE,
+          geography: 'FR',
+          urlsToConsult: ['http://url.com'],
+          requireGafamWebsiteAccess: true,
+          isIncompatibleIpadCertif: true,
+          deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+          isAwarenessChallenge: true,
+          toRephrase: true,
+          hasEmbedInternalValidation: true,
+          noValidationNeeded: true,
+          validatedAt: new Date('2020-01-01'),
+        });
+
+        // when
+        const { clonedLocalizedChallenge } = localizedChallenge.clone({
+          id: 'newLocId',
+          challengeId: 'newLocId',
+          status: LocalizedChallenge.STATUSES.PLAY,
+          attachments: [],
+          validatedAt: new Date('2023-03-03'),
+        });
+
+        // then
+        expect(clonedLocalizedChallenge).toStrictEqual(domainBuilder.buildLocalizedChallenge({
+          ...localizedChallenge,
+          id: 'newLocId',
+          challengeId: 'newLocId',
+          status: LocalizedChallenge.STATUSES.PLAY,
+          attachments: [],
+          validatedAt: new Date('2023-03-03'),
+        }));
+      });
+    });
   });
 
   describe('update', function() {


### PR DESCRIPTION
## 🥀 Problème
Avant l'internationalisation, certaines épreuves anglaises ont été créées sous forme de déclinaisons issues d'un prototype français. Il faut maintenant périmer ces déclis anglaises, en faire des localized anglais rattachés à leur équivalent français.

## 🏹 Proposition
Créer un script qui reprend ces données.

1/ On liste les acquis actifs par nom de référentiel
2/ Pour chaque acquis, on liste les challenges anglais legacy validés ou proposés
3/ Pour chaque acquis, on liste les challenges français validés.
4/ On vérifie qu'il y a suffisamment de challenges français validés pour le nbre de challenges anglais.
5/ On veut dupliquer les localized anglais et changer le challengeId pour que celui-ci corresponde au challenge ayant un primary français et `id = ${id}-EN`
6/ On clone le legacy localized et ses attachments en y mettant les bons ids
7/ si challenge anglais === proposé ? localized.status = 'pause', si challenge anglais === validé ? localized.status = 'play'
8/ On clone les clés de trads
9/ On périme les challenges anglais legacy
10/ Enfin, on persiste tout.

## 💌 Remarques
RAS

## ❤️‍🔥 Pour tester
Tester le script en dry run  après avoir créé de la dette (des déclis anglaises et des déclis françaises au même endroit) avec la commande suivante : `node scripts/bind-english-challenges-to-french-primary-equivalent --frameworkName=Pix`