### PR TITLE
[FEATURE] Ajout du endpoint GET /api/modules/:id (PIX-22929)

### DIFF
--- a/api/lib/application/modules/modules.js
+++ b/api/lib/application/modules/modules.js
@@ -2,7 +2,8 @@ import Joi from 'joi';
 
 import { moduleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
-import { listPaginatedModules } from '../../domain/usecases/index.js';
+import { getModuleById, listPaginatedModules } from '../../domain/usecases/index.js';
+import * as Types from '../types.js';
 
 export function register(server) {
   server.route([
@@ -28,6 +29,18 @@ export function register(server) {
               'visibility',
             ], meta,
           });
+        },
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/modules/{id}',
+      config: {
+        validate: { params: Joi.object({ id: Types.moduleId().required() }) },
+        handler: async (request) => {
+          const { id } = request.params;
+          const module = await getModuleById(id);
+          return moduleSerializer.serialize(module);
         },
       },
     },

--- a/api/lib/application/types.js
+++ b/api/lib/application/types.js
@@ -46,6 +46,10 @@ export function localizedChallengeId() {
   return Joi.string().pattern(/^(rec|challenge)[a-zA-Z0-9]+(-[a-zA-Z0-9]+)?$/);
 }
 
+export function moduleId() {
+  return Joi.string().pattern(/^\p{Hex_Digit}{8}-\p{Hex_Digit}{4}-\p{Hex_Digit}{4}-\p{Hex_Digit}{4}-\p{Hex_Digit}{12}$/u);
+}
+
 export function skillId() {
   return Joi.string().pattern(/^(rec|skill)[a-zA-Z0-9]+$/);
 }

--- a/api/lib/domain/usecases/get-module-by-id.js
+++ b/api/lib/domain/usecases/get-module-by-id.js
@@ -1,0 +1,5 @@
+import { moduleRepository } from '../../infrastructure/repositories/index.js';
+
+export async function getModuleById(id, dependencies = { moduleRepository }) {
+  return dependencies.moduleRepository.getById({ id });
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -19,6 +19,7 @@ export * from './export-translations.js';
 export * from './find-all-missions.js';
 export * from './get-competence-challenges-production-overview.js';
 export * from './get-competence-challenges-workbench-overview.js';
+export * from './get-module-by-id.js';
 export * from './get-phrase-translations-url.js';
 export * from './get-skill-challenges-production.js';
 export * from './find-attachment.js';

--- a/api/lib/infrastructure/repositories/module-repository.js
+++ b/api/lib/infrastructure/repositories/module-repository.js
@@ -1,6 +1,7 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { Module } from '../../domain/models/index.js';
 import { ModuleForReplication } from '../../domain/models/replication/index.js';
+import { NotFoundError } from '../errors.js';
 
 export async function count() {
   const { count } = await knex('modules').count().first();
@@ -52,6 +53,16 @@ export async function listForReplication() {
   return modules.map(toDomainForReplication);
 }
 
+export async function getById({ id }) {
+  const module = await knex('modules').where({ id }).first();
+
+  if (!module) {
+    throw new NotFoundError('Module not found');
+  }
+
+  return toDomain(module);
+}
+
 function toDomain({ image, description, duration, level, objectives, tabletSupport, ...module }) {
   return new Module({ ...module, details: { image, description, duration, level, objectives, tabletSupport } });
 }
@@ -59,3 +70,4 @@ function toDomain({ image, description, duration, level, objectives, tabletSuppo
 function toDomainForReplication(module) {
   return new ModuleForReplication(module);
 }
+

--- a/api/tests/acceptance/application/modules/modules_test.js
+++ b/api/tests/acceptance/application/modules/modules_test.js
@@ -102,4 +102,65 @@ describe('Acceptance | Route | modules', () => {
       });
     });
   });
+
+  describe('GET /modules/:id', () => {
+    let module;
+
+    beforeEach(async () => {
+      module = domainBuilder.buildModule();
+      databaseBuilder.factory.buildModule(module);
+      await databaseBuilder.commit();
+    });
+
+    it('responds with status 200 and modules data', async () => {
+      // given
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/modules/${module.id}`,
+        headers: generateAuthorizationHeader(editorUser),
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+
+      expect(response.result).toStrictEqual({
+        data: {
+          type: 'modules',
+          id: module.id,
+          attributes: {
+            'short-id': module.shortId,
+            'internal-title': module.internalTitle,
+            'is-beta': module.isBeta,
+            visibility: module.visibility,
+            details: module.details,
+            slug: module.slug,
+            title: module.title,
+            sections: module.sections,
+            glossary: module.glossary,
+          },
+        },
+      });
+    });
+
+    describe('when module does not exist', () => {
+      it('responds with status 404', async () => {
+        // given
+        const server = await createServer();
+        const notFoundId = crypto.randomUUID();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/modules/${notFoundId}`,
+          headers: generateAuthorizationHeader(editorUser),
+        });
+
+        // then
+        expect(response.statusCode).toBe(404);
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-repository_test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
-import { list, listForReplication, save, count } from '../../../../lib/infrastructure/repositories/module-repository.js';
+import { catchErr, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { list, listForReplication, save, count, getById } from '../../../../lib/infrastructure/repositories/module-repository.js';
 import { ModuleForReplication } from '../../../../lib/domain/models/replication/index.js';
+import { NotFoundError } from '../../../../lib/infrastructure/errors.js';
 
 describe('Module Repository', () => {
   describe('save', () => {
@@ -130,6 +131,33 @@ describe('Module Repository', () => {
 
       // then
       expect(result).toBe(2);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns a module by its id', async () => {
+      // given
+      const expectedModule = domainBuilder.buildModule();
+      const { id } = databaseBuilder.factory.buildModule(expectedModule);
+      databaseBuilder.factory.buildModule(domainBuilder.buildModule({ shortId: 'secondar', internalTitle: 'secondar' }));
+      await databaseBuilder.commit();
+
+      // when
+      const module = await getById({ id });
+
+      // then
+      expect(module).toStrictEqual(expectedModule);
+    });
+
+    it('throw a not Found error if module is not found', async () => {
+      // given
+      const inexistingModuleId = crypto.randomUUID();
+
+      // when
+      const error = await catchErr(getById)({ id: inexistingModuleId });
+
+      // then
+      expect(error).toBeInstanceOf(NotFoundError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-module-by-id_test.js
+++ b/api/tests/unit/domain/usecases/get-module-by-id_test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getModuleById } from '../../../../lib/domain/usecases/get-module-by-id.js';
+
+describe('Unit | Domain | Use Cases | getModuleById', () => {
+  it('returns module retrieved from repository', async () => {
+    // given
+    const id = Symbol('id');
+    const module = Symbol('module');
+    const moduleRepository = { getById: vi.fn().mockResolvedValueOnce(module) };
+
+    // when
+    const result = await getModuleById(id, { moduleRepository });
+
+    // then
+    expect(result).toBe(module);
+    expect(moduleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id });
+  });
+});


### PR DESCRIPTION
## 💥 Problème

On souhaite afficher la page de détail d’un module mais l’API ne permet pas de récupérer le détail d’un module.

## 👩‍🚀 Proposition

Ajouter un endpoint GET /api/modules/:id permettant de récupérer le détail d’un module.

## 👁️ Remarques

N/A

## ♻️ Pour tester

Faire un curl sur le endpoint :

```
curl -H 'authorization: Bearer xxx' https://pix-lcms-review-pr1495.osc-fr1.scalingo.io/api/modules/235c680e-cbd2-4c56-bef6-80d3ed4d417a
```