### PR TITLE
[FEATURE] Permettre de trier les entités dans le nouveau back-office (PIX-21072)

### DIFF
--- a/api/lib/application/admin/admin-controller.js
+++ b/api/lib/application/admin/admin-controller.js
@@ -55,7 +55,7 @@ export async function getEntities(request) {
   }
   const fields = entitySchema.fields.map((field) => field.key);
 
-  const { entities, meta } = await adminEntityRepository.listByEntityName(entityName, fields, query.page);
+  const { entities, meta } = await adminEntityRepository.listByEntityName(entityName, fields, query.page, entitySchema.defaultSort);
 
   return adminEntitySerializer.serialize(entityName, entities, meta);
 }

--- a/api/lib/application/admin/admin-controller.js
+++ b/api/lib/application/admin/admin-controller.js
@@ -53,11 +53,16 @@ export async function getEntities(request) {
   }
 
   const defaultSort = [entitySchema.defaultSort.field, entitySchema.defaultSort.direction];
-  const { page, sort: [querySort] } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [defaultSort] });
+  const { page, sort: [[sortField, sortDirection]] } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [defaultSort] });
+
+  const sortableFields = entitySchema.fields.filter((field) => field.sortable !== false).map((field) => field.key);
+  if (!sortableFields.includes(sortField)) {
+    return Boom.badRequest(`Column ${sortField} is not sortable for entity ${entityName}`);
+  }
 
   const sort = {
-    field: querySort[0],
-    direction: querySort[1],
+    field: sortField,
+    direction: sortDirection,
   };
   const fields = entitySchema.fields.map((field) => field.key);
   const { entities, meta } = await adminEntityRepository.listByEntityName(entityName, fields, page, sort);

--- a/api/lib/application/admin/admin-controller.js
+++ b/api/lib/application/admin/admin-controller.js
@@ -38,7 +38,7 @@ export async function save(request, h) {
   try {
     const newEntity = await adminEntityRepository.save(entityName, entityToSave);
 
-    return h.response(adminEntitySerializer.serialize({ ...newEntity, entityName })).created();
+    return h.response(adminEntitySerializer.serialize(entityName, newEntity)).created();
   } catch (err) {
     logger.error({ err, data: { entityName, entityToSave, entityPayload } });
     return Boom.badRequest('Entity was unable to be saved');
@@ -57,5 +57,5 @@ export async function getEntities(request) {
 
   const { entities, meta } = await adminEntityRepository.listByEntityName(entityName, fields, query.page);
 
-  return adminEntitySerializer.serialize(entities, meta);
+  return adminEntitySerializer.serialize(entityName, entities, meta);
 }

--- a/api/lib/application/admin/admin-controller.js
+++ b/api/lib/application/admin/admin-controller.js
@@ -47,15 +47,20 @@ export async function save(request, h) {
 
 export async function getEntities(request) {
   const { entityName } = request.params;
-  const query = extractParameters(request.query, { page: { size: 10, number: 1 } });
-
   const entitySchema = adminSchemaRepository.getByEntityName(entityName);
   if (!entitySchema) {
     return Boom.notFound(`Entity with name '${entityName}' not found in admin schemas list`);
   }
-  const fields = entitySchema.fields.map((field) => field.key);
 
-  const { entities, meta } = await adminEntityRepository.listByEntityName(entityName, fields, query.page, entitySchema.defaultSort);
+  const defaultSort = [entitySchema.defaultSort.field, entitySchema.defaultSort.direction];
+  const { page, sort: [querySort] } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [defaultSort] });
+
+  const sort = {
+    field: querySort[0],
+    direction: querySort[1],
+  };
+  const fields = entitySchema.fields.map((field) => field.key);
+  const { entities, meta } = await adminEntityRepository.listByEntityName(entityName, fields, page, sort);
 
   return adminEntitySerializer.serialize(entityName, entities, meta);
 }

--- a/api/lib/application/admin/index.js
+++ b/api/lib/application/admin/index.js
@@ -26,6 +26,7 @@ export async function register(server) {
             entityName: Joi.string().optional().description('Redundant but still sent by Ember Data'),
             'page[size]': Joi.number().min(1).max(100).optional(),
             'page[number]': Joi.number().min(1).max(999_999).optional(),
+            sort: Joi.string().optional(),
           }).unknown(false),
         },
       },

