### PR TITLE
[FEATURE] À la création d'un draft-module, patcher la release de recette (PIX-22784)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -78,7 +78,7 @@ export function register(server) {
                   data: Joi.object({
                     id: Types.moduleId().required(),
                     type: Joi.string().valid('modules').required(),
-                  }).optional(),
+                  }).empty(null).optional(),
                 }).optional(),
               }).optional(),
             }).required(),

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -15,12 +15,14 @@ import {
 import * as updatedRecordNotifier from '../../infrastructure/event-notifier/updated-record-notifier.js';
 import * as pixApiClient from '../../infrastructure/pix-api-client.js';
 import { child } from '../../infrastructure/logger.js';
+import { ModuleForRelease } from '../models/release/ModuleForRelease.js';
 
 /**
  * @typedef {import('../../../lib/domain/models').Area} Area
  * @typedef {import('../../../lib/domain/models').Attachment} Attachment
  * @typedef {import('../../../lib/domain/models').Competence} Competence
  * @typedef {import('../../../lib/domain/models').Framework} Framework
+ * @typedef {import('../../../lib/domain/models').DraftModule} DraftModule
  * @typedef {import('../../../lib/domain/models').Thematic} Thematic
  * @typedef {import('../../../lib/domain/models').Tube} Tube
  * @typedef {import('../../../lib/domain/models').Tutorial} Tutorial
@@ -231,6 +233,23 @@ export async function onTubeUpdated(tube) {
       model: 'tubes',
       updatedRecord: tubeTransformer.transformTube(tube, challenges),
       pixApiClient,
+    });
+  } catch (err) {
+    logger.error(err);
+  }
+}
+
+/**
+ * @param {DraftModule} draftModule
+ */
+export async function onDraftModuleCreated(draftModule) {
+  if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
+
+  try {
+    await updatedRecordNotifier.notify({
+      pixApiClient,
+      model: 'modules',
+      updatedRecord: new ModuleForRelease(draftModule),
     });
   } catch (err) {
     logger.error(err);

--- a/api/lib/domain/usecases/create-draft-module.js
+++ b/api/lib/domain/usecases/create-draft-module.js
@@ -1,14 +1,19 @@
 import { draftModuleRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 /**
  *
  * @param {import('../models/index.js').DraftModule} draftModule
  */
-export async function createDraftModule(draftModule, dependencies = { draftModuleRepository, moduleRepository }) {
+export async function createDraftModule(draftModule, dependencies = { draftModuleRepository, moduleRepository, updatePixApiReleaseCache }) {
   const module = draftModule.moduleId
     ? await dependencies.moduleRepository.getById({ id: draftModule.moduleId })
     : undefined;
 
   draftModule.prepareForCreation(module);
-  return dependencies.draftModuleRepository.save(draftModule);
+  const savedDraftModule = await dependencies.draftModuleRepository.save(draftModule);
+
+  await dependencies.updatePixApiReleaseCache.onDraftModuleCreated(savedDraftModule);
+
+  return savedDraftModule;
 }

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -40,6 +40,7 @@ describe('Acceptance | Route | draft-modules', () => {
           data: {
             type: 'draft-modules',
             attributes: draftModulePayload,
+            relationships: { module: { data: null } },
           },
         },
       });

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -102,7 +102,6 @@ describe('Integration | Service | update pix api release cache', function() {
               t3Status: true,
               timer: 1234,
               type: 'QCM',
-              shuffled: false,
               alternativeVersion: 2,
               accessibility1: 'OK',
               accessibility2: 'RAS',
@@ -123,7 +122,7 @@ describe('Integration | Service | update pix api release cache', function() {
           );
 
           // then
-          expect(pixApiCacheScope.isDone()).to.be.true;
+          expect(pixApiCacheScope.isDone()).toBe(true);
         });
       });
 
@@ -226,7 +225,7 @@ describe('Integration | Service | update pix api release cache', function() {
           );
 
           // then
-          expect(pixApiCacheScope.isDone()).to.be.true;
+          expect(pixApiCacheScope.isDone()).toBe(true);
         });
       });
     });
