### PR TITLE
[FEATURE] Bouton "Voir le détail du module en PROD" (PIX-23003)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -21,7 +21,13 @@ export function register(server) {
         handler: async (request) => {
           const { page, sort } = extractParameters(request.query, { page: { size: 10, number: 1 }, sort: [['visibility', 'desc'], ['internalTitle', 'asc']] });
           const { draftModules, meta } = await listPaginatedDraftModules({ page, sort });
-          return draftModuleSerializer.serialize(draftModules, { attributes: ['internalTitle', 'details'], meta });
+          return draftModuleSerializer.serialize(draftModules, {
+            attributes: [
+              'internalTitle',
+              'details',
+              'module',
+            ], meta,
+          });
         },
       },
     },

--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
@@ -25,12 +25,23 @@ const defaultAttributes = [
   'details',
   'sections',
   'glossary',
+  'module',
 ];
 
-export function serialize(modules, { meta, attributes = defaultAttributes } = {}) {
+export function serialize(draftModules, { meta, attributes = defaultAttributes } = {}) {
   const serializer = new Serializer('draft-module', {
     attributes,
     meta,
+    transform({ moduleId, ...draftModule }) {
+      return {
+        ...draftModule,
+        module: moduleId ? { id: moduleId } : null,
+      };
+    },
+    module: {
+      ref: 'id',
+      included: false,
+    },
   });
-  return serializer.serialize(modules);
+  return serializer.serialize(draftModules);
 }

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -54,6 +54,7 @@ describe('Acceptance | Route | draft-modules', () => {
             'short-id': expect.stringMatching(shortIdRegExp),
             ...draftModulePayload,
           },
+          relationships: { module: { data: null } },
         },
       });
 
