### PR TITLE
[BUGFIX] Pièces jointes sans extension (PIX-22193)

### DIFF
--- a/pix-editor/app/components/form/challenge.gjs
+++ b/pix-editor/app/components/form/challenge.gjs
@@ -509,7 +509,7 @@ export default class ChallengeForm extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type ? file.type : getMimeType(file.name),
+      mimeType: getMimeType(file),
       file,
       type: 'illustration',
     };
@@ -523,7 +523,7 @@ export default class ChallengeForm extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type ? file.type : getMimeType(file.name),
+      mimeType: getMimeType(file),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -177,7 +177,7 @@ export default class LocalizedChallenge extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type ? file.type : getMimeType(file.name),
+      mimeType: getMimeType(file),
       file,
       type: 'illustration',
       alt,
@@ -243,7 +243,7 @@ export default class LocalizedChallenge extends Component {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type ? file.type : getMimeType(file.name),
+      mimeType: getMimeType(file),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -257,7 +257,7 @@ export default class LocalizedController extends Controller {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type ? file.type : getMimeType(file.name),
+      mimeType: getMimeType(file),
       file,
       type: 'illustration',
       alt,
@@ -287,7 +287,7 @@ export default class LocalizedController extends Controller {
     const attachmentData = {
       filename: file.name,
       size: file.size,
-      mimeType: file.type ? file.type : getMimeType(file.name),
+      mimeType: getMimeType(file),
       file,
       type: 'attachment',
     };

--- a/pix-editor/app/helpers/get-mime-type.js
+++ b/pix-editor/app/helpers/get-mime-type.js
@@ -7,6 +7,16 @@ const mime = new Mime(standardTypes, otherTypes, {
   'image/x-xcf': ['xcf'],
 });
 
-export default function getMimeType(pathOrExtension) {
-  return mime.getType(pathOrExtension);
+/**
+ * Determines the file's MIME type according to its name.
+ *
+ * If no MIME type can be determined
+ * application/octet-stream is returned.
+ *
+ * @param {File} file File object to test
+ * @returns {string} MIME type
+ */
+export default function getMimeType(file) {
+  if (file.type) return file.type;
+  return mime.getType(file.name) ?? 'application/octet-stream';
 }


### PR DESCRIPTION
## (ง'̀-'́)ง - Pour tester

Uploader comme pièce jointe un fichier sans extension.

## ¯\\_(ツ)_/¯ - Remarques

N/A

## <(^_^)> - Proposition

Utiliser `application/octet-stream` comme MIME type par défaut.

## (╯°□°)╯︵ ┻━┻ - Problème

On ne peut pas uploader d'attachment sans extension de fichier, car PixEditor n'arrive pas à en déterminer le MIME type.
