### PR TITLE
[FEATURE] Phrase 🍓 : Se baser sur le nom des locales (PIX-22146)

### DIFF
--- a/api/lib/domain/usecases/download-translation-from-phrase.js
+++ b/api/lib/domain/usecases/download-translation-from-phrase.js
@@ -27,14 +27,14 @@ export async function downloadTranslationFromPhrase(phraseApi = { Configuration,
     apiKey: `token ${apiKey}`,
   });
 
-  for (const { phraseProjectId } of configs) {
+  for (const { phraseProjectId, uploadedLocales } of configs) {
     try {
       const localesApi = new phraseApi.LocalesApi(configuration);
 
       const phraseLocales = await localesApi.localesList({ projectId: phraseProjectId });
 
       for (const phraseLocale of phraseLocales) {
-        if (phraseLocale._default) continue;
+        if (uploadedLocales.includes(phraseLocale.name)) continue;
 
         const csvFile = await localesApi.localeDownload({
           projectId: phraseProjectId,

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -39,14 +39,14 @@ export async function uploadTranslationToPhrase(phraseApi = { Configuration, Loc
       const projectLocales = await localesApi.localesList({ projectId: phraseProjectId });
 
       for (const locale of locales) {
-        if (!projectLocales.some(({ code }) => code === locale)) {
+        if (!projectLocales.some(({ name }) => name === locale)) {
           logger.warn({ locale, phraseProjectId }, 'Locale not found for Phrase project');
           continue configsLoop;
         }
       }
 
       const [firstLocale] = locales;
-      const localeId = projectLocales.find(({ code }) => code === firstLocale).id;
+      const localeId = projectLocales.find(({ name }) => name === firstLocale).id;
 
       const stream = new PassThrough();
       await exportTranslations(

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -420,14 +420,17 @@ describe('Acceptance | Controller | phrase-controller', () => {
           {
             id: 'frLocaleId',
             code: 'fr',
+            name: 'fr',
           },
           {
             id: 'frFRLocaleId',
-            code: 'fr-FR',
+            code: 'fr',
+            name: 'fr-FR',
           },
           {
             id: 'nlLocaleId',
             code: 'nl',
+            name: 'nl',
           },
         ]);
 

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -665,13 +665,13 @@ describe('Acceptance | Controller | phrase-controller', () => {
         phraseProjectId: 'MY_AREA_1_PROJECT_ID',
         frameworkId: 'recFmk1',
         areaId: 'recnrCmBiPXGbgIyQ',
-        uploadedLocales: ['fr'],
+        uploadedLocales: ['fr', 'fr-FR'],
       });
       databaseBuilder.factory.buildTranslationsConfig({
         phraseProjectId: 'MY_AREA_2_PROJECT_ID',
         frameworkId: 'recFmk1',
         areaId: 'recDesCodesLaAreaDeux',
-        uploadedLocales: ['fr'],
+        uploadedLocales: ['fr', 'fr-FR'],
       });
 
       await databaseBuilder.commit();
@@ -681,33 +681,35 @@ describe('Acceptance | Controller | phrase-controller', () => {
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
         .reply(200, [
           {
-            id: 'frLocaleId',
+            id: 'frLocaleId1',
             name: 'fr',
             code: 'fr',
-            default: true,
           },
           {
-            id: 'enLocaleId',
+            id: 'frFrLocaleId2',
+            name: 'fr-FR',
+            code: 'fr',
+          },
+          {
+            id: 'enLocaleId1',
             name: 'en',
             code: 'en',
-            default: false,
           },
           {
-            id: 'nlLocaleId',
+            id: 'nlLocaleId1',
             name: 'nl',
             code: 'nl',
-            default: false,
           },
         ]);
 
       const phraseAPIAreaOneDownloadEn = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales/enLocaleId/download')
+        .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales/enLocaleId1/download')
         .query({ file_format: 'csv' })
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
         .reply(200, 'key_name,en,comment', { 'Content-type': 'text/csv' });
 
       const phraseAPIAreaOneDownloadNl = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales/nlLocaleId/download')
+        .get('/v2/projects/MY_AREA_1_PROJECT_ID/locales/nlLocaleId1/download')
         .query({ file_format: 'csv' })
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
         .reply(
@@ -721,33 +723,35 @@ describe('Acceptance | Controller | phrase-controller', () => {
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
         .reply(200, [
           {
-            id: 'frLocaleId',
+            id: 'frLocaleId2',
             name: 'fr',
             code: 'fr',
-            default: true,
           },
           {
-            id: 'enLocaleId',
+            id: 'frFrLocaleId2',
+            name: 'fr-FR',
+            code: 'fr',
+          },
+          {
+            id: 'enLocaleId2',
             name: 'en',
             code: 'en',
-            default: false,
           },
           {
-            id: 'nlLocaleId',
+            id: 'nlLocaleId2',
             name: 'nl',
             code: 'nl',
-            default: false,
           },
         ]);
 
       const phraseAPIAreaTwoDownloadEn = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales/enLocaleId/download')
+        .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales/enLocaleId2/download')
         .query({ file_format: 'csv' })
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
         .reply(200, 'key_name,en,comment', { 'Content-type': 'text/csv' });
 
       const phraseAPIAreaTwoDownloadNl = nock('https://api.phrase.com')
-        .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales/nlLocaleId/download')
+        .get('/v2/projects/MY_AREA_2_PROJECT_ID/locales/nlLocaleId2/download')
         .query({ file_format: 'csv' })
         .matchHeader('authorization', 'token MY_PHRASE_ACCESS_TOKEN')
         .reply(

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -43,7 +43,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
       }),
     ]);
 
-    localesListStub.mockResolvedValueOnce([{ id: 'frLocaleId', code: 'fr' }]);
+    localesListStub.mockResolvedValueOnce([{ id: 'frLocaleId', code: 'fr', name: 'fr' }]);
     uploadCreateStub.mockResolvedValueOnce({ id: 'upload-id' });
 
     exportTranslationsStub.mockImplementationOnce((stream) => stream.end());
@@ -114,8 +114,8 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
     ]);
 
     localesListStub
-      .mockResolvedValueOnce([{ id: 'frLocaleId-1', code: 'fr' }])
-      .mockResolvedValueOnce([{ id: 'frLocaleId-2', code: 'fr' }, { id: 'frFRLocaleId', code: 'fr-FR' }]);
+      .mockResolvedValueOnce([{ id: 'frLocaleId-1', code: 'fr', name: 'fr' }])
+      .mockResolvedValueOnce([{ id: 'frLocaleId-2', code: 'fr', name: 'fr' }, { id: 'frFRLocaleId', code: 'fr', name: 'fr-FR' }]);
 
     uploadCreateStub
       .mockResolvedValueOnce({ id: 'upload-id-1' })


### PR DESCRIPTION
## 🌎 Problème
Jusqu'ici, pour importer et exporter à partir de Phrase, on se basait sur le code de la locale. Or, deux nouvelles locales qu'on va ajouter `en-TZ` et `en-RW` ne sont pas disponibles chez Phrase. Donc, on leur ajoute le code `en`. Il faut donc qu'on se base sur leur `name`

## 🔭 Proposition
Comparer la locale avec le `name` qu'on a donné côté Phrase

## 🪐 Remarques
RAS

## 🚀 Pour tester
Tests au vert ✅ 
