### PR TITLE
[FEATURE] Ajout endpoint /api/draft-modules/:id/diff (PIX-23022)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { draftModuleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
-import { createDraftModule, getDraftModuleById, listPaginatedDraftModules } from '../../domain/usecases/index.js';
+import { draftModuleDiffSerializer, draftModuleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
+import { createDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import * as Types from '../types.js';
 
@@ -40,6 +40,18 @@ export function register(server) {
           const { id } = request.params;
           const draftModule = await getDraftModuleById(id);
           return draftModuleSerializer.serialize(draftModule);
+        },
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/draft-modules/{id}/diff',
+      config: {
+        validate: { params: Joi.object({ id: Types.moduleId().required() }) },
+        handler: async (request) => {
+          const { id: draftModuleId } = request.params;
+          const draftModuleDiff = await getDraftModuleDiff({ draftModuleId });
+          return draftModuleDiffSerializer.serialize(draftModuleDiff);
         },
       },
     },

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -97,3 +97,9 @@ export class InvalidLocalizedFrameworkTubesError extends DomainError {
     super(message);
   }
 }
+
+export class DraftModuleDiffError extends DomainError {
+  constructor(message) {
+    super(message);
+  }
+}

--- a/api/lib/domain/models/DraftModuleDiff.js
+++ b/api/lib/domain/models/DraftModuleDiff.js
@@ -1,0 +1,6 @@
+export class DraftModuleDiff {
+  constructor({ draftModuleId, structuredDiff }) {
+    this.draftModuleId = draftModuleId;
+    this.structuredDiff = structuredDiff;
+  }
+}

--- a/api/lib/domain/models/Module.js
+++ b/api/lib/domain/models/Module.js
@@ -27,6 +27,33 @@ export class Module {
     this.updatedAt = updatedAt;
   }
 
+  serializeToJSON() {
+    const {
+      id,
+      shortId,
+      internalTitle,
+      slug,
+      title,
+      isBeta,
+      visibility,
+      details,
+      sections,
+      glossary,
+    } = this;
+    return JSON.stringify({
+      id,
+      shortId,
+      internalTitle,
+      slug,
+      title,
+      isBeta,
+      visibility,
+      details,
+      sections,
+      glossary,
+    }, null, 2);
+  }
+
   static get LEVELS() {
     return {
       NOVICE: 'novice',

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -4,6 +4,7 @@ export * from './Challenge.js';
 export * from './ChangelogEntry.js';
 export * from './Competence.js';
 export * from './DraftModule.js';
+export * from './DraftModuleDiff.js';
 export * from './Framework.js';
 export * from './LocalizedChallenge.js';
 export * from './LocalizedFrameworkTubes.js';

--- a/api/lib/domain/usecases/get-draft-module-diff.js
+++ b/api/lib/domain/usecases/get-draft-module-diff.js
@@ -1,0 +1,19 @@
+import { structuredPatch } from 'diff';
+
+import { draftModuleRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
+import { DraftModuleDiffError } from '../errors.js';
+import { DraftModuleDiff } from '../models/index.js';
+
+export async function getDraftModuleDiff({ draftModuleId }, dependencies = { draftModuleRepository, moduleRepository, structuredPatch }) {
+  const draftModule = await dependencies.draftModuleRepository.getById({ id: draftModuleId });
+  if (!draftModule.moduleId) throw new DraftModuleDiffError('cannot generate diff for creation draft');
+
+  const module = await dependencies.moduleRepository.getById({ id: draftModule.moduleId });
+
+  const structuredDiff = dependencies.structuredPatch('', '', module.serializeToJSON(), draftModule.serializeToJSON());
+
+  return new DraftModuleDiff({
+    draftModuleId,
+    structuredDiff,
+  });
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -20,6 +20,7 @@ export * from './find-all-missions.js';
 export * from './get-competence-challenges-production-overview.js';
 export * from './get-competence-challenges-workbench-overview.js';
 export * from './get-draft-module-by-id.js';
+export * from './get-draft-module-diff.js';
 export * from './get-module-by-id.js';
 export * from './get-phrase-translations-url.js';
 export * from './get-skill-challenges-production.js';

--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-diff-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-diff-serializer.js
@@ -1,0 +1,23 @@
+import { formatPatch } from 'diff';
+import Jsonapi from 'jsonapi-serializer';
+import { codeToHtml } from 'shiki';
+
+const { Serializer } = Jsonapi;
+
+const serializer = new Serializer('draft-module-diff', { attributes: ['htmlDiff'] });
+
+/**
+ * @param {import('../../../domain/models/index.js').DraftModuleDiff} draftModuleDiff
+ */
+export async function serialize({ draftModuleId: id, structuredDiff }) {
+  const diffText = formatPatch(structuredDiff, {
+    includeFileHeaders: false,
+    includeIndex: false,
+    includeUnderline: false,
+  });
+  const htmlDiff = await codeToHtml(diffText, {
+    lang: 'diff',
+    theme: 'github-light',
+  });
+  return serializer.serialize({ id, htmlDiff });
+}

--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
@@ -26,6 +26,7 @@ const defaultAttributes = [
   'sections',
   'glossary',
   'module',
+  'diff',
 ];
 
 export function serialize(draftModules, { meta, attributes = defaultAttributes } = {}) {
@@ -33,14 +34,25 @@ export function serialize(draftModules, { meta, attributes = defaultAttributes }
     attributes,
     meta,
     transform({ moduleId, ...draftModule }) {
-      return {
+      const data = {
         ...draftModule,
         module: moduleId ? { id: moduleId } : null,
       };
+      if (moduleId) data.diff = {};
+      return data;
     },
     module: {
       ref: 'id',
       included: false,
+    },
+    diff: {
+      ref: 'id',
+      ignoreRelationshipData: true,
+      relationshipLinks: {
+        related({ id }) {
+          return `/api/draft-modules/${id}/diff`;
+        },
+      },
     },
   });
   return serializer.serialize(draftModules);

--- a/api/lib/infrastructure/serializers/jsonapi/index.js
+++ b/api/lib/infrastructure/serializers/jsonapi/index.js
@@ -13,6 +13,7 @@ export * as localizedChallengeSerializer from './localized-challenge-serializer.
 export * as localizedFrameworkTubesSerializer from './localized-framework-tubes-serializer.js';
 export * as missionSerializer from './mission-serializer.js';
 export * as moduleSerializer from './module-serializer.js';
+export * as draftModuleDiffSerializer from './draft-module-diff-serializer.js';
 export * as skillSerializer from './skill-serializer.js';
 export * as searchSerializer from './search-serializer.js';
 export * as staticCourseSerializer from './static-course-serializer.js';

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -105,6 +105,14 @@ function _mapToInfrastructureError(error) {
     };
   }
 
+  if (error instanceof DomainErrors.DraftModuleDiffError) {
+    const infraError = new InfraErrors.BadRequestError(error.message);
+    return {
+      infraErrors: [infraError],
+      statusCode: infraError.status,
+    };
+  }
+
   const infraError = new InfraErrors.InfrastructureError(error.message);
   return {
     infraErrors: [infraError],

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -45,6 +45,7 @@
         "pino-pretty": "^13.0.0",
         "qs": "^6.10.1",
         "sequelize": "^6.29.0",
+        "shiki": "^4.1.0",
         "showdown": "^2.0.0",
         "tough-cookie": "^6.0.0",
         "url-regex-safe": "^4.0.0"
@@ -4367,6 +4368,106 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.1.0",
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
+      "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
+      "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
+      "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
+      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
+      "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -5164,6 +5265,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
@@ -5197,6 +5307,15 @@
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/mdurl": {
@@ -5259,6 +5378,12 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
@@ -5284,6 +5409,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
@@ -5973,6 +6104,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5997,6 +6138,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -6151,6 +6312,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -6431,6 +6602,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -6439,6 +6619,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -7565,6 +7758,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
@@ -7593,6 +7822,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -8759,6 +8998,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -8769,6 +9029,95 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -9225,6 +9574,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/optionator": {
@@ -9923,6 +10289,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
@@ -10569,6 +10945,30 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
@@ -10998,6 +11398,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
+      "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.1.0",
+        "@shikijs/engine-javascript": "4.1.0",
+        "@shikijs/engine-oniguruma": "4.1.0",
+        "@shikijs/langs": "4.1.0",
+        "@shikijs/themes": "4.1.0",
+        "@shikijs/types": "4.1.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/showdown": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
@@ -11193,6 +11612,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -11302,6 +11731,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -11652,6 +12095,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -11744,6 +12197,74 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universal-user-agent": {
@@ -11877,6 +12398,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vitest": {
@@ -12367,6 +12916,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -25,6 +25,7 @@
         "blipp": "^4.0.2",
         "bull": "^4.10.4",
         "countries-list": "^3.0.6",
+        "diff": "^9.0.0",
         "fast-csv": "^5.0.5",
         "fetch-cookie": "^3.2.0",
         "file-saver": "^2.0.5",
@@ -6438,6 +6439,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-helpers": {

--- a/api/package.json
+++ b/api/package.json
@@ -78,6 +78,7 @@
     "pino-pretty": "^13.0.0",
     "qs": "^6.10.1",
     "sequelize": "^6.29.0",
+    "shiki": "^4.1.0",
     "showdown": "^2.0.0",
     "tough-cookie": "^6.0.0",
     "url-regex-safe": "^4.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -58,6 +58,7 @@
     "blipp": "^4.0.2",
     "bull": "^4.10.4",
     "countries-list": "^3.0.6",
+    "diff": "^9.0.0",
     "fast-csv": "^5.0.5",
     "fetch-cookie": "^3.2.0",
     "file-saver": "^2.0.5",

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -228,6 +228,7 @@ describe('Acceptance | Route | draft-modules', () => {
                 type: 'modules',
               },
             },
+            diff: { links: { related: `/api/draft-modules/${draftModule.id}/diff` } },
           },
         },
       });

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -251,4 +251,91 @@ describe('Acceptance | Route | draft-modules', () => {
       });
     });
   });
