### PR TITLE
[FEATURE] Incrémenter le numéro de version du module et du draft (PIX-23340)

### DIFF
--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -15,6 +15,7 @@ export class DraftModule extends Module {
   prepareForCreation(module) {
     this.id = module?.id ?? crypto.randomUUID();
     this.shortId = module?.shortId ?? this.id.slice(0, 8);
+    this.version = incrementMinorVersion(module?.version) ?? '0.1';
   }
 
   /**
@@ -53,4 +54,8 @@ export class DraftModule extends Module {
   get previewUrl() {
     return new URL(`/modules/preview/${this.shortId}/${this.slug}`, config.pixApp.recette.baseUrlFr).href;
   }
+}
+
+function incrementMinorVersion(version) {
+  return version?.replace(/\d+$/, (minorVersion) => parseInt(minorVersion) + 1);
 }

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -30,6 +30,7 @@ export class DraftModule extends Module {
     this.details = module.details;
     this.sections = module.sections;
     this.glossary = module.glossary;
+    this.version = incrementMinorVersion(this.version);
   }
 
   publish() {

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -45,6 +45,7 @@ export class DraftModule extends Module {
       slug: this.slug,
       title: this.title,
       visibility: this.visibility,
+      version: incrementMajorVersion(this.version),
     });
   }
 
@@ -59,4 +60,8 @@ export class DraftModule extends Module {
 
 function incrementMinorVersion(version) {
   return version?.replace(/\d+$/, (minorVersion) => parseInt(minorVersion) + 1);
+}
+
+function incrementMajorVersion(version) {
+  return version?.replace(/^(\d+)\.\d+$/, (_, majorVersion) => `${parseInt(majorVersion) + 1}.0`);
 }

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | Route | draft-modules', () => {
   describe('POST /draft-modules', () => {
     it('responds with status 201 and draft modules data', async () => {
       // given
-      const draftModule = domainBuilder.buildDraftModule();
+      const draftModule = domainBuilder.buildDraftModule({ version: '0.1' });
       const draftModulePayload = {
         slug: draftModule.slug,
         title: draftModule.title,
@@ -91,6 +91,7 @@ describe('Acceptance | Route | draft-modules', () => {
         const module = domainBuilder.buildModule({
           sections: [],
           glossary: [],
+          version: '4.0',
         });
         databaseBuilder.factory.buildModule(module);
         await databaseBuilder.commit();
@@ -104,6 +105,7 @@ describe('Acceptance | Route | draft-modules', () => {
           internalTitle: module.internalTitle + '_update',
           isBeta: true,
           visibility: Module.VISIBILITIES.PRIVATE,
+          version: '4.1',
           details: {
             image: module.details.image + '_update',
             description: module.details.description + ' update',

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -554,7 +554,7 @@ describe('Acceptance | Route | draft-modules', () => {
   describe('POST /draft-modules/:id/publish', () => {
     it('responds with status 200 and published module’s data', async () => {
       // given
-      const draftModule = domainBuilder.buildDraftModule();
+      const draftModule = domainBuilder.buildDraftModule({ version: '47.3' });
       databaseBuilder.factory.buildDraftModule(draftModule);
       await databaseBuilder.commit();
 
@@ -602,7 +602,7 @@ describe('Acceptance | Route | draft-modules', () => {
           visibility: draftModule.visibility,
           sections: draftModule.sections,
           glossary: draftModule.glossary,
-          version: draftModule.version,
+          version: '48.0',
           ...draftModule.details,
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -480,7 +480,7 @@ describe('Acceptance | Route | draft-modules', () => {
   describe('PATCH /draft-modules/:id', () => {
     it('responds with status 200 and draft modules data', async () => {
       // given
-      const draftModule = domainBuilder.buildDraftModule();
+      const draftModule = domainBuilder.buildDraftModule({ version: '6.4' });
       databaseBuilder.factory.buildDraftModule(draftModule);
       await databaseBuilder.commit();
 
@@ -540,7 +540,7 @@ describe('Acceptance | Route | draft-modules', () => {
           visibility: draftModule.visibility,
           sections: draftModule.sections,
           glossary: draftModule.glossary,
-          version: draftModule.version,
+          version: '6.5',
           hasBeenValidated: draftModule.hasBeenValidated,
           validationErrors: draftModule.validationErrors,
           ...draftModule.details,

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -20,12 +20,13 @@ describe('Unit | Domain | DraftModule', () => {
       expect(draftModule.id).toMatch(uuidRegExp);
       expect(draftModule.shortId).toMatch(shortIdRegExp);
       expect(draftModule.shortId).toBe(draftModule.id.slice(0, 8));
+      expect(draftModule.version).toBe('0.1');
     });
 
     describe('when a module is given', () => {
       it('uses module’s id and shortId', () => {
         // given
-        const module = domainBuilder.buildModule();
+        const module = domainBuilder.buildModule({ version: '2.0' });
         const draftModule = new DraftModule();
 
         // when
@@ -34,6 +35,7 @@ describe('Unit | Domain | DraftModule', () => {
         // then
         expect(draftModule.id).toBe(module.id);
         expect(draftModule.shortId).toBe(module.shortId);
+        expect(draftModule.version).toBe('2.1');
       });
     });
   });

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -46,6 +46,7 @@ describe('Unit | Domain | DraftModule', () => {
       const draftModule = domainBuilder.buildDraftModule({
         id: '704a89a6-983b-4e04-bfef-6a54f925c44e',
         shortId: '704a89a6',
+        version: '10.11',
         createdAt: new Date('2026-06-29T14:04:01Z'),
         updatedAt: new Date('2026-06-29T14:04:01Z'),
       });
@@ -80,6 +81,7 @@ describe('Unit | Domain | DraftModule', () => {
         slug: 'updated slug',
         title: 'updated title',
         visibility: 'updated visibility',
+        version: '10.12',
       }));
     });
   });

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -89,7 +89,7 @@ describe('Unit | Domain | DraftModule', () => {
   describe('#publish', () => {
     it('creates a published module from draft module', () => {
       // given
-      const draftModule = domainBuilder.buildDraftModule();
+      const draftModule = domainBuilder.buildDraftModule({ version: '0.341' });
       const expectedModule = new Module({
         id: draftModule.id,
         details: draftModule.details,
@@ -101,6 +101,7 @@ describe('Unit | Domain | DraftModule', () => {
         slug: draftModule.slug,
         title: draftModule.title,
         visibility: draftModule.visibility,
+        version: '1.0',
       });
 
       // when


### PR DESCRIPTION
## 🪧 Problème

Lorsqu’un draft est créé, on souhaite que son numéro de version soit valorisé.

## 🌈 Proposition

Faire cela.

- si c’est un draft de création, il prend la valeur “0.1”
- si c’est un draft de modification, il prend la version du module en incrémentant la version mineure (exemple : si le module a la version “3.0”, il prend la version “3.1”)

Lorsqu’un draft est modifié, on souhaite incrémenter sa version mineure, si il était à “2.3” alors il passe à “2.4”.

Lorsqu’un module est publié on souhaite que sa version majeure soit incrémentée :

- si le draft est en version 0.1 ou 0.2, alors le module doit prendre la version 1.0.
- si le draft est en version 2.1 ou 2.4, alors le module doit prendre la version 3.0.


<img width="896" height="264" alt="Capture d’écran 2026-07-08 à 17 17 28" src="https://github.com/user-attachments/assets/9622a792-5acf-491e-b634-75d5820b1ddc" />

## ✊ Remarques

RAS

## 🎉 Pour tester
- Tester la création de draft à partir d'un module existant et vérifier que la version existe bien dans la BDD.
- Tester la publication d'un module et vérifier que la version existe bien dans la BDD.
