### PR TITLE
[TECH] Déclenche l'action check node pour les merge queues.

### DIFF
--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -1,15 +1,17 @@
 name: Check node version availability on Scalingo
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+    pull_request:
+        types: [opened, reopened, synchronize]
+    merge_group:
+        types: [checks_requested]
 
 jobs:
-  check-node-compatibility:
-    if: github.head_ref == 'renovate/node' || (startsWith(github.head_ref, 'renovate/major-') && endsWith(github.head_ref, '-node'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
+    check-node-compatibility:
+        if: github.head_ref == 'renovate/node' || (startsWith(github.head_ref, 'renovate/major-') && endsWith(github.head_ref, '-node'))
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v6
 
-      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0
+            - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0


### PR DESCRIPTION
## 🚙 Problème

l'action check node n'est pas déclenchée par les merge group, ce qui bloque le merge des PR via la merge queue.

<!-- Décrivez ici le besoin ou l'intention couvert par cette Pull Request. -->

## 🍃 Proposition

on ajoute le trigger `on_merge_group`

<!-- Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés. -->

## 🦵 Remarques

<!-- Des infos supplémentaires, trucs et astuces ? -->

## 🔗 Pour tester
<!-- 
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. 
- [ ] Documentation de la fonctionnalité (lien)
-->
