### PR TITLE
[FEATURE] Ajout d'une liste pour copier les URL des preview (PIX-22192)

### DIFF
--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view-header.gjs
@@ -6,6 +6,7 @@ import PixTooltip from '@1024pix/pix-ui/components/pix-tooltip';
 import { concat } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import flagForLanguage from 'pixeditor/helpers/flag-for-language';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
@@ -35,6 +36,11 @@ export default class LocalizedChallengeViewHeader extends Component {
   @action
   async copyLocalizedChallengePreviewUrl() {
     await navigator.clipboard.writeText(this.args.challengeLocale.localizedPreviewUrl);
+  }
+
+  @action
+  async copyChallengePreviewUrl() {
+    await navigator.clipboard.writeText(this.args.challengeLocale.challenge.previewUrl);
   }
 
   get localizedChallenge() {
@@ -123,13 +129,30 @@ export default class LocalizedChallengeViewHeader extends Component {
             <:tooltip>Afficher la liste des previews
               <span class="sr-only">{{@challengeLocale.challenge.id}}</span></:tooltip>
           </PixTooltip>
-          <PixTooltip @id="copy-url-challenge-tooltip" @position="top" @isInline={{true}} @isLight={{true}}>
+          <PixTooltip
+            @id="copy-url-challenge-tooltip"
+            @position="top"
+            @isInline={{true}}
+            @isLight={{true}}
+            class="preview-menu"
+          >
             <:triggerElement>
-              <PixIconButton
-                aria-labelledby="copy-url-challenge-tooltip"
-                @iconName="copy"
-                @triggerAction={{this.copyLocalizedChallengePreviewUrl}}
-              />
+              <DropdownMenu @ariaLabel="Ouvrir la liste des liens de prévisualisations d'épreuves" @iconName="copy">
+                <ul>
+                  <li class="preview-menu__item">
+                    <button type="button" {{on "click" this.copyLocalizedChallengePreviewUrl}}>
+                      <PixIcon @name="copy" alt="" />
+                      Copier le lien de l'épreuve traduite
+                    </button>
+                  </li>
+                  <li class="preview-menu__item">
+                    <button type="button" {{on "click" this.copyChallengePreviewUrl}}>
+                      <PixIcon @name="copy" alt="" />
+                      Copier le lien de l'épreuve source
+                    </button>
+                  </li>
+                </ul>
+              </DropdownMenu>
             </:triggerElement>
             <:tooltip>Copier le lien de l'épreuve <span class="sr-only">{{this.localizedChallenge.id}}</span></:tooltip>
           </PixTooltip>

--- a/pix-editor/app/styles/components/challenge-view-header.scss
+++ b/pix-editor/app/styles/components/challenge-view-header.scss
@@ -27,6 +27,8 @@
         padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
         border-radius: var(--pix-spacing-2x);
         white-space: nowrap;
+        font-size: 1rem;
+        font-weight: 400;
 
         &:hover {
           color: var(--pix-neutral-800);

--- a/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
+++ b/pix-editor/tests/integration/components/localized-challenge-view/localized-challenge-view-test.gjs
@@ -292,13 +292,12 @@ module('Integration | Component | localized-challenge-view | localized-challenge
 
     test('it should display action buttons', async function (assert) {
       // given
-      const clipboardStub = sinon.stub().resolves();
+      const clipboardStub = sinon.spy();
 
       Object.defineProperty(navigator, 'clipboard', {
         writable: true,
         value: { writeText: clipboardStub },
       });
-      clipboardStub.withArgs('http://localhost:4300/previewURL?locale=en');
 
       // when
       screen = await render(
@@ -314,7 +313,6 @@ module('Integration | Component | localized-challenge-view | localized-challenge
         </template>,
       );
 
-      await click(screen.getByRole('button', { name: "Copier le lien de l'épreuve" }));
       await click(screen.getByRole('button', { name: "Ouvrir la liste des prévisualisations de l'épreuve" }));
 
       // then
@@ -331,10 +329,14 @@ module('Integration | Component | localized-challenge-view | localized-challenge
           .endsWith('/previewURL?locale=en'),
         'href ends with /previewURL?locale=en',
       );
-      assert
-        .dom(screen.getByRole('link', { name: "traduction de l'épreuve de version Proto" }))
-        .hasAttribute('href', '/api/challenges/challengeProtoValidee/translations/en');
-      assert.ok(clipboardStub.calledOnce);
+
+      await click(screen.getByRole('button', { name: "Ouvrir la liste des liens de prévisualisations d'épreuves" }));
+      await click(screen.getByRole('button', { name: "Copier le lien de l'épreuve traduite" }));
+      assert.ok(clipboardStub.lastCall.firstArg.endsWith('/previewURL?locale=en'));
+
+      await click(screen.getByRole('button', { name: "Ouvrir la liste des liens de prévisualisations d'épreuves" }));
+      await click(screen.getByRole('button', { name: "Copier le lien de l'épreuve source" }));
+      assert.ok(clipboardStub.lastCall.firstArg.endsWith('/previewURL'));
     });
 
     test('it should display readonly form', async function (assert) {


### PR DESCRIPTION
## 🌱 Problème

Il manque une liste contenant les liens de preview à copier lorsque l'on est sur un localizedChallenge.

## 🐣 Proposition

Faire une liste similaire aux liens de redirection juste à coté.


## 🌷 Remarques

ras

## 🐝 Pour tester
Se placer sur un localized challenge et cliquer sur le petit oeil. Et vérifier qu'au click il y a le bon lien de copié
=> [ici](https://pix-lcms-review-pr1444.osc-fr1.scalingo.io/v2/competences/competenceF0A0C0/challenges-production/skills/skillF0A0C0Th1Tu0S0Act/localized-challenges/challengeF0A0C0Th1Tu0S0ActCh3-en?locale=en)