### PR TITLE
[FEATURE] Créer un nouveau module dans Pix Editor (PIX-22708).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/pix-editor
-      - browser-tools/install_chrome
+      - browser-tools/install_firefox
       - run: cat package*.json > cachekey
       - restore_cache:
           keys:

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -1,0 +1,26 @@
+import PixInput from '@1024pix/pix-ui/components/pix-input';
+import PixLabel from '@1024pix/pix-ui/components/pix-label';
+import MonacoEditor from 'pixeditor/components/monaco-editor/monaco-editor';
+
+const monacoOptions = {
+  ariaLabel: 'Contenu (JSON)',
+  ariaRequired: true,
+  height: 500,
+  language: 'json',
+  theme: 'vs-light',
+};
+
+<template>
+  <div class="module-form">
+    <PixInput @id="title" readonly>
+      <:label>Titre</:label>
+    </PixInput>
+
+    <div class="module-form__data-field">
+      <PixLabel @requiredLabel="Champ obligatoire">
+        Contenu (JSON)
+      </PixLabel>
+      <MonacoEditor @options={{monacoOptions}} class="module-form__monaco-editor" />
+    </div>
+  </div>
+</template>

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -1,26 +1,68 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixLabel from '@1024pix/pix-ui/components/pix-label';
 import MonacoEditor from 'pixeditor/components/monaco-editor/monaco-editor';
 
-const monacoOptions = {
-  ariaLabel: 'Contenu (JSON)',
-  ariaRequired: true,
-  height: 500,
-  language: 'json',
-  theme: 'vs-light',
-};
+export default class ModuleForm extends Component {
+  @tracked moduleData;
 
-<template>
-  <div class="module-form">
-    <PixInput @id="title" readonly>
-      <:label>Titre</:label>
-    </PixInput>
+  @action
+  onChange(moduleJson) {
+    try {
+      this.moduleData = JSON.parse(moduleJson);
+    } catch {
+      this.moduleData = undefined;
+    }
+  }
 
-    <div class="module-form__data-field">
-      <PixLabel @requiredLabel="Champ obligatoire">
-        Contenu (JSON)
-      </PixLabel>
-      <MonacoEditor @options={{monacoOptions}} class="module-form__monaco-editor" />
+  get monacoOptions() {
+    return {
+      ariaLabel: 'Contenu (JSON)',
+      ariaRequired: true,
+      automaticLayout: true,
+      language: 'json',
+      theme: 'vs-light',
+    };
+  }
+
+  get title() {
+    return this.moduleData?.title;
+  }
+
+  get isSaveDisabled() {
+    return !this.moduleData;
+  }
+
+  @action
+  async saveModule() {
+    return this.args.saveModule(this.moduleData);
+  }
+
+  <template>
+    <div class="module-form">
+      <PixInput @id="title" @value={{this.title}} readonly>
+        <:label>Titre</:label>
+      </PixInput>
+
+      <div class="module-form__data-field">
+        <PixLabel @requiredLabel="Champ obligatoire">
+          Contenu (JSON)
+        </PixLabel>
+        <MonacoEditor @options={{this.monacoOptions}} class="module-form__monaco-editor" @onChange={{this.onChange}} />
+      </div>
+
+      <div class="module-form__actions">
+        <PixButton @triggerAction={{this.saveModule}} @isDisabled={{this.isSaveDisabled}}>
+          Enregistrer
+        </PixButton>
+        <PixButtonLink @route="authenticated.modules" @variant="secondary">
+          Annuler
+        </PixButtonLink>
+      </div>
     </div>
-  </div>
-</template>
+  </template>
+}

--- a/pix-editor/app/components/monaco-editor/monaco-editor.gjs
+++ b/pix-editor/app/components/monaco-editor/monaco-editor.gjs
@@ -18,6 +18,6 @@ export default class MonacoEditor extends Component {
   });
 
   <template>
