### PR TITLE
[TECH] Instancier les transaction via la couche Domaine (PIX-23186).

### DIFF
--- a/api/lib/domain/DomainTransaction.js
+++ b/api/lib/domain/DomainTransaction.js
@@ -1,0 +1,58 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { knex } from '../../db/knex-database-connection.js';
+
+/**
+ * @typedef {import('knex').Knex} Knex
+ * @typedef {import('knex').Knex.Transaction} Transaction
+ * @typedef {import('knex').Knex.TransactionConfig} TransactionConfig
+ */
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+class DomainTransaction {
+  /**
+   * @param {Transaction} knexTransaction
+   */
+  constructor(knexTransaction) {
+    this.knexTransaction = knexTransaction;
+  }
+
+  /**
+   * @template {Function} Lambda
+   * @param {Lambda} lambda
+   * @param {TransactionConfig=} transactionConfig
+   * @returns {ReturnType<Lambda> | Promise<ReturnType<Lambda>>}
+   */
+  static execute(lambda, transactionConfig) {
+    const existingConn = DomainTransaction.getConnection();
+    if (existingConn.isTransaction) {
+      return lambda();
+    }
+    let domainTransaction;
+    return knex
+      .transaction((trx) => {
+        domainTransaction = new DomainTransaction(trx);
+        return asyncLocalStorage.run({ transaction: domainTransaction }, lambda, domainTransaction);
+      }, transactionConfig);
+  }
+
+  /**
+   * @returns {Knex | Transaction}
+   */
+  static getConnection() {
+    const store = asyncLocalStorage.getStore();
+
+    if (store?.transaction) {
+      const domainTransaction = store.transaction;
+      return domainTransaction.knexTransaction;
+    }
+    return knex;
+  }
+
+  static emptyTransaction() {
+    return new DomainTransaction(null);
+  }
+}
+
+export { asyncLocalStorage, DomainTransaction };

--- a/api/lib/domain/usecases/import-translations.js
+++ b/api/lib/domain/usecases/import-translations.js
@@ -1,19 +1,19 @@
 import fp from 'lodash/fp.js';
 
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../DomainTransaction.js';
 import { localizedChallengeRepository, translationRepository } from '../../infrastructure/repositories/index.js';
 import { LocalizedChallenge } from '../models/index.js';
 
 export async function importTranslations(translations, dependencies = { translationRepository, localizedChallengeRepository }) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     if (translations.length === 0) return;
 
-    await dependencies.translationRepository.save({ translations, transaction });
+    await dependencies.translationRepository.save({ translations });
 
     const localizedChallenges = extractLocalizedChallengesFromTranslations(translations);
     if (localizedChallenges.length === 0) return;
 
-    await dependencies.localizedChallengeRepository.create({ localizedChallenges, transaction });
+    await dependencies.localizedChallengeRepository.create({ localizedChallenges });
   });
 }
 

