### PR TITLE
[FEATURE] Page de détail d’un draft de module (PIX-22924)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -1,8 +1,9 @@
 import Joi from 'joi';
 
 import { draftModuleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
-import { createDraftModule, listPaginatedDraftModules } from '../../domain/usecases/index.js';
+import { createDraftModule, getDraftModuleById, listPaginatedDraftModules } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
+import * as Types from '../types.js';
 
 export function register(server) {
   server.route([
@@ -21,6 +22,18 @@ export function register(server) {
           const { page, sort } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [['visibility', 'desc'], ['internalTitle', 'asc']] });
           const { draftModules, meta } = await listPaginatedDraftModules({ page, sort });
           return draftModuleSerializer.serialize(draftModules, { attributes: ['internalTitle', 'details'], meta });
+        },
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/draft-modules/{id}',
+      config: {
+        validate: { params: Joi.object({ id: Types.moduleId().required() }) },
+        handler: async (request) => {
+          const { id } = request.params;
+          const draftModule = await getDraftModuleById(id);
+          return draftModuleSerializer.serialize(draftModule);
         },
       },
     },

--- a/api/lib/domain/usecases/get-draft-module-by-id.js
+++ b/api/lib/domain/usecases/get-draft-module-by-id.js
@@ -1,0 +1,5 @@
+import { draftModuleRepository } from '../../infrastructure/repositories/index.js';
+
+export async function getDraftModuleById(id, dependencies = { draftModuleRepository }) {
+  return dependencies.draftModuleRepository.getById({ id });
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -19,6 +19,7 @@ export * from './export-translations.js';
 export * from './find-all-missions.js';
 export * from './get-competence-challenges-production-overview.js';
 export * from './get-competence-challenges-workbench-overview.js';
+export * from './get-draft-module-by-id.js';
 export * from './get-module-by-id.js';
 export * from './get-phrase-translations-url.js';
 export * from './get-skill-challenges-production.js';

--- a/api/lib/infrastructure/repositories/draft-module-repository.js
+++ b/api/lib/infrastructure/repositories/draft-module-repository.js
@@ -1,5 +1,6 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { DraftModule } from '../../domain/models/index.js';
+import { NotFoundError } from '../errors.js';
 
 export async function save({ details, sections, glossary, ...module }, transaction = knex) {
   const draftModuleDTO = {
@@ -34,6 +35,16 @@ export async function list({ page, sort = [['internalTitle', 'asc']] } = {}) {
 export async function count() {
   const { count } = await knex('draft-modules').count().first();
   return count;
+}
+
+export async function getById({ id }) {
+  const draftModule = await knex('draft-modules').where({ id }).first();
+
+  if (!draftModule) {
+    throw new NotFoundError('Draft module not found');
+  }
+
+  return toDomain(draftModule);
 }
 
 function toDomain({ image, description, duration, level, objectives, tabletSupport, ...draftModule }) {

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -168,4 +168,65 @@ describe('Acceptance | Route | draft-modules', () => {
       });
     });
   });
+
+  describe('GET /draft-modules/:id', () => {
+    let draftModule;
+
+    beforeEach(async () => {
+      draftModule = domainBuilder.buildDraftModule();
+      databaseBuilder.factory.buildDraftModule(draftModule);
+      await databaseBuilder.commit();
+    });
+
+    it('responds with status 200 and draft module’s data', async () => {
+      // given
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/draft-modules/${draftModule.id}`,
+        headers: generateAuthorizationHeader(editorUser),
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+
+      expect(response.result).toStrictEqual({
+        data: {
+          type: 'draft-modules',
+          id: draftModule.id,
+          attributes: {
+            'short-id': draftModule.shortId,
+            'internal-title': draftModule.internalTitle,
+            'is-beta': draftModule.isBeta,
+            visibility: draftModule.visibility,
+            details: draftModule.details,
+            slug: draftModule.slug,
+            title: draftModule.title,
+            sections: draftModule.sections,
+            glossary: draftModule.glossary,
+          },
+        },
+      });
+    });
+
+    describe('when module does not exist', () => {
+      it('responds with status 404', async () => {
+        // given
+        const server = await createServer();
+        const notFoundId = crypto.randomUUID();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/modules/${notFoundId}`,
+          headers: generateAuthorizationHeader(editorUser),
+        });
+
+        // then
+        expect(response.statusCode).toBe(404);
+      });
+    });
+  });
 });

