### PR TITLE
[BUGFIX] Le schéma Joi de création/modification de pièces-jointes n'est pas assez permissif (PIX-23034)

### DIFF
--- a/api/db/seeds/data/attachments.js
+++ b/api/db/seeds/data/attachments.js
@@ -56,7 +56,7 @@ export function buildAttachment({ challengeId, localizedChallengeId, type, datab
   });
   const attachmentData = iterForData.next().value;
   return databaseBuilder.factory.buildAttachment({
-    id: `attachment${localizedChallengeId.split('challenge')[1]}`,
+    id: `attachment${localizedChallengeId.split('challenge')[1]}`.replaceAll('-', ''),
     filename: attachmentData.filename,
     mimeType: attachmentData.mimeType,
     size: attachmentData.size,

--- a/api/lib/application/attachments.js
+++ b/api/lib/application/attachments.js
@@ -28,7 +28,7 @@ export function register(server) {
                 filename: Joi.string(),
                 size: Joi.number(),
                 url: Joi.string(),
-                'mime-type': Joi.string(),
+                'mime-type': Joi.string().allow(null),
                 type: Joi.string(),
               },
               relationships: {
@@ -81,7 +81,7 @@ export function register(server) {
                 filename: Joi.string(),
                 size: Joi.number(),
                 url: Joi.string(),
-                'mime-type': Joi.string(),
+                'mime-type': Joi.string().allow(null),
                 type: Joi.string(),
               },
               relationships: {

--- a/api/lib/infrastructure/validation.js
+++ b/api/lib/infrastructure/validation.js
@@ -1,0 +1,10 @@
+import { logger } from './logger.js';
+
+export function handleFailAction(request, h, err) {
+  logger.error({ err }, 'Request payload validation error');
+  return h.response({
+    error: 'Bad Request',
+    message: 'Invalid request payload input',
+    statusCode: 400,
+  }).code(400).takeover();
+}

--- a/api/server.js
+++ b/api/server.js
@@ -8,12 +8,14 @@ import { routes } from './lib/routes.js';
 import { plugins } from './lib/infrastructure/plugins/index.js';
 import * as security from './lib/infrastructure/security.js';
 import * as monitoringTools from './lib/infrastructure/monitoring-tools.js';
+import { handleFailAction } from './lib/infrastructure/validation.js';
 
 monitoringTools.installHapiHook();
 
 export async function createServer() {
   const server = new Hapi.server({
     routes: {
+      validate: { failAction: handleFailAction },
       cors: {
         origin: ['*'],
         additionalHeaders: ['X-Requested-With'],

--- a/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
+++ b/api/tests/acceptance/application/whitelisted-urls/whitelisted-urls_test.js
@@ -217,7 +217,7 @@ describe('Acceptance | Controller | whitelisted-urls', () => {
       expect(response.statusCode).to.equal(400);
       expect(response.result).to.deep.equal({
         error: 'Bad Request',
-        message: 'Invalid request params input',
+        message: 'Invalid request payload input',
         statusCode: 400,
       });
     });


### PR DESCRIPTION
## 🚙 Problème

Il arrive que le `mime-type` de certaines pièces-jointes avec des extensions peu communes (`.sql`, `.rs`) ne soit pas détecté, et soit `null`.
Le `mime-type` n'étant pas très important (optionnel dans la BDD), ce n'est pas grave.
Cependant, dans la validation Joi du payload de création ou modification des pièces-jointes, cette propriété n'est pas indiquée comme étant optionnelle, ce qui empêche la modification de certaines épreuves.

## 🍃 Proposition

Indiquer la propriété comme étant optionnelle dans les schémas Joi.

## 🦄 Remarques

- Réparation des seeds des attachments, qui généraient des ids qui n'étaient pas conformes au schéma Joi (`-en` à la fin).
- Ajout de logs d'erreur lorsqu'une erreur de validation a lieu, afin de faciliter le déboggage.

## 🔗 Pour tester

- Se rendre sur la review app de Pix Editor
- Créer/modifier une épreuve avec une pièce jointe `.abcdefg` ou autre extension inconnue.
- Constater que ça fonctionne.