### PR TITLE
[FEATURE] Inverser les champs "évaluation" et "traduction" (PIX-22838)

### DIFF
--- a/api/db/migrations/20260528121118_flush-maintenance-tags.js
+++ b/api/db/migrations/20260528121118_flush-maintenance-tags.js
@@ -1,0 +1,23 @@
+const TABLE_NAME = 'challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex(TABLE_NAME)
+    .whereNotNull('assessmentMaintenanceTags')
+    .update({ assessmentMaintenanceTags: null });
+
+  await knex(TABLE_NAME)
+    .whereNotNull('translationMaintenanceTags')
+    .update({ translationMaintenanceTags: null });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+
+}

--- a/api/db/migrations/20260528121118_flush-maintenance-tags.js
+++ b/api/db/migrations/20260528121118_flush-maintenance-tags.js
@@ -15,9 +15,7 @@ export async function up(knex) {
 }
 
 /**
- * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-export async function down(knex) {
-
+export async function down() {
 }

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -98,7 +98,7 @@ export class Challenge {
     this.#translate(this.primaryLocale);
   }
 
-  static get ASSESSMENT_MAINTENANCE_TAGS() {
+  static get TRANSLATION_MAINTENANCE_TAGS() {
     return {
       NAME: 'Prénom ou nom propre dans la consigne/propositions/réponse/indice',
       EMBED_NAME: 'Prénom ou nom propre dans un embed ou dans du HTML intégré à l’épreuve',
@@ -121,7 +121,7 @@ export class Challenge {
     };
   }
 
-  static get TRANSLATION_MAINTENANCE_TAGS() {
+  static get ASSESSMENT_MAINTENANCE_TAGS() {
     return {
       RULE: 'Règle, législation ou connaissance',
       INTERFACE: 'Charte graphique ou interface',

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -199,8 +199,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'has-embed-internal-validation': true,
               'no-validation-needed': true,
               'is-quality-ok': false,
-              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
             },
             relationships: {
               skill: {
@@ -310,8 +310,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'has-embed-internal-validation': false,
               'no-validation-needed': false,
               'is-quality-ok': true,
-              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
             },
             relationships: {
               skill: {
@@ -672,8 +672,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'has-embed-internal-validation': true,
             'no-validation-needed': true,
             'is-quality-ok': false,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
           },
           relationships: {
             skill: {
@@ -1167,8 +1167,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'to-rephrase': true,
               'has-embed-internal-validation': true,
               'no-validation-needed': true,
-              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
             },
             relationships: {
               skill: {
@@ -1244,8 +1244,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'has-embed-internal-validation': true,
             'no-validation-needed': true,
             'is-quality-ok': false,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
           },
           relationships: {
             skill: {
@@ -1393,8 +1393,9 @@ describe('Acceptance | Controller | challenges-controller', () => {
           updatedAt: expect.any(Date),
           validatedAt: null,
           version: challengeData.version,
-          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
+
         },
       ]);
       await expect(knex('localized_challenges').select()).resolves.toStrictEqual([
@@ -1787,8 +1788,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'has-embed-internal-validation': true,
               'no-validation-needed': true,
               'is-quality-ok': true,
-              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
             },
             relationships: {
               skill: {
@@ -1864,8 +1865,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'has-embed-internal-validation': true,
             'no-validation-needed': true,
             'is-quality-ok': true,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
           },
           relationships: {
             skill: {
@@ -2205,8 +2206,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'has-embed-internal-validation': false,
               'no-validation-needed': false,
               'is-quality-ok': false,
-              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
             },
             relationships: {
               skill: {
@@ -2282,8 +2283,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'has-embed-internal-validation': false,
             'no-validation-needed': false,
             'is-quality-ok': false,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
           },
           relationships: {
             skill: {

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -47,8 +47,8 @@ describe('Integration | Repository | challenge-repository', () => {
         madeObsoleteAt: null,
         shuffled: true,
         files: [{ fileId: 'attachmentA', localizedChallengeId: 'challengeA_id' }, { fileId: 'attachmentB', localizedChallengeId: 'locES_challengeA_id' }],
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
       };
       const primaryLoc_challengeA_data = {
         embedUrl: 'embedUrl primaryloc challengeA',
@@ -232,8 +232,8 @@ describe('Integration | Repository | challenge-repository', () => {
           updatedAt: '2025-10-23T10:18:00Z',
           madeObsoleteAt: null,
           shuffled: false,
-          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
         };
 
         databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -338,8 +338,8 @@ describe('Integration | Repository | challenge-repository', () => {
           madeObsoleteAt: null,
           updatedAt: '2025-10-23T10:20:00Z',
           shuffled: false,
-          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
+          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
         };
 
         databaseBuilder.factory.buildChallenge(challengeB_data);
@@ -530,8 +530,8 @@ describe('Integration | Repository | challenge-repository', () => {
           updatedAt: '2025-10-23T10:18:00Z',
           madeObsoleteAt: null,
           shuffled: false,
-          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME],
-          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+          assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+          translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME],
         };
 
         databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -707,8 +707,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:18:00Z',
         madeObsoleteAt: null,
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
       };
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -812,8 +812,8 @@ describe('Integration | Repository | challenge-repository', () => {
         madeObsoleteAt: null,
         updatedAt: '2025-10-23T10:20:00Z',
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FIRSTNAMES],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FIRSTNAMES],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
       };
 
       databaseBuilder.factory.buildChallenge(challengeB_data);
@@ -1007,8 +1007,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:18:00Z',
         madeObsoleteAt: null,
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.LOCALIZED_URL],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.LOCALIZED_URL],
       };
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -1112,8 +1112,8 @@ describe('Integration | Repository | challenge-repository', () => {
         madeObsoleteAt: null,
         updatedAt: '2025-10-23T10:20:00Z',
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.LOCALIZED_URL],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FIRSTNAMES],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FIRSTNAMES],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.LOCALIZED_URL],
       };
 
       databaseBuilder.factory.buildChallenge(challengeB_data);
@@ -1305,8 +1305,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:18:00Z',
         madeObsoleteAt: null,
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.HARD_CONTEXTUALIZATION_EMBED],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.HARD_CONTEXTUALIZATION_EMBED],
       };
       databaseBuilder.factory.buildSkill({ id: challengeA_data.skillId, tubeId: 'tube1' });
       databaseBuilder.factory.buildChallenge(challengeA_data);
@@ -1623,8 +1623,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:18:00Z',
         madeObsoleteAt: null,
         shuffled: true,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
       };
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -1673,8 +1673,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:20:00Z',
         madeObsoleteAt: null,
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
       };
 
       databaseBuilder.factory.buildChallenge(challengeActiveA_data);
@@ -1923,8 +1923,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:18:00Z',
         madeObsoleteAt: null,
         shuffled: true,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
       };
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -1973,8 +1973,8 @@ describe('Integration | Repository | challenge-repository', () => {
         updatedAt: '2025-10-23T10:20:00Z',
         madeObsoleteAt: null,
         shuffled: false,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.FILE_TO_REDO],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO],
       };
 
       databaseBuilder.factory.buildChallenge(challengeProtoB_data);
@@ -2192,8 +2192,8 @@ describe('Integration | Repository | challenge-repository', () => {
         accessibility2: Challenge.ACCESSIBILITY1.KO,
         alternativeVersion: 1,
         archivedAt: null,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.NAME],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.NAME],
         createdAt: null,
         validatedAt: null,
         madeObsoleteAt: null,
@@ -2262,8 +2262,8 @@ describe('Integration | Repository | challenge-repository', () => {
         accessibility2: Challenge.ACCESSIBILITY1.OK,
         alternativeVersion: 3,
         archivedAt: null,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.NAME],
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.NAME],
         createdAt: null,
         validatedAt: null,
         madeObsoleteAt: null,
@@ -2565,7 +2565,7 @@ describe('Integration | Repository | challenge-repository', () => {
         accessibility1: Challenge.ACCESSIBILITY1.OK,
         accessibility2: Challenge.ACCESSIBILITY1.KO,
         alternativeVersion: 1,
-        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME],
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE],
         archivedAt: null,
         createdAt: null,
         validatedAt: null,
@@ -2596,7 +2596,7 @@ describe('Integration | Repository | challenge-repository', () => {
         t3Status: true,
         t3StatusAirtable: 'Activé',
         timer: 123,
-        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.INTERFACE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME],
         type: 'type challengeToCreate',
         version: 4,
       };

--- a/api/tests/integration/tooling/database-builder/build-group_test.js
+++ b/api/tests/integration/tooling/database-builder/build-group_test.js
@@ -44,8 +44,8 @@ describe('Unit | Tooling | database Builder | buildGroup', function() {
       archivedAt: new Date('2023-03-03T10:47:05Z'),
       madeObsoleteAt: new Date('2023-04-04T10:47:05Z'),
       isQualityOk: false,
-      assessmentMaintenanceTags: ['Prénom ou nom propre dans un embed ou dans du HTML intégré à l’épreuve', 'Anglicismes à reformuler'],
-      translationMaintenanceTags: ['Règle, législation ou connaissance', 'Réponses ambiguës'],
+      assessmentMaintenanceTags: ['Réponses ambiguës', 'Liens externes'],
+      translationMaintenanceTags: ['Prénom ou nom propre dans un embed ou dans du HTML intégré à l’épreuve', 'Anglicismes à reformuler'],
     });
     expect(result.localizedChallenge).deep.equal({
       id: 'challenge1',

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -69,8 +69,8 @@ export function buildChallenge(
       },
     ],
     prototypePrimaryLocalizedChallenge,
-    assessmentMaintenanceTags = [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-    translationMaintenanceTags = [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+    assessmentMaintenanceTags = [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+    translationMaintenanceTags = [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
   } = {},
   fieldsToOmit = [],
 ) {

--- a/api/tests/tooling/domain-builder/factory/datasource-objects/build-challenge-datasource-object.js
+++ b/api/tests/tooling/domain-builder/factory/datasource-objects/build-challenge-datasource-object.js
@@ -35,8 +35,8 @@ export function buildChallengeDatasourceObject({
   madeObsoleteAt = '2023-04-04T10:47:05Z',
   shuffled = false,
   isQualityOk = false,
-  assessmentMaintenanceTags = [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-  translationMaintenanceTags = [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+  assessmentMaintenanceTags = [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+  translationMaintenanceTags = [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
 } = {}) {
   return {
     id,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/challenge-serializer_test.js
@@ -83,8 +83,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'has-embed-internal-validation': true,
             'no-validation-needed': true,
             'is-quality-ok': false,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
           },
           relationships: {
             skill: {
@@ -230,8 +230,8 @@ describe('Unit | Serializer | JSONAPI | challenge-serializer', () => {
             'has-embed-internal-validation': true,
             'no-validation-needed': true,
             'is-quality-ok': false,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.EMBED_NAME, Challenge.ASSESSMENT_MAINTENANCE_TAGS.ENGLISH_WORD],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE, Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
           },
           relationships: {
             skill: {

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -92,7 +92,7 @@ export default class ChallengeModel extends Model {
     };
   }
 
-  static get ASSESSMENT_MAINTENANCE_TAGS() {
+  static get TRANSLATION_MAINTENANCE_TAGS() {
     return {
       NAME: 'Prénom ou nom propre dans la consigne/propositions/réponse/indice',
       EMBED_NAME: 'Prénom ou nom propre dans un embed ou dans du HTML intégré à l’épreuve',
@@ -115,7 +115,7 @@ export default class ChallengeModel extends Model {
     };
   }
 
-  static get TRANSLATION_MAINTENANCE_TAGS() {
+  static get ASSESSMENT_MAINTENANCE_TAGS() {
     return {
       RULE: 'Règle, législation ou connaissance',
       INTERFACE: 'Charte graphique ou interface',

--- a/pix-editor/tests/acceptance/challenge/create-challenge/create-challenge-test.js
+++ b/pix-editor/tests/acceptance/challenge/create-challenge/create-challenge-test.js
@@ -131,13 +131,14 @@ module('Acceptance | Create-Challenge', function (hooks) {
     await waitForSelectToBeClosed(screen);
     await clickByName('Évaluation');
     await screen.findByRole('menu');
-    await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.NAME);
-    await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.MISC);
+    await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.FIRSTNAMES);
+    await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS);
     await clickByName('Traduction');
     const translationSelect = screen.getByTestId('translationSelect');
     await within(translationSelect).findByRole('menu');
-    await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.FIRSTNAMES);
-    await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS);
+    await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.NAME);
+    await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.MISC);
+
     await click(find('[data-test-save-challenge-button]'));
 
     // then
@@ -164,13 +165,13 @@ module('Acceptance | Create-Challenge', function (hooks) {
     assert.true(screen.getByRole('checkbox', { name: 'Sans validation (Pix Junior)' }).checked);
     assert.true(screen.getByRole('checkbox', { name: "Validation par l'embed (Pix Junior)" }).checked);
     assert.strictEqual((await screen.getByLabelText('Responsive')).childNodes[3].textContent, 'Non');
-    assert.deepEqual(challenge.assessmentMaintenanceTags, [
-      Challenge.ASSESSMENT_MAINTENANCE_TAGS.NAME,
-      Challenge.ASSESSMENT_MAINTENANCE_TAGS.MISC,
-    ]);
     assert.deepEqual(challenge.translationMaintenanceTags, [
-      Challenge.TRANSLATION_MAINTENANCE_TAGS.FIRSTNAMES,
-      Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS,
+      Challenge.TRANSLATION_MAINTENANCE_TAGS.NAME,
+      Challenge.TRANSLATION_MAINTENANCE_TAGS.MISC,
+    ]);
+    assert.deepEqual(challenge.assessmentMaintenanceTags, [
+      Challenge.ASSESSMENT_MAINTENANCE_TAGS.FIRSTNAMES,
+      Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS,
     ]);
   });
 });

--- a/pix-editor/tests/integration/components/form/challenge-test.gjs
+++ b/pix-editor/tests/integration/components/form/challenge-test.gjs
@@ -219,13 +219,13 @@ module('Integration | Component | challenge-form', function (hooks) {
         await clickByName('Évaluation');
         await screen.findByRole('menu');
 
-        await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.NAME);
-        await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.MISC);
+        await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.RULE);
+        await clickByName(Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS);
 
         // Then
         assert.ok(this.challengeData.assessmentMaintenanceTags, [
-          Challenge.ASSESSMENT_MAINTENANCE_TAGS.NAME,
-          Challenge.ASSESSMENT_MAINTENANCE_TAGS.MISC,
+          Challenge.ASSESSMENT_MAINTENANCE_TAGS.RULE,
+          Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS,
         ]);
       });
 
@@ -252,13 +252,13 @@ module('Integration | Component | challenge-form', function (hooks) {
         await clickByName('Traduction');
         await screen.findByRole('menu');
 
-        await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE);
-        await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS);
+        await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.NAME);
+        await clickByName(Challenge.TRANSLATION_MAINTENANCE_TAGS.MISC);
 
         // Then
         assert.ok(this.challengeData.translationMaintenanceTags, [
-          Challenge.TRANSLATION_MAINTENANCE_TAGS.RULE,
-          Challenge.TRANSLATION_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS,
+          Challenge.TRANSLATION_MAINTENANCE_TAGS.NAME,
+          Challenge.TRANSLATION_MAINTENANCE_TAGS.MISC,
         ]);
       });
     });


### PR DESCRIPTION
## 💥 Problème

Les champs “Évaluation” et “Traduction” sont inversés au niveau du prototype, partie “Maintenance”
Il faut remettre les bonnes valeurs dans les champs.

## 👩‍🚀 Proposition

Inverser les 2 champs dans le modèle 

## 👁️ Remarques

Aucun champ n'a encore été enregistré en base. Aucune reprise de données n'est donc nécessaire

## ♻️ Pour tester
Dans pix-editor, modifier un challenge. S'assurer que les valeurs des listes déroulantes "Evaluation" et "Traduction" de la section "Maintenance" ont bien été inversées.

