### PR TITLE
[TECH] Utiliser pgboss pour gérer le job d'export de la liste des urls externes.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
           working_directory: ~/pix-editor/api
           environment:
             DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
+            JOBS_DATABASE_URL: "postgres://circleci@localhost:5432/circleci"
           background: true
           command: npm run db:reset && npm start
 

--- a/api/index.js
+++ b/api/index.js
@@ -56,6 +56,7 @@ async function exitOnSignal(signal) {
     await deleteUnmentionedKeysAfterUploadJobQueue?.close();
     await exportExternalUrlListJobQueue?.close();
     await releaseTableCleaningAndRetentionJobQueue?.close();
+    await JobClient.instance.stop();
     process.exit(0);
   } catch (err) {
     logger.error(err);

--- a/api/index.js
+++ b/api/index.js
@@ -10,10 +10,17 @@ import * as exportExternalUrlListJob from './lib/infrastructure/scheduled-jobs/e
 import * as cleanReleasesJob from './lib/infrastructure/scheduled-jobs/release-table-cleaning-and-retention-job.js';
 import { disconnect } from './db/knex-database-connection.js';
 import { validateEnvironmentVariables } from './lib/infrastructure/validate-environement-variables.js';
+import { JobClient } from './lib/infrastructure/jobs/JobClient.js';
+import { JobGroup } from './lib/application/jobs/job-controller.js';
 
 validateEnvironmentVariables();
 
-let checkUrlsJobQueue, deleteUnmentionedKeysAfterUploadJobQueue, exportExternalUrlListJobQueue, releaseJobQueue, releaseTableCleaningAndRetentionJobQueue, uploadTranslationJobQueue;
+let checkUrlsJobQueue,
+  deleteUnmentionedKeysAfterUploadJobQueue,
+  exportExternalUrlListJobQueue,
+  releaseJobQueue,
+  releaseTableCleaningAndRetentionJobQueue,
+  uploadTranslationJobQueue;
 
 async function start() {
   try {
@@ -26,6 +33,11 @@ async function start() {
     checkUrlsJobQueue = await createCheckUrlsJobQueue();
     exportExternalUrlListJobQueue = await exportExternalUrlListJob.schedule();
     releaseTableCleaningAndRetentionJobQueue = await cleanReleasesJob.schedule();
+
+    await JobClient.instance.initialize({
+      worker: true,
+      jobGroups: [JobGroup.DEFAULT],
+    });
 
     logger.info('Server running at %s', server.info.uri);
   } catch (err) {

--- a/api/lib/application/jobs/job-controller.js
+++ b/api/lib/application/jobs/job-controller.js
@@ -1,0 +1,55 @@
+import Joi from 'joi';
+
+import * as config from '../../config.js';
+// import { JobExpireIn } from '../../infrastructure/repositories/jobs/job-repository.js';
+
+export const JobGroup = {
+  DEFAULT: 'default',
+  FAST: 'fast',
+  MADDO: 'maddo',
+};
+
+export function checkJobGroups(jobGroups) {
+  if (!jobGroups) throw new Error('Job groups are mandatory');
+  for (const jobGroup of jobGroups) {
+    if (!Object.values(JobGroup).includes(jobGroup)) {
+      throw new Error(`Job group invalid, allowed Job groups are [${Object.values(JobGroup)}]`);
+    }
+  }
+}
+
+export class JobController {
+  constructor(jobName, options = {}) {
+    this.jobName = jobName;
+    this.jobGroup = options.jobGroup ?? JobGroup.DEFAULT;
+    this.expireIn = options.expireIn ?? 6000; // JobExpireIn.INFINITE;
+
+    this.#validate();
+  }
+
+  get isJobEnabled() {
+    return true;
+  }
+
+  get legacyName() {
+    return null;
+  }
+
+  get localConcurrency() {
+    return config.pgBoss.localConcurrency;
+  }
+
+  #schema = Joi.object({
+    jobName: Joi.string().required(),
+    jobGroup: Joi.string()
+      .required()
+      .valid(...Object.values(JobGroup)),
+  });
+
+  #validate() {
+    const { error } = this.#schema.validate(this, { allowUnknown: true });
+    if (error) {
+      throw error;
+    }
+  }
+}

--- a/api/lib/application/jobs/job-schedule-controller.js
+++ b/api/lib/application/jobs/job-schedule-controller.js
@@ -1,0 +1,8 @@
+import { JobController } from './job-controller.js';
+
+export class JobScheduleController extends JobController {
+  constructor(jobName, { jobCron, ...options } = {}) {
+    super(jobName, options);
+    this.jobCron = jobCron;
+  }
+}

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -91,6 +91,18 @@ export const scheduledJobs = {
   cleanReleasesTableTime: process.env.CLEAN_RELEASES_TABLE_TIME,
 };
 
+export const pgBoss = {
+  clientConnexionPoolMaxSize: _getNumber(process.env.PGBOSS_CLIENT_CONNECTION_POOL_MAX_SIZE, 2),
+  workerConnexionPoolMaxSize: _getNumber(process.env.PGBOSS_WORKER_CONNECTION_POOL_MAX_SIZE, 15),
+  localConcurrency: _getNumber(process.env.PGBOSS_LOCAL_CONCURRENCY, 1),
+  retentionSeconds: _getNumber(process.env.PGBOSS_RETENTION_SECONDS, 30 * 24 * 3600),
+  persistWarnings: isFeatureEnabled(process.env.PGBOSS_PERSIST_WARNINGS),
+  statesMonitoringJobCron: process.env.PGBOSS_STATES_MONITORING_JOB_CRON || '* * * * *',
+  exportExternalUrlListJobEnabled: process.env.PGBOSS_EXPORT_EXTERNAL_URL_LIST_JOB_ENABLED
+    ? isFeatureEnabled(process.env.PGBOSS_EXPORT_EXTERNAL_URL_LIST_JOB_ENABLED)
+    : true,
+};
+
 export const database = {
   url: process.env.DATABASE_URL,
   poolMinSize: _getNumber(process.env.DATABASE_CONNECTION_POOL_MIN_SIZE, 0),

--- a/api/lib/infrastructure/jobs/JobClient.js
+++ b/api/lib/infrastructure/jobs/JobClient.js
@@ -9,7 +9,7 @@ import { importNamedExportFromFile } from '../utils/import-named-exports-from-di
 import { child } from '../logger.js';
 import { MonitoredJobHandler } from './MonitoredJobHandler.js';
 
-const workerDirPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const workerDirPath = resolve(dirname(fileURLToPath(import.meta.url)), '../');
 const logger = child('worker', { event: 'worker' });
 
 export class JobClient {
@@ -35,8 +35,8 @@ export class JobClient {
     if (this.#isInitialized) return;
     this.#isTestOnly = isTestOnly;
 
-    const connectionString =
-      process.env.NODE_ENV === 'test' ? process.env.TEST_JOBS_DATABASE_URL : process.env.JOBS_DATABASE_URL;
+    const connectionString
+      = process.env.NODE_ENV === 'test' ? process.env.TEST_JOBS_DATABASE_URL : process.env.JOBS_DATABASE_URL;
 
     if (worker) {
       this.#pgBoss = pgBossFactory
@@ -82,7 +82,7 @@ export class JobClient {
   }
 
   async #registerJobs(jobGroups = []) {
-    const globPattern = `${workerDirPath}/application/**/*job-controller.js`;
+    const globPattern = `${workerDirPath}/scheduled-jobs/*job-controller.js`;
 
     logger.info(`Search for job handlers in ${globPattern}`);
     const jobFiles = await Array.fromAsync(glob(globPattern, { exclude: ['**/job-controller.js'] }));
@@ -151,7 +151,7 @@ export class JobClient {
     const { localConcurrency } = jobHandler;
 
     await this.#pgBoss.work(name, { localConcurrency, includeMetadata: true }, async ([job]) => {
-      const monitoredJobHandler = new MonitoredJobHandler({ jobHandler, logger });
+      const monitoredJobHandler = new MonitoredJobHandler({ handler: jobHandler, logger });
       return monitoredJobHandler.handle(name, job);
     });
   }

--- a/api/lib/infrastructure/jobs/JobClient.js
+++ b/api/lib/infrastructure/jobs/JobClient.js
@@ -1,0 +1,225 @@
+import { glob } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PgBoss } from 'pg-boss';
+
+import * as config from '../../config.js';
+import { importNamedExportFromFile } from '../utils/import-named-exports-from-directory.js';
+import { child } from '../logger.js';
+import { MonitoredJobHandler } from './MonitoredJobHandler.js';
+
+const workerDirPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const logger = child('worker', { event: 'worker' });
+
+export class JobClient {
+  /** @type JobClient */
+  static #jobClient;
+
+  /** @type {PgBoss} */
+  #pgBoss = null;
+  #isTestOnly = false;
+  #isInitialized = false;
+
+  static get instance() {
+    if (!JobClient.#jobClient) {
+      JobClient.#jobClient = new JobClient();
+    }
+    return JobClient.#jobClient;
+  }
+
+  async initialize(
+    { worker, isTestOnly, jobGroups } = { worker: false, isTestOnly: false, jobGroups: [] },
+    pgBossFactory,
+  ) {
+    if (this.#isInitialized) return;
+    this.#isTestOnly = isTestOnly;
+
+    const connectionString =
+      process.env.NODE_ENV === 'test' ? process.env.TEST_JOBS_DATABASE_URL : process.env.JOBS_DATABASE_URL;
+
+    if (worker) {
+      this.#pgBoss = pgBossFactory
+        ? pgBossFactory()
+        : new PgBoss({
+            connectionString,
+            max: config.pgBoss.workerConnexionPoolMaxSize,
+            persistWarnings: config.pgBoss.persistWarnings,
+            warningRetentionDays: 30,
+          });
+
+      this.#pgBoss.on('error', (err) => {
+        logger.error({ event: 'pg-boss-error', err }, 'PGBOSS ERROR');
+      });
+      this.#pgBoss.on('warning', ({ message, data }) => {
+        logger.warn({ event: 'pg-boss-warning', data }, message);
+      });
+      this.#pgBoss.on('wip', (data) => {
+        logger.info({ event: 'pg-boss-wip', data }, 'PGBOSS WIP');
+      });
+
+      await this.#pgBoss.start();
+      await this.#registerJobs(jobGroups);
+    } else {
+      this.#pgBoss = pgBossFactory
+        ? pgBossFactory()
+        : new PgBoss({
+            connectionString,
+            max: config.pgBoss.clientConnexionPoolMaxSize,
+            supervise: false,
+            schedule: false,
+          });
+      await this.#pgBoss.start();
+    }
+
+    this.#isInitialized = true;
+  }
+
+  #assertIsInitialized() {
+    if (!this.#isInitialized) {
+      throw new Error('JobClient has not been initialized before use');
+    }
+  }
+
+  async #registerJobs(jobGroups = []) {
+    const globPattern = `${workerDirPath}/application/**/*job-controller.js`;
+
+    logger.info(`Search for job handlers in ${globPattern}`);
+    const jobFiles = await Array.fromAsync(glob(globPattern, { exclude: ['**/job-controller.js'] }));
+    logger.info(`${jobFiles.length} job handlers files found.`);
+
+    let jobModules = {};
+    for (const jobFile of jobFiles) {
+      const fileModules = await importNamedExportFromFile(jobFile);
+      jobModules = { ...jobModules, ...fileModules };
+    }
+
+    let jobRegisteredCount = 0;
+    let cronJobCount = 0;
+    for (const [moduleName, ModuleClass] of Object.entries(jobModules)) {
+      const job = new ModuleClass();
+
+      if (!jobGroups.includes(job.jobGroup) && !this.#isTestOnly) continue;
+
+      if (job.isJobEnabled) {
+        logger.info(`Job "${job.jobName}" registered from module "${moduleName}."`);
+        await this.registerJob(job.jobName, ModuleClass);
+
+        if (!job.jobCron && job.legacyName) {
+          logger.warn(`Temporary Job" ${job.legacyName}" registered from module "${moduleName}."`);
+          await this.registerJob(job.legacyName, ModuleClass);
+        }
+
+        if (job.jobCron) {
+          await this.scheduleCronJob({
+            name: job.jobName,
+            cron: job.jobCron,
+            options: { tz: 'Europe/Paris', expireInSeconds: job.expireIn },
+          });
+          logger.info(`Cron for job "${job.jobName}" scheduled "${job.jobCron}"`);
+
+          // For cronJob we need to unschedule older cron
+          if (job.legacyName) {
+            await this.#unscheduleCronJob(job.legacyName);
+          }
+
+          cronJobCount++;
+        } else {
+          jobRegisteredCount++;
+        }
+      } else {
+        logger.warn(`Job "${job.jobName}" is disabled.`);
+
+        // For cronJob we need to unschedule older cron
+        if (job.jobCron) {
+          await this.#unscheduleCronJob(job.jobName);
+          logger.info(`Job CRON "${job.jobName}" is unscheduled.`);
+        }
+      }
+    }
+    logger.info(`${jobRegisteredCount} jobs registered for groups "${jobGroups}".`);
+    logger.info(`${cronJobCount} cron jobs scheduled for groups "${jobGroups}".`);
+  }
+
+  async registerJob(name, handlerClass) {
+    await this.#pgBoss.createQueue(name, { retentionSeconds: config.pgBoss.retentionSeconds });
+
+    if (this.#isTestOnly) return;
+
+    const jobHandler = new handlerClass();
+
+    const { localConcurrency } = jobHandler;
+
+    await this.#pgBoss.work(name, { localConcurrency, includeMetadata: true }, async ([job]) => {
+      const monitoredJobHandler = new MonitoredJobHandler({ jobHandler, logger });
+      return monitoredJobHandler.handle(name, job);
+    });
+  }
+
+  async scheduleCronJob({ name, cron, data, options }) {
+    await this.#pgBoss.createQueue(name, { retentionSeconds: config.pgBoss.retentionSeconds });
+    return this.#pgBoss.schedule(name, cron, data, options);
+  }
+
+  async #unscheduleCronJob(name) {
+    return this.#pgBoss.unschedule(name);
+  }
+
+  async send(name, payload, options) {
+    this.#assertIsInitialized();
+    logger.info({ type: 'JOB_LOG', handlerName: name }, 'PGBOSS JOB CREATED');
+    await this.#pgBoss.send(name, payload, options);
+  }
+
+  async fetch(name, options) {
+    this.#assertIsInitialized();
+    return this.#pgBoss.fetch(name, options);
+  }
+
+  async getSchedules() {
+    this.#assertIsInitialized();
+    return this.#pgBoss.getSchedules();
+  }
+
+  async flushJobs() {
+    this.#assertIsInitialized();
+    await this.#pgBoss.deleteAllJobs();
+  }
+
+  async stop(options = { graceful: false, timeout: 1000 }) {
+    this.#assertIsInitialized();
+    await this.#pgBoss.stop(options);
+    this.#isInitialized = false;
+  }
+
+  async getQueuesStats() {
+    const queues = await this.#pgBoss.getQueues();
+    const emptyStat = {
+      pending: 0,
+      created: 0,
+      retry: 0,
+      active: 0,
+      completed: 0,
+      cancelled: 0,
+      failed: 0,
+      all: 0,
+    };
+
+    const stats = { global: { ...emptyStat } };
+
+    for (const queue of queues) {
+      stats[queue.name] = { ...emptyStat };
+    }
+
+    const { rows } = await this.#pgBoss
+      .getDb()
+      .executeSql('SELECT name, state, COUNT(id) FROM pgboss.job GROUP BY 1, 2');
+
+    for (const row of rows) {
+      stats[row.name] = { ...stats[row.name], [row.state]: row.count, all: (stats[row.name].all += row.count) };
+      stats.global[row.state] += row.count;
+      stats.global.all += row.count;
+    }
+    return stats;
+  }
+}

