### PR TITLE
[FEATURE] Migration du titre interne des modules (PIX-22861)

### DIFF
--- a/api/scripts/migrate-modules.js
+++ b/api/scripts/migrate-modules.js
@@ -1,3 +1,5 @@
+import { basename } from 'node:path';
+
 import { Octokit } from '@octokit/rest';
 
 import { Module } from '../lib/domain/models/index.js';
@@ -42,8 +44,12 @@ export class MigrateModules extends Script {
     await knex.transaction(async (transaction) => {
       for (const { path } of moduleFiles) {
         const { content } = await getFile(octokit, ref, path, { logger });
+        const internalTitle = basename(path, '.json');
 
-        const module = new Module(JSON.parse(content));
+        const module = new Module({
+          ...JSON.parse(content),
+          internalTitle,
+        });
         logger.info({ id: module.id, title: module.title }, 'Saving module');
         await moduleRepository.save(module, transaction);
       }

--- a/api/tests/scripts/migrate-modules_test.js
+++ b/api/tests/scripts/migrate-modules_test.js
@@ -25,14 +25,15 @@ describe('Script | MigrateModules', () => {
     octokit.repos.getContent.mockResolvedValueOnce({ data: pixModuleFiles });
 
     modules = [
-      domainBuilder.buildModule({ shortId: 'derniera', title: 'dernier module' }),
-      domainBuilder.buildModule({ shortId: 'deuxieme', title: 'deuxieme module' }),
-      domainBuilder.buildModule({ shortId: 'premiera', title: 'premier module' }),
-      domainBuilder.buildModule({ shortId: 'troisiem', title: 'troisieme module' }),
-    ].map(({ internalTitle: _, ...module }) => module);
+      domainBuilder.buildModule({ shortId: 'derniera', internalTitle: 'dernier-module', title: 'dernier module' }),
+      domainBuilder.buildModule({ shortId: 'deuxieme', internalTitle: 'deuxieme-module', title: 'deuxieme module' }),
+      domainBuilder.buildModule({ shortId: 'premiera', internalTitle: 'premier-module', title: 'premier module' }),
+      domainBuilder.buildModule({ shortId: 'troisiem', internalTitle: 'troisieme-module', title: 'troisieme module' }),
+    ];
 
-    modules.forEach((module) => {
-      octokit.repos.getContent.mockResolvedValueOnce({ data: { type: 'file', encoding: 'utf8', content: JSON.stringify(module) } });
+    modules.forEach(({ internalTitle: _, ...module }) => {
+      const content = JSON.stringify(module);
+      octokit.repos.getContent.mockResolvedValueOnce({ data: { type: 'file', encoding: 'utf8', content } });
     });
   });
 
@@ -45,9 +46,10 @@ describe('Script | MigrateModules', () => {
       await script.handle({ options, logger }, { octokit });
 
       // then
-      await expect(knex.select('id', 'shortId', 'title').from('modules').orderBy('shortId')).resolves.toStrictEqual(modules.map((module) => ({
+      await expect(knex.select('id', 'shortId', 'internalTitle', 'title').from('modules').orderBy('shortId')).resolves.toStrictEqual(modules.map((module) => ({
         id: module.id,
         shortId: module.shortId,
+        internalTitle: module.internalTitle,
         title: module.title,
       })));
 


### PR DESCRIPTION
## 💥 Problème

On souhaite utiliser le nom des fichiers de module comme titre interne de module.

## 👩‍🚀 Proposition

Modifier le script de migration pour mettre le nom de fichier dans la colonne `internalTitle`.

## 👁️ Remarques

N/A

## ♻️ Pour tester

Le script de migration a été exécuté sur la RA.

Vérifier que la colonne est correctement valorisée :

```
scalingo -a pix-lcms-review-pr1484 psql-console
select "internalTitle" from modules;
```
