### PR TITLE
[FEATURE] Afficher la comparaison du JSON pour un module DRAFT d’un module de PROD (PIX-23024)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-diff-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-diff-serializer.js
@@ -1,4 +1,4 @@
-import { formatPatch } from 'diff';
+import { formatPatch, OMIT_HEADERS } from 'diff';
 import Jsonapi from 'jsonapi-serializer';
 import { codeToHtml } from 'shiki';
 
@@ -10,11 +10,7 @@ const serializer = new Serializer('draft-module-diff', { attributes: ['htmlDiff'
  * @param {import('../../../domain/models/index.js').DraftModuleDiff} draftModuleDiff
  */
 export async function serialize({ draftModuleId: id, structuredDiff }) {
-  const diffText = formatPatch(structuredDiff, {
-    includeFileHeaders: false,
-    includeIndex: false,
-    includeUnderline: false,
-  });
+  const diffText = formatPatch(structuredDiff, OMIT_HEADERS);
   const htmlDiff = await codeToHtml(diffText, {
     lang: 'diff',
     theme: 'github-light',

--- a/api/tests/tooling/database-builder/factory/build-draft-module.js
+++ b/api/tests/tooling/database-builder/factory/build-draft-module.js
@@ -15,22 +15,30 @@ export function buildDraftModule({
   createdAt,
   updatedAt,
 } = {}) {
+  const values = {
+    id,
+    moduleId,
+    internalTitle,
+    shortId,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    ...details,
+    sections,
+    glossary,
+    createdAt,
+    updatedAt,
+  };
+
+  const valuesForDb = {
+    ...values,
+    sections: JSON.stringify(values.sections),
+    glossary: JSON.stringify(values.glossary),
+  };
+
   return databaseBuffer.pushInsertable({
     tableName: 'draft-modules',
-    values: {
-      id,
-      moduleId,
-      internalTitle,
-      shortId,
-      slug,
-      title,
-      isBeta,
-      visibility,
-      ...details,
-      sections: JSON.stringify(sections),
-      glossary: JSON.stringify(glossary),
-      createdAt,
-      updatedAt,
-    },
+    values: valuesForDb,
   });
 }

--- a/api/tests/tooling/database-builder/factory/build-module.js
+++ b/api/tests/tooling/database-builder/factory/build-module.js
@@ -14,21 +14,31 @@ export function buildModule({
   createdAt,
   updatedAt,
 } = {}) {
-  return databaseBuffer.pushInsertable({
+  const values = {
+    id,
+    shortId,
+    internalTitle,
+    slug,
+    title,
+    isBeta,
+    visibility,
+    ...details,
+    sections,
+    glossary,
+    createdAt,
+    updatedAt,
+  };
+
+  const valuesForDb = {
+    ...values,
+    sections: JSON.stringify(values.sections),
+    glossary: JSON.stringify(values.glossary),
+  };
+
+  databaseBuffer.pushInsertable({
     tableName: 'modules',
-    values: {
-      id,
-      shortId,
-      internalTitle,
-      slug,
-      title,
-      isBeta,
-      visibility,
-      ...details,
-      sections: JSON.stringify(sections),
-      glossary: JSON.stringify(glossary),
-      createdAt,
-      updatedAt,
-    },
+    values: valuesForDb,
   });
+
+  return values;
 }

--- a/api/tests/unit/domain/models/Module_test.js
+++ b/api/tests/unit/domain/models/Module_test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 
-describe('Unit | Domain | DraftModule', () => {
+describe('Unit | Domain | Module', () => {
   describe('#serializeToJSON', () => {
     it('serializes module fields to JSON discarding irrelevant fields', () => {
       // given

--- a/pix-editor/app/components/modules/draft-module-diff.gjs
+++ b/pix-editor/app/components/modules/draft-module-diff.gjs
@@ -1,0 +1,8 @@
+import { htmlSafe } from '@ember/template';
+
+<template>
+  <h2 class="module-internal-title">{{@internalTitle}}</h2>
+  <div class="draft-module-diff">
+    {{htmlSafe @htmlDiff}}
+  </div>
+</template>

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -58,15 +58,18 @@ export default class ModuleForm extends Component {
 
   <template>
     <div class="module-form">
-      <PixInput
-        @id="internalTitle"
-        @value={{this.internalTitle}}
-        @requiredLabel="Champ obligatoire"
-        {{on "change" this.onInternalTitleChange}}
-        readonly={{@readonly}}
-      >
-        <:label>Titre interne</:label>
-      </PixInput>
+      {{#if @readonly}}
+        <h2 class="module-internal-title">{{this.internalTitle}}</h2>
+      {{else}}
+        <PixInput
+          @id="internalTitle"
+          @value={{this.internalTitle}}
+          @requiredLabel="Champ obligatoire"
+          {{on "change" this.onInternalTitleChange}}
+        >
+          <:label>Titre interne</:label>
+        </PixInput>
+      {{/if}}
 
       <div class="module-form__data-field">
         <PixLabel @requiredLabel="Champ obligatoire">

--- a/pix-editor/app/models/draft-module-diff.js
+++ b/pix-editor/app/models/draft-module-diff.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class DraftModuleDiff extends Model {
+  @attr htmlDiff;
+}

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -4,6 +4,7 @@ import BaseModule from './base-module';
 
 export default class DraftModule extends BaseModule {
   @belongsTo('module', { inverse: null, async: true }) module;
+  @belongsTo('draft-module-diff', { inverse: null, async: true }) diff;
 
   get isDraft() {
     return true;

--- a/pix-editor/app/routes/authenticated/modules/draft-module.js
+++ b/pix-editor/app/routes/authenticated/modules/draft-module.js
@@ -6,7 +6,14 @@ export default class DraftModuleRoute extends Route {
 
   async model(params, { from }) {
     const draftModule = await this.store.findRecord('draft-module', params.draft_module_id, { reload: true });
+
+    let draftModuleDiff;
+    if (draftModule.isEditionDraft) {
+      draftModuleDiff = await draftModule.diff;
+    }
+
     const fromRoute = from?.name ?? 'authenticated.modules.workbench';
-    return { draftModule, fromRoute };
+
+    return { draftModule, draftModuleDiff, fromRoute };
   }
 }

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -1,3 +1,5 @@
+@use 'pix-design-tokens/typography';
+
 .modules-list {
   display: flex;
   flex-direction: column;
@@ -19,4 +21,24 @@ td.modules-list__actions {
   display: flex;
   flex-direction: row-reverse;
   gap: var(--pix-spacing-2x);
+}
+
+.module-internal-title {
+  @extend %pix-title-xs;
+}
+
+.draft-module-diff {
+  pre.shiki {
+    height: 70vh;
+    margin: 0;
+    padding: var(--pix-spacing-4x);
+    overflow: scroll;
+
+    span {
+      @extend %pix-monospace;
+
+      font-size: 14px;
+      line-height: 14px;
+    }
+  }
 }

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,3 +1,4 @@
+import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 
@@ -7,7 +8,14 @@ import ModuleForm from 'pixeditor/components/modules/module-form';
   </header>
   <main class="page-body">
     <section class="page-section module-form">
-      <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
+      {{#if @model.draftModule.isEditionDraft}}
+        <DraftModuleDiff
+          @internalTitle={{@model.draftModule.internalTitle}}
+          @htmlDiff={{@model.draftModuleDiff.htmlDiff}}
+        />
+      {{else}}
+        <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
+      {{/if}}
       <div class="page-actions">
         <ModuleBackButton @fromRoute={{@model.fromRoute}} />
       </div>

--- a/pix-editor/tests/integration/components/modules/draft-module-diff-test.gjs
+++ b/pix-editor/tests/integration/components/modules/draft-module-diff-test.gjs
@@ -1,0 +1,34 @@
+import { render } from '@1024pix/ember-testing-library';
+import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | modules/draft-module-diff', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when module-form is readonly', function () {
+    test('it should not display actions buttons', async function (assert) {
+      // given
+      const internalTitle = 'MOD_test-diff';
+      const htmlDiff = `
+        <pre class="shiki">
+          <code>
+            <span>première ligne de diff</span>
+            <span>deuxième ligne de diff</span>
+          </code>
+        </pre>
+      `;
+
+      // when
+      const screen = await render(
+        <template><DraftModuleDiff @internalTitle={{internalTitle}} @htmlDiff={{htmlDiff}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByRole('heading', { name: internalTitle })).exists();
+      assert.dom(screen.getByText('première ligne de diff')).exists();
+      assert.dom(screen.getByText('deuxième ligne de diff')).exists();
+    });
+  });
+});

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -91,6 +91,9 @@ module('Integration | Component | modules/module-form', function (hooks) {
       const screen = await render(<template><ModuleForm @module={{module}} @readonly={{true}} /></template>);
 
       // then
+      assert.dom(await screen.queryByRole('textbox', { name: /^Titre interne/ })).doesNotExist();
+      assert.dom(screen.getByRole('heading', { name: 'MOL_escargot-loiret' })).exists();
+
       assert.dom(await screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
       assert.dom(await screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
     });


### PR DESCRIPTION
## 🚙 Problème

On souhaite afficher le diff pour un draft de module quand celui-ci appartient à un module déjà en prod.

## 🍃 Proposition

Remplacer le formulaire de module readonly par le diff quand le draft est rattaché à un module de prod.

## 🦵 Remarques

N/A

## 🔗 Pour tester

Aller sur le détail d’un draft rattaché à un module de prod, et vérifier que le diff s’affiche bien.
Aller sur le détail d’un draft de création de module, et vérifier que c’est le formulaire en readonly qui s’affiche.
