### PR TITLE
[TECH] Utiliser npmrc plutot que check-engine pour valider la version de Node.js (PIX-XXXX).

### DIFF
--- a/api/.npmrc
+++ b/api/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/api/package.json
+++ b/api/package.json
@@ -25,7 +25,7 @@
     "db:rollback:latest": "knex --knexfile db/knexfile.js migrate:down",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "preinstall": "npx check-engine && git config core.hooksPath .githooks || true",
+    "preinstall": "git config core.hooksPath .githooks || true",
     "start": "node --env-file-if-exists=.env index.js",
     "dev": "nodemon --env-file-if-exists=.env --ext js,cjs,json,jsx --signal SIGTERM index.js",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",

--- a/pix-editor/.npmrc
+++ b/pix-editor/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 ignore-scripts=true

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -20,7 +20,7 @@
     "lint:scss": "stylelint app/styles/*.scss",
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:js": "eslint . --cache",
-    "preinstall": "npx check-engine && git config core.hooksPath .githooks || true",
+    "preinstall": "git config core.hooksPath .githooks || true",
     "lint:js:fix": "eslint . --fix",
     "start": "vite",
     "test": "npm-run-all lint test:*",


### PR DESCRIPTION
## 🪧 Problème

on utilise check-engine alors que Node.js gère très bien la validation de version

## 🌈 Proposition

Se baser sur ce qui a été fait sur le monorepo : https://github.com/1024pix/pix/pull/16611

## ✊ Remarques

A voir ce que fait les dernier scripts dans preinstall et si on peut s'en passer pour les supprimer ?

## 🎉 Pour tester
Ci au vert 