--- a/api/lib/domain/usecases/modify-localized-challenge.js
+++ b/api/lib/domain/usecases/modify-localized-challenge.js
@@ -1,23 +1,17 @@
 import { localizedChallengeRepository } from '../../infrastructure/repositories/index.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../DomainTransaction.js';
 import { ForbiddenError } from '../errors.js';
 
 export async function modifyLocalizedChallenge(
   { isAdmin, localizedChallenge },
   dependencies = { localizedChallengeRepository },
 ) {
-  return knex.transaction(async (transaction) => {
-    const originalLocalizedChallenge = await dependencies.localizedChallengeRepository.get({
-      id: localizedChallenge.id,
-      transaction,
-    });
+  return DomainTransaction.execute(async () => {
+    const originalLocalizedChallenge = await dependencies.localizedChallengeRepository.get({ id: localizedChallenge.id });
     if (!isAdmin && localizedChallenge.status !== originalLocalizedChallenge.status) {
       throw new ForbiddenError();
     }
     originalLocalizedChallenge.update(localizedChallenge);
-    return dependencies.localizedChallengeRepository.update({
-      localizedChallenge: originalLocalizedChallenge,
-      transaction,
-    });
+    return dependencies.localizedChallengeRepository.update({ localizedChallenge: originalLocalizedChallenge });
   });
 }

--- a/api/lib/infrastructure/repositories/admin-entity-repository.js
+++ b/api/lib/infrastructure/repositories/admin-entity-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { fetchPage } from '../utils/knex-utils.js';
 
 /**
@@ -13,7 +13,8 @@ import { fetchPage } from '../utils/knex-utils.js';
  * @returns {Promise<{ entities: object[], meta: object }>}
  */
 export async function listByEntityName(entityName, fields, pagination, sort) {
-  const getEntitiesQuery = knex(entityName).select(fields).orderBy(sort.field, sort.direction);
+  const knexConn = DomainTransaction.getConnection();
+  const getEntitiesQuery = knexConn(entityName).select(fields).orderBy(sort.field, sort.direction);
   const { results: entities, pagination: meta } = await fetchPage(getEntitiesQuery, pagination);
 
   return { entities, meta };
@@ -25,7 +26,8 @@ export async function listByEntityName(entityName, fields, pagination, sort) {
  * @returns {Promise<object>}
  */
 export async function save(entityName, entityToSave) {
-  const [record] = await knex(entityName).insert(entityToSave, ['*']);
+  const knexConn = DomainTransaction.getConnection();
+  const [record] = await knexConn(entityName).insert(entityToSave, ['*']);
   return record;
 }
 
@@ -36,7 +38,8 @@ export async function save(entityName, entityToSave) {
  * @returns {Promise<object | undefined>}
  */
 export async function get(entityName, primaryKeyColumn, id) {
-  const record = await knex(entityName).where(primaryKeyColumn, id).first();
+  const knexConn = DomainTransaction.getConnection();
+  const record = await knexConn(entityName).where(primaryKeyColumn, id).first();
   return record;
 }
 
@@ -47,5 +50,6 @@ export async function get(entityName, primaryKeyColumn, id) {
  * @returns {Promise<void>}
  */
 export async function destroy(entityName, primaryKeyColumn, id) {
-  await knex(entityName).where(primaryKeyColumn, id).del();
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn(entityName).where(primaryKeyColumn, id).del();
 }

--- a/api/lib/infrastructure/repositories/area-repository.js
+++ b/api/lib/infrastructure/repositories/area-repository.js
@@ -2,7 +2,7 @@ import * as translationRepository from './translation-repository.js';
 import * as areaTranslations from '../translations/area.js';
 import { Area } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const TABLE_NAME = 'areas';
 const model = 'area';
@@ -11,23 +11,24 @@ const model = 'area';
  * @param {Area} area
  */
 export async function create(area) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     area.id = idGenerator.generateNewId('area');
 
     const translations = areaTranslations.extractFromDomainObject(area);
 
+    const knexConn = DomainTransaction.getConnection();
     await Promise.all([
-      transaction
+      knexConn
         .insert({
           id: area.id,
           code: area.code,
           frameworkId: area.frameworkId,
         })
         .into(TABLE_NAME),
-      translationRepository.save({ translations, transaction }),
+      translationRepository.save({ translations }),
     ]);
 
-    const dto = await selectAreas(transaction).where('areas.id', area.id).first();
+    const dto = await selectAreas().where('areas.id', area.id).first();
 
     return toDomain(dto, translations);
   });
@@ -39,8 +40,8 @@ export async function list() {
   return toDomainList(dtos, translations);
 }
 
-export async function listByFrameworkId(frameworkId, { transaction: knexConn } = {}) {
-  const [dtos, translations] = await Promise.all([selectAreas(knexConn).where('frameworkId', frameworkId).orderBy('code'), translationRepository.listByModel(model, { knexConn })]);
+export async function listByFrameworkId(frameworkId) {
+  const [dtos, translations] = await Promise.all([selectAreas().where('frameworkId', frameworkId).orderBy('code'), translationRepository.listByModel(model)]);
 
   return toDomainList(dtos, translations);
 }
@@ -54,10 +55,11 @@ export async function get(id) {
 }
 
 export async function getByChallengeId(challengeId) {
+  const knexConn = DomainTransaction.getConnection();
   const dto = await selectAreas()
     .whereIn(
       'areas.id',
-      knex.select('competences.areaId')
+      knexConn.select('competences.areaId')
         .from('challenges')
         .join('skills', 'skills.id', 'challenges.skillId')
         .join('tubes', 'tubes.id', 'skills.tubeId')
@@ -69,7 +71,8 @@ export async function getByChallengeId(challengeId) {
   return toDomain(dto);
 }
 
-function selectAreas(knexConn = knex) {
+function selectAreas() {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       'areas.*',

--- a/api/lib/infrastructure/repositories/attachment-repository.js
+++ b/api/lib/infrastructure/repositories/attachment-repository.js
@@ -1,17 +1,19 @@
 import { Attachment } from '../../domain/models/index.js';
 import { AttachmentForReplication } from '../../domain/models/replication/index.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import * as idGenerator from '../utils/id-generator.js';
 
 export async function get(id) {
-  const dto = await knex.select('*').from('attachments').where('id', id).first();
+  const knexConn = DomainTransaction.getConnection();
+  const dto = await knexConn.select('*').from('attachments').where('id', id).first();
 
   if (!dto) return null;
   return toDomain(dto);
 }
 
 export async function list() {
-  const dtos = await knex.select('*').from('attachments').orderBy('id');
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('*').from('attachments').orderBy('id');
 
   return toDomainList(dtos);
 }
@@ -20,7 +22,8 @@ export async function list() {
  * @param {AbortSignal=} signal
  */
 export async function* streamForReplication(signal) {
-  const stream = knex
+  const knexConn = DomainTransaction.getConnection();
+  const stream = knexConn
     .select(
       'attachments.id',
       'attachments.type',
@@ -36,7 +39,7 @@ export async function* streamForReplication(signal) {
       this.onVal('illustration_alt_translations.model', 'challenge')
         .on('illustration_alt_translations.entityId', 'localized_challenges.challengeId')
         .on('illustration_alt_translations.locale', 'localized_challenges.locale')
-        .on(knex.raw('?? like ?', ['illustration_alt_translations.key', '%.illustrationAlt']));
+        .on(knexConn.raw('?? like ?', ['illustration_alt_translations.key', '%.illustrationAlt']));
     })
     .orderBy('id')
     .stream();
@@ -51,7 +54,8 @@ export async function* streamForReplication(signal) {
 }
 
 export async function listByLocalizedChallengeIds(localizedChallengeIds) {
-  const dtos = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn
     .select('*')
     .from('attachments')
     .whereIn('localizedChallengeId', localizedChallengeIds)
@@ -61,15 +65,17 @@ export async function listByLocalizedChallengeIds(localizedChallengeIds) {
 }
 
 export async function listByLocalizedChallengeId(localizedChallengeId) {
-  const dtos = await knex.select('*').from('attachments').where('localizedChallengeId', localizedChallengeId);
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('*').from('attachments').where('localizedChallengeId', localizedChallengeId);
 
   return toDomainList(dtos);
 }
 
-export async function createBatch(attachments, transaction = knex) {
+export async function createBatch(attachments) {
   if (!attachments || attachments.length === 0) return [];
 
-  const dtos = await transaction
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn
     .insert(
       attachments.map((attachment) => ({
         id: idGenerator.generateNewId('attachment'),
@@ -90,9 +96,10 @@ export async function createBatch(attachments, transaction = knex) {
 }
 
 export async function create(attachment) {
+  const knexConn = DomainTransaction.getConnection();
   const id = idGenerator.generateNewId('attachment');
 
-  const [dto] = await knex
+  const [dto] = await knexConn
     .insert({
       id,
       url: attachment.url,
@@ -110,10 +117,11 @@ export async function create(attachment) {
 }
 
 export async function update(attachment) {
-  const [dto] = await knex('attachments')
+  const knexConn = DomainTransaction.getConnection();
+  const [dto] = await knexConn('attachments')
     .update({
       filename: attachment.filename,
-      updatedAt: knex.fn.now(),
+      updatedAt: knexConn.fn.now(),
     })
     .where('id', attachment.id)
     .returning('*');
@@ -122,7 +130,8 @@ export async function update(attachment) {
 }
 
 export async function remove(attachmentId) {
-  await knex.delete().from('attachments').where('id', attachmentId);
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn.delete().from('attachments').where('id', attachmentId);
 }
 
 /**

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { Challenge, Skill, Translation, Tube } from '../../domain/models/index.js';
 import * as translationRepository from './translation-repository.js';
 import * as localizedChallengeRepository from './localized-challenge-repository.js';
@@ -44,7 +44,8 @@ export async function list() {
  * @param {AbortSignal=} signal
  */
 export async function* streamForReplication(signal) {
-  const stream = selectChallenges(undefined, [
+  const knexConn = DomainTransaction.getConnection();
+  const stream = selectChallenges([
     selectTableColumnsAsObject('prototypes', [
       'id',
       'accessibility1',
@@ -64,9 +65,9 @@ export async function* streamForReplication(signal) {
   ])
     .with(
       'prototypes',
-      knex.select('*')
+      knexConn.select('*')
         .from(
-          knex.select(
+          knexConn.select(
             'id',
             'skillId',
             'version',
@@ -74,7 +75,7 @@ export async function* streamForReplication(signal) {
             'accessibility2',
             'assessmentMaintenanceTags',
             'translationMaintenanceTags',
-            knex.raw('ROW_NUMBER() OVER (PARTITION BY ??, ?? ORDER BY ??) AS ??', [
+            knexConn.raw('ROW_NUMBER() OVER (PARTITION BY ??, ?? ORDER BY ??) AS ??', [
               'skillId',
               'version',
               'id',
@@ -109,7 +110,8 @@ export async function* streamForReplication(signal) {
   }
 }
 
-function selectTableColumnsAsObject(table, columns, alias, knexConn = knex) {
+function selectTableColumnsAsObject(table, columns, alias) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn.raw(
     `case when ?? is null then null else json_build_object(${columns.map(() => '?::text, ??').join(', ')}) end as ??`,
     [
@@ -128,6 +130,7 @@ export async function getMany(ids) {
 }
 
 export async function filter(params = {}) {
+  const knexConn = DomainTransaction.getConnection();
   const localizedEntities = await translationRepository.searchLocalizedEntities({
     model,
     fields: ['instruction', 'proposals'],
@@ -139,7 +142,7 @@ export async function filter(params = {}) {
     .whereIn('challenges.id', localizedEntities.map(({ entityId }) => entityId))
     .orWhereIn(
       'challenges.id',
-      knex
+      knexConn
         .select('challengeId')
         .from('localized_challenges')
         .whereILike('embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`),
@@ -155,9 +158,10 @@ export async function filter(params = {}) {
 }
 
 export async function create(challenge) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
     challenge.id = generateNewId(Challenge.ID_PREFIX);
-    await transaction
+    await knexConn
       .insert({
         id: challenge.id,
         type: challenge.type,
@@ -190,21 +194,22 @@ export async function create(challenge) {
       .into('challenges');
 
     const primaryLocalizedChallenge = { ...challenge.localizedChallenges[0], id: challenge.id, challengeId: challenge.id };
-    await localizedChallengeRepository.create({ localizedChallenges: [primaryLocalizedChallenge], transaction });
+    await localizedChallengeRepository.create({ localizedChallenges: [primaryLocalizedChallenge] });
 
     const translations = extractTranslationsFromChallenge(challenge);
-    await translationRepository.save({ translations, transaction });
+    await translationRepository.save({ translations });
 
-    const dto = await selectChallenges(transaction).where('challenges.id', challenge.id).first();
+    const dto = await selectChallenges().where('challenges.id', challenge.id).first();
 
     return toDomain(dto, translations, [primaryLocalizedChallenge]);
   });
 }
 
 export async function createBatch(challenges) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     if (!challenges || challenges.length === 0) return [];
 
+    const knexConn = DomainTransaction.getConnection();
     const allLocalizedChallenges = challenges.flatMap((challenge) => challenge.localizedChallenges);
     const allTranslations = challenges.flatMap((challenge) => {
       const translationModels = [];
@@ -222,7 +227,7 @@ export async function createBatch(challenges) {
       return translationModels;
     });
 
-    await transaction
+    await knexConn
       .insert(
         challenges.map((challenge) => ({
           id: challenge.id,
@@ -256,10 +261,10 @@ export async function createBatch(challenges) {
       )
       .into('challenges');
 
-    await localizedChallengeRepository.create({ localizedChallenges: allLocalizedChallenges, transaction });
-    await translationRepository.save({ translations: allTranslations, transaction });
+    await localizedChallengeRepository.create({ localizedChallenges: allLocalizedChallenges });
+    await translationRepository.save({ translations: allTranslations });
 
-    const dtos = await selectChallenges(transaction)
+    const dtos = await selectChallenges()
       .whereIn(
         'challenges.id',
         challenges.map(({ id }) => id),
@@ -272,8 +277,9 @@ export async function createBatch(challenges) {
 
 // TODO : faire une méthode update au niveau du modèle challenge, comme ça ça update le primary localized challenge en cascade
 // là c'est un peu moche mais on utilise le update de LocalizedChallenge avec un "faux" localizedChallenge de support
-export async function update(challenge, transaction = knex) {
-  await transaction('challenges')
+export async function update(challenge) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('challenges')
     .update({
       type: challenge.type,
       t1Status: challenge.t1Status,
@@ -301,17 +307,14 @@ export async function update(challenge, transaction = knex) {
       archivedAt: challenge.archivedAt,
       madeObsoleteAt: challenge.madeObsoleteAt,
       validatedAt: challenge.validatedAt,
-      updatedAt: transaction.fn.now(),
+      updatedAt: knexConn.fn.now(),
       isQualityOk: challenge.isQualityOk,
       assessmentMaintenanceTags: challenge.assessmentMaintenanceTags,
       translationMaintenanceTags: challenge.translationMaintenanceTags,
     })
     .where('id', challenge.id);
 
-  const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({
-    challengeIds: [challenge.id],
-    transaction,
-  });
+  const localizedChallenges = await localizedChallengeRepository.listByChallengeIds({ challengeIds: [challenge.id] });
   const primaryLocalizedChallenge = localizedChallenges.find(({ isPrimary }) => isPrimary);
 
   const oldPrimaryLocale = primaryLocalizedChallenge.locale;
@@ -330,20 +333,16 @@ export async function update(challenge, transaction = knex) {
   };
   primaryLocalizedChallenge.update(updateLocalizedChallengePOJO);
 
-  await localizedChallengeRepository.update({
-    localizedChallenge: primaryLocalizedChallenge,
-    transaction,
-  });
+  await localizedChallengeRepository.update({ localizedChallenge: primaryLocalizedChallenge });
 
   const translations = extractTranslationsFromChallenge(challenge);
   await translationRepository.deleteByKeyPrefixAndLocales({
     prefix: prefixFor(challenge),
     locales: [oldPrimaryLocale],
-    transaction,
   });
-  await translationRepository.save({ translations, transaction });
+  await translationRepository.save({ translations });
 
-  const dto = await selectChallenges(transaction).where('challenges.id', challenge.id).first();
+  const dto = await selectChallenges().where('challenges.id', challenge.id).first();
 
   return toDomain(dto, translations, localizedChallenges);
 }
@@ -420,7 +419,8 @@ async function loadTranslationsAndLocalizedChallengesForChallengeIds(challengeId
   return Promise.all([translationRepository.listByEntities(model, challengeIds), localizedChallengeRepository.listByChallengeIds({ challengeIds })]);
 }
 
-function selectChallenges(knexConn = knex, projection = []) {
+function selectChallenges(projection = []) {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       'challenges.*',

--- a/api/lib/infrastructure/repositories/changelog-entry-repository.js
+++ b/api/lib/infrastructure/repositories/changelog-entry-repository.js
@@ -1,15 +1,17 @@
 import { ChangelogEntry } from '../../domain/models/ChangelogEntry.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import * as idGenerator from '../utils/id-generator.js';
 
 export async function listByElementId(elementId) {
-  const dtos = await knex.select('*').from('changelog_entries').where('elementId', elementId).orderBy('createdAt', 'asc');
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('*').from('changelog_entries').where('elementId', elementId).orderBy('createdAt', 'asc');
 
   return dtos.map(toDomain);
 }
 
 export async function create(changelogEntry) {
-  const [dto] = await knex.insert({
+  const knexConn = DomainTransaction.getConnection();
+  const [dto] = await knexConn.insert({
     id: idGenerator.generateNewId('changelog'),
     text: changelogEntry.text,
     author: changelogEntry.author,

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -2,7 +2,7 @@ import * as translationRepository from './translation-repository.js';
 import * as competenceTranslations from '../translations/competence.js';
 import { Competence } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const model = 'competence';
 const TABLE_NAME = 'competences';
@@ -28,43 +28,44 @@ export async function get(id) {
 }
 
 export async function create(competence) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     competence.id = idGenerator.generateNewId('competence');
     const translations = competenceTranslations.extractFromDomainObject(competence);
 
+    const knexConn = DomainTransaction.getConnection();
     await Promise.all([
-      transaction
+      knexConn
         .insert({
           id: competence.id,
           index: competence.index,
           areaId: competence.areaAirtableId,
         })
         .into(TABLE_NAME),
-      translationRepository.save({ translations, transaction }),
+      translationRepository.save({ translations }),
     ]);
 
-    const dto = await _selectCompetences(transaction).where('competences.id', competence.id).first();
+    const dto = await _selectCompetences().where('competences.id', competence.id).first();
 
     return toDomain(dto, translations);
   });
 }
 
 export async function update(competence) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     const translations = competenceTranslations.extractFromDomainObject(competence);
 
     await translationRepository.deleteByKeyPrefixAndLocales({
       prefix: `${competenceTranslations.prefix}${competence.id}.`,
       locales: ['fr', 'en'],
-      transaction,
     });
-    await translationRepository.save({ translations, transaction });
+    await translationRepository.save({ translations });
 
     return competence;
   });
 }
 
-export function _selectCompetences(knexConn = knex) {
+export function _selectCompetences() {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       'competences.*',

--- a/api/lib/infrastructure/repositories/draft-module-repository.js
+++ b/api/lib/infrastructure/repositories/draft-module-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { DraftModule } from '../../domain/models/index.js';
 import { NotFoundError } from '../errors.js';
 
-export async function save({ details, sections, glossary, ...module }, transaction = knex) {
+export async function save({ details, sections, glossary, ...module }) {
+  const knexConn = DomainTransaction.getConnection();
   const draftModuleDTO = {
     ...module,
     ...details,
@@ -10,13 +11,14 @@ export async function save({ details, sections, glossary, ...module }, transacti
     glossary: JSON.stringify(glossary),
   };
 
-  const [savedDraftModule] = await transaction.insert(draftModuleDTO).into('draft-modules').onConflict('id').merge({ ...draftModuleDTO, updatedAt: transaction.fn.now() }).returning('*');
+  const [savedDraftModule] = await knexConn.insert(draftModuleDTO).into('draft-modules').onConflict('id').merge({ ...draftModuleDTO, updatedAt: knexConn.fn.now() }).returning('*');
 
   return toDomain(savedDraftModule);
 }
 
 export async function list({ page, sort = [['internalTitle', 'asc']] } = {}) {
-  const query = knex.select().from('draft-modules');
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn.select().from('draft-modules');
   sort.forEach(([column, order]) => {
     if (['internalTitle', 'title'].includes(column)) {
       query.orderByRaw(`?? collate ?? ${order}`, [column, 'fr-x-icu']);
@@ -33,12 +35,14 @@ export async function list({ page, sort = [['internalTitle', 'asc']] } = {}) {
 }
 
 export async function count() {
-  const { count } = await knex('draft-modules').count().first();
+  const knexConn = DomainTransaction.getConnection();
+  const { count } = await knexConn('draft-modules').count().first();
   return count;
 }
 
 export async function getById({ id }) {
-  const draftModule = await knex('draft-modules').where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const draftModule = await knexConn('draft-modules').where({ id }).first();
 
   if (!draftModule) {
     throw new NotFoundError('Draft module not found');

--- a/api/lib/infrastructure/repositories/framework-repository.js
+++ b/api/lib/infrastructure/repositories/framework-repository.js
@@ -1,11 +1,12 @@
 import { Framework } from '../../domain/models/index.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import * as idGenerator from '../utils/id-generator.js';
 
 const TABLE_NAME = 'frameworks';
 
 export async function list() {
-  const dtos = await selectFrameworks().orderBy('createdAt');
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await selectFrameworks(knexConn).orderBy('createdAt');
 
   return dtos.map(toDomain);
 }
@@ -14,30 +15,31 @@ export async function list() {
  * @param {Framework} framework
  */
 export async function create(framework) {
+  const knexConn = DomainTransaction.getConnection();
   const id = idGenerator.generateNewId('framework');
 
-  await knex
+  await knexConn
     .insert({
       id,
       name: framework.name,
     })
     .into(TABLE_NAME);
 
-  const dto = await selectFrameworks().where('id', id).first();
+  const dto = await selectFrameworks(knexConn).where('id', id).first();
 
   return toDomain(dto);
 }
 
-function selectFrameworks() {
-  return knex
+function selectFrameworks(knexConn) {
+  return knexConn
     .select(
       '*',
-      knex.raw(
+      knexConn.raw(
         'coalesce((??), \'[]\') as "areaIds"',
-        knex
-          .select(knex.raw('json_agg(?? order by ??)', ['areas.id', 'areas.code']))
+        knexConn
+          .select(knexConn.raw('json_agg(?? order by ??)', ['areas.id', 'areas.code']))
           .from('areas')
-          .where('areas.frameworkId', '=', knex.ref(`${TABLE_NAME}.id`)),
+          .where('areas.frameworkId', '=', knexConn.ref(`${TABLE_NAME}.id`)),
       ),
     )
     .from(TABLE_NAME);

--- a/api/lib/infrastructure/repositories/localized-challenge-repository.js
+++ b/api/lib/infrastructure/repositories/localized-challenge-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { NotFoundError } from '../../domain/errors.js';
 import { LocalizedChallenge } from '../../domain/models/index.js';
 import { generateNewId } from '../utils/id-generator.js';
@@ -17,13 +17,13 @@ function _generateId() {
 export async function create({
   localizedChallenges = [],
   generateId = _generateId,
-  transaction: knexConnection = knex,
 }) {
   if (localizedChallenges.length === 0) {
     return;
   }
+  const knexConn = DomainTransaction.getConnection();
   const dataToInsert = adaptModelsForDB(localizedChallenges, generateId);
-  await knexConnection('localized_challenges').insert(dataToInsert).onConflict().ignore();
+  await knexConn('localized_challenges').insert(dataToInsert).onConflict().ignore();
 }
 
 export async function getByChallengeIdAndLocale({ challengeId, locale }) {
@@ -39,23 +39,23 @@ export async function getByChallengeIdAndLocale({ challengeId, locale }) {
   return toDomain(dto);
 }
 
-export async function listByChallengeIds({ challengeIds, transaction: knexConnection = knex }) {
-  const dtos = await _queryLocalizedChallengeWithAttachment(knexConnection)
+export async function listByChallengeIds({ challengeIds }) {
+  const dtos = await _queryLocalizedChallengeWithAttachment()
     .whereIn('localized_challenges.challengeId', challengeIds)
     .orderBy(['localized_challenges.challengeId', 'localized_challenges.locale']);
   return dtos.map(toDomain);
 }
 
-export async function get({ id, transaction: knexConnection = knex }) {
-  const dto = await _queryLocalizedChallengeWithAttachment(knexConnection).where('localized_challenges.id', id).first();
+export async function get({ id }) {
+  const dto = await _queryLocalizedChallengeWithAttachment().where('localized_challenges.id', id).first();
 
   if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');
 
   return toDomain(dto);
 }
 
-export async function getMany({ ids, transaction: knexConnection = knex }) {
-  const dtos = await _queryLocalizedChallengeWithAttachment(knexConnection)
+export async function getMany({ ids }) {
+  const dtos = await _queryLocalizedChallengeWithAttachment()
     .whereIn('localized_challenges.id', ids)
     .orderBy(['localized_challenges.challengeId', 'localized_challenges.locale']);
 
@@ -63,6 +63,7 @@ export async function getMany({ ids, transaction: knexConnection = knex }) {
 }
 
 export async function filter(params = {}) {
+  const knexConn = DomainTransaction.getConnection();
   const localizedEntities = await translationRepository.searchLocalizedEntities({
     model: 'challenge',
     fields: ['instruction', 'proposals'],
@@ -70,7 +71,7 @@ export async function filter(params = {}) {
     limit: params.page?.limit,
   });
 
-  let query = knex.select().from('localized_challenges')
+  let query = knexConn.select().from('localized_challenges')
     .whereIn(['challengeId', 'locale'], localizedEntities.map(({ entityId, locale }) => [entityId, locale]))
     .orWhereILike('embedUrl', `%${escapeLikeWildcards(params.filter.search)}%`)
     .orderBy('id');
@@ -84,17 +85,18 @@ export async function filter(params = {}) {
   return dtos.map(toDomain);
 }
 
-export async function update({ localizedChallenge, transaction: knexConnection = knex }) {
+export async function update({ localizedChallenge }) {
+  const knexConn = DomainTransaction.getConnection();
   const localizedChallengeForDB = adaptModelForDB(localizedChallenge);
   delete localizedChallengeForDB.id;
-  const [dto] = await knexConnection('localized_challenges')
+  const [dto] = await knexConn('localized_challenges')
     .where('id', localizedChallenge.id)
     .update(localizedChallengeForDB)
     .returning('*');
 
   if (!dto) throw new NotFoundError('Épreuve ou langue introuvable');
 
-  const [primaryEmbedUrl] = await knexConnection('localized_challenges')
+  const [primaryEmbedUrl] = await knexConn('localized_challenges')
     .where({ id: dto.challengeId })
     .pluck('embedUrl');
 
@@ -133,18 +135,19 @@ function adaptModelForDB(localizedChallenge, generateId) {
   };
 }
 
-function _queryLocalizedChallengeWithAttachment(knexConnection = knex) {
-  return knexConnection
+function _queryLocalizedChallengeWithAttachment() {
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn
     .select(
       'localized_challenges.*',
       'primaryLocalizedChallenge.embedUrl as primaryEmbedUrl',
-      knex.raw(
+      knexConn.raw(
         'coalesce((??), \'[]\') as "fileIds"',
-        knex
-          .select(knex.raw('json_agg(??)', 'attachments.id'))
+        knexConn
+          .select(knexConn.raw('json_agg(??)', 'attachments.id'))
           .from('attachments')
-          .where('attachments.challengeId', knex.ref('localized_challenges.challengeId')) // necessary to use index on (challengeId, localizedChallengeId)
-          .where('attachments.localizedChallengeId', knex.ref('localized_challenges.id')),
+          .where('attachments.challengeId', knexConn.ref('localized_challenges.challengeId')) // necessary to use index on (challengeId, localizedChallengeId)
+          .where('attachments.localizedChallengeId', knexConn.ref('localized_challenges.id')),
       ),
     )
     .from('localized_challenges')

--- a/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
+++ b/api/lib/infrastructure/repositories/localized-framework-tubes-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { LocalizedFrameworkTubes } from '../../domain/models/index.js';
 
 export async function filter({ competenceId, locale }) {
-  const localizedFrameworkTubesDtos = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const localizedFrameworkTubesDtos = await knexConn
     .select('localized_framework_tubes.*')
     .from('thematics')
     .join('tubes', 'tubes.thematicId', 'thematics.id')
@@ -13,7 +14,8 @@ export async function filter({ competenceId, locale }) {
   return toDomainList(localizedFrameworkTubesDtos);
 }
 
-export async function save(localizedFrameworkTubes, { transaction: knexConn = knex, onConflict = 'merge' } = {}) {
+export async function save(localizedFrameworkTubes, { onConflict = 'merge' } = {}) {
+  const knexConn = DomainTransaction.getConnection();
   let query = knexConn('localized_framework_tubes')
     .insert(localizedFrameworkTubes.map((localizedFrameworkTube) => ({
       id: localizedFrameworkTube.id,

--- a/api/lib/infrastructure/repositories/mission-repository.js
+++ b/api/lib/infrastructure/repositories/mission-repository.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { fetchPage } from '../utils/knex-utils.js';
 import { Mission } from '../../domain/models/index.js';
 import * as missionTranslations from '../translations/mission.js';
@@ -9,7 +9,8 @@ import * as translationRepository from './translation-repository.js';
 const model = 'mission';
 
 export async function getById(id) {
-  const [mission, translations] = await Promise.all([knex('missions').select('*').where({ id }).first(), translationRepository.listByEntity(model, id)]);
+  const knexConn = DomainTransaction.getConnection();
+  const [mission, translations] = await Promise.all([knexConn('missions').select('*').where({ id }).first(), translationRepository.listByEntity(model, id)]);
 
   if (!mission) {
     throw new NotFoundError('Mission introuvable');
@@ -19,7 +20,8 @@ export async function getById(id) {
 }
 
 export async function findAllMissions({ filter, page }) {
-  const query = knex('missions').select('*').orderBy('createdAt', 'desc');
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn('missions').select('*').orderBy('createdAt', 'desc');
   if (filter?.statuses) {
     query.whereIn(
       'status',
@@ -39,13 +41,15 @@ export async function findAllMissions({ filter, page }) {
 }
 
 export async function list() {
-  const [missions, translations] = await Promise.all([knex('missions').select('*').orderBy('id'), translationRepository.listByModel(model)]);
+  const knexConn = DomainTransaction.getConnection();
+  const [missions, translations] = await Promise.all([knexConn('missions').select('*').orderBy('id'), translationRepository.listByModel(model)]);
 
   return _toDomainList(missions, translations);
 }
 
 export async function save(mission) {
-  const [insertedMission] = await knex('missions')
+  const knexConn = DomainTransaction.getConnection();
+  const [insertedMission] = await knexConn('missions')
     .insert({
       id: mission.id,
       cardImageUrl: mission.cardImageUrl,

--- a/api/lib/infrastructure/repositories/module-repository.js
+++ b/api/lib/infrastructure/repositories/module-repository.js
@@ -1,14 +1,16 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { Module, ModuleForConsultation } from '../../domain/models/index.js';
 import { ModuleForReplication } from '../../domain/models/replication/index.js';
 import { NotFoundError } from '../errors.js';
 
 export async function count() {
-  const { count } = await knex('modules').count().first();
+  const knexConn = DomainTransaction.getConnection();
+  const { count } = await knexConn('modules').count().first();
   return count;
 }
 
-export async function save({ details, sections, glossary, ...module }, transaction = knex) {
+export async function save({ details, sections, glossary, ...module }) {
+  const knexConn = DomainTransaction.getConnection();
   const moduleDTO = {
     ...module,
     ...details,
@@ -16,13 +18,14 @@ export async function save({ details, sections, glossary, ...module }, transacti
     glossary: JSON.stringify(glossary),
   };
 
-  const [savedModule] = await transaction.insert(moduleDTO).into('modules').onConflict('id').merge({ ...moduleDTO, updatedAt: transaction.fn.now() }).returning('*');
+  const [savedModule] = await knexConn.insert(moduleDTO).into('modules').onConflict('id').merge({ ...moduleDTO, updatedAt: knexConn.fn.now() }).returning('*');
 
   return toDomain(savedModule);
 }
 
 export async function list({ page, sort = [['internalTitle', 'asc']] } = {}) {
-  const query = knex.select().from('modules');
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn.select().from('modules');
   sort.forEach(([column, order]) => {
     if (['internalTitle', 'title'].includes(column)) {
       query.orderByRaw(`?? collate ?? ${order}`, [column, 'fr-x-icu']);
@@ -39,7 +42,8 @@ export async function list({ page, sort = [['internalTitle', 'asc']] } = {}) {
 }
 
 export async function listForReplication() {
-  const modules = await knex.select(
+  const knexConn = DomainTransaction.getConnection();
+  const modules = await knexConn.select(
     'id',
     'shortId',
     'slug',
@@ -54,9 +58,9 @@ export async function listForReplication() {
 }
 
 export async function getById({ id }) {
-  const module = await knex
-    .select('modules.*', 'draft-modules.id as draftModuleId')
-    .from('modules')
+  const knexConn = DomainTransaction.getConnection();
+
+  const module = await knexConn('modules').select('modules.*', 'draft-modules.id as draftModuleId')
     .leftOuterJoin('draft-modules', 'draft-modules.moduleId', 'modules.id')
     .where('modules.id', id)
     .first();

--- a/api/lib/infrastructure/repositories/note-repository.js
+++ b/api/lib/infrastructure/repositories/note-repository.js
@@ -1,15 +1,17 @@
 import { Note } from '../../domain/models/Note.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import * as idGenerator from '../utils/id-generator.js';
 
 export async function listByChallengeId(challengeId) {
-  const dtos = await knex.select('*').from('notes').where('challengeId', challengeId).orderBy('createdAt', 'asc');
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('*').from('notes').where('challengeId', challengeId).orderBy('createdAt', 'asc');
 
   return dtos.map(toDomain);
 }
 
 export async function create(note) {
-  const [dto] = await knex.insert({
+  const knexConn = DomainTransaction.getConnection();
+  const [dto] = await knexConn.insert({
     id: idGenerator.generateNewId('note'),
     status: note.status,
     text: note.text,
@@ -21,12 +23,13 @@ export async function create(note) {
 }
 
 export async function update(noteId, note) {
-  const [dto] = await knex('notes').update({
+  const knexConn = DomainTransaction.getConnection();
+  const [dto] = await knexConn('notes').update({
     status: note.status,
     text: note.text,
     author: note.author,
     challengeId: note.challengeId,
-    updatedAt: knex.fn.now(),
+    updatedAt: knexConn.fn.now(),
   }).where('id', noteId).returning('*');
 
   return toDomain(dto);

--- a/api/lib/infrastructure/repositories/release-repository.js
+++ b/api/lib/infrastructure/repositories/release-repository.js
@@ -25,33 +25,37 @@ import {
 } from '../transformers/index.js';
 import { Content, Release } from '../../domain/models/release/index.js';
 
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 export function getCurrentContent() {
   return _getCurrentContent();
 }
 
 export async function create(getCurrentContent = _getCurrentContent) {
+  const knexConn = DomainTransaction.getConnection();
   const content = await getCurrentContent();
-  const release = await knex('releases').insert({ content }, ['id']);
+  const release = await knexConn('releases').insert({ content }, ['id']);
 
   return release[0].id;
 }
 
 export async function getLatestRelease() {
-  const release = await knex('releases').select('id', 'content', 'createdAt').orderBy('createdAt', 'desc').limit(1);
+  const knexConn = DomainTransaction.getConnection();
+  const release = await knexConn('releases').select('id', 'content', 'createdAt').orderBy('createdAt', 'desc').limit(1);
 
   return _toDomain(release[0]);
 }
 
 export async function getLatestReleaseDate() {
-  const [createdAt] = await knex('releases').pluck('createdAt').orderBy('createdAt', 'desc').limit(1);
+  const knexConn = DomainTransaction.getConnection();
+  const [createdAt] = await knexConn('releases').pluck('createdAt').orderBy('createdAt', 'desc').limit(1);
 
   return createdAt;
 }
 
 export async function getRelease(id) {
-  const release = await knex('releases').select('id', 'content', 'createdAt').where('id', id);
+  const knexConn = DomainTransaction.getConnection();
+  const release = await knexConn('releases').select('id', 'content', 'createdAt').where('id', id);
 
   return _toDomain(release[0]);
 }
@@ -128,7 +132,8 @@ async function _getCurrentContent() {
 }
 
 async function getStaticCourses() {
-  const staticCoursesDTO = await knex('static_courses')
+  const knexConn = DomainTransaction.getConnection();
+  const staticCoursesDTO = await knexConn('static_courses')
     .select([
       'id',
       'name',

--- a/api/lib/infrastructure/repositories/skill-repository.js
+++ b/api/lib/infrastructure/repositories/skill-repository.js
@@ -1,7 +1,7 @@
 import * as translationRepository from './translation-repository.js';
 import * as skillTranslations from '../translations/skill.js';
 import { Skill } from '../../domain/models/Skill.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const TABLE_NAME = 'skills';
 const TUTORIALS_RELATION_TABLE_NAME = 'skills-tutorials';
@@ -118,7 +118,8 @@ export async function search(params) {
   return toDomainList(dtos, translations);
 }
 
-export function selectSkills(knexConn = knex) {
+export function selectSkills() {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       'skills.*',
@@ -162,8 +163,9 @@ export function selectSkills(knexConn = knex) {
 }
 
 export async function create(skill) {
-  return knex.transaction(async (transaction) => {
-    await transaction
+  return DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn
       .insert({
         id: skill.id,
         status: skill.status,
@@ -178,7 +180,7 @@ export async function create(skill) {
       .into(TABLE_NAME);
 
     const translations = skillTranslations.extractFromDomainObject(skill);
-    await translationRepository.save({ translations, transaction });
+    await translationRepository.save({ translations });
 
     const skillTutorials = [
       ...(skill.tutorialAirtableIds?.map((tutorialId) => ({
@@ -193,18 +195,19 @@ export async function create(skill) {
       })) ?? []),
     ];
     if (skillTutorials.length > 0) {
-      await transaction.insert(skillTutorials).into(TUTORIALS_RELATION_TABLE_NAME);
+      await knexConn.insert(skillTutorials).into(TUTORIALS_RELATION_TABLE_NAME);
     }
 
-    const dto = await selectSkills(transaction).where('skills.id', skill.id).first();
+    const dto = await selectSkills().where('skills.id', skill.id).first();
 
     return toDomain(dto, translations);
   });
 }
 
 export async function update(skill) {
-  return knex.transaction(async (transaction) => {
-    await transaction(TABLE_NAME)
+  return DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn(TABLE_NAME)
       .update({
         status: skill.status,
         hintStatus: skill.hintStatus,
@@ -216,7 +219,7 @@ export async function update(skill) {
         activatedAt: skill.activatedAt,
         archivedAt: skill.archivedAt,
         obsoletedAt: skill.obsoletedAt,
-        updatedAt: transaction.fn.now(),
+        updatedAt: knexConn.fn.now(),
       })
       .where('id', skill.id);
 
@@ -224,9 +227,8 @@ export async function update(skill) {
     await translationRepository.deleteByKeyPrefixAndLocales({
       prefix: `${skillTranslations.prefix}${skill.id}.`,
       locales: ['fr', 'en'],
-      transaction,
     });
-    await translationRepository.save({ translations, transaction });
+    await translationRepository.save({ translations });
 
     const skillTutorials = [
       ...skill.tutorialAirtableIds.map((tutorialId) => ({
@@ -240,7 +242,7 @@ export async function update(skill) {
         type: TUTORIAL_RELATION_TYPES.LEARNING_MORE,
       })),
     ];
-    await transaction
+    await knexConn
       .delete()
       .from(TUTORIALS_RELATION_TABLE_NAME)
       .where('skillId', skill.id)
@@ -249,7 +251,7 @@ export async function update(skill) {
         skillTutorials.map(({ tutorialId, type }) => [tutorialId, type]),
       );
     if (skillTutorials.length > 0) {
-      await transaction
+      await knexConn
         .insert(skillTutorials)
         .into(TUTORIALS_RELATION_TABLE_NAME)
         .onConflict([
@@ -257,10 +259,10 @@ export async function update(skill) {
           'tutorialId',
           'type',
         ])
-        .merge({ updatedAt: transaction.fn.now() });
+        .merge({ updatedAt: knexConn.fn.now() });
     }
 
-    const dto = await selectSkills(transaction).where('skills.id', skill.id).first();
+    const dto = await selectSkills().where('skills.id', skill.id).first();
 
     return toDomain(dto, translations);
   });

--- a/api/lib/infrastructure/repositories/static-course-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-repository.js
@@ -1,4 +1,4 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { fetchPage } from '../utils/knex-utils.js';
 import {
   ChallengeSummary as ChallengeSummary_Read,
@@ -15,14 +15,15 @@ import _ from 'lodash';
 import { escapeLikeWildcards } from './sql-utils.js';
 
 export async function findReadSummaries({ filter, page }) {
-  const query = knex('static_courses')
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn('static_courses')
     .select({
       id: 'static_courses.id',
       name: 'static_courses.name',
       createdAt: 'static_courses.createdAt',
       challengeIds: 'static_courses.challengeIds',
       isActive: 'static_courses.isActive',
-      tags: knex.raw(`
+      tags: knexConn.raw(`
         json_agg(
           json_build_object('id', "static_course_tags"."id", 'label', "static_course_tags"."label")
           ORDER BY "static_course_tags"."label" ASC
@@ -42,7 +43,7 @@ export async function findReadSummaries({ filter, page }) {
   if (filter.tagIds?.length) {
     query.whereIn(
       'static_courses.id',
-      knex.select('staticCourseId').from('static_courses_tags_link').whereIn('staticCourseTagId', filter.tagIds),
+      knexConn.select('staticCourseId').from('static_courses_tags_link').whereIn('staticCourseTagId', filter.tagIds),
     );
   }
 
@@ -66,7 +67,8 @@ export async function findReadSummaries({ filter, page }) {
 }
 
 export async function getRead(id, { baseUrl }) {
-  const staticCourse = await knex('static_courses')
+  const knexConn = DomainTransaction.getConnection();
+  const staticCourse = await knexConn('static_courses')
     .select({
       id: 'static_courses.id',
       name: 'static_courses.name',
@@ -76,7 +78,7 @@ export async function getRead(id, { baseUrl }) {
       deactivationReason: 'static_courses.deactivationReason',
       challengeIds: 'static_courses.challengeIds',
       isActive: 'static_courses.isActive',
-      tags: knex.raw(`
+      tags: knexConn.raw(`
         json_agg(
           json_build_object('id', "static_course_tags"."id", 'label', "static_course_tags"."label")
           ORDER BY "static_course_tags"."label" ASC
@@ -109,7 +111,8 @@ export async function getRead(id, { baseUrl }) {
 }
 
 export async function get(id) {
-  const staticCourse = await knex('static_courses')
+  const knexConn = DomainTransaction.getConnection();
+  const staticCourse = await knexConn('static_courses')
     .select({
       id: 'static_courses.id',
       name: 'static_courses.name',
@@ -119,7 +122,7 @@ export async function get(id) {
       deactivationReason: 'static_courses.deactivationReason',
       challengeIds: 'static_courses.challengeIds',
       isActive: 'static_courses.isActive',
-      tags: knex.raw(`
+      tags: knexConn.raw(`
         json_agg(
           json_build_object('id', "static_course_tags"."id")
           ORDER BY "static_course_tags"."label" ASC
@@ -159,11 +162,12 @@ export async function save(staticCourseForCreation) {
     createdAt: staticCourseDTO.createdAt,
     updatedAt: staticCourseDTO.updatedAt,
   };
-  await knex.transaction(async (trx) => {
-    await trx('static_courses').insert(serializedStaticCourseForDB).onConflict('id').merge();
-    await trx('static_courses_tags_link').del().where('staticCourseId', serializedStaticCourseForDB.id);
+  await DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn('static_courses').insert(serializedStaticCourseForDB).onConflict('id').merge();
+    await knexConn('static_courses_tags_link').del().where('staticCourseId', serializedStaticCourseForDB.id);
     if (staticCourseDTO.tagIds.length > 0) {
-      await trx('static_courses_tags_link').insert(
+      await knexConn('static_courses_tags_link').insert(
         staticCourseDTO.tagIds.map((staticCourseDtoTagId) => ({
           staticCourseTagId: staticCourseDtoTagId,
           staticCourseId: serializedStaticCourseForDB.id,
@@ -201,7 +205,8 @@ async function findChallengeSummaries(localizedChallengeIds, { baseUrl }) {
 }
 
 export async function listForReplication() {
-  const dtos = await knex.select('id', 'name').from('static_courses').orderBy('id');
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('id', 'name').from('static_courses').orderBy('id');
   return dtos.map((dto) => new CourseForReplication(dto));
 }
 

--- a/api/lib/infrastructure/repositories/static-course-tag-repository.js
+++ b/api/lib/infrastructure/repositories/static-course-tag-repository.js
@@ -1,11 +1,13 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { StaticCourseTag } from '../../domain/readmodels/index.js';
 
 export async function listIds() {
-  return knex('static_course_tags').pluck('id').orderBy('id', 'ASC');
+  const knexConn = DomainTransaction.getConnection();
+  return knexConn('static_course_tags').pluck('id').orderBy('id', 'ASC');
 }
 
 export async function list() {
-  const tags = await knex('static_course_tags').select('id', 'label').orderBy('id', 'ASC');
+  const knexConn = DomainTransaction.getConnection();
+  const tags = await knexConn('static_course_tags').select('id', 'label').orderBy('id', 'ASC');
   return tags.map((tag) => new StaticCourseTag({ id: tag.id, label: tag.label }));
 }

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -1,20 +1,22 @@
 import { Tag } from '../../domain/models/index.js';
 import { generateNewId } from '../utils/id-generator.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { escapeLikeWildcards } from './sql-utils.js';
 
 const TABLE_NAME = 'tutorial_tags';
 
 export async function create(tag) {
+  const knexConn = DomainTransaction.getConnection();
   const dto = { id: generateNewId('tag'), title: tag.title };
 
-  await knex(TABLE_NAME).insert(dto);
+  await knexConn(TABLE_NAME).insert(dto);
 
   return toDomain(dto);
 }
 
 export async function get(id) {
-  const dto = await knex.select('*').from(TABLE_NAME).where('id', id).first();
+  const knexConn = DomainTransaction.getConnection();
+  const dto = await knexConn.select('*').from(TABLE_NAME).where('id', id).first();
   if (!dto) return null;
 
   return toDomain(dto);
@@ -23,13 +25,15 @@ export async function get(id) {
 export async function getMany(ids) {
   if (!ids?.length) return [];
 
-  const dtos = await knex.select('*').from(TABLE_NAME).whereIn('id', ids).orderBy('id');
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('*').from(TABLE_NAME).whereIn('id', ids).orderBy('id');
 
   return dtos.map(toDomain);
 }
 
 export async function searchByTitle(title) {
-  const dtos = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn
     .select('*')
     .from(TABLE_NAME)
     .whereILike('title', `%${escapeLikeWildcards(title)}%`)
@@ -40,10 +44,11 @@ export async function searchByTitle(title) {
 }
 
 export async function findByTitle(title) {
-  const dto = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const dto = await knexConn
     .select('*')
     .from(TABLE_NAME)
-    .where(knex.raw('LOWER(??)', 'title'), title.toLowerCase())
+    .where(knexConn.raw('LOWER(??)', 'title'), title.toLowerCase())
     .first();
 
   if (!dto) return null;

--- a/api/lib/infrastructure/repositories/thematic-repository.js
+++ b/api/lib/infrastructure/repositories/thematic-repository.js
@@ -4,7 +4,7 @@ import * as translationRepository from './translation-repository.js';
 import * as thematicTranslations from '../translations/thematic.js';
 import { Thematic } from '../../domain/models/index.js';
 import * as idGenerator from '../utils/id-generator.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const model = 'thematic';
 const TABLE_NAME = 'thematics';
@@ -45,48 +45,50 @@ export async function listByCompetenceId(competenceId) {
 }
 
 export async function create(thematic) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     thematic.id = idGenerator.generateNewId('thematic');
     const translations = thematicTranslations.extractFromDomainObject(thematic);
 
+    const knexConn = DomainTransaction.getConnection();
     await Promise.all([
-      transaction
+      knexConn
         .insert({
           id: thematic.id,
           index: thematic.index,
           competenceId: thematic.competenceAirtableId,
         })
         .into(TABLE_NAME),
-      translationRepository.save({ translations, transaction }),
+      translationRepository.save({ translations }),
     ]);
 
-    const dto = await selectThematics(transaction).where('id', thematic.id).first();
+    const dto = await selectThematics().where('id', thematic.id).first();
 
     return toDomain(dto, translations);
   });
 }
 
 export async function update(thematic) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     const translations = thematicTranslations.extractFromDomainObject(thematic);
 
-    await transaction(TABLE_NAME)
-      .update({ index: thematic.index, updatedAt: transaction.fn.now() })
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn(TABLE_NAME)
+      .update({ index: thematic.index, updatedAt: knexConn.fn.now() })
       .where('id', thematic.id);
-    const dto = await selectThematics(transaction).where('id', thematic.id).first();
+    const dto = await selectThematics().where('id', thematic.id).first();
 
     await translationRepository.deleteByKeyPrefixAndLocales({
       prefix: `${thematicTranslations.prefix}${thematic.id}.`,
       locales: ['fr', 'en'],
-      transaction,
     });
-    await translationRepository.save({ translations, transaction });
+    await translationRepository.save({ translations });
 
     return toDomain(dto, translations);
   });
 }
 
-function selectThematics(knexConn = knex) {
+function selectThematics() {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       '*',

--- a/api/lib/infrastructure/repositories/translation-repository.js
+++ b/api/lib/infrastructure/repositories/translation-repository.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { Translation } from '../../domain/models/index.js';
 import { LocalizedEntity } from '../../domain/readmodels/index.js';
 import { TranslationForReplication } from '../../domain/models/replication/index.js';
@@ -12,26 +12,30 @@ const projection = [
   'value',
 ];
 
-export async function save({ translations, transaction: knexConnection = knex }) {
+export async function save({ translations }) {
   if (translations.length === 0) return [];
 
-  await knexConnection('translations').insert(translations).onConflict(['key', 'locale']).merge();
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('translations').insert(translations).onConflict(['key', 'locale']).merge();
 }
 
 /**
  * @deprecated use one of {@link listByModel}, {@link listByEntity} or {@link listByEntities}
  */
-export async function listByPrefix(prefix, { transaction = knex } = {}) {
-  const translationDtos = await transaction.select(projection).from('translations').whereLike('key', `${prefix}%`);
+export async function listByPrefix(prefix) {
+  const knexConn = DomainTransaction.getConnection();
+  const translationDtos = await knexConn.select(projection).from('translations').whereLike('key', `${prefix}%`);
   return translationDtos.map(_toDomain);
 }
 
-export async function listByModel(model, { knexConn = knex } = {}) {
+export async function listByModel(model) {
+  const knexConn = DomainTransaction.getConnection();
   const translationDtos = await knexConn.select(projection).from('translations').where('model', model);
   return translationDtos.map(_toDomain);
 }
 
-export async function listByEntity(model, entityId, { knexConn = knex } = {}) {
+export async function listByEntity(model, entityId) {
+  const knexConn = DomainTransaction.getConnection();
   const translationDtos = await knexConn
     .select(projection)
     .from('translations')
@@ -40,7 +44,8 @@ export async function listByEntity(model, entityId, { knexConn = knex } = {}) {
   return translationDtos.map(_toDomain);
 }
 
-export async function listByEntities(model, entityIds, { knexConn = knex } = {}) {
+export async function listByEntities(model, entityIds) {
+  const knexConn = DomainTransaction.getConnection();
   const translationDtos = await knexConn
     .select(projection)
     .from('translations')
@@ -49,13 +54,15 @@ export async function listByEntities(model, entityIds, { knexConn = knex } = {})
   return translationDtos.map(_toDomain);
 }
 
-export async function listByPattern(pattern, { transaction = knex } = {}) {
-  const translationDtos = await transaction.select(projection).from('translations').whereLike('key', `${pattern}`);
+export async function listByPattern(pattern) {
+  const knexConn = DomainTransaction.getConnection();
+  const translationDtos = await knexConn.select(projection).from('translations').whereLike('key', `${pattern}`);
   return translationDtos.map(_toDomain);
 }
 
 export async function list() {
-  const translationDtos = await knex.select(projection).from('translations').orderBy(['key', 'locale']);
+  const knexConn = DomainTransaction.getConnection();
+  const translationDtos = await knexConn.select(projection).from('translations').orderBy(['key', 'locale']);
   return translationDtos.map(_toDomain);
 }
 
@@ -63,14 +70,15 @@ export async function list() {
  * @param {AbortSignal=} signal
  */
 export async function* streamForReplication(signal) {
-  const stream = knex.select(
-    knex.raw('?? || ? || ?? AS ??', [
+  const knexConn = DomainTransaction.getConnection();
+  const stream = knexConn.select(
+    knexConn.raw('?? || ? || ?? AS ??', [
       'translations.key',
       ':',
       'translations.locale',
       'id',
     ]),
-    knex.raw('CASE WHEN ?? IS NULL THEN ?? ELSE REPLACE(??, ??, ??) END AS ??', [
+    knexConn.raw('CASE WHEN ?? IS NULL THEN ?? ELSE REPLACE(??, ??, ??) END AS ??', [
       'localized_challenges.id',
       'translations.key',
       'translations.key',
@@ -81,12 +89,12 @@ export async function* streamForReplication(signal) {
     'translations.locale',
     'translations.value',
     'translations.model',
-    knex.raw('COALESCE(??, ??) AS ??', [
+    knexConn.raw('COALESCE(??, ??) AS ??', [
       'localized_challenges.id',
       'translations.entityId',
       'entityId',
     ]),
-    knex.raw('CASE WHEN ?? = ? AND ?? = ?? THEN NULL ELSE ?? END AS ??', [
+    knexConn.raw('CASE WHEN ?? = ? AND ?? = ?? THEN NULL ELSE ?? END AS ??', [
       'translations.model',
       'challenge',
       'localized_challenges.id',
@@ -114,7 +122,8 @@ export async function* streamForReplication(signal) {
 }
 
 export async function searchLocalizedEntities({ model, fields, search, limit }) {
-  const query = knex('translations')
+  const knexConn = DomainTransaction.getConnection();
+  const query = knexConn('translations')
     .select('model', 'entityId', 'locale')
     .distinct()
     .whereILike('value', `%${escapeLikeWildcards(search)}%`)
@@ -136,6 +145,7 @@ function _toDomain(dto) {
   return new Translation(dto);
 }
 
-export async function deleteByKeyPrefixAndLocales({ prefix, locales, transaction: knexConnection = knex }) {
-  await knexConnection('translations').delete().whereLike('key', `${prefix}%`).whereIn('locale', locales);
+export async function deleteByKeyPrefixAndLocales({ prefix, locales }) {
+  const knexConn = DomainTransaction.getConnection();
+  await knexConn('translations').delete().whereLike('key', `${prefix}%`).whereIn('locale', locales);
 }

--- a/api/lib/infrastructure/repositories/translations-config-repository.js
+++ b/api/lib/infrastructure/repositories/translations-config-repository.js
@@ -1,8 +1,9 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { TranslationsConfig } from '../../domain/models/index.js';
 
 export async function listWithPhraseProjectId() {
-  const dtos = await knex.select('*')
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn.select('*')
     .from('translations_config')
     .whereNotNull('phraseProjectId')
     .orderBy('id');
@@ -13,7 +14,8 @@ export async function listWithPhraseProjectId() {
  * @param {string} phraseProjectId
  */
 export async function getByPhraseProjectId(phraseProjectId) {
-  const dto = await knex.select('*').from('translations_config').where('phraseProjectId', phraseProjectId).first();
+  const knexConn = DomainTransaction.getConnection();
+  const dto = await knexConn.select('*').from('translations_config').where('phraseProjectId', phraseProjectId).first();
   if (dto == null) return undefined;
   return toDomain(dto);
 }
@@ -22,7 +24,8 @@ export async function getByPhraseProjectId(phraseProjectId) {
  * @param {string} competenceId
  */
 export async function getByCompetenceId(competenceId) {
-  const frameworkDto = await knex.select('frameworks.id')
+  const knexConn = DomainTransaction.getConnection();
+  const frameworkDto = await knexConn.select('frameworks.id')
     .from('competences')
     .where('competences.id', competenceId)
     .join('areas', 'areas.id', 'competences.areaId')
@@ -31,7 +34,7 @@ export async function getByCompetenceId(competenceId) {
 
   if (frameworkDto == null) return undefined;
 
-  const translationConfigDto = await knex.select('*').from('translations_config').where('frameworkId', frameworkDto.id).first();
+  const translationConfigDto = await knexConn.select('*').from('translations_config').where('frameworkId', frameworkDto.id).first();
   if (translationConfigDto == null) return undefined;
 
   return toDomain(translationConfigDto);

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -4,19 +4,20 @@ import * as tubeTranslations from '../translations/tube.js';
 import { Tube } from '../../domain/models/Tube.js';
 import { TubeForReplication } from '../../domain/models/replication/index.js';
 import * as idGenerator from '../utils/id-generator.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const model = 'tube';
 const TABLE_NAME = 'tubes';
 
-export async function list({ transaction: knexConn } = {}) {
-  const [dtos, translations] = await Promise.all([selectTubes(knexConn).orderBy(`${TABLE_NAME}.id`), translationRepository.listByModel(model, { knexConn })]);
+export async function list() {
+  const [dtos, translations] = await Promise.all([selectTubes().orderBy(`${TABLE_NAME}.id`), translationRepository.listByModel(model)]);
 
   return toDomainList(dtos, translations);
 }
 
 export async function listForReplication() {
-  const dtos = await knex
+  const knexConn = DomainTransaction.getConnection();
+  const dtos = await knexConn
     .select(`${TABLE_NAME}.id`, `${TABLE_NAME}.name`, `${TABLE_NAME}.thematicId`, 'thematics.competenceId')
     .from(TABLE_NAME)
     .join('thematics', 'thematics.id', `${TABLE_NAME}.thematicId`)
@@ -34,15 +35,14 @@ export async function get(id) {
   return toDomain(dto, translations);
 }
 
-export async function listByCompetenceId(competenceId, { transaction: knexConn } = {}) {
-  const dtos = await selectTubes(knexConn).where('thematics.competenceId', competenceId).orderBy('tubes.id');
+export async function listByCompetenceId(competenceId) {
+  const dtos = await selectTubes().where('thematics.competenceId', competenceId).orderBy('tubes.id');
 
   if (dtos.length === 0) return [];
 
   const translations = await translationRepository.listByEntities(
     model,
     dtos.map(({ id }) => id),
-    { knexConn },
   );
 
   return toDomainList(dtos, translations);
@@ -59,12 +59,13 @@ export async function getMany(ids) {
 }
 
 export async function create(tube) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     tube.id = idGenerator.generateNewId('tube');
     const translations = tubeTranslations.extractFromDomainObject(tube);
 
+    const knexConn = DomainTransaction.getConnection();
     await Promise.all([
-      transaction
+      knexConn
         .insert({
           id: tube.id,
           name: tube.name,
@@ -72,40 +73,41 @@ export async function create(tube) {
           thematicId: tube.thematicAirtableId,
         })
         .into(TABLE_NAME),
-      translationRepository.save({ translations, transaction }),
+      translationRepository.save({ translations }),
     ]);
 
-    const dto = await selectTubes(transaction).where('tubes.id', tube.id).first();
+    const dto = await selectTubes().where('tubes.id', tube.id).first();
 
     return toDomain(dto, translations);
   });
 }
 
 export async function update(tube) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
     const translations = tubeTranslations.extractFromDomainObject(tube);
 
-    await transaction(TABLE_NAME)
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn(TABLE_NAME)
       .update({
         name: tube.name,
         index: tube.index,
         thematicId: tube.thematicAirtableId,
       })
       .where('id', tube.id);
-    const dto = await selectTubes(transaction).where('tubes.id', tube.id).first();
+    const dto = await selectTubes().where('tubes.id', tube.id).first();
 
     await translationRepository.deleteByKeyPrefixAndLocales({
       prefix: `${tubeTranslations.prefix}${tube.id}.`,
       locales: ['fr', 'en'],
-      transaction,
     });
-    await translationRepository.save({ translations, transaction });
+    await translationRepository.save({ translations });
 
     return toDomain(dto, translations);
   });
 }
 
-function selectTubes(knexConn = knex) {
+function selectTubes() {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       `${TABLE_NAME}.*`,

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -1,16 +1,17 @@
 import { Tutorial } from '../../domain/models/index.js';
 import { generateNewId } from '../utils/id-generator.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { escapeLikeWildcards } from './sql-utils.js';
 
 const TABLE_NAME = 'tutorials';
 const TAGS_RELATION_TABLE_NAME = 'tutorials-tutorial_tags';
 
 export async function create(tutorial) {
-  return knex.transaction(async (transaction) => {
+  return DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
     const id = generateNewId('tutorial');
 
-    await transaction
+    await knexConn
       .insert({
         id,
         title: tutorial.title,
@@ -26,7 +27,7 @@ export async function create(tutorial) {
       .into(TABLE_NAME);
 
     if (tutorial.tagAirtableIds?.length) {
-      await transaction
+      await knexConn
         .insert(
           tutorial.tagAirtableIds.map((tutorialTagId) => ({
             tutorialId: id,
@@ -36,58 +37,54 @@ export async function create(tutorial) {
         .into(TAGS_RELATION_TABLE_NAME);
     }
 
-    const dto = await selectTutorials(transaction).where('tutorials.id', id).first();
+    const dto = await selectTutorials().where('tutorials.id', id).first();
 
     return toDomain(dto);
   });
 }
 
-export async function update(tutorial, { transaction } = {}) {
-  if (transaction) {
-    return doUpdate(tutorial, transaction);
-  } else {
-    return knex.transaction(async(transaction) => doUpdate(tutorial, transaction));
-  }
-}
+export async function update(tutorial) {
+  return DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
 
-async function doUpdate(tutorial, transaction) {
-  await transaction(TABLE_NAME)
-    .update({
-      title: tutorial.title,
-      duration: tutorial.duration,
-      source: tutorial.source,
-      format: tutorial.format,
-      link: tutorial.link,
-      license: tutorial.license,
-      level: tutorial.level,
-      crush: tutorial.crush,
-      locale: tutorial.locale,
-      updatedAt: transaction.fn.now(),
-    })
-    .where('id', tutorial.id);
+    await knexConn(TABLE_NAME)
+      .update({
+        title: tutorial.title,
+        duration: tutorial.duration,
+        source: tutorial.source,
+        format: tutorial.format,
+        link: tutorial.link,
+        license: tutorial.license,
+        level: tutorial.level,
+        crush: tutorial.crush,
+        locale: tutorial.locale,
+        updatedAt: knexConn.fn.now(),
+      })
+      .where('id', tutorial.id);
 
-  await transaction
-    .delete()
-    .from(TAGS_RELATION_TABLE_NAME)
-    .where('tutorialId', tutorial.id)
-    .whereNotIn('tutorialTagId', tutorial.tagAirtableIds);
-  if (tutorial.tagAirtableIds.length !== 0) {
-    await transaction
-      .insert(
-        tutorial.tagAirtableIds.map((tutorialTagId) => ({
-          tutorialId: tutorial.id,
-          tutorialTagId,
-          updatedAt: transaction.fn.now(),
-        })),
-      )
-      .into(TAGS_RELATION_TABLE_NAME)
-      .onConflict(['tutorialId', 'tutorialTagId'])
-      .merge({ updatedAt: transaction.fn.now() });
-  }
+    await knexConn
+      .delete()
+      .from(TAGS_RELATION_TABLE_NAME)
+      .where('tutorialId', tutorial.id)
+      .whereNotIn('tutorialTagId', tutorial.tagAirtableIds);
+    if (tutorial.tagAirtableIds.length !== 0) {
+      await knexConn
+        .insert(
+          tutorial.tagAirtableIds.map((tutorialTagId) => ({
+            tutorialId: tutorial.id,
+            tutorialTagId,
+            updatedAt: knexConn.fn.now(),
+          })),
+        )
+        .into(TAGS_RELATION_TABLE_NAME)
+        .onConflict(['tutorialId', 'tutorialTagId'])
+        .merge({ updatedAt: knexConn.fn.now() });
+    }
 
-  const dto = await selectTutorials(transaction).where('tutorials.id', tutorial.id).first();
+    const dto = await selectTutorials().where('tutorials.id', tutorial.id).first();
 
-  return toDomain(dto);
+    return toDomain(dto);
+  });
 }
 
 export async function get(id) {
@@ -116,12 +113,13 @@ export async function searchBySource(source) {
 }
 
 export async function searchByTagTitles(tagTitles) {
+  const knexConn = DomainTransaction.getConnection();
   let tutorialsQuery = selectTutorials().orderByRaw('?? collate ??', ['title', 'fr-x-icu']).limit(100);
 
   for (const tagTitle of tagTitles) {
     tutorialsQuery = tutorialsQuery.whereIn(
       'id',
-      knex
+      knexConn
         .select('tutorials-tutorial_tags.tutorialId')
         .from('tutorial_tags')
         .join('tutorials-tutorial_tags', 'tutorials-tutorial_tags.tutorialTagId', 'tutorial_tags.id')
@@ -142,8 +140,8 @@ export async function getMany(ids) {
   return dtos.map(toDomain);
 }
 
-export async function list({ transaction, forUpdate = false } = {}) {
-  const query = selectTutorials(transaction).orderBy('id');
+export async function list({ forUpdate = false } = {}) {
+  const query = selectTutorials().orderBy('id');
   if (forUpdate) query.forUpdate();
 
   const dtos = await query;
@@ -152,15 +150,17 @@ export async function list({ transaction, forUpdate = false } = {}) {
 }
 
 async function _delete(ids) {
-  return knex.transaction(async (transaction) => {
-    await transaction.delete().from('tutorials-tutorial_tags').whereIn('tutorialId', ids);
-    await transaction.delete().from('tutorials').whereIn('id', ids);
+  return DomainTransaction.execute(async () => {
+    const knexConn = DomainTransaction.getConnection();
+    await knexConn.delete().from('tutorials-tutorial_tags').whereIn('tutorialId', ids);
+    await knexConn.delete().from('tutorials').whereIn('id', ids);
   });
 }
 
 export { _delete as delete };
 
-function selectTutorials(knexConn = knex) {
+function selectTutorials() {
+  const knexConn = DomainTransaction.getConnection();
   return knexConn
     .select(
       '*',

--- a/api/lib/infrastructure/repositories/url-repository.js
+++ b/api/lib/infrastructure/repositories/url-repository.js
@@ -1,7 +1,7 @@
 import * as google from '@googleapis/sheets';
 import { logger } from '../logger.js';
 import * as config from '../../config.js';
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 const sheets = google.sheets('v4');
 
@@ -133,7 +133,8 @@ const TUTORIAL_KO_URLS_TABLE_NAME = 'tutorial_ko_urls';
 const CONTINUOUS_FAILURE_MINIMUM_COUNT = 2;
 async function keepUrlsThatFailedAtLeastTwiceInARow(dataToUpload) {
   const finalDataToUpload = [];
-  await knex.transaction(async (trx) => {
+  await DomainTransaction.execute(async () => {
+    const trx = DomainTransaction.getConnection();
     const tutorialKoUrlsInDB = await trx(TUTORIAL_KO_URLS_TABLE_NAME);
 
     const tutorialKoUrlsToInsertInDB = [];

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,9 +1,10 @@
 import { User } from '../../domain/models/index.js';
-import { knex } from '../../../db/knex-database-connection.js';
 import { UserNotFoundError } from '../../domain/errors.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 
 export async function findByApiKey(apiKey) {
-  const user = await knex('users').where('apiKey', apiKey).first();
+  const knexConn = DomainTransaction.getConnection();
+  const user = await knexConn('users').where('apiKey', apiKey).first();
   if (!user) {
     throw new UserNotFoundError();
   }

--- a/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-read-repository.js
@@ -1,8 +1,8 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { WhitelistedUrl } from '../../domain/readmodels/WhitelistedUrl.js';
 
-function buildBaseReadQuery() {
-  return knex('whitelisted_urls')
+function buildBaseReadQuery(knexConn) {
+  return knexConn('whitelisted_urls')
     .select({
       id: 'whitelisted_urls.id',
       createdAt: 'whitelisted_urls.createdAt',
@@ -20,13 +20,15 @@ function buildBaseReadQuery() {
 }
 
 export async function list() {
-  const whitelistedUrlDtos = await buildBaseReadQuery().orderBy('url');
+  const knexConn = DomainTransaction.getConnection();
+  const whitelistedUrlDtos = await buildBaseReadQuery(knexConn).orderBy('url');
 
   return toDomainList(whitelistedUrlDtos);
 }
 
 export async function find(id) {
-  const whitelistedUrlDto = await buildBaseReadQuery().where('whitelisted_urls.id', id).first();
+  const knexConn = DomainTransaction.getConnection();
+  const whitelistedUrlDto = await buildBaseReadQuery(knexConn).where('whitelisted_urls.id', id).first();
 
   if (!whitelistedUrlDto) return null;
   return toDomain(whitelistedUrlDto);

--- a/api/lib/infrastructure/repositories/whitelisted-url-repository.js
+++ b/api/lib/infrastructure/repositories/whitelisted-url-repository.js
@@ -1,8 +1,8 @@
-import { knex } from '../../../db/knex-database-connection.js';
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
 import { WhitelistedUrl } from '../../domain/models/index.js';
 
-function buildBaseReadQuery() {
-  return knex('whitelisted_urls').select([
+function buildBaseReadQuery(knexConn) {
+  return knexConn('whitelisted_urls').select([
     'id',
     'createdBy',
     'latestUpdatedBy',
@@ -18,26 +18,29 @@ function buildBaseReadQuery() {
 }
 
 export async function list() {
-  const whitelistedUrlDtos = await buildBaseReadQuery().orderBy('url');
+  const knexConn = DomainTransaction.getConnection();
+  const whitelistedUrlDtos = await buildBaseReadQuery(knexConn).orderBy('url');
 
   return toDomainList(whitelistedUrlDtos);
 }
 
 export async function find(id) {
-  const whitelistedUrlDto = await buildBaseReadQuery().where({ id }).first();
+  const knexConn = DomainTransaction.getConnection();
+  const whitelistedUrlDto = await buildBaseReadQuery(knexConn).where({ id }).first();
 
   if (!whitelistedUrlDto) return null;
   return toDomain(whitelistedUrlDto);
 }
 
 export async function save(whitelistedUrl) {
+  const knexConn = DomainTransaction.getConnection();
   const dataToSave = adaptModelToDB(whitelistedUrl);
   let id;
   if (whitelistedUrl.id) {
     id = whitelistedUrl.id;
-    await knex('whitelisted_urls').update(dataToSave).where({ id });
+    await knexConn('whitelisted_urls').update(dataToSave).where({ id });
   } else {
-    const dataInserted = await knex('whitelisted_urls').insert(dataToSave, ['id']);
+    const dataInserted = await knexConn('whitelisted_urls').insert(dataToSave, ['id']);
     id = dataInserted[0].id;
   }
   return id;

--- a/api/scripts/create-localized-framework.js
+++ b/api/scripts/create-localized-framework.js
@@ -2,7 +2,7 @@ import { areaRepository, localizedFrameworksTubesRepository, tubeRepository } fr
 import { Script } from '../lib/application/scripts/script.js';
 import { ScriptRunner } from '../lib/application/scripts/script-runner.js';
 import { LocalizedFrameworkTubes } from '../lib/domain/models/LocalizedFrameworkTubes.js';
-import { knex } from '../db/knex-database-connection.js';
+import { DomainTransaction } from '../lib/domain/DomainTransaction.js';
 
 export class CreateLocalizedFrameworks extends Script {
   constructor() {
@@ -33,13 +33,15 @@ export class CreateLocalizedFrameworks extends Script {
   async handle({ options, logger }) {
     logger.info({ dryRun: options.dryRun, locales: options.locales, frameworkIds: options.frameworkIds }, 'Script options');
 
-    await knex.transaction(async (transaction) => {
+    return DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
+
       let tubes;
       if (options.frameworkIds) {
-        const frameworksTubes = await Promise.all(options.frameworkIds.map((frameworkId) => loadFrameworkTubes(frameworkId, transaction)));
+        const frameworksTubes = await Promise.all(options.frameworkIds.map((frameworkId) => loadFrameworkTubes(frameworkId)));
         tubes = frameworksTubes.flat();
       } else {
-        tubes = await tubeRepository.list({ transaction });
+        tubes = await tubeRepository.list();
       }
 
       const tubesWithoutWorkbench = tubes.filter((tube) => !tube.isWorkbench);
@@ -53,22 +55,22 @@ export class CreateLocalizedFrameworks extends Script {
       for (const locale of options.locales) {
         const localizedFrameworkTubes = tubesWithoutWorkbench.map((tube) => new LocalizedFrameworkTubes({ tubeId: tube.id, locale, maxLevel: 8 }));
 
-        await localizedFrameworksTubesRepository.save(localizedFrameworkTubes, { transaction, onConflict: 'ignore' });
+        await localizedFrameworksTubesRepository.save(localizedFrameworkTubes, { onConflict: 'ignore' });
 
         logger.info({ locale, count: localizedFrameworkTubes.length }, 'Localized framework tubes were created for locale');
       }
 
       if (options.dryRun) {
         logger.info('Dry run, will rollback modifications');
-        await transaction.rollback();
+        await knexConn.rollback();
       }
     });
   }
 }
 
-async function loadFrameworkTubes(frameworkId, transaction) {
-  const areas = await areaRepository.listByFrameworkId(frameworkId, { transaction });
-  const areasTubes = await Promise.all(areas.flatMap((area) => area.competenceIds.map((competenceId) => tubeRepository.listByCompetenceId(competenceId, { transaction }))));
+async function loadFrameworkTubes(frameworkId) {
+  const areas = await areaRepository.listByFrameworkId(frameworkId);
+  const areasTubes = await Promise.all(areas.flatMap((area) => area.competenceIds.map((competenceId) => tubeRepository.listByCompetenceId(competenceId))));
   return areasTubes.flat();
 }
 

--- a/api/scripts/update-tubes-translation.js
+++ b/api/scripts/update-tubes-translation.js
@@ -4,6 +4,7 @@ import Joi from 'joi';
 import { csvFileParser } from '../lib/application/scripts/parsers.js';
 import { knex } from '../db/knex-database-connection.js';
 import { translationRepository } from '../lib/infrastructure/repositories/index.js';
+import { DomainTransaction } from '../lib/domain/DomainTransaction.js';
 
 export const csvSchemas = [
   { name: 'Thèmes/acquis', schema: Joi.string().required() },
@@ -56,7 +57,8 @@ export class UpdateTubesTranslationScript extends Script {
     logger.info({ dryRun: options.dryRun, ids: options.id }, 'Script options');
     const tubesFromPix = await getTubeIdsFromPixFramework();
 
-    await knex.transaction(async (trx) => {
+    return DomainTransaction.execute(async () => {
+      const knexConn = DomainTransaction.getConnection();
       try {
         let updatedTubesCount = 0;
         for (const row of options.file) {
@@ -70,20 +72,20 @@ export class UpdateTubesTranslationScript extends Script {
 
           const tubeId = tubeIds[0].id;
           const translations = [{ key: `tube.${tubeId}.practicalTitle`, locale: 'fr', value: practicalTitle }, { key: `tube.${tubeId}.practicalDescription`, locale: 'fr', value: practicalDescription }];
-          await translationRepository.save({ translations, transaction: trx });
+          await translationRepository.save({ translations });
           updatedTubesCount++;
         }
 
         if (options.dryRun) {
           logger.info(`Dry run is enabled, stopping before updating ${updatedTubesCount} tube(s)`);
-          await trx.rollback();
+          await knexConn.rollback();
           return;
         }
-        await trx.commit();
+        await knexConn.commit();
         logger.info(`Successfully updated translations for ${updatedTubesCount} tube(s)`);
       } catch (error) {
         logger.error('unhandled error found', { error });
-        await trx.rollback();
+        await knexConn.rollback();
       }
     });
   }

--- a/api/tests/integration/domain/DomainTransaction_test.js
+++ b/api/tests/integration/domain/DomainTransaction_test.js
@@ -1,0 +1,78 @@
+import { DomainTransaction } from '../../../lib/domain/DomainTransaction.js';
+import { catchErr, knex } from '../../test-helper.js';
+import { describe, expect, it } from 'vitest';
+
+describe('API | Integration | Domain | DomainTransaction', function() {
+  describe('behaviour when nesting', function() {
+    describe('DomainTransaction.execute in DomainTransaction.execute', function() {
+      it('should use the same transaction all the way', async function() {
+        // given
+        let didIGoAllTheWayToTheEnd = false;
+        const addTwoframeworksInTwoDomainTrExecute = async function() {
+          const knexConnA = DomainTransaction.getConnection();
+
+          // check empty in scope A
+          const keys0 = await knexConnA('frameworks').pluck('name');
+          expect(keys0, 'it starts with an empty table').toEqual([]);
+
+          // insert in scope A
+          await knexConnA('frameworks').insert({ id: 'scopeA', name: 'scopeA' });
+
+          // check has one in scope A
+          const keys1 = await knexConnA('frameworks').pluck('name');
+          expect(keys1, '"scopeA" has been inserted in first layer').toEqual(['scopeA']);
+
+          // nested scope
+          await DomainTransaction.execute(async function() {
+            const knexConnB = DomainTransaction.getConnection();
+
+            // check already has one in scope B
+            const keys1 = await knexConnB('frameworks').pluck('name');
+            expect(keys1, '"scopeA" found in second layer').toEqual(['scopeA']);
+
+            // insert in scope B
+            await knexConnB('frameworks').insert({ id: 'scopeB', name: 'scopeB' });
+
+            // check has two in scope B
+            const keys2 = await knexConnB('frameworks').pluck('name').orderBy('name');
+            expect(keys2, '"scopeB" also inserted, but in second layer').toEqual(['scopeA', 'scopeB']);
+            didIGoAllTheWayToTheEnd = true;
+          });
+        };
+
+        // when
+        await DomainTransaction.execute(addTwoframeworksInTwoDomainTrExecute);
+
+        // then
+        expect(didIGoAllTheWayToTheEnd).toBe(true);
+        const finalKeys = await knex('frameworks').pluck('name').orderBy('name');
+        expect(finalKeys).toEqual(['scopeA', 'scopeB']);
+      });
+
+      it('should rollback everything when something goes wrong in the nested scope', async function() {
+        // given
+        const addTwoframeworksInTwoDomainTrExecute = async function() {
+          const knexConnA = DomainTransaction.getConnection();
+
+          await knexConnA('frameworks').insert({ id: 'scopeA', name: 'scopeA' });
+
+          await DomainTransaction.execute(async function() {
+            const knexConnB = DomainTransaction.getConnection();
+
+            await knexConnB('frameworks').insert({ id: 'scopeB', name: 'scopeB' });
+
+            throw new Error("Let's rollback !");
+          });
+        };
+
+        // when
+        const err = await catchErr(DomainTransaction.execute)(addTwoframeworksInTwoDomainTrExecute);
+
+        // then
+        expect(err.message).toEqual("Let's rollback !");
+        const { count } = await knex('frameworks').count('id').first();
+        expect(parseInt(count)).toEqual(0);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/DomainTransaction_test.js
+++ b/api/tests/unit/domain/DomainTransaction_test.js
@@ -1,0 +1,74 @@
+import {
+  asyncLocalStorage,
+  DomainTransaction,
+} from '../../../lib/domain/DomainTransaction.js';
+import { describe, expect, it, vi } from 'vitest';
+import { knex } from '../../test-helper.js';
+
+describe('API | Infrastructure | DomainTransaction', function() {
+  describe('#getConnection', function() {
+    it('should return connection from store', function() {
+      const transaction = Symbol('transaction');
+      const domainTransaction = new DomainTransaction(transaction);
+      const storeStub = { transaction: domainTransaction };
+      vi.spyOn(asyncLocalStorage, 'getStore').mockReturnValue(storeStub);
+
+      const connection = DomainTransaction.getConnection();
+
+      expect(connection).toBe(transaction);
+    });
+
+    it('should return knex connection by default', function() {
+      vi.spyOn(asyncLocalStorage, 'getStore').mockReturnValue(undefined);
+
+      const connection = DomainTransaction.getConnection();
+
+      expect(connection).toBe(knex);
+    });
+  });
+
+  describe('#execute', function() {
+    it('should store transaction', async function() {
+      const transactionStub = {};
+      const domainTransaction = new DomainTransaction(transactionStub);
+      vi.spyOn(asyncLocalStorage, 'run').mockImplementation(() => {});
+      vi.spyOn(knex, 'transaction').mockImplementation(async (fn) => fn(transactionStub));
+
+      await DomainTransaction.execute(function() {
+        // Something
+      });
+
+      expect(asyncLocalStorage.run).toHaveBeenCalledWith(
+        { transaction: domainTransaction },
+        expect.any(Function),
+        domainTransaction,
+      );
+    });
+
+    it('should return function result', async function() {
+      const transactionConfiguration = { isolationLevel: 'read committed' };
+      vi.spyOn(knex, 'transaction').mockImplementation(async (fn) => fn({}));
+
+      await DomainTransaction.execute(() => {}, transactionConfiguration);
+
+      expect(knex.transaction).toHaveBeenCalledWith(expect.any(Function), transactionConfiguration);
+    });
+
+    it('should use configuration for transaction', async function() {
+      const transactionStub = {};
+      const domainTransaction = new DomainTransaction(transactionStub);
+      vi.spyOn(asyncLocalStorage, 'run').mockImplementation(() => {});
+      vi.spyOn(knex, 'transaction').mockImplementation(async (fn) => fn(transactionStub));
+
+      await DomainTransaction.execute(function() {
+        // Something
+      });
+
+      expect(asyncLocalStorage.run).toHaveBeenCalledWith(
+        { transaction: domainTransaction },
+        expect.any(Function),
+        domainTransaction,
+      );
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/import-translations_test.js
+++ b/api/tests/unit/domain/usecases/import-translations_test.js
@@ -36,7 +36,7 @@ describe('Unit | Domain | Use Cases | import-translations', () => {
 
       // then
       expect(localizedChallengeRepository.create).not.toHaveBeenCalled();
-      expect(translationRepository.save).toHaveBeenCalledExactlyOnceWith({ translations, transaction: expect.any(Function) });
+      expect(translationRepository.save).toHaveBeenCalledExactlyOnceWith({ translations });
     });
   });
 
@@ -64,9 +64,8 @@ describe('Unit | Domain | Use Cases | import-translations', () => {
           domainBuilder.buildLocalizedChallenge({ challengeId: 'challenge789', locale: 'es', id: null, embedUrl: null, status: LocalizedChallenge.STATUSES.PAUSE, urlsToConsult: null }),
           domainBuilder.buildLocalizedChallenge({ challengeId: 'challenge321', locale: 'nl', id: null, embedUrl: null, status: LocalizedChallenge.STATUSES.PAUSE, urlsToConsult: null }),
         ],
-        transaction: expect.any(Function),
       });
-      expect(translationRepository.save).toHaveBeenCalledExactlyOnceWith({ translations, transaction: expect.any(Function) });
+      expect(translationRepository.save).toHaveBeenCalledExactlyOnceWith({ translations });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/modify-localized-challenge_test.js
+++ b/api/tests/unit/domain/usecases/modify-localized-challenge_test.js
@@ -16,10 +16,7 @@ describe('Unit | Domain | Usecases | modify localized challenge', () => {
 
       await modifyLocalizedChallenge({ localizedChallenge }, { localizedChallengeRepository });
 
-      expect(localizedChallengeRepository.update).toHaveBeenCalledWith({
-        localizedChallenge: originalLocalizedChallenge,
-        transaction: expect.anything(),
-      });
+      expect(localizedChallengeRepository.update).toHaveBeenCalledWith({ localizedChallenge: originalLocalizedChallenge });
       expect(updateSpy).to.toHaveBeenCalledWith(localizedChallenge);
     });
     describe('when user is admin', () => {
@@ -39,10 +36,7 @@ describe('Unit | Domain | Usecases | modify localized challenge', () => {
 
         await modifyLocalizedChallenge({ isAdmin: true, localizedChallenge }, { localizedChallengeRepository });
 
-        expect(localizedChallengeRepository.update).toHaveBeenCalledWith({
-          localizedChallenge: originalLocalizedChallenge,
-          transaction: expect.anything(),
-        });
+        expect(localizedChallengeRepository.update).toHaveBeenCalledWith({ localizedChallenge: originalLocalizedChallenge });
       });
     });
     describe('when user is not admin', () => {
@@ -94,14 +88,8 @@ describe('Unit | Domain | Usecases | modify localized challenge', () => {
           { localizedChallengeRepository },
         );
 
-        expect(localizedChallengeRepository.update).toHaveBeenCalledWith({
-          localizedChallenge: originalLocalizedChallenge,
-          transaction: expect.anything(),
-        });
-        expect(localizedChallengeRepository.get).toHaveBeenCalledWith({
-          id: 'localized-challenge-id',
-          transaction: expect.anything(),
-        });
+        expect(localizedChallengeRepository.update).toHaveBeenCalledWith({ localizedChallenge: originalLocalizedChallenge });
+        expect(localizedChallengeRepository.get).toHaveBeenCalledWith({ id: 'localized-challenge-id' });
       });
     });
   });


### PR DESCRIPTION
## 🪧 Problème

Pour passer les transactions d'un repo a un autre on passe par des arguments en plus. Ce qui n'est pas très clean

## 🌈 Proposition

Utiliser le même domainTransaction que celui du monorepo

## ✊ Remarques

On a retiré le successhandler et le withinTransaction pour ne pas retomber dans des travers que nous avions eu côté monorepo

## 🎉 Pour tester
Tout est vert . un petit tour sur soi même. et sur PixEditor ?
