### PR TITLE
[FEATURE]  Transformer les select de langue et de référentiel en select avec recherche (PIX-22244).

### DIFF
--- a/pix-editor/app/components/competence/competence-header.gjs
+++ b/pix-editor/app/components/competence/competence-header.gjs
@@ -1,7 +1,9 @@
 import PixSelect from '@1024pix/pix-ui/components/pix-select';
 import { LinkTo } from '@ember/routing';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 export default class CompetenceHeader extends Component {
   @service config;
@@ -76,6 +78,8 @@ export default class CompetenceHeader extends Component {
     },
   ];
 
+  @tracked languageOptionsResult = this.languageOptions;
+
   get liteClass() {
     return this.config.lite ? ' lite ' : '';
   }
@@ -97,6 +101,17 @@ export default class CompetenceHeader extends Component {
     return this.args.section === 'challenges' && this.args.view === 'production';
   }
 
+  @action
+  updateLanguageOptions(filter) {
+    if (!filter.trim()) {
+      this.languageOptionsResult = this.languageOptions;
+      return;
+    }
+    this.languageOptionsResult = this.languageOptions.filter(({ label }) =>
+      label.toLowerCase().includes(filter.trim().toLowerCase()),
+    );
+  }
+
   <template>
     <section class="ui main-title{{this.liteClass}}">
       <h1 class="ui left floated header">
