### PR TITLE
[FEATURE] Ajouter un script pour modifier en masse les titre et description "Pratiques" des sujets (PIX-22809).

### DIFF
--- a/api/scripts/update-tubes-translation.js
+++ b/api/scripts/update-tubes-translation.js
@@ -19,7 +19,7 @@ class TubeTranslationsDTO {
   }
 }
 
-function getTubeIdsFromPixFramework(knexConn = knex) {
+export function getTubeIdsFromPixFramework(knexConn = knex) {
   return knexConn
     .select('tubes.id', 'tubes.name')
     .from('tubes')
@@ -70,7 +70,6 @@ export class UpdateTubesTranslationScript extends Script {
 
           const tubeId = tubeIds[0].id;
           const translations = [{ key: `tube.${tubeId}.practicalTitle`, locale: 'fr', value: practicalTitle }, { key: `tube.${tubeId}.practicalDescription`, locale: 'fr', value: practicalDescription }];
-          logger.log(translations);
           await translationRepository.save({ translations, transaction: trx });
           updatedTubesCount++;
         }
@@ -80,7 +79,6 @@ export class UpdateTubesTranslationScript extends Script {
           await trx.rollback();
           return;
         }
-
         await trx.commit();
         logger.info(`Successfully updated translations for ${updatedTubesCount} tube(s)`);
       } catch (error) {

--- a/api/scripts/update-tubes-translation.js
+++ b/api/scripts/update-tubes-translation.js
@@ -64,7 +64,7 @@ export class UpdateTubesTranslationScript extends Script {
           const tubeIds = tubesFromPix.filter(({ name }) => name === tubeName);
 
           if (tubeIds.length !== 1) {
-            logger.error(`${tubeName} found ${tubeIds.length}`, { tubeIds });
+            logger.error(`Found ${tubeIds.length} tube(s) with name ${tubeName}`, { tubeIds: tubeIds.map(({ id }) => id) });
             continue;
           }
 

--- a/api/scripts/update-tubes-translation.js
+++ b/api/scripts/update-tubes-translation.js
@@ -75,7 +75,7 @@ export class UpdateTubesTranslationScript extends Script {
         }
 
         if (options.dryRun) {
-          logger.info('Dry run, stopping');
+          logger.info(`Dry run is enabled, stopping before updating ${updatedTubesCount} tube(s)`);
           await trx.rollback();
           return;
         }

--- a/api/scripts/update-tubes-translation.js
+++ b/api/scripts/update-tubes-translation.js
@@ -1,0 +1,94 @@
+import { Script } from '../lib/application/scripts/script.js';
+import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
+import Joi from 'joi';
+import { csvFileParser } from '../lib/application/scripts/parsers.js';
+import { knex } from '../db/knex-database-connection.js';
+import { translationRepository } from '../lib/infrastructure/repositories/index.js';
+
+export const csvSchemas = [
+  { name: 'Thèmes/acquis', schema: Joi.string().required() },
+  { name: 'Titre pratique', schema: Joi.string().required() },
+  { name: 'description', schema: Joi.string().required() },
+];
+
+class TubeTranslationsDTO {
+  constructor(row) {
+    this.tubeName = row['Thèmes/acquis'];
+    this.practicalTitle = row['Titre pratique'];
+    this.practicalDescription = row['description'];
+  }
+}
+
+function getTubeIdsFromPixFramework(knexConn = knex) {
+  return knexConn
+    .select('tubes.id', 'tubes.name')
+    .from('tubes')
+    .join('thematics', 'thematics.id', 'tubes.thematicId')
+    .join('competences', 'competences.id', 'thematics.competenceId')
+    .join('areas', 'areas.id', 'competences.areaId')
+    .join('frameworks', 'frameworks.id', 'areas.frameworkId')
+    .where('frameworks.name', 'Pix');
+}
+
+export class UpdateTubesTranslationScript extends Script {
+  constructor() {
+    super({
+      description: 'Script de mise à jour des traductions des sujets',
+      permanent: true,
+      options: {
+        dryRun: {
+          type: 'boolean',
+          describe: 'If true, it does not perform any update.',
+          demandOption: true,
+          default: true,
+        },
+        file: {
+          type: 'string',
+          describe: 'Chemin du fichier CSV à lire',
+          demandOption: true,
+          coerce: csvFileParser(csvSchemas),
+        },
+      },
+    });
+  }
+
+  async handle({ options, logger }) {
+    logger.info({ dryRun: options.dryRun, ids: options.id }, 'Script options');
+    const tubesFromPix = await getTubeIdsFromPixFramework();
+
+    await knex.transaction(async (trx) => {
+      try {
+        let updatedTubesCount = 0;
+        for (const row of options.file) {
+          const { tubeName, practicalTitle, practicalDescription } = new TubeTranslationsDTO(row);
+          const tubeIds = tubesFromPix.filter(({ name }) => name === tubeName);
+
+          if (tubeIds.length !== 1) {
+            logger.error(`${tubeName} found ${tubeIds.length}`, { tubeIds });
+            continue;
+          }
+
+          const tubeId = tubeIds[0].id;
+          const translations = [{ key: `tube.${tubeId}.practicalTitle`, locale: 'fr', value: practicalTitle }, { key: `tube.${tubeId}.practicalDescription`, locale: 'fr', value: practicalDescription }];
+          logger.log(translations);
+          await translationRepository.save({ translations, transaction: trx });
+          updatedTubesCount++;
+        }
+
+        if (options.dryRun) {
+          logger.info('Dry run, stopping');
+          await trx.rollback();
+          return;
+        }
+
+        await trx.commit();
+        logger.info(`Successfully updated translations for ${updatedTubesCount} tube(s)`);
+      } catch (error) {
+        logger.error('unhandled error found', { error });
+        await trx.rollback();
+      }
+    });
+  }
+}
+
+await ScriptRunner.execute(import.meta.url, UpdateTubesTranslationScript);

--- a/api/tests/scripts/files/update-tubes-translation-missing-column-ko.csv
+++ b/api/tests/scripts/files/update-tubes-translation-missing-column-ko.csv
@@ -1,0 +1,2 @@
+comp,niveau,pouet,riri,fifi
+1.1,°°°,@tube_un,mon_nouveau_titre,ma_nouvelle_description

--- a/api/tests/scripts/files/update-tubes-translation-ok.csv
+++ b/api/tests/scripts/files/update-tubes-translation-ok.csv
@@ -1,0 +1,2 @@
+comp,niveau,Thèmes/acquis,Titre pratique,description
+1.1,°°°,@tube_un,mon_nouveau_titre,ma_nouvelle_description

--- a/api/tests/scripts/update-tubes-translation_test.js
+++ b/api/tests/scripts/update-tubes-translation_test.js
@@ -29,11 +29,17 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
       const tubes = await getTubeIdsFromPixFramework();
       expect(tubes).lengthOf(3);
-      expect(tubes).deep.members([{ id: tube.id, name: tube.name }, { id: '12', name: '@tube_un' }, { id: '13', name: '@tube_un' }]);
+      expect(tubes).deep.members([
+        { id: tube.id, name: tube.name },
+        { id: '12', name: '@tube_un' },
+        { id: '13', name: '@tube_un' },
+      ]);
     });
   });
 
   describe('#handle', () => {
+    const testCsvFile = `${currentDirectory}files/update-tubes-translation-ok.csv`;
+
     it('update only given tubes translation', async () => {
       // given
       const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});
@@ -63,7 +69,6 @@ describe('Script | UpdateTubesTranslationScript', () => {
       await databaseBuilder.commit();
 
       // when
-      const testCsvFile = `${currentDirectory}files/update-tubes-translation-ok.csv`;
       const { options: scriptMeta } = script.metaInfo;
       const fileData = await scriptMeta.file.coerce(testCsvFile);
 
@@ -88,6 +93,79 @@ describe('Script | UpdateTubesTranslationScript', () => {
       expect(enDescriptionTranslation).equal('my description');
 
       expect(logger.info).toHaveBeenCalledWith('Successfully updated translations for 1 tube(s)');
+    });
+
+    it('should ignore update tube translation when several tube has same name', async () => {
+      // given
+      const tubeId1 = 'tibeId1';
+      const tubeId2 = 'tibeId2';
+      const { thematic } = databaseBuilder.factory.buildChallengeInGroup({ tube: { id: tubeId1, name: '@tube_un' }, skill: { tubeId: tubeId1 } });
+      databaseBuilder.factory.buildTube({ id: tubeId2, name: '@tube_un', thematicId: thematic.id });
+
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeId1}.practicalDescription`,
+        locale: 'fr',
+        value: 'ma vielle description',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeId1}.practicalTitle`,
+        locale: 'fr',
+        value: 'mon vieux titre',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeId2}.practicalDescription`,
+        locale: 'fr',
+        value: 'ma vielle description 2',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeId2}.practicalTitle`,
+        locale: 'fr',
+        value: 'mon vieux titre 2',
+      });
+      await databaseBuilder.commit();
+
+      const { options: scriptMeta } = script.metaInfo;
+      const fileData = await scriptMeta.file.coerce(testCsvFile);
+
+      const options = {
+        file: fileData,
+        dryRun: false,
+      };
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      const { value: frTitleTranslation1 } = await knex('translations').select('value').where({ key: `tube.${tubeId1}.practicalTitle`, locale: 'fr' }).first();
+      expect(frTitleTranslation1).equal('mon vieux titre');
+
+      const { value: frDescriptionTranslation1 } = await knex('translations').select('value').where({ key: `tube.${tubeId1}.practicalDescription`, locale: 'fr' }).first();
+      expect(frDescriptionTranslation1).equal('ma vielle description');
+
+      const { value: frTitleTranslation2 } = await knex('translations').select('value').where({ key: `tube.${tubeId2}.practicalTitle`, locale: 'fr' }).first();
+      expect(frTitleTranslation2).equal('mon vieux titre 2');
+
+      const { value: frDescriptionTranslation2 } = await knex('translations').select('value').where({ key: `tube.${tubeId2}.practicalDescription`, locale: 'fr' }).first();
+      expect(frDescriptionTranslation2).equal('ma vielle description 2');
+
+      expect(logger.error).toHaveBeenCalledWith('Found 2 tube(s) with name @tube_un', { tubeIds: [tubeId1, tubeId2] });
+    });
+
+    it('should ignore update tube translation when no tube has given name', async () => {
+      // given
+      const { options: scriptMeta } = script.metaInfo;
+      const fileData = await scriptMeta.file.coerce(testCsvFile);
+
+      const options = {
+        file: fileData,
+        dryRun: false,
+      };
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(logger.error).toHaveBeenCalledWith('Found 0 tube(s) with name @tube_un', { tubeIds: [] });
     });
   });
 });