-    <div {{this.setup}} style="width: 80vw; height: 80vh;"></div>
+    <div {{this.setup}} ...attributes></div>
   </template>
 }

--- a/pix-editor/app/models/module-summary.js
+++ b/pix-editor/app/models/module-summary.js
@@ -12,7 +12,7 @@ const levelForDisplay = {
   expert: 'Expert',
 };
 
-export default class ModulesSummary extends Model {
+export default class ModuleSummary extends Model {
   @attr title;
   @attr isBeta;
   @attr visibility;

--- a/pix-editor/app/models/module.js
+++ b/pix-editor/app/models/module.js
@@ -1,0 +1,11 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Module extends Model {
+  @attr title;
+  @attr isBeta;
+  @attr slug;
+  @attr visibility;
+  @attr details;
+  @attr sections;
+  @attr glossary;
+}

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -40,6 +40,7 @@
 @use 'components/competence-overview-skill';
 @use 'components/login-form';
 @use 'components/markdown-editor/markdown-editor';
+@use 'components/modules/module-form';
 @use 'components/field';
 @use 'components/field/quality';
 @use 'components/field/select-search';

--- a/pix-editor/app/styles/components/modules/module-form.scss
+++ b/pix-editor/app/styles/components/modules/module-form.scss
@@ -12,4 +12,11 @@
   &__monaco-editor {
     height: 70vh;
   }
+
+  &__actions {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: var(--pix-spacing-4x);
+    justify-items: start;
+  }
 }

--- a/pix-editor/app/styles/components/modules/module-form.scss
+++ b/pix-editor/app/styles/components/modules/module-form.scss
@@ -1,0 +1,15 @@
+.module-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-6x);
+
+  &__data-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-2x);
+  }
+
+  &__monaco-editor {
+    height: 70vh;
+  }
+}

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -1,12 +1,46 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 
-<template>
-  <header class="page-header">
-    <h1 class="page-title">Création d'un module</h1>
-  </header>
-  <main class="page-body">
-    <section class="page-section module-form">
-      <ModuleForm />
-    </section>
-  </main>
-</template>
+export default class NewModule extends Component {
+  @service loader;
+  @service notify;
+  @service router;
+  @service store;
+
+  @action
+  async saveModule({ title, isBeta, slug, visibility, details, sections, glossary }) {
+    const newModule = this.store.createRecord('module', {
+      title,
+      isBeta,
+      slug,
+      visibility,
+      details,
+      sections,
+      glossary,
+    });
+
+    try {
+      this.loader.start();
+      await newModule.save();
+      this.router.replaceWith('authenticated.modules');
+      this.notify.message(`Le module ${newModule.title} a été enregistré.`);
+    } catch (err) {
+      this.notify.error('Erreur lors de l’enregistrement du module.');
+    } finally {
+      this.loader.stop();
+    }
+  }
+
+  <template>
+    <header class="page-header">
+      <h1 class="page-title">Création d'un module</h1>
+    </header>
+    <main class="page-body">
+      <section class="page-section module-form">
+        <ModuleForm @saveModule={{this.saveModule}} />
+      </section>
+    </main>
+  </template>
+}

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -1,10 +1,12 @@
+import ModuleForm from 'pixeditor/components/modules/module-form';
+
 <template>
   <header class="page-header">
     <h1 class="page-title">Création d'un module</h1>
   </header>
   <main class="page-body">
-    <section class="page-section">
-
+    <section class="page-section module-form">
+      <ModuleForm />
     </section>
   </main>
 </template>

