### PR TITLE
[FEATURE] Permettre de modifier un module déjà en Draft (PIX-23284) 

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 import { draftModuleDiffSerializer, draftModuleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
-import { createDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules } from '../../domain/usecases/index.js';
+import { createDraftModule, updateDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import * as Types from '../types.js';
 
@@ -89,6 +89,44 @@ export function register(server) {
           const module = await draftModuleSerializer.deserialize(request.payload);
           const savedModule = await createDraftModule(module);
           return h.response(draftModuleSerializer.serialize(savedModule)).code(201);
+        },
+      },
+    },
+    {
+      method: 'PATCH',
+      path: '/api/draft-modules/{id}',
+      config: {
+        validate: {
+          params: Joi.object({ id: Types.moduleId().required() }).required(),
+          payload: Joi.object({
+            data: Joi.object({
+              id: Types.moduleId().required(),
+              type: Joi.string().valid('draft-modules').required(),
+              attributes: Joi.object({
+                'internal-title': Joi.string().required(),
+                title: Joi.string().required(),
+                'is-beta': Joi.boolean().required(),
+                slug: Joi.string().required(),
+                visibility: Joi.string().required(),
+                details: Joi.object().required(),
+                sections: Joi.array().required(),
+                glossary: Joi.array().required(),
+              }).required(),
+              relationships: Joi.object({
+                module: Joi.object({
+                  data: Joi.object({
+                    id: Types.moduleId().required(),
+                    type: Joi.string().valid('modules').required(),
+                  }).empty(null).optional(),
+                }).optional(),
+              }).optional(),
+            }).required(),
+          }).required(),
+        },
+        handler: async (request, h) => {
+          const draftModule = await draftModuleSerializer.deserialize(request.payload);
+          const updatedModule = await updateDraftModule(draftModule);
+          return h.response(draftModuleSerializer.serialize(updatedModule)).code(200);
         },
       },
     },

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -17,6 +17,20 @@ export class DraftModule extends Module {
     this.shortId = module?.shortId ?? this.id.slice(0, 8);
   }
 
+  /**
+   * @param {DraftModule} module
+   */
+  update(module) {
+    this.internalTitle = module.internalTitle;
+    this.slug = module.slug;
+    this.title = module.title;
+    this.isBeta = module.isBeta;
+    this.visibility = module.visibility;
+    this.details = module.details;
+    this.sections = module.sections;
+    this.glossary = module.glossary;
+  }
+
   get url() {
     return new URL(`/modules/${this.shortId}/${this.slug}`, config.pixApp.recette.baseUrlFr).href;
   }