--- a/api/lib/infrastructure/jobs/MonitoredJobHandler.js
+++ b/api/lib/infrastructure/jobs/MonitoredJobHandler.js
@@ -1,0 +1,94 @@
+import dayjs from 'dayjs';
+
+class MonitoredJobHandler {
+  constructor({ metrics, handler, logger }) {
+    this.metrics = metrics;
+    this.handler = handler;
+    this.logger = logger;
+  }
+
+  async handle(name, job) {
+    let result;
+    try {
+      this.logJobStarting(name, job);
+      result = await this.handler.handle({ data: job.data, jobId: job.id });
+    } catch (error) {
+      this.logJobFailed(name, job, error);
+      throw error;
+    }
+    this.logJobCompleted(name, job);
+    return result;
+  }
+
+  logJobStarting(name, job) {
+    this.logger.info(
+      {
+        type: 'JOB_LOG',
+        jobId: job.id,
+        data: job.data,
+        handlerName: name,
+      },
+      'PGBOSS JOB STARTING',
+    );
+  }
+
+  logJobCompleted(name, job) {
+    const createdOn = dayjs(job.createdOn);
+    const startedOn = dayjs(job.startedOn);
+    const completedOn = dayjs();
+    const totalTime = completedOn.diff(createdOn, 'second', true);
+    const executionTime = completedOn.diff(startedOn, 'second', true);
+
+    this.logger.info(
+      {
+        event: 'pg-boss-execution-time',
+        type: 'JOB_LOG_EXEC_TIME',
+        jobId: job.id,
+        handlerName: name,
+        executionTime,
+        totalTime,
+      },
+      'PGBOSS JOB COMPLETED',
+    );
+    this.metrics?.addMetricPoint({
+      type: 'histogram',
+      name: 'captain.job.duration',
+      tags: [
+        'method:pg-boss',
+        `jobName:${name}`,
+        'statusCode:SUCCESS',
+      ],
+      value: executionTime,
+    });
+  }
+
+  logJobFailed(name, job, error) {
+    const startedOn = dayjs(job.startedOn);
+    const completedOn = dayjs();
+    const executionTime = completedOn.diff(startedOn, 'second', true);
+
+    this.logger.error(
+      {
+        type: 'JOB_LOG_ERROR',
+        message: 'Job failed',
+        jobId: job.id,
+        data: job.data,
+        handlerName: name,
+        error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
+      },
+      'PGBOSS ERROR IN JOB',
+    );
+    this.metrics?.addMetricPoint({
+      type: 'histogram',
+      name: 'captain.job.duration',
+      tags: [
+        'method:pg-boss',
+        `jobName:${name}`,
+        'statusCode:FAILED',
+      ],
+      value: executionTime,
+    });
+  }
+}
+
+export { MonitoredJobHandler };