--- a/api/tests/scripts/update-tubes-translation_test.js
+++ b/api/tests/scripts/update-tubes-translation_test.js
@@ -2,7 +2,7 @@ import * as url from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { databaseBuilder, knex } from '../test-helper.js';
-import { UpdateTubesTranslationScript } from '../../scripts/update-tubes-translation.js';
+import { UpdateTubesTranslationScript, getTubeIdsFromPixFramework } from '../../scripts/update-tubes-translation.js';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 
@@ -16,6 +16,21 @@ describe('Script | UpdateTubesTranslationScript', () => {
       info: vi.fn(),
       error: vi.fn(),
     };
+  });
+
+  describe('#getTubeIdsFromPixFramework', () => {
+    it('return tubes from Pix Framework', async() => {
+      databaseBuilder.factory.buildChallengeInGroup({ framework: { name: 'POUET' } });
+      const { thematic, tube } = databaseBuilder.factory.buildChallengeInGroup({});
+      databaseBuilder.factory.buildTube({ id: 12, name: '@tube_un', thematicId: thematic.id });
+      databaseBuilder.factory.buildTube({ id: 13, name: '@tube_un', thematicId: thematic.id });
+
+      await databaseBuilder.commit();
+
+      const tubes = await getTubeIdsFromPixFramework();
+      expect(tubes).lengthOf(3);
+      expect(tubes).deep.members([{ id: tube.id, name: tube.name }, { id: '12', name: '@tube_un' }, { id: '13', name: '@tube_un' }]);
+    });
   });
 
   describe('#handle', () => {

--- a/api/tests/scripts/update-tubes-translation_test.js
+++ b/api/tests/scripts/update-tubes-translation_test.js
@@ -81,6 +81,13 @@ describe('Script | UpdateTubesTranslationScript', () => {
       });
     });
 
