### PR TITLE
[FEATURE] Ajout d'un message quand il n'y a pas de cadre de traduction. (PIX-23156)

### DIFF
--- a/pix-editor/.template-lintrc.mjs
+++ b/pix-editor/.template-lintrc.mjs
@@ -7,6 +7,7 @@ export default {
     'style-concatenation': false,
     'no-potential-path-strings': false,
     'link-rel-noopener': false,
+    'no-whitespace-within-word': false,
   },
   overrides: [
     {

--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -25,12 +25,10 @@ export default class CompetenceOverview extends Component {
   }
 
   get canDisplayGrid() {
-    return (
-      (this.args.locale &&
-        (this.args.localizedFrameworkTubes?.length !== 0 ||
-          this.args.competenceOverview.thematicOverviews.length !== 0)) ||
-      !this.args.locale
-    );
+    if (!this.args.locale) return true;
+    const areThereLocalizedFrameworkTubes = this.args.localizedFrameworkTubes?.length !== 0;
+    const areThereThematicOverviews = this.args.competenceOverview.thematicOverviews.length !== 0;
+    return areThereLocalizedFrameworkTubes || areThereThematicOverviews;
   }
 
   @action
@@ -133,8 +131,17 @@ export default class CompetenceOverview extends Component {
           {{/each}}
         </div>
       {{else}}
-        <p>Vérifiez qu'un cadre de traduction a bien été créé, ou qu'il y a bien au moins une épreuve de type validé
-          qualité sur cette compétence</p>
+        <p>
+          Si vous voyez ce message :
+        </p>
+        <ul>
+          <li>
+            Vérifiez qu'un cadre de traduction a bien été créé,
+          </li>
+          <li>
+            Ou qu'il y a bien au moins une épreuve de type validé qualité sur cette compétence
+          </li>
+        </ul>
       {{/if}}
       <div class="competence-overview-footer">
         {{#if @locale}}

--- a/pix-editor/app/components/competence-overview/competence-overview.gjs
+++ b/pix-editor/app/components/competence-overview/competence-overview.gjs
@@ -24,6 +24,15 @@ export default class CompetenceOverview extends Component {
     return this.access.mayEditLocalized;
   }
 
+  get canDisplayGrid() {
+    return (
+      (this.args.locale &&
+        (this.args.localizedFrameworkTubes?.length !== 0 ||
+          this.args.competenceOverview.thematicOverviews.length !== 0)) ||
+      !this.args.locale
+    );
+  }
+
   @action
   async fetchTranslations() {
     try {
@@ -74,7 +83,9 @@ export default class CompetenceOverview extends Component {
                 class="competence-overview-actions__fetch"
                 @route="authenticated.v2.localized-framework"
                 @variant="secondary"
-              >Cadre de traduction</PixButtonLink>
+              >
+                Cadre de traduction
+              </PixButtonLink>
             {{/if}}
             <PixButton
               class="competence-overview-actions__fetch"
@@ -99,27 +110,32 @@ export default class CompetenceOverview extends Component {
           </PixButton>
         </div>
       </div>
-      <div class="competence-overview-grid">
-        {{#each @competenceOverview.thematicOverviews as |thematicOverview|}}
-          <div class="thematic" style={{this.thematicStyle thematicOverview}}>
-            <h3>{{thematicOverview.name}}</h3>
-            {{#each thematicOverview.tubeOverviews as |tubeOverview|}}
-              <div class="tube">
-                <h4>{{tubeOverview.name}}</h4>
-                {{#each tubeOverview.skillOverviews as |skillOverview|}}
-                  <CompetenceOverviewSkill
-                    @skillOverview={{skillOverview}}
-                    @locale={{@locale}}
-                    class="skill"
-                    @onSkillClicked={{this.updateSelectedSkillId}}
-                    @isActive={{eq skillOverview.id this.selectedSkillId}}
-                  />
-                {{/each}}
-              </div>
-            {{/each}}
-          </div>
-        {{/each}}
-      </div>
+      {{#if this.canDisplayGrid}}
+        <div class="competence-overview-grid">
+          {{#each @competenceOverview.thematicOverviews as |thematicOverview|}}
+            <div class="thematic" style={{this.thematicStyle thematicOverview}}>
+              <h3>{{thematicOverview.name}}</h3>
+              {{#each thematicOverview.tubeOverviews as |tubeOverview|}}
+                <div class="tube">
+                  <h4>{{tubeOverview.name}}</h4>
+                  {{#each tubeOverview.skillOverviews as |skillOverview|}}
+                    <CompetenceOverviewSkill
+                      @skillOverview={{skillOverview}}
+                      @locale={{@locale}}
+                      class="skill"
+                      @onSkillClicked={{this.updateSelectedSkillId}}
+                      @isActive={{eq skillOverview.id this.selectedSkillId}}
+                    />
+                  {{/each}}
+                </div>
+              {{/each}}
+            </div>
+          {{/each}}
+        </div>
+      {{else}}
+        <p>Vérifiez qu'un cadre de traduction a bien été créé, ou qu'il y a bien au moins une épreuve de type validé
+          qualité sur cette compétence</p>
+      {{/if}}
       <div class="competence-overview-footer">
         {{#if @locale}}
           <ul class="competence-overview-legend">

--- a/pix-editor/app/routes/authenticated/v2/competence-overview.js
+++ b/pix-editor/app/routes/authenticated/v2/competence-overview.js
@@ -9,7 +9,15 @@ export default class CompetenceOverviewRoute extends Route {
   async model(params) {
     const overview = params.overview;
     const { competence, locale } = this.modelFor('authenticated.v2');
+    let localizedFrameworkTubes;
+    const themes = await competence.rawThemes;
 
+    await Promise.all(themes.map((theme) => theme.rawTubes));
+    if (locale) {
+      localizedFrameworkTubes = await this.store.query('localized-framework-tube', {
+        filter: { competenceId: competence.id, locale },
+      });
+    }
     let id = `${competence.pixId}:${overview}`;
     if (locale) id += `:${locale}`;
     const competenceOverview = await this.store.findRecord('competence-overview', id);
@@ -17,6 +25,7 @@ export default class CompetenceOverviewRoute extends Route {
     return {
       competenceOverview,
       locale,
+      localizedFrameworkTubes,
     };
   }
 }

--- a/pix-editor/app/templates/authenticated/v2/competence-overview.gjs
+++ b/pix-editor/app/templates/authenticated/v2/competence-overview.gjs
@@ -19,6 +19,7 @@ export default class CompetenceOverviewTemplate extends Component {
       <CompetenceOverview
         @competenceOverview={{@controller.model.competenceOverview}}
         @locale={{@controller.model.locale}}
+        @localizedFrameworkTubes={{@controller.model.localizedFrameworkTubes}}
       />
     {{/if}}
     {{outlet}}


### PR DESCRIPTION
## 🚙 Problème
Quand il n'y a pas d'épreuve validée qualité et qu'on créé un cadre de traduction, il n'affiche logiquement pas de grille. Mais personne ne sait pourquoi.

## 🍃 Proposition
Afficher donc une phrase qui annonce qu'il n'y a pas d'épreuve validée qualité pour cette compétence.

## 🦵 Remarques
RAS

## 🔗 Pour tester
Tests au vert.
Aller sur la v2, sur une compétence sans épreuve validé qualitée, afficher une langue du type Anglais (rwanda). Normalement, il devrait s'afficher la phrase `Il n’y a aucune épreuve validée qualité sur cette compétence` à la place de la grille d'épreuves.