--- a/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-controller.js
+++ b/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-controller.js
@@ -1,0 +1,30 @@
+import { JobScheduleController } from '../../application/jobs/job-schedule-controller.js';
+import * as config from '../../config.js';
+import { exportExternalUrlsFromRelease } from '../../domain/usecases/index.js';
+import {
+  localizedChallengeRepository,
+  releaseRepository,
+  urlRepository,
+  whitelistedUrlRepository,
+} from '../repositories/index.js';
+import * as UrlUtils from '../utils/url-utils.js';
+
+export class ExportExternalUrlListJobController extends JobScheduleController {
+  constructor() {
+    super('ExportExternalUrlListJob', { jobCron: config.scheduledJobs.exportExternalUrlListTime });
+  }
+
+  get isJobEnabled() {
+    return config.pgBoss.exportExternalUrlListJobEnabled;
+  }
+
+  async handle() {
+    return exportExternalUrlsFromRelease({
+      releaseRepository,
+      urlRepository,
+      localizedChallengeRepository,
+      whitelistedUrlRepository,
+      UrlUtils,
+    });
+  }
+}

--- a/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-processor.js
@@ -7,8 +7,14 @@ import {
   whitelistedUrlRepository,
 } from '../repositories/index.js';
 import * as UrlUtils from '../utils/url-utils.js';
