### PR TITLE
[TECH] Skip les tests Monaco editor sur Chrome (PIX-22781)

### DIFF
--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -6,6 +6,8 @@ import { module, test } from 'qunit';
 
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 
+const isChrome = navigator?.userAgent?.includes(' Chrome/');
+
 module('Acceptance | Modules | New', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -19,7 +21,7 @@ module('Acceptance | Modules | New', function (hooks) {
     return authenticateSession();
   });
 
-  test('displays module creation page', async function (assert) {
+  test.if('creates a new module', !isChrome, async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Modules');

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -5,10 +5,12 @@ import { module, test } from 'qunit';
 import { click, fillIn } from '@ember/test-helpers';
 import sinon from 'sinon';
 
+const isChrome = navigator?.userAgent?.includes(' Chrome/');
+
 module('Integration | Component | modules/module-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
+  test.if('it parses and saves a module data', !isChrome, async function (assert) {
     // given
     const saveModule = sinon.stub();
 


### PR DESCRIPTION
## 💥 Problème

Les tests utilisant Monaco Editor sont en échec sur Chrome.

## 👩‍🚀 Proposition

Skip ces tests quand on est sur Chrome.

## 👁️ Remarques

N/A

## ♻️ Pour tester

Démarrer l’appli :

```
cd pix-editor
npm start
```

 - Lancer [les tests des modules](http://localhost:4300/tests?filter=modules) avec Firefox, vérifier que 5 tests sont aux vert.
 - Lancer [les tests des modules](http://localhost:4300/tests?filter=modules) avec Chrome ou un dérivé, vérifier que 3 tests sont aux vert et 2 tests skips.