### PR TITLE
[FEATURE] Ajout endpoint de liste des modules (PIX-22639)

### DIFF
--- a/api/lib/application/modules.js
+++ b/api/lib/application/modules.js
@@ -1,8 +1,8 @@
 import Joi from 'joi';
 
-import { moduleRepository } from '../infrastructure/repositories/index.js';
 import { moduleSummarySerializer } from '../infrastructure/serializers/jsonapi/index.js';
 import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
+import { listPaginatedModules } from '../domain/usecases/index.js';
 
 export function register(server) {
   server.route([
@@ -18,8 +18,8 @@ export function register(server) {
         },
         handler: async (request) => {
           const { page } = extractParameters(request.query, { page: { size: 10, number: 1 } });
-          const modules = await moduleRepository.list({ page });
-          return moduleSummarySerializer.serialize(modules);
+          const { modules, meta } = await listPaginatedModules({ page });
+          return moduleSummarySerializer.serialize(modules, meta);
         },
       },
     },

--- a/api/lib/application/modules.js
+++ b/api/lib/application/modules.js
@@ -1,5 +1,8 @@
+import Joi from 'joi';
+
 import { moduleRepository } from '../infrastructure/repositories/index.js';
 import { moduleSummarySerializer } from '../infrastructure/serializers/jsonapi/index.js';
+import { extractParameters } from '../infrastructure/utils/query-params-utils.js';
 
 export function register(server) {
   server.route([
@@ -7,8 +10,15 @@ export function register(server) {
       method: 'GET',
       path: '/api/module-summaries',
       config: {
-        handler: async () => {
-          const modules = await moduleRepository.list();
+        validate: {
+          query: Joi.object({
+            'page[size]': Joi.number().min(1).max(100).optional(),
+            'page[number]': Joi.number().min(1).optional(),
+          }),
+        },
+        handler: async (request) => {
+          const { page } = extractParameters(request.query, { page: { size: 10, number: 1 } });
+          const modules = await moduleRepository.list({ page });
           return moduleSummarySerializer.serialize(modules);
         },
       },

--- a/api/lib/application/modules.js
+++ b/api/lib/application/modules.js
@@ -1,0 +1,19 @@
+import { moduleRepository } from '../infrastructure/repositories/index.js';
+import { moduleSummarySerializer } from '../infrastructure/serializers/jsonapi/index.js';
+
+export function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/module-summaries',
+      config: {
+        handler: async () => {
+          const modules = await moduleRepository.list();
+          return moduleSummarySerializer.serialize(modules);
+        },
+      },
+    },
+  ]);
+}
+
+export const name = 'modules';

--- a/api/lib/domain/models/Module.js
+++ b/api/lib/domain/models/Module.js
@@ -24,4 +24,20 @@ export class Module {
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }
+
+  static get LEVELS() {
+    return {
+      NOVICE: 'novice',
+      INDEPENDENT: 'independent',
+      ADVANDCED: 'advandced',
+      EXPERT: 'expert',
+    };
+  }
+
+  static get VISIBILITIES() {
+    return {
+      PUBLIC: 'public',
+      PRIVATE: 'private',
+    };
+  }
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -23,6 +23,7 @@ export * from './get-skill-challenges-production.js';
 export * from './find-attachment.js';
 export * from './find-attachments.js';
 export * from './import-translations.js';
+export * from './list-paginated-modules.js';
 export * from './list-skills.js';
 export * from './list-thematics.js';
 export * from './list-tubes.js';

--- a/api/lib/domain/usecases/list-paginated-modules.js
+++ b/api/lib/domain/usecases/list-paginated-modules.js
@@ -1,0 +1,14 @@
+import { moduleRepository } from '../../infrastructure/repositories/index.js';
+
+export async function listPaginatedModules({ page }, dependencies = { moduleRepository }) {
+  const modules = await dependencies.moduleRepository.list({ page });
+  const rowCount = await dependencies.moduleRepository.count();
+  const meta = {
+    page: page.number,
+    pageSize: page.size,
+    rowCount,
+    pageCount: Math.ceil(rowCount / page.size),
+  };
+
+  return { modules, meta };
+}

--- a/api/lib/infrastructure/repositories/module-repository.js
+++ b/api/lib/infrastructure/repositories/module-repository.js
@@ -2,6 +2,11 @@ import { knex } from '../../../db/knex-database-connection.js';
 import { Module } from '../../domain/models/index.js';
 import { ModuleForReplication } from '../../domain/models/replication/index.js';
 
+export async function count() {
+  const { count } = await knex('modules').count().first();
+  return count;
+}
+
 export async function save({ details, sections, glossary, ...module }, transaction = knex) {
   const moduleDTO = {
     ...module,

--- a/api/lib/infrastructure/repositories/module-repository.js
+++ b/api/lib/infrastructure/repositories/module-repository.js
@@ -13,8 +13,15 @@ export async function save({ details, sections, glossary, ...module }, transacti
   await transaction.insert(moduleDTO).into('modules').onConflict('id').merge({ ...moduleDTO, updatedAt: transaction.fn.now() });
 }
 
-export async function list() {
-  const modules = await knex.select().from('modules').orderBy('slug', 'asc');
+export async function list({ page } = {}) {
+  const query = knex.select()
+    .from('modules')
+    .orderBy('slug', 'asc');
+  if (page) {
+    const offset = (page.number - 1) * page.size;
+    query.offset(offset).limit(page.size);
+  }
+  const modules = await query;
   return modules.map(toDomain);
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/index.js
+++ b/api/lib/infrastructure/serializers/jsonapi/index.js
@@ -11,6 +11,7 @@ export * as frameworkSerializer from './framework-serializer.js';
 export * as localizedChallengeSerializer from './localized-challenge-serializer.js';
 export * as localizedFrameworkTubesSerializer from './localized-framework-tubes-serializer.js';
 export * as missionSerializer from './mission-serializer.js';
+export * as moduleSummarySerializer from './module-summary-serializer.js';
 export * as skillSerializer from './skill-serializer.js';
 export * as searchSerializer from './search-serializer.js';
 export * as staticCourseSerializer from './static-course-serializer.js';

--- a/api/lib/infrastructure/serializers/jsonapi/module-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/module-summary-serializer.js
@@ -2,18 +2,18 @@ import Jsonapi from 'jsonapi-serializer';
 
 const { Serializer } = Jsonapi;
 
-const serializer = new Serializer('module-summary', {
-  attributes: [
-    'title',
-    'isBeta',
-    'visibility',
-    'level',
-  ],
-  transform({ details, ...module }) {
-    return { ...module, ...details };
-  },
-});
-
-export function serialize(frameworks) {
-  return serializer.serialize(frameworks);
+export function serialize(modules, meta) {
+  const serializer = new Serializer('module-summary', {
+    attributes: [
+      'title',
+      'isBeta',
+      'visibility',
+      'level',
+    ],
+    meta,
+    transform({ details, ...module }) {
+      return { ...module, ...details };
+    },
+  });
+  return serializer.serialize(modules);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/module-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/module-summary-serializer.js
@@ -1,0 +1,19 @@
+import Jsonapi from 'jsonapi-serializer';
+
+const { Serializer } = Jsonapi;
+
+const serializer = new Serializer('module-summary', {
+  attributes: [
+    'title',
+    'isBeta',
+    'visibility',
+    'level',
+  ],
+  transform({ details, ...module }) {
+    return { ...module, ...details };
+  },
+});
+
+export function serialize(frameworks) {
+  return serializer.serialize(frameworks);
+}

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -13,6 +13,7 @@ import * as heapdumpRoute from './application/heapdump.js';
 import * as localizedChallengesRoute from './application/localized-challenges.js';
 import * as localizedFrameworkTubesRoute from './application/localized-framework-tubes/index.js';
 import * as missionsRoute from './application/missions/index.js';
+import * as modulesRoute from './application/modules.js';
 import * as notesRoute from './application/notes.js';
 import * as phraseRoute from './application/phrase.js';
 import * as releasesRoute from './application/releases.js';
@@ -45,6 +46,7 @@ export const routes = [
   localizedChallengesRoute,
   localizedFrameworkTubesRoute,
   missionsRoute,
+  modulesRoute,
   notesRoute,
   phraseRoute,
   releasesRoute,

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -62,5 +62,32 @@ describe('Acceptance | Route | modules', () => {
         ],
       });
     });
+
+    describe('when using pagination query params', () => {
+      it('responds with status 200 and modules data', async () => {
+        // given
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/module-summaries?page[size]=2&page[number]=2',
+          headers: generateAuthorizationHeader(editorUser),
+        });
+
+        // then
+        expect(response.statusCode).toBe(200);
+
+        expect(response.result).toEqual({
+          data: [
+            {
+              type: 'module-summaries',
+              id: modules[2].id,
+              attributes: { title: modules[2].title, 'is-beta': modules[2].isBeta, visibility: modules[2].visibility, level: modules[2].details.level },
+            },
+          ],
+        });
+      });
+    });
   });
 });

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder, generateAuthorizationHeader } from '../../test-helper.js';
+import { createServer } from '../../../server.js';
+import { Module } from '../../../lib/domain/models/index.js';
+
+describe('Acceptance | Route | modules', () => {
+  let editorUser;
+
+  beforeEach(async function() {
+    editorUser = databaseBuilder.factory.buildEditorUser();
+    await databaseBuilder.commit();
+  });
+
+  describe('GET /modules', () => {
+    let modules;
+
+    beforeEach(async () => {
+      modules = [
+        { id: '79cc8f8d-d948-4ce5-bd35-1250b61d6011', shortId: 'abcd1234', slug: 'a', title: 'Module 1', isBeta: true, visibility: Module.VISIBILITIES.PRIVATE, details: { level: Module.LEVELS.NOVICE } },
+        { id: '6e7f16ae-4d96-4a71-b646-d6c86029e05e', shortId: 'abcd5678', slug: 'b', title: 'Module 2', isBeta: false, visibility: Module.VISIBILITIES.PUBLIC, details: { level: Module.LEVELS.INDEPENDENT } },
+        { id: 'f995ce82-1373-4758-b839-7a844893ef07', shortId: 'abcd9012', slug: 'c', title: 'Module 3', isBeta: false, visibility: Module.VISIBILITIES.PRIVATE, details: { level: Module.LEVELS.EXPERT } },
+      ];
+
+      modules.forEach((module) => {
+        databaseBuilder.factory.buildModule(domainBuilder.buildModule(module));
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('responds with status 200 and modules data', async () => {
+      // given
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/module-summaries',
+        headers: generateAuthorizationHeader(editorUser),
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+
+      expect(response.result).toEqual({
+        data: [
+          {
+            type: 'module-summaries',
+            id: modules[0].id,
+            attributes: { title: modules[0].title, 'is-beta': modules[0].isBeta, visibility: modules[0].visibility, level: modules[0].details.level },
+          },
+          {
+            type: 'module-summaries',
+            id: modules[1].id,
+            attributes: { title: modules[1].title, 'is-beta': modules[1].isBeta, visibility: modules[1].visibility, level: modules[1].details.level },
+          },
+          {
+            type: 'module-summaries',
+            id: modules[2].id,
+            attributes: { title: modules[2].title, 'is-beta': modules[2].isBeta, visibility: modules[2].visibility, level: modules[2].details.level },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -28,7 +28,7 @@ describe('Acceptance | Route | modules', () => {
       await databaseBuilder.commit();
     });
 
-    it('responds with status 200 and modules data', async () => {
+    it.fails('responds with status 200 and modules data', async () => {
       // given
       const server = await createServer();
 
@@ -60,11 +60,17 @@ describe('Acceptance | Route | modules', () => {
             attributes: { title: modules[2].title, 'is-beta': modules[2].isBeta, visibility: modules[2].visibility, level: modules[2].details.level },
           },
         ],
+        meta: {
+          page: 1,
+          pageSize: 10,
+          rowCount: 3,
+          pageCount: 1,
+        },
       });
     });
 
     describe('when using pagination query params', () => {
-      it('responds with status 200 and modules data', async () => {
+      it.fails('responds with status 200 and modules data', async () => {
         // given
         const server = await createServer();
 
@@ -86,6 +92,12 @@ describe('Acceptance | Route | modules', () => {
               attributes: { title: modules[2].title, 'is-beta': modules[2].isBeta, visibility: modules[2].visibility, level: modules[2].details.level },
             },
           ],
+          meta: {
+            page: 2,
+            pageSize: 2,
+            rowCount: 3,
+            pageCount: 2,
+          },
         });
       });
     });

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -28,7 +28,7 @@ describe('Acceptance | Route | modules', () => {
       await databaseBuilder.commit();
     });
 
-    it.fails('responds with status 200 and modules data', async () => {
+    it('responds with status 200 and modules data', async () => {
       // given
       const server = await createServer();
 
@@ -70,7 +70,7 @@ describe('Acceptance | Route | modules', () => {
     });
 
     describe('when using pagination query params', () => {
-      it.fails('responds with status 200 and modules data', async () => {
+      it('responds with status 200 and modules data', async () => {
         // given
         const server = await createServer();
 

--- a/api/tests/integration/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-repository_test.js
@@ -56,6 +56,29 @@ describe('Module Repository', () => {
       // then
       expect(modules).toStrictEqual([firstModule, secondModule]);
     });
+
+    it('lists modules with pagination parameters', async () => {
+      // given
+      const firstModule = domainBuilder.buildModule({ slug: 'a' });
+      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', slug: 'b' });
+      const thirdModule = domainBuilder.buildModule({ shortId: 'terzio', slug: 'c' });
+      const page = {
+        size: 2,
+        number: 1,
+      };
+
+      databaseBuilder.factory.buildModule(firstModule);
+      databaseBuilder.factory.buildModule(secondModule);
+      databaseBuilder.factory.buildModule(thirdModule);
+
+      await databaseBuilder.commit();
+
+      // when
+      const modules = await list({ page });
+
+      // then
+      expect(modules).toStrictEqual([firstModule, secondModule]);
+    });
   });
 
   describe('listForReplication', () => {

--- a/api/tests/integration/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-repository_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
-import { list, listForReplication, save } from '../../../../lib/infrastructure/repositories/module-repository.js';
+import { list, listForReplication, save, count } from '../../../../lib/infrastructure/repositories/module-repository.js';
 import { ModuleForReplication } from '../../../../lib/domain/models/replication/index.js';
 
 describe('Module Repository', () => {
@@ -98,6 +98,21 @@ describe('Module Repository', () => {
 
       // then
       expect(modules).toStrictEqual(expectedModules);
+    });
+  });
+
+  describe('count', () => {
+    it('returns number of modules', async () => {
+      // given
+      databaseBuilder.factory.buildModule(domainBuilder.buildModule());
+      databaseBuilder.factory.buildModule(domainBuilder.buildModule({ shortId: 'secondar' }));
+      await databaseBuilder.commit();
+
+      // when
+      const result = await count();
+
+      // then
+      expect(result).toBe(2);
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-module.js
+++ b/api/tests/tooling/domain-builder/factory/build-module.js
@@ -31,15 +31,8 @@ export function buildModule({
   slug = 'petit-escargot-pignouf',
   title = 'apprendre à être mou',
   isBeta = false,
-  visibility = 'public',
-  details = {
-    image: 'https://assets.pix.org/draft/escargots.jpg',
-    description: "<p>Ce module est dédié aux escargots</p><p>Il contient normalement l'intégralité de leurs secrets disponibles à date.</p>",
-    duration: 7,
-    level: 'novice',
-    objectives: ['Connaître les petits secrets des gastéropodes'],
-    tabletSupport: 'inconvenient',
-  },
+  visibility = Module.VISIBILITIES.PUBLIC,
+  details = {},
   sections = defaultSections,
   glossary = [
     {
@@ -50,6 +43,14 @@ export function buildModule({
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
+  const {
+    image = 'https=//assets.pix.org/draft/escargots.jpg',
+    description = "<p>Ce module est dédié aux escargots</p><p>Il contient normalement l'intégralité de leurs secrets disponibles à date.</p>",
+    duration = 7,
+    level = Module.LEVELS.NOVICE,
+    objectives = ['Connaître les petits secrets des gastéropodes'],
+    tabletSupport = 'inconvenient',
+  } = details;
   return new Module({
     id,
     shortId,
@@ -57,7 +58,7 @@ export function buildModule({
     title,
     isBeta,
     visibility,
-    details,
+    details: { image, description, duration, level, objectives, tabletSupport },
     sections,
     glossary,
     createdAt,

--- a/api/tests/unit/domain/usecases/list-paginated-modules_test.js
+++ b/api/tests/unit/domain/usecases/list-paginated-modules_test.js
@@ -1,0 +1,34 @@
+import { vi, it, describe, expect } from 'vitest';
+import { listPaginatedModules } from '../../../../lib/domain/usecases/list-paginated-modules.js';
+
+describe('Unit | Domain | Use Cases | list-paginated-modules', () => {
+  it('returns data and pagination metadata', async () => {
+    // given
+    const page = {
+      size: 10,
+      number: 2,
+    };
+    const expectedPaginationMetadata = {
+      page: 2,
+      pageSize: 10,
+      rowCount: 70,
+      pageCount: 7,
+    };
+    const expectedData = Symbol('modules');
+    const moduleRepository = {
+      list: vi.fn().mockResolvedValueOnce(expectedData),
+      count: vi.fn().mockResolvedValueOnce(expectedPaginationMetadata.rowCount),
+    };
+
+    // when
+    const result = await listPaginatedModules({ page }, { moduleRepository });
+
+    // then
+    expect(moduleRepository.list).toHaveBeenCalledExactlyOnceWith({ page });
+    expect(moduleRepository.count).toHaveBeenCalledExactlyOnceWith();
+    expect(result).toStrictEqual({
+      modules: expectedData,
+      meta: expectedPaginationMetadata,
+    });
+  });
+});


### PR DESCRIPTION
## 💥 Problème

On souhaite créer une page permettant de lister les modules, avec de la pagination.

## 👩‍🚀 Proposition

Créer un endpoint d'API permettant de lister les modules avec des query params et des metadata de pagination.

## 👁️ Remarques

N/A

## ♻️ Pour tester

Faire du curl sur le endpoint `GET /module-summaries` et vérifier qu'on a bien `meta`et les modules qui sont renvoyés.