+    describe('when csv file missing required column on coerce', () => {
+      it('should throw an error', async () => {
+        const { options: scriptMeta } = script.metaInfo;
+        await expect(scriptMeta.file.coerce(`${currentDirectory}files/update-tubes-translation-missing-column-ko.csv`)).rejects.toThrow('MISSING_REQUIRED_FIELD_NAMES');
+      });
+    });
+
     it('update only given tubes translation', async () => {
       // given
       const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});

--- a/api/tests/scripts/update-tubes-translation_test.js
+++ b/api/tests/scripts/update-tubes-translation_test.js
@@ -1,0 +1,78 @@
+import * as url from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { databaseBuilder, knex } from '../test-helper.js';
+import { UpdateTubesTranslationScript } from '../../scripts/update-tubes-translation.js';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+
+describe('Script | UpdateTubesTranslationScript', () => {
+  let script;
+  let logger;
+
+  beforeEach(() => {
+    script = new UpdateTubesTranslationScript();
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  describe('#handle', () => {
+    it('update only given tubes translation', async () => {
+      // given
+      const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});
+      const tubeToUpdate = databaseBuilder.factory.buildTube({ id: 1, name: '@tube_un', thematicId: thematic.id });
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeToUpdate.id}.practicalTitle`,
+        locale: 'fr',
+        value: 'mon titre',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeToUpdate.id}.practicalTitle`,
+        locale: 'en',
+        value: 'my title',
+      });
+
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeToUpdate.id}.practicalDescription`,
+        locale: 'fr',
+        value: 'ma description',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `tube.${tubeToUpdate.id}.practicalDescription`,
+        locale: 'en',
+        value: 'my description',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const testCsvFile = `${currentDirectory}files/update-tubes-translation-ok.csv`;
+      const { options: scriptMeta } = script.metaInfo;
+      const fileData = await scriptMeta.file.coerce(testCsvFile);
+
+      const options = {
+        file: fileData,
+        dryRun: false,
+      };
+
+      await script.handle({ options, logger });
+
+      // then
+      const { value: frTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale: 'fr' }).first();
+      expect(frTitleTranslation).equal('mon_nouveau_titre');
+
+      const { value: frDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale: 'fr' }).first();
+      expect(frDescriptionTranslation).equal('ma_nouvelle_description');
+
+      const { value: enTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale: 'en' }).first();
+      expect(enTitleTranslation).equal('my title');
+
+      const { value: enDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale: 'en' }).first();
+      expect(enDescriptionTranslation).equal('my description');
+
+      expect(logger.info).toHaveBeenCalledWith('Successfully updated translations for 1 tube(s)');
+    });
+  });
+});

--- a/api/tests/scripts/update-tubes-translation_test.js
+++ b/api/tests/scripts/update-tubes-translation_test.js
@@ -40,6 +40,47 @@ describe('Script | UpdateTubesTranslationScript', () => {
   describe('#handle', () => {
     const testCsvFile = `${currentDirectory}files/update-tubes-translation-ok.csv`;
 
+    describe('when dryRun is true', () => {
+      it('should not update any tube translations', async () => {
+        // given
+        const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});
+        const tubeToUpdate = databaseBuilder.factory.buildTube({ id: 1, name: '@tube_un', thematicId: thematic.id });
+        databaseBuilder.factory.buildTranslation({
+          key: `tube.${tubeToUpdate.id}.practicalTitle`,
+          locale: 'fr',
+          value: 'mon titre',
+        });
+
+        databaseBuilder.factory.buildTranslation({
+          key: `tube.${tubeToUpdate.id}.practicalDescription`,
+          locale: 'fr',
+          value: 'ma description',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { options: scriptMeta } = script.metaInfo;
+        const fileData = await scriptMeta.file.coerce(testCsvFile);
+
+        const options = {
+          file: fileData,
+          dryRun: true,
+        };
+
+        await script.handle({ options, logger });
+
+        // then
+        const { value: frTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale: 'fr' }).first();
+        expect(frTitleTranslation).equal('mon titre');
+
+        const { value: frDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale: 'fr' }).first();
+        expect(frDescriptionTranslation).equal('ma description');
+
+        expect(logger.info).toHaveBeenCalledWith('Dry run is enabled, stopping before updating 1 tube(s)');
+      });
+    });
+
     it('update only given tubes translation', async () => {
       // given
       const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});


### PR DESCRIPTION
## 💥 Problème

Nous avons besoin de modifier toutes les titres / description des sujets. c'est un peu fastidieux.

## 👩‍🚀 Proposition

Créer un script qui permet de modifier ces deux valeurs pour la langue FR seulement

## 👁️ Remarques

Si la langue EN est amené a être modifier. on pourra tout à fait adapter le script pour prendre une langue en paramètre par défaut. 

## ♻️ Pour tester

se faire un csv sur le referentiel de RA.
modifier les titres/description du réferentiel Pix
Executer le script
vérifier que tout est inséré en bdd.
