### PR TITLE
[FEATURE] Publier un module (PIX-23425)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
-import { draftModuleDiffSerializer, draftModuleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
-import { createDraftModule, updateDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules } from '../../domain/usecases/index.js';
+import { draftModuleDiffSerializer, draftModuleSerializer, moduleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
+import { createDraftModule, updateDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules, publishDraftModule } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import * as Types from '../types.js';
 
@@ -127,6 +127,18 @@ export function register(server) {
           const draftModule = await draftModuleSerializer.deserialize(request.payload);
           const updatedModule = await updateDraftModule(draftModule);
           return h.response(draftModuleSerializer.serialize(updatedModule)).code(200);
+        },
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/draft-modules/{id}/publish',
+      config: {
+        validate: { params: Joi.object({ id: Types.moduleId().required() }).required() },
+        handler: async (request, h) => {
+          const { id } = request.params;
+          const publishedModule = await publishDraftModule({ draftModuleId: id });
+          return h.response(moduleSerializer.serialize(publishedModule)).code(200);
         },
       },
     },

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -31,6 +31,8 @@ export class DraftModule extends Module {
     this.glossary = module.glossary;
   }
 
+  publish() {}
+
   get url() {
     return new URL(`/modules/${this.shortId}/${this.slug}`, config.pixApp.recette.baseUrlFr).href;
   }

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -31,7 +31,20 @@ export class DraftModule extends Module {
     this.glossary = module.glossary;
   }
 
-  publish() {}
+  publish() {
+    return new Module({
+      id: this.id,
+      details: this.details,
+      glossary: this.glossary,
+      internalTitle: this.internalTitle,
+      isBeta: this.isBeta,
+      sections: this.sections,
+      shortId: this.shortId,
+      slug: this.slug,
+      title: this.title,
+      visibility: this.visibility,
+    });
+  }
 
   get url() {
     return new URL(`/modules/${this.shortId}/${this.slug}`, config.pixApp.recette.baseUrlFr).href;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -34,6 +34,7 @@ export * from './list-thematics.js';
 export * from './list-tubes.js';
 export * from './modify-localized-challenge.js';
 export * from './preview-challenge.js';
+export * from './publish-draft-module.js';
 export * from './search-tags.js';
 export * from './search.js';
 export * from './search-tutorials.js';

--- a/api/lib/domain/usecases/publish-draft-module.js
+++ b/api/lib/domain/usecases/publish-draft-module.js
@@ -1,0 +1,14 @@
+import { draftModuleRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
+import { DomainTransaction } from '../DomainTransaction.js';
+
+export async function publishDraftModule({ draftModuleId }, dependencies = { draftModuleRepository, moduleRepository }) {
+  return DomainTransaction.execute(async () => {
+    const draftModule = await dependencies.draftModuleRepository.getById({ id: draftModuleId, forUpdate: true });
+
+    const module = await dependencies.moduleRepository.save(draftModule.publish());
+
+    await dependencies.draftModuleRepository.remove({ id: draftModuleId });
+
+    return module;
+  });
+}

--- a/api/lib/infrastructure/repositories/draft-module-repository.js
+++ b/api/lib/infrastructure/repositories/draft-module-repository.js
@@ -40,15 +40,25 @@ export async function count() {
   return count;
 }
 
-export async function getById({ id }) {
+export async function getById({ id, forUpdate = false }) {
   const knexConn = DomainTransaction.getConnection();
-  const draftModule = await knexConn('draft-modules').where({ id }).first();
+
+  let query = knexConn.select('*').from('draft-modules').where({ id }).first();
+  if (forUpdate) query = query.forUpdate();
+
+  const draftModule = await query;
 
   if (!draftModule) {
     throw new NotFoundError('Draft module not found');
   }
 
   return toDomain(draftModule);
+}
+
+export async function remove({ id }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn.delete().from('draft-modules').where('id', id);
 }
 
 function toDomain({ image, description, duration, level, objectives, tabletSupport, ...draftModule }) {

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -545,4 +545,64 @@ describe('Acceptance | Route | draft-modules', () => {
       ]);
     });
   });
+
+  describe('POST /draft-modules/:id/publish', () => {
+    it('responds with status 200 and published module’s data', async () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule();
+      databaseBuilder.factory.buildDraftModule(draftModule);
+      await databaseBuilder.commit();
+
+      const server = await createServer();
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/draft-modules/${draftModule.id}/publish`,
+        headers: generateAuthorizationHeader(editorUser),
+      });
+
+      // then
+      expect(response.statusCode).toBe(200);
+
+      expect(response.result).toEqual({
+        data: {
+          type: 'modules',
+          id: draftModule.id,
+          attributes: {
+            'short-id': draftModule.shortId,
+            'internal-title': draftModule.internalTitle,
+            'is-beta': draftModule.isBeta,
+            visibility: draftModule.visibility,
+            details: draftModule.details,
+            slug: draftModule.slug,
+            title: draftModule.title,
+            sections: draftModule.sections,
+            glossary: draftModule.glossary,
+            url: `${config.pixApp.production.baseUrlFr}/modules/${draftModule.shortId}/${draftModule.slug}`,
+            'preview-url': `${config.pixApp.production.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
+          },
+          relationships: { 'draft-module': { data: null } },
+        },
+      });
+
+      await expect(knex.select('*').from('modules')).resolves.toStrictEqual([
+        {
+          id: draftModule.id,
+          shortId: draftModule.shortId,
+          internalTitle: draftModule.internalTitle,
+          slug: draftModule.slug,
+          title: draftModule.title,
+          isBeta: draftModule.isBeta,
+          visibility: draftModule.visibility,
+          sections: draftModule.sections,
+          glossary: draftModule.glossary,
+          ...draftModule.details,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+        },
+      ]);
+      await expect(knex.select('*').from('draft-modules')).resolves.toStrictEqual([]);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/draft-module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/draft-module-repository_test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { catchErr, databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
-import { save, list, count, getById } from '../../../../lib/infrastructure/repositories/draft-module-repository.js';
+import * as draftModuleRepository from '../../../../lib/infrastructure/repositories/draft-module-repository.js';
 import { NotFoundError } from '../../../../lib/infrastructure/errors.js';
 
 describe('Draft Module Repository', () => {
@@ -11,7 +11,7 @@ describe('Draft Module Repository', () => {
       const expectedDraftModule = { ...draftModule, createdAt: expect.any(Date), updatedAt: expect.any(Date) };
 
       // when
-      const savedDraftModule = await save({ ...draftModule });
+      const savedDraftModule = await draftModuleRepository.save({ ...draftModule });
 
       // then
       const { details: expectedDetails, ...expectedDraftModuleData } = expectedDraftModule;
@@ -29,7 +29,7 @@ describe('Draft Module Repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const savedDraftModule = await save({ ...module, moduleId: module.id });
+      const savedDraftModule = await draftModuleRepository.save({ ...module, moduleId: module.id });
 
       // then
       const { details: expectedDetails, ...expectedDraftModuleData } = expectedDraftModule;
@@ -56,7 +56,7 @@ describe('Draft Module Repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const savedDraftModule = await save({ ...updatedModule, moduleId: module.id });
+      const savedDraftModule = await draftModuleRepository.save({ ...updatedModule, moduleId: module.id });
 
       // then
       const { details: expectedDetails, ...expectedDraftModuleData } = expectedDraftModule;
@@ -77,7 +77,7 @@ describe('Draft Module Repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const draftModules = await list();
+      const draftModules = await draftModuleRepository.list();
 
       // then
       expect(draftModules).toStrictEqual([firstDraftModule, secondDraftModule]);
@@ -101,7 +101,7 @@ describe('Draft Module Repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const draftModules = await list({ page, sort });
+      const draftModules = await draftModuleRepository.list({ page, sort });
 
       // then
       expect(draftModules).toStrictEqual([firstDraftModule, thirdDraftModule]);
@@ -116,7 +116,7 @@ describe('Draft Module Repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const result = await count();
+      const result = await draftModuleRepository.count();
 
       // then
       expect(result).toBe(2);
@@ -134,7 +134,7 @@ describe('Draft Module Repository', () => {
       await databaseBuilder.commit();
 
       // when
-      const draftModule = await getById({ id: expectedDraftModule.id });
+      const draftModule = await draftModuleRepository.getById({ id: expectedDraftModule.id });
 
       // then
       expect(draftModule).toStrictEqual(expectedDraftModule);
@@ -145,10 +145,25 @@ describe('Draft Module Repository', () => {
       const inexistingDraftModuleId = crypto.randomUUID();
 
       // when
-      const error = await catchErr(getById)({ id: inexistingDraftModuleId });
+      const error = await catchErr(draftModuleRepository.getById)({ id: inexistingDraftModuleId });
 
       // then
       expect(error).toBeInstanceOf(NotFoundError);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes draft module by id', async () => {
+      // given
+      const { id } = databaseBuilder.factory.buildDraftModule(domainBuilder.buildDraftModule({ shortId: 'modtest1', internalTitle: 'MOD_test1', slug: 'test1' }));
+      databaseBuilder.factory.buildDraftModule(domainBuilder.buildDraftModule({ shortId: 'modtest2', internalTitle: 'MOD_test2', slug: 'test2' }));
+      await databaseBuilder.commit();
+
+      // when
+      await draftModuleRepository.remove({ id });
+
+      // then
+      expect(knex.pluck('shortId').from('draft-modules')).resolves.toStrictEqual(['modtest2']);
     });
   });
 });

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import * as config from '../../../../lib/config.js';
-import { DraftModule } from '../../../../lib/domain/models/index.js';
+import { DraftModule, Module } from '../../../../lib/domain/models/index.js';
 import { domainBuilder } from '../../../test-helper.js';
 
 const uuidRegExp = /^\p{Hex_Digit}{8}-\p{Hex_Digit}{4}-\p{Hex_Digit}{4}-\p{Hex_Digit}{4}-\p{Hex_Digit}{12}$/u;
@@ -79,6 +79,31 @@ describe('Unit | Domain | DraftModule', () => {
         title: 'updated title',
         visibility: 'updated visibility',
       }));
+    });
+  });
+
+  describe('#publish', () => {
+    it('creates a published module from draft module', () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule();
+      const expectedModule = new Module({
+        id: draftModule.id,
+        details: draftModule.details,
+        glossary: draftModule.glossary,
+        internalTitle: draftModule.internalTitle,
+        isBeta: draftModule.isBeta,
+        sections: draftModule.sections,
+        shortId: draftModule.shortId,
+        slug: draftModule.slug,
+        title: draftModule.title,
+        visibility: draftModule.visibility,
+      });
+
+      // when
+      const publishedModule = draftModule.publish();
+
+      // then
+      expect(publishedModule).toStrictEqual(expectedModule);
     });
   });
 

--- a/api/tests/unit/domain/usecases/publish-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/publish-draft-module_test.js
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { publishDraftModule } from '../../../../lib/domain/usecases/index.js';
+
+describe('Unit | Domain | Use Cases | publish-draft-module', () => {
+  const publishedModule = Symbol('publishedModule');
+  const savedModule = Symbol('savedModule');
+
+  let moduleRepository, draftModuleRepository, draftModule, publish;
+
+  beforeEach(() => {
+    draftModule = domainBuilder.buildDraftModule();
+    publish = vi.spyOn(draftModule, 'publish').mockReturnValueOnce(publishedModule);
+
+    draftModuleRepository = { getById: vi.fn().mockResolvedValueOnce(draftModule), remove: vi.fn().mockResolvedValueOnce() };
+    moduleRepository = { save: vi.fn().mockResolvedValueOnce(savedModule) };
+  });
+
+  it('saves draft module as a module then removes draft module', async () => {
+    // when
+    const result = await publishDraftModule({ draftModuleId: draftModule.id }, { draftModuleRepository, moduleRepository });
+
+    // then
+    expect(result).toBe(savedModule);
+
+    expect(draftModuleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: draftModule.id, forUpdate: true });
+    expect(publish).toHaveBeenCalledExactlyOnceWith();
+    expect(moduleRepository.save).toHaveBeenCalledExactlyOnceWith(publishedModule);
+    expect(draftModuleRepository.remove).toHaveBeenCalledExactlyOnceWith({ id: draftModule.id });
+  });
+});

--- a/pix-editor/app/adapters/module.js
+++ b/pix-editor/app/adapters/module.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class ModuleAdapter extends ApplicationAdapter {
+  queryRecord(store, type, query, options) {
+    if (options.adapterOptions?.publish) {
+      const url = `${this.buildURL('draft-module', query.draftModuleId)}/publish`;
+      return this.ajax(url, 'POST');
+    }
+    return super.queryRecord(store, type, query, options);
+  }
+}

--- a/pix-editor/app/components/modules/publish-module-button.gjs
+++ b/pix-editor/app/components/modules/publish-module-button.gjs
@@ -1,0 +1,32 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class PublishModuleButton extends Component {
+  @service loader;
+  @service notifications;
+  @service router;
+
+  @action async publish() {
+    try {
+      const module = await this.args.draftModule.publish();
+      this.notifications.sendSuccess(`Le module "${module.internalTitle}" a été publié.`);
+      this.router.replaceWith('authenticated.modules.production-module', module.id);
+    } catch {
+      this.notifications.sendError('Erreur lors de la publication du module.');
+    } finally {
+      this.loader.stop();
+    }
+  }
+
+  get ariaLabel() {
+    return `Publier le module "${this.args.draftModule.internalTitle}"`;
+  }
+
+  <template>
+    <PixButton @triggerAction={{this.publish}} @variant="success" aria-label={{this.ariaLabel}}>
+      Publier
+    </PixButton>
+  </template>
+}

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -21,4 +21,14 @@ export default class DraftModule extends BaseModule {
   get isEditionDraft() {
     return this.belongsToModule;
   }
+
+  async publish() {
+    const module = await this.store.queryRecord(
+      'module',
+      { draftModuleId: this.id },
+      { adapterOptions: { publish: true } },
+    );
+    this.store.unloadRecord(this);
+    return module;
+  }
 }

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -4,6 +4,7 @@ import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModuleNotification from 'pixeditor/components/modules/module-notification';
 import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons';
+import PublishModuleButton from 'pixeditor/components/modules/publish-module-button';
 
 <template>
   <header class="page-header">
@@ -18,6 +19,7 @@ import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons'
       >
         Modifier
       </PixButtonLink>
+      <PublishModuleButton @draftModule={{@model.draftModule}} />
     </div>
   </header>
   <main class="page-body">

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -1,5 +1,5 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -53,6 +53,25 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+  });
+
+  module('when user clicks "Publier"', function () {
+    test('publishes module and navigates to module’s details page', async function (assert) {
+      // given
+      const screen = await visit(`/modules/workbench/${id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // when
+      await click(screen.getByRole('button', { name: 'Publier le module "MON_BEAU_MODULE"' }));
+
+      // then
+      assert.dom(await screen.findByText('Le module "MON_BEAU_MODULE" a été publié.')).exists();
+      assert.strictEqual(currentURL(), `/modules/production/${id}`);
+
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));
     });

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -397,6 +397,11 @@ export default function routes() {
 
   this.patch('/draft-modules/:id');
 
+  this.post('/draft-modules/:id/publish', function (schema, request) {
+    const draftModule = schema.draftModules.find(request.params.id);
+    return schema.create('module', { ...draftModule.attrs });
+  });
+
   this.get('/draft-modules', function (schema, request) {
     const pagination = _getPaginationFromQueryParams(request.queryParams);
 


### PR DESCRIPTION
## 🪧 Problème

On souhaite pouvoir publier un module.

## 🌈 Proposition

Sur la page de détail d’un draft, on ajoute un bouton Publier qui publie le module.

## ✊ Remarques

N/A

## 🎉 Pour tester

Créer un draft soit à partir d’un module existant ou from scratch, puis le publier.
Vérifier que le module en production est bien créé/à jour, et que le draft est bien supprimé.