### PR TITLE
[FEATURE] Boutons de prévisualisation du draft de module (PIX-22783)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -26,6 +26,7 @@ export function register(server) {
               'internalTitle',
               'details',
               'module',
+              'previewUrl',
             ], meta,
           });
         },

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -1,3 +1,4 @@
+import * as config from '../../config.js';
 import { Module } from './Module.js';
 
 export class DraftModule extends Module {
@@ -12,5 +13,13 @@ export class DraftModule extends Module {
   prepareForCreation(module) {
     this.id = module?.id ?? crypto.randomUUID();
     this.shortId = module?.shortId ?? this.id.slice(0, 8);
+  }
+
+  get url() {
+    return new URL(`/modules/${this.shortId}/${this.slug}`, config.pixApp.baseUrlFr).href;
+  }
+
+  get previewUrl() {
+    return new URL(`/modules/preview/${this.shortId}/${this.slug}`, config.pixApp.baseUrlFr).href;
   }
 }

--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
@@ -32,15 +32,19 @@ const defaultAttributes = [
   'glossary',
   'module',
   'diff',
+  'url',
+  'previewUrl',
 ];
 
 export function serialize(draftModules, { meta, attributes = defaultAttributes } = {}) {
   const serializer = new Serializer('draft-module', {
     attributes,
     meta,
-    transform({ moduleId, ...draftModule }) {
+    transform({ moduleId, url, previewUrl, ...draftModule }) {
       const data = {
         ...draftModule,
+        url,
+        previewUrl,
         module: moduleId ? { id: moduleId } : null,
       };
       if (moduleId) data.diff = {};

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+
+import * as config from '../../../../lib/config.js';
 import { databaseBuilder, domainBuilder, generateAuthorizationHeader, knex } from '../../../test-helper.js';
 import { createServer } from '../../../../server.js';
 import { Module } from '../../../../lib/domain/models/index.js';
@@ -54,6 +56,8 @@ describe('Acceptance | Route | draft-modules', () => {
           attributes: {
             'short-id': expect.stringMatching(shortIdRegExp),
             ...draftModulePayload,
+            url: expect.stringMatching(new RegExp(`^${config.pixApp.baseUrlFr.replace(/([.])/g, '\\$1')}/modules/.{8}/${draftModule.slug}$`)),
+            'preview-url': expect.stringMatching(new RegExp(`^${config.pixApp.baseUrlFr.replace(/([.])/g, '\\$1')}/modules/preview/.{8}/${draftModule.slug}$`)),
           },
           relationships: { module: { data: null } },
         },
@@ -149,6 +153,8 @@ describe('Acceptance | Route | draft-modules', () => {
             attributes: {
               'short-id': draftModule.shortId,
               ...draftModulePayload,
+              url: `${config.pixApp.baseUrlFr}/modules/${draftModule.shortId}/${draftModule.slug}`,
+              'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
             },
             relationships: {
               module: {
@@ -325,6 +331,8 @@ describe('Acceptance | Route | draft-modules', () => {
             title: draftModule.title,
             sections: draftModule.sections,
             glossary: draftModule.glossary,
+            url: `${config.pixApp.baseUrlFr}/modules/${draftModule.shortId}/${draftModule.slug}`,
+            'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
           },
           relationships: {
             module: {

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -226,7 +226,11 @@ describe('Acceptance | Route | draft-modules', () => {
           {
             type: 'draft-modules',
             id: draftModules[1].id,
-            attributes: { 'internal-title': draftModules[1].internalTitle, details: draftModules[1].details },
+            attributes: {
+              'internal-title': draftModules[1].internalTitle,
+              details: draftModules[1].details,
+              'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModules[1].shortId}/${draftModules[1].slug}`,
+            },
             relationships: {
               module: {
                 data: {
@@ -239,13 +243,21 @@ describe('Acceptance | Route | draft-modules', () => {
           {
             type: 'draft-modules',
             id: draftModules[0].id,
-            attributes: { 'internal-title': draftModules[0].internalTitle, details: draftModules[0].details },
+            attributes: {
+              'internal-title': draftModules[0].internalTitle,
+              details: draftModules[0].details,
+              'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModules[0].shortId}/${draftModules[0].slug}`,
+            },
             relationships: { module: { data: null } },
           },
           {
             type: 'draft-modules',
             id: draftModules[2].id,
-            attributes: { 'internal-title': draftModules[2].internalTitle, details: draftModules[2].details },
+            attributes: {
+              'internal-title': draftModules[2].internalTitle,
+              details: draftModules[2].details,
+              'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModules[2].shortId}/${draftModules[2].slug}`,
+            },
             relationships: { module: { data: null } },
           },
         ],
@@ -278,7 +290,11 @@ describe('Acceptance | Route | draft-modules', () => {
             {
               type: 'draft-modules',
               id: draftModules[0].id,
-              attributes: { 'internal-title': draftModules[0].internalTitle, details: draftModules[0].details },
+              attributes: {
+                'internal-title': draftModules[0].internalTitle,
+                details: draftModules[0].details,
+                'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModules[0].shortId}/${draftModules[0].slug}`,
+              },
               relationships: { module: { data: null } },
             },
           ],

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as config from '../../../../lib/config.js';
 import { DraftModule } from '../../../../lib/domain/models/index.js';
 import { domainBuilder } from '../../../test-helper.js';
 
@@ -63,6 +65,34 @@ describe('Unit | Domain | DraftModule', () => {
 
       // then
       expect(json).toStrictEqual(expectedJSON);
+    });
+  });
+
+  describe('#url', () => {
+    it('returns URL to run draft module', () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule({ shortId: 'abcd1234', slug: 'poueeeeeeet' });
+      vi.spyOn(config.pixApp, 'baseUrlFr', 'get').mockReturnValue('https://enorme.fr');
+
+      // when
+      const { url } = draftModule;
+
+      // then
+      expect(url).toBe('https://enorme.fr/modules/abcd1234/poueeeeeeet');
+    });
+  });
+
+  describe('#previewUrl', () => {
+    it('returns URL to run draft module', () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule({ shortId: 'abcd1234', slug: 'poueeeeeeet' });
+      vi.spyOn(config.pixApp, 'baseUrlFr', 'get').mockReturnValue('https://enorme.fr');
+
+      // when
+      const { previewUrl } = draftModule;
+
+      // then
+      expect(previewUrl).toBe('https://enorme.fr/modules/preview/abcd1234/poueeeeeeet');
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+
+import * as config from '../../../../../lib/config.js';
 import { deserialize, serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/draft-module-serializer.js';
 import { domainBuilder } from '../../../../test-helper.js';
 import { Module } from '../../../../../lib/domain/models/Module.js';
@@ -23,6 +25,8 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
             details: draftModule.details,
             sections: draftModule.sections,
             glossary: draftModule.glossary,
+            url: `${config.pixApp.baseUrlFr}/modules/${draftModule.shortId}/${draftModule.slug}`,
+            'preview-url': `${config.pixApp.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
           },
           relationships: {
             module: {

--- a/pix-editor/app/components/modules/module-preview-buttons.gjs
+++ b/pix-editor/app/components/modules/module-preview-buttons.gjs
@@ -1,0 +1,10 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+
+<template>
+  <PixButtonLink @href={{@module.url}} target="_blank" @variant="secondary">
+    Jouer le draft
+  </PixButtonLink>
+  <PixButtonLink @href={{@module.previewUrl}} target="_blank" @variant="secondary">
+    Prévisualiser
+  </PixButtonLink>
+</template>

--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -69,6 +69,11 @@ export default class Product extends Component {
             >
               Voir le détail
             </PixButtonLink>
+            {{#if module.isDraft}}
+              <PixButtonLink @href={{module.previewUrl}} target="_blank" @variant="secondary">
+                Prévisualiser
+              </PixButtonLink>
+            {{/if}}
             {{#if module.isEditionDraft}}
               <PixButtonLink
                 @route="authenticated.modules.production-module"

--- a/pix-editor/app/models/area.js
+++ b/pix-editor/app/models/area.js
@@ -1,7 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class AreaModel extends Model {
-  @attr({ readOnly: true }) name;
+  @attr name;
   @attr pixId;
   @attr titleFrFr;
   @attr titleEnUs;

--- a/pix-editor/app/models/base-module.js
+++ b/pix-editor/app/models/base-module.js
@@ -22,6 +22,8 @@ export default class BaseModule extends Model {
   @attr details;
   @attr sections;
   @attr glossary;
+  @attr url;
+  @attr previewUrl;
 
   get visibilityForDisplay() {
     return visibilityForDisplay[this.visibility] ?? this.visibility;

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -21,7 +21,7 @@ export default class ChallengeModel extends Model {
   @attr('number') version;
   @attr genealogy;
   @attr status;
-  @attr({ readOnly: true }) preview;
+  @attr preview;
   @attr('number') timer;
   @attr embedURL;
   @attr embedTitle;

--- a/pix-editor/app/models/skill.js
+++ b/pix-editor/app/models/skill.js
@@ -10,7 +10,7 @@ export default class SkillModel extends Model {
   @attr clue;
   @attr clueEn;
   @attr clueStatus;
-  @attr({ readOnly: true }) createdAt;
+  @attr createdAt;
   @attr description;
   @attr descriptionStatus;
   @attr level;

--- a/pix-editor/app/serializers/area.js
+++ b/pix-editor/app/serializers/area.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+export default class AreaSerializer extends ApplicationSerializer {
+  attrs = {
+    name: { serialize: false },
+  };
+}

--- a/pix-editor/app/serializers/challenge.js
+++ b/pix-editor/app/serializers/challenge.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+export default class ChallengeSerializer extends ApplicationSerializer {
+  attrs = {
+    preview: { serialize: false },
+  };
+}

--- a/pix-editor/app/serializers/draft-module.js
+++ b/pix-editor/app/serializers/draft-module.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+
+export default class DraftModuleSerializer extends ApplicationSerializer {
+  attrs = {
+    previewUrl: { serialize: false },
+    url: { serialize: false },
+  };
+}

--- a/pix-editor/app/serializers/module.js
+++ b/pix-editor/app/serializers/module.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+
+export default class ModuleSerializer extends ApplicationSerializer {
+  attrs = {
+    previewUrl: { serialize: false },
+    url: { serialize: false },
+  };
+}

--- a/pix-editor/app/serializers/skill.js
+++ b/pix-editor/app/serializers/skill.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+export default class SkillSerializer extends ApplicationSerializer {
+  attrs = {
+    createdAt: { serialize: false },
+  };
+}

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -2,10 +2,14 @@ import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModuleNotification from 'pixeditor/components/modules/module-notification';
+import ModulePreviewButtons from 'pixeditor/components/modules/module-preview-buttons';
 
 <template>
   <header class="page-header">
     <h1 class="page-title">Détail du draft de module</h1>
+    <div class="page-actions">
+      <ModulePreviewButtons @module={{@model.draftModule}} />
+    </div>
   </header>
   <main class="page-body">
     <section class="page-section module-form">

--- a/pix-editor/tests/integration/components/modules/module-preview-buttons-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-preview-buttons-test.gjs
@@ -1,0 +1,32 @@
+import { render } from '@1024pix/ember-testing-library';
+import ModulePreviewButtons from 'pixeditor/components/modules/module-preview-buttons';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Components | modules/module-preview-buttons', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it displays play and preview buttons', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const draftModule = store.createRecord('draft-module', {
+      id: 'moduleId',
+      url: 'https://kapoue.org/module/play',
+      previewUrl: 'https://kapoue.org/module/preview',
+    });
+
+    // when
+    const screen = await render(<template><ModulePreviewButtons @module={{draftModule}} /></template>);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Jouer le draft' })).exists();
+    assert
+      .dom(screen.getByRole('link', { name: 'Jouer le draft' }))
+      .hasAttribute('href', 'https://kapoue.org/module/play');
+    assert.dom(screen.getByRole('link', { name: 'Prévisualiser' })).exists();
+    assert
+      .dom(screen.getByRole('link', { name: 'Prévisualiser' }))
+      .hasAttribute('href', 'https://kapoue.org/module/preview');
+  });
+});

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -1,5 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
-import { getByText, queryByText } from '@testing-library/dom';
+import { getByRole, getByText, queryByRole, queryByText } from '@testing-library/dom';
 import ModulesList from 'pixeditor/components/modules/modules-list';
 import { module, test } from 'qunit';
 
@@ -88,6 +88,7 @@ module('Integration | Component | modules-list', function (hooks) {
 
       draftModules = [
         store.createRecord('draft-module', {
+          id: 'super-1',
           module,
           internalTitle: 'MOD_super_1',
           isBeta: false,
@@ -95,14 +96,17 @@ module('Integration | Component | modules-list', function (hooks) {
           details: {
             level: 'novice',
           },
+          previewUrl: 'https://graou.asso/modules/preview/super-1',
         }),
         store.createRecord('draft-module', {
+          id: 'super-2',
           internalTitle: 'MOD_super_2',
           isBeta: true,
           visibility: 'private',
           details: {
             level: 'advanced',
           },
+          previewUrl: 'https://graou.asso/modules/preview/super-2',
         }),
       ];
     });
@@ -119,12 +123,28 @@ module('Integration | Component | modules-list', function (hooks) {
       assert.dom(screen.getByText('MOD_super_2')).exists();
 
       const firstRow = screen.getByText('MOD_super_1').closest('tr');
-      assert.dom(getByText(firstRow, 'Voir le détail')).exists();
-      assert.dom(getByText(firstRow, 'Voir le détail du module en prod')).exists();
+      assert.dom(getByRole(firstRow, 'link', { name: 'Voir le détail' })).exists();
+      assert
+        .dom(getByRole(firstRow, 'link', { name: 'Voir le détail' }))
+        .hasAttribute('href', `/modules/workbench/super-1`);
+      assert.dom(getByRole(firstRow, 'link', { name: 'Voir le détail du module en prod' })).exists();
+      assert
+        .dom(getByRole(firstRow, 'link', { name: 'Voir le détail du module en prod' }))
+        .hasAttribute('href', '/modules/production/moduleId');
+      assert.dom(getByRole(firstRow, 'link', { name: 'Prévisualiser' })).exists();
+      assert
+        .dom(getByRole(firstRow, 'link', { name: 'Prévisualiser' }))
+        .hasAttribute('href', 'https://graou.asso/modules/preview/super-1');
 
       const secondRow = screen.getByText('MOD_super_2').closest('tr');
-      assert.dom(getByText(secondRow, 'Voir le détail')).exists();
-      assert.dom(queryByText(secondRow, 'Voir le détail du module en prod')).doesNotExist();
+      assert.dom(getByRole(secondRow, 'link', { name: 'Voir le détail' })).exists();
+      assert
+        .dom(getByRole(secondRow, 'link', { name: 'Voir le détail' }))
+        .hasAttribute('href', `/modules/workbench/super-2`);
+      assert.dom(queryByRole(secondRow, 'link', { name: 'Voir le détail du module en prod' })).doesNotExist();
+      assert
+        .dom(getByRole(secondRow, 'link', { name: 'Prévisualiser' }))
+        .hasAttribute('href', 'https://graou.asso/modules/preview/super-2');
     });
   });
 });

--- a/pix-editor/tests/unit/models/challenge-test.js
+++ b/pix-editor/tests/unit/models/challenge-test.js
@@ -33,7 +33,6 @@ module('Unit | Model | challenge', function (hooks) {
       t3Status: 'proto t3Status',
       pedagogy: 'proto pedagogy',
       declinable: 'proto declinable',
-      preview: 'proto preview',
       timer: 123,
       embedURL: 'proto embedURL',
       embedTitle: 'proto embedTitle',
@@ -88,7 +87,6 @@ module('Unit | Model | challenge', function (hooks) {
       t3Status: 'alternative t3Status',
       pedagogy: 'alternative pedagogy',
       declinable: 'alternative declinable',
-      preview: 'alternative preview',
       timer: 123,
       embedURL: 'alternative embedURL',
       embedTitle: 'alternative embedTitle',
@@ -148,7 +146,6 @@ module('Unit | Model | challenge', function (hooks) {
       assert.strictEqual(clonedChallenge.t3Status, prototype.t3Status, 'champ t3Status');
       assert.strictEqual(clonedChallenge.pedagogy, prototype.pedagogy, 'champ pedagogy');
       assert.strictEqual(clonedChallenge.declinable, prototype.declinable, 'champ declinable');
-      assert.strictEqual(clonedChallenge.preview, prototype.preview, 'champ preview');
       assert.strictEqual(clonedChallenge.timer, prototype.timer, 'champ timer');
       assert.strictEqual(clonedChallenge.embedURL, prototype.embedURL, 'champ embedURL');
       assert.strictEqual(clonedChallenge.embedTitle, prototype.embedTitle, 'champ embedTitle');
@@ -231,7 +228,6 @@ module('Unit | Model | challenge', function (hooks) {
       assert.strictEqual(clonedChallenge.t3Status, alternative.t3Status, 'champ t3Status');
       assert.strictEqual(clonedChallenge.pedagogy, alternative.pedagogy, 'champ pedagogy');
       assert.strictEqual(clonedChallenge.declinable, alternative.declinable, 'champ declinable');
-      assert.strictEqual(clonedChallenge.preview, alternative.preview, 'champ preview');
       assert.strictEqual(clonedChallenge.timer, alternative.timer, 'champ timer');
       assert.strictEqual(clonedChallenge.embedURL, alternative.embedURL, 'champ embedURL');
       assert.strictEqual(clonedChallenge.embedTitle, alternative.embedTitle, 'champ embedTitle');


### PR DESCRIPTION
## 🪧 Problème

On souhaite pouvoir jouer et prévisualiser les drafts de modules depuis Pix Editor.

## 🌈 Proposition

Pour les drafts on ajoute :
 - Sur la page de détail, un bouton "Jouer le draft" et un bouton "Prévisualiser"
 - Sur l’onglet Atelier des modules, un bouton "Prévisualiser" pour chaque draft

Les boutons "Prévisualiser" et "Jouer le draft" envoient vers une URL permettant d’accéder à la preview du module dans sa version draftée, sur un environnement prévu à cet effet (à terme la recette).

Le bouton "Jouer le draft" envoie vers une URL permettant de jouer le module dans sa version draftée, sur le même environnement.

## ✊ Remarques

- Si on crée un module dont la structure n'est pas valide, la preview et visualisation ne marcheront pas puisque pixApp ne saura pas gérer un module avec une mauvaise structure (logique).
- 
## 🎉 Pour tester

Créer un draft (de zéro ou à partir d’un module), puis cliquer sur les boutons "Prévisualiser" (dans la liste ou sur la page de détails) et "Jouer le draft" de ce draft.

Vérifier qu’on arrive bien sur les pages attendues.