+import { pgBoss } from '../../config.js';
+import { logger } from '../logger.js';
 
 export default function exportExternalUrlsJobProcessor() {
+  if (!pgBoss.exportExternalUrlListJobEnabled) {
+    logger.info('Export external url list job has been migrated to pgboss, skipping bull processor');
+    return;
+  }
   return exportExternalUrlsFromRelease({
     releaseRepository,
     urlRepository,

--- a/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-processor.js
+++ b/api/lib/infrastructure/scheduled-jobs/export-external-url-list-job-processor.js
@@ -11,7 +11,7 @@ import { pgBoss } from '../../config.js';
 import { logger } from '../logger.js';
 
 export default function exportExternalUrlsJobProcessor() {
-  if (!pgBoss.exportExternalUrlListJobEnabled) {
+  if (pgBoss.exportExternalUrlListJobEnabled) {
     logger.info('Export external url list job has been migrated to pgboss, skipping bull processor');
     return;
   }

--- a/api/lib/infrastructure/utils/import-named-exports-from-directory.js
+++ b/api/lib/infrastructure/utils/import-named-exports-from-directory.js
@@ -1,0 +1,48 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export async function importNamedExportsFromDirectory({ path, ignoredFileNames = [] }) {
+  const imports = {};
+  const exportsLocations = {};
+  const files = await readdir(path, { withFileTypes: true });
+
+  for (const file of files) {
+    if (file.isDirectory()) {
+      continue;
+    }
+
+    if (!file.name.endsWith('.js') || ignoredFileNames.includes(file.name)) {
+      continue;
+    }
+
+    const fileURL = pathToFileURL(join(path, file.name));
+    const module = await import(fileURL);
+    const namedExports = Object.entries(module);
+
+    for (const [exportName, exportedValue] of namedExports) {
+      if (exportName === 'default') {
+        continue;
+      }
+      if (imports[exportName]) {
+        throw new Error(`Duplicate export name ${exportName} : ${exportsLocations[exportName]} and ${file.name}`);
+      }
+      imports[exportName] = exportedValue;
+      exportsLocations[exportName] = file.name;
+    }
+  }
+  return imports;
+}
+
+export async function importNamedExportFromFile(filepath) {
+  const fileURL = pathToFileURL(filepath);
+  const module = await import(fileURL);
+  const namedExports = Object.entries(module);
+
+  return namedExports
+    .filter(([exportName]) => exportName !== 'default')
+    .reduce((exports, [exportName, exportedValue]) => {
+      exports[exportName] = exportedValue;
+      return exports;
+    }, {});
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -52,6 +52,7 @@
         "@babel/eslint-parser": "^7.25.1",
         "@babel/plugin-syntax-import-assertions": "^7.22.5",
         "@stylistic/eslint-plugin": "^5.5.0",
+        "dayjs": "^1.11.20",
         "eslint": "^9.9.0",
         "eslint-plugin-mocha": "^11.2.0",
         "flush-write-stream": "^2.0.0",
@@ -1769,9 +1770,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6349,6 +6350,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -61,6 +61,7 @@
         "nodemon": "^3.0.0",
         "papaparse": "^5.5.2",
         "parse-multipart-data": "^1.5.0",
+        "pg-boss": "^12.18.2",
         "split2": "^4.1.0",
         "vitest": "^4.0.7",
         "yargs": "^18.0.0"
@@ -9120,6 +9121,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/non-error": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/non-error/-/non-error-0.1.0.tgz",
+      "integrity": "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9452,6 +9466,37 @@
         "pg-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pg-boss": {
+      "version": "12.18.2",
+      "resolved": "https://registry.npmjs.org/pg-boss/-/pg-boss-12.18.2.tgz",
+      "integrity": "sha512-06kXeWvVWY+BUNsOt2me1okg6NXx2DBnAQHTurA9jtrvbAO9qUOSE3/0ERERQDrokI+FREFM2Twha+JbrFT/8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^5.5.0",
+        "pg": "^8.20.0",
+        "serialize-error": "^13.0.1"
+      },
+      "bin": {
+        "pg-boss": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/pg-boss/node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pg-cloudflare": {
@@ -10873,6 +10918,23 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-13.0.1.tgz",
+      "integrity": "sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "non-error": "^0.1.0",
+        "type-fest": "^5.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -11385,6 +11447,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tarn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
@@ -11576,6 +11651,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uc.micro": {

--- a/api/package.json
+++ b/api/package.json
@@ -85,6 +85,7 @@
     "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-syntax-import-assertions": "^7.22.5",
     "@stylistic/eslint-plugin": "^5.5.0",
+    "dayjs": "^1.11.20",
     "eslint": "^9.9.0",
     "eslint-plugin-mocha": "^11.2.0",
     "flush-write-stream": "^2.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -94,6 +94,7 @@
     "nodemon": "^3.0.0",
     "papaparse": "^5.5.2",
     "parse-multipart-data": "^1.5.0",
+    "pg-boss": "^12.18.2",
     "split2": "^4.1.0",
     "vitest": "^4.0.7",
     "yargs": "^18.0.0"

--- a/api/sample.env
+++ b/api/sample.env
@@ -13,6 +13,7 @@
 #   - logging
 #   - storage
 #   - pix api
+#   - pg-boss
 #
 # Line size max: 80 characters.
 
@@ -627,3 +628,55 @@ EXPORT_EXTERNAL_URLS_LIST_SPREADSHEET_ID=
 # type: String
 # default: fr,en
 # SEEDS_LOCALES=fr,en
+
+
+# ========
+# pg-boss CONFIGURATION
+# ========
+
+# URL of the PostgreSQL database used for storing jobs
+#
+# presence: required
+# type: Url
+# default: none
+JOBS_DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms
+
+# URL of the PostgreSQL database used for API local testing.
+#
+# presence: required
+# type: Url
+# default: none
+TEST_JOBS_DATABASE_URL=postgresql://postgres@localhost:5444/pix_lcms_test
+
+# Size of database connection pool for pgboss client
+#
+# presence: optional
+# type: positive integer
+# default: 2
+# sample: PGBOSS_CLIENT_CONNECTION_POOL_MAX_SIZE=10
+# PGBOSS_CLIENT_CONNECTION_POOL_MAX_SIZE=
+
+# Size of database connection pool for pgboss worker
+#
+# presence: optional
+# type: positive integer
+# default: 15
+# sample: PGBOSS_WORKER_CONNECTION_POOL_MAX_SIZE=10
+# PGBOSS_WORKER_CONNECTION_POOL_MAX_SIZE=
+
+
+# Cron of states monitoring job
+#
+# presence: optional
+# type: string
+# default: * * * * * (every minute)
+# sample: PGBOSS_STATES_MONITORING_JOB_CRON=* * * * *
+
+
+# Allow async event handling through pg-boss
+#
+# presence: optional
+# type: Boolean
+# default: `false`
+# sample: START_JOB_IN_WEB_PROCESS=true
+START_JOB_IN_WEB_PROCESS=


### PR DESCRIPTION
## 💥 Problème

Nous ne voulons remplacer bul par pgboss pour gérer nos job planifiés.

## 👩‍🚀 Proposition

Utiliser pgboss pour le job d'export de la liste des urls externes afin de le tester.

## 👁️ Remarques

Pour le job de release, étant donné qu'il y a besoin d'attendre que celui-ci se termine dans la route `POST /api/releases`, on aura besoin d'avoir un `release-job-repository` qui aura une méthode `performAsync` ou `performSync` qui récuperéra l'id du job lancé, ce qui nous permettra d'appeler [la méthode `await pgBoss.complete(jobId)`](https://timgit.github.io/pg-boss/#/./api/jobs?id=completename-ids-options).

Reste à faire
- [x] Ajouter les env var sur les différents environnements 
	```
	JOBS_DATABASE_URL=$SCALINGO_POSTGRESQL_URL
	PGBOSS_CLIENT_CONNECTION_POOL_MAX_SIZE=1
	PGBOSS_CONNECTION_POOL_MAX_SIZE=1
	PGBOSS_LOCAL_CONCURRENCY=1
	PGBOSS_EXPORT_EXTERNAL_URL_LIST_JOB_ENABLED=true
	START_JOB_IN_WEB_PROCESS=true
	```

	- [x] Review App
	- [x] Intégration
	- [x] Production
	- [x] Minimal
- [x] Stopper pgboss lors de l'arrêt du serveur
- [X] Voir s'il faut un conteneur `worker` dédié ?
  ➡️ on va commencer sans worker dédié, comme c'est le cas actuellement avec Bull, pour cela on garde la variable `START_JOB_IN_WEB_PROCESS` à `true`
- [x] quid du monitoring des queues ? avec l'instance de DB partagée avec Pix-API, on peut peut-être s'en passer
  ➡️ on va commencer sans job de monitoring au sein de LCMS car celui de Pix-API doit être suffisant, on ajustera si besoin

## ♻️ Pour tester
 none
