### PR TITLE
[TECH] Autoriser l'absence de `phraseProjectId` dans l'entité `translations_config` (PIX-23112)

### DIFF
--- a/api/db/migrations/20260612080334_alter-translations-config-table-making-phraseId-optional.js
+++ b/api/db/migrations/20260612080334_alter-translations-config-table-making-phraseId-optional.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'translations_config';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('phraseProjectId').nullable().alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('phraseProjectId').notNullable().default('').alter();
+  });
+}

--- a/api/lib/domain/usecases/download-translation-from-phrase.js
+++ b/api/lib/domain/usecases/download-translation-from-phrase.js
@@ -17,7 +17,7 @@ export async function downloadTranslationFromPhrase(phraseApi = { Configuration,
     return;
   }
 
-  const configs = await translationsConfigRepository.list();
+  const configs = await translationsConfigRepository.listWithPhraseProjectId();
 
   if (!configs.length) {
     logger.warn('No translations config defined, skipping upload translations');

--- a/api/lib/domain/usecases/get-phrase-translations-url.js
+++ b/api/lib/domain/usecases/get-phrase-translations-url.js
@@ -9,7 +9,7 @@ export async function getPhraseTranslationsURL(
 ) {
   try {
     const area = await areaRepository.getByChallengeId(challengeId);
-    const configs = await translationsConfigRepository.list();
+    const configs = await translationsConfigRepository.listWithPhraseProjectId();
 
     const configuration = new phrase.Configuration({
       apiKey: `token ${config.phrase.apiKey}`,

--- a/api/lib/domain/usecases/upload-translation-to-phrase.js
+++ b/api/lib/domain/usecases/upload-translation-to-phrase.js
@@ -18,7 +18,7 @@ export async function uploadTranslationToPhrase(phraseApi = { Configuration, Loc
     return;
   }
 
-  const configs = await translationsConfigRepository.list();
+  const configs = await translationsConfigRepository.listWithPhraseProjectId();
 
   if (!configs.length) {
     logger.warn('No translations config defined, skipping upload translations');

--- a/api/lib/infrastructure/repositories/admin-schemas/translations-config-schema.json
+++ b/api/lib/infrastructure/repositories/admin-schemas/translations-config-schema.json
@@ -21,7 +21,8 @@
     {
       "key": "phraseProjectId",
       "label": "Identifiant projet Phrase",
-      "type": "string"
+      "type": "string",
+      "optional": true
     },
     {
       "key": "frameworkId",

--- a/api/lib/infrastructure/repositories/translations-config-repository.js
+++ b/api/lib/infrastructure/repositories/translations-config-repository.js
@@ -1,8 +1,11 @@
 import { knex } from '../../../db/knex-database-connection.js';
 import { TranslationsConfig } from '../../domain/models/index.js';
 
-export async function list() {
-  const dtos = await knex.select('*').from('translations_config').orderBy('id');
+export async function listWithPhraseProjectId() {
+  const dtos = await knex.select('*')
+    .from('translations_config')
+    .whereNotNull('phraseProjectId')
+    .orderBy('id');
   return dtos.map(toDomain);
 }
 

--- a/api/tests/integration/infrastructure/repositories/translations-config-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translations-config-repository_test.js
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { getByCompetenceId, getByPhraseProjectId, list } from '../../../../lib/infrastructure/repositories/translations-config-repository.js';
+import {
+  getByCompetenceId,
+  getByPhraseProjectId,
+  listWithPhraseProjectId,
+} from '../../../../lib/infrastructure/repositories/translations-config-repository.js';
 import { databaseBuilder, domainBuilder } from '../../../test-helper.js';
 
 describe('Integration | Infrastructure | Repositories | TranslationsConfig', () => {
@@ -47,14 +51,19 @@ describe('Integration | Infrastructure | Repositories | TranslationsConfig', () 
       frameworkId: 'frameworkPixEdu',
       uploadedLocales: ['fr', 'fr-FR'],
     });
+    databaseBuilder.factory.buildTranslationsConfig({
+      phraseProjectId: null,
+      frameworkId: 'frameworkPixEdu',
+      uploadedLocales: ['fr', 'fr-FR'],
+    });
 
     await databaseBuilder.commit();
   });
 
-  describe('#list', () => {
-    it('lists all translations configs', async () => {
+  describe('#listWithPhraseProjectId', () => {
+    it('lists all translations configs with phraseProjectId', async () => {
       // when
-      const translationsConfigs = await list();
+      const translationsConfigs = await listWithPhraseProjectId();
 
       // then
       expect(translationsConfigs).toStrictEqual([

--- a/api/tests/unit/domain/usecases/download-translation-from-phrase_test.js
+++ b/api/tests/unit/domain/usecases/download-translation-from-phrase_test.js
@@ -14,7 +14,7 @@ describe('Unit | Domain | Usecases | download-translation-from-phrase', () => {
         return localesListStub();
       }
     };
-    vi.spyOn(translationsConfigRepository, 'list').mockResolvedValueOnce([domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_ONE_PROJECT', frameworkId: 'framework1', areaId: 'area1', uploadedLocales: ['fr'] }), domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_TWO_PROJECT', frameworkId: 'framework1', areaId: 'area2', uploadedLocales: ['fr'] })]);
+    vi.spyOn(translationsConfigRepository, 'listWithPhraseProjectId').mockResolvedValueOnce([domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_ONE_PROJECT', frameworkId: 'framework1', areaId: 'area1', uploadedLocales: ['fr'] }), domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_TWO_PROJECT', frameworkId: 'framework1', areaId: 'area2', uploadedLocales: ['fr'] })]);
 
     // when
     await downloadTranslationFromPhrase({ Configuration: ConfigurationStub, LocalesApi: LocalesApiStub });
@@ -27,7 +27,7 @@ describe('Unit | Domain | Usecases | download-translation-from-phrase', () => {
     it('should not download from Phrase', async () => {
       // given
       vi.spyOn(config.phrase, 'apiKey', 'get').mockReturnValue(undefined);
-      vi.spyOn(translationsConfigRepository, 'list').mockResolvedValueOnce([domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_ONE_PROJECT', frameworkId: 'framework1', areaId: 'area1', uploadedLocales: ['fr'] }), domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_TWO_PROJECT', frameworkId: 'framework1', areaId: 'area2', uploadedLocales: ['fr'] })]);
+      vi.spyOn(translationsConfigRepository, 'listWithPhraseProjectId').mockResolvedValueOnce([domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_ONE_PROJECT', frameworkId: 'framework1', areaId: 'area1', uploadedLocales: ['fr'] }), domainBuilder.buildTranslationsConfig({ phraseProjectId: 'PHRASE_AREA_TWO_PROJECT', frameworkId: 'framework1', areaId: 'area2', uploadedLocales: ['fr'] })]);
       const ConfigurationStub = vi.fn();
 
       // when

--- a/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
+++ b/api/tests/unit/domain/usecases/upload-translation-to-phrase_test.js
@@ -26,7 +26,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
       }),
     };
 
-    listTranslationsConfigStub = vi.spyOn(translationsConfigRepository, 'list');
+    listTranslationsConfigStub = vi.spyOn(translationsConfigRepository, 'listWithPhraseProjectId');
     getLatestReleaseStub = vi.spyOn(releaseRepository, 'getLatestRelease').mockResolvedValue(release);
     exportTranslationsStub = vi.spyOn(exportTranslationsUsecase, 'exportTranslations');
     scheduleDeleteUnmentionedStub = vi.spyOn(deleteUnmentionedKeysAfterUploadJob, 'schedule');
@@ -219,7 +219,7 @@ describe('Unit | Domain | Usecases | upload-translation-to-phrase', () => {
   });
 
   describe('when no translations configs are defined', () => {
-    it('oes not upload to Phrase', async () => {
+    it('does not upload to Phrase', async () => {
       // given
       const ConfigurationStub = vi.fn();
 


### PR DESCRIPTION
## 🚙 Problème

L'entité `translations_config` n'est désormais plus forcément liée à un projet Phrase. Cependant, la colonne `phraseProjectId` est obligatoire.

## 🍃 Proposition

Rendre cette colonne optionnelle.

## 🔗 Pour tester

- Tests OK ✅
- Se rendre dans le back-office d'administration de Pix Editor.
- Créer une entité `Configuration des traductions` sans renseigner d'identifiant de projet Phrase.
- Constater que l'entité a bien été créée.