### PR TITLE
[BUGFIX] Ajoute le header `content-type` quand on patch la release.

### DIFF
--- a/api/lib/infrastructure/pix-api-client.js
+++ b/api/lib/infrastructure/pix-api-client.js
@@ -8,7 +8,10 @@ export async function request({ payload, url }) {
     return fetch(`${config.pixApi.baseUrl}${url}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
     });
   });
 }

--- a/api/lib/infrastructure/repositories/file-storage-token-repository.js
+++ b/api/lib/infrastructure/repositories/file-storage-token-repository.js
@@ -25,6 +25,7 @@ export async function create() {
   const response = await fetch(config.storage.authUrl, {
     method: 'POST',
     body: JSON.stringify(payload),
+    headers: { 'content-type': 'application/json' },
   });
   if (response.status === 401) throw new UnauthorizedError();
   if (!response.ok) throw new Error('error while fetching file storage token', response.status);

--- a/api/tests/integration/infrastructure/notifications/SlackNotifier_test.js
+++ b/api/tests/integration/infrastructure/notifications/SlackNotifier_test.js
@@ -21,10 +21,10 @@ describe('Integration | Infrastructure | SlackNotifier', function() {
       // given
       const webhookUrl = 'https://webhook.url';
       const slackNotifier = new SlackNotifier(`${webhookUrl}/testurl`);
-      const blocks = Symbol();
+      const blocks = { some: 'blocks' };
 
       const sendScope = nock(webhookUrl)
-        .post('/testurl', JSON.stringify(blocks))
+        .post('/testurl', blocks)
         .reply(200, { 'Content-Type': 'application/json' });
 
       // when

--- a/api/tests/unit/infrastructure/pix-api-client_test.js
+++ b/api/tests/unit/infrastructure/pix-api-client_test.js
@@ -8,7 +8,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
     context('when token is in cache', () => {
       it('should call the API', async () => {
         // given
-        const payload = 'payload';
+        const payload = { some: 'payload' };
         const token = 'token';
         vi.spyOn(cache, 'get').mockImplementation((spyKey) => {
           if (spyKey === 'pix-api-token') {
@@ -17,7 +17,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
         });
 
         const requestInterceptor = nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${token}`)
           .reply(200);
 
@@ -30,7 +30,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
 
       it('should refresh the token when receiving a 401', async () => {
         // given
-        const payload = 'payload';
+        const payload = { some: 'payload' };
         const token = 'token';
         const newToken = 'myNewToken';
         vi.spyOn(cache, 'get').mockImplementation((spyKey) => {
@@ -40,7 +40,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
         });
 
         const firstRequestInterceptor = nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${token}`)
           .reply(401);
 
@@ -50,7 +50,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
           .reply(200, { access_token: newToken });
 
         const secondRequestInterceptor = nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${newToken}`)
           .reply(200);
 
@@ -65,7 +65,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
 
       it('should not refresh the token forever and returns the error', async () => {
         // given
-        const payload = 'payload';
+        const payload = { some: 'payload' };
         const token = 'token';
         const newToken = 'myNewToken';
         vi.spyOn(cache, 'get').mockImplementation((spyKey) => {
@@ -75,7 +75,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
         });
 
         const firstRequestInterceptor = nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${token}`)
           .reply(401);
 
@@ -85,7 +85,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
           .reply(200, { access_token: newToken });
 
         const secondRequestInterceptor = nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${newToken}`)
           .reply(401);
 
@@ -106,7 +106,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
 
     context('when token is not in cache', () => {
       it('should authenticate', async () => {
-        const payload = 'payload';
+        const payload = { some: 'payload' };
         const token = 'token';
         vi.spyOn(cache, 'get').mockImplementation((spyKey) => {
           if (spyKey === 'pix-api-token') {
@@ -115,7 +115,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
         });
 
         const requestInterceptor = nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${token}`)
           .reply(200);
 
@@ -133,7 +133,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
       });
 
       it('should store token in cache', async () => {
-        const payload = 'payload';
+        const payload = { some: 'payload' };
         const token = 'token';
         vi.spyOn(cache, 'get').mockImplementation((spyKey) => {
           if (spyKey === 'pix-api-token') {
@@ -143,7 +143,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
         vi.spyOn(cache, 'set');
 
         nock('https://api.test.pix.fr')
-          .patch('/api/cache/model/id', JSON.stringify(payload))
+          .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${token}`)
           .reply(200);
 


### PR DESCRIPTION
# 💥 Problème

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

Depuis la suppression d'axios, aucune mise à jour de référentiel ne fonctionne (pour la preview).

## 👩‍🚀 Proposition

Il manque le header `Content-Type: application/json`.
On en profite pour réparer les tests qui utilisaient une string au lieu d'un objet pour les payloads.

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 👁️ Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## ♻️ Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->

<sub><sub>☝️ Mon tout est un jeu-vidéo</sub></sub>
