### PR TITLE
[FEATURE] Création de module : saisie du titre interne (PIX-22862)

### DIFF
--- a/api/db/migrations/20260522143459_module-internal-title-not-nullable.js
+++ b/api/db/migrations/20260522143459_module-internal-title-not-nullable.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable('modules', function(table) {
+    table.text('internalTitle').notNullable().alter();
+  });
+  await knex.schema.alterTable('draft-modules', function(table) {
+    table.text('internalTitle').notNullable().alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable('modules', function(table) {
+    table.text('internalTitle').nullable().alter();
+  });
+  await knex.schema.alterTable('draft-modules', function(table) {
+    table.text('internalTitle').nullable().alter();
+  });
+}

--- a/api/db/seeds/data/modules/bac-a-sable.json
+++ b/api/db/seeds/data/modules/bac-a-sable.json
@@ -1,5 +1,6 @@
 {
   "id": "6282925d-4775-4bca-b513-4c3009ec5886",
+  "internalTitle": "DEMO_bac-a-sable",
   "shortId": "6a68bf32",
   "slug": "bac-a-sable",
   "title": "Bac à sable",

--- a/api/db/seeds/data/modules/demo-combinix-1.json
+++ b/api/db/seeds/data/modules/demo-combinix-1.json
@@ -1,5 +1,6 @@
 {
   "id": "eeeb4951-6f38-4467-a4ba-0c85ed71321a",
+  "internalTitle": "DEMO_combinix-1",
   "shortId": "27d6ca4f",
   "slug": "demo-combinix-1",
   "title": "Demo combinix 1",

--- a/api/db/seeds/data/modules/demo-combinix-2.json
+++ b/api/db/seeds/data/modules/demo-combinix-2.json
@@ -1,5 +1,6 @@
 {
   "id": "f32a2238-4f65-4698-b486-15d51935d335",
+  "internalTitle": "DEMO_combinix-2",
   "shortId": "df82ec66",
   "slug": "demo-combinix-2",
   "title": "Demo combinix 2",

--- a/api/db/seeds/data/modules/demo-epreuves-components.json
+++ b/api/db/seeds/data/modules/demo-epreuves-components.json
@@ -1,5 +1,6 @@
 {
   "id": "235c680e-cbd2-4c56-bef6-80d3ed4d417a",
+  "internalTitle": "DEMO_epreuves-components",
   "shortId": "0aefd71f",
   "slug": "demo-epreuves-components",
   "title": "Démonstration des composants Pix Épreuves",
@@ -10,9 +11,7 @@
     "description": "<p>Ce module est dédié à des tests internes à Pix.</p><p>Il contient normalement tous les composants Pix Épreuves.</p>",
     "duration": 2,
     "level": "novice",
-    "objectives": [
-      "<p>Non régression sur les composants Pix Épreuves.</p>"
-    ],
+    "objectives": ["<p>Non régression sur les composants Pix Épreuves.</p>"],
     "tabletSupport": "comfortable"
   },
   "sections": [
@@ -52,9 +51,7 @@
                       "body": [
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Bonjour,"
-                          ]
+                          "content": ["Bonjour,"]
                         },
                         {
                           "type": "paragraph",
@@ -70,21 +67,14 @@
                         },
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Cordialement,"
-                          ]
+                          "content": ["Cordialement,"]
                         },
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Service des impôts"
-                          ]
+                          "content": ["Service des impôts"]
                         }
                       ],
-                      "answers": [
-                        "from.name",
-                        "from.address"
-                      ],
+                      "answers": ["from.name", "from.address"],
                       "correctFeedback": "Le nom de l’expéditeur est orthographié ‘impost.g0uv’ au lieu de ‘impots.gouv’. Les erreurs dans les noms ou dans les adresses mail sont de bons indicateurs d’arnaques.",
                       "incorrectFeedback": "Observez bien l’orthographe du nom et de l’adresse d’expéditeur. Retentez votre chance !"
                     },
@@ -97,9 +87,7 @@
                       "body": [
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Bonjour,"
-                          ]
+                          "content": ["Bonjour,"]
                         },
                         {
                           "type": "paragraph",
@@ -115,20 +103,14 @@
                         },
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Merci,"
-                          ]
+                          "content": ["Merci,"]
                         },
                         {
                           "type": "paragraph",
-                          "content": [
-                            "EDF — Service Client"
-                          ]
+                          "content": ["EDF — Service Client"]
                         }
                       ],
-                      "answers": [
-                        "from.address"
-                      ],
+                      "answers": ["from.address"],
                       "correctFeedback": "La partie après l’arobase de l’adresse mail ‘yxztbnc85de.ru’ n’a aucun lien avec EDF ou la demande, et n’est même pas compréhensible. C’est un indicateur de hameçonnage.",
                       "incorrectFeedback": "Concentrez-vous sur l’adresse mail de l’expediteur. Retentez votre chance !"
                     },