--- a/api/lib/infrastructure/repositories/admin-entity-repository.js
+++ b/api/lib/infrastructure/repositories/admin-entity-repository.js
@@ -11,9 +11,7 @@ import { fetchPage } from '../utils/knex-utils.js';
  */
 export async function listByEntityName(entityName, fields, pagination) {
   const getEntitiesQuery = knex(entityName).select(fields);
-  const { results, pagination: meta } = await fetchPage(getEntitiesQuery, pagination);
-
-  const entities = results.map(toDomain(entityName));
+  const { results: entities, pagination: meta } = await fetchPage(getEntitiesQuery, pagination);
 
   return { entities, meta };
 }
@@ -21,11 +19,4 @@ export async function listByEntityName(entityName, fields, pagination) {
 export async function save(entityName, entityToSave) {
   const [record] = await knex(entityName).insert(entityToSave, ['*']);
   return record;
-}
-
-function toDomain(entityName) {
-  return (entity) => ({
-    entityName,
-    ...entity,
-  });
 }

--- a/api/lib/infrastructure/repositories/admin-entity-repository.js
+++ b/api/lib/infrastructure/repositories/admin-entity-repository.js
@@ -7,10 +7,13 @@ import { fetchPage } from '../utils/knex-utils.js';
  * @param {object} pagination
  * @param {number} pagination.size
  * @param {number} pagination.number
+ * @param {object} sort
+ * @param {string} sort.field
+ * @param {'desc' | 'asc'} sort.direction
  * @returns {Promise<{ entities: object[], meta: object }>}
  */
-export async function listByEntityName(entityName, fields, pagination) {
-  const getEntitiesQuery = knex(entityName).select(fields);
+export async function listByEntityName(entityName, fields, pagination, sort) {
+  const getEntitiesQuery = knex(entityName).select(fields).orderBy(sort.field, sort.direction);
   const { results: entities, pagination: meta } = await fetchPage(getEntitiesQuery, pagination);
 
   return { entities, meta };

--- a/api/lib/infrastructure/repositories/admin-schemas/$schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/$schema.json
@@ -56,6 +56,10 @@
           "readonly": {
             "type": "boolean"
           },
+          "sortable": {
+            "type": "boolean",
+            "default": true
+          },
           "options": {
             "type": "array",
             "items": {

--- a/api/lib/infrastructure/repositories/admin-schemas/$schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/$schema.json
@@ -24,8 +24,20 @@
     "creatable": {
       "type": "boolean"
     },
+    "defaultSort": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "direction": {
+          "enum": ["asc", "desc"]
+        }
+      }
+    },
     "fields": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
@@ -67,5 +79,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["id", "label", "entityName", "editable", "deletable", "creatable", "fields"]
+  "required": ["id", "label", "entityName", "editable", "deletable", "creatable", "fields", "defaultSort"]
 }

--- a/api/lib/infrastructure/repositories/admin-schemas/localized-challenge-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/localized-challenge-schema.json
@@ -6,6 +6,10 @@
   "editable": false,
   "deletable": false,
   "creatable": false,
+  "defaultSort": {
+    "field": "id",
+    "direction": "asc"
+  },
   "fields": [
     {
       "key": "id",

--- a/api/lib/infrastructure/repositories/admin-schemas/localized-challenge-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/localized-challenge-schema.json
@@ -24,7 +24,8 @@
     {
       "key": "embedUrl",
       "label": "URL de l'embed",
-      "type": "string"
+      "type": "string",
+      "sortable": false
     },
     {
       "key": "status",

--- a/api/lib/infrastructure/repositories/admin-schemas/localized-challenge-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/localized-challenge-schema.json
@@ -33,11 +33,11 @@
       "type": "enum",
       "options": [
         {
-          "label": "Validé",
+          "label": "En prod",
           "value": "validé"
         },
         {
-          "label": "Proposé",
+          "label": "En pause",
           "value": "proposé"
         },
         {

--- a/api/lib/infrastructure/repositories/admin-schemas/release-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/release-schema.json
@@ -6,6 +6,10 @@
   "editable": false,
   "deletable": false,
   "creatable": false,
+  "defaultSort": {
+    "field": "id",
+    "direction": "desc"
+  },
   "fields": [
     {
       "key": "id",

--- a/api/lib/infrastructure/repositories/admin-schemas/translation-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/translation-schema.json
@@ -6,6 +6,10 @@
   "editable": false,
   "deletable": false,
   "creatable": true,
+  "defaultSort": {
+    "field": "key",
+    "direction": "asc"
+  },
   "fields": [
     {
       "key": "key",

--- a/api/lib/infrastructure/repositories/admin-schemas/translation-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/translation-schema.json
@@ -25,7 +25,8 @@
     {
       "key": "value",
       "label": "Contenu",
-      "type": "string"
+      "type": "string",
+      "sortable": false
     },
     {
       "key": "model",

--- a/api/lib/infrastructure/repositories/admin-schemas/user-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/user-schema.json
@@ -32,7 +32,8 @@
       "key": "apiKey",
       "label": "Clé API",
       "type": "secret",
-      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "sortable": false
     },
     {
       "key": "access",

--- a/api/lib/infrastructure/repositories/admin-schemas/user-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/user-schema.json
@@ -6,6 +6,10 @@
   "editable": true,
   "deletable": true,
   "creatable": true,
+  "defaultSort": {
+    "field": "id",
+    "direction": "asc"
+  },
   "fields": [
     {
       "key": "id",

--- a/api/lib/infrastructure/serializers/jsonapi/admin-entity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/admin-entity-serializer.js
@@ -2,11 +2,11 @@ import Jsonapi from 'jsonapi-serializer';
 
 const { Deserializer, Serializer } = Jsonapi;
 
-export function serialize(entities, meta) {
+export function serialize(entityName, entities, meta) {
   const serializer = new Serializer('admin-entity', {
     attributes: ['properties'],
     meta,
-    transform({ id, type, entityName, ...properties }) {
+    transform({ id, type, ...properties }) {
       const entityId = id ?? ID_GENERATORS[entityName]?.(properties);
 
       return {

--- a/api/tests/acceptance/application/admin/admin_test.js
+++ b/api/tests/acceptance/application/admin/admin_test.js
@@ -64,6 +64,7 @@ describe('Acceptance | Controller | admin', () => {
                 label: 'Clé API',
                 type: 'secret',
                 pattern: expect.any(String),
+                sortable: false,
               },
               {
                 key: 'access',
@@ -284,6 +285,25 @@ describe('Acceptance | Controller | admin', () => {
                 },
               },
             ],
+          });
+        });
+
+        describe('when given field is not sortable', () => {
+          it('should return a 400', async () => {
+            // given
+            const server = await createServer();
+            const request = {
+              method: 'GET',
+              url: '/api/admin/entities/users?sort=apiKey',
+              headers: generateAuthorizationHeader(user),
+            };
+
+            // when
+            const response = await server.inject(request);
+
+            // then
+            expect(response.statusCode).to.equal(400);
+            expect(response.result.message).to.equal('Column apiKey is not sortable for entity users');
           });
         });
       });

--- a/api/tests/acceptance/application/admin/admin_test.js
+++ b/api/tests/acceptance/application/admin/admin_test.js
@@ -165,6 +165,129 @@ describe('Acceptance | Controller | admin', () => {
         });
       });
 
+      describe('when sort query params are passed', () => {
+        beforeEach(async function() {
+          databaseBuilder.factory.buildRelease({
+            id: 1,
+            content: { name: 'release1' },
+            createdAt: new Date('2026-01-01'),
+          });
+          databaseBuilder.factory.buildRelease({
+            id: 2,
+            content: { name: 'release2' },
+            createdAt: new Date('2025-01-01'),
+          });
+          databaseBuilder.factory.buildRelease({
+            id: 3,
+            content: { name: 'release3' },
+            createdAt: new Date('2024-01-01'),
+          });
+          await databaseBuilder.commit();
+        });
+
+        it('should return the list of entities sorted asc', async () => {
+          // given
+          const server = await createServer();
+          const request = {
+            method: 'GET',
+            url: '/api/admin/entities/releases?sort=createdAt',
+            headers: generateAuthorizationHeader(user),
+          };
+
+          // when
+          const response = await server.inject(request);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result).toStrictEqual({
+            meta: { page: 1, pageSize: 10, rowCount: 3, pageCount: 1 },
+            data: [
+              {
+                id: expect.stringContaining('releases:3'),
+                type: 'admin-entities',
+                attributes: {
+                  properties: {
+                    createdAt: expect.any(Date),
+                    id: 3,
+                  },
+                },
+              },
+              {
+                id: expect.stringContaining('releases:2'),
+                type: 'admin-entities',
+                attributes: {
+                  properties: {
+                    createdAt: expect.any(Date),
+                    id: 2,
+                  },
+                },
+              },
+              {
+                id: expect.stringContaining('releases:1'),
+                type: 'admin-entities',
+                attributes: {
+                  properties: {
+                    createdAt: expect.any(Date),
+                    id: 1,
+                  },
+                },
+              },
+            ],
+          });
+        });
+
+        it('should return the list of entities sorted desc', async () => {
+          // given
+          const server = await createServer();
+          const request = {
+            method: 'GET',
+            url: '/api/admin/entities/releases?sort=-createdAt',
+            headers: generateAuthorizationHeader(user),
+          };
+
+          // when
+          const response = await server.inject(request);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+          expect(response.result).toStrictEqual({
+            meta: { page: 1, pageSize: 10, rowCount: 3, pageCount: 1 },
+            data: [
+              {
+                id: expect.stringContaining('releases:1'),
+                type: 'admin-entities',
+                attributes: {
+                  properties: {
+                    createdAt: expect.any(Date),
+                    id: 1,
+                  },
+                },
+              },
+              {
+                id: expect.stringContaining('releases:2'),
+                type: 'admin-entities',
+                attributes: {
+                  properties: {
+                    createdAt: expect.any(Date),
+                    id: 2,
+                  },
+                },
+              },
+              {
+                id: expect.stringContaining('releases:3'),
+                type: 'admin-entities',
+                attributes: {
+                  properties: {
+                    createdAt: expect.any(Date),
+                    id: 3,
+                  },
+                },
+              },
+            ],
+          });
+        });
+      });
+
       describe('when given entityName is not in the admin schemas list', () => {
         it('should return a 404', async () => {
           // given

--- a/api/tests/integration/infrastructure/repositories/admin-entity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/admin-entity-repository_test.js
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { databaseBuilder } from '../../../test-helper.js';
+import { listByEntityName } from '../../../../lib/infrastructure/repositories/admin-entity-repository.js';
+
+describe('Integration | Infrastructure | Repository | admin-entity-repository', () => {
+  describe('#listByEntityName', () => {
+    it('should return the list of all entities by name', async () => {
+      // given
+      const entityName = 'frameworks';
+      const fields = ['id', 'name'];
+      const pagination = {
+        size: 10,
+        number: 1,
+      };
+      const sort = {
+        field: 'id',
+        direction: 'asc',
+      };
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId1', name: 'A' });
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId2', name: 'B' });
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId3', name: 'C' });
+      databaseBuilder.factory.buildWhitelistedUrl({ id: 1, comment: 'Not in results' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { entities, meta } = await listByEntityName(entityName, fields, pagination, sort);
+
+      // then
+      expect(entities).toEqual([
+        {
+          id: 'frameworkId1',
+          name: 'A',
+        },
+        {
+          id: 'frameworkId2',
+          name: 'B',
+        },
+        {
+          id: 'frameworkId3',
+          name: 'C',
+        },
+      ]);
+      expect(meta).toEqual({
+        page: 1,
+        pageCount: 1,
+        pageSize: pagination.size,
+        rowCount: 3,
+      });
+    });
+
+    it('should return only given fields', async () => {
+      // given
+      const entityName = 'frameworks';
+      const fields = ['name'];
+      const pagination = {
+        size: 10,
+        number: 1,
+      };
+      const sort = {
+        field: 'id',
+        direction: 'asc',
+      };
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId1', name: 'A' });
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId2', name: 'B' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { entities, meta } = await listByEntityName(entityName, fields, pagination, sort);
+
+      // then
+      expect(entities).toEqual([{ name: 'A' }, { name: 'B' }]);
+      expect(meta).toEqual({
+        page: 1,
+        pageCount: 1,
+        pageSize: pagination.size,
+        rowCount: 2,
+      });
+    });
+
+    it('should return sorted entities based on sort param', async () => {
+      // given
+      const entityName = 'frameworks';
+      const fields = ['name'];
+      const pagination = {
+        size: 10,
+        number: 1,
+      };
+      const sort = {
+        field: 'name',
+        direction: 'desc',
+      };
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId1', name: 'A' });
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId2', name: 'Z' });
+      databaseBuilder.factory.buildFramework({ id: 'frameworkId3', name: 'N' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { entities, meta } = await listByEntityName(entityName, fields, pagination, sort);
+
+      // then
+      expect(entities).toEqual([
+        { name: 'Z' },
+        { name: 'N' },
+        { name: 'A' },
+      ]);
+      expect(meta).toEqual({
+        page: 1,
+        pageCount: 1,
+        pageSize: pagination.size,
+        rowCount: 3,
+      });
+    });
+
+    describe('when pagination.size is smaller than entities count', () => {
+      it('should return only pagination.size elements', async () => {
+        // given
+        const entityName = 'frameworks';
+        const fields = ['id', 'name'];
+        const pagination = {
+          size: 2,
+          number: 1,
+        };
+        const sort = {
+          field: 'id',
+          direction: 'asc',
+        };
+        databaseBuilder.factory.buildFramework({ id: 'frameworkId1', name: 'A' });
+        databaseBuilder.factory.buildFramework({ id: 'frameworkId2', name: 'B' });
+        databaseBuilder.factory.buildFramework({ id: 'frameworkId3', name: 'C' });
+        databaseBuilder.factory.buildWhitelistedUrl({ id: 1, comment: 'Not in results' });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { entities, meta } = await listByEntityName(entityName, fields, pagination, sort);
+
+        // then
+        expect(entities).toEqual([
+          {
+            id: 'frameworkId1',
+            name: 'A',
+          },
+          {
+            id: 'frameworkId2',
+            name: 'B',
+          },
+        ]);
+        expect(meta).toEqual({
+          page: 1,
+          pageCount: 2,
+          pageSize: pagination.size,
+          rowCount: 3,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/admin-entity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/admin-entity-serializer_test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { deserialize, serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/admin-entity-serializer.js';
+
+describe('Unit | Serializer | JSONAPI | admin-entity-serializer', () => {
+  describe('#serialize', () => {
+    it('serializes an admin entity', () => {
+      // given
+      const tagEntity = {
+        id: 'recTag1',
+        title: 'Internet',
+      };
+      const entityName = 'tags';
+
+      // when
+      const serializedTag = serialize(entityName, tagEntity);
+
+      // then
+      expect(serializedTag).toStrictEqual({
+        data: {
+          type: 'admin-entities',
+          id: 'tags:recTag1',
+          attributes: {
+            properties: {
+              id: 'recTag1',
+              title: 'Internet',
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('#deserialize', () => {
+    it('deserializes an admin entity', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'admin-entities',
+          attributes: { properties: { title: 'Internet' } },
+        },
+      };
+
+      // when
+      const deserializedTag = await deserialize(payload);
+
+      // then
+      expect(deserializedTag).toStrictEqual(
+        { title: 'Internet' },
+      );
+    });
+  });
+});

--- a/pix-editor/app/components/admin/entity-list.gjs
+++ b/pix-editor/app/components/admin/entity-list.gjs
@@ -15,12 +15,17 @@ export default class AdminEntityList extends Component {
 
   get columns() {
     return this.args.schema.fields.map((field) => {
-      const columnType = this.getColumnType(field);
+      const column = {
+        columnType: this.getColumnType(field),
+        field,
+      };
+
+      if (field.sortable === false) return column;
+
       const sortOrder = this.getFieldSortOrder(field);
 
       return {
-        field,
-        type: columnType,
+        ...column,
         onSort: () => this.onFieldSort(field, sortOrder),
         sortOrder,
         ariaLabelDefaultSort: `Trier le tableau dans l'ordre croissant du champ ${field.label}`,

--- a/pix-editor/app/components/admin/entity-list.gjs
+++ b/pix-editor/app/components/admin/entity-list.gjs
@@ -2,12 +2,32 @@ import Component from '@glimmer/component';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import { inject as service } from '@ember/service';
 
 import AdminEntityCell from './entity-cell';
 
 export default class AdminEntityList extends Component {
+  @service router;
+
   get lowercaseEntityName() {
     return this.args.schema.label.toLowerCase();
+  }
+
+  get columns() {
+    return this.args.schema.fields.map((field) => {
+      const columnType = this.getColumnType(field);
+      const sortOrder = this.getFieldSortOrder(field);
+
+      return {
+        field,
+        type: columnType,
+        onSort: () => this.onFieldSort(field, sortOrder),
+        sortOrder,
+        ariaLabelDefaultSort: `Trier le tableau dans l'ordre croissant du champ ${field.label}`,
+        ariaLabelSortAsc: 'Rétablir le tri par défaut du tableau',
+        ariaLabelSortDesc: `Trier le tableau dans l'ordre décroissant du champ ${field.label}`,
+      };
+    });
   }
 
   getColumnType(field) {
@@ -21,6 +41,32 @@ export default class AdminEntityList extends Component {
     }
   }
 
+  getFieldSortOrder(field) {
+    if (!this.args.sort) return;
+
+    let sortedField = this.args.sort;
+    let sortOrder = 'asc';
+    if (sortedField.startsWith('-')) {
+      sortedField = sortedField.slice(1);
+      sortOrder = 'desc';
+    }
+
+    if (sortedField !== field.key) return;
+
+    return sortOrder;
+  }
+
+  onFieldSort(field, currentSortOrder) {
+    let sort = field.key;
+    if (currentSortOrder === 'asc') {
+      sort = `-${sort}`;
+    }
+    if (currentSortOrder === 'desc') {
+      sort = undefined;
+    }
+    this.router.replaceWith({ queryParams: { sort } });
+  }
+
   <template>
     <div class="entity-list__header">
       <h1>Liste des {{this.lowercaseEntityName}}</h1>
@@ -32,13 +78,21 @@ export default class AdminEntityList extends Component {
     </div>
     <PixTable @data={{@entityList}} @caption="liste">
       <:columns as |row context|>
-        {{#each @schema.fields as |field|}}
-          <PixTableColumn @context={{context}} @type={{this.getColumnType field}}>
+        {{#each this.columns as |column|}}
+          <PixTableColumn
+            @context={{context}}
+            @type={{column.type}}
+            @onSort={{column.onSort}}
+            @sortOrder={{column.sortOrder}}
+            @ariaLabelDefaultSort={{column.ariaLabelDefaultSort}}
+            @ariaLabelSortAsc={{column.ariaLabelSortAsc}}
+            @ariaLabelSortDesc={{column.ariaLabelSortDesc}}
+          >
             <:header>
-              {{field.label}}
+              {{column.field.label}}
             </:header>
             <:cell>
-              <AdminEntityCell @row={{row}} @field={{field}} />
+              <AdminEntityCell @row={{row}} @field={{column.field}} />
             </:cell>
           </PixTableColumn>
         {{/each}}

--- a/pix-editor/app/controllers/admin/entities/list.js
+++ b/pix-editor/app/controllers/admin/entities/list.js
@@ -1,6 +1,11 @@
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
 
 export default class AdminEntityListController extends Controller {
+  queryParams = ['sort'];
+
+  @tracked sort;
+
   get entityList() {
     return this.model.entityList;
   }

--- a/pix-editor/app/models/admin-schema.js
+++ b/pix-editor/app/models/admin-schema.js
@@ -7,4 +7,5 @@ export default class AdminSchemaModel extends Model {
   @attr creatable;
   @attr entityName;
   @attr fields;
+  @attr defaultSort;
 }

--- a/pix-editor/app/routes/admin/entities/list.js
+++ b/pix-editor/app/routes/admin/entities/list.js
@@ -8,7 +8,11 @@ export default class AdminEntityListRoute extends Route {
   @service store;
   @service router;
 
-  queryParams = { pageNumber: { refreshModel: true }, pageSize: { refreshModel: true } };
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    sort: { refreshModel: true },
+  };
 
   beforeModel() {
     const { schemas } = this.modelFor('admin');
@@ -33,6 +37,7 @@ export default class AdminEntityListRoute extends Route {
           number: params.pageNumber,
           size: params.pageSize,
         },
+        sort: params.sort,
       },
       { reload: true },
     );

--- a/pix-editor/app/templates/admin/entities/list.gjs
+++ b/pix-editor/app/templates/admin/entities/list.gjs
@@ -2,7 +2,7 @@ import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
 import AdminEntityList from 'pixeditor/components/admin/entity-list';
 
 <template>
-  <AdminEntityList @schema={{@controller.schema}} @entityList={{@controller.entityList}} />
+  <AdminEntityList @schema={{@controller.schema}} @entityList={{@controller.entityList}} @sort={{@controller.sort}} />
   <div class="pagination">
     <PixPagination @pagination={{@controller.entityList.meta}} />
   </div>

--- a/pix-editor/tests/acceptance/admin/create-admin-entity-test.js
+++ b/pix-editor/tests/acceptance/admin/create-admin-entity-test.js
@@ -16,6 +16,10 @@ module('Acceptance | Admin | Create-Admin-Entity', function (hooks) {
     this.server.create('admin-schema', {
       label: 'Utilisateurs',
       entityName: 'users',
+      defaultSort: {
+        field: 'id',
+        direction: 'desc',
+      },
       fields: [
         { key: 'id', label: 'Identifiant', type: 'number', readonly: true },
         { key: 'name', label: 'Nom', type: 'string' },

--- a/pix-editor/tests/acceptance/admin/filter-admin-entities-test.js
+++ b/pix-editor/tests/acceptance/admin/filter-admin-entities-test.js
@@ -1,0 +1,74 @@
+import { visit, within } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
+
+module('Acceptance | Admin | Filter-Admin-Entities', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC', access: 'admin' });
+    this.server.create('admin-schema', {
+      label: 'Utilisateurs',
+      entityName: 'users',
+      defaultSort: {
+        direction: 'desc',
+        field: 'id',
+      },
+      fields: [
+        { key: 'id', label: 'Identifiant', type: 'number', readonly: true },
+        { key: 'name', label: 'Nom', type: 'string' },
+        { key: 'trigram', label: 'Trigramme', type: 'string' },
+        {
+          key: 'access',
+          label: 'Accès',
+          type: 'enum',
+          options: [
+            { label: 'Lecture seule', value: 'readonly' },
+            { label: 'Administrateur', value: 'admin' },
+          ],
+        },
+      ],
+    });
+
+    return authenticateSession();
+  });
+
+  test('it should sort users by default order', async function (assert) {
+    // given
+    this.server.create('admin-entity', {
+      id: 'users:200',
+      properties: { id: 200, name: 'Milieu', trigram: 'MIL', access: 'readonly' },
+    });
+    this.server.create('admin-entity', {
+      id: 'users:300',
+      properties: { id: 300, name: 'Premier', trigram: 'PRM', access: 'readonly' },
+    });
+    this.server.create('admin-entity', {
+      id: 'users:100',
+      properties: { id: 100, name: 'Dernier', trigram: 'DER', access: 'readonly' },
+    });
+
+    // when
+    const screen = await visit('/administration/users/list');
+
+    // then
+    const rows = await screen.findAllByRole('row');
+
+    const row1 = rows[1];
+    assert.dom(within(row1).getByText('300')).exists();
+    assert.dom(within(row1).getByText('Premier')).exists();
+
+    const row2 = rows[2];
+    assert.dom(within(row2).getByText('200')).exists();
+    assert.dom(within(row2).getByText('Milieu')).exists();
+
+    const row3 = rows[3];
+    assert.dom(within(row3).getByText('100')).exists();
+    assert.dom(within(row3).getByText('Dernier')).exists();
+  });
+});

--- a/pix-editor/tests/acceptance/admin/filter-admin-entities-test.js
+++ b/pix-editor/tests/acceptance/admin/filter-admin-entities-test.js
@@ -1,4 +1,5 @@
 import { visit, within } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
@@ -70,5 +71,48 @@ module('Acceptance | Admin | Filter-Admin-Entities', function (hooks) {
     const row3 = rows[3];
     assert.dom(within(row3).getByText('100')).exists();
     assert.dom(within(row3).getByText('Dernier')).exists();
+  });
+
+  module('when sorting a column on demand', function () {
+    test('it should sort entities by given order and column', async function (assert) {
+      // given
+      this.server.create('admin-entity', {
+        id: 'users:200',
+        properties: { id: 200, name: 'AAAA', trigram: 'AAA', access: 'readonly' },
+      });
+      this.server.create('admin-entity', {
+        id: 'users:300',
+        properties: { id: 300, name: 'CCCC', trigram: 'CCC', access: 'readonly' },
+      });
+      this.server.create('admin-entity', {
+        id: 'users:100',
+        properties: { id: 100, name: 'BBBB', trigram: 'BBB', access: 'readonly' },
+      });
+
+      // when
+      const screen = await visit('/administration/users/list');
+      const sortNameAscButton = await screen.findByRole('button', {
+        name: "Trier le tableau dans l'ordre croissant du champ Nom",
+      });
+      await click(sortNameAscButton);
+
+      // then
+      assert.strictEqual(currentURL(), '/administration/users/list?sort=name');
+      assert.dom(screen.getByText("Trier le tableau dans l'ordre décroissant du champ Nom")).exists();
+
+      const rows = await screen.findAllByRole('row');
+
+      const row1 = rows[1];
+      assert.dom(within(row1).getByText('200')).exists();
+      assert.dom(within(row1).getByText('AAAA')).exists();
+
+      const row2 = rows[2];
+      assert.dom(within(row2).getByText('100')).exists();
+      assert.dom(within(row2).getByText('BBBB')).exists();
+
+      const row3 = rows[3];
+      assert.dom(within(row3).getByText('300')).exists();
+      assert.dom(within(row3).getByText('CCCC')).exists();
+    });
   });
 });

--- a/pix-editor/tests/acceptance/admin/navigation-test.js
+++ b/pix-editor/tests/acceptance/admin/navigation-test.js
@@ -70,6 +70,10 @@ module('Acceptance | Admin | Navigation', function (hooks) {
       this.server.create('admin-schema', {
         label: 'Utilisateurs',
         entityName: 'users',
+        defaultSort: {
+          field: 'name',
+          direction: 'asc',
+        },
         fields: [
           { key: 'name', label: 'Nom', type: 'string' },
           { key: 'patate', label: 'Chocolat', type: 'string' },
@@ -98,6 +102,10 @@ module('Acceptance | Admin | Navigation', function (hooks) {
           label: 'Fraises',
           entityName: 'strawberries',
           creatable: false,
+          defaultSort: {
+            field: 'name',
+            direction: 'asc',
+          },
           fields: [{ key: 'name', label: 'Nom', type: 'string' }],
         });
         const screen = await visit('/administration/strawberries/list');

--- a/pix-editor/tests/acceptance/admin/navigation-test.js
+++ b/pix-editor/tests/acceptance/admin/navigation-test.js
@@ -75,8 +75,8 @@ module('Acceptance | Admin | Navigation', function (hooks) {
           direction: 'asc',
         },
         fields: [
-          { key: 'name', label: 'Nom', type: 'string' },
-          { key: 'patate', label: 'Chocolat', type: 'string' },
+          { key: 'name', label: 'Nom', type: 'string', sortable: false },
+          { key: 'patate', label: 'Chocolat', type: 'string', sortable: false },
         ],
       });
       this.server.create('admin-entity', { properties: { name: 'Dinguou', patate: '123' } });

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -11,7 +11,29 @@ export default function routes() {
   });
   // this route doesn't exist, but ember-data calls it in tests ☺️
   this.get('/admin/entities', ({ adminEntities }) => adminEntities.all());
-  this.get('/admin/entities/:entity_name', ({ adminEntities }) => adminEntities.all());
+  this.get('/admin/entities/:entity_name', ({ adminEntities, adminSchemas }, { params, queryParams }) => {
+    let columnToSort;
+    let sortOrder;
+
+    if (!queryParams.sort) {
+      const entityName = params.entity_name;
+      const entitySchema = adminSchemas.findBy({ entityName });
+      columnToSort = entitySchema.defaultSort.field;
+      sortOrder = entitySchema.defaultSort.direction;
+    }
+
+    const adminEntitiesObject = adminEntities.all();
+
+    adminEntitiesObject.models.sort((a, b) => {
+      if (sortOrder === 'asc') {
+        return a[columnToSort].localeCompare(b[columnToSort]);
+      } else {
+        return b[columnToSort].localeCompare(a[columnToSort]);
+      }
+    });
+
+    return adminEntitiesObject;
+  });
   this.get('/admin/schemas', ({ adminSchemas }) => adminSchemas.all());
 
   this.get('/users/me', ({ users }) => users.first());
@@ -495,6 +517,7 @@ export default function routes() {
 
   this.get('/search', (schema) => schema.searchResults.all());
 }
+
 /* eslint-enable ember/no-get */
 
 function _getPaginationFromQueryParams(queryParams) {

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -20,15 +20,24 @@ export default function routes() {
       const entitySchema = adminSchemas.findBy({ entityName });
       columnToSort = entitySchema.defaultSort.field;
       sortOrder = entitySchema.defaultSort.direction;
+    } else {
+      sortOrder = 'asc';
+      columnToSort = queryParams.sort;
+      if (columnToSort.startsWith('-')) {
+        sortOrder = 'desc';
+      }
+      columnToSort = columnToSort.replace('-', '');
     }
 
     const adminEntitiesObject = adminEntities.all();
 
     adminEntitiesObject.models.sort((a, b) => {
+      const aField = a.attrs.properties[columnToSort].toString();
+      const bField = b.attrs.properties[columnToSort].toString();
       if (sortOrder === 'asc') {
-        return a[columnToSort].localeCompare(b[columnToSort]);
+        return aField.localeCompare(bField);
       } else {
-        return b[columnToSort].localeCompare(a[columnToSort]);
+        return bField.localeCompare(aField);
       }
     });
 


### PR DESCRIPTION
## 🥀 Problème

Dans le nouveau back-office, nous ne pouvons pas trier les entités.
De plus, leur tri par défaut est souvent inadéquat.

## 🏹 Proposition

Permettre de trier les entités selon la colonne voulue.
Empêcher le tri sur certaines colonnes sensibles ou non pertinentes.
Rendre la configuration du tri par défaut obligatoire dans le schéma des entités.

## 💌 Remarques

Renommage des labels de statut de l'entité `localized-challenge` (en prod, en pause), qui correspondaient aux statuts des `challenges` (validé, proposé).

## ❤️‍🔥 Pour tester

- Se rendre sur la [section d'administration de la RA](https://pix-lcms-review-pr1423.osc-fr1.scalingo.io/administration).
- Sélectionner l'entité Utilisateurs.
- Constater que des boutons de tri son présents sur toutes les colonnes, sauf "Clé API".
- Essayer de trier dans n'importe quelle direction.
- Constater que les entités sont triées correctement.