--- a/pix-editor/playwright.global-setup.js
+++ b/pix-editor/playwright.global-setup.js
@@ -19,7 +19,7 @@ export default async function globalSetup(config) {
 
       try {
         const page = await context.newPage();
-        await page.goto('/');
+        await page.goto('/', { timeout: 60000 });
         await page.getByRole('textbox', { name: 'Clé API' }).fill(user.apiKey);
         await page.getByRole('button', { name: 'Se connecter' }).click();
         await page.waitForURL('/');

--- a/pix-editor/testem.js
+++ b/pix-editor/testem.js
@@ -3,8 +3,8 @@ const config = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   reporter: 'dot',
-  launch_in_ci: ['Chrome'],
-  launch_in_dev: ['Chrome'],
+  launch_in_ci: ['Firefox'],
+  launch_in_dev: ['Firefox'],
   browser_start_timeout: 120,
   browser_args: {
     Chrome: {
@@ -20,6 +20,9 @@ const config = {
         '--remote-debugging-port=9222',
         '--window-size=1440,900',
       ].filter(Boolean),
+    },
+    Firefox: {
+      ci: ['--headless', '--remote-debugging-port=9222', '--window-size=1440,900'],
     },
   },
 };

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -29,7 +29,7 @@ module('Acceptance | Modules | New', function (hooks) {
     assert.strictEqual(currentURL(), '/modules/new');
     assert.dom(await screen.findByRole('heading', { name: "Création d'un module" })).exists();
 
-    const editor = await screen.findByRole('textbox', { name: 'Contenu (JSON)' });
+    const editor = await screen.findByLabelText('Contenu (JSON)');
 
     await fillIn(
       editor,

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -1,5 +1,5 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { currentURL, fillIn } from '@ember/test-helpers';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { module, test } from 'qunit';
@@ -28,5 +28,40 @@ module('Acceptance | Modules | New', function (hooks) {
     // then
     assert.strictEqual(currentURL(), '/modules/new');
     assert.dom(await screen.findByRole('heading', { name: "Création d'un module" })).exists();
+
+    const editor = await screen.findByRole('textbox', { name: 'Contenu (JSON)' });
+
+    await fillIn(
+      editor,
+      JSON.stringify({
+        title: 'Nouveau module',
+        isBeta: true,
+        slug: 'slug',
+        visibility: 'public',
+        details: {
+          level: 'novice',
+        },
+        sections: [
+          {
+            id: 'section1',
+          },
+          {
+            id: 'section2',
+          },
+        ],
+        glossary: [
+          {
+            word: 'pouet',
+            definition: 'sound',
+          },
+        ],
+      }),
+    );
+
+    await screen.getByRole('button', { name: 'Enregistrer' }).click();
+
+    assert.dom(await screen.findByRole('heading', { name: 'Modules' })).exists();
+    assert.dom(await screen.findByText('Nouveau module')).exists();
+    assert.dom(await screen.findByText('Le module Nouveau module a été enregistré.')).exists();
   });
 });

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -17,11 +17,9 @@ module('Integration | Component | modules/module-form', function (hooks) {
 
     // then
     assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasAttribute('readonly');
-    const monacoEditor = screen.getByRole('textbox', { name: 'Contenu (JSON)' });
+    const monacoEditor = await screen.findByLabelText('Contenu (JSON)');
     assert.dom(monacoEditor).exists();
     const saveButton = screen.getByRole('button', { name: 'Enregistrer' });
-    assert.dom(saveButton).hasAttribute('aria-disabled');
-    assert.dom(screen.getByRole('link', { name: 'Annuler' })).exists();
 
     await fillIn(monacoEditor, JSON.stringify({ title: 'Mon titre' }));
 

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -1,0 +1,37 @@
+import ModuleForm from 'pixeditor/components/modules/module-form';
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import { module, test } from 'qunit';
+import { click, fillIn } from '@ember/test-helpers';
+import sinon from 'sinon';
+
+module('Integration | Component | modules/module-form', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // given
+    const saveModule = sinon.stub();
+
+    // when
+    const screen = await render(<template><ModuleForm @saveModule={{saveModule}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasAttribute('readonly');
+    const monacoEditor = screen.getByRole('textbox', { name: 'Contenu (JSON)' });
+    assert.dom(monacoEditor).exists();
+    const saveButton = screen.getByRole('button', { name: 'Enregistrer' });
+    assert.dom(saveButton).hasAttribute('aria-disabled');
+    assert.dom(screen.getByRole('link', { name: 'Annuler' })).exists();
+
+    await fillIn(monacoEditor, JSON.stringify({ title: 'Mon titre' }));
+
+    assert.dom(saveButton).doesNotHaveAttribute('aria-disabled');
+    assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasValue('Mon titre');
+
+    await click(saveButton);
+    sinon.assert.calledWithExactly(saveModule, { title: 'Mon titre' });
+
+    // WORKAROUND: let some time for monaco-editor to dismount
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+});

--- a/pix-editor/tests/mirage/factories.js
+++ b/pix-editor/tests/mirage/factories.js
@@ -9,6 +9,7 @@ import competence from './factories/competence';
 import framework from './factories/framework';
 import localizedChallenge from './factories/localized-challenge';
 import moduleSummary from './factories/module-summary';
+import module from './factories/module';
 import note from './factories/note';
 import searchResult from './factories/search-result';
 import skill from './factories/skill';
@@ -27,6 +28,7 @@ export default {
   competence,
   framework,
   localizedChallenge,
+  module,
   moduleSummary,
   note,
   searchResult,

--- a/pix-editor/tests/mirage/factories/module.js
+++ b/pix-editor/tests/mirage/factories/module.js
@@ -1,0 +1,41 @@
+import { Factory } from 'miragejs';
+
+export default Factory.extend({
+  id() {
+    return crypto.randomUUID();
+  },
+
+  title(i) {
+    return `Module ${i}`;
+  },
+
+  slug(i) {
+    return `module-${i}`;
+  },
+
+  details() {
+    return {
+      level: 'novice',
+    };
+  },
+
+  sections() {
+    return [
+      {
+        id: crypto.randomUUID(),
+      },
+    ];
+  },
+
+  glossary() {
+    return [
+      {
+        word: 'pouet',
+        definition: 'sound',
+      },
+    ];
+  },
+
+  isBeta: false,
+  visibility: 'public',
+});

--- a/pix-editor/tests/mirage/models.js
+++ b/pix-editor/tests/mirage/models.js
@@ -18,6 +18,7 @@ import localizedChallenge from './models/localized-challenge';
 import localizedFrameworkTube from './models/localized-framework-tube';
 import missionSummary from './models/mission-summary';
 import mission from './models/mission';
+import module from './models/module';
 import moduleSummary from './models/module-summary';
 import note from './models/note';
 import searchResult from './models/search-result';
@@ -51,6 +52,7 @@ export default {
   localizedFrameworkTube,
   missionSummary,
   mission,
+  module,
   moduleSummary,
   note,
   searchResult,

--- a/pix-editor/tests/mirage/models/module.js
+++ b/pix-editor/tests/mirage/models/module.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -383,6 +383,13 @@ export default function routes() {
     return mission;
   });
 
+  this.post('modules', function (schema, request) {
+    const attributes = JSON.parse(request.requestBody).data.attributes;
+    const module = schema.create('module', { id: crypto.randomUUID(), attributes });
+    schema.create('module-summary', { id: module.id, ...attributes });
+    return module;
+  });
+
   this.get('/module-summaries', function (schema, request) {
     const pagination = _getPaginationFromQueryParams(request.queryParams);
 


### PR DESCRIPTION
## 💥 Problème
On souhaite pouvoir enregistrer des nouveaux modules dans pix editor

## 👩‍🚀 Proposition
Créer la page de création des nouveaux modules.

## 👁️ Remarques


## ♻️ Pour tester

- [Aller sur pix editor](https://pix-lcms-review-pr1471.osc-fr1.scalingo.io/connexion)
- Copier/coller un json de module depuis modulix editor
- Vérifier que la sauvegarde se passe bien