@@ -141,9 +123,7 @@
                       "body": [
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Bonjour,"
-                          ]
+                          "content": ["Bonjour,"]
                         },
                         {
                           "type": "paragraph",
@@ -161,20 +141,14 @@
                         },
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Cordialement,"
-                          ]
+                          "content": ["Cordialement,"]
                         },
                         {
                           "type": "paragraph",
-                          "content": [
-                            "Service des infractions de l’ANTAI"
-                          ]
+                          "content": ["Service des infractions de l’ANTAI"]
                         }
                       ],
-                      "answers": [
-                        "from.address"
-                      ],
+                      "answers": ["from.address"],
                       "correctFeedback": "L’adresse de l’expéditeur ne correspond à aucun organisme officiel. Les incohérences dans les noms et les adresses mails sont de bons indicateurs d’arnaques.",
                       "incorrectFeedback": "Observez bien le nom et l’adresse de l’expéditeur. Retentez votre chance ! "
                     }
@@ -461,11 +435,7 @@
                   ],
                   "userMessage": "Avec quoi peut-on tartiner une crêpe pour qu’elle soit bonne ?",
                   "llmMessage": "On peut mettre du ",
-                  "wordsToAdd": [
-                    "beurre",
-                    "et",
-                    "du "
-                  ]
+                  "wordsToAdd": ["beurre", "et", "du "]
                 },
                 "title": "",
                 "functionalInstruction": ""
@@ -905,12 +875,7 @@
                 "instruction": "",
                 "tagName": "mdp-classement",
                 "props": {
-                  "passwords": [
-                    "r7&Kp9!qZ4#tV2",
-                    "MonCh@t!23",
-                    "Bonjour1",
-                    "1234567"
-                  ]
+                  "passwords": ["r7&Kp9!qZ4#tV2", "MonCh@t!23", "Bonjour1", "1234567"]
                 },
                 "title": "",
                 "functionalInstruction": ""