@@ -345,7 +344,7 @@ describe('Integration | Service | update pix api release cache', function() {
           );
 
           // then
-          expect(pixApiCacheScope.isDone()).to.be.true;
+          expect(pixApiCacheScope.isDone()).toBe(true);
         });
       });
 
@@ -448,7 +447,7 @@ describe('Integration | Service | update pix api release cache', function() {
           );
 
           // then
-          expect(pixApiCacheScope.isDone()).to.be.true;
+          expect(pixApiCacheScope.isDone()).toBe(true);
         });
       });
     });
@@ -530,7 +529,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onFrameworkCreated(framework);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -597,7 +596,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onAreaCreated(area);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -669,7 +668,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onCompetenceCreated(competence);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -741,7 +740,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onCompetenceUpdated(competence);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -806,7 +805,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onThematicCreated(thematic);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -871,7 +870,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onThematicUpdated(thematic);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -942,7 +941,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onTutorialCreated(tutorial);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -1013,7 +1012,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onTutorialUpdated(tutorial);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -1066,7 +1065,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onTubeCreated(tube);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -1148,7 +1147,7 @@ describe('Integration | Service | update pix api release cache', function() {
         await updatePixApiReleaseCache.onTubeUpdated(tube);
 
         // then
-        expect(pixApiCacheScope.isDone()).to.be.true;
+        expect(pixApiCacheScope.isDone()).toBe(true);
       });
     });
 
