### PR TITLE
[TECH] Amélioration de la DX avec jsconfig (PIX-22527)

### DIFF
--- a/api/jsconfig.json
+++ b/api/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "checkJs": false,
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "disableSizeLimit": true,
+    "maxNodeModuleJsDepth": 0
+  },
+  "include": ["**/*.js", "**/*.mjs", "**/*.cjs"],
+  "exclude": ["node_modules", "dist", "tmp", "build", ".adminjs", "*.json"]
+}

--- a/pix-editor/jsconfig.json
+++ b/pix-editor/jsconfig.json
@@ -1,1 +1,18 @@
-{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "checkJs": false,
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "pix-editor/*": ["./app/*", "./*"]
+    }
+  },
+  "include": ["app/**/*.js", "app/**/*.gjs", "tests/**/*.js", "config/**/*.js", "mirage/**/*.js"],
+  "exclude": ["node_modules", "bower_components", "tmp", "vendor", ".git", "dist"]
+}


### PR DESCRIPTION
## 🌱 Problème
Sur de nombreux IDE (VSCode, Zed...), parfois voire même souvent, on perd l'auto-completion, les imports automatiques, les "go to definition"...

## 🐣 Proposition

- [x]  Améliorer le fichier de jsconfig côté front. 
- [x] Créer un fichier de jsconfig côté back.

## 🌷 Remarques

RAS

## 🐝 Pour tester

1. Récupérer la branche
2. Relancer votre IDE
3. Ouvrez un fichier JS
  - Attendez que le LSP soit initialisé (il s'initialise à l'ouverture d'un premier fichier js)
4. Tester l'autocompletion <kbd>ctrl+space</kbd>

**Pour info:** L'autocompletion dans les fichiers `gjs` ne se sont pas réalisés via les LSP ts/js mais par des LSP ember à installer via des extensions/plugins dédiés. Donc ce n'est pas lié à la configuration des `jsconfig.json`