--- a/api/db/seeds/data/modules/demo-llm.json
+++ b/api/db/seeds/data/modules/demo-llm.json
@@ -1,5 +1,6 @@
 {
   "id": "ab82925d-4775-4bca-b513-4c3009ec5886",
+  "internalTitle": "DEMO_llm",
   "shortId": "f2eeb056",
   "slug": "demo-llm",
   "title": "Démo LLM",

--- a/api/lib/application/modules.js
+++ b/api/lib/application/modules.js
@@ -33,6 +33,7 @@ export function register(server) {
             data: Joi.object({
               type: Joi.string().valid('modules').required(),
               attributes: Joi.object({
+                'internal-title': Joi.string().required(),
                 title: Joi.string().required(),
                 'is-beta': Joi.boolean().required(),
                 slug: Joi.string().required(),

--- a/api/lib/infrastructure/serializers/jsonapi/module-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/module-serializer.js
@@ -17,6 +17,7 @@ export function deserialize(payload) {
 
 const serializer = new Serializer('module', {
   attributes: [
+    'internalTitle',
     'shortId',
     'slug',
     'title',

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -111,6 +111,7 @@ describe('Acceptance | Route | modules', () => {
       // given
       const module = domainBuilder.buildModule();
       const modulePayload = {
+        'internal-title': module.internalTitle,
         slug: module.slug,
         title: module.title,
         'is-beta': module.isBeta,
@@ -152,7 +153,7 @@ describe('Acceptance | Route | modules', () => {
         {
           id: expect.stringMatching(uuidRegExp),
           shortId: expect.stringMatching(shortIdRegExp),
-          internalTitle: null,
+          internalTitle: module.internalTitle,
           slug: module.slug,
           title: module.title,
           isBeta: module.isBeta,

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -736,7 +736,7 @@ async function mockContentForRelease() {
         documentationUrl: null,
       }),
     ],
-    modules: [{ ...domainBuilder.buildModuleForRelease(), title: 'Module 1' }, { ...domainBuilder.buildModuleForRelease({ shortId: 'tatatiti', title: 'Module 2' }) }],
+    modules: [domainBuilder.buildModuleForRelease({ title: 'Module 1' }), domainBuilder.buildModuleForRelease({ shortId: 'tatatiti', title: 'Module 2' })],
   };
 
   const attachments = [
@@ -891,7 +891,8 @@ async function mockContentForRelease() {
 
   attachments.forEach(databaseBuilder.factory.buildAttachment);
 
-  expectedCurrentContent.modules.forEach(databaseBuilder.factory.buildModule);
+  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[0], internalTitle: 'module-1' });
+  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[1], internalTitle: 'module-2' });
 
   await databaseBuilder.commit();
   return expectedCurrentContent;

--- a/api/tests/tooling/database-builder/factory/build-draft-module.js
+++ b/api/tests/tooling/database-builder/factory/build-draft-module.js
@@ -3,6 +3,7 @@ import { databaseBuffer } from '../database-buffer.js';
 export function buildDraftModule({
   id,
   moduleId,
+  internalTitle,
   shortId,
   slug,
   title,
@@ -19,6 +20,7 @@ export function buildDraftModule({
     values: {
       id,
       moduleId,
+      internalTitle,
       shortId,
       slug,
       title,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/module-serializer_test.js
@@ -44,6 +44,7 @@ describe('Unit | Serializer | JSONAPI | module-serializer', () => {
           type: 'modules',
           id: module.id,
           attributes: {
+            'internal-title': module.internalTitle,
             'short-id': module.shortId,
             slug: module.slug,
             title: module.title,

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { on } from '@ember/modifier';
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
@@ -8,6 +9,7 @@ import PixLabel from '@1024pix/pix-ui/components/pix-label';
 import MonacoEditor from 'pixeditor/components/monaco-editor/monaco-editor';
 
 export default class ModuleForm extends Component {
+  @tracked internalTitle;
   @tracked moduleData;
 
   @action
@@ -29,23 +31,27 @@ export default class ModuleForm extends Component {
     };
   }
 
-  get title() {
-    return this.moduleData?.title;
-  }
-
   get isSaveDisabled() {
-    return !this.moduleData;
+    return !this.internalTitle || !this.moduleData;
   }
 
-  @action
-  async saveModule() {
-    return this.args.saveModule(this.moduleData);
+  @action onInternalTitleChange(event) {
+    this.internalTitle = event.target.value;
+  }
+
+  @action async saveModule() {
+    return this.args.saveModule({ ...this.moduleData, internalTitle: this.internalTitle });
   }
 
   <template>
     <div class="module-form">
-      <PixInput @id="title" @value={{this.title}} readonly>
-        <:label>Titre</:label>
+      <PixInput
+        @id="internalTitle"
+        @value={{this.internalTitle}}
+        @requiredLabel="Champ obligatoire"
+        {{on "change" this.onInternalTitleChange}}
+      >
+        <:label>Titre interne</:label>
       </PixInput>
 
       <div class="module-form__data-field">

--- a/pix-editor/app/models/module.js
+++ b/pix-editor/app/models/module.js
@@ -1,6 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class Module extends Model {
+  @attr internalTitle;
   @attr title;
   @attr isBeta;
   @attr slug;

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -10,8 +10,9 @@ export default class NewModule extends Component {
   @service store;
 
   @action
-  async saveModule({ title, isBeta, slug, visibility, details, sections, glossary }) {
+  async saveModule({ internalTitle, title, isBeta, slug, visibility, details, sections, glossary }) {
     const newModule = this.store.createRecord('module', {
+      internalTitle,
       title,
       isBeta,
       slug,

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -31,10 +31,10 @@ module('Acceptance | Modules | New', function (hooks) {
     assert.strictEqual(currentURL(), '/modules/new');
     assert.dom(await screen.findByRole('heading', { name: "Création d'un module" })).exists();
 
-    const editor = await screen.findByLabelText('Contenu (JSON)');
+    await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'NEW_MODULE');
 
     await fillIn(
-      editor,
+      await screen.findByLabelText('Contenu (JSON)'),
       JSON.stringify({
         title: 'Nouveau module',
         isBeta: true,

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -18,18 +18,26 @@ module('Integration | Component | modules/module-form', function (hooks) {
     const screen = await render(<template><ModuleForm @saveModule={{saveModule}} /></template>);
 
     // then
-    assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasAttribute('readonly');
+    const saveButton = screen.getByRole('button', { name: 'Enregistrer' });
+    assert.dom(saveButton).hasAttribute('aria-disabled');
+
+    const internalTitle = screen.getByRole('textbox', { name: /^Titre interne/ });
+    await fillIn(internalTitle, 'PALOURDE_MAGIQUE');
+
+    assert.dom(saveButton).hasAttribute('aria-disabled');
+
     const monacoEditor = await screen.findByLabelText('Contenu (JSON)');
     assert.dom(monacoEditor).exists();
-    const saveButton = screen.getByRole('button', { name: 'Enregistrer' });
 
-    await fillIn(monacoEditor, JSON.stringify({ title: 'Mon titre' }));
+    await fillIn(monacoEditor, JSON.stringify({ slug: 'limaçoooooooooooooooooooon' }));
 
     assert.dom(saveButton).doesNotHaveAttribute('aria-disabled');
-    assert.dom(screen.getByRole('textbox', { name: 'Titre' })).hasValue('Mon titre');
 
     await click(saveButton);
-    sinon.assert.calledWithExactly(saveModule, { title: 'Mon titre' });
+    sinon.assert.calledWithExactly(saveModule, {
+      internalTitle: 'PALOURDE_MAGIQUE',
+      slug: 'limaçoooooooooooooooooooon',
+    });
 
     // WORKAROUND: let some time for monaco-editor to dismount
     await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
## 💥 Problème

On souhaite pouvoir saisir un titre interne lors de la création d’un module.

## 👩‍🚀 Proposition

Dans le formulaire de création, on remplace le champ en lecture seule "Titre" par le champ saisissable "Titre interne".

## 👁️ Remarques

Nécessite de MEP les PRs précédentes et de re-passer les scripts de migration sur les environnements d’intégration et de prod.

## ♻️ Pour tester

Créer un nouveau module sur la RA et vérifier que le titre interne est bien enregistré en BdD.

Vérifier que le champ titre interne est obligatoire.