### PR TITLE
[TECH] Ne pas importer les modifications de clef de traducitons source depuis phrase.

### DIFF
--- a/api/lib/application/phrase.js
+++ b/api/lib/application/phrase.js
@@ -128,5 +128,9 @@ async function validatePhraseWebhookRequest(request, h) {
     return h.response().code(400).takeover();
   }
 
+  if (translationConfig.uploadedLocales.includes(request.payload.translation.locale.name)) {
+    return h.response().code(204).takeover();
+  }
+
   return h.response(true);
 }

--- a/api/lib/infrastructure/serializers/phrase/translation-serializer.js
+++ b/api/lib/infrastructure/serializers/phrase/translation-serializer.js
@@ -1,5 +1,5 @@
 import { Translation } from '../../../domain/models/index.js';
 
 export function deserialize(payload) {
-  return new Translation({ key: payload.translation.key.name, locale: payload.translation.locale.code, value: payload.translation.content });
+  return new Translation({ key: payload.translation.key.name, locale: payload.translation.locale.name, value: payload.translation.content });
 }

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -981,6 +981,71 @@ describe('Acceptance | Controller | phrase-controller', () => {
       });
     });
 
+    describe('when locale is an uploadedLocale', () => {
+      it('skips upload', async () => {
+        const payload = {
+          event: 'translations:create',
+          project: { id: 'phraseProject666' },
+          branch: null,
+          translation: {
+            id: 'translationId',
+            content: 'Ne doit pas être enregistré',
+            unverified: false,
+            excluded: false,
+            plural_suffix: '',
+            created_at: '2025-12-22T21:30:39Z',
+            updated_at: '2025-12-22T21:30:39Z',
+            placeholders: [],
+            state: 'translated',
+            linked_translation: null,
+            key: {
+              id: 'keyId',
+              name: 'area.area1.title',
+              plural: false,
+              use_ordinal_rules: false,
+              data_type: 'string',
+              tags: ['tag-1', 'tag-2'],
+              description: '',
+            },
+            locale: {
+              id: 'localeId',
+              name: 'fr',
+              code: 'fr',
+            },
+          },
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+
+        const signature = await generatePhraseAppSignature(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'framework1', name: 'Pix' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'framework1' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+
+        databaseBuilder.factory.buildTranslationsConfig({ phraseProjectId: 'phraseProject666', frameworkId: 'framework1', areaId: 'area1', uploadedLocales: ['fr'] });
+
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/phrase/webhook',
+          payload: serializedPayload,
+          headers: { 'x-phraseapp-signature': signature },
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+        await expect(knex.select('key', 'locale', 'value')
+          .from('translations')
+          .orderBy(['key', 'locale']))
+          .resolves.toStrictEqual([{ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' }]);
+      });
+    });
+
     describe('when event is translations:create', () => {
       it('saves the translation in database', async () => {
         const payload = {


### PR DESCRIPTION
## 🌎 Problème

Nous avons un webhook qui export les modifications des clefs de traductions depuis phrase même si la modification provient d'une langue source.

## 🔭 Proposition

Exclure les modifications provenant de la langue source.

## 🪐 Remarques
RAS

## 🚀 Pour tester
Teste vert