### PR TITLE
[BUGFIX] Corriger la duplication de challenge (PIX-23246).

### DIFF
--- a/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/new.js
@@ -32,9 +32,9 @@ export default class NewController extends Prototype {
       await this._handleIllustration(this.challenge);
       await this._handlePiecesJointes(this.challenge);
       // create challenge without patching Pix API cache
+      await this._setVersion(this.challenge);
       await this._saveChallenge(this.challenge);
       await this._saveFiles(this.challenge);
-      await this._setVersion(this.challenge);
       // update challenge's version and patch Pix API cache
       await this._saveChallenge(this.challenge);
       this.edition = false;


### PR DESCRIPTION
## 🪧 Problème

Lors de la duplication d'un challenge, nous devons mettre à jour une nouvelle version. Or il arrive que cette version soit null ce qui ne permet pas de faire la mise à jour correctement.

## 🌈 Proposition

Définir la version avant de sauvegarder le challenge

## ✊ Remarques

Cette logique sera déplacer côté Back dans un futur ticket afin de laisser la connaissance des règles métier au back

## 🎉 Pour tester
Se connecter sur pix editor
dupliquer un challenge
ne pas voir de 500 lors de l'enregistrement et constater un numéro de version dans celui-ci nouvellement créée