### PR TITLE
[FEATURE] Ajouter un lien de prévisualisation de l'épreuve source depuis une épreuve traduite en V2 (PIX-21872)

### DIFF
--- a/pix-editor/app/components/challenge-view/challenge-view-header.gjs
+++ b/pix-editor/app/components/challenge-view/challenge-view-header.gjs
@@ -32,11 +32,7 @@ export default class ChallengesViewHeader extends Component {
 
   @action
   async copyChallengePreviewUrl(challenge) {
-    await navigator.clipboard.writeText(this.getChallengePreviewUrl(challenge));
-  }
-
-  getChallengePreviewUrl(challenge) {
-    return new URL(challenge.preview, window.location).href;
+    await navigator.clipboard.writeText(challenge.previewUrl);
   }
 
   buildStatusText(challenge) {
@@ -102,7 +98,7 @@ export default class ChallengesViewHeader extends Component {
             <:triggerElement>
               <a
                 class="challenge-view-header-action__preview"
-                href="{{this.getChallengePreviewUrl @challenge}}"
+                href="{{@challenge.previewUrl}}"
                 target="_blank"
                 aria-labelledby="preview-challenge-tooltip"
               >

--- a/pix-editor/app/components/challenges-production/challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/challenges-production.gjs
@@ -52,13 +52,9 @@ export default class ChallengesProduction extends Component {
     return challengeStatus ?? 'absence de statut ❓';
   }
 
-  getChallengePreviewUrl(challenge) {
-    return new URL(challenge.preview, window.location).href;
-  }
-
   @action
   async copyChallengePreviewUrl(challenge) {
-    await navigator.clipboard.writeText(this.getChallengePreviewUrl(challenge));
+    await navigator.clipboard.writeText(challenge.previewUrl);
   }
 
   @action
@@ -155,7 +151,7 @@ export default class ChallengesProduction extends Component {
               </:header>
               <:cell>
                 <a
-                  href="{{this.getChallengePreviewUrl challenge}}"
+                  href="{{challenge.previewUrl}}"
                   target="_blank"
                   aria-label="Prévisualiser l'épreuve {{challenge.id}}"
                 >

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
@@ -9,6 +9,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import flagForLanguage from 'pixeditor/helpers/flag-for-language';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
+import DropdownMenu from '../dropdown-menu';
 
 export default class LocalizedChallengeViewHeader extends Component {
   @service access;
@@ -94,18 +95,33 @@ export default class LocalizedChallengeViewHeader extends Component {
         </div>
         <span class="challenge-view-header__dark-separator"></span>
         <div class="challenge-view-header-second__actions">
-          <PixTooltip @id="preview-challenge-tooltip" @position="top" @isInline={{true}} @isLight={{true}}>
+          <PixTooltip
+            @id="preview-challenge-tooltip"
+            @position="top"
+            @isInline={{true}}
+            @isLight={{true}}
+            class="preview-menu"
+          >
             <:triggerElement>
-              <a
-                class="challenge-view-header-action__preview"
-                href="{{@challengeLocale.localizedPreviewUrl}}"
-                target="_blank"
-                aria-labelledby="preview-challenge-tooltip"
-              >
-                <PixIcon @name="eye" />
-              </a>
+              <DropdownMenu @ariaLabel="Ouvrir la liste des prévisualisations de l'épreuve" @iconName="eye">
+                <ul>
+                  <li class="preview-menu__item">
+                    <a href={{@challengeLocale.localizedPreviewUrl}} target="_blank">
+                      <PixIcon @name="eye" alt="" />
+                      Prévisualiser l'épreuve traduite
+                    </a>
+                  </li>
+                  <li class="preview-menu__item">
+                    <a href={{@challengeLocale.challenge.previewUrl}} target="_blank">
+                      <PixIcon @name="eye" alt="" />
+                      Prévisualiser l'épreuve source
+                    </a>
+                  </li>
+                </ul>
+              </DropdownMenu>
             </:triggerElement>
-            <:tooltip>Prévisualiser l'épreuve <span class="sr-only">{{this.localizedChallenge.id}}</span></:tooltip>
+            <:tooltip>Afficher la liste des previews
+              <span class="sr-only">{{@challengeLocale.challenge.id}}</span></:tooltip>
           </PixTooltip>
           <PixTooltip @id="copy-url-challenge-tooltip" @position="top" @isInline={{true}} @isLight={{true}}>
             <:triggerElement>

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -139,7 +139,7 @@ export default class SingleController extends Controller {
   }
 
   get absolutePreviewUrl() {
-    return new URL(this.challenge.preview, window.location).href;
+    return this.challenge.previewUrl;
   }
 
   get localizedChallengeLinkRoute() {

--- a/pix-editor/app/models/challenge-locale.js
+++ b/pix-editor/app/models/challenge-locale.js
@@ -61,12 +61,12 @@ export default class ChallengeLocaleModel extends Model {
   }
 
   get primaryPreviewUrl() {
-    return new URL(this.challenge.preview, window.location).href;
+    return this.challenge.previewUrl;
   }
 
   get localizedPreviewUrl() {
     if (this.isPrimaryInLocale || !this.localizedChallengeValue) return null;
-    return new URL(`${this.challenge.preview}?locale=${this.localizedChallengeValue.locale}`, window.location).href;
+    return `${this.primaryPreviewUrl}?locale=${this.localizedChallengeValue.locale}`;
   }
 
   get translationsUrl() {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -286,6 +286,10 @@ export default class ChallengeModel extends Model {
     return localizedChallenges.filter((localizedChallenge) => localizedChallenge.locale !== this.primaryLocale);
   }
 
+  get previewUrl() {
+    return new URL(this.preview, window.location).href;
+  }
+
   archive() {
     this.status = 'archivé';
     this.archivedAt = new Date();

--- a/pix-editor/app/styles/components/challenge-view-header.scss
+++ b/pix-editor/app/styles/components/challenge-view-header.scss
@@ -17,6 +17,30 @@
     width: 100%;
     align-items: center;
     font-size: 18px;
+
+    .preview-menu {
+      &__item a,
+      &__item button {
+        display: flex;
+        align-items: center;
+        gap: var(--pix-spacing-2x);
+        padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+        border-radius: var(--pix-spacing-2x);
+        white-space: nowrap;
+
+        &:hover {
+          color: var(--pix-neutral-800);
+          background: var(--pix-primary-10);
+        }
+      }
+
+      .title {
+        display: block;
+        background: var(--pix-neutral-20);
+        padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+        border-radius: var(--pix-spacing-2x);
+      }
+    }
   }
 
   &-first {

--- a/pix-editor/app/styles/components/challenges-production.scss
+++ b/pix-editor/app/styles/components/challenges-production.scss
@@ -31,6 +31,7 @@
       align-items: center;
       gap: var(--pix-spacing-2x);
       padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+      border-radius: var(--pix-spacing-2x);
       white-space: nowrap;
 
       &:hover {

--- a/pix-editor/app/styles/components/dropdown-menu.scss
+++ b/pix-editor/app/styles/components/dropdown-menu.scss
@@ -1,7 +1,8 @@
 @use 'pix-design-tokens/shadows' as *;
 
 .dropdown {
-  .dropdown-button[aria-expanded="true"],
+  .dropdown-button[aria-expanded='true'],
+  .dropdown-button[aria-expanded='true']:hover,
   .dropdown-button:hover {
     background: var(--pix-neutral-100);
   }

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
@@ -142,11 +142,11 @@ import SelectLocation from 'pixeditor/components/pop-in/select-location';
           Annuler
         </button>
       {{else}}
-        <a class="ui button item" href={{@controller.absolutePreviewUrl}} target="_blank">
+        <a class="ui button item" href={{@controller.challenge.previewUrl}} target="_blank">
           <i class="eye icon"></i>
           Prévisualiser
         </a>
-        <CopyLink @link={{@controller.absolutePreviewUrl}} />
+        <CopyLink @link={{@controller.challenge.previewUrl}} />
         {{#each @controller.challenge.otherLocalizedChallenges as |localizedChallenge|}}
           <LinkTo
             @route={{@controller.localizedChallengeLinkRoute}}

--- a/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
@@ -315,11 +315,18 @@ module('Integration | Component | localized-challenge-view | localized-challenge
       );
 
       await click(screen.getByRole('button', { name: "Copier le lien de l'épreuve" }));
+      await click(screen.getByRole('button', { name: "Ouvrir la liste des prévisualisations de l'épreuve" }));
 
       // then
       assert.ok(
+        (await screen.findByRole('link', { name: "Prévisualiser l'épreuve source" }))
+          .getAttribute('href')
+          .endsWith('/previewURL'),
+        'href ends with /previewURL',
+      );
+      assert.ok(
         screen
-          .getByRole('link', { name: "Prévisualiser l'épreuve" })
+          .getByRole('link', { name: "Prévisualiser l'épreuve traduite" })
           .getAttribute('href')
           .endsWith('/previewURL?locale=en'),
         'href ends with /previewURL?locale=en',


### PR DESCRIPTION
## 🌎 Problème

Depuis un localizeChallenge on ne peut pas faire la prévisualisation directement vers la langue source.


## 🔭 Proposition

Donner un choix au moment de prévisualiser un localizeChallenge de choisir soit la version source ou traduite.

## 🪐 Remarques

RAS

## 🚀 Pour tester

Aller sur la V2 et esseyer de visualiser un localizeChallenge avec le petit oeil de préview [ici](https://pix-lcms-review-pr1427.osc-fr1.scalingo.io/v2/competences/competenceF0A0C0/challenges-production/skills/skillF0A0C0Th1Tu0S0Act/localized-challenges/challengeF0A0C0Th1Tu0S0ActCh1-en?locale=en)
<img width="403" height="188" alt="image" src="https://github.com/user-attachments/assets/3ccb7311-51f7-4a3e-8997-756816f7727f" />

Observer que l'on à un choix entre 2 (source / traduit) et qu'il renvoie bien vers les préview associé