### PR TITLE
[FEATURE] Script de migration des modules : valoriser le numéro de version (PIX-23335)

### DIFF
--- a/api/scripts/migrate-modules.js
+++ b/api/scripts/migrate-modules.js
@@ -49,6 +49,7 @@ export class MigrateModules extends Script {
         const module = new Module({
           ...JSON.parse(content),
           internalTitle,
+          version: '1.0',
         });
         logger.info({ id: module.id, title: module.title }, 'Saving module');
         await moduleRepository.save(module, transaction);

--- a/api/tests/scripts/migrate-modules_test.js
+++ b/api/tests/scripts/migrate-modules_test.js
@@ -46,11 +46,12 @@ describe('Script | MigrateModules', () => {
       await script.handle({ options, logger }, { octokit });
 
       // then
-      await expect(knex.select('id', 'shortId', 'internalTitle', 'title').from('modules').orderBy('shortId')).resolves.toStrictEqual(modules.map((module) => ({
+      await expect(knex.select('id', 'shortId', 'internalTitle', 'title', 'version').from('modules').orderBy('shortId')).resolves.toStrictEqual(modules.map((module) => ({
         id: module.id,
         shortId: module.shortId,
         internalTitle: module.internalTitle,
         title: module.title,
+        version: '1.0',
       })));
 
       expect(octokit.repos.getContent).toHaveBeenCalledTimes(5);


### PR DESCRIPTION
## 🪧 Problème

Lorsque les modules sont migrés depuis le mono-repo vers la base de données de Pix Editor, on souhaite que leur numéro de version soit valorisé à “v1.0”.

## 🌈 Proposition

Modifier le script de migration afin de systématiquement remplir la colonne version de la table modules avec la valeur “v1.0”.

## ✊ Remarques

N/A

## 🎉 Pour tester

Le script de migration a été exécuté sur la RA.

Vérifier que les modules migrés ont bien la version 1.0 :

```
scalingo -a pix-lcms-review-pr1543 psql-console
select version from modules;
```