@@ -1159,6 +1158,58 @@ describe('Integration | Service | update pix api release cache', function() {
 
         // when
         await updatePixApiReleaseCache.onTubeUpdated(domainBuilder.buildTube());
+
+        // then
+        expect(notifyStub).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('#onDraftModuleCreated', function() {
+    describe('when patching Pix API is enabled', function() {
+      beforeEach(function() {
+        baseUrl.mockReturnValue('https://some-api-base-url.fr');
+      });
+
+      it.fails('should patch the module', async function() {
+        // given
+        const draftModule = domainBuilder.buildDraftModule();
+
+        const pixApiToken = 'secret';
+        nock('https://some-api-base-url.fr')
+          .post('/api/token', { username: 'adminUser', password: '123', grant_type: 'password' })
+          .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+          .reply(200, { access_token: pixApiToken });
+        const pixApiCacheScope = nock('https://some-api-base-url.fr')
+          .patch(`/api/cache/modules/${draftModule.id}`, {
+            id: draftModule.id,
+            shortId: draftModule.shortId,
+            slug: draftModule.slug,
+            title: draftModule.title,
+            isBeta: draftModule.isBeta,
+            visibility: draftModule.visibility,
+            details: draftModule.details,
+            sections: draftModule.sections,
+            glossary: draftModule.glossary,
+          })
+          .matchHeader('Authorization', `Bearer ${pixApiToken}`)
+          .reply(200);
+
+        // when
+        await updatePixApiReleaseCache.onDraftModuleCreated(draftModule);
+
+        // then
+        expect(pixApiCacheScope.isDone()).toBe(true);
+      });
+    });
+
+    describe('when patching Pix API is disabled', function() {
+      it.fails('should not patch anything', async function() {
+        // given
+        baseUrl.mockReturnValue(undefined);
+
+        // when
+        await updatePixApiReleaseCache.onDraftModuleCreated(domainBuilder.buildDraftModule());
 
         // then
         expect(notifyStub).not.toHaveBeenCalled();

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1171,7 +1171,7 @@ describe('Integration | Service | update pix api release cache', function() {
         baseUrl.mockReturnValue('https://some-api-base-url.fr');
       });
 
-      it.fails('should patch the module', async function() {
+      it('should patch the module', async function() {
         // given
         const draftModule = domainBuilder.buildDraftModule();
 
@@ -1204,7 +1204,7 @@ describe('Integration | Service | update pix api release cache', function() {
     });
 
     describe('when patching Pix API is disabled', function() {
-      it.fails('should not patch anything', async function() {
+      it('should not patch anything', async function() {
         // given
         baseUrl.mockReturnValue(undefined);
 

--- a/api/tests/unit/domain/usecases/create-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/create-draft-module_test.js
@@ -19,7 +19,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
     updatePixApiReleaseCache = { onDraftModuleCreated: vi.fn().mockResolvedValueOnce() };
   });
 
-  it.fails('prepares draft module for creation and saves it', async () => {
+  it('prepares draft module for creation and saves it', async () => {
     // when
     const result = createDraftModule(draftModule, { draftModuleRepository, updatePixApiReleaseCache });
 
@@ -32,7 +32,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
   });
 
   describe('when draft module has a moduleId', () => {
-    it.fails('prepares for creation using module', async () => {
+    it('prepares for creation using module', async () => {
       // given
       const module = Symbol('module');
       const moduleRepository = { getById: vi.fn().mockResolvedValueOnce(module) };

--- a/api/tests/unit/domain/usecases/create-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/create-draft-module_test.js
@@ -5,7 +5,7 @@ import { createDraftModule } from '../../../../lib/domain/usecases/index.js';
 describe('Unit | Domain | Use Cases | create-draft-module', () => {
   const savedDraftModule = Symbol('savedDraftModule');
 
-  let draftModuleRepository, draftModule, prepareForCreation;
+  let draftModuleRepository, draftModule, prepareForCreation, updatePixApiReleaseCache;
 
   beforeEach(() => {
     draftModuleRepository = { save: vi.fn().mockResolvedValueOnce(savedDraftModule) };
@@ -15,21 +15,24 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
       shortId: null,
     });
     prepareForCreation = vi.spyOn(draftModule, 'prepareForCreation');
+
+    updatePixApiReleaseCache = { onDraftModuleCreated: vi.fn().mockResolvedValueOnce() };
   });
 
-  it('prepares draft module for creation and saves it', async () => {
+  it.fails('prepares draft module for creation and saves it', async () => {
     // when
-    const result = createDraftModule(draftModule, { draftModuleRepository });
+    const result = createDraftModule(draftModule, { draftModuleRepository, updatePixApiReleaseCache });
 
     // then
     await expect(result).resolves.toBe(savedDraftModule);
 
     expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(undefined);
     expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
+    expect(updatePixApiReleaseCache.onDraftModuleCreated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
   });
 
   describe('when draft module has a moduleId', () => {
-    it('prepares for creation using module', async () => {
+    it.fails('prepares for creation using module', async () => {
       // given
       const module = Symbol('module');
       const moduleRepository = { getById: vi.fn().mockResolvedValueOnce(module) };
@@ -38,7 +41,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
       draftModule.moduleId = moduleId;
 
       // when
-      const result = createDraftModule(draftModule, { draftModuleRepository, moduleRepository });
+      const result = createDraftModule(draftModule, { draftModuleRepository, moduleRepository, updatePixApiReleaseCache });
 
       // then
       await expect(result).resolves.toBe(savedDraftModule);
@@ -46,6 +49,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
       expect(moduleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: moduleId });
       expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(module);
       expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
+      expect(updatePixApiReleaseCache.onDraftModuleCreated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
     });
   });
 });


### PR DESCRIPTION
## 🪧 Problème

On veut pouvoir jouer un draft de module sur la recette.

## 🌈 Proposition

Dans le use-case “create draft module” on appelle la route `/api/cache/{model}/{id}` de PixApi, afin de patcher les modules pour une preview en recette.

## ✊ Remarques

Il y a aussi une petite correction sur le Joi de la route de création de draft.

## 🎉 Pour tester

Créer un draft et vérifier qu’il est jouable sur https://app-pr16619.review.pix.fr/ avec une URL au format `https://app-pr16619.review.pix.fr/modules/<shortId>/<slug>`

On peut mettre n’importe quoi dans le slug, Pix App va remettre le bon.