--- a/api/tests/acceptance/application/modules/modules_test.js
+++ b/api/tests/acceptance/application/modules/modules_test.js
@@ -112,7 +112,7 @@ describe('Acceptance | Route | modules', () => {
       await databaseBuilder.commit();
     });
 
-    it('responds with status 200 and modules data', async () => {
+    it('responds with status 200 and module’s data', async () => {
       // given
       const server = await createServer();
 

--- a/api/tests/integration/infrastructure/repositories/draft-module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/draft-module-repository_test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
-import { save, list, count } from '../../../../lib/infrastructure/repositories/draft-module-repository.js';
+import { catchErr, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import { save, list, count, getById } from '../../../../lib/infrastructure/repositories/draft-module-repository.js';
+import { NotFoundError } from '../../../../lib/infrastructure/errors.js';
 
 describe('Draft Module Repository', () => {
   describe('save', () => {
@@ -114,6 +115,35 @@ describe('Draft Module Repository', () => {
 
       // then
       expect(result).toBe(2);
+    });
+  });
+
+  describe('getById', () => {
+    it('returns a draft module by its id', async () => {
+      // given
+      const module = domainBuilder.buildModule();
+      databaseBuilder.factory.buildModule(module);
+      const expectedDraftModule = domainBuilder.buildDraftModule({ id: module.id, shortId: module.shortId, moduleId: module.id });
+      databaseBuilder.factory.buildDraftModule(expectedDraftModule);
+      databaseBuilder.factory.buildDraftModule(domainBuilder.buildDraftModule({ shortId: 'secondar', internalTitle: 'secondar' }));
+      await databaseBuilder.commit();
+
+      // when
+      const draftModule = await getById({ id: expectedDraftModule.id });
+
+      // then
+      expect(draftModule).toStrictEqual(expectedDraftModule);
+    });
+
+    it('throw a not Found error if draft module is not found', async () => {
+      // given
+      const inexistingDraftModuleId = crypto.randomUUID();
+
+      // when
+      const error = await catchErr(getById)({ id: inexistingDraftModuleId });
+
+      // then
+      expect(error).toBeInstanceOf(NotFoundError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-draft-module-by-id_test.js
+++ b/api/tests/unit/domain/usecases/get-draft-module-by-id_test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getDraftModuleById } from '../../../../lib/domain/usecases/get-draft-module-by-id.js';
+
+describe('Unit | Domain | Use Cases | getDraftModuleById', () => {
+  it('returns draft module retrieved from repository', async () => {
+    // given
+    const id = Symbol('id');
+    const draftModule = Symbol('draftModule');
+    const draftModuleRepository = { getById: vi.fn().mockResolvedValueOnce(draftModule) };
+
+    // when
+    const result = await getDraftModuleById(id, { draftModuleRepository });
+
+    // then
+    expect(result).toBe(draftModule);
+    expect(draftModuleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id });
+  });
+});

--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import PixTable from '@1024pix/pix-ui/components/pix-table';
 import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
-import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 
 function getVisibilityColor(visibility) {
   return { public: 'green', private: 'grey' }[visibility];
@@ -55,20 +55,25 @@ export default class Product extends Component {
             {{module.levelForDisplay}}
           </:cell>
         </PixTableColumn>
-        {{#if module.mayShowProductionDetails}}
-          <PixTableColumn @context={{context}}>
-            <:header>
-              Actions
-            </:header>
-            <:cell>
-              <div class="modules-list__actions">
-                <PixButton @triggerAction={{fn this.goToDetailPage module.id}}>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            Actions
+          </:header>
+          <:cell>
+            <div class="modules-list__actions">
+              {{#if module.mayShowProductionDetails}}
+                <PixButtonLink @route="authenticated.modules.production-module" @model={{module.id}}>
                   Voir le détail
-                </PixButton>
-              </div>
-            </:cell>
-          </PixTableColumn>
-        {{/if}}
+                </PixButtonLink>
+              {{/if}}
+              {{#if module.mayShowDraftDetails}}
+                <PixButtonLink @route="authenticated.modules.draft-module" @model={{module.id}}>
+                  Voir le détail
+                </PixButtonLink>
+              {{/if}}
+            </div>
+          </:cell>
+        </PixTableColumn>
       </:columns>
     </PixTable>
   </template>

--- a/pix-editor/app/components/modules/modules-tabs.gjs
+++ b/pix-editor/app/components/modules/modules-tabs.gjs
@@ -2,7 +2,7 @@ import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
 
 <template>
-  <PixTabs>
+  <PixTabs @ariaLabel="Navigation">
     <LinkTo @route="authenticated.modules.workbench">
       Atelier
     </LinkTo>

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -5,4 +5,8 @@ export default class DraftModule extends Module {
     // FIXME must return true if draft belongs to an existing module
     return false;
   }
+
+  get mayShowDraftDetails() {
+    return true;
+  }
 }

--- a/pix-editor/app/models/module.js
+++ b/pix-editor/app/models/module.js
@@ -33,4 +33,9 @@ export default class Module extends Model {
   get mayShowProductionDetails() {
     return true;
   }
+
+  get mayShowDraftDetails() {
+    // FIXME must return true if module has an existing draft
+    return false;
+  }
 }

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -89,6 +89,7 @@ Router.map(function () {
       this.route('production');
       this.route('workbench');
       this.route('production-module', { path: '/production/:module_id' });
+      this.route('draft-module', { path: '/workbench/:draft_module_id' });
     });
     this.route('missions', function () {
       this.route('list', { path: '/' });

--- a/pix-editor/app/routes/authenticated/modules/draft-module.js
+++ b/pix-editor/app/routes/authenticated/modules/draft-module.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class DraftModuleRoute extends Route {
+  @service store;
+
+  async model(params) {
+    const draftModule = await this.store.findRecord('draft-module', params.draft_module_id);
+    return { draftModule };
+  }
+}

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -12,9 +12,5 @@
   &__actions {
     display: flex;
     flex-direction: row-reverse;
-
-    a:hover {
-      color: var(--pix-neutral-0);
-    }
   }
 }

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -12,5 +12,9 @@
   &__actions {
     display: flex;
     flex-direction: row-reverse;
+
+    a:hover {
+      color: var(--pix-neutral-0);
+    }
   }
 }

--- a/pix-editor/app/styles/globals/global.scss
+++ b/pix-editor/app/styles/globals/global.scss
@@ -10,22 +10,28 @@
 
 .form-error {
   width: 100%;
+  margin-bottom: 16px;
   color: colors.$pix-error-70;
   font-weight: bold;
-  margin-bottom: 16px;
 }
 
 .pix-button-link-with-icon {
   &:hover{
     color: colors.$pix-neutral-90;
   }
+
   > svg {
     margin-right: 8px;
   }
 }
 
+a.pix-button--primary {
+  color: var(--pix-neutral-0);
+}
+
 .disabled-link-with-icon {
   pointer-events: none;
+
   > svg {
     color: colors.$pix-neutral-30;
   }

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,0 +1,12 @@
+import ModuleForm from 'pixeditor/components/modules/module-form';
+
+<template>
+  <header class="page-header">
+    <h1 class="page-title">Détail du draft de module {{@model.draftModule.internalTitle}}</h1>
+  </header>
+  <main class="page-body">
+    <section class="page-section module-form">
+      <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
+    </section>
+  </main>
+</template>

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,12 +1,16 @@
 import ModuleForm from 'pixeditor/components/modules/module-form';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 
 <template>
   <header class="page-header">
-    <h1 class="page-title">Détail du draft de module {{@model.draftModule.internalTitle}}</h1>
+    <h1 class="page-title">Détail du draft de module</h1>
   </header>
   <main class="page-body">
     <section class="page-section module-form">
       <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
+      <div class="page-actions">
+        <PixButtonLink @route="authenticated.modules.workbench">Retour</PixButtonLink>
+      </div>
     </section>
   </main>
 </template>

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,12 +1,17 @@
 import ModuleForm from 'pixeditor/components/modules/module-form';
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 
 <template>
   <header class="page-header">
-    <h1 class="page-title">Détail du module {{@model.module.internalTitle}}</h1>
+    <h1 class="page-title">Détail du module</h1>
+
   </header>
   <main class="page-body">
     <section class="page-section module-form">
       <ModuleForm @module={{@model.module}} @readonly={{true}} />
+      <div class="page-actions">
+        <PixButtonLink @route="authenticated.modules.production">Retour</PixButtonLink>
+      </div>
     </section>
   </main>
 </template>

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -30,6 +30,10 @@ module('Acceptance | Modules | Production Module', function (hooks) {
     // then
     assert.strictEqual(currentURL(), `/modules/production/${id}`);
 
+    await clickByName('Retour');
+
+    assert.strictEqual(currentURL(), `/modules/production`);
+
     // WORKAROUND: let some time for monaco-editor to dismount
     await new Promise((resolve) => setTimeout(resolve, 100));
   });

--- a/pix-editor/tests/acceptance/modules/workbench-module-test.js
+++ b/pix-editor/tests/acceptance/modules/workbench-module-test.js
@@ -1,0 +1,35 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
+import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { module, test } from 'qunit';
+
+module('Acceptance | Modules | Workbench Module', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  let id;
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    id = crypto.randomUUID();
+    this.server.create('draft-module', { id, internalTitle: 'MON_BEAU_MODULE' });
+
+    return authenticateSession();
+  });
+
+  test('displays module details page on click', async function (assert) {
+    // when
+    await visit('/');
+    await clickByName('Modules');
+    await clickByName('Voir le détail');
+
+    // then
+    assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
+
+    // WORKAROUND: let some time for monaco-editor to dismount
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+});

--- a/pix-editor/tests/acceptance/modules/workbench-module-test.js
+++ b/pix-editor/tests/acceptance/modules/workbench-module-test.js
@@ -22,12 +22,17 @@ module('Acceptance | Modules | Workbench Module', function (hooks) {
 
   test('displays module details page on click', async function (assert) {
     // when
-    await visit('/');
+    const screen = await visit('/');
     await clickByName('Modules');
     await clickByName('Voir le détail');
 
     // then
     assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
+    assert.dom(screen.getByRole('heading', { name: 'Détail du draft de module' })).exists();
+
+    await clickByName('Retour');
+
+    assert.strictEqual(currentURL(), `/modules/workbench`);
 
     // WORKAROUND: let some time for monaco-editor to dismount
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
 import { getByRole, getByText, queryByRole, queryByText } from '@testing-library/dom';
 import { module, test } from 'qunit';
@@ -48,13 +49,13 @@ module('Integration | Component | modules-list', function (hooks) {
         assert.dom(getByText(firstRow, 'Public')).exists();
         assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
         assert.dom(getByText(firstRow, 'Novice')).exists();
-        assert.dom(getByRole(firstRow, 'button', { name: 'Voir le détail' })).exists();
+        assert.dom(getByText(firstRow, 'Voir le détail')).exists();
 
         const secondRow = screen.getByText('MOD_super_2').closest('tr');
         assert.dom(getByText(secondRow, 'Privé')).exists();
         assert.dom(getByText(secondRow, 'Beta')).exists();
         assert.dom(getByText(secondRow, 'Avancé')).exists();
-        assert.dom(getByRole(secondRow, 'button', { name: 'Voir le détail' })).exists();
+        assert.dom(getByText(secondRow, 'Voir le détail')).exists();
       });
     });
 
@@ -115,10 +116,10 @@ module('Integration | Component | modules-list', function (hooks) {
       assert.dom(screen.getByText('MOD_super_2')).exists();
 
       const firstRow = screen.getByText('MOD_super_1').closest('tr');
-      assert.dom(queryByRole(firstRow, 'button', { name: 'Voir le détail' })).doesNotExist();
+      assert.dom(getByText(firstRow, 'Voir le détail')).exists();
 
       const secondRow = screen.getByText('MOD_super_2').closest('tr');
-      assert.dom(queryByRole(secondRow, 'button', { name: 'Voir le détail' })).doesNotExist();
+      assert.dom(getByText(secondRow, 'Voir le détail')).exists();
     });
   });
 });

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -411,6 +411,8 @@ export default function routes() {
     return json;
   });
 
+  this.get('/draft-modules/:id');
+
   this.get('/modules', function (schema, request) {
     const pagination = _getPaginationFromQueryParams(request.queryParams);
 


### PR DESCRIPTION
## 🚙 Problème

On souhaite consulter le détail d’un draft de module.

## 🍃 Proposition

Créer la page de détail d’un draft de module, accessible depuis l’onglet workbench des modules via le bouton "Voir le détail".
Ajouter un bouton "Retour" sur les pages de détails d’un module de prod et d’un draft de module.

## 🦵 Remarques

N/A

## 🔗 Pour tester

Aller sur la page des modules et consulter le détail d’un draft, puis tester le bouton "Retour".
Créer un draft et consuler son détail.