@@ -81,9 +82,10 @@ describe('Acceptance | Route | draft-modules', () => {
     let draftModules;
 
     beforeEach(async () => {
+      const { id: moduleId } = databaseBuilder.factory.buildModule(domainBuilder.buildModule());
       draftModules = [
         { id: '79cc8f8d-d948-4ce5-bd35-1250b61d6011', shortId: 'abcd1234', internalTitle: 'MOD_a', slug: 'a', details: { level: Module.LEVELS.NOVICE }, visibility: Module.VISIBILITIES.PRIVATE },
-        { id: '6e7f16ae-4d96-4a71-b646-d6c86029e05e', shortId: 'abcd5678', internalTitle: 'MOD_b', slug: 'b', details: { level: Module.LEVELS.INDEPENDENT }, visibility: Module.VISIBILITIES.PUBLIC },
+        { id: moduleId, moduleId, shortId: 'abcd5678', internalTitle: 'MOD_b', slug: 'b', details: { level: Module.LEVELS.INDEPENDENT }, visibility: Module.VISIBILITIES.PUBLIC },
         { id: 'f995ce82-1373-4758-b839-7a844893ef07', shortId: 'abcd9012', internalTitle: 'MOD_c', slug: 'c', details: { level: Module.LEVELS.EXPERT }, visibility: Module.VISIBILITIES.PRIVATE },
       ].map(domainBuilder.buildDraftModule);
 
@@ -114,16 +116,26 @@ describe('Acceptance | Route | draft-modules', () => {
             type: 'draft-modules',
             id: draftModules[1].id,
             attributes: { 'internal-title': draftModules[1].internalTitle, details: draftModules[1].details },
+            relationships: {
+              module: {
+                data: {
+                  id: draftModules[1].moduleId,
+                  type: 'modules',
+                },
+              },
+            },
           },
           {
             type: 'draft-modules',
             id: draftModules[0].id,
             attributes: { 'internal-title': draftModules[0].internalTitle, details: draftModules[0].details },
+            relationships: { module: { data: null } },
           },
           {
             type: 'draft-modules',
             id: draftModules[2].id,
             attributes: { 'internal-title': draftModules[2].internalTitle, details: draftModules[2].details },
+            relationships: { module: { data: null } },
           },
         ],
         meta: {
@@ -156,6 +168,7 @@ describe('Acceptance | Route | draft-modules', () => {
               type: 'draft-modules',
               id: draftModules[0].id,
               attributes: { 'internal-title': draftModules[0].internalTitle, details: draftModules[0].details },
+              relationships: { module: { data: null } },
             },
           ],
           meta: {
@@ -173,7 +186,8 @@ describe('Acceptance | Route | draft-modules', () => {
     let draftModule;
 
     beforeEach(async () => {
-      draftModule = domainBuilder.buildDraftModule();
+      const { id: moduleId } = databaseBuilder.factory.buildModule(domainBuilder.buildModule());
+      draftModule = domainBuilder.buildDraftModule({ id: moduleId, moduleId });
       databaseBuilder.factory.buildDraftModule(draftModule);
       await databaseBuilder.commit();
     });
@@ -206,6 +220,14 @@ describe('Acceptance | Route | draft-modules', () => {
             title: draftModule.title,
             sections: draftModule.sections,
             glossary: draftModule.glossary,
+          },
+          relationships: {
+            module: {
+              data: {
+                id: draftModule.moduleId,
+                type: 'modules',
+              },
+            },
           },
         },
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/draft-module-serializer.js';
+import { domainBuilder } from '../../../../test-helper.js';
+import { Module } from '../../../../../lib/domain/models/Module.js';
+
+describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
+  describe('#serialize', () => {
+    it('serializes a DraftModule model to a module payload', () => {
+      // given
+      const id = crypto.randomUUID();
+      const draftModule = domainBuilder.buildDraftModule({ id, moduleId: id });
+      const expectedPayload = {
+        data: {
+          type: 'draft-modules',
+          id: draftModule.id,
+          attributes: {
+            'internal-title': draftModule.internalTitle,
+            'short-id': draftModule.shortId,
+            slug: draftModule.slug,
+            title: draftModule.title,
+            'is-beta': draftModule.isBeta,
+            visibility: draftModule.visibility,
+            details: draftModule.details,
+            sections: draftModule.sections,
+            glossary: draftModule.glossary,
+          },
+          relationships: {
+            module: {
+              data: {
+                type: 'modules',
+                id: draftModule.moduleId,
+              },
+            },
+          },
+        },
+      };
+
+      // when
+      const serializedPayload = serialize(draftModule);
+
+      // then
+      expect(serializedPayload).toStrictEqual(expectedPayload);
+    });
+
+    it('serializes a paginated draft modules excerpt list to a payload', () => {
+      // given
+      const draftModules = [domainBuilder.buildDraftModule({ id: 'module1', moduleId: 'module1', internalTitle: 'MOD_1', details: { level: Module.LEVELS.EXPERT }, visibility: Module.VISIBILITIES.PRIVATE, isBeta: true }), domainBuilder.buildDraftModule({ id: 'module2', internalTitle: 'MOD_2', details: { level: Module.LEVELS.INDEPENDENT }, visibility: Module.VISIBILITIES.PUBLIC, isBeta: false })];
+      const meta = {
+        page: 33,
+        pageSize: 2,
+        rowCount: 666,
+        pageCount: 333,
+      };
+      const attributes = [
+        'internalTitle',
+        'details',
+        'visibility',
+        'isBeta',
+        'module',
+      ];
+
+      // when
+      const serializedPayload = serialize(draftModules, { attributes, meta });
+
+      // then
+      expect(serializedPayload).toStrictEqual({
+        data: [
+          {
+            type: 'draft-modules',
+            id: draftModules[0].id,
+            attributes: { 'internal-title': draftModules[0].internalTitle, 'is-beta': draftModules[0].isBeta, visibility: draftModules[0].visibility, details: draftModules[0].details },
+            relationships: {
+              module: {
+                data: {
+                  id: 'module1',
+                  type: 'modules',
+                },
+              },
+            },
+          },
+          {
+            type: 'draft-modules',
+            id: draftModules[1].id,
+            attributes: { 'internal-title': draftModules[1].internalTitle, 'is-beta': draftModules[1].isBeta, visibility: draftModules[1].visibility, details: draftModules[1].details },
+            relationships: { module: { data: null } },
+          },
+        ],
+        meta: {
+          page: 33,
+          pageSize: 2,
+          rowCount: 666,
+          pageCount: 333,
+        },
+      });
+    });
+  });
+});

--- a/pix-editor/app/components/modules/module-back-button.gjs
+++ b/pix-editor/app/components/modules/module-back-button.gjs
@@ -1,0 +1,5 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+
+<template>
+  <PixButtonLink @route={{@fromRoute}}>Retour</PixButtonLink>
+</template>

--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -55,23 +55,30 @@ export default class Product extends Component {
             {{module.levelForDisplay}}
           </:cell>
         </PixTableColumn>
-        <PixTableColumn @context={{context}}>
+        <PixTableColumn @context={{context}} class="modules-list__actions">
           <:header>
             Actions
           </:header>
           <:cell>
-            <div class="modules-list__actions">
-              {{#if module.mayShowProductionDetails}}
-                <PixButtonLink @route="authenticated.modules.production-module" @model={{module.id}}>
-                  Voir le détail
-                </PixButtonLink>
-              {{/if}}
-              {{#if module.mayShowDraftDetails}}
-                <PixButtonLink @route="authenticated.modules.draft-module" @model={{module.id}}>
-                  Voir le détail
-                </PixButtonLink>
-              {{/if}}
-            </div>
+            <PixButtonLink
+              @route={{if
+                module.isDraft
+                "authenticated.modules.draft-module"
+                "authenticated.modules.production-module"
+              }}
+              @model={{module.id}}
+            >
+              Voir le détail
+            </PixButtonLink>
+            {{#if module.isEditionDraft}}
+              <PixButtonLink
+                @route="authenticated.modules.production-module"
+                @model={{module.moduleId}}
+                @variant="secondary"
+              >
+                Voir le détail du module en prod
+              </PixButtonLink>
+            {{/if}}
           </:cell>
         </PixTableColumn>
       </:columns>

--- a/pix-editor/app/models/base-module.js
+++ b/pix-editor/app/models/base-module.js
@@ -1,0 +1,40 @@
+import Model, { attr } from '@ember-data/model';
+
+const visibilityForDisplay = {
+  public: 'Public',
+  private: 'Privé',
+};
+
+const levelForDisplay = {
+  novice: 'Novice',
+  independent: 'Indépendant',
+  advanced: 'Avancé',
+  expert: 'Expert',
+};
+
+export default class BaseModule extends Model {
+  @attr internalTitle;
+  @attr title;
+  @attr isBeta;
+  @attr slug;
+  @attr visibility;
+  @attr details;
+  @attr sections;
+  @attr glossary;
+
+  get visibilityForDisplay() {
+    return visibilityForDisplay[this.visibility] ?? this.visibility;
+  }
+
+  get levelForDisplay() {
+    return levelForDisplay[this.details.level] ?? this.details.level;
+  }
+
+  get isDraft() {
+    throw new TypeError('isDraft must be overriden');
+  }
+
+  get isEditionDraft() {
+    throw new TypeError('isEditionDraft must be overriden');
+  }
+}

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -1,12 +1,23 @@
-import Module from './module';
+import { belongsTo } from '@ember-data/model';
 
-export default class DraftModule extends Module {
-  get mayShowProductionDetails() {
-    // FIXME must return true if draft belongs to an existing module
-    return false;
+import BaseModule from './base-module';
+
+export default class DraftModule extends BaseModule {
+  @belongsTo('module', { inverse: null, async: true }) module;
+
+  get isDraft() {
+    return true;
   }
 
-  get mayShowDraftDetails() {
-    return true;
+  get moduleId() {
+    return this.belongsTo('module').id();
+  }
+
+  get belongsToModule() {
+    return !!this.moduleId;
+  }
+
+  get isEditionDraft() {
+    return this.belongsToModule;
   }
 }

--- a/pix-editor/app/models/module.js
+++ b/pix-editor/app/models/module.js
@@ -1,41 +1,11 @@
-import Model, { attr } from '@ember-data/model';
+import BaseModule from './base-module';
 
-const visibilityForDisplay = {
-  public: 'Public',
-  private: 'Privé',
-};
-
-const levelForDisplay = {
-  novice: 'Novice',
-  independent: 'Indépendant',
-  advanced: 'Avancé',
-  expert: 'Expert',
-};
-
-export default class Module extends Model {
-  @attr internalTitle;
-  @attr title;
-  @attr isBeta;
-  @attr slug;
-  @attr visibility;
-  @attr details;
-  @attr sections;
-  @attr glossary;
-
-  get visibilityForDisplay() {
-    return visibilityForDisplay[this.visibility] ?? this.visibility;
+export default class Module extends BaseModule {
+  get isDraft() {
+    return false;
   }
 
-  get levelForDisplay() {
-    return levelForDisplay[this.details.level] ?? this.details.level;
-  }
-
-  get mayShowProductionDetails() {
-    return true;
-  }
-
-  get mayShowDraftDetails() {
-    // FIXME must return true if module has an existing draft
+  get isEditionDraft() {
     return false;
   }
 }

--- a/pix-editor/app/routes/authenticated/modules/draft-module.js
+++ b/pix-editor/app/routes/authenticated/modules/draft-module.js
@@ -4,8 +4,9 @@ import { service } from '@ember/service';
 export default class DraftModuleRoute extends Route {
   @service store;
 
-  async model(params) {
+  async model(params, { from }) {
     const draftModule = await this.store.findRecord('draft-module', params.draft_module_id, { reload: true });
-    return { draftModule };
+    const fromRoute = from?.name ?? 'authenticated.modules.workbench';
+    return { draftModule, fromRoute };
   }
 }

--- a/pix-editor/app/routes/authenticated/modules/production-module.js
+++ b/pix-editor/app/routes/authenticated/modules/production-module.js
@@ -4,8 +4,9 @@ import { service } from '@ember/service';
 export default class ProductionModuleRoute extends Route {
   @service store;
 
-  async model(params) {
+  async model(params, { from }) {
     const module = await this.store.findRecord('module', params.module_id, { reload: true });
-    return { module };
+    const fromRoute = from?.name ?? 'authenticated.modules.production';
+    return { module, fromRoute };
   }
 }

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -8,9 +8,15 @@
     flex-wrap: wrap;
     gap: var(--pix-spacing-1x);
   }
+}
 
-  &__actions {
-    display: flex;
-    flex-direction: row-reverse;
-  }
+th.modules-list__actions {
+  display: flex;
+  justify-content: center;
+}
+
+td.modules-list__actions {
+  display: flex;
+  flex-direction: row-reverse;
+  gap: var(--pix-spacing-2x);
 }

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,5 +1,5 @@
 import ModuleForm from 'pixeditor/components/modules/module-form';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 
 <template>
   <header class="page-header">
@@ -9,7 +9,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
     <section class="page-section module-form">
       <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
       <div class="page-actions">
-        <PixButtonLink @route="authenticated.modules.workbench">Retour</PixButtonLink>
+        <ModuleBackButton @fromRoute={{@model.fromRoute}} />
       </div>
     </section>
   </main>

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,5 +1,5 @@
+import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 
 <template>
   <header class="page-header">
@@ -10,7 +10,7 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
     <section class="page-section module-form">
       <ModuleForm @module={{@model.module}} @readonly={{true}} />
       <div class="page-actions">
-        <PixButtonLink @route="authenticated.modules.production">Retour</PixButtonLink>
+        <ModuleBackButton @fromRoute={{@model.fromRoute}} />
       </div>
     </section>
   </main>

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -45,5 +45,9 @@ module('Acceptance | Modules | Production Module', function (hooks) {
 
     // WORKAROUND: let some time for monaco-editor to settle
     await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await clickByName('Retour');
+
+    assert.strictEqual(currentURL(), `/modules/workbench`);
   });
 });

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -15,7 +15,8 @@ module('Acceptance | Modules | Production Module', function (hooks) {
     this.server.create('user', { trigram: 'ABC' });
 
     id = crypto.randomUUID();
-    this.server.create('module', { id, internalTitle: 'MON_BEAU_MODULE' });
+    const module = this.server.create('module', { id, internalTitle: 'MON_BEAU_MODULE' });
+    this.server.create('draft-module', { id, module, internalTitle: 'MON_BEAU_MODULE' });
 
     return authenticateSession();
   });
@@ -36,5 +37,13 @@ module('Acceptance | Modules | Production Module', function (hooks) {
     await clickByName('Retour');
 
     assert.strictEqual(currentURL(), `/modules/production`);
+
+    await clickByName('Atelier');
+    await clickByName('Voir le détail du module en prod');
+
+    assert.strictEqual(currentURL(), `/modules/production/${id}`);
+
+    // WORKAROUND: let some time for monaco-editor to settle
+    await new Promise((resolve) => setTimeout(resolve, 100));
   });
 });

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -84,8 +84,12 @@ module('Integration | Component | modules-list', function (hooks) {
 
     hooks.beforeEach(function () {
       const store = this.owner.lookup('service:store');
+
+      const module = store.createRecord('module', { id: 'moduleId' });
+
       draftModules = [
         store.createRecord('draft-module', {
+          module,
           internalTitle: 'MOD_super_1',
           isBeta: false,
           visibility: 'public',
@@ -117,9 +121,11 @@ module('Integration | Component | modules-list', function (hooks) {
 
       const firstRow = screen.getByText('MOD_super_1').closest('tr');
       assert.dom(getByText(firstRow, 'Voir le détail')).exists();
+      assert.dom(getByText(firstRow, 'Voir le détail du module en prod')).exists();
 
       const secondRow = screen.getByText('MOD_super_2').closest('tr');
       assert.dom(getByText(secondRow, 'Voir le détail')).exists();
+      assert.dom(queryByText(secondRow, 'Voir le détail du module en prod')).doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/mirage/models/draft-module.js
+++ b/pix-editor/tests/mirage/models/draft-module.js
@@ -1,3 +1,5 @@
-import { Model } from 'miragejs';
+import { Model, belongsTo } from 'miragejs';
 
-export default Model.extend({});
+export default Model.extend({
+  module: belongsTo('module'),
+});


### PR DESCRIPTION
## 🚙 Problème

Sur la liste des drafts, si un draft est rattaché à un module en prod, on souhaite pouvoir accéder directement à la page de détails de ce module en prod.

## 🍃 Proposition

Ajouter un bouton "Voir le détail du module en PROD" dans la liste des drafts.

## 🦵 Remarques

Le bouton de retour devrait écraser l’historique, mais cela nécessite une amélioration côté pix-ui : 1024pix/pix-ui#1011

## 🔗 Pour tester

Aller sur les modules dans l’onglet atelier, et cliquer sur le bouton "Voir le détail du module en PROD".

Aller sur un module en prod en passant par l’onglet workbench ou l’onglet production, et vérifier que le bouton de retour revient bien au bon onglet.