### PR TITLE
[FEATURE] Amélioration du job qui nettoie la table des releases (PIX-21869)

### DIFF
--- a/api/lib/infrastructure/scheduled-jobs/create-queue.js
+++ b/api/lib/infrastructure/scheduled-jobs/create-queue.js
@@ -1,54 +1,48 @@
-import { logger } from '../logger.js';
+import { child } from '../logger.js';
 import Queue from 'bull';
 import * as config from '../../config.js';
 
 export const queues = [];
 
-const queueError = (queueName, err, ...messages) => {
-  logger.error(err, queueName, ...messages);
-};
-const queueMessage = (queueName, message) => {
-  logger.info(queueName + ': ' + message);
-};
-
 export function createQueue(queueName) {
   const queue = new Queue(queueName, config.scheduledJobs.redisUrl);
-  queue.on('error', (err, additionalError) => queueError(queueName, err, 'Queue error', additionalError));
-  queue.on('failed', (job, err) => queueError(queueName, err, `Job ${job.id} failed`));
-  queue.on('waiting', (jobId) => queueMessage(queueName, `Job ${jobId} has been scheduled`));
-  queue.on('active', (job) => queueMessage(queueName, `Job ${job.id} has started`));
-  queue.on('stalled', (job) => queueMessage(queueName, `Job ${job.id} has stalled`));
-  queue.on('completed', (job) => queueMessage(queueName, `Job ${job.id} has finished`));
-  queue.on('paused', () => queueMessage(queueName, 'The queue has been paused'));
-  queue.on('resumed', () => queueMessage(queueName, 'The queue has been resumed'));
-  queue.on('cleaned', () => queueMessage(queueName, 'The queue has been cleaned'));
+  const logger = child(`job:${queueName}`, { event: queueName });
+  queue.on('error', (err, additionalError) => logger.error({ err, additionalError }, 'Error in job queue'));
+  queue.on('failed', (job, err) => logger.error({ jobId: job.id, err }, 'Job failed'));
+  queue.on('waiting', (jobId) => logger.info({ jobId }, 'Job has been scheduled'));
+  queue.on('active', (job) => logger.info({ jobId: job.id }, 'Job has started'));
+  queue.on('stalled', (job) => logger.info({ jobId: job.id }, 'Job has stalled'));
+  queue.on('completed', (job) => logger.info({ jobId: job.id }, 'Job has finished'));
+  queue.on('paused', () => logger.info('The queue has been paused'));
+  queue.on('resumed', () => logger.info('The queue has been resumed'));
+  queue.on('cleaned', () => logger.info('The queue has been cleaned'));
   queue.on('drained', async function() {
-    queueMessage(queueName, 'The queue has been drained');
-    await cleanQueue(queues.find((queue) => queue.name === queueName));
+    logger.info('The queue has been drained');
+    await cleanQueue(queues.find((queue) => queue.name === queueName), logger);
   });
-  queue.on('removed', () => queueMessage(queueName, 'A job has been removed'));
+  queue.on('removed', () => logger.info('A job has been removed'));
   queues.push(queue);
   return queue;
 }
 