@@ -111,9 +126,13 @@ export default class CompetenceHeader extends Component {
           <PixSelect
             @className="competence-header__language-filter"
             @onChange={{@selectLanguageToFilter}}
-            @options={{this.languageOptions}}
+            @options={{this.languageOptionsResult}}
             @value={{this.selectedLanguageToFilter}}
             @placeholder="Filtre par langue"
+            @isSearchable={{true}}
+            @onSearch={{this.updateLanguageOptions}}
+            @searchPlaceholder="Rechercher une langue"
+            @emptySearchMessage="Aucune langue correspondante"
           >
             <:default as |languageOption|>
               {{languageOption.label}}

--- a/pix-editor/app/components/sidebar/navigation.gjs
+++ b/pix-editor/app/components/sidebar/navigation.gjs
@@ -23,6 +23,7 @@ export default class SidebarNavigationComponent extends Component {
 
   @tracked newFramework;
   @tracked displayNewFrameworkPopIn;
+  @tracked frameworkOptionsResult = this.frameworkOptionList;
 
   get areas() {
     return this.currentData.getAreas();
@@ -103,17 +104,40 @@ export default class SidebarNavigationComponent extends Component {
     }
   }
 
+  @action
+  updateFrameworkOptionsResult(filter) {
+    if (!filter.trim()) {
+      this.frameworkOptionsResult = this.frameworkOptionList;
+      return;
+    }
+    this.frameworkOptionsResult = this.frameworkOptionList.filter(({ label }) =>
+      this.removeDiacritic(label).includes(this.removeDiacritic(filter)),
+    );
+  }
+
+  removeDiacritic(str) {
+    return str
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim();
+  }
+
   <template>
     {{#if @displayFrameworkList}}
       <PixSelect
         @id="select-framework"
         @value={{this.selectedFrameworkId}}
-        @options={{this.frameworkOptionList}}
+        @options={{this.frameworkOptionsResult}}
         @onChange={{this.setFramework}}
         @placeholder="Sélectionner un référentiel"
         @placement="bottom"
         class="select-framework"
         @hideDefaultOption={{true}}
+        @isSearchable={{true}}
+        @onSearch={{this.updateFrameworkOptionsResult}}
+        @searchPlaceholder="Rechercher un référentiel"
+        @emptySearchMessage="Aucun référentiel correspondant"
       >
         <:label>
           <span class="sr-only">Sélectionner un référentiel</span>

--- a/pix-editor/app/components/v2/competence-header.gjs
+++ b/pix-editor/app/components/v2/competence-header.gjs
@@ -3,7 +3,8 @@ import { action } from '@ember/object';
 import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-import LocaleTag from './v2/locale-tag';
+import { tracked } from '@glimmer/tracking';
+import LocaleTag from './locale-tag';
 
 export default class CompetenceHeader extends Component {
   @service router;
@@ -75,6 +76,7 @@ export default class CompetenceHeader extends Component {
       value: 'quality',
     },
   ];
+  @tracked localeOptionsResult = this.localeOptions;
 
   get localeValue() {
     if (!this.args.locale) return 'source';
@@ -93,6 +95,17 @@ export default class CompetenceHeader extends Component {
   setLocale(locale) {
     if (locale === 'source') locale = undefined;
     this.router.transitionTo({ queryParams: { locale } });
+  }
+
+  @action
+  updateLocaleOptions(filter) {
+    if (!filter.trim()) {
+      this.localeOptionsResult = this.localeOptions;
+      return;
+    }
+    this.localeOptionsResult = this.localeOptions.filter(({ label }) =>
+      label.toLowerCase().includes(filter.trim().toLowerCase()),
+    );
   }
 
   @action
@@ -123,11 +136,15 @@ export default class CompetenceHeader extends Component {
       </h2>
       <div class="competence-header__spacer"></div>
       <PixSelect
-        @options={{this.localeOptions}}
+        @options={{this.localeOptionsResult}}
         @value={{this.localeValue}}
         @onChange={{this.setLocale}}
         @hideDefaultOption={{true}}
         @screenReaderOnly={{true}}
+        @isSearchable={{true}}
+        @onSearch={{this.updateLocaleOptions}}
+        @searchPlaceholder="Rechercher une locale"
+        @emptySearchMessage="Aucune locale correspondante"
       >
         <:label>Choix de la langue</:label>
       </PixSelect>

--- a/pix-editor/app/templates/authenticated/v2.gjs
+++ b/pix-editor/app/templates/authenticated/v2.gjs
@@ -1,4 +1,4 @@
-import CompetenceHeader from 'pixeditor/components/competence-header';
+import CompetenceHeader from 'pixeditor/components/v2/competence-header';
 <template>
   <CompetenceHeader @competence={{@controller.model.competence}} @locale={{@controller.model.locale}} />
   {{outlet}}

--- a/pix-editor/tests/integration/components/competence/competence-header-test.gjs
+++ b/pix-editor/tests/integration/components/competence/competence-header-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import CompetenceHeader from 'pixeditor/components/competence-header';
+import CompetenceHeader from 'pixeditor/components/competence/competence-header';
 import { module, test } from 'qunit';
 
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
@@ -20,7 +20,6 @@ module('Integration | Component | competence/competence-header', function (hooks
   test('renders the language and the challenges menu', async function (assert) {
     // given
     const mockFn = () => {};
-
     //  when
     screen = await render(
       <template>
@@ -37,8 +36,8 @@ module('Integration | Component | competence/competence-header', function (hooks
 
     //  then
 
-    assert.dom('h2').hasText('HACHE10 Lancer de hache');
-    assert.dom(screen.getByRole('button', { name: 'Choix de la langue' })).exists();
+    assert.dom('h1').hasText('HACHE10 Lancer de hache');
+    assert.dom(screen.getByRole('button', { name: 'Filtre par langue' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Epreuves' })).exists();
   });
 });

--- a/pix-editor/tests/integration/components/competence/competence-header-test.gjs
+++ b/pix-editor/tests/integration/components/competence/competence-header-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, fillByLabel, within } from '@1024pix/ember-testing-library';
 import CompetenceHeader from 'pixeditor/components/competence/competence-header';
 import { module, test } from 'qunit';
 
@@ -39,5 +39,35 @@ module('Integration | Component | competence/competence-header', function (hooks
     assert.dom('h1').hasText('HACHE10 Lancer de hache');
     assert.dom(screen.getByRole('button', { name: 'Filtre par langue' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Epreuves' })).exists();
+  });
+
+  test('should filter locales options', async function (assert) {
+    // given
+    const mockFn = () => {};
+
+    //  when
+    screen = await render(
+      <template>
+        <CompetenceHeader
+          @competence={{competence}}
+          @section="challenges"
+          @languageFilter={{undefined}}
+          @selectLanguageToFilter={{mockFn}}
+          @view="production"
+          @selectSection={{mockFn}}
+        />
+      </template>,
+    );
+    await screen.getByRole('button', { name: 'Filtre par langue' }).click();
+
+    await fillByLabel('Rechercher', 'ouganda');
+    const listOptions = await screen.findByRole('listbox');
+
+    const filteredOptions = within(listOptions).queryAllByRole('option');
+
+    //  then
+    assert.strictEqual(filteredOptions.length, 2);
+    assert.strictEqual(filteredOptions[0].innerText, 'Filtre par langue');
+    assert.strictEqual(filteredOptions[1].innerText, 'Anglais (Ouganda)');
   });
 });

--- a/pix-editor/tests/integration/components/sidebar/navigation-test.gjs
+++ b/pix-editor/tests/integration/components/sidebar/navigation-test.gjs
@@ -1,4 +1,4 @@
-import { clickByName, render } from '@1024pix/ember-testing-library';
+import { clickByName, fillByLabel, render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
 import SidebarNavigation from 'pixeditor/components/sidebar/navigation';
@@ -105,6 +105,26 @@ module('Integration | Component | sidebar/navigation', function (hooks) {
       frameworksList.forEach((framework) => {
         assert.ok(expectedFrameworks.includes(framework.textContent.trim()));
       });
+    });
+
+    test('it should filter framework list', async function (assert) {
+      //  when
+      const screen = await render(
+        <template>
+          <SidebarNavigation @displayFrameworkList={{displayFrameworkList}} @close={{closeAction}} />
+        </template>,
+      );
+
+      await screen.getByRole('button', { name: 'Sélectionner un référentiel' }).click();
+
+      await fillByLabel('Rechercher', '+');
+      const listOptions = await screen.findByRole('listbox');
+
+      const filteredOptions = within(listOptions).queryAllByRole('option');
+
+      //  then
+      assert.strictEqual(filteredOptions.length, 1);
+      assert.strictEqual(filteredOptions[0].innerText, 'Pix +');
     });
 
     test('it should display only a list of areas', async function (assert) {

--- a/pix-editor/tests/integration/components/v2/competence-header-test.gjs
+++ b/pix-editor/tests/integration/components/v2/competence-header-test.gjs
@@ -1,0 +1,45 @@
+import { render, fillByLabel, within } from '@1024pix/ember-testing-library';
+import CompetenceHeader from 'pixeditor/components/v2/competence-header';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | v2/competence-header', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let screen, store, competence;
+
+  hooks.beforeEach(async function () {
+    store = this.owner.lookup('service:store');
+    competence = store.createRecord('competence', {
+      title: 'Lancer de hache',
+      description: 'Wzzziiii',
+      code: 'HACHE10',
+    });
+  });
+
+  test('renders the language and the challenges menu', async function (assert) {
+    //  when
+    screen = await render(<template><CompetenceHeader @competence={{competence}} /></template>);
+
+    //  then
+
+    assert.dom('h2').hasText('HACHE10 Lancer de hache');
+    assert.dom(screen.getByRole('button', { name: 'Choix de la langue' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Epreuves' })).exists();
+  });
+
+  test('should filter locales options', async function (assert) {
+    //  when
+    screen = await render(<template><CompetenceHeader @competence={{competence}} /></template>);
+    await screen.getByRole('button', { name: 'Choix de la langue' }).click();
+
+    await fillByLabel('Rechercher', 'ouganda');
+    const listOptions = await screen.findByRole('listbox');
+
+    const filteredOptions = within(listOptions).queryAllByRole('option');
+
+    //  then
+    assert.strictEqual(filteredOptions.length, 1);
+    assert.strictEqual(filteredOptions[0].innerText, 'Anglais (Ouganda)');
+  });
+});


### PR DESCRIPTION
## 🌱 Problème
Nos selecteur de langue et de référentiel possèdent beaucoup d'option ce qui rend laborieux leur recherche.

## 🐣 Proposition

Ajouter une fonction de filtre dans les sélecteurs.

## 🌷 Remarques
RAS

## 🐝 Pour tester

sur la sidebar:
- faire une recherche de référentiel en la filtrant

dans le header d'une compétence en v1 et v2
- faire une recherche de locale en la filtrant 
