### PR TITLE
[FEATURE] Script de migration des modules (PIX-22258)

### DIFF
--- a/api/lib/domain/models/Module.js
+++ b/api/lib/domain/models/Module.js
@@ -1,0 +1,27 @@
+export class Module {
+  constructor({
+    id,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    details,
+    sections,
+    glossary,
+    createdAt,
+    updatedAt,
+  } = {}) {
+    this.id = id;
+    this.shortId = shortId;
+    this.slug = slug;
+    this.title = title;
+    this.isBeta = isBeta;
+    this.visibility = visibility;
+    this.details = details;
+    this.sections = sections;
+    this.glossary = glossary;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -7,6 +7,7 @@ export * from './Framework.js';
 export * from './LocalizedChallenge.js';
 export * from './LocalizedFrameworkTubes.js';
 export * from './Mission.js';
+export * from './Module.js';
 export * from './Note.js';
 export * from './Skill.js';
 export * from './StaticCourse.js';

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -9,6 +9,7 @@ export * as frameworkRepository from './framework-repository.js';
 export * as localizedChallengeRepository from './localized-challenge-repository.js';
 export * as localizedFrameworksTubesRepository from './localized-framework-tubes-repository.js';
 export * as missionRepository from './mission-repository.js';
+export * as moduleRepository from './module-repository.js';
 export * as releaseRepository from './release-repository.js';
 export * as skillRepository from './skill-repository.js';
 export * as staticCourseRepository from './static-course-repository.js';

--- a/api/lib/infrastructure/repositories/module-repository.js
+++ b/api/lib/infrastructure/repositories/module-repository.js
@@ -1,0 +1,12 @@
+import { knex } from '../../../db/knex-database-connection.js';
+
+export async function save({ details, sections, glossary, ...module }, transaction = knex) {
+  const moduleDTO = {
+    ...module,
+    ...details,
+    sections: JSON.stringify(sections),
+    glossary: JSON.stringify(glossary),
+  };
+
+  await transaction.insert(moduleDTO).into('modules').onConflict('id').merge({ ...moduleDTO, updatedAt: transaction.fn.now() });
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -19,6 +19,7 @@
         "@hapi/hapi": "^21.3.0",
         "@hapi/inert": "^7.0.0",
         "@hapi/vision": "^7.0.0",
+        "@octokit/rest": "^22.0.1",
         "adminjs": "7.8.17",
         "axios": "1.13.6",
         "axios-cookiejar-support": "^6.0.0",
@@ -3299,6 +3300,161 @@
         "eslint-scope": "5.1.1"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
@@ -5199,6 +5355,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -6408,6 +6570,22 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -7547,6 +7725,12 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -10812,6 +10996,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "@hapi/hapi": "^21.3.0",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",
+    "@octokit/rest": "^22.0.1",
     "adminjs": "7.8.17",
     "axios": "1.13.6",
     "axios-cookiejar-support": "^6.0.0",

--- a/api/scripts/migrate-modules.js
+++ b/api/scripts/migrate-modules.js
@@ -1,0 +1,98 @@
+import { Octokit } from '@octokit/rest';
+
+import { Module } from '../lib/domain/models/index.js';
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+import { moduleRepository } from '../lib/infrastructure/repositories/index.js';
+import { knex } from '../db/knex-database-connection.js';
+
+const owner = '1024pix';
+const repo = 'pix';
+const ref = 'dev';
+const modulesDirectory = 'api/src/devcomp/infrastructure/datasources/learning-content/modules/';
+
+export class MigrateModules extends Script {
+  constructor() {
+    super({
+      description: 'Script de migration des modules',
+      permanent: false,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not perform any deletion.',
+          demandOption: true,
+          default: true,
+        },
+        accessToken: {
+          type: 'string',
+          describe: 'Github access token',
+          demandOption: true,
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }, { octokit = new Octokit({ auth: options.accessToken }) } = {}) {
+    logger.info({ dryRun: options.dryRun }, 'Script options');
+
+    const moduleFiles = await getDirectory(octokit, ref, modulesDirectory, { logger });
+
+    logger.info(`🔍  Found ${moduleFiles.length} modules to be stored`);
+
+    await knex.transaction(async (transaction) => {
+      for (const { path } of moduleFiles) {
+        const { content } = await getFile(octokit, ref, path, { logger });
+
+        const module = new Module(JSON.parse(content));
+        logger.info({ id: module.id, title: module.title }, 'Saving module');
+        await moduleRepository.save(module, transaction);
+      }
+
+      if (options.dryRun) {
+        await transaction.rollback();
+      }
+    });
+  }
+}
+
+async function getFile(octokit, ref, path, { encoding = 'utf8', logger } = {}) {
+  const data = await getContent(octokit, ref, path, { logger });
+
+  if (data.type !== 'file') {
+    logger.error({ path, ref }, 'given path is not a file');
+    throw new Error('error while fetching content from repository');
+  }
+
+  const content = Buffer.from(data.content, data.encoding);
+
+  return { content: content.toString(encoding) };
+}
+
+async function getDirectory(octokit, ref, path, { logger } = {}) {
+  const data = await getContent(octokit, ref, path, { logger });
+
+  if (!Array.isArray(data)) {
+    logger.error({ path, ref }, 'given path is not a directory');
+    throw new Error('error while fetching content from repository');
+  }
+
+  return data;
+}
+
+async function getContent(octokit, ref, path, { logger } = {}) {
+  try {
+    const { data } = await octokit.repos.getContent({
+      owner,
+      repo,
+      ref,
+      path,
+    });
+
+    return data;
+  } catch (err) {
+    logger.error({ err }, 'error while fetching content');
+    throw new Error('error while fetching content from repository');
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, MigrateModules);

--- a/api/tests/integration/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-repository_test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { save } from '../../../../lib/infrastructure/repositories/module-repository.js';
+
+describe('Module Repository', () => {
+  describe('save', () => {
+    it('saves a module', async () => {
+      // given
+      const module = domainBuilder.buildModule();
+
+      // when
+      await save(module);
+
+      // then
+      const { details, ...moduleData } = module;
+      await expect(knex.select().from('modules')).resolves.toStrictEqual([{ ...details, ...moduleData }]);
+    });
+
+    it('updates a module', async () => {
+      // given
+      const module = domainBuilder.buildModule();
+      databaseBuilder.factory.buildModule(module);
+      await databaseBuilder.commit();
+
+      const moduleWithUpdate = domainBuilder.buildModule({
+        id: module.id,
+        shortId: module.shortId,
+        title: 'apprendre à être mou ou molle',
+        details: { ...module.details, description: "<p>Ce module est dédié aux escargots, mâle et femelle</p><p>Il contient normalement l'intégralité de leurs secrets disponibles à date (août 2025).</p>" },
+      });
+
+      // when
+      await save(moduleWithUpdate);
+
+      // then
+      const { details, ...moduleData } = moduleWithUpdate;
+      await expect(knex.select().from('modules')).resolves.toStrictEqual([{ ...details, ...moduleData, updatedAt: expect.any(Date) }]);
+    });
+  });
+});

--- a/api/tests/scripts/migrate-modules_test.js
+++ b/api/tests/scripts/migrate-modules_test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { domainBuilder, knex } from '../test-helper.js';
+import { MigrateModules } from '../../scripts/migrate-modules.js';
+import { logger } from '../../lib/infrastructure/logger.js';
+
+describe('Script | MigrateModules', () => {
+  /** @type {MigrateModules} */
+  let script;
+  let octokit;
+  let modules;
+
+  beforeEach(() => {
+    script = new MigrateModules();
+
+    const pixModuleFiles = [
+      { path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/dernier-module.json' },
+      { path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/deuxieme-module.json' },
+      { path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/premier-module.json' },
+      { path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/troisieme-module.json' },
+    ];
+
+    octokit = { repos: { getContent: vi.fn() } };
+
+    octokit.repos.getContent.mockResolvedValueOnce({ data: pixModuleFiles });
+
+    modules = [
+      domainBuilder.buildModule({ shortId: 'derniera', title: 'dernier module' }),
+      domainBuilder.buildModule({ shortId: 'deuxieme', title: 'deuxieme module' }),
+      domainBuilder.buildModule({ shortId: 'premiera', title: 'premier module' }),
+      domainBuilder.buildModule({ shortId: 'troisiem', title: 'troisieme module' }),
+    ];
+
+    modules.forEach((module) => {
+      octokit.repos.getContent.mockResolvedValueOnce({ data: { type: 'file', encoding: 'utf8', content: JSON.stringify(module) } });
+    });
+  });
+
+  describe('#handle', () => {
+    it('fetches and inserts modules from Pix repository', async () => {
+      // given
+      const options = { dryRun: false };
+
+      // when
+      await script.handle({ options, logger }, { octokit });
+
+      // then
+      await expect(knex.select('id', 'shortId', 'title').from('modules').orderBy('shortId')).resolves.toStrictEqual(modules.map((module) => ({
+        id: module.id,
+        shortId: module.shortId,
+        title: module.title,
+      })));
+
+      expect(octokit.repos.getContent).toHaveBeenCalledTimes(5);
+
+      expect(octokit.repos.getContent).toHaveBeenNthCalledWith(1, { owner: '1024pix', repo: 'pix', ref: 'dev', path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/' });
+
+      expect(octokit.repos.getContent).toHaveBeenNthCalledWith(2, { owner: '1024pix', repo: 'pix', ref: 'dev', path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/dernier-module.json' });
+      expect(octokit.repos.getContent).toHaveBeenNthCalledWith(3, { owner: '1024pix', repo: 'pix', ref: 'dev', path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/deuxieme-module.json' });
+      expect(octokit.repos.getContent).toHaveBeenNthCalledWith(4, { owner: '1024pix', repo: 'pix', ref: 'dev', path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/premier-module.json' });
+      expect(octokit.repos.getContent).toHaveBeenNthCalledWith(5, { owner: '1024pix', repo: 'pix', ref: 'dev', path: 'api/src/devcomp/infrastructure/datasources/learning-content/modules/troisieme-module.json' });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-module.js
+++ b/api/tests/tooling/domain-builder/factory/build-module.js
@@ -1,0 +1,66 @@
+import { Module } from '../../../../lib/domain/models/index.js';
+
+const defaultSections = [
+  {
+    id: 'cfaefec9-e185-43b8-8258-e8beff6dd56b',
+    type: 'question-yourself',
+    grains: [
+      {
+        id: '9de10c46-df0e-41f5-a709-81637f0d5cc3',
+        type: 'challenge',
+        title: 'Element text avec tags',
+        components: [
+          {
+            type: 'element',
+            element: {
+              id: 'd5e369ec-2a5e-4692-ac46-5be5a49f2acd',
+              type: 'text',
+              tag: 'context',
+              content: "<p>Ceci&nbsp;est un contenu pour les amateurs de coquille d'escargots.</p>",
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export function buildModule({
+  id = crypto.randomUUID(),
+  shortId = 'escargou',
+  slug = 'petit-escargot-pignouf',
+  title = 'apprendre à être mou',
+  isBeta = false,
+  visibility = 'public',
+  details = {
+    image: 'https://assets.pix.org/draft/escargots.jpg',
+    description: "<p>Ce module est dédié aux escargots</p><p>Il contient normalement l'intégralité de leurs secrets disponibles à date.</p>",
+    duration: 7,
+    level: 'novice',
+    objectives: ['Connaître les petits secrets des gastéropodes'],
+    tabletSupport: 'inconvenient',
+  },
+  sections = defaultSections,
+  glossary = [
+    {
+      word: 'coquille',
+      description: 'Une coquille est un agglomérat de calcaire très résistant. Sa structure cristalline spécifique lui confère une résistance protectrice. Elle prodique à l\'escargot toute sa force et sa vitalité.',
+    },
+  ],
+  createdAt = new Date(),
+  updatedAt = new Date(),
+} = {}) {
+  return new Module({
+    id,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    details,
+    sections,
+    glossary,
+    createdAt,
+    updatedAt,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -15,6 +15,7 @@ export * from './build-framework-for-release.js';
 export * from './build-localized-challenge.js';
 export * from './build-mission.js';
 export * from './build-mission-summary.js';
+export * from './build-module.js';
 export * from './build-release.js';
 export * from './build-skill.js';
 export * from './build-skill-for-release.js';


### PR DESCRIPTION
## 🌱 Problème

On souhaite migrer les modules depuis le dépôt github de pix vers la table `modules` de PixEditor.

## 🐣 Proposition

Créer un script de migration qui télécharge les modules depuis le dépôt github de pix et les insert dans la table `module` de PixEditor.

## 🌷 Remarques

Le script nécessite un access token github avec les droits d’accès en lecture sur le dépôt pix.

## 🐝 Pour tester

Lancer le script :

```
cd api
node scripts/migrate-modules.js --dryRun false --accessToken github_pat_xxx
```

Vérifier que les modules sont bien présents dans la table `modules`.
