### PR TITLE
[FEATURE] Ajout visuel de la langue et de son drapeau (PIX-21870)

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -4,8 +4,8 @@ export const LOCALE = {
   FRENCH_BELGIUM: 'fr-BE',
   FRENCH_SPOKEN: 'fr',
   ITALIAN_SPOKEN: 'it',
-  DEUTSCH_AUSTRIA: 'de-AT',
-  DEUTSCH_SPOKEN: 'de',
+  GERMAN_AUSTRIA: 'de-AT',
+  GERMAN_SPOKEN: 'de',
   PORTUGUESE_SPOKEN: 'pt',
   SPANISH_SPOKEN: 'es',
   DUTCH_SPOKEN: 'nl',
@@ -13,8 +13,8 @@ export const LOCALE = {
 };
 
 export const LOCALE_TO_LANGUAGE_MAP = Object.freeze({
-  [LOCALE.DEUTSCH_SPOKEN]: 'Allemand (Autriche)',
-  [LOCALE.DEUTSCH_SPOKEN]: 'Allemand',
+  [LOCALE.GERMAN_AUSTRIA]: 'Allemand (Autriche)',
+  [LOCALE.GERMAN_SPOKEN]: 'Allemand',
   [LOCALE.ENGLISH_SPOKEN]: 'Anglais',
   [LOCALE.SPANISH_SPOKEN]: 'Espagnol',
   [LOCALE.FRENCH_FRANCE]: 'Franco Français',

--- a/pix-editor/app/components/challenges-production/challenges-production-header.gjs
+++ b/pix-editor/app/components/challenges-production/challenges-production-header.gjs
@@ -4,8 +4,9 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import LocaleTag from '../v2/locale-tag';
 
-export default class ChallengesProduction extends Component {
+export default class ChallengesProductionHeader extends Component {
   @service router;
   @service multipanelManager;
 
@@ -22,7 +23,7 @@ export default class ChallengesProduction extends Component {
 
   <template>
     <header class="challenges-production-header">
-      <p>
+      <p class="challenges-production-header__info">
         {{@skill.name}}
         <PixTag @color="green">
           actif
@@ -35,6 +36,9 @@ export default class ChallengesProduction extends Component {
           </PixTag>
         {{/if}}
       </p>
+      {{#if @locale}}
+        <LocaleTag @locale={{@locale}} />
+      {{/if}}
       <div class="challenges-production-header__action-buttons">
         {{#if @canExpand}}
           <PixIconButton

--- a/pix-editor/app/components/challenges-production/challenges-production-header.gjs
+++ b/pix-editor/app/components/challenges-production/challenges-production-header.gjs
@@ -32,7 +32,7 @@ export default class ChallengesProductionHeader extends Component {
         V{{@skill.version}}
         {{#if @isToRephrase}}
           <PixTag @color="error">
-            A revoir
+            À revoir
           </PixTag>
         {{/if}}
       </p>

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -53,6 +53,7 @@ export default class LocalizedChallengesProduction extends Component {
       @competenceId={{@competence.id}}
       @canExpand={{@canExpand}}
       @isToRephrase={{this.isToRephrase}}
+      @locale={{@locale}}
     />
     <section
       class="challenges-production

--- a/pix-editor/app/components/competence-header.gjs
+++ b/pix-editor/app/components/competence-header.gjs
@@ -3,32 +3,10 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import flagForLanguage from 'pixeditor/helpers/flag-for-language.js';
+import LocaleTag from './v2/locale-tag';
 
 export default class CompetenceHeader extends Component {
   @service router;
-
-  @action
-  setLocale(locale) {
-    if (locale === 'source') locale = undefined;
-    this.router.transitionTo({ queryParams: { locale } });
-  }
-
-  @action
-  setSection(section) {
-    if (section === 'skills') {
-      this.router.transitionTo('authenticated.competence.skills', this.args.competence.id, {
-        queryParams: {
-          view: 'production',
-          languageFilter: this.args.locale,
-        },
-      });
-    }
-    if (section === 'quality') {
-      this.router.transitionTo('authenticated.competence.quality', this.args.competence.id);
-    }
-  }
-
   localeOptions = [
     {
       label: 'Langue source',
@@ -71,7 +49,6 @@ export default class CompetenceHeader extends Component {
       value: 'nl',
     },
   ];
-
   sections = [
     {
       label: 'Epreuves',
@@ -100,13 +77,31 @@ export default class CompetenceHeader extends Component {
     return !!this.args.locale;
   }
 
+  @action
+  setLocale(locale) {
+    if (locale === 'source') locale = undefined;
+    this.router.transitionTo({ queryParams: { locale } });
+  }
+
+  @action
+  setSection(section) {
+    if (section === 'skills') {
+      this.router.transitionTo('authenticated.competence.skills', this.args.competence.id, {
+        queryParams: {
+          view: 'production',
+          languageFilter: this.args.locale,
+        },
+      });
+    }
+    if (section === 'quality') {
+      this.router.transitionTo('authenticated.competence.quality', this.args.competence.id);
+    }
+  }
+
   <template>
     <div class="competence-header">
       {{#if this.hasLocaleSelected}}
-        <p class="locale-tag">
-          <span>{{flagForLanguage this.localeEntry.value}}</span>
-          {{this.localeEntry.label}}
-        </p>
+        <LocaleTag @locale={{this.localeEntry.value}} />
       {{/if}}
       <h2>
         <LinkTo

--- a/pix-editor/app/components/v2/locale-tag.gjs
+++ b/pix-editor/app/components/v2/locale-tag.gjs
@@ -2,12 +2,11 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import flagForLanguage from 'pixeditor/helpers/flag-for-language.js';
 
-
 export default class LocaleTag extends Component {
   @service config;
 
   get label() {
-    return this.config.localeToLanguageMap[this.args.locale];
+    return this.config.localeToLanguageMap?.[this.args.locale];
   }
 
   <template>

--- a/pix-editor/app/components/v2/locale-tag.gjs
+++ b/pix-editor/app/components/v2/locale-tag.gjs
@@ -1,0 +1,19 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import flagForLanguage from 'pixeditor/helpers/flag-for-language.js';
+
+
+export default class LocaleTag extends Component {
+  @service config;
+
+  get label() {
+    return this.config.localeToLanguageMap[this.args.locale];
+  }
+
+  <template>
+    <p class="locale-tag" title={{@locale}}>
+      <span>{{flagForLanguage @locale}}</span>
+      {{this.label}}
+    </p>
+  </template>
+}

--- a/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview/localized-challenges.js
@@ -33,6 +33,7 @@ export default class LocalizedChallengesRoute extends Route {
       skill,
       competence,
       overview,
+      locale,
     };
   }
 }

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -65,3 +65,4 @@
 @use 'components/v2/field/illustration';
 @use 'components/v2/field/toggle-field';
 @use 'components/v2/localized-framework-tube';
+@use 'components/v2/locale-tag';

--- a/pix-editor/app/styles/components/challenge-view-header.scss
+++ b/pix-editor/app/styles/components/challenge-view-header.scss
@@ -3,18 +3,20 @@
   flex-direction: column;
   color: var(--pix-neutral-0);
 
-
   p {
     display: flex;
     gap: var(--pix-spacing-2x);
     align-items: center;
+    font-weight: 700;
+    font-size: 16px;
   }
 
-  &-first, &-second {
+  &-first,
+  &-second {
     display: flex;
     width: 100%;
     align-items: center;
-    font-size: 14px;
+    font-size: 18px;
   }
 
   &-first {
@@ -25,11 +27,12 @@
 
   &-second {
     color: var(--pix-neutral-900);
-    border-bottom: 1px solid var(--pix-neutral-100, #CDD1D9);
+    border-bottom: 1px solid var(--pix-neutral-100, #cdd1d9);
     background: var(--pix-neutral-20);
     padding: var(--pix-spacing-4x);
 
-    &__locales, &__infos {
+    &__locales,
+    &__infos {
       display: flex;
       flex-direction: column;
     }
@@ -65,9 +68,11 @@
   }
 
   &__separator {
-    height: 24px;
+    height: 28px;
     width: 1px;
     border-right: solid 1px var(--pix-neutral-0);
+    margin-right: 4px;
+    margin-left: 4px;
   }
 
   &__dark-separator {
@@ -76,7 +81,6 @@
     border-right: solid 1px var(--pix-neutral-900);
     padding: 0 var(--pix-spacing-4x);
   }
-
 
   &__action-buttons {
     display: flex;

--- a/pix-editor/app/styles/components/challenges-production-header.scss
+++ b/pix-editor/app/styles/components/challenges-production-header.scss
@@ -1,13 +1,13 @@
 .challenges-production-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   color: var(--pix-neutral-0);
   background-color: var(--pix-neutral-900);
   padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
   border-bottom: 1px solid var(--pix-neutral-100);
 
-  p {
+  &__info {
+    flex: 1;
     display: flex;
     gap: var(--pix-spacing-2x);
   }
@@ -19,8 +19,10 @@
   }
 
   &__action-buttons {
+    flex: 1;
     display: flex;
-    align-items:center;
+    align-items: center;
+    justify-content: end;
     gap: var(--pix-spacing-2x);
   }
 

--- a/pix-editor/app/styles/components/challenges-production-header.scss
+++ b/pix-editor/app/styles/components/challenges-production-header.scss
@@ -10,12 +10,17 @@
     flex: 1;
     display: flex;
     gap: var(--pix-spacing-2x);
+    align-items: center;
+    font-weight: 700;
+    font-size: 16px;
   }
 
   &__separator {
-    height: 24px;
+    height: 28px;
     width: 1px;
     border-right: solid 1px var(--pix-neutral-0);
+    margin-right: 4px;
+    margin-left: 4px;
   }
 
   &__action-buttons {

--- a/pix-editor/app/styles/components/competence-header.scss
+++ b/pix-editor/app/styles/components/competence-header.scss
@@ -20,16 +20,6 @@
   &__spacer {
     flex-grow: 1;
   }
-
-  .locale-tag {
-    background:var(--pix-neutral-20);
-    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
-    border-radius: var(--pix-spacing-2x);
-    @extend %pix-body-m;
-
-    span {
-      display: inline-block;
-      margin-right:  var(--pix-spacing-2x);
-    }
-  }
 }
+
+

--- a/pix-editor/app/styles/components/v2/locale-tag.scss
+++ b/pix-editor/app/styles/components/v2/locale-tag.scss
@@ -1,0 +1,14 @@
+@use 'pix-design-tokens/typography' as *;
+
+.locale-tag {
+  color: black;
+  background: var(--pix-neutral-20);
+  padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+  border-radius: var(--pix-spacing-2x);
+  @extend %pix-body-m;
+
+  span {
+    display: inline-block;
+    margin-right: var(--pix-spacing-2x);
+  }
+}

--- a/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.gjs
+++ b/pix-editor/app/templates/authenticated/v2/competence-overview/localized-challenges.gjs
@@ -5,6 +5,7 @@ import LocalizedChallengesProduction from 'pixeditor/components/challenges-produ
     @challengeLocales={{@controller.model.challengeLocales}}
     @overview={{@controller.model.overview}}
     @competence={{@controller.model.competence}}
+    @locale={{@controller.model.locale}}
     @canExpand={{true}}
   />
 </template>

--- a/pix-editor/tests/integration/components/challenges-production/challenges-production-header-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/challenges-production-header-test.gjs
@@ -1,0 +1,147 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import Service from '@ember/service';
+import ChallengesProductionHeader from 'pixeditor/components/challenges-production/challenges-production-header';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | challenges-production | challenges-production-header', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let skill;
+
+  hooks.beforeEach(async function () {
+    const store = this.owner.lookup('service:store');
+    skill = store.createRecord('skill', {
+      id: 'skillAId',
+      name: '@skillA1',
+      version: 3,
+    });
+
+    class MultipanelManager extends Service {
+      onTableClosed = sinon.stub();
+      expandTable = sinon.stub();
+    }
+    this.owner.register('service:multipanelManager', MultipanelManager);
+
+    class Router extends Service {
+      transitionTo = sinon.stub();
+    }
+    this.owner.register('service:router', Router);
+
+    class Config extends Service {
+      localeToLanguageMap = { en: 'Anglais' };
+    }
+    this.owner.register('service:config', Config);
+  });
+
+  test('should render all information if present', async function (assert) {
+    // given
+    const locale = 'en';
+    const canExpand = true;
+    const isToRephrase = true;
+
+    // when
+    const screen = await render(
+      <template>
+        <ChallengesProductionHeader
+          @skill={{skill}}
+          @locale={{locale}}
+          @canExpand={{canExpand}}
+          @isToRephrase={{isToRephrase}}
+        />
+      </template>,
+    );
+
+    // then
+    assert.dom(screen.getByText(skill.name, { exact: false })).exists();
+    assert.dom(screen.getByText('actif', { exact: false })).exists();
+    assert.dom(screen.getByText(`V${skill.version}`, { exact: false })).exists();
+    assert.dom(screen.getByText('À revoir', { exact: false })).exists();
+    assert.dom(screen.getByText('Anglais', { exact: false })).exists();
+
+    assert.dom(screen.getByRole('button', { name: 'Agrandir la liste des épreuves' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Fermer la liste des épreuves' })).exists();
+  });
+
+  module('when isToRephrase is false', function () {
+    test('should not display À revoir tag', async function (assert) {
+      // given
+      const isToRephrase = false;
+
+      // when
+      const screen = await render(
+        <template><ChallengesProductionHeader @skill={{skill}} @isToRephrase={{isToRephrase}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(skill.name, { exact: false })).exists();
+      assert.notOk(await screen.queryByText('À revoir', { exact: false }), 'À revoir tag shoud not be visible');
+    });
+  });
+
+  module('when canExpand is false', function () {
+    test('should not display expand button', async function (assert) {
+      // given
+      const canExpand = false;
+
+      // when
+      const screen = await render(
+        <template><ChallengesProductionHeader @skill={{skill}} @canExpand={{canExpand}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(skill.name, { exact: false })).exists();
+      assert.notOk(
+        await screen.queryByRole('button', { name: 'Agrandir la liste des épreuves' }),
+        'Expand button should not be visible',
+      );
+    });
+  });
+
+  module('when expanding panel', function () {
+    test('should call multipanel manager expand method', async function (assert) {
+      // given
+      const canExpand = true;
+      const multipanelManagerStub = this.owner.lookup('service:multipanelManager');
+
+      // when
+      const screen = await render(
+        <template><ChallengesProductionHeader @skill={{skill}} @canExpand={{canExpand}} /></template>,
+      );
+      await click(screen.getByRole('button', { name: 'Agrandir la liste des épreuves' }));
+
+      // then
+      assert.ok(multipanelManagerStub.expandTable.calledOnce);
+    });
+  });
+
+  module('when closing panel', function () {
+    test('should call multipanel manager close method and router transitionTo', async function (assert) {
+      // given
+      const canExpand = true;
+      const competenceId = 'competenceId';
+      const overview = 'overview';
+      const multipanelManagerStub = this.owner.lookup('service:multipanelManager');
+      const routerStub = this.owner.lookup('service:router');
+
+      // when
+      const screen = await render(
+        <template>
+          <ChallengesProductionHeader
+            @skill={{skill}}
+            @canExpand={{canExpand}}
+            @competenceId={{competenceId}}
+            @overview={{overview}}
+          />
+        </template>,
+      );
+      await click(screen.getByRole('button', { name: 'Fermer la liste des épreuves' }));
+
+      // then
+      assert.ok(multipanelManagerStub.onTableClosed.calledOnce);
+      assert.ok(routerStub.transitionTo.calledWith('authenticated.v2.competence-overview', competenceId, overview));
+    });
+  });
+});

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -270,7 +270,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
     test('it should display resume skill state', async function (assert) {
       // then
       assert.dom(screen.getByText(`actif`)).exists();
-      assert.dom(screen.getByText(`A revoir`)).exists();
+      assert.dom(screen.getByText(`À revoir`)).exists();
     });
 
     test('should display all expected info for a given challenge', async function (assert) {


### PR DESCRIPTION
## 🌎 Problème

Les utilisateurs sont un peu perdu pour savoir si le l'Acquis affiché est dans une langue spécifique?

<img width="1816" height="435" alt="image" src="https://github.com/user-attachments/assets/f52631b5-77f4-4bbc-9896-0ac662d8dec3" />


## 🔭 Proposition

Ajouter l'info dans le header de l'Acquis

## 🪐 Remarques

On à ajouté des tests


## 🚀 Pour tester
Aller ici => [lien](https://pix-lcms-review-pr1424.osc-fr1.scalingo.io/v2/competences/competenceF0A0C0/challenges-production/skills/skillF0A0C0Th0Tu0S0Act/localized-challenges?locale=fr-fr)
utilisateur: `b03b5cca-10b7-11ec-91a9-1b6020fa19dc`
Il faut que ca resemble à ça !
<img width="1816" height="435" alt="image" src="https://github.com/user-attachments/assets/f5232a6e-545a-4643-b8d5-6fec43c5bcb4" />