+
+  describe('GET /draft-modules/:id/diff', () => {
+    it('responds with status 200 and draft module’s data', async () => {
+      // given
+      const module = domainBuilder.buildModule();
+      databaseBuilder.factory.buildModule(module);
+      const { id: draftModuleId } = databaseBuilder.factory.buildDraftModule(domainBuilder.buildDraftModule({
+        id: module.id,
+        moduleId: module.id,
+        details: { level: Module.LEVELS.EXPERT },
+        glossary: [
+          ...module.glossary,
+          {
+            word: 'antennes',
+            description: 'La paire d’antennes de l’escargot lui sert, en gros, à tâter le terrain et à découvrir, par le toucher, son environnement immédiat.',
+          },
+        ],
+      }));
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/draft-modules/${draftModuleId}/diff`,
+        headers: generateAuthorizationHeader(editorUser),
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+      expect(response.result).toStrictEqual({
+        data: {
+          type: 'draft-module-diffs',
+          id: draftModuleId,
+          attributes: { 'html-diff': expect.any(String) },
+        },
+      });
+      expect(response.result.data.attributes['html-diff']).toMatchInlineSnapshot(`
+        "<pre class="shiki github-light" style="background-color:#fff;color:#24292e" tabindex="0"><code><span class="line"><span style="color:#6F42C1;font-weight:bold">@@ -9,9 +9,9 @@</span></span>
+        <span class="line"><span style="color:#24292E">   "details": {</span></span>
+        <span class="line"><span style="color:#24292E">     "image": "https=//assets.pix.org/draft/escargots.jpg",</span></span>
+        <span class="line"><span style="color:#24292E">     "description": "&#x3C;p>Ce module est dédié aux escargots&#x3C;/p>&#x3C;p>Il contient normalement l'intégralité de leurs secrets disponibles à date.&#x3C;/p>",</span></span>
+        <span class="line"><span style="color:#24292E">     "duration": 7,</span></span>
+        <span class="line"><span style="color:#B31D28">-    "level": "novice",</span></span>
+        <span class="line"><span style="color:#22863A">+    "level": "expert",</span></span>
+        <span class="line"><span style="color:#24292E">     "objectives": [</span></span>
+        <span class="line"><span style="color:#24292E">       "Connaître les petits secrets des gastéropodes"</span></span>
+        <span class="line"><span style="color:#24292E">     ],</span></span>
+        <span class="line"><span style="color:#24292E">     "tabletSupport": "inconvenient"</span></span>
+        <span class="line"><span style="color:#6F42C1;font-weight:bold">@@ -43,7 +43,11 @@</span></span>
+        <span class="line"><span style="color:#24292E">   "glossary": [</span></span>
+        <span class="line"><span style="color:#24292E">     {</span></span>
+        <span class="line"><span style="color:#24292E">       "word": "coquille",</span></span>
+        <span class="line"><span style="color:#24292E">       "description": "Une coquille est un agglomérat de calcaire très résistant. Sa structure cristalline spécifique lui confère une résistance protectrice. Elle prodique à l'escargot toute sa force et sa vitalité."</span></span>
+        <span class="line"><span style="color:#22863A">+    },</span></span>
+        <span class="line"><span style="color:#22863A">+    {</span></span>
+        <span class="line"><span style="color:#22863A">+      "word": "antennes",</span></span>
+        <span class="line"><span style="color:#22863A">+      "description": "La paire d’antennes de l’escargot lui sert, en gros, à tâter le terrain et à découvrir, par le toucher, son environnement immédiat."</span></span>
+        <span class="line"><span style="color:#24292E">     }</span></span>
+        <span class="line"><span style="color:#24292E">   ]</span></span>
+        <span class="line"><span style="color:#24292E"> }</span></span>
+        <span class="line"><span style="color:#24292E">\\ No newline at end of file</span></span>
+        <span class="line"></span></code></pre>"
+      `);
+    });
+
+    describe('when draft is a creation draft', () => {
+      it('responds with status 400', async () => {
+        // given
+        const { id: draftModuleId } = databaseBuilder.factory.buildDraftModule(domainBuilder.buildDraftModule());
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/draft-modules/${draftModuleId}/diff`,
+          headers: generateAuthorizationHeader(editorUser),
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DraftModule } from '../../../../lib/domain/models/index.js';
+import { domainBuilder } from '../../../test-helper.js';
 
 const uuidRegExp = /^\p{Hex_Digit}{8}-\p{Hex_Digit}{4}-\p{Hex_Digit}{4}-\p{Hex_Digit}{4}-\p{Hex_Digit}{12}$/u;
 const shortIdRegExp = /^\p{Hex_Digit}{8}$/u;
@@ -17,6 +18,36 @@ describe('Unit | Domain | DraftModule', () => {
       expect(draftModule.id).toMatch(uuidRegExp);
       expect(draftModule.shortId).toMatch(shortIdRegExp);
       expect(draftModule.shortId).toBe(draftModule.id.slice(0, 8));
+    });
+  });
+
+  describe('#serializeToJSON', () => {
+    it('serializes module fields to JSON discarding irrelevant fields', () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule({ moduleId: 'pouet' });
+      const serializedFields = [
+        'id',
+        'shortId',
+        'internalTitle',
+        'slug',
+        'title',
+        'isBeta',
+        'visibility',
+        'details',
+        'sections',
+        'glossary',
+      ];
+      const expectedJSON = JSON.stringify(
+        Object.fromEntries(Object.entries(draftModule).filter(([field]) => serializedFields.includes(field))),
+        null,
+        2,
+      );
+
+      // when
+      const json = draftModule.serializeToJSON();
+
+      // then
+      expect(json).toStrictEqual(expectedJSON);
     });
   });
 });

