### PR TITLE
[TECH] Pouvoir lancer adminjs dans la window(s)

### DIFF
--- a/api/lib/infrastructure/plugins/adminjs/index.js
+++ b/api/lib/infrastructure/plugins/adminjs/index.js
@@ -1,5 +1,7 @@
 import { AdminJS, ComponentLoader } from 'adminjs';
 import AdminJSSequelize from '@adminjs/sequelize';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { User, Release, Translations, LocalizedChallenge } from './models.js';
 import { checkUserIsAuthenticatedViaBasicAndAdmin } from '../../../application/security-pre-handlers.js';
 
@@ -7,11 +9,13 @@ AdminJS.registerAdapter(AdminJSSequelize);
 
 export { default as plugin } from '@adminjs/hapi';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const componentLoader = new ComponentLoader();
 const Components = {
-  ImportExportComponent: componentLoader.add('ImportExportComponent', './components/ImportExportComponent.jsx'),
-  GetEmbedList: componentLoader.add('GetEmbedList', './components/GetEmbedList.jsx'),
-  Dashboard: componentLoader.add('Dashboard', './components/Dashboard.jsx'),
+  ImportExportComponent: componentLoader.add('ImportExportComponent', join(__dirname, './components/ImportExportComponent.jsx')),
+  GetEmbedList: componentLoader.add('GetEmbedList', join(__dirname, './components/GetEmbedList.jsx')),
+  Dashboard: componentLoader.add('Dashboard', join(__dirname, './components/Dashboard.jsx')),
 };
 
 const readOnlyOptions = {


### PR DESCRIPTION
## 🚙 Problème

```
$ npm start
npm warn Unknown user config "python". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.

> learning-content-api@4.31.1 start
> node --env-file-if-exists=.env index.js

file:///C:/Users/Documents/projects/pix-editor/api/node_modules/adminjs/lib/backend/utils/component-loader.js:80
    throw new ConfigurationError(`Trying to bundle file '${src}' but it doesn't exist`, 'AdminJS.html');
          ^

ConfigurationError:
    Trying to bundle file '.\file:\C:\Users\Documents\projects\pix-editor\api\lib\infrastructure\plugins\adminjs\components\ImportExportComponent.jsx' but it doesn't exist
    More information can be found at: https://docs.adminjs.co/AdminJS.html

    at ComponentLoader.resolveFilePath (file:///C:/Users/Documents/projects/pix-editor/api/node_modules/adminjs/lib/backend/utils/component-loader.js:80:11)
    at ComponentLoader.add (file:///C:/Users/Documents/projects/pix-editor/api/node_modules/adminjs/lib/backend/utils/component-loader.js:8:46)
    at file:///C:/Users/Documents/projects/pix-editor/api/lib/infrastructure/plugins/adminjs/index.js:12:42
    at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
    at async node:internal/modules/esm/loader:639:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```


## 🍃 Proposition

Utiliser les chemin relatif pour builder adminJs

## 🦵 Remarques

RAS

## 🔗 Pour tester
ça build sur scalingo ? 