### PR TITLE
[BUGFIX] Réparer les logs d'erreur des requêtes `fetch` (PIX-23326)

### DIFF
--- a/api/lib/infrastructure/notifications/SlackNotifier.js
+++ b/api/lib/infrastructure/notifications/SlackNotifier.js
@@ -17,7 +17,10 @@ export class SlackNotifier {
         body: JSON.stringify(blocks),
         headers: { 'content-type': 'application/json' },
       });
-      if (!response.ok) throw new Error('error while sending notification to Slack', response.status);
+      if (!response.ok) {
+        logger.error('error while sending notification to Slack', { status: response.status, content: await response.text().catch() });
+        throw new Error(`error while sending notification to Slack with status ${response.status}`);
+      };
     } catch (err) {
       logger.error({ err }, 'error while sending notification to slack');
     }

--- a/api/lib/infrastructure/pix-api-client.js
+++ b/api/lib/infrastructure/pix-api-client.js
@@ -30,7 +30,10 @@ async function _callAPIWithRetry(fn, renewToken = false) {
   const token = await _getToken(renewToken);
   const response = await fn(token);
   if (response.status === 401 && !renewToken) return _callAPIWithRetry(fn, true);
-  if (!response.ok) throw new Error('something went wrong when reaching PixAPI Client', response.status);
+  if (!response.ok) {
+    logger.error('something went wrong when reaching PixAPI Client', { status: response.status, content: await response.text().catch() });
+    throw new Error(`something went wrong when reaching PixAPI Client, with status ${response.status}`);
+  }
 }
 
 async function _authenticate() {
@@ -45,7 +48,10 @@ async function _authenticate() {
     body: data,
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   });
-  if (!response.ok) throw new Error('fetching token to pix API failed', response.status);
+  if (!response.ok) {
+    logger.error('Error when fetching token to pix API', { status: response.status, content: await response.text().catch() });
+    throw new Error(`fetching token to pix API failed with status ${response.status}`);
+  };
 
   const jsonResponse = await response.json();
 

--- a/api/lib/infrastructure/repositories/file-storage-token-repository.js
+++ b/api/lib/infrastructure/repositories/file-storage-token-repository.js
@@ -28,7 +28,10 @@ export async function create() {
     headers: { 'content-type': 'application/json' },
   });
   if (response.status === 401) throw new UnauthorizedError();
-  if (!response.ok) throw new Error('error while fetching file storage token', response.status);
+  if (!response.ok) {
+    logger.error('error while fetching file storage token', { status: response.status, content: await response.text().catch() });
+    throw new Error(`error while fetching file storage token with status ${response.status}`);
+  }
   const jsonResponse = await response.json();
 
   return {

--- a/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
+++ b/api/tests/tooling/database-builder/factory/build-group-from-framework-to-challenge.js
@@ -26,7 +26,7 @@ import { buildTranslation } from './build-translation.js';
  * }} groupToBuild
  */
 export function buildChallengeInGroup({ challenge, localizedChallenge, challengeTranslations, skill, framework, tube }) {
-  const randomId = generateRandomId();
+  const randomId = idGenerator.next().value;
 
   const chalengeDTO = buildChallengeDatasourceObject({
     id: `challenge${randomId}`,
@@ -89,6 +89,10 @@ export function buildChallengeInGroup({ challenge, localizedChallenge, challenge
   };
 }
 
-function generateRandomId() {
-  return (Math.random() * 100).toFixed();
-}
+const idGenerator = (function* () {
+  let i = 1;
+  while (true) {
+    yield i.toString().padStart(5, '0');
+    i++;
+  }
+})();

--- a/api/tests/unit/infrastructure/pix-api-client_test.js
+++ b/api/tests/unit/infrastructure/pix-api-client_test.js
@@ -2,6 +2,7 @@ import { describe, describe as context, expect, it, vi } from 'vitest';
 import nock from 'nock';
 import * as pixApiClient from '../../../lib/infrastructure/pix-api-client.js';
 import { cache } from '../../../lib/infrastructure/cache.js';
+import { logger } from '../../../lib/infrastructure/logger.js';
 
 describe('Unit | Infrastructure | PIX API Client', () => {
   describe('#request', () => {
@@ -73,6 +74,7 @@ describe('Unit | Infrastructure | PIX API Client', () => {
             return token;
           }
         });
+        const loggerSpy = vi.spyOn(logger, 'error');
 
         const firstRequestInterceptor = nock('https://api.test.pix.fr')
           .patch('/api/cache/model/id', payload)
@@ -87,17 +89,18 @@ describe('Unit | Infrastructure | PIX API Client', () => {
         const secondRequestInterceptor = nock('https://api.test.pix.fr')
           .patch('/api/cache/model/id', payload)
           .matchHeader('Authorization', `Bearer ${newToken}`)
-          .reply(401);
+          .reply(401, 'Non');
 
         try {
           // when
           await pixApiClient.request({ url: '/api/cache/model/id', payload });
           expect.fail('should raise an error');
         } catch (e) {
-          expect(e.message).to.equal('something went wrong when reaching PixAPI Client');
+          expect(e.message).to.equal('something went wrong when reaching PixAPI Client, with status 401');
         }
 
         // then
+        expect(loggerSpy).toHaveBeenCalledWith('something went wrong when reaching PixAPI Client', { status: 401, content: 'Non' });
         expect(firstRequestInterceptor.isDone()).to.be.true;
         expect(authInterceptor.isDone()).to.be.true;
         expect(secondRequestInterceptor.isDone()).to.be.true;


### PR DESCRIPTION
## 🪧 Problème

Certains logs d’erreur de l'API (ceux qui ont lieu après une requête fetch) ne construisent pas les messages d’erreur correctement. 
En effet, ils donnent plusieurs arguments à new Error(), ce qui n’est pas autorisé (sauf cas spécifique) :

❌ `new Error('fetch error', response.status)`

De ce fait, nous perdons des informations critiques à la résolution des problèmes.

## 🌈 Proposition

Concaténer les arguments donnés au constructeur `new Error()` en une seule chaîne de caractères.

✅ ```new Error(`fetch error ${response.status}`)```

## ✊ Remarques

Ajout de logs d'erreur avec le body de la réponse.

## 🎉 Pour tester
CI OK ✅