--- a/api/tests/unit/domain/models/Module_test.js
+++ b/api/tests/unit/domain/models/Module_test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+
+describe('Unit | Domain | DraftModule', () => {
+  describe('#serializeToJSON', () => {
+    it('serializes module fields to JSON discarding irrelevant fields', () => {
+      // given
+      const module = domainBuilder.buildModule();
+      const serializedFields = [
+        'id',
+        'shortId',
+        'internalTitle',
+        'slug',
+        'title',
+        'isBeta',
+        'visibility',
+        'details',
+        'sections',
+        'glossary',
+      ];
+      const expectedJSON = JSON.stringify(
+        Object.fromEntries(Object.entries(module).filter(([field]) => serializedFields.includes(field))),
+        null,
+        2,
+      );
+
+      // when
+      const json = module.serializeToJSON();
+
+      // then
+      expect(json).toStrictEqual(expectedJSON);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-draft-module-by-id_test.js
+++ b/api/tests/unit/domain/usecases/get-draft-module-by-id_test.js
@@ -1,18 +1,66 @@
 import { describe, expect, it, vi } from 'vitest';
-import { getDraftModuleById } from '../../../../lib/domain/usecases/get-draft-module-by-id.js';
+
+import { getDraftModuleDiff } from '../../../../lib/domain/usecases/get-draft-module-diff.js';
+import { domainBuilder } from '../../../test-helper.js';
+import { DraftModuleDiffError } from '../../../../lib/domain/errors.js';
+import { DraftModuleDiff } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | getDraftModuleById', () => {
   it('returns draft module retrieved from repository', async () => {
     // given
-    const id = Symbol('id');
-    const draftModule = Symbol('draftModule');
+    const draftModuleId = Symbol('draftModuleId');
+    const moduleId = Symbol('moduleId');
+    const draftModuleJSON = Symbol('draftModuleJSON');
+    const moduleJSON = Symbol('moduleJSON');
+    const structuredDiff = Symbol('structuredDiff');
+
+    const draftModule = domainBuilder.buildDraftModule({ id: draftModuleId, moduleId });
+    vi.spyOn(draftModule, 'serializeToJSON').mockReturnValueOnce(draftModuleJSON);
+
+    const module = domainBuilder.buildModule({ id: moduleId });
+    vi.spyOn(module, 'serializeToJSON').mockReturnValueOnce(moduleJSON);
+
     const draftModuleRepository = { getById: vi.fn().mockResolvedValueOnce(draftModule) };
+    const moduleRepository = { getById: vi.fn().mockResolvedValueOnce(module) };
+
+    const structuredPatch = vi.fn().mockReturnValueOnce(structuredDiff);
 
     // when
-    const result = await getDraftModuleById(id, { draftModuleRepository });
+    const result = await getDraftModuleDiff(
+      { draftModuleId },
+      { draftModuleRepository, moduleRepository, structuredPatch },
+    );
 
     // then
-    expect(result).toBe(draftModule);
-    expect(draftModuleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id });
+    expect(result).toStrictEqual(new DraftModuleDiff({
+      draftModuleId,
+      structuredDiff,
+    }));
+    expect(draftModuleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: draftModuleId });
+    expect(moduleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: moduleId });
+    expect(structuredPatch).toHaveBeenCalledExactlyOnceWith('', '', moduleJSON, draftModuleJSON);
+  });
+
+  describe('when draft module doesn’t belong to a module', () => {
+    it('throws a DraftModuleDiffError', async () => {
+      // given
+      const draftModuleId = Symbol('draftModuleId');
+
+      const draftModule = domainBuilder.buildDraftModule({ id: draftModuleId, moduleId: null });
+
+      const draftModuleRepository = { getById: vi.fn().mockResolvedValueOnce(draftModule) };
+
+      const expectedError = new DraftModuleDiffError('cannot generate diff for creation draft');
+
+      // when
+      const result = getDraftModuleDiff(
+        { draftModuleId },
+        { draftModuleRepository },
+      );
+
+      // then
+      expect(result).rejects.toStrictEqual(expectedError);
+      expect(draftModuleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: draftModuleId });
+    });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
@@ -31,6 +31,7 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
                 id: draftModule.moduleId,
               },
             },
+            diff: { links: { related: `/api/draft-modules/${draftModule.moduleId}/diff` } },
           },
         },
       };

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -197,8 +197,21 @@ describe('Unit | Infrastructure | ErrorManager', function() {
               },
             ],
           });
