### PR TITLE
[TECH] Ajouter des titres aux boutons qui en manquent

### DIFF
--- a/pix-editor/app/components/competence/competence-footer.gjs
+++ b/pix-editor/app/components/competence/competence-footer.gjs
@@ -9,6 +9,7 @@ export default class CompetenceFooter extends Component {
     <div class="ui borderless bottom attached labelled icon menu{{this.skillClass}}">
       {{#if this.displayWorkbenchViews}}
         <button
+          title="Grille d'atelier des épreuves"
           class={{concat "ui button item" (if (eq @view "workbench") " active" "")}}
           {{on "click" (fn @selectView "workbench")}}
           type="button"
@@ -16,6 +17,7 @@ export default class CompetenceFooter extends Component {
           <i class="grid layout icon"></i>
         </button>
         <button
+          title="Atelier d'atelier des épreuves"
           class={{concat "ui button item" (if (eq @view "workbench-list") " active" "")}}
           {{on "click" (fn @selectView "workbench-list")}}
           type="button"

--- a/pix-editor/app/components/competence/competence-grid-thematic.gjs
+++ b/pix-editor/app/components/competence/competence-grid-thematic.gjs
@@ -14,13 +14,7 @@ export default class CompetenceCompetenceGridThematicComponent extends Component
         <td data-test-theme-cell class="theme-cell create-tube">
           <LinkTo @route="authenticated.competence.themes.single" @model={{@thematic}}>{{this.name}}</LinkTo>
           <div class="ui mini basic icon buttons tube-management">
-            <button
-              data-test-add-tube
-              class="ui icon button"
-              {{on "click" (fn @newTube @thematic)}}
-              title="Nouveau tube"
-              type="button"
-            >
+            <button class="ui icon button" title="Nouveau sujet" type="button" {{on "click" (fn @newTube @thematic)}}>
               <i class="plus square outline icon"></i>
             </button>
           </div>
@@ -48,20 +42,18 @@ export default class CompetenceCompetenceGridThematicComponent extends Component
               {{#if this.mayCreateTube}}
                 <div class="ui mini basic icon buttons tube-management">
                   <button
-                    data-test-add-tube
                     class="ui icon button"
-                    {{on "click" (fn @newTube @thematic)}}
-                    title="Nouveau tube"
+                    title="Nouveau sujet"
                     type="button"
+                    {{on "click" (fn @newTube @thematic)}}
                   >
                     <i class="plus square outline icon"></i>
                   </button>
                   <button
-                    data-test-sort-tube
                     class="ui icon button"
-                    {{on "click" (fn @displaySortTubesPopIn @thematic.tubes)}}
-                    title="Trier les Tubes"
+                    title="Trier les sujets"
                     type="button"
+                    {{on "click" (fn @displaySortTubesPopIn @thematic.tubes)}}
                   >
                     <i class="exchange icon rotate-90"></i>
                   </button>

--- a/pix-editor/app/components/competence/prototypes/challenge-header.gjs
+++ b/pix-editor/app/components/competence/prototypes/challenge-header.gjs
@@ -11,17 +11,17 @@ import { on } from '@ember/modifier';
       </div>
       <div class="ui right menu">
         {{#if @maximized}}
-          <button class="ui icon button item" {{on "click" @minimize}} type="button"><i
-              class="window minimize icon"
-            ></i></button>
+          <button {{on "click" @minimize}} class="ui icon button item" type="button" title="Minimiser la fenêtre">
+            <i class="window minimize icon"></i>
+          </button>
         {{else}}
-          <button class="ui icon button item" {{on "click" @maximize}} type="button"><i
-              class="window maximize outline icon"
-            ></i></button>
+          <button {{on "click" @maximize}} class="ui icon button item" type="button" title="Maximiser la fenêtre">
+            <i class="window maximize outline icon"></i>
+          </button>
         {{/if}}
-        <button class="ui icon button item" {{on "click" @close}} type="button"><i
-            class="icon window close"
-          ></i></button>
+        <button {{on "click" @close}} class="ui icon button item" type="button" title="Fermer la fenêtre">
+          <i class="icon window close"></i>
+        </button>
       </div>
     </div>
   </div>

--- a/pix-editor/app/components/field/files.gjs
+++ b/pix-editor/app/components/field/files.gjs
@@ -15,17 +15,19 @@ export default class Files extends Component {
       {{/if}}
       {{#if @value.length}}
         {{#each @value as |file|}}
-          <a href={{file.url}} download={{file.filename}} target="_blank" referrerpolicy="strict-origin"><i
-              class="file icon"
-            ></i>
-            {{file.filename}}</a>
+          <a href={{file.url}} download={{file.filename}} target="_blank" referrerpolicy="strict-origin">
+            <i class="file icon"></i>
+            {{file.filename}}
+          </a>
           {{#if @edition}}
             <button
               {{on "click" (fn this.remove file)}}
               class="ui button file-remove"
-              data-test-delete-attachment-button
               type="button"
-            ><i class="remove icon"></i></button>
+              title="Supprimer le fichier"
+            >
+              <i class="remove icon"></i>
+            </button>
           {{/if}}
         {{/each}}
       {{/if}}

--- a/pix-editor/app/components/field/illustration.gjs
+++ b/pix-editor/app/components/field/illustration.gjs
@@ -19,10 +19,9 @@ export default class Illustration extends Component {
           octets)
         {{/if}}
         {{#if @edition}}
-          <button {{on "click" this.remove}} class="ui button file-remove" type="button"><i
-              class="remove icon"
-              data-test-delete-illustration-button
-            ></i></button>
+          <button class="ui button file-remove" type="button" title="Supprimer l'image" {{on "click" this.remove}}>
+            <i class="remove icon"></i>
+          </button>
         {{/if}}
       {{/if}}
       {{#if @edition}}

--- a/pix-editor/app/controllers/authenticated/competence/themes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/themes/single.js
@@ -52,7 +52,7 @@ export default class CompetenceThemesSingleController extends Controller {
       .then(() => {
         this.edition = false;
         this.loader.stop();
-        this.notifications.sendSuccess('Thématique mis à jour');
+        this.notifications.sendSuccess('Thématique mise à jour');
       })
       .catch((error) => {
         /* eslint-disable-next-line no-console */

--- a/pix-editor/app/templates/authenticated.gjs
+++ b/pix-editor/app/templates/authenticated.gjs
@@ -12,11 +12,14 @@ import Main from 'pixeditor/components/sidebar/main';
     <Main @openLogout={{@controller.openLogout}} @open={{@controller.menuOpen}} @close={{@controller.closeMenu}} />
     <div class="pusher">
       <div class="ui vertical inverted icon menu main-menu {{if @controller.config.lite 'lite' ''}}">
-        {{! template-lint-disable }}
-        <button class="ui icon button menu-toggle" type="button" {{on "click" @controller.toggleMenu}}>
+        <button
+          class="ui icon button menu-toggle"
+          type="button"
+          title="Afficher/cacher la barre latérale"
+          {{on "click" @controller.toggleMenu}}
+        >
           <i class="bars icon"></i>
         </button>
-        {{! template-lint-enable }}
       </div>
       <div class="{{if @controller.shouldApplyV2Styles 'v2-main' 'main'}}" {{on "click" @controller.closeMenu}}>
         {{#if @controller.isIndex}}

--- a/pix-editor/app/templates/authenticated/competence-management/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence-management/single.gjs
@@ -14,7 +14,6 @@ import Textarea from 'pixeditor/components/field/textarea';
       <div class="competence-management__data">
         <form action class="ui form">
           <Input
-            data-test-competence-title-input
             @value={{@controller.competence.title}}
             @edition={{@controller.edition}}
             @label="Titre"
@@ -48,22 +47,17 @@ import Textarea from 'pixeditor/components/field/textarea';
       </div>
       <div class="ui vertical compact labeled icon menu competence-management__menu">
         {{#if @controller.mayEdit}}
-          <button data-test-edit-button class="ui button item" {{on "click" @controller.edit}} type="button">
+          <button class="ui button item" type="button" {{on "click" @controller.edit}}>
             <i class="edit icon"></i>
             Modifier
           </button>
         {{/if}}
         {{#if @controller.edition}}
-          <button
-            data-test-save-button
-            class="ui button item important-action"
-            {{on "click" @controller.save}}
-            type="button"
-          >
+          <button class="ui button item important-action" type="button" {{on "click" @controller.save}}>
             <i class="save icon"></i>
             Enregistrer
           </button>
-          <button data-test-cancel-button class="ui button item" {{on "click" @controller.cancelEdit}} type="button">
+          <button class="ui button item" type="button" {{on "click" @controller.cancelEdit}}>
             <i class="ban icon"></i>
             Annuler
           </button>

--- a/pix-editor/app/templates/authenticated/competence/prototypes/list.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/list.gjs
@@ -6,9 +6,8 @@ import Prototypes from 'pixeditor/components/list/prototypes';
   <div class="main-title {{if @controller.config.lite 'lite' ''}}">
     <h1 class="ui header">
       <div class="ui right floated menu">
-        <button class="ui button icon item" {{on "click" @controller.close}} type="button"><i
-            class="icon window close"
-          ></i>
+        <button class="ui button icon item" type="button" {{on "click" @controller.close}}>
+          <i class="icon window close"></i>
         </button>
       </div>
       Prototypes de
@@ -36,12 +35,7 @@ import Prototypes from 'pixeditor/components/list/prototypes';
   </div>
   <div class="ui borderless bottom attached labelled icon menu">
     {{#if @controller.mayCreatePrototype}}
-      <button
-        data-test-new-prototype-action
-        class="ui button right item"
-        {{on "click" @controller.newVersion}}
-        type="button"
-      >
+      <button class="ui button right item" {{on "click" @controller.newVersion}} type="button">
         <i class="plus square outline icon"></i>
         Nouvelle version
       </button>

--- a/pix-editor/app/templates/authenticated/competence/skills/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/skills/single.gjs
@@ -42,13 +42,13 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
               {{#if @controller.isStatusActionMenuOpen}}
                 <div class="skill-status-actions__menu">
                   {{#if @controller.mayArchive}}
-                    <button class="ui button archive item" {{on "click" @controller.archiveSkill}} type="button">
+                    <button class="ui button archive item" type="button" {{on "click" @controller.archiveSkill}}>
                       <i class="archive icon"></i>
                       {{t "competence.skills.archive"}}
                     </button>
                   {{/if}}
                   {{#if @controller.mayObsolete}}
-                    <button class="ui button delete item" {{on "click" @controller.obsoleteSkill}} type="button">
+                    <button class="ui button delete item" type="button" {{on "click" @controller.obsoleteSkill}}>
                       <i class="trash alternate icon"></i>
                       {{t "competence.skills.obsolete"}}
                     </button>
@@ -65,18 +65,17 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
       </div>
       <div class="ui right menu">
         {{#if @controller.maximized}}
-          <button class="ui icon button" {{on "click" @controller.minimize}} type="button"><i
-              class="window minimize icon"
-            ></i>
+          <button class="ui icon button" type="button" title="Minimiser la fenêtre" {{on "click" @controller.minimize}}>
+            <i class="window minimize icon"></i>
           </button>
         {{else}}
-          <button class="ui icon button" {{on "click" @controller.maximize}} type="button"><i
-              class="window maximize outline icon"
-            ></i></button>
+          <button class="ui icon button" type="button" title="Maximiser la fenêtre" {{on "click" @controller.maximize}}>
+            <i class="window maximize outline icon"></i>
+          </button>
         {{/if}}
-        <button class="ui icon button" {{on "click" @controller.close}} type="button"><i
-            class="icon window close"
-          ></i></button>
+        <button class="ui icon button" type="button" title="Fermer la fenêtre" {{on "click" @controller.close}}>
+          <i class="icon window close"></i>
+        </button>
       </div>
     </div>
   </div>

--- a/pix-editor/app/templates/authenticated/competence/themes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/themes/single.gjs
@@ -12,9 +12,9 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
         {{/if}}
       </div>
       <div class="ui right menu">
-        <button class="ui button icon item" {{on "click" @controller.close}} type="button"><i
-            class="icon window close"
-          ></i></button>
+        <button class="ui button icon item" type="button" title="Fermer la fenêtre" {{on "click" @controller.close}}>
+          <i class="icon window close"></i>
+        </button>
       </div>
     </div>
   </div>
@@ -24,17 +24,17 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
     </div>
     <div class="ui vertical compact labeled icon menu tube-menu">
       {{#if @controller.edition}}
-        <button class="ui button item important-action" {{on "click" @controller.save}} type="button">
+        <button class="ui button item important-action" type="button" {{on "click" @controller.save}}>
           <i class="save icon"></i>
           Enregistrer
         </button>
-        <button class="ui button item" {{on "click" @controller.cancelEdit}} type="button">
+        <button class="ui button item" type="button" {{on "click" @controller.cancelEdit}}>
           <i class="ban icon"></i>
           Annuler
         </button>
       {{else}}
         {{#if @controller.mayEdit}}
-          <button class="ui button item" {{on "click" @controller.edit}} type="button">
+          <button class="ui button item" type="button" {{on "click" @controller.edit}}>
             <i class="edit icon"></i>
             Modifier
           </button>

--- a/pix-editor/app/templates/authenticated/competence/tubes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/tubes/single.gjs
@@ -10,9 +10,14 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
     <div class="ui menu">
       <div class="ui left menu">
         {{#if (and @controller.mayMove (not @controller.creation) (not @controller.edition))}}
-          <button class="ui button icon item" {{on "click" @controller.selectCompetence}} type="button"><i
-              class="icon random"
-            ></i></button>
+          <button
+            class="ui button icon item"
+            type="button"
+            title="Déplacer le sujet"
+            {{on "click" @controller.selectCompetence}}
+          >
+            <i class="icon random"></i>
+          </button>
         {{/if}}
       </div>
       <div class="item header {{if @controller.creation 'creation'}}">
@@ -24,17 +29,27 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
       </div>
       <div class="ui right menu">
         {{#if @controller.maximized}}
-          <button class="ui button icon item" {{on "click" @controller.minimize}} type="button"><i
-              class="window minimize icon"
-            ></i></button>
+          <button
+            class="ui button icon item"
+            type="button"
+            title="Minimiser la fenêtre"
+            {{on "click" @controller.minimize}}
+          >
+            <i class="window minimize icon"></i>
+          </button>
         {{else}}
-          <button class="ui button icon item" {{on "click" @controller.maximize}} type="button"><i
-              class="window maximize outline icon"
-            ></i></button>
+          <button
+            class="ui button icon item"
+            type="button"
+            title="Maximiser la fenêtre"
+            {{on "click" @controller.maximize}}
+          >
+            <i class="window maximize outline icon"></i>
+          </button>
         {{/if}}
-        <button class="ui button icon item" {{on "click" @controller.close}} type="button"><i
-            class="icon window close"
-          ></i></button>
+        <button class="ui button icon item" type="button" title="Fermer la fenêtre" {{on "click" @controller.close}}>
+          <i class="icon window close"></i>
+        </button>
       </div>
     </div>
   </div>

--- a/pix-editor/tests/acceptance/challenge/create-challenge/create-challenge-alternative-test.js
+++ b/pix-editor/tests/acceptance/challenge/create-challenge/create-challenge-alternative-test.js
@@ -158,7 +158,7 @@ module('Acceptance | Controller | Create alternative challenge', function (hooks
     await click(find('[data-test-save-challenge-button]'));
 
     await click(findAll('[data-test-modify-challenge-button]')[1]);
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
     await click(find('[data-test-save-challenge-button]'));
     await click(find('[data-test-confirm-log-approve]'));
 

--- a/pix-editor/tests/acceptance/challenge/modify-challenge/modify-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/challenge/modify-challenge/modify-challenge-attachment-test.js
@@ -134,7 +134,7 @@ module('Acceptance | Modify-Challenge-Attachment', function (hooks) {
 
     // replace attachmentA with attachmentB
     await click(find('[data-test-modify-challenge-button]'));
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
     await selectFiles('[data-test-file-input-attachment] input', attachmentB);
     await runTask(this, async () => {}, 400);
     await click(find('[data-test-save-challenge-button]'));
@@ -163,7 +163,7 @@ module('Acceptance | Modify-Challenge-Attachment', function (hooks) {
     // when
     const screen = await visit('/competence/recCompetence1.1/prototypes/recChallenge1');
     await click(find('[data-test-modify-challenge-button]'));
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
 
     await runTask(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));
@@ -190,7 +190,7 @@ module('Acceptance | Modify-Challenge-Attachment', function (hooks) {
     // when
     const screen = await visit('/competence/recCompetence1.1/prototypes/recChallenge1');
     await click(find('[data-test-modify-challenge-button]'));
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
 
     await runTask(this, async () => {}, 200);
     await click(find('[data-test-cancel-challenge-button]'));

--- a/pix-editor/tests/acceptance/challenge/modify-challenge/modify-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/challenge/modify-challenge/modify-challenge-illustration-test.js
@@ -133,7 +133,7 @@ module('Acceptance | Modify-Challenge-Illustration', function (hooks) {
 
     // replace illustrationA with illustrationB
     await click(find('[data-test-modify-challenge-button]'));
-    await click(find('[data-test-delete-illustration-button]'));
+    await click(screen.getByRole('button', { name: "Supprimer l'image" }));
     await selectFiles('[data-test-file-input-illustration] input', illustrationB);
     await runTask(this, async () => {}, 400);
     await click(find('[data-test-save-challenge-button]'));
@@ -164,7 +164,7 @@ module('Acceptance | Modify-Challenge-Illustration', function (hooks) {
     // when
     const screen = await visit('/competence/recCompetence1.1/prototypes/recChallenge1');
     await click(find('[data-test-modify-challenge-button]'));
-    await click(find('[data-test-delete-illustration-button]'));
+    await click(screen.getByRole('button', { name: "Supprimer l'image" }));
 
     await runTask(this, async () => {}, 200);
     await click(find('[data-test-save-challenge-button]'));

--- a/pix-editor/tests/acceptance/competence-management/new-test.js
+++ b/pix-editor/tests/acceptance/competence-management/new-test.js
@@ -1,5 +1,5 @@
-import { clickByName, clickByText, visit } from '@1024pix/ember-testing-library';
-import { click, currentURL, fillIn, find } from '@ember/test-helpers';
+import { clickByName, clickByText, fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -50,8 +50,8 @@ module('Acceptance | competence-management/new', function (hooks) {
     await clickByText('Pix+');
     await click(screen.getByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: 'Ajouter une compétence' }));
-    await fillIn('[data-test-competence-title-input] input', newCompetenceTitle);
-    await click(find('[data-test-save-button]'));
+    await fillByLabel('Titre :', newCompetenceTitle);
+    await click(screen.getByRole('button', { name: 'Enregistrer' }));
 
     // then
     const area = await store.peekRecord('area', 'recArea1');
@@ -64,7 +64,7 @@ module('Acceptance | competence-management/new', function (hooks) {
   test('it should cancel creation', async function (assert) {
     // when
     const screen = await visit('/competence-management/new/recArea1');
-    await click(find('[data-test-cancel-button]'));
+    await click(screen.getByRole('button', { name: 'Annuler' }));
 
     // then
     assert.dom(screen.getByText('Création de la compétence annulée')).exists();

--- a/pix-editor/tests/acceptance/competence-management/new-test.js
+++ b/pix-editor/tests/acceptance/competence-management/new-test.js
@@ -78,7 +78,7 @@ module('Acceptance | competence-management/new', function (hooks) {
 
     // when
     const screen = await visit('/competence-management/new/recArea1');
-    await click(find('.bars.icon'));
+    await click(screen.getByRole('button', { name: 'Afficher/cacher la barre latérale' }));
     await click(await screen.findByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: 'Code Titre' }));
 

--- a/pix-editor/tests/acceptance/competence-management/single-test.js
+++ b/pix-editor/tests/acceptance/competence-management/single-test.js
@@ -73,7 +73,7 @@ module('Acceptance | competence-management/single', function (hooks) {
     // when
     const screen = await visit('/competence-management/recCompetence1.1');
     await click(find('[data-test-edit-button]'));
-    await click(find('.bars.icon'));
+    await click(screen.getByRole('button', { name: 'Afficher/cacher la barre latérale' }));
     await click(await screen.findByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: 'Code Titre' }));
 

--- a/pix-editor/tests/acceptance/competence-management/single-test.js
+++ b/pix-editor/tests/acceptance/competence-management/single-test.js
@@ -1,5 +1,5 @@
-import { visit } from '@1024pix/ember-testing-library';
-import { click, currentURL, fillIn, find } from '@ember/test-helpers';
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -39,9 +39,9 @@ module('Acceptance | competence-management/single', function (hooks) {
 
     // when
     const screen = await visit('/competence-management/recCompetence1.1');
-    await click(find('[data-test-edit-button]'));
-    await fillIn('[data-test-competence-title-input] input', newCompetenceTitle);
-    await click(find('[data-test-save-button]'));
+    await click(await screen.findByRole('button', { name: 'Modifier' }));
+    await fillByLabel('Titre :', newCompetenceTitle);
+    await click(screen.getByRole('button', { name: 'Enregistrer' }));
 
     // then
     const competence = await store.peekRecord('competence', 'recCompetence1.1');
@@ -55,9 +55,9 @@ module('Acceptance | competence-management/single', function (hooks) {
 
     // when
     const screen = await visit('/competence-management/recCompetence1.1');
-    await click(find('[data-test-edit-button]'));
-    await fillIn('[data-test-competence-title-input] input', newCompetenceTitle);
-    await click(find('[data-test-cancel-button]'));
+    await click(await screen.findByRole('button', { name: 'Modifier' }));
+    await fillByLabel('Titre :', newCompetenceTitle);
+    await click(screen.getByRole('button', { name: 'Annuler' }));
 
     // then
     const competence = await store.peekRecord('competence', 'recCompetence1.1');
@@ -72,7 +72,7 @@ module('Acceptance | competence-management/single', function (hooks) {
 
     // when
     const screen = await visit('/competence-management/recCompetence1.1');
-    await click(find('[data-test-edit-button]'));
+    await click(await screen.findByRole('button', { name: 'Modifier' }));
     await click(screen.getByRole('button', { name: 'Afficher/cacher la barre latérale' }));
     await click(await screen.findByRole('button', { name: '1. Information et données' }));
     await click(screen.getByRole('link', { name: 'Code Titre' }));

--- a/pix-editor/tests/acceptance/competence/prototypes/list-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/list-test.js
@@ -1,4 +1,5 @@
-import { click, currentURL, find, findAll, visit, waitUntil } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, find, findAll, waitUntil } from '@ember/test-helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -19,7 +20,7 @@ module('Acceptance | competence/prototypes/list', function () {
   module('visiting /competence/:competence_id/prototypes/list/:tube_id/:skill_id', function (hooks) {
     setupApplicationTest(hooks);
     setupMirage(hooks);
-
+    let screen;
     hooks.beforeEach(async function () {
       // given
       this.server.create('config', 'default');
@@ -103,7 +104,7 @@ module('Acceptance | competence/prototypes/list', function () {
       await authenticateSession();
 
       // when
-      await visit(`/competence/${competenceId1}/prototypes/list/${tubeId1}/${skillId1}?view=workbench`);
+      screen = await visit(`/competence/${competenceId1}/prototypes/list/${tubeId1}/${skillId1}?view=workbench`);
     });
 
     test('it should display a list of prototype of `skill1`', function (assert) {
@@ -147,7 +148,7 @@ module('Acceptance | competence/prototypes/list', function () {
 
       // when
       await click(findAll('[data-test-skill-tab]')[1]);
-      await click(find('[data-test-new-prototype-action]'));
+      await click(screen.getByRole('button', { name: 'Nouvelle version' }));
 
       // then
       assert.strictEqual(currentURL().indexOf(expectedResult), 0);

--- a/pix-editor/tests/acceptance/competence/skills/single-test.js
+++ b/pix-editor/tests/acceptance/competence/skills/single-test.js
@@ -1,5 +1,5 @@
 import { clickByText, visit } from '@1024pix/ember-testing-library';
-import { click, currentURL, fillIn, find } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { waitForSelectToBeClosed } from 'pixeditor/tests/helpers/wait-for-select-to-be-closed';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
@@ -83,8 +83,10 @@ module('Acceptance | skill | single', function (hooks) {
     const confirmStub = sinon.stub(window, 'confirm');
     confirmStub.returns(true);
 
-    await visit(`/competence/${competence1.id}/skills/new/${tube1.id}/0?leftMaximized=true&view=workbench`);
-    await click(find('.icon.window.close'));
+    const screen = await visit(
+      `/competence/${competence1.id}/skills/new/${tube1.id}/0?leftMaximized=true&view=workbench`,
+    );
+    await click(screen.getByRole('button', { name: 'Fermer la fenêtre' }));
 
     assert.strictEqual(currentURL(), `/competence/${competence1.id}/skills?view=workbench`);
   });

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-attachment-test.js
@@ -1,6 +1,6 @@
 import { clickByText, visit } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click, find, findAll } from '@ember/test-helpers';
+import { click, findAll } from '@ember/test-helpers';
 import { selectFiles } from 'ember-file-upload/test-support';
 import { runTask } from 'ember-lifeline';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -185,7 +185,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function (hooks) {
 
     // replace attachmentA with attachmentB
     await clickByText('Modifier');
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
     await selectFiles('[data-test-file-input-attachment] input', attachmentB);
     await runTask(this, async () => {}, 400);
     saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
@@ -217,7 +217,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function (hooks) {
     await clickByText('Version nl');
     await clickByText('Modifier');
 
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
 
     await runTask(this, async () => {}, 200);
     const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
@@ -246,7 +246,7 @@ module('Acceptance | Modify-Localized-Challenge-Attachment', function (hooks) {
     const screen = await visit('/competence/recCompetence1.1/prototypes/recChallenge1');
     await clickByText('Version nl');
     await clickByText('Modifier');
-    await click(find('[data-test-delete-attachment-button]'));
+    await click(screen.getByRole('button', { name: 'Supprimer le fichier' }));
 
     await runTask(this, async () => {}, 200);
     const cancelButton = await screen.findByRole('button', { name: 'Annuler' });

--- a/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
+++ b/pix-editor/tests/acceptance/modify-localized-challenge/modify-localized-challenge-illustration-test.js
@@ -1,6 +1,6 @@
 import { clickByText, visit, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import { click, find, findAll } from '@ember/test-helpers';
+import { click, findAll } from '@ember/test-helpers';
 import { selectFiles } from 'ember-file-upload/test-support';
 import { runTask } from 'ember-lifeline';
 import { authenticateSession } from 'ember-simple-auth/test-support';
@@ -158,7 +158,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function (hooks) 
 
     // replace illustrationA with illustrationB
     await clickByText('Modifier');
-    await click(find('[data-test-delete-illustration-button]'));
+    await click(screen.getByRole('button', { name: "Supprimer l'image" }));
     await selectFiles('[data-test-file-input-illustration] input', illustrationB);
     await runTask(this, async () => {}, 400);
     saveButton = await screen.findByRole('button', { name: 'Enregistrer' });
@@ -195,7 +195,7 @@ module('Acceptance | Modify-Localized-Challenge-Illustration', function (hooks) 
     const screen = await visit('/competence/recCompetence1.1/prototypes/recChallenge1');
     await clickByText('Version nl');
     await clickByText('Modifier');
-    await click(find('[data-test-delete-illustration-button]'));
+    await click(screen.getByRole('button', { name: "Supprimer l'image" }));
 
     await runTask(this, async () => {}, 200);
     const saveButton = await screen.findByRole('button', { name: 'Enregistrer' });

--- a/pix-editor/tests/integration/components/competence/competence-footer-test.gjs
+++ b/pix-editor/tests/integration/components/competence/competence-footer-test.gjs
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import CompetenceFooter from 'pixeditor/components/competence/competence-footer';
 import { module, test } from 'qunit';
 
@@ -11,15 +11,15 @@ module('Integration | Component | competence/competence-footer', function (hooks
     const self = this;
 
     // given
-    this.section = 'skills';
+    this.section = 'challenges';
     this.competence = {};
-    this.view = 'production';
+    this.view = 'workbench';
     this.mayCreateTube = true;
     this.externalAction = () => {};
 
     // when
 
-    await render(
+    const screen = await render(
       <template>
         <CompetenceFooter
           @competence={{self.competence}}
@@ -34,7 +34,8 @@ module('Integration | Component | competence/competence-footer', function (hooks
     );
 
     // then
-
     assert.dom('.ui.borderless.bottom').exists();
+    assert.dom(screen.getByRole('button', { name: "Grille d'atelier des épreuves" })).exists();
+    assert.dom(screen.getByRole('button', { name: "Atelier d'atelier des épreuves" })).exists();
   });
 });

--- a/pix-editor/tests/integration/components/competence/competence-grid-thematic-test.gjs
+++ b/pix-editor/tests/integration/components/competence/competence-grid-thematic-test.gjs
@@ -1,6 +1,6 @@
+import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import { render } from '@ember/test-helpers';
 import CompetenceGridThematic from 'pixeditor/components/competence/competence-grid-thematic';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -180,7 +180,7 @@ module('Integration | Component | competence/competence-grid-thematic', function
       this.section = 'skills';
 
       // when
-      await render(
+      const screen = await render(
         <template>
           <CompetenceGridThematic
             @section={{self.section}}
@@ -191,9 +191,10 @@ module('Integration | Component | competence/competence-grid-thematic', function
           />
         </template>,
       );
+
       // then
-      assert.dom('[data-test-add-tube]').exists();
-      assert.dom('[data-test-sort-tube]').exists();
+      assert.dom(screen.getByRole('button', { name: 'Nouveau sujet' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Trier les sujets' })).exists();
     });
   });
 
@@ -253,7 +254,7 @@ module('Integration | Component | competence/competence-grid-thematic', function
       this.section = 'skills';
 
       // when
-      await render(
+      const screen = await render(
         <template>
           <CompetenceGridThematic
             @section={{self.section}}
@@ -266,7 +267,7 @@ module('Integration | Component | competence/competence-grid-thematic', function
       // then
       assert.dom('[data-test-theme-cell] a').hasText('Thematic');
       assert.dom('[data-test-empty-row]').exists();
-      assert.dom('[data-test-add-tube]').exists();
+      assert.dom(screen.getByRole('button', { name: 'Nouveau sujet' })).exists();
     });
   });
 });

--- a/pix-editor/tests/unit/controllers/competence/themes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/themes/single-test.js
@@ -63,7 +63,7 @@ module('Unit | Controller | competence/themes/single', function (hooks) {
     assert.notOk(controller.edition);
     assert.ok(saveStub.calledOnce);
     assert.ok(loaderStopStub.calledOnce);
-    assert.ok(pixToastSendSuccess.calledWith('Thématique mis à jour'));
+    assert.ok(pixToastSendSuccess.calledWith('Thématique mise à jour'));
   });
 
   test('it should catch an error if save action failed', async function (assert) {


### PR DESCRIPTION
## 🪧 Problème
Dans Pix-Editor, il y a plein de boutons qui n'ont qu'une icône, et on ne sait pas ce qu'ils font. Ça peut faire un peu peur quand on y va pour la première fois, savoir ce qu'on peut faire ou pas sans risque.

## 🌈 Proposition
Ajout d'un `title` sur tous les boutons qui ne sont matérialisés que par une icône.

## ✊ Remarques
On en profite aussi pour faire un peu de nettoyage et dégager les `data-test-bla-bla` sur les boutons concernés (ou ceux qui ont un titre mais dont on les cherche via leur attribut `data-test-bla-bla`)

## 🎉 Pour tester
Tests au vert
Se balader dans Pix-Editor et constater qu'au survol des icônes de type bouton, on a une infobulle qui indique ce que le bouton fait. (Les boutons de minimisation/maximisation/fermeture de fenêtre, etc.)