### PR TITLE
[TECH] Rendre l'autocomplétion plus intelligente dans les tests

### DIFF
--- a/api/lib/infrastructure/translations/challenge.js
+++ b/api/lib/infrastructure/translations/challenge.js
@@ -2,7 +2,7 @@ import { Challenge, Translation } from '../../domain/models/index.js';
 
 export const prefix = 'challenge.';
 
-export const fields = [
+export const fields = /** @type {const} */ ([
   'instruction',
   'alternativeInstruction',
   'proposals',
@@ -10,7 +10,7 @@ export const fields = [
   'solutionToDisplay',
   'embedTitle',
   'illustrationAlt',
-];
+]);
 
 export function extractFromChallenge(challenge) {
   const locale = Challenge.getPrimaryLocale(challenge.locales);

--- a/api/server.js
+++ b/api/server.js
@@ -12,6 +12,9 @@ import { handleFailAction } from './lib/infrastructure/validation.js';
 
 monitoringTools.installHapiHook();
 
+/**
+ * @returns {Promise<Hapi.Server}
+ */
 export async function createServer() {
   const server = new Hapi.server({
     routes: {

--- a/api/tests/tooling/database-builder/database-buffer.js
+++ b/api/tests/tooling/database-builder/database-buffer.js
@@ -3,6 +3,13 @@ const databaseBuffer = {
   objectsToInsert: {},
   nextId: INITIAL_ID,
 
+  /**
+   * @template InsertedObject
+   * @param {object} params
+   * @param {string} params.tableName
+   * @param {InsertedObject} params.values
+   * @returns {InsertedObject}
+   */
   pushInsertable({ tableName, values }) {
     if (!this.objectsToInsert[tableName]) this.objectsToInsert[tableName] = [];
     this.objectsToInsert[tableName].push(values);

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -22,10 +22,9 @@ export class DatabaseBuilder {
   #dirtyTables = new Set();
 
   constructor({ knex, emptyFirst = true, databaseBuffer = defaultDatabaseBuffer, beforeEmptyDatabase }) {
+    /** @property {typeof knex} knex */
     this.knex = knex;
-    /**
-     *  @property {(typeof factory)} factory
-     */
+    /** @property {typeof factory} factory */
     this.factory = factory;
     this.#databaseBuffer = databaseBuffer;
     this.#emptyFirst = emptyFirst;

--- a/api/tests/tooling/database-builder/factory/build-area.js
+++ b/api/tests/tooling/database-builder/factory/build-area.js
@@ -1,5 +1,15 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   code: `${number}`
+ *   color?: string
+ *   frameworkId: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} areaToBuild
+ */
 export function buildArea({ id, code, color, frameworkId, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'areas',

--- a/api/tests/tooling/database-builder/factory/build-attachment.js
+++ b/api/tests/tooling/database-builder/factory/build-attachment.js
@@ -1,5 +1,19 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   text: string
+ *   size: number
+ *   type: string
+ *   mimeType?: string
+ *   filename: string
+ *   challengeId?: string
+ *   localizedChallengeId: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} attachmentToBuild
+ */
 export function buildAttachment({
   id,
   url,

--- a/api/tests/tooling/database-builder/factory/build-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-challenge.js
@@ -1,5 +1,43 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   type?: string
+ *   t1Status?: boolean
+ *   t2Status?: boolean
+ *   t3Status?: boolean
+ *   status?: string
+ *   skillId?: string
+ *   embedHeight?: number
+ *   timer?: number
+ *   format?: string
+ *   autoReply?: boolean
+ *   locales?: string[]
+ *   focusable?: boolean
+ *   genealogy?: string
+ *   pedagogy?: string
+ *   author?: string[]
+ *   declinable?: string
+ *   version?: number
+ *   alternativeVersion?: number
+ *   accessibility1?: string
+ *   accessibility2?: string
+ *   spoil?: string
+ *   responsive?: string
+ *   delta?: number
+ *   alpha?: number
+ *   shuffled?: boolean
+ *   contextualizedField: string[]
+ *   assessmentMaintenanceTags?: string[]
+ *   translationMaintenanceTags?: string[]
+ *   validatedAt?: string | number | Date
+ *   archivedAt?: string | number | Date
+ *   createdAt?: string | number | Date
+ *   madeObsoleteAt: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} challengeToBuild
+ */
 export function buildChallenge({
   id,
   type,

--- a/api/tests/tooling/database-builder/factory/build-changelog-entry.js
+++ b/api/tests/tooling/database-builder/factory/build-changelog-entry.js
@@ -1,5 +1,15 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   text: string
+ *   author: string
+ *   elementId: string
+ *   elementType?: string
+ *   createdAt?: string | number | Date
+ * }} changelogEntryToBuild
+ */
 export function buildChangelogEntry({ id, text, author, elementId, elementType, createdAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'changelog_entries',

--- a/api/tests/tooling/database-builder/factory/build-competence.js
+++ b/api/tests/tooling/database-builder/factory/build-competence.js
@@ -1,5 +1,14 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   index: `${number}.${number}`
+ *   areaId: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} competenceToBuild
+ */
 export function buildCompetence({ id, index, areaId, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'competences',

--- a/api/tests/tooling/database-builder/factory/build-draft-module.js
+++ b/api/tests/tooling/database-builder/factory/build-draft-module.js
@@ -1,5 +1,29 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   moduleId?: string
+ *   shortId: string
+ *   slug: string
+ *   title: string
+ *   internalTitle: string
+ *   isBeta?: boolean
+ *   visibility: string
+ *   details: {
+ *     image: string
+ *     duration: number
+ *     description: string
+ *     objectives: string[]
+ *     tabletSupport: string
+ *     level: string
+ *   },
+ *   sections: object
+ *   glossary?: object
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} draftModuleToBuild
+ */
 export function buildDraftModule({
   id,
   moduleId,

--- a/api/tests/tooling/database-builder/factory/build-framework.js
+++ b/api/tests/tooling/database-builder/factory/build-framework.js
@@ -1,5 +1,13 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   name: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} frameworkToBuild
+ */
 export function buildFramework({ id, name, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'frameworks',

--- a/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
@@ -10,6 +10,21 @@ import { buildChallenge } from './build-challenge.js';
 import { buildLocalizedChallenge } from './build-localized-challenge.js';
 import { buildTranslation } from './build-translation.js';
 
+/**
+ * @typedef {import('../../../../lib/infrastructure/translations/challenge.js').fields} TranslatedChallengeFieldList
+ * @typedef {TranslatedChallengeFieldList[number]} TranslatedChallengeField
+ */
+
+/**
+ * @param {{
+ *   challenge?: Parameters<typeof buildChallengeDatasourceObject>[0]
+ *   localizedChallenge?: Omit<Parameters<typeof buildLocalizedChallenge>[0], 'id' | 'challengeId'>
+ *   challengeTranslations?: Partial<Record<TranslatedChallengeField, string>>
+ *   skill?: Omit<Parameters<typeof buildSkillDatasourceObject>[0], 'id'>
+ *   framework?: Parameters<typeof buildFramework>[0]
+ *   tube?: Parameters<typeof buildTube>[0]
+ * }} groupToBuild
+ */
 export function buildChallengeInGroup({ challenge, localizedChallenge, challengeTranslations, skill, framework, tube }) {
   const randomId = generateRandomId();
 

--- a/api/tests/tooling/database-builder/factory/build-localized-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-challenge.js
@@ -1,5 +1,26 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id?: string
+ *   challengeId?: string
+ *   locale?: string
+ *   embedUrl?: string
+ *   status?: string
+ *   geography?: string
+ *   urlsToConsult?: string[]
+ *   requireGafamWebsiteAccess?: boolean
+ *   isIncompatibleIpadCertif?: boolean
+ *   isAwarenessChallenge?: boolean
+ *   toRephrase?: boolean
+ *   deafAndHardOfHearing?: string
+ *   hasEmbedInternalValidation?: boolean
+ *   noValidationNeeded?: boolean
+ *   validatedAt?: string | number | Date
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} localizedChallengeToBuild
+ */
 export function buildLocalizedChallenge({
   id = 'i18nChallenge123',
   challengeId = 'challenge123',

--- a/api/tests/tooling/database-builder/factory/build-localized-framework-tubes.js
+++ b/api/tests/tooling/database-builder/factory/build-localized-framework-tubes.js
@@ -1,9 +1,17 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id?: number
+ *   tubeId: string
+ *   maxLevel?: number
+ *   locale?: string
+ * }} localizedFrameworkTubeToBuild
+ */
 export function buildLocalizedFrameworkTubes(
   {
     id = databaseBuffer.nextId++,
-    tubeId = '',
+    tubeId,
     maxLevel = 5,
     locale = 'bz',
   } = {},

--- a/api/tests/tooling/database-builder/factory/build-module.js
+++ b/api/tests/tooling/database-builder/factory/build-module.js
@@ -1,5 +1,29 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   moduleId?: string
+ *   shortId: string
+ *   slug: string
+ *   title: string
+ *   internalTitle: string
+ *   isBeta?: boolean
+ *   visibility: string
+ *   details: {
+ *     image: string
+ *     duration: number
+ *     description: string
+ *     objectives: string[]
+ *     tabletSupport: string
+ *     level: string
+ *   },
+ *   sections: object
+ *   glossary?: object
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} moduleToBuild
+ */
 export function buildModule({
   id,
   shortId,

--- a/api/tests/tooling/database-builder/factory/build-note.js
+++ b/api/tests/tooling/database-builder/factory/build-note.js
@@ -1,5 +1,16 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   status?: string
+ *   text: string
+ *   author: string
+ *   challengeId: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} noteToBuild
+ */
 export function buildNote({ id, status, text, author, challengeId, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'notes',

--- a/api/tests/tooling/database-builder/factory/build-release.js
+++ b/api/tests/tooling/database-builder/factory/build-release.js
@@ -1,5 +1,12 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: number
+ *   content: string
+ *   createdAt?: string | number | Date
+ * }} releaseToBuild
+ */
 export function buildRelease({ id = databaseBuffer.nextId++, content, createdAt = new Date() } = {}) {
   const values = { id, content, createdAt };
 

--- a/api/tests/tooling/database-builder/factory/build-skill.js
+++ b/api/tests/tooling/database-builder/factory/build-skill.js
@@ -1,5 +1,25 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   status?: string
+ *   hintStatus?: string
+ *   description?: string
+ *   descriptionStatus?: string
+ *   level?: number
+ *   internationalisation?: string
+ *   version?: number
+ *   tubeId?: string
+ *   tutorialIds?: string[]
+ *   learningMoreTutorialIds?: string[]
+ *   activatedAt?: string | number | Date
+ *   archivedAt?: string | number | Date
+ *   obsoletedAt?: string | number | Date
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} skillToBuild
+ */
 export function buildSkill({
   id,
   status,

--- a/api/tests/tooling/database-builder/factory/build-static-course-tag.js
+++ b/api/tests/tooling/database-builder/factory/build-static-course-tag.js
@@ -1,5 +1,11 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id?: number
+ *   label: string
+ * }} staticCourseTagToBuild
+ */
 export function buildStaticCourseTag({ id = databaseBuffer.nextId++, label } = {}) {
   const values = { id, label };
 
@@ -9,6 +15,12 @@ export function buildStaticCourseTag({ id = databaseBuffer.nextId++, label } = {
   });
 }
 
+/**
+ * @param {{
+ *   staticCourseTagIds: number[]
+ *   staticCourseId: number
+ * }} courseTagsInfo
+ */
 export function linkTagsTo({ staticCourseTagIds, staticCourseId } = {}) {
   for (const staticCourseTagId of staticCourseTagIds) {
     databaseBuffer.pushInsertable({

--- a/api/tests/tooling/database-builder/factory/build-tag.js
+++ b/api/tests/tooling/database-builder/factory/build-tag.js
@@ -1,5 +1,14 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   title: string
+ *   notes?: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} tagToBuild
+ */
 export function buildTag({ id, title, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'tutorial_tags',

--- a/api/tests/tooling/database-builder/factory/build-thematic.js
+++ b/api/tests/tooling/database-builder/factory/build-thematic.js
@@ -1,5 +1,14 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   index?: number
+ *   competenceId: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} thematicToBuild
+ */
 export function buildThematic({ id, index, competenceId, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'thematics',

--- a/api/tests/tooling/database-builder/factory/build-translation.js
+++ b/api/tests/tooling/database-builder/factory/build-translation.js
@@ -1,5 +1,12 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   key: string
+ *   locale: string
+ *   value: string
+ * }} translationToBuild
+ */
 export function buildTranslation({ key, locale, value } = {}) {
   const translation = databaseBuffer.pushInsertable({
     tableName: 'translations',

--- a/api/tests/tooling/database-builder/factory/build-translations-config.js
+++ b/api/tests/tooling/database-builder/factory/build-translations-config.js
@@ -1,5 +1,14 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id?: number
+ *   phraseProjectId: string
+ *   frameworkId: string
+ *   areaId?: string
+ *   uploadedLocales: string[]
+ * }} translationsConfigToBuild
+ */
 export function buildTranslationsConfig({
   id = databaseBuffer.getNextId(),
   phraseProjectId,

--- a/api/tests/tooling/database-builder/factory/build-tube.js
+++ b/api/tests/tooling/database-builder/factory/build-tube.js
@@ -1,5 +1,15 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   name: string
+ *   index?: string
+ *   thematicId: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} tubeToBuild
+ */
 export function buildTube({ id, name, index, thematicId, createdAt, updatedAt } = {}) {
   return databaseBuffer.pushInsertable({
     tableName: 'tubes',

--- a/api/tests/tooling/database-builder/factory/build-tutorial.js
+++ b/api/tests/tooling/database-builder/factory/build-tutorial.js
@@ -1,5 +1,22 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id: string
+ *   title: string
+ *   duration: string
+ *   source: string
+ *   format: string
+ *   link: string
+ *   license?: string
+ *   level?: string
+ *   crush?: boolean
+ *   locale: string
+ *   tagIds: string[]
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} staticCourseTagToBuild
+ */
 export function buildTutorial({
   id,
   title,

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -1,5 +1,16 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id?: number
+ *   name: string
+ *   trigram?: string
+ *   access: 'admin' | 'editor' | 'replicator' | 'readonly' | 'readpixonly'
+ *   apiKey?: string
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} userToBuild
+ */
 export function buildUser({
   id = databaseBuffer.nextId++,
   name,

--- a/api/tests/tooling/database-builder/factory/build-whitelisted-url.js
+++ b/api/tests/tooling/database-builder/factory/build-whitelisted-url.js
@@ -1,5 +1,20 @@
 import { databaseBuffer } from '../database-buffer.js';
 
+/**
+ * @param {{
+ *   id?: number
+ *   url?: string
+ *   relatedSkillNames?: string
+ *   comment?: string
+ *   checkType?: 'exact_match' | 'starts_with'
+ *   createdBy?: number
+ *   latestUpdatedBy?: number
+ *   deletedBy?: number
+ *   deletedAt?: string | number | Date
+ *   createdAt?: string | number | Date
+ *   updatedAt?: string | number | Date
+ * }} whitelistedUrlToBuild
+ */
 export function buildWhitelistedUrl({
   id = databaseBuffer.nextId++,
   createdBy = null,


### PR DESCRIPTION
## 🚙 Problème

L'autocomplétion sur les databaseBuilders ne donne pas d'indication sur la nécessité des arguments acceptés.

## 🍃 Proposition

Ajouter de la JSDoc qui explicite la liste des arguments attendus par ces fonctions.

## 🦵 Remarques

- La notation TypeScript est utilisée, car la notation JSDoc est trop lourde pour les objets.
- Les builders ayant des valeurs par défaut n'ont pas besoin de JSDoc.

## 🔗 Pour tester

- Tests OK
- Vérifier que l'autocomplétion fonctionne bien.