+        } else if (domainErrorName === 'DraftModuleDiffError') {
+          const errorInstance = new domainErrorClass('mon message');
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(400);
+          expect(responseForError.source).toStrictEqual({
+            errors: [
+              {
+                status: '400',
+                title: 'Bad Request',
+                detail: 'mon message',
+              },
+            ],
+          });
         } else {
-          expect(true, `Conversion for ${domainErrorName} not tested`).to.be.false;
+          expect(true, `Conversion for ${domainErrorName} not tested`).toBe(false);
         }
       }
     });


### PR DESCRIPTION
## 🚙 Problème

On souhaite afficher un diff entre le draft de module et son module de prod.

## 🍃 Proposition

Ajout d’un endpoint GET /api/draft-modules/:id/diff

Ce endpoint renvoie un model draft-module-diff avec un attribut html-diff contenant un diff unifié en HTML avec coloration syntaxique.

Ajouter une relationship diff sur la payload de GET /api/draft-modules/:id référençant le nouveau endpoint.

## 🦵 Remarques

N/A

## 🔗 Pour tester

Faire les curls suivants afin de vérifier le nouveau endpoint et la nouvelle relationship :

```
curl -H 'authorization: Bearer xxx' https://pix-lcms-review-pr1505.osc-fr1.scalingo.io/api/draft-modules/6282925d-4775-4bca-b513-4c3009ec5886/diff
curl -H 'authorization: Bearer xxx' https://pix-lcms-review-pr1505.osc-fr1.scalingo.io/api/draft-modules/6282925d-4775-4bca-b513-4c3009ec5886
```