-async function cleanQueue(queue) {
+async function cleanQueue(queue, logger) {
   if (!queue.childPool) {
-    logger.info(`No childPool to clean up for queue '${queue.name}'`);
+    logger.info('No childPool to clean up');
     return;
   }
 
   const freeProcesses = queue.childPool?.getAllFree();
   if (!freeProcesses || freeProcesses.length === 0) {
-    logger.info(`No free process to clean up in childPool for queue '${queue.name}'`);
+    logger.info('No free process to clean up in childPool');
     return;
   }
 
-  logger.info(`About to kill ${freeProcesses.length} free Bull processes to free memory in queue '${queue.name}'...`);
+  logger.info({ count: freeProcesses.length }, 'About to kill free Bull processes to free memory');
   for (const freeProcess of freeProcesses) {
     try {
       await queue.childPool.kill(freeProcess, 'SIGTERM');
-    } catch (error) {
-      logger.error(`Error while killing free bull process in queue '${queue.name}'`, error);
+    } catch (err) {
+      logger.error({ err }, 'Error while killing free bull process');
     }
   }
 }

--- a/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
@@ -8,7 +8,7 @@ import * as learningContentNotification from '../../domain/services/learning-con
 import { child } from '../logger.js';
 import { releaseRepository } from '../repositories/index.js';
 
-const logger = child('job:create-release', { event: 'create-release' });
+const logger = child('job:create-release-queue', { event: 'create-release-queue' });
 
 export default async function releaseJobProcessor(job) {
   try {

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
@@ -2,7 +2,7 @@ import './job-process.js';
 import { child } from '../logger.js';
 import { knex } from '../../../db/knex-database-connection.js';
 
-const logger = child('job:release-table-cleaning-and-retention', { event: 'release-table-cleaning-and-retention' });
+const logger = child('job:release-table-cleaning-and-retention-queue', { event: 'release-table-cleaning-and-retention-queue' });
 const MONTHS_FULL_DATA = 3;
 
 export default async function releasesTableCleaningAndRetention(job) {
@@ -37,7 +37,7 @@ export default async function releasesTableCleaningAndRetention(job) {
     for (const chunk of chunks(releaseIdsToDelete, chunkSize)) {
       logger.info({ ids: chunk }, 'will delete releases');
       const deletedReleasesCount = await knex.delete().from('releases').whereIn('id', chunk);
-      logger.info(`${deletedReleasesCount} rows deleted`);
+      logger.info({ count: deletedReleasesCount }, 'deleted rows');
       totalDeletedCount += deletedReleasesCount;
     }
   } catch (err) {
@@ -45,8 +45,11 @@ export default async function releasesTableCleaningAndRetention(job) {
     throw err;
   }
 
-  if (totalDeletedCount === 0) return;
-  logger.info(`${totalDeletedCount} rows deleted in total`);
+  if (totalDeletedCount === 0) {
+    logger.info('no deleted rows');
+  } else {
+    logger.info({ count: totalDeletedCount }, 'total deleted rows');
+  }
   await knex.raw('VACUUM ANALYZE releases');
 }
 

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
@@ -5,44 +5,53 @@ import { knex } from '../../../db/knex-database-connection.js';
 const logger = child('job:release-table-cleaning-and-retention', { event: 'release-table-cleaning-and-retention' });
 const MONTHS_FULL_DATA = 3;
 
-export default async function releasesTableCleaningAndRetention() {
-  const deletedReleasesCount = await knex.transaction(async (transaction) => {
-    try {
-      const now = new Date();
-      const dailyRetentionDate = new Date(now.getFullYear(), now.getMonth() - MONTHS_FULL_DATA, now.getDate());
+export default async function releasesTableCleaningAndRetention(job) {
+  const { chunkSize = 10 } = job.data;
+  let totalDeletedCount = 0;
 
-      const releaseDtos = await transaction
-        .select(
-          'id',
-          transaction.raw('to_char(??, ?) as ??', [
-            'createdAt',
-            'YYYYMM',
-            'yearMonth',
-          ]),
-        )
-        .from('releases')
-        .where('createdAt', '<', dailyRetentionDate)
-        .orderBy('createdAt');
+  try {
+    const now = new Date();
+    const dailyRetentionDate = new Date(now.getFullYear(), now.getMonth() - MONTHS_FULL_DATA, now.getDate());
 
-      const groupedByMonth = Object.groupBy(releaseDtos, (release) => release.yearMonth);
+    const releaseDtos = await knex
+      .select(
+        'id',
+        knex.raw('to_char(??, ?) as ??', [
+          'createdAt',
+          'YYYYMM',
+          'yearMonth',
+        ]),
+      )
+      .from('releases')
+      .where('createdAt', '<', dailyRetentionDate)
+      .orderBy('createdAt');
 
-      const releaseIdsToDelete = Object.values(groupedByMonth).flatMap(
-        (releasesInSameMonth) => releasesInSameMonth
-          .slice(1)
-          .map((release) => release.id),
-      );
+    const groupedByMonth = Object.groupBy(releaseDtos, (release) => release.yearMonth);
 
-      const deletedReleasesCount = await transaction.delete().from('releases').whereIn('id', releaseIdsToDelete);
+    const releaseIdsToDelete = Object.values(groupedByMonth).flatMap(
+      (releasesInSameMonth) => releasesInSameMonth
+        .slice(1)
+        .map((release) => release.id),
+    );
+
+    for (const chunk of chunks(releaseIdsToDelete, chunkSize)) {
+      logger.info({ ids: chunk }, 'will delete releases');
+      const deletedReleasesCount = await knex.delete().from('releases').whereIn('id', chunk);
       logger.info(`${deletedReleasesCount} rows deleted`);
-
-      return deletedReleasesCount;
-    } catch (err) {
-      logger.error(err);
-      throw err;
+      totalDeletedCount += deletedReleasesCount;
     }
-  });
+  } catch (err) {
+    logger.error(err);
+    throw err;
+  }
 
-  if (deletedReleasesCount === 0) return;
-
+  if (totalDeletedCount === 0) return;
+  logger.info(`${totalDeletedCount} rows deleted in total`);
   await knex.raw('VACUUM ANALYZE releases');
+}
+
+function* chunks(array, chunkSize) {
+  for (let i = 0; i < array.length; i += chunkSize) {
+    yield array.slice(i, i + chunkSize);
+  }
 }

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor.js
@@ -5,7 +5,7 @@ import { knex } from '../../../db/knex-database-connection.js';
 const logger = child('job:release-table-cleaning-and-retention', { event: 'release-table-cleaning-and-retention' });
 const MONTHS_FULL_DATA = 3;
 
-export default async function releasesTableCleaningAndRetention(dependencies = { logger: logger }) {
+export default async function releasesTableCleaningAndRetention() {
   const deletedReleasesCount = await knex.transaction(async (transaction) => {
     try {
       const now = new Date();
@@ -33,11 +33,11 @@ export default async function releasesTableCleaningAndRetention(dependencies = {
       );
 
       const deletedReleasesCount = await transaction.delete().from('releases').whereIn('id', releaseIdsToDelete);
-      dependencies.logger.info(`${deletedReleasesCount} rows deleted`);
+      logger.info(`${deletedReleasesCount} rows deleted`);
 
       return deletedReleasesCount;
     } catch (err) {
-      dependencies.logger.error(err);
+      logger.error(err);
       throw err;
     }
   });

--- a/api/tests/integration/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor_test.js
+++ b/api/tests/integration/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job-processor_test.js
@@ -3,12 +3,7 @@ import releasesTableCleaningAndRetention from '../../../../lib/infrastructure/sc
 import { databaseBuilder, knex } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | scheduled-jobs | releases-table-cleaning-and-retention-job', function() {
-  let logger;
   beforeEach(function() {
-    logger = {
-      info: vi.fn(),
-      error: vi.fn(),
-    };
     vi.useFakeTimers({ now: new Date('2021-02-15T03:04:00Z') });
   });
 
@@ -36,7 +31,7 @@ describe('Integration | Infrastructure | scheduled-jobs | releases-table-cleanin
     await databaseBuilder.commit();
 
     // when
-    await releasesTableCleaningAndRetention({ logger });
+    await releasesTableCleaningAndRetention({ data: { chunkSize: 2 } });
 
     // then
     const idsInDB = await knex('releases').pluck('id').orderBy('id');
@@ -49,7 +44,5 @@ describe('Integration | Infrastructure | scheduled-jobs | releases-table-cleanin
       7,
       13,
     ]);
-    expect(logger.info).toHaveBeenCalledWith('6 rows deleted');
-    expect(logger.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 🥀 Problème
Le job qui supprimait des releases tous les 5 du mois ne fonctionnait pas du tout.

## 🏹 Proposition
Améliorer le code permettant cette suppression. En profiter pour faire le job par _chunks_ (10 par 10) afin d'alléger PG pour ces requêtes.

## 💌 Remarques
On en profite pour améliorer les logger.

## ❤️‍🔥 Pour tester
Tests au vert.
Vérifier qu'on a supprimé pour ne sauvegarder plus qu'une release par mois. (la plus récente)