### PR TITLE
[FEATURE] Permettre de trier les épreuves traduites d'un acquis en V2 (PIX-22520)

### DIFF
--- a/pix-editor/app/components/alternatives.gjs
+++ b/pix-editor/app/components/alternatives.gjs
@@ -5,6 +5,7 @@ import { LinkTo } from '@ember/routing';
 import Alternatives0 from 'pixeditor/components/list/alternatives';
 import { Input } from '@ember/component';
 import { on } from '@ember/modifier';
+import Challenge from 'pixeditor/models/challenge';
 
 export default class Alternatives extends Component {
   <template>
@@ -52,7 +53,7 @@ export default class Alternatives extends Component {
   get alternatives() {
     return this.arePerimeDeclisDisplayed
       ? this.args.challenge.alternatives
-      : this.args.challenge.alternatives.filter((alternative) => alternative.status !== 'périmé');
+      : this.args.challenge.alternatives.filter((alternative) => alternative.status !== Challenge.STATUSES.PERIME);
   }
 
   get canCreateAlternative() {

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -13,7 +13,7 @@ import { tracked } from '@glimmer/tracking';
 import formatDate from 'ember-intl/helpers/format-date';
 import Challenge from 'pixeditor/models/challenge';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
-import { PRIMARY_IN_LOCALE_STATUS, NOT_TRANSLATED_STATUS } from 'pixeditor/models/challenge-locale';
+import ChallengeLocale from 'pixeditor/models/challenge-locale';
 import DropdownMenu from '../dropdown-menu';
 import ChallengesProductionHeader from './challenges-production-header';
 
@@ -30,10 +30,10 @@ export default class LocalizedChallengesProduction extends Component {
   sortFunctions = {
     status: (a, b) => {
       const orders = [
-        PRIMARY_IN_LOCALE_STATUS,
+        ChallengeLocale.STATUSES.PRIMARY_IN_LOCALE_STATUS,
         LocalizedChallenge.STATUSES.PLAY,
         LocalizedChallenge.STATUSES.PAUSE,
-        NOT_TRANSLATED_STATUS,
+        ChallengeLocale.STATUSES.NOT_TRANSLATED_STATUS,
       ];
 
       const aOrder = orders.indexOf(a.status);

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -12,6 +12,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import formatDate from 'ember-intl/helpers/format-date';
 import Challenge from 'pixeditor/models/challenge';
+import LocalizedChallenge from 'pixeditor/models/localized-challenge';
+import { PRIMARY_IN_LOCALE_STATUS, NOT_TRANSLATED_STATUS } from 'pixeditor/models/challenge-locale';
 import DropdownMenu from '../dropdown-menu';
 import ChallengesProductionHeader from './challenges-production-header';
 
@@ -20,6 +22,45 @@ export default class LocalizedChallengesProduction extends Component {
   @service multipanelManager;
 
   @tracked shouldDisplayObsoleteChallenges = false;
+  @tracked sortStatus = {
+    column: 'status',
+    order: 'desc',
+  };
+
+  sortFunctions = {
+    status: (a, b) => {
+      const orders = [
+        PRIMARY_IN_LOCALE_STATUS,
+        LocalizedChallenge.STATUSES.PLAY,
+        LocalizedChallenge.STATUSES.PAUSE,
+        NOT_TRANSLATED_STATUS,
+      ];
+
+      const aOrder = orders.indexOf(a.status);
+      const bOrder = orders.indexOf(b.status);
+
+      if (aOrder === bOrder) {
+        return this.sortFunctions.version(a, b);
+      }
+
+      if (this.sortStatus.order === 'asc') {
+        return bOrder - aOrder;
+      }
+      return aOrder - bOrder;
+    },
+
+    version: (a, b) => {
+      if (this.sortStatus.order === 'asc') {
+        if (a.isPrototype) return 1;
+        if (b.isPrototype) return -1;
+        return b.alternativeVersion - a.alternativeVersion;
+      }
+
+      if (a.isPrototype) return -1;
+      if (b.isPrototype) return 1;
+      return a.alternativeVersion - b.alternativeVersion;
+    }
+  }
 
   get challengeLocales() {
     const excludeStatuses = [];
@@ -32,8 +73,19 @@ export default class LocalizedChallengesProduction extends Component {
     );
   }
 
+  get sortedChallengeLocales() {
+    if (!this.sortStatus.column) return this.challengeLocales;
+
+    return this.challengeLocales.toSorted(this.sortFunctions[this.sortStatus.column]);
+  }
+
   get isToRephrase() {
     return this.args.skill.productionPrototype.toRephrase;
+  }
+
+  get translationStatusColumnSortOrder() {
+    if (this.sortStatus.column !== 'status') return null;
+    return this.sortStatus.order;
   }
 
   @action
@@ -44,6 +96,24 @@ export default class LocalizedChallengesProduction extends Component {
   @action
   async copyChallengePreviewUrl(previewUrl) {
     await navigator.clipboard.writeText(previewUrl);
+  }
+
+  @action
+  sortBy(column) {
+    if (this.sortStatus.column !== column) {
+      this.sortStatus = { column: column, order: 'asc' };
+      return;
+    }
+
+    if (this.sortStatus.order === 'desc') {
+      this.sortStatus = {
+        column: null,
+        order: null,
+      };
+      return;
+    }
+
+    this.sortStatus = { column: column, order: 'desc' };
   }
 
   <template>
@@ -62,7 +132,7 @@ export default class LocalizedChallengesProduction extends Component {
       <div class="challenges-production-table">
         <PixTable
           @condensed={{true}}
-          @data={{this.challengeLocales}}
+          @data={{this.sortedChallengeLocales}}
           @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}}
         >
           <:columns as |challengeLocale context|>
@@ -140,7 +210,14 @@ export default class LocalizedChallengesProduction extends Component {
                 </PixTag>
               </:cell>
             </PixTableColumn>
-            <PixTableColumn @context={{context}}>
+            <PixTableColumn
+              @context={{context}}
+              @onSort={{fn this.sortBy "status"}}
+              @sortOrder={{this.translationStatusColumnSortOrder}}
+              @ariaLabelDefaultSort="Trier dans l'ordre de la traduction la moins opérationnelle à la plus opérationnelle"
+              @ariaLabelSortDesc="Trier dans l'ordre de la traduction la plus opérationnelle à la moins opérationnelle"
+              @ariaLabelSortAsc="Rétablir le tri par défaut"
+            >
               <:header>
                 Traduction
               </:header>

--- a/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
+++ b/pix-editor/app/components/challenges-production/localized-challenges-production.gjs
@@ -59,8 +59,48 @@ export default class LocalizedChallengesProduction extends Component {
       if (a.isPrototype) return -1;
       if (b.isPrototype) return 1;
       return a.alternativeVersion - b.alternativeVersion;
-    }
-  }
+    },
+
+    updatedAt: (a, b) => {
+      if (this.sortStatus.order === 'asc') {
+        return b.primaryUpdatedAt.getTime() - a.primaryUpdatedAt.getTime();
+      }
+      return a.primaryUpdatedAt.getTime() - b.primaryUpdatedAt.getTime();
+    },
+
+    author: (a, b) => {
+      if (a.primaryAuthor[0] === b.primaryAuthor[0]) {
+        return this.sortFunctions.version(a, b);
+      }
+
+      if (this.sortStatus.order === 'asc') {
+        return b.primaryAuthor[0].localeCompare(a.primaryAuthor[0]);
+      }
+      return a.primaryAuthor[0].localeCompare(b.primaryAuthor[0]);
+    },
+
+    source: (a, b) => {
+      const orders = [
+        Challenge.STATUSES.VALIDE_QUALITE,
+        Challenge.STATUSES.VALIDE,
+        Challenge.STATUSES.PROPOSE,
+        Challenge.STATUSES.ARCHIVE,
+        Challenge.STATUSES.PERIME,
+      ];
+
+      const aOrder = orders.indexOf(a.primaryComputedStatus);
+      const bOrder = orders.indexOf(b.primaryComputedStatus);
+
+      if (aOrder === bOrder) {
+        return this.sortFunctions.version(a, b);
+      }
+
+      if (this.sortStatus.order === 'asc') {
+        return bOrder - aOrder;
+      }
+      return aOrder - bOrder;
+    },
+  };
 
   get challengeLocales() {
     const excludeStatuses = [];
@@ -81,6 +121,26 @@ export default class LocalizedChallengesProduction extends Component {
 
   get isToRephrase() {
     return this.args.skill.productionPrototype.toRephrase;
+  }
+
+  get versionColumnSortOrder() {
+    if (this.sortStatus.column !== 'version') return null;
+    return this.sortStatus.order;
+  }
+
+  get updatedAtColumnSortOrder() {
+    if (this.sortStatus.column !== 'updatedAt') return null;
+    return this.sortStatus.order;
+  }
+
+  get authorColumnSortOrder() {
+    if (this.sortStatus.column !== 'author') return null;
+    return this.sortStatus.order;
+  }
+
+  get sourceColumnSortOrder() {
+    if (this.sortStatus.column !== 'source') return null;
+    return this.sortStatus.order;
   }
 
   get translationStatusColumnSortOrder() {
@@ -136,7 +196,14 @@ export default class LocalizedChallengesProduction extends Component {
           @caption={{concat "Tableau des épreuves de l'acquis " @skill.name}}
         >
           <:columns as |challengeLocale context|>
-            <PixTableColumn @context={{context}}>
+            <PixTableColumn
+              @context={{context}}
+              @onSort={{fn this.sortBy "version"}}
+              @sortOrder={{this.versionColumnSortOrder}}
+              @ariaLabelDefaultSort="Trier dans l'ordre décroissant des versions"
+              @ariaLabelSortDesc="Trier dans l'ordre croissant des versions"
+              @ariaLabelSortAsc="Rétablir le tri par défaut"
+            >
               <:header>
                 Version
               </:header>
@@ -184,7 +251,14 @@ export default class LocalizedChallengesProduction extends Component {
                 {{/if}}
               </:cell>
             </PixTableColumn>
-            <PixTableColumn @context={{context}}>
+            <PixTableColumn
+              @context={{context}}
+              @onSort={{fn this.sortBy "updatedAt"}}
+              @sortOrder={{this.updatedAtColumnSortOrder}}
+              @ariaLabelDefaultSort="Trier dans l'ordre du plus récent au moins récent"
+              @ariaLabelSortDesc="Trier dans l'ordre du moins récent au plus récent"
+              @ariaLabelSortAsc="Rétablir le tri par défaut"
+            >
               <:header>
                 Dernière MAJ
               </:header>
@@ -192,7 +266,14 @@ export default class LocalizedChallengesProduction extends Component {
                 {{formatDate challengeLocale.primaryUpdatedAt "DD/MM/YYYY" allow-empty=true}}
               </:cell>
             </PixTableColumn>
-            <PixTableColumn @context={{context}}>
+            <PixTableColumn
+              @context={{context}}
+              @onSort={{fn this.sortBy "author"}}
+              @sortOrder={{this.authorColumnSortOrder}}
+              @ariaLabelDefaultSort="Trier dans l'ordre anti-alphabétique des auteurs"
+              @ariaLabelSortDesc="Trier dans l'ordre alphabétique des auteurs"
+              @ariaLabelSortAsc="Rétablir le tri par défaut"
+            >
               <:header>
                 Auteur
               </:header>
@@ -200,7 +281,14 @@ export default class LocalizedChallengesProduction extends Component {
                 {{challengeLocale.primaryAuthor}}
               </:cell>
             </PixTableColumn>
-            <PixTableColumn @context={{context}}>
+            <PixTableColumn
+              @context={{context}}
+              @onSort={{fn this.sortBy "source"}}
+              @sortOrder={{this.sourceColumnSortOrder}}
+              @ariaLabelDefaultSort="Trier dans l'ordre du challenge le moins opérationnel au plus opérationnel"
+              @ariaLabelSortDesc="Trier dans l'ordre du challenge le plus opérationnel au moins opérationnel"
+              @ariaLabelSortAsc="Rétablir le tri par défaut"
+            >
               <:header>
                 Source
               </:header>

--- a/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
+++ b/pix-editor/app/components/localized-challenge-view/localized-challenge-view.gjs
@@ -9,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import getMimeType from 'pixeditor/helpers/get-mime-type';
+import Challenge from 'pixeditor/models/challenge';
 
 import PopInImage from '../pop-in/image';
 import PopInConfirm from '../pop-in/confirm';
@@ -269,7 +270,9 @@ export default class LocalizedChallenge extends Component {
   @action
   async updateStatusProduction() {
     this.displayConfirm = false;
-    this.args.localizedChallenge.status = this.args.localizedChallenge.isInProduction ? 'proposé' : 'validé';
+    this.args.localizedChallenge.status = this.args.localizedChallenge.isInProduction
+      ? Challenge.STATUSES.PROPOSE
+      : Challenge.STATUSES.VALIDE;
     try {
       this.loader.start('Enregistrement');
       await this.args.localizedChallenge.save();

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/localized.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import getMimeType from 'pixeditor/helpers/get-mime-type';
+import Challenge from 'pixeditor/models/challenge';
 
 export default class LocalizedController extends Controller {
   @service router;
@@ -160,7 +161,9 @@ export default class LocalizedController extends Controller {
   }
 
   @action async confirmApprove() {
-    this.localizedChallenge.status = this.localizedChallenge.isInProduction ? 'proposé' : 'validé';
+    this.localizedChallenge.status = this.localizedChallenge.isInProduction
+      ? Challenge.STATUSES.PROPOSE
+      : Challenge.STATUSES.VALIDE;
     try {
       await this._saveChallenge(this.localizedChallenge);
     } catch (error) {

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import * as Sentry from '@sentry/ember';
 import yaml from 'js-yaml';
+import Challenge from 'pixeditor/models/challenge';
 
 export default class SingleController extends Controller {
   wasMaximized = false;
@@ -707,7 +708,7 @@ export default class SingleController extends Controller {
     }
     await Promise.all([skill.tutoMore, skill.tutoSolution]);
     const prototypesStatusOtherVersion = this._getPrototypesStatusOtherVersion(skill, challenge);
-    const haveProposalPrototype = prototypesStatusOtherVersion.includes('proposé');
+    const haveProposalPrototype = prototypesStatusOtherVersion.includes(Challenge.STATUSES.PROPOSE);
     if (haveProposalPrototype) {
       return skill.deactivate();
     }
@@ -721,10 +722,10 @@ export default class SingleController extends Controller {
     }
     await Promise.all([skill.tutoMore, skill.tutoSolution]);
     const prototypesStatusOtherVersion = this._getPrototypesStatusOtherVersion(skill, challenge);
-    if (prototypesStatusOtherVersion.includes('proposé')) {
+    if (prototypesStatusOtherVersion.includes(Challenge.STATUSES.PROPOSE)) {
       return skill.deactivate();
     }
-    if (prototypesStatusOtherVersion.includes('archivé')) {
+    if (prototypesStatusOtherVersion.includes(Challenge.STATUSES.ARCHIVE)) {
       return skill.archive();
     }
     return skill.obsolete();

--- a/pix-editor/app/models/challenge-locale.js
+++ b/pix-editor/app/models/challenge-locale.js
@@ -2,9 +2,6 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 import Challenge from 'pixeditor/models/challenge';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
 
-export const PRIMARY_IN_LOCALE_STATUS = 'PRIMARY_IN_LOCALE';
-export const NOT_TRANSLATED_STATUS = 'NOT_TRANSLATED';
-
 export default class ChallengeLocaleModel extends Model {
   @attr locale;
 
@@ -56,8 +53,8 @@ export default class ChallengeLocaleModel extends Model {
   }
 
   get status() {
-    if (this.isPrimaryInLocale) return PRIMARY_IN_LOCALE_STATUS;
-    return this.localizedChallengeValue?.status ?? NOT_TRANSLATED_STATUS;
+    if (this.isPrimaryInLocale) return ChallengeLocaleModel.STATUSES.PRIMARY_IN_LOCALE_STATUS;
+    return this.localizedChallengeValue?.status ?? ChallengeLocaleModel.STATUSES.NOT_TRANSLATED_STATUS;
   }
 
   get primaryPreviewUrl() {
@@ -106,10 +103,10 @@ export default class ChallengeLocaleModel extends Model {
     if (this.status === LocalizedChallenge.STATUSES.PAUSE) {
       return 'yellow';
     }
-    if (this.status === PRIMARY_IN_LOCALE_STATUS) {
+    if (this.status === ChallengeLocaleModel.STATUSES.PRIMARY_IN_LOCALE_STATUS) {
       return 'grey';
     }
-    if (this.status === NOT_TRANSLATED_STATUS) {
+    if (this.status === ChallengeLocaleModel.STATUSES.NOT_TRANSLATED_STATUS) {
       return 'blue';
     }
     return 'orange';
@@ -122,12 +119,19 @@ export default class ChallengeLocaleModel extends Model {
     if (this.status === LocalizedChallenge.STATUSES.PAUSE) {
       return 'En pause';
     }
-    if (this.status === PRIMARY_IN_LOCALE_STATUS) {
+    if (this.status === ChallengeLocaleModel.STATUSES.PRIMARY_IN_LOCALE_STATUS) {
       return 'Source dans la langue';
     }
-    if (this.status === NOT_TRANSLATED_STATUS) {
+    if (this.status === ChallengeLocaleModel.STATUSES.NOT_TRANSLATED_STATUS) {
       return 'Pas traduit';
     }
     return 'absence de statut ❓';
+  }
+
+  static get STATUSES() {
+    return {
+      PRIMARY_IN_LOCALE_STATUS: 'PRIMARY_IN_LOCALE',
+      NOT_TRANSLATED_STATUS: 'NOT_TRANSLATED',
+    };
   }
 }

--- a/pix-editor/app/models/challenge-locale.js
+++ b/pix-editor/app/models/challenge-locale.js
@@ -2,8 +2,8 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 import Challenge from 'pixeditor/models/challenge';
 import LocalizedChallenge from 'pixeditor/models/localized-challenge';
 
-const PRIMARY_IN_LOCALE_STATUS = 'PRIMARY_IN_LOCALE';
-const NOT_TRANSLATED_STATUS = 'NOT_TRANSLATED';
+export const PRIMARY_IN_LOCALE_STATUS = 'PRIMARY_IN_LOCALE';
+export const NOT_TRANSLATED_STATUS = 'NOT_TRANSLATED';
 
 export default class ChallengeLocaleModel extends Model {
   @attr locale;

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -165,7 +165,7 @@ export default class ChallengeModel extends Model {
   }
 
   get isValidated() {
-    return this.status === 'validé';
+    return this.status === ChallengeModel.STATUSES.VALIDE;
   }
 
   get skillName() {
@@ -173,31 +173,23 @@ export default class ChallengeModel extends Model {
   }
 
   get isDraft() {
-    return this.status === 'proposé';
+    return this.status === ChallengeModel.STATUSES.PROPOSE;
   }
 
   get isArchived() {
-    return this.status === 'archivé';
+    return this.status === ChallengeModel.STATUSES.ARCHIVE;
   }
 
   get isObsolete() {
-    return this.status === 'périmé';
+    return this.status === ChallengeModel.STATUSES.PERIME;
   }
 
   get statusCSS() {
-    const status = this.status;
-    switch (status) {
-      case 'validé':
-        return 'validated';
-      case 'proposé':
-        return 'suggested';
-      case 'archivé':
-        return 'archived';
-      case 'périmé':
-        return 'deleted';
-      default:
-        return '';
-    }
+    if (this.isValidated) return 'validated';
+    if (this.isDraft) return 'suggested';
+    if (this.isArchived) return 'archived';
+    if (this.isObsolete) return 'deleted';
+    return '';
   }
 
   get computedStatus() {
@@ -335,19 +327,19 @@ export default class ChallengeModel extends Model {
   }
 
   archive() {
-    this.status = 'archivé';
+    this.status = ChallengeModel.STATUSES.ARCHIVE;
     this.archivedAt = new Date();
     return this.save();
   }
 
   obsolete() {
-    this.status = 'périmé';
+    this.status = ChallengeModel.STATUSES.PERIME;
     this.madeObsoleteAt = new Date();
     return this.save();
   }
 
   validate() {
-    this.status = 'validé';
+    this.status = ChallengeModel.STATUSES.VALIDE;
     this.validatedAt = new Date();
     return this.save();
   }
@@ -370,7 +362,7 @@ export default class ChallengeModel extends Model {
     }
     const data = this._getJSON(ignoredFields);
     data.author = [this.config.author];
-    data.status = 'proposé';
+    data.status = ChallengeModel.STATUSES.PROPOSE;
     data.skill = await this.skill;
 
     const newChallenge = this.myStore.createRecord(this.constructor.modelName, data);
@@ -389,7 +381,7 @@ export default class ChallengeModel extends Model {
       'isQualityOk',
     ];
     const data = this._getJSON(ignoredFields);
-    data.status = 'proposé';
+    data.status = ChallengeModel.STATUSES.PROPOSE;
 
     const newChallenge = this.myStore.createRecord(this.constructor.modelName, data);
     await this._cloneAttachments(newChallenge);
@@ -399,7 +391,7 @@ export default class ChallengeModel extends Model {
   async derive() {
     const alternative = await this.duplicate();
     alternative.version = this.version;
-    alternative.genealogy = 'Décliné 1';
+    alternative.genealogy = ChallengeModel.GENEALOGIES.DECLINAISON;
     return alternative;
   }
 

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -84,6 +84,7 @@ export default class ChallengeModel extends Model {
 
   static get STATUSES() {
     return {
+      VALIDE_QUALITE: 'validé qualité',
       VALIDE: 'validé',
       PROPOSE: 'proposé',
       ARCHIVE: 'archivé',

--- a/pix-editor/app/models/localized-challenge.js
+++ b/pix-editor/app/models/localized-challenge.js
@@ -58,7 +58,7 @@ export default class LocalizedChallengeModel extends Model {
   }
 
   get isStatusEditable() {
-    return ['validé', 'archivé'].includes(this.challenge.get('status'));
+    return [Challenge.STATUSES.VALIDE, Challenge.STATUSES.ARCHIVE].includes(this.challenge.get('status'));
   }
 
   get firstAttachmentBaseName() {

--- a/pix-editor/app/routes/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/routes/authenticated/competence/prototypes/new.js
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 
 import PrototypeRoute from './single';
+import Challenge from 'pixeditor/models/challenge';
 
 export default class NewRoute extends PrototypeRoute {
   templateName = 'authenticated/competence/prototypes/single';
@@ -15,11 +16,11 @@ export default class NewRoute extends PrototypeRoute {
     } else {
       const newChallenge = this.store.createRecord('challenge', {
         competence: [this.modelFor('authenticated.competence').id],
-        status: 'proposé',
+        status: Challenge.STATUSES.PROPOSE,
         t1Status: true,
         t2Status: true,
         t3Status: true,
-        genealogy: 'Prototype 1',
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
         author: [this.config.author],
         requireGafamWebsiteAccess: false,
         isIncompatibleIpadCertif: false,

--- a/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
+++ b/pix-editor/tests/integration/components/challenges-production/localized-challenges-production-test.gjs
@@ -276,7 +276,7 @@ module('Integration | Component | challenges-production | localized-challenges-p
     test('should display all expected info for a given challenge', async function (assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
-      const prototype = validatedChallenges[1];
+      const prototype = validatedChallenges[2];
       assert.dom(prototype).includesText('Proto');
       assert.dom(prototype).includesText('Een super maxi lange instructie');
       assert.dom(prototype).includesText('25/12/2019');
@@ -323,24 +323,24 @@ module('Integration | Component | challenges-production | localized-challenges-p
       });
     });
 
-    test('should display appropriate translation statuses for each challenge', async function (assert) {
+    test('should display appropriate translation statuses for each challenge, sorted by translation status', async function (assert) {
       // then
       const validatedChallenges = screen.queryAllByRole('row');
 
-      const prototype = validatedChallenges[1];
+      const primaryAlreadyNl = validatedChallenges[1];
+      assert.dom(primaryAlreadyNl).includesText('consigne challengeDecliNl');
+      assert.dom(primaryAlreadyNl).includesText('validé');
+      assert.dom(primaryAlreadyNl).includesText('Source dans la langue');
+
+      const prototype = validatedChallenges[2];
       assert.dom(prototype).includesText('Een super maxi lange instructie');
       assert.dom(prototype).includesText('validé');
       assert.dom(prototype).includesText('En prod');
 
-      const archivedAndPausedNl = validatedChallenges[2];
+      const archivedAndPausedNl = validatedChallenges[3];
       assert.dom(archivedAndPausedNl).includesText('consigne NL challengeDecliArchivee');
       assert.dom(archivedAndPausedNl).includesText('archivé');
       assert.dom(archivedAndPausedNl).includesText('En pause');
-
-      const primaryAlreadyNl = validatedChallenges[3];
-      assert.dom(primaryAlreadyNl).includesText('consigne challengeDecliNl');
-      assert.dom(primaryAlreadyNl).includesText('validé');
-      assert.dom(primaryAlreadyNl).includesText('Source dans la langue');
 
       const notTranslated = validatedChallenges[4];
       assert.dom(notTranslated).includesText('consigne challengeDecliProposee');
@@ -446,6 +446,43 @@ module('Integration | Component | challenges-production | localized-challenges-p
         assert.strictEqual(obsoleteChallenges.length, 1);
         assert.strictEqual(archivedChallenges.length, 1);
         assert.strictEqual(proposedChallenges.length, 1);
+      });
+    });
+
+    module('#sort', function () {
+      test('when resetting sort, it should display challenges sorted by version', async function (assert) {
+        screen = await render(
+          <template>
+            <LocalizedChallengesProduction
+              @skill={{skill}}
+              @challengeLocales={{challengeLocalesNl}}
+              @competence={{competence}}
+            />
+          </template>,
+        );
+
+        await click(screen.getByRole('button', { name: 'Rétablir le tri par défaut' }));
+
+        const challenges = screen.queryAllByRole('row');
+
+        const prototype = challenges[1];
+        assert.dom(prototype).includesText('Proto');
+        assert.dom(prototype).includesText('En prod');
+
+        const archivedAndPausedNl = challenges[2];
+        assert.dom(archivedAndPausedNl).includesText('consigne NL challengeDecliArchivee');
+        assert.dom(archivedAndPausedNl).includesText('archivé');
+        assert.dom(archivedAndPausedNl).includesText('En pause');
+
+        const primaryAlreadyNl = challenges[3];
+        assert.dom(primaryAlreadyNl).includesText('consigne challengeDecliNl');
+        assert.dom(primaryAlreadyNl).includesText('validé');
+        assert.dom(primaryAlreadyNl).includesText('Source dans la langue');
+
+        const notTranslated = challenges[4];
+        assert.dom(notTranslated).includesText('consigne challengeDecliProposee');
+        assert.dom(notTranslated).includesText('proposé');
+        assert.dom(notTranslated).includesText('Pas traduit');
       });
     });
   });


### PR DESCRIPTION
## 💥 Problème

Les utilisateurs doivent parfois scroller dans la vue V2 afin de se rendre compte que des déclinaisons sont traduites.

## 👩‍🚀 Proposition

- Lorsqu'une langue (autre que "Langue source") est sélectionnée, pré-trier la liste des épreuves dans l'ordre suivant : 
`Source dans la langue` > `En prod` > `En pause` > ` Pas traduit`.
- Permettre de trier les épreuves en fonction des colonnes suivantes : `Version`, `Dernière MAJ`, `Auteur`, `Source`, `Traduction`.

## 👁️ Remarques

Au passage, remplacement des derniers usages de `"validé"`, `"proposé"`, `"Prototype 1"`, etc. par les constantes définies dans le modèle `Challenge`.

## ♻️ Pour tester

- Se rendre sur la V2 de la review app.
- Sélectionner une compétence.
- Sélectionner la langue "Anglais".
- Sélectionner un acquis.
- Constater que le tableau des épreuves est trié dans l'ordre des traductions les plus opérationnelles aux moins opérationnelles.
- Essayer de trier dans d'autres ordres / sur d'autres colonnes.
- Constater que le tri fonctionne d'une manière convenable.