### PR TITLE
[BUGFIX] Épreuves en double dans le stream de réplication

### DIFF
--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -36,7 +36,7 @@ export async function* streamForReplication(signal) {
       this.onVal('illustration_alt_translations.model', 'challenge')
         .on('illustration_alt_translations.entityId', 'localized_challenges.challengeId')
         .on('illustration_alt_translations.locale', 'localized_challenges.locale')
-        .on(knex.raw('?? like ?', ['illustration_alt_translations.key', '%.illustrationAlt'])); // FIXME
+        .on(knex.raw('?? like ?', ['illustration_alt_translations.key', '%.illustrationAlt']));
     })
     .orderBy('id')
     .stream();

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -60,12 +60,35 @@ export async function* streamForReplication(signal) {
       'noValidationNeeded',
     ], 'prototypePrimaryLocalizedChallenge'),
   ])
-    .leftOuterJoin('challenges as prototypes', function() {
+    .with(
+      'prototypes',
+      knex.select('*')
+        .from(
+          knex.select(
+            'id',
+            'skillId',
+            'version',
+            'accessibility1',
+            'accessibility2',
+            knex.raw('ROW_NUMBER() OVER (PARTITION BY ??, ?? ORDER BY ??) AS ??', [
+              'skillId',
+              'version',
+              'id',
+              'rank',
+            ]),
+          )
+            .from('challenges')
+            .where('genealogy', Challenge.GENEALOGIES.PROTOTYPE)
+            .whereNotNull('skillId')
+            .whereNotNull('version'),
+        )
+        .where('rank', 1),
+    )
+    .leftOuterJoin('prototypes', function() {
       this.onVal('tubes.name', '<>', Tube.WORKBENCH_NAME)
         .onVal('challenges.genealogy', '<>', Challenge.GENEALOGIES.PROTOTYPE)
         .on('prototypes.skillId', 'challenges.skillId')
-        .on('prototypes.version', 'challenges.version')
-        .onVal('prototypes.genealogy', Challenge.GENEALOGIES.PROTOTYPE);
+        .on('prototypes.version', 'challenges.version');
     })
     .leftOuterJoin('localized_challenges as prototypes_primary', 'prototypes_primary.id', 'prototypes.id')
     .orderBy('challenges.id')


### PR DESCRIPTION
## 🌱 Problème

Les doublons viennent de prototypes en double sur le même acquis même version.

## 🐣 Proposition

Prendre le premier prototype qu’on trouve.

## 🌷 Remarques

N/A

## 🐝 Pour tester

Faire un curl sur le endpoint :

```
curl -H 'authorization: Bearer xxx' https://pix-lcms-review-pr1442.osc-fr1.scalingo.io/api/replication-stream
```

