### PR TITLE
[FEATURE] Add github action to upload SBOMs to Dependency-Track

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,71 @@
+name: "Security Checks"
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  upload_sboms:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Cyclone DX
+        run: npm install @cyclonedx/cyclonedx-npm@4.2.0
+
+      - name: Pix Editor Monorepo - Create SBOM
+        run: npm ci && npx @cyclonedx/cyclonedx-npm --output-file pix-editor-repo-sbom.json package.json && [ -e "pix-editor-repo-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Editor Monorepo - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          # change these variables for each project
+          projectName: Pix Editor Monorepo
+          projectVersion: dev
+          bomFilename: "pix-editor-repo-sbom.json"
+          autoCreate: true
+
+      - name: Pix Editor front - Create SBOM
+        run: npm ci --prefix pix-editor/ && npx @cyclonedx/cyclonedx-npm --output-file pix-editor-front-sbom.json pix-editor/package.json && [ -e "pix-editor-front-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Editor front - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          # change these variables for each project
+          projectName: Pix Editor front
+          projectVersion: dev
+          bomFilename: "pix-editor-front-sbom.json"
+          autoCreate: true
+
+      - name: Pix Editor API - Create SBOM
+        run: npm ci --prefix api/ && npx @cyclonedx/cyclonedx-npm --output-file pix-editor-api-sbom.json api/package.json && [ -e "pix-editor-api-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Editor API - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          # change these variables for each project
+          projectName: Pix Editor API
+          projectVersion: dev
+          bomFilename: "pix-editor-api-sbom.json"
+          autoCreate: true
+
+      - name: Pix Editor Challenge-Parser - Create SBOM
+        run: npm ci --prefix api/ && npx @cyclonedx/cyclonedx-npm --output-file pix-editor-challengeparser-sbom.json api/package.json && [ -e "pix-editor-challengeparser-sbom.json" ] && echo '[+] SBOM created' || echo '[!] Fail to create SBOM'
+
+      - name: Pix Editor Challenge-Parser - Upload BOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@48feab3080ff9e8f51f4d21861d9fc914eb744f5
+        with:
+          serverHostname: ${{ secrets.DEPENDENCYTRACK_HOSTNAME }}
+          apiKey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
+          # change these variables for each project
+          projectName: Pix Editor Challenge-Parser
+          projectVersion: dev
+          bomFilename: "pix-editor-challengeparser-sbom.json"
+          autoCreate: true


### PR DESCRIPTION
## 🌱 Problème

On aimerait avoir un alerting efficace sur les dépendances de l'application et les versions utilisées.

## 🐣 Proposition

* Ajout d'une Github Action qui se lance au merge sur `dev`.
* Elle crée des SBOMs (Software Bill of Material = inventaire des dépendances directes et indirectes) pour chaque dossier (le repo, l'API et le front)

## 🌷 Remarques

* L'action est lancée dans un runner Github standard, il y a un impact à surveiller si le repo devient privé
* la librairie `@cyclonedx/cyclonedx-npm` est installée pour générer les SBOMs
* Pas de création de SBOM pour challenge-parser pour cibler les parties les plus critiques

> L'action fail actuellement à cause de soucis de sync du package-lock.json

## 🐝 Pour tester

* Test des GH actions [sur ce fork](https://github.com/romain-pix-cyber/pix-editor/actions/workflows/security.yml)
* en local : 
    * récupérer la clé d'API dans lockself
    * `act push --defaultbranch dev -s DEPENDENCYTRACK_HOSTNAME=XXXXX -s DEPENDENCYTRACK_APIKEY=XXXXXXXXX`