### PR TITLE
[TECH] Améliorer la résilience des jobs `bull` (PIX-22692)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -4,7 +4,8 @@ import { createServer } from './server.js';
 import { logger } from './lib/infrastructure/logger.js';
 import { queue as checkUrlQueue } from './lib/infrastructure/scheduled-jobs/check-urls-job.js';
 import { scheduleReleaseJobQueue } from './lib/infrastructure/scheduled-jobs/release-job.js';
-import { createUploadTranslationJobQueue, uploadTranslationJobOptions } from './lib/infrastructure/scheduled-jobs/upload-translation-job.js';
+import { createUploadTranslationJobQueue } from './lib/infrastructure/scheduled-jobs/upload-translation-job.js';
+import { createDeleteUnmentionedKeysAfterUploadJobQueue } from './lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 import * as exportExternalUrlListJob from './lib/infrastructure/scheduled-jobs/export-external-url-list-job.js';
 import * as cleanReleasesJob from './lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js';
 import { disconnect } from './db/knex-database-connection.js';
@@ -12,7 +13,7 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 
 validateEnvironmentVariables();
 
-let releaseJobQueue, uploadTranslationJobQueue;
+let deleteUnmentionedKeysAfterUploadJobQueue, releaseJobQueue, uploadTranslationJobQueue;
 
 async function start() {
   try {
@@ -21,6 +22,7 @@ async function start() {
 
     releaseJobQueue = scheduleReleaseJobQueue();
     uploadTranslationJobQueue = await createUploadTranslationJobQueue();
+    deleteUnmentionedKeysAfterUploadJobQueue = await createDeleteUnmentionedKeysAfterUploadJobQueue();
     exportExternalUrlListJob.schedule();
     cleanReleasesJob.schedule();
 
@@ -38,6 +40,7 @@ async function exitOnSignal(signal) {
     await checkUrlQueue.close();
     await releaseJobQueue?.close();
     await uploadTranslationJobQueue?.close();
+    await deleteUnmentionedKeysAfterUploadJobQueue?.close();
     await cleanReleasesJob.queue.close();
     process.exit(0);
   } catch (err) {

--- a/api/index.js
+++ b/api/index.js
@@ -13,7 +13,7 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 
 validateEnvironmentVariables();
 
-let checkUrlsJobQueue, deleteUnmentionedKeysAfterUploadJobQueue, releaseJobQueue, uploadTranslationJobQueue;
+let checkUrlsJobQueue, deleteUnmentionedKeysAfterUploadJobQueue, exportExternalUrlListJobQueue, releaseJobQueue, uploadTranslationJobQueue;
 
 async function start() {
   try {
@@ -24,7 +24,7 @@ async function start() {
     uploadTranslationJobQueue = await createUploadTranslationJobQueue();
     deleteUnmentionedKeysAfterUploadJobQueue = await createDeleteUnmentionedKeysAfterUploadJobQueue();
     checkUrlsJobQueue = await createCheckUrlsJobQueue();
-    exportExternalUrlListJob.schedule();
+    exportExternalUrlListJobQueue = await exportExternalUrlListJob.schedule();
     cleanReleasesJob.schedule();
 
     logger.info('Server running at %s', server.info.uri);
@@ -42,6 +42,7 @@ async function exitOnSignal(signal) {
     await releaseJobQueue?.close();
     await uploadTranslationJobQueue?.close();
     await deleteUnmentionedKeysAfterUploadJobQueue?.close();
+    await exportExternalUrlListJobQueue?.close();
     await cleanReleasesJob.queue.close();
     process.exit(0);
   } catch (err) {

--- a/api/index.js
+++ b/api/index.js
@@ -20,7 +20,7 @@ async function start() {
     const server = await createServer();
     await server.start();
 
-    releaseJobQueue = scheduleReleaseJobQueue();
+    releaseJobQueue = await scheduleReleaseJobQueue();
     uploadTranslationJobQueue = await createUploadTranslationJobQueue();
     deleteUnmentionedKeysAfterUploadJobQueue = await createDeleteUnmentionedKeysAfterUploadJobQueue();
     checkUrlsJobQueue = await createCheckUrlsJobQueue();

--- a/api/index.js
+++ b/api/index.js
@@ -13,7 +13,7 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 
 validateEnvironmentVariables();
 
-let checkUrlsJobQueue, deleteUnmentionedKeysAfterUploadJobQueue, exportExternalUrlListJobQueue, releaseJobQueue, uploadTranslationJobQueue;
+let checkUrlsJobQueue, deleteUnmentionedKeysAfterUploadJobQueue, exportExternalUrlListJobQueue, releaseJobQueue, releaseTableCleaningAndRetentionJobQueue, uploadTranslationJobQueue;
 
 async function start() {
   try {
@@ -25,7 +25,7 @@ async function start() {
     deleteUnmentionedKeysAfterUploadJobQueue = await createDeleteUnmentionedKeysAfterUploadJobQueue();
     checkUrlsJobQueue = await createCheckUrlsJobQueue();
     exportExternalUrlListJobQueue = await exportExternalUrlListJob.schedule();
-    cleanReleasesJob.schedule();
+    releaseTableCleaningAndRetentionJobQueue = await cleanReleasesJob.schedule();
 
     logger.info('Server running at %s', server.info.uri);
   } catch (err) {
@@ -43,7 +43,7 @@ async function exitOnSignal(signal) {
     await uploadTranslationJobQueue?.close();
     await deleteUnmentionedKeysAfterUploadJobQueue?.close();
     await exportExternalUrlListJobQueue?.close();
-    await cleanReleasesJob.queue.close();
+    await releaseTableCleaningAndRetentionJobQueue?.close();
     process.exit(0);
   } catch (err) {
     logger.error(err);

--- a/api/index.js
+++ b/api/index.js
@@ -2,7 +2,7 @@
 
 import { createServer } from './server.js';
 import { logger } from './lib/infrastructure/logger.js';
-import { queue as checkUrlQueue } from './lib/infrastructure/scheduled-jobs/check-urls-job.js';
+import { createCheckUrlsJobQueue } from './lib/infrastructure/scheduled-jobs/check-urls-job.js';
 import { scheduleReleaseJobQueue } from './lib/infrastructure/scheduled-jobs/release-job.js';
 import { createUploadTranslationJobQueue } from './lib/infrastructure/scheduled-jobs/upload-translation-job.js';
 import { createDeleteUnmentionedKeysAfterUploadJobQueue } from './lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
@@ -13,7 +13,7 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 
 validateEnvironmentVariables();
 
-let deleteUnmentionedKeysAfterUploadJobQueue, releaseJobQueue, uploadTranslationJobQueue;
+let checkUrlsJobQueue, deleteUnmentionedKeysAfterUploadJobQueue, releaseJobQueue, uploadTranslationJobQueue;
 
 async function start() {
   try {
@@ -23,6 +23,7 @@ async function start() {
     releaseJobQueue = scheduleReleaseJobQueue();
     uploadTranslationJobQueue = await createUploadTranslationJobQueue();
     deleteUnmentionedKeysAfterUploadJobQueue = await createDeleteUnmentionedKeysAfterUploadJobQueue();
+    checkUrlsJobQueue = await createCheckUrlsJobQueue();
     exportExternalUrlListJob.schedule();
     cleanReleasesJob.schedule();
 
@@ -37,7 +38,7 @@ async function exitOnSignal(signal) {
   logger.info(`Received signal ${signal}. Closing DB connections and queues before exiting.`);
   try {
     await disconnect();
-    await checkUrlQueue.close();
+    await checkUrlsJobQueue?.close();
     await releaseJobQueue?.close();
     await uploadTranslationJobQueue?.close();
     await deleteUnmentionedKeysAfterUploadJobQueue?.close();

--- a/api/index.js
+++ b/api/index.js
@@ -4,6 +4,7 @@ import { createServer } from './server.js';
 import { logger } from './lib/infrastructure/logger.js';
 import { queue as checkUrlQueue } from './lib/infrastructure/scheduled-jobs/check-urls-job.js';
 import { scheduleReleaseJobQueue } from './lib/infrastructure/scheduled-jobs/release-job.js';
+import { createUploadTranslationJobQueue, uploadTranslationJobOptions } from './lib/infrastructure/scheduled-jobs/upload-translation-job.js';
 import * as exportExternalUrlListJob from './lib/infrastructure/scheduled-jobs/export-external-url-list-job.js';
 import * as cleanReleasesJob from './lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js';
 import { disconnect } from './db/knex-database-connection.js';
@@ -11,7 +12,7 @@ import { validateEnvironmentVariables } from './lib/infrastructure/validate-envi
 
 validateEnvironmentVariables();
 
-let releaseJobQueue;
+let releaseJobQueue, uploadTranslationJobQueue;
 
 async function start() {
   try {
@@ -19,6 +20,7 @@ async function start() {
     await server.start();
 
     releaseJobQueue = scheduleReleaseJobQueue();
+    uploadTranslationJobQueue = await createUploadTranslationJobQueue();
     exportExternalUrlListJob.schedule();
     cleanReleasesJob.schedule();
 
@@ -35,6 +37,7 @@ async function exitOnSignal(signal) {
     await disconnect();
     await checkUrlQueue.close();
     await releaseJobQueue?.close();
+    await uploadTranslationJobQueue?.close();
     await cleanReleasesJob.queue.close();
     process.exit(0);
   } catch (err) {

--- a/api/lib/application/releases.js
+++ b/api/lib/application/releases.js
@@ -28,7 +28,7 @@ export async function register(server) {
       config: {
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function() {
-          const releaseJobQueue = createReleaseJobQueue();
+          const releaseJobQueue = await createReleaseJobQueue();
           const job = await releaseJobQueue.add({ slackNotification: true });
           const promise = async () => {
             const releaseId = await job.finished();

--- a/api/lib/infrastructure/scheduled-jobs/check-urls-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/check-urls-job.js
@@ -1,18 +1,21 @@
 import { createQueue } from './create-queue.js';
 import * as config from '../../config.js';
 import { fileURLToPath } from 'node:url';
+import Queue from 'bull';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
-export const queue = createQueue('check-urls-queue');
 const cjsFile = __dirname + '/check-urls-job-processor.cjs';
 const esmFile = __dirname + '/check-urls-job-processor.js';
-if (process.env.NODE_ENV === 'test') {
-  import(esmFile).then((module) => {
+
+export async function createCheckUrlsJobQueue() {
+  const queue = createQueue('check-urls-queue');
+  if (process.env.NODE_ENV === 'test') {
+    const module = await import(esmFile);
     queue.process(module.default);
-  });
-} else {
-  queue.process(cjsFile);
+  } else {
+    queue.process(cjsFile);
+  }
+  return queue;
 }
 
 const checkUrlsJobOptions = {
@@ -22,6 +25,8 @@ const checkUrlsJobOptions = {
   removeOnFail: 1,
 };
 
-export function start() {
-  queue.add({}, checkUrlsJobOptions);
+export async function start() {
+  const queue = new Queue('check-urls-queue', config.scheduledJobs.redisUrl);
+  await queue.add({}, checkUrlsJobOptions);
+  await queue.close();
 }

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js
@@ -9,6 +9,6 @@ export default async function deleteUnmentionedKeysAfterUploadJobProcessor(job) 
   });
 
   if (status === RETRY) {
-    schedule(job.data);
+    await schedule(job.data);
   }
 }

--- a/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js
@@ -1,18 +1,22 @@
 import { createQueue } from './create-queue.js';
 import * as config from '../../config.js';
 import { fileURLToPath } from 'node:url';
+import Queue from 'bull';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
-export const queue = createQueue('delete-unmentioned-keys-after-upload-queue');
-
 const esmFile = __dirname + '/delete-unmentioned-keys-after-upload-job-processor.js';
 const cjsFile = __dirname + '/delete-unmentioned-keys-after-upload-job-processor.cjs';
-if (process.env.NODE_ENV === 'test') {
-  const module = await import(esmFile);
-  queue.process(module.default);
-} else {
-  queue.process(cjsFile);
+
+export async function createDeleteUnmentionedKeysAfterUploadJobQueue() {
+  const queue = createQueue('delete-unmentioned-keys-after-upload-queue');
+  if (process.env.NODE_ENV === 'test') {
+    const module = await import(esmFile);
+    queue.process(module.default);
+  } else {
+    queue.process(cjsFile);
+  }
+  return queue;
 }
 
 const deleteUnmentionedKeysAfterUploadJobOptions = {
@@ -23,6 +27,8 @@ const deleteUnmentionedKeysAfterUploadJobOptions = {
   delay: 3 * 60 * 1000,
 };
 
-export function schedule({ uploadId, projectId }) {
-  return queue.add({ uploadId, projectId }, deleteUnmentionedKeysAfterUploadJobOptions);
+export async function schedule({ uploadId, projectId }) {
+  const queue = new Queue('delete-unmentioned-keys-after-upload-queue', config.scheduledJobs.redisUrl);
+  await queue.add({ uploadId, projectId }, deleteUnmentionedKeysAfterUploadJobOptions);
+  await queue.close();
 }

--- a/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job.js
@@ -4,16 +4,18 @@ import { logger } from '../logger.js';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
-export const queue = createQueue('export-external-url-list-queue');
 const cjsFile = __dirname + '/export-external-url-list-job-processor.cjs';
 const esmFile = __dirname + '/export-external-url-list-job-processor.js';
-if (process.env.NODE_ENV === 'test') {
-  import(esmFile).then((module) => {
+
+export async function createExportExternalUrlListJobQueue() {
+  const queue = createQueue('export-external-url-list-queue');
+  if (process.env.NODE_ENV === 'test') {
+    const module = await import(esmFile);
     queue.process(module.default);
-  });
-} else {
-  queue.process(cjsFile);
+  } else {
+    queue.process(cjsFile);
+  }
+  return queue;
 }
 
 const externalUrlJobOptions = {
@@ -27,14 +29,16 @@ const externalUrlJobOptions = {
   },
 };
 
-export function schedule() {
+export async function schedule() {
   if (!_isScheduledExportEnabled()) {
     logger.info(
       'Scheduled export of external list is not enabled - check `EXPORT_EXTERNAL_URL_LIST_TIME` and `REDIS_URL` variables',
     );
     return;
   }
-  queue.add({}, externalUrlJobOptions);
+  const queue = await createExportExternalUrlListJobQueue();
+  await queue.add({}, externalUrlJobOptions);
+  return queue;
 }
 
 function _isScheduledExportEnabled() {

--- a/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job-processor.js
@@ -21,7 +21,7 @@ export default async function releaseJobProcessor(job) {
     }
     logger.info(`Periodic release created with id ${releaseId}`);
     if (config.scheduledJobs.startCheckUrlJob) {
-      checkUrlsJob.start();
+      await checkUrlsJob.start();
     }
     await uploadTranslationJob.start();
     return releaseId;

--- a/api/lib/infrastructure/scheduled-jobs/release-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-job.js
@@ -7,12 +7,11 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const cjsFile = __dirname + '/release-job-processor.cjs';
 const esmFile = __dirname + '/release-job-processor.js';
 
-export function createReleaseJobQueue() {
+export async function createReleaseJobQueue() {
   const queue = createQueue('create-release-queue');
   if (process.env.NODE_ENV === 'test') {
-    import(esmFile).then((module) => {
-      queue.process(module.default);
-    });
+    const module = await import(esmFile);
+    queue.process(module.default);
   } else {
     queue.process(cjsFile);
   }
@@ -30,7 +29,7 @@ const releaseJobOptions = {
   },
 };
 
-export function scheduleReleaseJobQueue() {
+export async function scheduleReleaseJobQueue() {
   const isScheduledReleaseEnabled = config.scheduledJobs.createReleaseTime && config.scheduledJobs.redisUrl;
 
   if (!isScheduledReleaseEnabled) {
@@ -38,7 +37,7 @@ export function scheduleReleaseJobQueue() {
     return;
   }
 
-  const queue = createReleaseJobQueue();
-  queue.add({}, releaseJobOptions);
+  const queue = await createReleaseJobQueue();
+  await queue.add({}, releaseJobOptions);
   return queue;
 }

--- a/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js
@@ -4,16 +4,18 @@ import { logger } from '../logger.js';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
-export const queue = createQueue('release-table-cleaning-and-retention-queue');
 const cjsFile = __dirname + '/release-table-cleaning-and-retention-job-processor.cjs';
 const esmFile = __dirname + '/release-table-cleaning-and-retention-job-processor.js';
-if (process.env.NODE_ENV === 'test') {
-  import(esmFile).then((module) => {
+
+export async function createReleaseTableCleaningAndRetentionJobQueue() {
+  const queue = createQueue('release-table-cleaning-and-retention-queue');
+  if (process.env.NODE_ENV === 'test') {
+    const module = await import(esmFile);
     queue.process(module.default);
-  });
-} else {
-  queue.process(cjsFile);
+  } else {
+    queue.process(cjsFile);
+  }
+  return queue;
 }
 
 const releaseTableCleaningAndRetentionJobOptions = {
@@ -27,12 +29,14 @@ const releaseTableCleaningAndRetentionJobOptions = {
   },
 };
 
-export function schedule() {
+export async function schedule() {
   if (!config.scheduledJobs.cleanReleasesTableTime) {
     logger.info(
       'Scheduled releases cleaning and retention is not enabled - check `CLEAN_RELEASES_TABLE_TIME` variable',
     );
     return;
   }
-  queue.add({}, releaseTableCleaningAndRetentionJobOptions);
+  const queue = await createReleaseTableCleaningAndRetentionJobQueue();
+  await queue.add({}, releaseTableCleaningAndRetentionJobOptions);
+  return queue;
 }

--- a/api/lib/infrastructure/scheduled-jobs/upload-translation-job.js
+++ b/api/lib/infrastructure/scheduled-jobs/upload-translation-job.js
@@ -1,18 +1,22 @@
 import { createQueue } from './create-queue.js';
 import * as config from '../../config.js';
 import { fileURLToPath } from 'node:url';
+import Queue from 'bull';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
-export const queue = createQueue('upload-translation-queue');
-
 const esmFile = __dirname + '/upload-translation-job-processor.js';
 const cjsFile = __dirname + '/upload-translation-job-processor.cjs';
-if (process.env.NODE_ENV === 'test') {
-  const module = await import(esmFile);
-  queue.process(module.default);
-} else {
-  queue.process(cjsFile);
+
+export async function createUploadTranslationJobQueue() {
+  const queue = createQueue('upload-translation-queue');
+  if (process.env.NODE_ENV === 'test') {
+    const module = await import(esmFile);
+    queue.process(module.default);
+  } else {
+    queue.process(cjsFile);
+  }
+  return queue;
 }
 
 const uploadTranslationJobOptions = {
@@ -23,6 +27,8 @@ const uploadTranslationJobOptions = {
   delay: 1000,
 };
 
-export function start() {
-  return queue.add({}, uploadTranslationJobOptions);
+export async function start() {
+  const queue = new Queue('upload-translation-queue', config.scheduledJobs.redisUrl);
+  await queue.add({}, uploadTranslationJobOptions);
+  await queue.close();
 }

--- a/api/tests/unit/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job_test.js
+++ b/api/tests/unit/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job_test.js
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import * as deleteUnmentionedKeysAfterUploadJob from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 import deleteUnmentionedKeysAfterUploadJobProcessor from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job-processor.js';
 import * as deleteUnmentionedKeysAfterUploadUsecase from '../../../../lib/domain/usecases/delete-unmentioned-keys-after-upload.js';
-import { queue } from '../../../../lib/infrastructure/scheduled-jobs/delete-unmentioned-keys-after-upload-job.js';
 
 describe('Unit | Infrastructure | scheduled-jobs | delete-unmentioned-keys-after-upload-job', function() {
   it('should schedule a new job when delete-unmentioned-keys-after-upload return status is `retry`', async function() {
@@ -11,18 +10,11 @@ describe('Unit | Infrastructure | scheduled-jobs | delete-unmentioned-keys-after
       .spyOn(deleteUnmentionedKeysAfterUploadUsecase, 'deleteUnmentionedKeysAfterUpload')
       .mockResolvedValue(deleteUnmentionedKeysAfterUploadUsecase.RETRY);
     const scheduleStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
-    const queueAddStub = vi.spyOn(queue, 'add');
+
     // when
     await deleteUnmentionedKeysAfterUploadJobProcessor({ data: { uploadId: 'upload-id', projectId: 'phrase-project-id' } });
 
     // then
-    expect(queueAddStub).toHaveBeenCalledWith(
-      {
-        uploadId: 'upload-id',
-        projectId: 'phrase-project-id',
-      },
-      expect.anything(),
-    );
     expect(scheduleStub).toHaveBeenCalledWith({
       uploadId: 'upload-id',
       projectId: 'phrase-project-id',


### PR DESCRIPTION
## 💥 Problème

Il arrive que des jobs `bull` rencontrent des erreurs, ou se lancent et ne soient jamais exécutés.
En inspectant le code de plus près, on a constaté un problème d'instanciation des `Queue`. Certaines étaient instanciées au démarrage du serveur, et d'autres étaient instanciées dans le cadre de l'exécution d'un autre job.

## 👩‍🚀 Proposition

Instancier toutes les `Queue` au démarrage du serveur.

## ♻️ Pour tester

✅ CI OK