### PR TITLE
[FEATURE] Liste des modules : afficher le titre interne (PIX-22864)

### DIFF
--- a/api/lib/application/modules.js
+++ b/api/lib/application/modules.js
@@ -18,7 +18,7 @@ export function register(server) {
           }),
         },
         handler: async (request) => {
-          const { page, sort } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [['visibility', 'desc'], ['title', 'asc']] });
+          const { page, sort } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [['visibility', 'desc'], ['internalTitle', 'asc']] });
           const { modules, meta } = await listPaginatedModules({ page, sort });
           return moduleSummarySerializer.serialize(modules, meta);
         },

--- a/api/lib/infrastructure/repositories/module-repository.js
+++ b/api/lib/infrastructure/repositories/module-repository.js
@@ -20,10 +20,10 @@ export async function save({ details, sections, glossary, ...module }, transacti
   return toDomain(savedModule);
 }
 
-export async function list({ page, sort = [['slug', 'asc']] } = {}) {
+export async function list({ page, sort = [['internalTitle', 'asc']] } = {}) {
   const query = knex.select().from('modules');
   sort.forEach(([column, order]) => {
-    if (column === 'title') {
+    if (['internalTitle', 'title'].includes(column)) {
       query.orderByRaw(`?? collate ?? ${order}`, [column, 'fr-x-icu']);
     } else {
       query.orderBy(column, order);

--- a/api/lib/infrastructure/serializers/jsonapi/module-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/module-summary-serializer.js
@@ -5,7 +5,7 @@ const { Serializer } = Jsonapi;
 export function serialize(modules, meta) {
   const serializer = new Serializer('module-summary', {
     attributes: [
-      'title',
+      'internalTitle',
       'isBeta',
       'visibility',
       'level',

--- a/api/tests/acceptance/application/modules_test.js
+++ b/api/tests/acceptance/application/modules_test.js
@@ -50,17 +50,17 @@ describe('Acceptance | Route | modules', () => {
           {
             type: 'module-summaries',
             id: modules[1].id,
-            attributes: { title: modules[1].title, 'is-beta': modules[1].isBeta, visibility: modules[1].visibility, level: modules[1].details.level },
+            attributes: { 'internal-title': modules[1].internalTitle, 'is-beta': modules[1].isBeta, visibility: modules[1].visibility, level: modules[1].details.level },
           },
           {
             type: 'module-summaries',
             id: modules[0].id,
-            attributes: { title: modules[0].title, 'is-beta': modules[0].isBeta, visibility: modules[0].visibility, level: modules[0].details.level },
+            attributes: { 'internal-title': modules[0].internalTitle, 'is-beta': modules[0].isBeta, visibility: modules[0].visibility, level: modules[0].details.level },
           },
           {
             type: 'module-summaries',
             id: modules[2].id,
-            attributes: { title: modules[2].title, 'is-beta': modules[2].isBeta, visibility: modules[2].visibility, level: modules[2].details.level },
+            attributes: { 'internal-title': modules[2].internalTitle, 'is-beta': modules[2].isBeta, visibility: modules[2].visibility, level: modules[2].details.level },
           },
         ],
         meta: {
@@ -92,7 +92,7 @@ describe('Acceptance | Route | modules', () => {
             {
               type: 'module-summaries',
               id: modules[0].id,
-              attributes: { title: modules[0].title, 'is-beta': modules[0].isBeta, visibility: modules[0].visibility, level: modules[0].details.level },
+              attributes: { 'internal-title': modules[0].internalTitle, 'is-beta': modules[0].isBeta, visibility: modules[0].visibility, level: modules[0].details.level },
             },
           ],
           meta: {

--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -26,10 +26,10 @@ function getVisibilityColor(visibility) {
       </PixTableColumn>
       <PixTableColumn @context={{context}}>
         <:header>
-          Titre
+          Titre interne
         </:header>
         <:cell>
-          {{module.title}}
+          {{module.internalTitle}}
         </:cell>
       </PixTableColumn>
       <PixTableColumn @context={{context}}>

--- a/pix-editor/app/models/module-summary.js
+++ b/pix-editor/app/models/module-summary.js
@@ -13,7 +13,7 @@ const levelForDisplay = {
 };
 
 export default class ModuleSummary extends Model {
-  @attr title;
+  @attr internalTitle;
   @attr isBeta;
   @attr visibility;
   @attr level;

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -26,7 +26,7 @@ export default class NewModule extends Component {
       this.loader.start();
       await newModule.save();
       this.router.replaceWith('authenticated.modules');
-      this.notifications.sendSuccess(`Le module "${newModule.title}" a été enregistré.`);
+      this.notifications.sendSuccess(`Le module "${newModule.internalTitle}" a été enregistré.`);
     } catch (err) {
       this.notifications.sendError('Erreur lors de l’enregistrement du module.');
     } finally {

--- a/pix-editor/tests/acceptance/modules/list-test.js
+++ b/pix-editor/tests/acceptance/modules/list-test.js
@@ -39,29 +39,29 @@ module('Acceptance | Modules | List', function (hooks) {
 
     assert.dom(await screen.findByText('1-10 sur 36 éléments')).exists();
     assert.dom(await screen.findByText('Page 1 / 4')).exists();
-    assert.dom(await screen.findByText('Module 0')).exists();
-    assert.dom(await screen.findByText('Module 5')).exists();
-    assert.dom(await screen.findByText('Module 9')).exists();
+    assert.dom(await screen.findByText('MOD_0')).exists();
+    assert.dom(await screen.findByText('MOD_5')).exists();
+    assert.dom(await screen.findByText('MOD_9')).exists();
 
     await screen.getByRole('button', { name: 'Aller à la page suivante' }).click();
     assert.dom(await screen.findByText('11-20 sur 36 éléments')).exists();
     assert.dom(await screen.findByText('Page 2 / 4')).exists();
-    assert.dom(await screen.findByText('Module 10')).exists();
-    assert.dom(await screen.findByText('Module 15')).exists();
-    assert.dom(await screen.findByText('Module 19')).exists();
+    assert.dom(await screen.findByText('MOD_10')).exists();
+    assert.dom(await screen.findByText('MOD_15')).exists();
+    assert.dom(await screen.findByText('MOD_19')).exists();
 
     await screen.getByRole('button', { name: 'Aller à la page suivante' }).click();
     assert.dom(await screen.findByText('21-30 sur 36 éléments')).exists();
     assert.dom(await screen.findByText('Page 3 / 4')).exists();
-    assert.dom(await screen.findByText('Module 20')).exists();
-    assert.dom(await screen.findByText('Module 25')).exists();
-    assert.dom(await screen.findByText('Module 29')).exists();
+    assert.dom(await screen.findByText('MOD_20')).exists();
+    assert.dom(await screen.findByText('MOD_25')).exists();
+    assert.dom(await screen.findByText('MOD_29')).exists();
 
     await screen.getByRole('button', { name: 'Aller à la page suivante' }).click();
     assert.dom(await screen.findByText('31-36 sur 36 éléments')).exists();
     assert.dom(await screen.findByText('Page 4 / 4')).exists();
-    assert.dom(await screen.findByText('Module 30')).exists();
-    assert.dom(await screen.findByText('Module 35')).exists();
+    assert.dom(await screen.findByText('MOD_30')).exists();
+    assert.dom(await screen.findByText('MOD_35')).exists();
 
     await screen.getByRole('button', { name: 'Aller à la page précédente' }).click();
     assert.dom(await screen.findByText('Page 3 / 4')).exists();
@@ -72,7 +72,7 @@ module('Acceptance | Modules | List', function (hooks) {
     await screen.getByRole('option', { name: '50' }).click();
     assert.dom(await screen.findByText('Page 1 / 1')).exists();
     assert.dom(await screen.findByText('36 éléments')).exists();
-    assert.dom(await screen.findByText('Module 0')).exists();
-    assert.dom(await screen.findByText('Module 35')).exists();
+    assert.dom(await screen.findByText('MOD_0')).exists();
+    assert.dom(await screen.findByText('MOD_35')).exists();
   });
 });

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -60,10 +60,13 @@ module('Acceptance | Modules | New', function (hooks) {
       }),
     );
 
+    // WORKAROUND: let some time for Monaco
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     await screen.getByRole('button', { name: 'Enregistrer' }).click();
 
     assert.dom(await screen.findByRole('heading', { name: 'Modules' })).exists();
-    assert.dom(await screen.findByText('Nouveau module')).exists();
-    assert.dom(await screen.findByText('Le module "Nouveau module" a été enregistré.')).exists();
+    assert.dom(await screen.findByText('NEW_MODULE')).exists();
+    assert.dom(await screen.findByText('Le module "NEW_MODULE" a été enregistré.')).exists();
   });
 });

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -12,13 +12,13 @@ module('Integration | Component | modules-list', function (hooks) {
     const store = this.owner.lookup('service:store');
     const moduleSummaries = [
       store.createRecord('module-summary', {
-        title: 'Super module 1',
+        internalTitle: 'MOD_super_1',
         isBeta: false,
         visibility: 'public',
         level: 'novice',
       }),
       store.createRecord('module-summary', {
-        title: 'Super module 2',
+        internalTitle: 'MOD_super_2',
         isBeta: true,
         visibility: 'private',
         level: 'advanced',
@@ -27,15 +27,15 @@ module('Integration | Component | modules-list', function (hooks) {
 
     const screen = await render(<template><ModulesList @modules={{moduleSummaries}} /></template>);
 
-    assert.dom(screen.queryByText('Super module 1')).exists();
-    assert.dom(screen.queryByText('Super module 2')).exists();
+    assert.dom(screen.queryByText('MOD_super_1')).exists();
+    assert.dom(screen.queryByText('MOD_super_2')).exists();
 
-    const firstRow = screen.getByText('Super module 1').closest('tr');
+    const firstRow = screen.getByText('MOD_super_1').closest('tr');
     assert.dom(queryByText(firstRow, 'Public')).exists();
     assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
     assert.dom(queryByText(firstRow, 'Novice')).exists();
 
-    const secondRow = screen.getByText('Super module 2').closest('tr');
+    const secondRow = screen.getByText('MOD_super_2').closest('tr');
     assert.dom(queryByText(secondRow, 'Privé')).exists();
     assert.dom(queryByText(secondRow, 'Beta')).exists();
     assert.dom(queryByText(secondRow, 'Avancé')).exists();

--- a/pix-editor/tests/mirage/factories/module-summary.js
+++ b/pix-editor/tests/mirage/factories/module-summary.js
@@ -5,8 +5,8 @@ export default Factory.extend({
     return crypto.randomUUID();
   },
 
-  title(i) {
-    return `Module ${i}`;
+  internalTitle(i) {
+    return `MOD_${i}`;
   },
 
   isBeta: false,


### PR DESCRIPTION
## 💥 Problème

On souhaite afficher le titre interne au lieu du titre dans la liste des modules.

## 👩‍🚀 Proposition

Remplacer le titre par le titre interne.

## 👁️ Remarques

N/A

## ♻️ Pour tester

Aller sur la liste des modules, et vérifier que c’est bien le titre interne qui est affiché, et que le tri est fait selon ce titre interne.

Créer un nouveau module, vérifier que dans la notif de création c’est le titre interne qui est affiché.