### PR TITLE
[FEATURE] Ajout de la colonne "titre interne" sur les modules (PIX-22860)

### DIFF
--- a/api/db/migrations/20260522090948_add-module-internal-title-column.js
+++ b/api/db/migrations/20260522090948_add-module-internal-title-column.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable('modules', function(table) {
+    table.text('internalTitle').nullable().unique();
+  });
+  await knex.schema.alterTable('draft-modules', function(table) {
+    table.text('internalTitle').nullable().unique();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable('modules', function(table) {
+    table.dropColumn('internalTitle');
+  });
+  await knex.schema.alterTable('draft-modules', function(table) {
+    table.dropColumn('internalTitle');
+  });
+}

--- a/api/lib/domain/models/Module.js
+++ b/api/lib/domain/models/Module.js
@@ -2,6 +2,7 @@ export class Module {
   constructor({
     id,
     shortId,
+    internalTitle,
     slug,
     title,
     isBeta,
@@ -14,6 +15,7 @@ export class Module {
   } = {}) {
     this.id = id;
     this.shortId = shortId;
+    this.internalTitle = internalTitle;
     this.slug = slug;
     this.title = title;
     this.isBeta = isBeta;

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -19,9 +19,9 @@ describe('Acceptance | Route | modules', () => {
 
     beforeEach(async () => {
       modules = [
-        { id: '79cc8f8d-d948-4ce5-bd35-1250b61d6011', shortId: 'abcd1234', slug: 'a', title: 'Module 1', isBeta: true, visibility: Module.VISIBILITIES.PRIVATE, details: { level: Module.LEVELS.NOVICE } },
-        { id: '6e7f16ae-4d96-4a71-b646-d6c86029e05e', shortId: 'abcd5678', slug: 'b', title: 'Module 2', isBeta: false, visibility: Module.VISIBILITIES.PUBLIC, details: { level: Module.LEVELS.INDEPENDENT } },
-        { id: 'f995ce82-1373-4758-b839-7a844893ef07', shortId: 'abcd9012', slug: 'c', title: 'Module 3', isBeta: false, visibility: Module.VISIBILITIES.PRIVATE, details: { level: Module.LEVELS.EXPERT } },
+        { id: '79cc8f8d-d948-4ce5-bd35-1250b61d6011', shortId: 'abcd1234', internalTitle: 'MOD_a', slug: 'a', title: 'Module 1', isBeta: true, visibility: Module.VISIBILITIES.PRIVATE, details: { level: Module.LEVELS.NOVICE } },
+        { id: '6e7f16ae-4d96-4a71-b646-d6c86029e05e', shortId: 'abcd5678', internalTitle: 'MOD_b', slug: 'b', title: 'Module 2', isBeta: false, visibility: Module.VISIBILITIES.PUBLIC, details: { level: Module.LEVELS.INDEPENDENT } },
+        { id: 'f995ce82-1373-4758-b839-7a844893ef07', shortId: 'abcd9012', internalTitle: 'MOD_c', slug: 'c', title: 'Module 3', isBeta: false, visibility: Module.VISIBILITIES.PRIVATE, details: { level: Module.LEVELS.EXPERT } },
       ];
 
       modules.forEach((module) => {
@@ -152,6 +152,7 @@ describe('Acceptance | Route | modules', () => {
         {
           id: expect.stringMatching(uuidRegExp),
           shortId: expect.stringMatching(shortIdRegExp),
+          internalTitle: null,
           slug: module.slug,
           title: module.title,
           isBeta: module.isBeta,

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -14,6 +14,7 @@ async function mockCurrentContent() {
   const firstModule = domainBuilder.buildModule();
   const secondModule = domainBuilder.buildModule({
     shortId: 'secondar',
+    internalTitle: 'secondar',
     title: 'Second Module',
   });
   const modules = [firstModule, secondModule];

--- a/api/tests/acceptance/application/replication-data-controller_test.js
+++ b/api/tests/acceptance/application/replication-data-controller_test.js
@@ -290,7 +290,7 @@ async function mockCurrentContent() {
     },
   ];
 
-  const modules = [domainBuilder.buildModule({ shortId: 'moduleab', slug: 'ab' }), domainBuilder.buildModule({ shortId: 'modulecd', slug: 'cd' })];
+  const modules = [domainBuilder.buildModule({ shortId: 'moduleab', slug: 'ab' }), domainBuilder.buildModule({ shortId: 'modulecd', internalTitle: 'modulecd', slug: 'cd' })];
   expectedCurrentContent.modules = modules.map(({ details, ...module }) => new ModuleForReplication({ ...module, ...details }));
 
   expectedCurrentContent.frameworks.forEach(databaseBuilder.factory.buildFramework);

--- a/api/tests/integration/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-repository_test.js
@@ -59,7 +59,7 @@ describe('Module Repository', () => {
     it('lists all modules', async () => {
       // given
       const firstModule = domainBuilder.buildModule({ slug: 'a' });
-      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', slug: 'b' });
+      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', internalTitle: 'secondar', slug: 'b' });
 
       databaseBuilder.factory.buildModule(firstModule);
       databaseBuilder.factory.buildModule(secondModule);
@@ -75,9 +75,9 @@ describe('Module Repository', () => {
 
     it('lists modules with pagination and sort parameters', async () => {
       // given
-      const firstModule = domainBuilder.buildModule({ shortId: 'first', slug: 'c', title: 'Module A', visibility: 'public' });
-      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', slug: 'b', title: 'Module B', visibility: 'private' });
-      const thirdModule = domainBuilder.buildModule({ shortId: 'terzio', slug: 'a', title: 'Module C', visibility: 'public' });
+      const firstModule = domainBuilder.buildModule({ shortId: 'first', internalTitle: 'first', slug: 'c', title: 'Module A', visibility: 'public' });
+      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', internalTitle: 'secondar', slug: 'b', title: 'Module B', visibility: 'private' });
+      const thirdModule = domainBuilder.buildModule({ shortId: 'terzio', internalTitle: 'terzio', slug: 'a', title: 'Module C', visibility: 'public' });
       const page = {
         size: 2,
         number: 1,
@@ -102,7 +102,7 @@ describe('Module Repository', () => {
     it('lists all modules for replication', async () => {
       // given
       const firstModule = domainBuilder.buildModule({ slug: 'a' });
-      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', slug: 'b' });
+      const secondModule = domainBuilder.buildModule({ shortId: 'secondar', internalTitle: 'secondar', slug: 'b' });
 
       databaseBuilder.factory.buildModule(firstModule);
       databaseBuilder.factory.buildModule(secondModule);
@@ -122,7 +122,7 @@ describe('Module Repository', () => {
     it('returns number of modules', async () => {
       // given
       databaseBuilder.factory.buildModule(domainBuilder.buildModule());
-      databaseBuilder.factory.buildModule(domainBuilder.buildModule({ shortId: 'secondar' }));
+      databaseBuilder.factory.buildModule(domainBuilder.buildModule({ shortId: 'secondar', internalTitle: 'secondar' }));
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/release-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/release-repository_test.js
@@ -240,6 +240,7 @@ describe('Integration | Repository | release-repository', function() {
       const firstModule = domainBuilder.buildModule();
       const secondModule = domainBuilder.buildModule({
         shortId: 'secondar',
+        internalTitle: 'secondar',
         title: 'Second Module',
       });
       modules = [firstModule, secondModule];

--- a/api/tests/scripts/migrate-modules_test.js
+++ b/api/tests/scripts/migrate-modules_test.js
@@ -29,7 +29,7 @@ describe('Script | MigrateModules', () => {
       domainBuilder.buildModule({ shortId: 'deuxieme', title: 'deuxieme module' }),
       domainBuilder.buildModule({ shortId: 'premiera', title: 'premier module' }),
       domainBuilder.buildModule({ shortId: 'troisiem', title: 'troisieme module' }),
-    ];
+    ].map(({ internalTitle: _, ...module }) => module);
 
     modules.forEach((module) => {
       octokit.repos.getContent.mockResolvedValueOnce({ data: { type: 'file', encoding: 'utf8', content: JSON.stringify(module) } });

--- a/api/tests/tooling/database-builder/factory/build-module.js
+++ b/api/tests/tooling/database-builder/factory/build-module.js
@@ -3,6 +3,7 @@ import { databaseBuffer } from '../database-buffer.js';
 export function buildModule({
   id,
   shortId,
+  internalTitle,
   slug,
   title,
   isBeta,
@@ -18,6 +19,7 @@ export function buildModule({
     values: {
       id,
       shortId,
+      internalTitle,
       slug,
       title,
       isBeta,

--- a/api/tests/tooling/domain-builder/factory/build-module.js
+++ b/api/tests/tooling/domain-builder/factory/build-module.js
@@ -29,6 +29,7 @@ export function buildModule({
   id = crypto.randomUUID(),
   shortId = 'escargou',
   slug = 'petit-escargot-pignouf',
+  internalTitle = 'NAT_escagot',
   title = 'apprendre à être mou',
   isBeta = false,
   visibility = Module.VISIBILITIES.PUBLIC,
@@ -54,6 +55,7 @@ export function buildModule({
   return new Module({
     id,
     shortId,
+    internalTitle,
     slug,
     title,
     isBeta,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -14,6 +14,7 @@ describe('Unit | Serializer | JSONAPI | module-serializer', () => {
           type: 'modules',
           id: expectedModule.id,
           attributes: {
+            'internal-title': expectedModule.internalTitle,
             'short-id': expectedModule.shortId,
             slug: expectedModule.slug,
             title: expectedModule.title,


### PR DESCRIPTION
## 💥 Problème

On souhaite garder l’équivalent du nom de fichier des modules, dont la nomenclature est importante pour les concepteurs.

## 👩‍🚀 Proposition

Ajouter une colonne `internalTitle` sur les tables `modules` et `draft-modules`.

## 👁️ Remarques

N/A

## ♻️ Pour tester

Vérifier que la RA se déploie correctement et que la nouvelle colonne est dans les 2 tables :

```
scalingo -a pix-lcms-review-pr1483 psql-console
\d modules
```