### PR TITLE
[BUGFIX] Chargement du module/draft sur les pages de détails

### DIFF
--- a/pix-editor/app/routes/authenticated/modules/draft-module.js
+++ b/pix-editor/app/routes/authenticated/modules/draft-module.js
@@ -5,7 +5,7 @@ export default class DraftModuleRoute extends Route {
   @service store;
 
   async model(params) {
-    const draftModule = await this.store.findRecord('draft-module', params.draft_module_id);
+    const draftModule = await this.store.findRecord('draft-module', params.draft_module_id, { reload: true });
     return { draftModule };
   }
 }

--- a/pix-editor/app/routes/authenticated/modules/production-module.js
+++ b/pix-editor/app/routes/authenticated/modules/production-module.js
@@ -5,7 +5,7 @@ export default class ProductionModuleRoute extends Route {
   @service store;
 
   async model(params) {
-    const module = await this.store.findRecord('module', params.module_id);
+    const module = await this.store.findRecord('module', params.module_id, { reload: true });
     return { module };
   }
 }

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -30,11 +30,11 @@ module('Acceptance | Modules | Production Module', function (hooks) {
     // then
     assert.strictEqual(currentURL(), `/modules/production/${id}`);
 
+    // WORKAROUND: let some time for monaco-editor to settle
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     await clickByName('Retour');
 
     assert.strictEqual(currentURL(), `/modules/production`);
-
-    // WORKAROUND: let some time for monaco-editor to dismount
-    await new Promise((resolve) => setTimeout(resolve, 100));
   });
 });

--- a/pix-editor/tests/acceptance/modules/workbench-module-test.js
+++ b/pix-editor/tests/acceptance/modules/workbench-module-test.js
@@ -30,11 +30,11 @@ module('Acceptance | Modules | Workbench Module', function (hooks) {
     assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
     assert.dom(screen.getByRole('heading', { name: 'Détail du draft de module' })).exists();
 
+    // WORKAROUND: let some time for monaco-editor to settle
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     await clickByName('Retour');
 
     assert.strictEqual(currentURL(), `/modules/workbench`);
-
-    // WORKAROUND: let some time for monaco-editor to dismount
-    await new Promise((resolve) => setTimeout(resolve, 100));
   });
 });


### PR DESCRIPTION
## 🚙 Problème

Quand on ouvre la page de détails d’un draft/module, les données sont incomplètes.

## 🍃 Proposition

Forcer le reload des modèles.

## 🦵 Remarques

N/A

## 🔗 Pour tester

Aller sur la page de détail d’un draft/module et vérifier que toutes les données sont présentes.
