### PR TITLE
[FEATURE] Créer un draft à partir d’un module en production (PIX-22928)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -73,6 +73,14 @@ export function register(server) {
                 sections: Joi.array().required(),
                 glossary: Joi.array().required(),
               }).required(),
+              relationships: Joi.object({
+                module: Joi.object({
+                  data: Joi.object({
+                    id: Types.moduleId().required(),
+                    type: Joi.string().valid('modules').required(),
+                  }).optional(),
+                }).optional(),
+              }).optional(),
             }).required(),
           }).required(),
         },

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -6,8 +6,11 @@ export class DraftModule extends Module {
     this.moduleId = moduleId;
   }
 
-  prepareForCreation() {
-    this.id = crypto.randomUUID();
-    this.shortId = this.id.slice(0, 8);
+  /**
+   * @param {import('./Module.js').Module} module
+   */
+  prepareForCreation(module) {
+    this.id = module?.id ?? crypto.randomUUID();
+    this.shortId = module?.shortId ?? this.id.slice(0, 8);
   }
 }

--- a/api/lib/domain/usecases/create-draft-module.js
+++ b/api/lib/domain/usecases/create-draft-module.js
@@ -1,10 +1,14 @@
-import { draftModuleRepository } from '../../infrastructure/repositories/index.js';
+import { draftModuleRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
 
 /**
  *
- * @param {import('../models/index.js').Module} module
+ * @param {import('../models/index.js').DraftModule} draftModule
  */
-export async function createDraftModule(module, dependencies = { draftModuleRepository }) {
-  module.prepareForCreation();
-  return dependencies.draftModuleRepository.save(module);
+export async function createDraftModule(draftModule, dependencies = { draftModuleRepository, moduleRepository }) {
+  const module = draftModule.moduleId
+    ? await dependencies.moduleRepository.getById({ id: draftModule.moduleId })
+    : undefined;
+
+  draftModule.prepareForCreation(module);
+  return dependencies.draftModuleRepository.save(draftModule);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
@@ -6,8 +6,13 @@ const { Deserializer, Serializer } = Jsonapi;
 
 const deserializer = new Deserializer({
   keyForAttribute: 'camelCase',
-  transform(draftModuleDto) {
-    return new DraftModule(draftModuleDto);
+  modules: {
+    valueForRelationship(module) {
+      return module.id;
+    },
+  },
+  transform({ module: moduleId = null, ...draftModuleDto }) {
+    return new DraftModule({ ...draftModuleDto, moduleId });
   },
 });
 

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -78,7 +78,7 @@ describe('Acceptance | Route | draft-modules', () => {
     });
 
     describe('when creating a draft for a production module', () => {
-      it.fails('responds with status 201 and draft modules data', async () => {
+      it('responds with status 201 and draft modules data', async () => {
         // given
         const module = domainBuilder.buildModule({
           sections: [],

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -76,6 +76,110 @@ describe('Acceptance | Route | draft-modules', () => {
         },
       ]);
     });
+
+    describe('when creating a draft for a production module', () => {
+      it.fails('responds with status 201 and draft modules data', async () => {
+        // given
+        const module = domainBuilder.buildModule({
+          sections: [],
+          glossary: [],
+        });
+        databaseBuilder.factory.buildModule(module);
+        await databaseBuilder.commit();
+
+        const draftModule = domainBuilder.buildDraftModule({
+          id: module.id,
+          shortId: module.shortId,
+          moduleId: module.id,
+          slug: module.slug + '_update',
+          title: module.title + ' update',
+          internalTitle: module.internalTitle + '_update',
+          isBeta: true,
+          visibility: Module.VISIBILITIES.PRIVATE,
+          details: {
+            image: module.details.image + '_update',
+            description: module.details.description + ' update',
+            duration: module.details.duration + 1,
+            level: Module.LEVELS.ADVANDCED,
+            objectives: [...module.details.objectives, 'update'],
+            tabletSupport: module.details.tabletSupport + '_update',
+          },
+        });
+        const draftModulePayload = {
+          slug: draftModule.slug,
+          title: draftModule.title,
+          'internal-title': draftModule.internalTitle,
+          'is-beta': draftModule.isBeta,
+          visibility: draftModule.visibility,
+          details: draftModule.details,
+          sections: draftModule.sections,
+          glossary: draftModule.glossary,
+        };
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/draft-modules',
+          headers: generateAuthorizationHeader(editorUser),
+          payload: {
+            data: {
+              type: 'draft-modules',
+              attributes: draftModulePayload,
+              relationships: {
+                module: {
+                  data: {
+                    id: draftModule.moduleId,
+                    type: 'modules',
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).toBe(201);
+        expect(response.result).toStrictEqual({
+          data: {
+            type: 'draft-modules',
+            id: draftModule.id,
+            attributes: {
+              'short-id': draftModule.shortId,
+              ...draftModulePayload,
+            },
+            relationships: {
+              module: {
+                data: {
+                  id: module.id,
+                  type: 'modules',
+                },
+              },
+              diff: { links: { related: `/api/draft-modules/${draftModule.id}/diff` } },
+            },
+          },
+        });
+
+        await expect(knex.select('*').from('draft-modules')).resolves.toStrictEqual([
+          {
+            id: draftModule.id,
+            shortId: draftModule.shortId,
+            moduleId: draftModule.moduleId,
+            internalTitle: draftModule.internalTitle,
+            slug: draftModule.slug,
+            title: draftModule.title,
+            isBeta: draftModule.isBeta,
+            visibility: draftModule.visibility,
+            sections: draftModule.sections,
+            glossary: draftModule.glossary,
+            ...draftModule.details,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          },
+        ]);
+      });
+    });
   });
 
   describe('GET /draft-modules', () => {

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -19,6 +19,21 @@ describe('Unit | Domain | DraftModule', () => {
       expect(draftModule.shortId).toMatch(shortIdRegExp);
       expect(draftModule.shortId).toBe(draftModule.id.slice(0, 8));
     });
+
+    describe('when a module is given', () => {
+      it('uses module’s id and shortId', () => {
+        // given
+        const module = domainBuilder.buildModule();
+        const draftModule = new DraftModule();
+
+        // when
+        draftModule.prepareForCreation(module);
+
+        // then
+        expect(draftModule.id).toBe(module.id);
+        expect(draftModule.shortId).toBe(module.shortId);
+      });
+    });
   });
 
   describe('#serializeToJSON', () => {

--- a/api/tests/unit/domain/usecases/create-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/create-draft-module_test.js
@@ -8,26 +8,44 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
   let draftModuleRepository, draftModule, prepareForCreation;
 
   beforeEach(() => {
-    draftModuleRepository = { save: vi.fn() };
+    draftModuleRepository = { save: vi.fn().mockResolvedValueOnce(savedDraftModule) };
 
     draftModule = domainBuilder.buildDraftModule({
       id: null,
       shortId: null,
-      moduleId: null,
     });
     prepareForCreation = vi.spyOn(draftModule, 'prepareForCreation');
-
-    draftModuleRepository.save.mockResolvedValueOnce(savedDraftModule);
   });
 
-  it('prepares module for creation and saves it', async () => {
+  it('prepares draft module for creation and saves it', async () => {
     // when
     const result = createDraftModule(draftModule, { draftModuleRepository });
 
     // then
     await expect(result).resolves.toBe(savedDraftModule);
 
-    expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith();
+    expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(undefined);
     expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
+  });
+
+  describe('when draft module has a moduleId', () => {
+    it('prepares for creation using module', async () => {
+      // given
+      const module = Symbol('module');
+      const moduleRepository = { getById: vi.fn().mockResolvedValueOnce(module) };
+
+      const moduleId = Symbol('moduleId');
+      draftModule.moduleId = moduleId;
+
+      // when
+      const result = createDraftModule(draftModule, { draftModuleRepository, moduleRepository });
+
+      // then
+      await expect(result).resolves.toBe(savedDraftModule);
+
+      expect(moduleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: moduleId });
+      expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(module);
+      expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
+    });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/draft-module-serializer.js';
+import { deserialize, serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/draft-module-serializer.js';
 import { domainBuilder } from '../../../../test-helper.js';
 import { Module } from '../../../../../lib/domain/models/Module.js';
 
@@ -92,6 +92,78 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
           rowCount: 666,
           pageCount: 333,
         },
+      });
+    });
+  });
+
+  describe('#deserialize', () => {
+    it('deserializes payload to DraftModule model', async () => {
+      // given
+      const expectedDraftModule = domainBuilder.buildDraftModule();
+      expectedDraftModule.createdAt = undefined;
+      expectedDraftModule.updatedAt = undefined;
+      const payload = {
+        data: {
+          type: 'draft-modules',
+          id: expectedDraftModule.id,
+          attributes: {
+            'internal-title': expectedDraftModule.internalTitle,
+            'short-id': expectedDraftModule.shortId,
+            slug: expectedDraftModule.slug,
+            title: expectedDraftModule.title,
+            'is-beta': expectedDraftModule.isBeta,
+            visibility: expectedDraftModule.visibility,
+            details: expectedDraftModule.details,
+            sections: expectedDraftModule.sections,
+            glossary: expectedDraftModule.glossary,
+          },
+        },
+      };
+
+      // when
+      const draftModule = await deserialize(payload);
+
+      // then
+      expect(draftModule).toStrictEqual(expectedDraftModule);
+    });
+
+    describe('when payload has a module relationship', () => {
+      it('deserializes payload to DraftModule model', async () => {
+        // given
+        const expectedDraftModule = domainBuilder.buildDraftModule({ moduleId: crypto.randomUUID() });
+        expectedDraftModule.createdAt = undefined;
+        expectedDraftModule.updatedAt = undefined;
+        const payload = {
+          data: {
+            type: 'draft-modules',
+            id: expectedDraftModule.id,
+            attributes: {
+              'internal-title': expectedDraftModule.internalTitle,
+              'short-id': expectedDraftModule.shortId,
+              slug: expectedDraftModule.slug,
+              title: expectedDraftModule.title,
+              'is-beta': expectedDraftModule.isBeta,
+              visibility: expectedDraftModule.visibility,
+              details: expectedDraftModule.details,
+              sections: expectedDraftModule.sections,
+              glossary: expectedDraftModule.glossary,
+            },
+            relationships: {
+              module: {
+                data: {
+                  type: 'modules',
+                  id: expectedDraftModule.moduleId,
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        const draftModule = await deserialize(payload);
+
+        // then
+        expect(draftModule).toStrictEqual(expectedDraftModule);
       });
     });
   });

--- a/pix-editor/app/components/modules/create-module-button.gjs
+++ b/pix-editor/app/components/modules/create-module-button.gjs
@@ -1,9 +1,34 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import Component from '@glimmer/component';
 
-<template>
-  <PixButtonLink @route="authenticated.modules.new" class="pix-button-link-with-icon white-font">
-    <PixIcon @name="add" @ariaHidden={{true}} />
-    Créer un module
-  </PixButtonLink>
-</template>
+export default class CreateModuleButton extends Component {
+  get isDisplayed() {
+    return !this.args.module?.hasDraft;
+  }
+
+  get query() {
+    const { module } = this.args;
+    if (!module) return {};
+    return {
+      moduleId: module.id,
+    };
+  }
+
+  <template>
+    {{#if this.isDisplayed}}
+      <PixButtonLink
+        @route="authenticated.modules.new"
+        @query={{this.query}}
+        class="pix-button-link-with-icon white-font"
+      >
+        <PixIcon @name="add" @ariaHidden={{true}} />
+        {{#if @module}}
+          Créer un draft
+        {{else}}
+          Créer un module
+        {{/if}}
+      </PixButtonLink>
+    {{/if}}
+  </template>
+}

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -1,5 +1,4 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
-import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixLabel from '@1024pix/pix-ui/components/pix-label';
 import { on } from '@ember/modifier';
@@ -56,6 +55,10 @@ export default class ModuleForm extends Component {
     return this.args.saveModule({ ...this.moduleData, internalTitle: this.internalTitle });
   }
 
+  back() {
+    window.history.back();
+  }
+
   <template>
     <div class="module-form">
       {{#if @readonly}}
@@ -83,9 +86,9 @@ export default class ModuleForm extends Component {
           <PixButton @triggerAction={{this.saveModule}} @isDisabled={{this.isSaveDisabled}}>
             Enregistrer
           </PixButton>
-          <PixButtonLink @route="authenticated.modules" @variant="secondary">
+          <PixButton @triggerAction={{this.back}} @variant="secondary">
             Annuler
-          </PixButtonLink>
+          </PixButton>
         </div>
       {{/unless}}
     </div>

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -1,6 +1,7 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
 import PixInput from '@1024pix/pix-ui/components/pix-input';
 import PixLabel from '@1024pix/pix-ui/components/pix-label';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -59,8 +60,23 @@ export default class ModuleForm extends Component {
     window.history.back();
   }
 
+  get isIdsChangedWarningDisplayed() {
+    if (!this.moduleData || !this.args.module) return false;
+    return this.moduleData.id !== this.args.module.id || this.moduleData.shortId !== this.args.module.shortId;
+  }
+
   <template>
     <div class="module-form">
+      {{#if this.isIdsChangedWarningDisplayed}}
+        <PixNotificationAlert @type="warning">
+          Les champs
+          <code>id</code>
+          et
+          <code>shortId</code>
+          ne peuvent pas être modifiés.
+        </PixNotificationAlert>
+      {{/if}}
+
       {{#if @readonly}}
         <h2 class="module-internal-title">{{this.internalTitle}}</h2>
       {{else}}

--- a/pix-editor/app/controllers/authenticated/modules/new.js
+++ b/pix-editor/app/controllers/authenticated/modules/new.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class NewModuleController extends Controller {
+  queryParams = ['moduleId'];
+}

--- a/pix-editor/app/models/base-module.js
+++ b/pix-editor/app/models/base-module.js
@@ -13,6 +13,7 @@ const levelForDisplay = {
 };
 
 export default class BaseModule extends Model {
+  @attr shortId;
   @attr internalTitle;
   @attr title;
   @attr isBeta;

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -85,7 +85,7 @@ Router.map(function () {
     });
     this.route('modules', function () {
       this.route('index', { path: '/' });
-      this.route('new');
+      this.route('new', { path: '/workbench/new' });
       this.route('production');
       this.route('workbench');
       this.route('production-module', { path: '/production/:module_id' });

--- a/pix-editor/app/routes/authenticated/modules/new.js
+++ b/pix-editor/app/routes/authenticated/modules/new.js
@@ -1,0 +1,18 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class NewModuleRoute extends Route {
+  @service store;
+
+  async model(params) {
+    if (!params.moduleId) return {};
+    const module = await this.store.findRecord('module', params.moduleId, { reload: true });
+    return { module };
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('moduleId', undefined);
+    }
+  }
+}

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -29,7 +29,7 @@ td.modules-list__actions {
 
 .draft-module-diff {
   pre.shiki {
-    height: 70vh;
+    max-height: 70vh;
     margin: 0;
     padding: var(--pix-spacing-4x);
     overflow: scroll;

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -11,6 +11,8 @@ export default class NewModule extends Component {
 
   @action
   async saveModule({ internalTitle, title, isBeta, slug, visibility, details, sections, glossary }) {
+    const { module } = this.args.model;
+
     const newModule = this.store.createRecord('draft-module', {
       internalTitle,
       title,
@@ -20,15 +22,25 @@ export default class NewModule extends Component {
       details,
       sections,
       glossary,
+      module,
     });
 
     try {
       this.loader.start();
       await newModule.save();
-      this.router.replaceWith('authenticated.modules.workbench');
-      this.notifications.sendSuccess(`Le module "${newModule.internalTitle}" a été enregistré.`);
+      if (module) {
+        this.router.replaceWith('authenticated.modules.draft-module', newModule.id);
+        this.notifications.sendSuccess(`Le draft "${newModule.internalTitle}" a été enregistré.`);
+      } else {
+        this.router.replaceWith('authenticated.modules.workbench');
+        this.notifications.sendSuccess(`Le module "${newModule.internalTitle}" a été enregistré.`);
+      }
     } catch {
-      this.notifications.sendError('Erreur lors de l’enregistrement du module.');
+      if (module) {
+        this.notifications.sendError('Erreur lors de l’enregistrement du draft.');
+      } else {
+        this.notifications.sendError('Erreur lors de l’enregistrement du module.');
+      }
     } finally {
       this.loader.stop();
     }
@@ -36,11 +48,17 @@ export default class NewModule extends Component {
 
   <template>
     <header class="page-header">
-      <h1 class="page-title">Création d'un module</h1>
+      <h1 class="page-title">
+        {{#if @model.module}}
+          Création d’un draft
+        {{else}}
+          Création d’un module
+        {{/if}}
+      </h1>
     </header>
     <main class="page-body">
       <section class="page-section module-form">
-        <ModuleForm @saveModule={{this.saveModule}} />
+        <ModuleForm @module={{@model.module}} @saveModule={{this.saveModule}} />
       </section>
     </main>
   </template>

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,3 +1,4 @@
+import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModuleNotification from 'pixeditor/components/modules/module-notification';
@@ -5,7 +6,9 @@ import ModuleNotification from 'pixeditor/components/modules/module-notification
 <template>
   <header class="page-header">
     <h1 class="page-title">Détail du module</h1>
-
+    <div class="page-actions">
+      <CreateModuleButton @module={{@model.module}} />
+    </div>
   </header>
   <main class="page-body">
     <section class="page-section module-form">

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -5,7 +5,7 @@ import { setupApplicationTest } from 'pixeditor/tests/setup-application-renderin
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
 
-module('Acceptance | Modules | Workbench Module', function (hooks) {
+module('Acceptance | Modules | Draft Module', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let id;

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -1,5 +1,6 @@
-import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL, fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { getByRole } from '@testing-library/dom';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -23,8 +24,9 @@ module('Acceptance | Modules | New', function (hooks) {
   test.if('creates a new module', !isChrome, async function (assert) {
     // when
     const screen = await visit('/');
-    await clickByName('Modules');
-    await screen.getByRole('link', { name: 'Créer un module' }).click();
+
+    await click(await screen.findByRole('link', { name: 'Modules' }));
+    await click(await screen.findByRole('link', { name: 'Créer un module' }));
 
     // then
     assert.dom(await screen.findByRole('heading', { name: 'Création d’un module' })).exists();
@@ -68,5 +70,38 @@ module('Acceptance | Modules | New', function (hooks) {
     assert.strictEqual(currentURL(), '/modules/workbench');
     assert.dom(screen.getByText('NEW_MODULE')).exists();
     assert.dom(await screen.findByText('Le module "NEW_MODULE" a été enregistré.')).exists();
+  });
+
+  test.if('creates a new draft', !isChrome, async function (assert) {
+    // when
+    const screen = await visit('/');
+
+    await click(await screen.findByRole('link', { name: 'Modules' }));
+
+    await click(await screen.findByRole('link', { name: 'En production' }));
+
+    assert.dom(await screen.findByText('MOD_0')).exists();
+    const firstModule = screen.getByText('MOD_0').closest('tr');
+    await click(getByRole(firstModule, 'link', { name: 'Voir le détail' }));
+
+    const [, moduleId] = currentURL().match(/\/modules\/production\/(.*)$/);
+
+    await screen.getByRole('link', { name: 'Créer un draft' }).click();
+
+    // then
+    assert.dom(await screen.findByRole('heading', { name: 'Création d’un draft' })).exists();
+    assert.strictEqual(currentURL(), `/modules/workbench/new?moduleId=${moduleId}`);
+
+    await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'MOD_666');
+
+    // WORKAROUND: let some time for Monaco
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    await screen.getByRole('button', { name: 'Enregistrer' }).click();
+
+    assert.dom(await screen.findByRole('heading', { name: 'Détail du draft de module' })).exists();
+    assert.strictEqual(currentURL(), `/modules/workbench/${moduleId}`);
+    assert.dom(await screen.findByRole('heading', { name: 'MOD_666' })).exists();
+    assert.dom(await screen.findByText('Le draft "MOD_666" a été enregistré.')).exists();
   });
 });

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -27,8 +27,8 @@ module('Acceptance | Modules | New', function (hooks) {
     await screen.getByRole('link', { name: 'Créer un module' }).click();
 
     // then
+    assert.dom(await screen.findByRole('heading', { name: 'Création d’un module' })).exists();
     assert.strictEqual(currentURL(), '/modules/workbench/new');
-    assert.dom(await screen.findByRole('heading', { name: "Création d'un module" })).exists();
 
     await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'NEW_MODULE');
 

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Modules | New', function (hooks) {
     await screen.getByRole('link', { name: 'Créer un module' }).click();
 
     // then
-    assert.strictEqual(currentURL(), '/modules/new');
+    assert.strictEqual(currentURL(), '/modules/workbench/new');
     assert.dom(await screen.findByRole('heading', { name: "Création d'un module" })).exists();
 
     await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'NEW_MODULE');

--- a/pix-editor/tests/integration/components/modules/create-module-button-test.gjs
+++ b/pix-editor/tests/integration/components/modules/create-module-button-test.gjs
@@ -1,0 +1,63 @@
+import { render } from '@1024pix/ember-testing-library';
+import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Components | modules/create-module-button', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when module has a draft', function () {
+    test('it displays nothing', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const module = store.createRecord('module', {
+        id: 'moduleId',
+        draftModule: store.createRecord('draft-module', {
+          id: 'moduleId',
+        }),
+      });
+
+      // when
+      const screen = await render(<template><CreateModuleButton @module={{module}} /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('link')).doesNotExist();
+    });
+  });
+
+  module('when module does not have a draft', function () {
+    test('it displays draft creation button', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const module = store.createRecord('module', {
+        id: 'moduleId',
+      });
+
+      // when
+      const screen = await render(<template><CreateModuleButton @module={{module}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Créer un draft' })).exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Créer un draft' }))
+        .hasAttribute('href', /\/modules\/workbench\/new\?moduleId=moduleId$/);
+    });
+  });
+
+  module('when no module', function () {
+    test('it displays module creation button', async function (assert) {
+      // given
+      const module = undefined;
+
+      // when
+      const screen = await render(<template><CreateModuleButton @module={{module}} /></template>);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Créer un module' })).exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Créer un module' }))
+        .hasAttribute('href', /\/modules\/workbench\/new$/);
+    });
+  });
+});

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -384,8 +384,15 @@ export default function routes() {
   });
 
   this.post('/draft-modules', function (schema, request) {
-    const attributes = JSON.parse(request.requestBody).data.attributes;
-    return schema.create('draft-module', { id: crypto.randomUUID(), ...attributes });
+    const body = JSON.parse(request.requestBody);
+    const attributes = body.data.attributes;
+
+    const moduleId = body.data.relationships?.module?.data?.id;
+    if (moduleId) {
+      attributes.module = schema.modules.find(moduleId);
+    }
+
+    return schema.create('draft-module', { id: moduleId ?? crypto.randomUUID(), ...attributes });
   });
 
   this.get('/draft-modules', function (schema, request) {


### PR DESCRIPTION
## 🪧 Problème

On veut pouvoir créer un draft à partir d’un module en production.

## 🌈 Proposition

Ajouter un bouton "Créer un draft" qui ouvre un formulaire de création de draft pré-rempli avec les données du module.
Quand on enregistre un nouveau draft est créé, rattaché au module.

## ✊ Remarques

- J'ai ajouté une fonctionnalité : si l'utilisateur veut modifier le shortId ou l'id du draft-module, un message l'avertit qu'il ne peut pas le faire

## 🎉 Pour tester

Créer un draft à partir d’un module.
