### PR TITLE
[FEATURE] Page de détails d'un module en PROD (PIX-22930)

### DIFF
--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -12,6 +12,29 @@ export default class ModuleForm extends Component {
   @tracked internalTitle;
   @tracked moduleData;
 
+  constructor(...args) {
+    super(...args);
+
+    this.monacoOptions = {
+      ariaLabel: 'Contenu (JSON)',
+      ariaRequired: true,
+      automaticLayout: true,
+      domReadOnly: this.args.readonly,
+      language: 'json',
+      readOnly: this.args.readonly,
+      theme: 'vs-light',
+    };
+
+    if (!this.args.module) return;
+
+    const { id, internalTitle, shortId, slug, title, isBeta, visibility, details, sections, glossary } =
+      this.args.module;
+
+    this.internalTitle = internalTitle;
+    this.moduleData = { id, shortId, slug, title, isBeta, visibility, details, sections, glossary };
+    this.monacoOptions.value = JSON.stringify(this.moduleData, null, 2);
+  }
+
   @action
   onChange(moduleJson) {
     try {
@@ -19,16 +42,6 @@ export default class ModuleForm extends Component {
     } catch {
       this.moduleData = undefined;
     }
-  }
-
-  get monacoOptions() {
-    return {
-      ariaLabel: 'Contenu (JSON)',
-      ariaRequired: true,
-      automaticLayout: true,
-      language: 'json',
-      theme: 'vs-light',
-    };
   }
 
   get isSaveDisabled() {
@@ -50,6 +63,7 @@ export default class ModuleForm extends Component {
         @value={{this.internalTitle}}
         @requiredLabel="Champ obligatoire"
         {{on "change" this.onInternalTitleChange}}
+        readonly={{@readonly}}
       >
         <:label>Titre interne</:label>
       </PixInput>
@@ -61,14 +75,16 @@ export default class ModuleForm extends Component {
         <MonacoEditor @options={{this.monacoOptions}} class="module-form__monaco-editor" @onChange={{this.onChange}} />
       </div>
 
-      <div class="module-form__actions">
-        <PixButton @triggerAction={{this.saveModule}} @isDisabled={{this.isSaveDisabled}}>
-          Enregistrer
-        </PixButton>
-        <PixButtonLink @route="authenticated.modules" @variant="secondary">
-          Annuler
-        </PixButtonLink>
-      </div>
+      {{#unless @readonly}}
+        <div class="module-form__actions">
+          <PixButton @triggerAction={{this.saveModule}} @isDisabled={{this.isSaveDisabled}}>
+            Enregistrer
+          </PixButton>
+          <PixButtonLink @route="authenticated.modules" @variant="secondary">
+            Annuler
+          </PixButtonLink>
+        </div>
+      {{/unless}}
     </div>
   </template>
 }

--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -1,47 +1,75 @@
+import Component from '@glimmer/component';
+import { fn } from '@ember/helper';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+import PixButton from '@1024pix/pix-ui/components/pix-button';
 
 function getVisibilityColor(visibility) {
   return { public: 'green', private: 'grey' }[visibility];
 }
 
-<template>
-  <PixTable @variant="modulix" @data={{@modules}} @caption="Liste des modules">
-    <:columns as |module context|>
-      {{#if @showStatus}}
+export default class Product extends Component {
+  @service router;
+
+  @action
+  goToDetailPage(moduleId) {
+    this.router.transitionTo('authenticated.modules.production-module', moduleId);
+  }
+
+  <template>
+    <PixTable @variant="modulix" @data={{@modules}} @caption="Liste des modules">
+      <:columns as |module context|>
+        {{#if @showStatus}}
+          <PixTableColumn @context={{context}}>
+            <:header>
+              Statut
+            </:header>
+            <:cell>
+              <div class="modules-list__status">
+                <PixTag @color={{getVisibilityColor module.visibility}}>
+                  {{module.visibilityForDisplay}}
+                </PixTag>
+                {{#if module.isBeta}}
+                  <PixTag @color="yellow">Beta</PixTag>
+                {{/if}}
+              </div>
+            </:cell>
+          </PixTableColumn>
+        {{/if}}
         <PixTableColumn @context={{context}}>
           <:header>
-            Statut
+            Titre interne
           </:header>
           <:cell>
-            <div class="modules-list__status">
-              <PixTag @color={{getVisibilityColor module.visibility}}>
-                {{module.visibilityForDisplay}}
-              </PixTag>
-              {{#if module.isBeta}}
-                <PixTag @color="yellow">Beta</PixTag>
-              {{/if}}
-            </div>
+            {{module.internalTitle}}
           </:cell>
         </PixTableColumn>
-      {{/if}}
-      <PixTableColumn @context={{context}}>
-        <:header>
-          Titre interne
-        </:header>
-        <:cell>
-          {{module.internalTitle}}
-        </:cell>
-      </PixTableColumn>
-      <PixTableColumn @context={{context}}>
-        <:header>
-          Niveau
-        </:header>
-        <:cell>
-          {{module.levelForDisplay}}
-        </:cell>
-      </PixTableColumn>
-    </:columns>
-  </PixTable>
-</template>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            Niveau
+          </:header>
+          <:cell>
+            {{module.levelForDisplay}}
+          </:cell>
+        </PixTableColumn>
+        {{#if module.mayShowProductionDetails}}
+          <PixTableColumn @context={{context}}>
+            <:header>
+              Actions
+            </:header>
+            <:cell>
+              <div class="modules-list__actions">
+                <PixButton @triggerAction={{fn this.goToDetailPage module.id}}>
+                  Voir le détail
+                </PixButton>
+              </div>
+            </:cell>
+          </PixTableColumn>
+        {{/if}}
+      </:columns>
+    </PixTable>
+  </template>
+}

--- a/pix-editor/app/components/monaco-editor/monaco-editor.gjs
+++ b/pix-editor/app/components/monaco-editor/monaco-editor.gjs
@@ -8,7 +8,10 @@ import * as monaco from 'monaco-editor';
 
 export default class MonacoEditor extends Component {
   setup = modifier((element) => {
-    const editor = monaco.editor.create(element, this.args.options);
+    const { value, ...options } = this.args.options;
+    const editor = monaco.editor.create(element, options);
+    // WORKAROUND: passing value in options does not fill textarea’s value
+    if (value) editor.setValue(value);
     editor.onDidChangeModelContent((event) => {
       this.args.onChange?.(editor.getValue());
     });

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -1,3 +1,8 @@
 import Module from './module';
 
-export default class DraftModule extends Module {}
+export default class DraftModule extends Module {
+  get mayShowProductionDetails() {
+    // FIXME must return true if draft belongs to an existing module
+    return false;
+  }
+}

--- a/pix-editor/app/models/module.js
+++ b/pix-editor/app/models/module.js
@@ -29,4 +29,8 @@ export default class Module extends Model {
   get levelForDisplay() {
     return levelForDisplay[this.details.level] ?? this.details.level;
   }
+
+  get mayShowProductionDetails() {
+    return true;
+  }
 }

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -88,6 +88,7 @@ Router.map(function () {
       this.route('new');
       this.route('production');
       this.route('workbench');
+      this.route('production-module', { path: '/production/:module_id' });
     });
     this.route('missions', function () {
       this.route('list', { path: '/' });

--- a/pix-editor/app/routes/authenticated/modules/index.js
+++ b/pix-editor/app/routes/authenticated/modules/index.js
@@ -1,12 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class ModulesRoute extends Route {
-  queryParams = {
-    pageNumber: { refreshModel: true },
-    pageSize: { refreshModel: true },
-  };
-
+export default class ModulesIndexRoute extends Route {
   @service router;
 
   redirect() {

--- a/pix-editor/app/routes/authenticated/modules/production-module.js
+++ b/pix-editor/app/routes/authenticated/modules/production-module.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class ProductionModuleRoute extends Route {
+  @service store;
+
+  async model(params) {
+    const module = await this.store.findRecord('module', params.module_id);
+    return { module };
+  }
+}

--- a/pix-editor/app/routes/authenticated/modules/production.js
+++ b/pix-editor/app/routes/authenticated/modules/production.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class ModulesRoute extends Route {
+export default class ProductionModulesRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },

--- a/pix-editor/app/routes/authenticated/modules/workbench.js
+++ b/pix-editor/app/routes/authenticated/modules/workbench.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class ModulesRoute extends Route {
+export default class WorkbenchModulesRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -8,4 +8,9 @@
     flex-wrap: wrap;
     gap: var(--pix-spacing-1x);
   }
+
+  &__actions {
+    display: flex;
+    flex-direction: row-reverse;
+  }
 }

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,0 +1,12 @@
+import ModuleForm from 'pixeditor/components/modules/module-form';
+
+<template>
+  <header class="page-header">
+    <h1 class="page-title">Détail du module {{@model.module.internalTitle}}</h1>
+  </header>
+  <main class="page-body">
+    <section class="page-section module-form">
+      <ModuleForm @module={{@model.module}} @readonly={{true}} />
+    </section>
+  </main>
+</template>

--- a/pix-editor/app/templates/authenticated/modules/production.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production.gjs
@@ -13,7 +13,7 @@ import ModuleList from 'pixeditor/components/modules/modules-list';
   <main class="page-body">
     <section class="page-section modules-list">
       <ModulesTabs />
-      <ModuleList @modules={{@model.modules}} @showStatus={{true}} />
+      <ModuleList @modules={{@model.modules}} @showStatus={{true}} @goToDetailPage={{this.goToDetailPage}} />
       <PixPagination @pagination={{@model.modules.meta}} />
     </section>
   </main>

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -1,0 +1,36 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
+import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+module('Acceptance | Modules | Production Module', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  let id;
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    id = crypto.randomUUID();
+    this.server.create('module', { id, internalTitle: 'MON_BEAU_MODULE' });
+
+    return authenticateSession();
+  });
+
+  test('displays module details page on click', async function (assert) {
+    // when
+    await visit('/');
+    await clickByName('Modules');
+    await clickByName('En production');
+    await clickByName('Voir le détail');
+
+    // then
+    assert.strictEqual(currentURL(), `/modules/production/${id}`);
+
+    // WORKAROUND: let some time for monaco-editor to dismount
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+});

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -10,6 +10,11 @@ const isChrome = navigator?.userAgent?.includes(' Chrome/');
 module('Integration | Component | modules/module-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  hooks.afterEach(async function () {
+    // WORKAROUND: let some time for monaco-editor to dismount
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
   test.if('it parses and saves a module data', !isChrome, async function (assert) {
     // given
     const saveModule = sinon.stub();
@@ -38,9 +43,6 @@ module('Integration | Component | modules/module-form', function (hooks) {
       internalTitle: 'PALOURDE_MAGIQUE',
       slug: 'limaçoooooooooooooooooooon',
     });
-
-    // WORKAROUND: let some time for monaco-editor to dismount
-    await new Promise((resolve) => setTimeout(resolve, 100));
   });
 
   module('when a module is given in argument', function () {
@@ -67,9 +69,29 @@ module('Integration | Component | modules/module-form', function (hooks) {
       assert
         .dom(await screen.findByLabelText('Contenu (JSON)'))
         .hasValue(JSON.stringify(moduleWoInternalTitle, null, 2));
+    });
+  });
 
-      // WORKAROUND: let some time for monaco-editor to dismount
-      await new Promise((resolve) => setTimeout(resolve, 100));
+  module('when module-form is readonly', function () {
+    test('it should not display actions buttons', async function (assert) {
+      const moduleWoInternalTitle = {
+        id: 'dadfd2d4-0430-47ce-ae0f-455459f12d3b',
+        shortId: 'dadfd2d4',
+        slug: 'escargot-du loiret',
+        details: { level: 1001 },
+        sections: [],
+      };
+      const module = {
+        ...moduleWoInternalTitle,
+        internalTitle: 'MOL_escargot-loiret',
+      };
+
+      // when
+      const screen = await render(<template><ModuleForm @module={{module}} @readonly={{true}} /></template>);
+
+      // then
+      assert.dom(await screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
+      assert.dom(await screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -42,4 +42,33 @@ module('Integration | Component | modules/module-form', function (hooks) {
     // WORKAROUND: let some time for monaco-editor to dismount
     await new Promise((resolve) => setTimeout(resolve, 100));
   });
+
+  module('when a module is given in argument', function () {
+    test.if('it uses module’s data as default value', !isChrome, async function (assert) {
+      // given
+      const moduleWoInternalTitle = {
+        id: 'dadfd2d3-0430-47ce-ae0f-455459f12d3b',
+        shortId: 'dadfd2d3',
+        slug: 'escargot-de-bourgogne',
+        details: { level: 1000 },
+        sections: [],
+      };
+      const module = {
+        ...moduleWoInternalTitle,
+        internalTitle: 'MOL_escargot-bourgogne',
+      };
+
+      // when
+      const screen = await render(<template><ModuleForm @module={{module}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('textbox', { name: /^Titre interne/ })).hasValue(module.internalTitle);
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      assert
+        .dom(await screen.findByLabelText('Contenu (JSON)'))
+        .hasValue(JSON.stringify(moduleWoInternalTitle, null, 2));
+    });
+  });
 });

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -64,11 +64,12 @@ module('Integration | Component | modules/module-form', function (hooks) {
       // then
       assert.dom(screen.getByRole('textbox', { name: /^Titre interne/ })).hasValue(module.internalTitle);
 
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
       assert
         .dom(await screen.findByLabelText('Contenu (JSON)'))
         .hasValue(JSON.stringify(moduleWoInternalTitle, null, 2));
+
+      // WORKAROUND: let some time for monaco-editor to dismount
+      await new Promise((resolve) => setTimeout(resolve, 100));
     });
   });
 });

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import { getByText, queryByText } from '@testing-library/dom';
+import { getByRole, getByText, queryByRole, queryByText } from '@testing-library/dom';
 import { module, test } from 'qunit';
 import ModulesList from 'pixeditor/components/modules/modules-list';
 
@@ -8,73 +8,117 @@ import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 module('Integration | Component | modules-list', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  let moduleSummaries;
+  module('when listing production modules', function (hooks) {
+    let modules;
 
-  hooks.beforeEach(function () {
-    const store = this.owner.lookup('service:store');
-    moduleSummaries = [
-      store.createRecord('module', {
-        internalTitle: 'MOD_super_1',
-        isBeta: false,
-        visibility: 'public',
-        details: {
-          level: 'novice',
-        },
-      }),
-      store.createRecord('module', {
-        internalTitle: 'MOD_super_2',
-        isBeta: true,
-        visibility: 'private',
-        details: {
-          level: 'advanced',
-        },
-      }),
-    ];
-  });
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      modules = [
+        store.createRecord('module', {
+          internalTitle: 'MOD_super_1',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            level: 'novice',
+          },
+        }),
+        store.createRecord('module', {
+          internalTitle: 'MOD_super_2',
+          isBeta: true,
+          visibility: 'private',
+          details: {
+            level: 'advanced',
+          },
+        }),
+      ];
+    });
 
-  module('when @showStatus is true', () => {
-    test('it renders with status column', async function (assert) {
-      const screen = await render(
-        <template><ModulesList @modules={{moduleSummaries}} @showStatus={{true}} /></template>,
-      );
+    module('when @showStatus is true', () => {
+      test('it renders with status column', async function (assert) {
+        const screen = await render(<template><ModulesList @modules={{modules}} @showStatus={{true}} /></template>);
 
-      assert.dom(screen.getByRole('columnheader', { name: 'Statut' })).exists();
-      assert.dom(screen.getByRole('columnheader', { name: 'Titre interne' })).exists();
-      assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
+        assert.dom(screen.getByRole('columnheader', { name: 'Statut' })).exists();
+        assert.dom(screen.getByRole('columnheader', { name: 'Titre interne' })).exists();
+        assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
 
-      assert.dom(screen.getByText('MOD_super_1')).exists();
-      assert.dom(screen.getByText('MOD_super_2')).exists();
+        assert.dom(screen.getByText('MOD_super_1')).exists();
+        assert.dom(screen.getByText('MOD_super_2')).exists();
 
-      const firstRow = screen.getByText('MOD_super_1').closest('tr');
-      assert.dom(getByText(firstRow, 'Public')).exists();
-      assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
-      assert.dom(getByText(firstRow, 'Novice')).exists();
+        const firstRow = screen.getByText('MOD_super_1').closest('tr');
+        assert.dom(getByText(firstRow, 'Public')).exists();
+        assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
+        assert.dom(getByText(firstRow, 'Novice')).exists();
+        assert.dom(getByRole(firstRow, 'button', { name: 'Voir le détail' })).exists();
 
-      const secondRow = screen.getByText('MOD_super_2').closest('tr');
-      assert.dom(getByText(secondRow, 'Privé')).exists();
-      assert.dom(getByText(secondRow, 'Beta')).exists();
-      assert.dom(getByText(secondRow, 'Avancé')).exists();
+        const secondRow = screen.getByText('MOD_super_2').closest('tr');
+        assert.dom(getByText(secondRow, 'Privé')).exists();
+        assert.dom(getByText(secondRow, 'Beta')).exists();
+        assert.dom(getByText(secondRow, 'Avancé')).exists();
+        assert.dom(getByRole(secondRow, 'button', { name: 'Voir le détail' })).exists();
+      });
+    });
+
+    module('when @showStatus is false', () => {
+      test('it renders without status column', async function (assert) {
+        const screen = await render(<template><ModulesList @modules={{modules}} @showStatus={{false}} /></template>);
+
+        assert.dom(screen.queryByRole('columnheader', { name: 'Statut' })).doesNotExist();
+        assert.dom(screen.getByRole('columnheader', { name: 'Titre interne' })).exists();
+        assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
+
+        assert.dom(screen.getByText('MOD_super_1')).exists();
+        assert.dom(screen.getByText('MOD_super_2')).exists();
+
+        const firstRow = screen.getByText('MOD_super_1').closest('tr');
+        assert.dom(getByText(firstRow, 'Novice')).exists();
+
+        const secondRow = screen.getByText('MOD_super_2').closest('tr');
+        assert.dom(getByText(secondRow, 'Avancé')).exists();
+      });
     });
   });
 
-  module('when @showStatus is false', () => {
-    test('it renders without status column', async function (assert) {
-      const screen = await render(
-        <template><ModulesList @modules={{moduleSummaries}} @showStatus={{false}} /></template>,
-      );
+  module('when listing draft modules', function (hooks) {
+    let draftModules;
 
-      assert.dom(screen.queryByRole('columnheader', { name: 'Statut' })).doesNotExist();
-      assert.dom(screen.getByRole('columnheader', { name: 'Titre interne' })).exists();
-      assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      draftModules = [
+        store.createRecord('draft-module', {
+          internalTitle: 'MOD_super_1',
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            level: 'novice',
+          },
+        }),
+        store.createRecord('draft-module', {
+          internalTitle: 'MOD_super_2',
+          isBeta: true,
+          visibility: 'private',
+          details: {
+            level: 'advanced',
+          },
+        }),
+      ];
+    });
 
+    test('these don’t have a show detail button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+
+      // when
+      const screen = await render(<template><ModulesList @modules={{draftModules}} /></template>);
+
+      // then
       assert.dom(screen.getByText('MOD_super_1')).exists();
       assert.dom(screen.getByText('MOD_super_2')).exists();
 
       const firstRow = screen.getByText('MOD_super_1').closest('tr');
-      assert.dom(getByText(firstRow, 'Novice')).exists();
+      assert.dom(queryByRole(firstRow, 'button', { name: 'Voir le détail' })).doesNotExist();
 
       const secondRow = screen.getByText('MOD_super_2').closest('tr');
-      assert.dom(getByText(secondRow, 'Avancé')).exists();
+      assert.dom(queryByRole(secondRow, 'button', { name: 'Voir le détail' })).doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -434,6 +434,8 @@ export default function routes() {
     return json;
   });
 
+  this.get('modules/:id');
+
   this.get('/static-course-summaries', function (schema, request) {
     const queryParams = request.queryParams;
     const { 'filter[isActive]': isActiveFilter, 'filter[name]': nameFilter, 'filter[tagIds]': tagFilter } = queryParams;


### PR DESCRIPTION
## 💥 Problème

On souhaite afficher le détail d’un module en production.

## 👩‍🚀 Proposition

Ajout de la page de détails d’un module en production, accessible depuis la liste des modules en production via un bouton "Voir le détail".

## 👁️ Remarques

N/A

## ♻️ Pour tester

Aller sur la liste des modules en prod et cliquer sur le bouton.
Faire précédent et aller voir un autre...