--- a/api/lib/domain/services/update-pix-api-release-cache.js
+++ b/api/lib/domain/services/update-pix-api-release-cache.js
@@ -242,7 +242,7 @@ export async function onTubeUpdated(tube) {
 /**
  * @param {DraftModule} draftModule
  */
-export async function onDraftModuleCreated(draftModule) {
+export async function onDraftModuleCreatedOrUpdated(draftModule) {
   if (!pixApiClient.isPixApiCachePatchingEnabled()) return;
 
   try {

--- a/api/lib/domain/usecases/create-draft-module.js
+++ b/api/lib/domain/usecases/create-draft-module.js
@@ -13,7 +13,7 @@ export async function createDraftModule(draftModule, dependencies = { draftModul
   draftModule.prepareForCreation(module);
   const savedDraftModule = await dependencies.draftModuleRepository.save(draftModule);
 
-  await dependencies.updatePixApiReleaseCache.onDraftModuleCreated(savedDraftModule);
+  await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(savedDraftModule);
 
   return savedDraftModule;
 }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -41,6 +41,7 @@ export * from './stream-learning-content-for-replication.js';
 export * from './update-attachment.js';
 export * from './update-challenge.js';
 export * from './update-competence.js';
+export * from './update-draft-module.js';
 export * from './update-mission.js';
 export * from './update-skill.js';
 export * from './update-thematic.js';

--- a/api/lib/domain/usecases/update-draft-module.js
+++ b/api/lib/domain/usecases/update-draft-module.js
@@ -1,0 +1,14 @@
+import { draftModuleRepository } from '../../infrastructure/repositories/index.js';
+import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
+
+/**
+ * @param {import('../models/index.js').DraftModule} draftModule
+ */
+export async function updateDraftModule(draftModule, dependencies = { draftModuleRepository, updatePixApiReleaseCache }) {
+  const existingDraftModule = await dependencies.draftModuleRepository.getById({ id: draftModule.id });
+  existingDraftModule.update(draftModule);
+
+  const updatedDraftModule = await dependencies.draftModuleRepository.save(existingDraftModule);
+  await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(updatedDraftModule);
+  return updatedDraftModule;
+}

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -472,4 +472,77 @@ describe('Acceptance | Route | draft-modules', () => {
       });
     });
   });
+
+  describe('PATCH /draft-modules/:id', () => {
+    it.fails('responds with status 200 and draft modules data', async () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule();
+      databaseBuilder.factory.buildDraftModule(draftModule);
+      await databaseBuilder.commit();
+
+      const draftModulePayload = {
+        slug: 'kebab-royal',
+        title: draftModule.title,
+        'internal-title': draftModule.internalTitle,
+        'is-beta': draftModule.isBeta,
+        visibility: draftModule.visibility,
+        details: draftModule.details,
+        sections: draftModule.sections,
+        glossary: draftModule.glossary,
+      };
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/draft-modules/${draftModule.id}`,
+        headers: generateAuthorizationHeader(editorUser),
+        payload: {
+          data: {
+            type: 'draft-modules',
+            id: draftModule.id,
+            attributes: draftModulePayload,
+            relationships: { module: { data: null } },
+          },
+        },
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+      expect(response.result).toStrictEqual({
+        data: {
+          type: 'draft-modules',
+          id: draftModule.id,
+          attributes: {
+            'short-id': draftModule.shortId,
+            ...draftModulePayload,
+            url: `${config.pixApp.recette.baseUrlFr}/modules/${draftModule.shortId}/kebab-royal`,
+            'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModule.shortId}/kebab-royal`,
+          },
+          relationships: { module: { data: null } },
+        },
+      });
+
+      await expect(knex.select('*').from('draft-modules')).resolves.toStrictEqual([
+        {
+          id: draftModule.id,
+          shortId: draftModule.shortId,
+          moduleId: null,
+          internalTitle: draftModule.internalTitle,
+          slug: 'kebab-royal',
+          title: draftModule.title,
+          isBeta: draftModule.isBeta,
+          visibility: draftModule.visibility,
+          sections: draftModule.sections,
+          glossary: draftModule.glossary,
+          hasBeenValidated: draftModule.hasBeenValidated,
+          validationErrors: draftModule.validationErrors,
+          ...draftModule.details,
+          createdAt: draftModule.createdAt,
+          updatedAt: expect.any(Date),
+        },
+      ]);
+    });
+  });
 });

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -474,7 +474,7 @@ describe('Acceptance | Route | draft-modules', () => {
   });
 
   describe('PATCH /draft-modules/:id', () => {
-    it.fails('responds with status 200 and draft modules data', async () => {
+    it('responds with status 200 and draft modules data', async () => {
       // given
       const draftModule = domainBuilder.buildDraftModule();
       databaseBuilder.factory.buildDraftModule(draftModule);

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1165,7 +1165,7 @@ describe('Integration | Service | update pix api release cache', function() {
     });
   });
 
-  describe('#onDraftModuleCreated', function() {
+  describe('#onDraftModuleCreatedOrUpdated', function() {
     describe('when patching Pix API is enabled', function() {
       beforeEach(function() {
         baseUrl.mockReturnValue('https://some-api-base-url.fr');
@@ -1196,7 +1196,7 @@ describe('Integration | Service | update pix api release cache', function() {
           .reply(200);
 
         // when
-        await updatePixApiReleaseCache.onDraftModuleCreated(draftModule);
+        await updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(draftModule);
 
         // then
         expect(pixApiCacheScope.isDone()).toBe(true);
@@ -1209,7 +1209,7 @@ describe('Integration | Service | update pix api release cache', function() {
         baseUrl.mockReturnValue(undefined);
 
         // when
-        await updatePixApiReleaseCache.onDraftModuleCreated(domainBuilder.buildDraftModule());
+        await updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(domainBuilder.buildDraftModule());
 
         // then
         expect(notifyStub).not.toHaveBeenCalled();

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -38,6 +38,50 @@ describe('Unit | Domain | DraftModule', () => {
     });
   });
 
+  describe('#update', () => {
+    it('udpates updatable draft module’s fields', () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule({
+        id: '704a89a6-983b-4e04-bfef-6a54f925c44e',
+        shortId: '704a89a6',
+        createdAt: new Date('2026-06-29T14:04:01Z'),
+        updatedAt: new Date('2026-06-29T14:04:01Z'),
+      });
+      const updates = domainBuilder.buildDraftModule({
+        id: 'updated id',
+        moduleId: 'updated moduleId',
+        shortId: 'updated shortId',
+        details: 'updated details',
+        glossary: 'updated glossary',
+        internalTitle: 'updated internalTitle',
+        isBeta: 'updated isBeta',
+        sections: 'updated sections',
+        slug: 'updated slug',
+        title: 'updated title',
+        visibility: 'updated visibility',
+      });
+
+      // when
+      draftModule.update(updates);
+
+      // then
+      expect(draftModule).toStrictEqual(domainBuilder.buildDraftModule({
+        id: '704a89a6-983b-4e04-bfef-6a54f925c44e',
+        shortId: '704a89a6',
+        createdAt: new Date('2026-06-29T14:04:01Z'),
+        updatedAt: new Date('2026-06-29T14:04:01Z'),
+        details: 'updated details',
+        glossary: 'updated glossary',
+        internalTitle: 'updated internalTitle',
+        isBeta: 'updated isBeta',
+        sections: 'updated sections',
+        slug: 'updated slug',
+        title: 'updated title',
+        visibility: 'updated visibility',
+      }));
+    });
+  });
+
   describe('#serializeToJSON', () => {
     it('serializes module fields to JSON discarding irrelevant fields', () => {
       // given

--- a/api/tests/unit/domain/usecases/create-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/create-draft-module_test.js
@@ -16,7 +16,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
     });
     prepareForCreation = vi.spyOn(draftModule, 'prepareForCreation');
 
-    updatePixApiReleaseCache = { onDraftModuleCreated: vi.fn().mockResolvedValueOnce() };
+    updatePixApiReleaseCache = { onDraftModuleCreatedOrUpdated: vi.fn().mockResolvedValueOnce() };
   });
 
   it('prepares draft module for creation and saves it', async () => {
@@ -28,7 +28,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
 
     expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(undefined);
     expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
-    expect(updatePixApiReleaseCache.onDraftModuleCreated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
+    expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
   });
 
   describe('when draft module has a moduleId', () => {
@@ -49,7 +49,7 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
       expect(moduleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: moduleId });
       expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(module);
       expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
-      expect(updatePixApiReleaseCache.onDraftModuleCreated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
+      expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/update-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/update-draft-module_test.js
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { updateDraftModule } from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | Domain | Use Cases | update-draft-module', () => {
+  const draftModuleId = Symbol('draftModuleId');
+  const savedDraftModule = Symbol('savedDraftModule');
+
+  let draftModuleRepository, existingDraftModule, update, updatePixApiReleaseCache, draftModule;
+
+  beforeEach(() => {
+    existingDraftModule = domainBuilder.buildDraftModule();
+
+    draftModuleRepository = {
+      getById: vi.fn().mockResolvedValueOnce(existingDraftModule),
+      save: vi.fn().mockResolvedValueOnce(savedDraftModule),
+    };
+
+    update = vi.spyOn(existingDraftModule, 'update');
+
+    updatePixApiReleaseCache = { onDraftModuleCreatedOrUpdated: vi.fn().mockResolvedValueOnce() };
+
+    draftModule = domainBuilder.buildDraftModule({ id: draftModuleId });
+  });
+
+  it('prepares updates existing module and saves it', async () => {
+    // when
+    const result = updateDraftModule(draftModule, { draftModuleRepository, updatePixApiReleaseCache });
+
+    // then
+    await expect(result).resolves.toBe(savedDraftModule);
+
+    expect(update).toHaveBeenCalledExactlyOnceWith(draftModule);
+    expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(existingDraftModule);
+    expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
+  });
+});

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -90,6 +90,7 @@ Router.map(function () {
       this.route('workbench');
       this.route('production-module', { path: '/production/:module_id' });
       this.route('draft-module', { path: '/workbench/:draft_module_id' });
+      this.route('edit-draft-module', { path: '/workbench/:draft_module_id/edit' });
     });
     this.route('missions', function () {
       this.route('list', { path: '/' });

--- a/pix-editor/app/routes/authenticated/modules/edit-draft-module.js
+++ b/pix-editor/app/routes/authenticated/modules/edit-draft-module.js
@@ -1,17 +1,11 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
-export default class DraftModuleRoute extends Route {
+export default class EditDraftModuleRoute extends Route {
   @service store;
 
   async model(params) {
     const draftModule = await this.store.findRecord('draft-module', params.draft_module_id, { reload: true });
-
-    let draftModuleDiff;
-    if (draftModule.isEditionDraft) {
-      draftModuleDiff = await draftModule.belongsTo('diff').reload();
-    }
-
-    return { draftModule, draftModuleDiff };
+    return { draftModule };
   }
 }

--- a/pix-editor/app/serializers/draft-module.js
+++ b/pix-editor/app/serializers/draft-module.js
@@ -2,6 +2,8 @@ import ApplicationSerializer from './application';
 
 export default class DraftModuleSerializer extends ApplicationSerializer {
   attrs = {
+    diff: { serialize: false },
+    shortId: { serialize: false },
     previewUrl: { serialize: false },
     url: { serialize: false },
   };

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,3 +1,4 @@
+import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
@@ -9,6 +10,14 @@ import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons'
     <h1 class="page-title">Détail du draft de module</h1>
     <div class="page-actions">
       <PlayModuleButtons @module={{@model.draftModule}} />
+      <PixButtonLink
+        @route="authenticated.modules.edit-draft-module"
+        @model={{@model.draftModule.id}}
+        class="pix-button-link-with-icon white-font"
+        @iconBefore="edit"
+      >
+        Modifier
+      </PixButtonLink>
     </div>
   </header>
   <main class="page-body">

--- a/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
@@ -1,0 +1,51 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import ModuleForm from 'pixeditor/components/modules/module-form';
+
+export default class NewModule extends Component {
+  @service loader;
+  @service notifications;
+  @service router;
+  @service store;
+
+  @action
+  async saveModule({ internalTitle, title, isBeta, slug, visibility, details, sections, glossary }) {
+    const { draftModule } = this.args.model;
+
+    Object.assign(draftModule, {
+      internalTitle,
+      title,
+      isBeta,
+      slug,
+      visibility,
+      details,
+      sections,
+      glossary,
+    });
+
+    try {
+      this.loader.start();
+      await draftModule.save();
+      this.router.replaceWith('authenticated.modules.draft-module', draftModule.id);
+      this.notifications.sendSuccess(`Le draft "${draftModule.internalTitle}" a été enregistré.`);
+    } catch {
+      this.notifications.sendError('Erreur lors de l’enregistrement du draft.');
+    } finally {
+      this.loader.stop();
+    }
+  }
+
+  <template>
+    <header class="page-header">
+      <h1 class="page-title">
+        Édition du draft de module
+      </h1>
+    </header>
+    <main class="page-body">
+      <section class="page-section module-form">
+        <ModuleForm @module={{@model.draftModule}} @saveModule={{this.saveModule}} />
+      </section>
+    </main>
+  </template>
+}

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -33,4 +33,28 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
     // WORKAROUND: let some time for monaco-editor to settle
     await new Promise((resolve) => setTimeout(resolve, 100));
   });
+
+  module('when user clicks on "Modifier"', function () {
+    test('displays draft module edition page', async function (assert) {
+      // when
+      const screen = await visit(`/modules/workbench/${id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await clickByName('Modifier');
+
+      // then
+      assert.strictEqual(currentURL(), `/modules/workbench/${id}/edit`);
+      assert.dom(screen.getByRole('heading', { name: 'Édition du draft de module' })).exists();
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // when
+      await clickByName('Enregistrer');
+
+      // then
+      assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+  });
 });

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -86,6 +86,7 @@ module('Acceptance | Modules | New', function (hooks) {
 
     const [, moduleId] = currentURL().match(/\/modules\/production\/(.*)$/);
 
+    await new Promise((resolve) => setTimeout(resolve, 100));
     await screen.getByRole('link', { name: 'Créer un draft' }).click();
 
     // then
@@ -95,7 +96,7 @@ module('Acceptance | Modules | New', function (hooks) {
     await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'MOD_666');
 
     // WORKAROUND: let some time for Monaco
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     await screen.getByRole('button', { name: 'Enregistrer' }).click();
 

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -395,6 +395,8 @@ export default function routes() {
     return schema.create('draft-module', { id: moduleId ?? crypto.randomUUID(), ...attributes });
   });
 
+  this.patch('/draft-modules/:id');
+
   this.get('/draft-modules', function (schema, request) {
     const pagination = _getPaginationFromQueryParams(request.queryParams);
 


### PR DESCRIPTION
## 🪧 Problème

On peut créer un module draft, mais une fois enregistré, on ne peut pas le modifier.

## 🌈 Proposition

- Ajouter un bouton pour Modifier un draft-module déjà créé
- Quand on clique dessus, ça ouvre une page d'édition du draft-module

## ✊ Remarques

RAS

## 🎉 Pour tester

- Ouvrir pix-editor comme il se doit
- Choisir un draft-module de son choix, et afficher sa page détails
- Vous devriez trouver le bouton "Modifier" en haut à droite; Cliquez dessus, ça va être magique
- Pouf ! Vous pouvez de nouveau éditer le module. Faites-le. Sisi
- Après modification, cliquez sur "Enregistrer". Vous devez voir de nouveau la page de détails du module, avec les modifications incluses. Tada