### PR TITLE
[TECH] Rendre les colonnes version des modules et drafts obligatoires (PIX-23339)

### DIFF
--- a/api/db/migrations/20260709082412_alter-module-version-columns.js
+++ b/api/db/migrations/20260709082412_alter-module-version-columns.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable('modules', function(table) {
+    table.string('version').notNullable().alter();
+  });
+  await knex.schema.alterTable('draft-modules', function(table) {
+    table.string('version').notNullable().alter();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable('modules', function(table) {
+    table.string('version').nullable().alter();
+  });
+  await knex.schema.alterTable('draft-modules', function(table) {
+    table.string('version').nullable().alter();
+  });
+}

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -891,8 +891,8 @@ async function mockContentForRelease() {
 
   attachments.forEach(databaseBuilder.factory.buildAttachment);
 
-  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[0], internalTitle: 'module-1' });
-  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[1], internalTitle: 'module-2' });
+  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[0], internalTitle: 'module-1', version: '1.0' });
+  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[1], internalTitle: 'module-2', version: '2.0' });
 
   await databaseBuilder.commit();
   return expectedCurrentContent;

--- a/api/tests/integration/infrastructure/repositories/module-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-repository_test.js
@@ -138,17 +138,18 @@ describe('Module Repository', () => {
     it('returns a module by its id', async () => {
       // given
       const id = crypto.randomUUID();
-      const expectedModule = domainBuilder.buildModuleForConsultation({ id, draftModuleId: id });
-      databaseBuilder.factory.buildModule(expectedModule);
+      const expectedModule = domainBuilder.buildModule({ id });
+      const expectedModuleForConsultation = domainBuilder.buildModuleForConsultation({ ...expectedModule, draftModuleId: id });
+      databaseBuilder.factory.buildModule(expectedModuleForConsultation);
       databaseBuilder.factory.buildDraftModule(domainBuilder.buildDraftModule({ id, moduleId: id }));
-      databaseBuilder.factory.buildModule(domainBuilder.buildModuleForConsultation({ shortId: 'secondar', internalTitle: 'secondar' }));
+      databaseBuilder.factory.buildModule(domainBuilder.buildModule({ shortId: 'secondar', internalTitle: 'secondar' }));
       await databaseBuilder.commit();
 
       // when
       const module = await getById({ id });
 
       // then
-      expect(module).toStrictEqual(expectedModule);
+      expect(module).toStrictEqual(expectedModuleForConsultation);
     });
 
     it('throw a not Found error if module is not found', async () => {

--- a/api/tests/tooling/domain-builder/factory/build-draft-module.js
+++ b/api/tests/tooling/domain-builder/factory/build-draft-module.js
@@ -5,9 +5,10 @@ export function buildDraftModule({
   moduleId = null,
   hasBeenValidated = false,
   validationErrors = null,
+  version = '0.1',
   ...moduleAttributes
 } = {}) {
-  const module = buildModule(moduleAttributes);
+  const module = buildModule({ ...moduleAttributes, version });
   return new DraftModule({
     ...module,
     moduleId,

--- a/api/tests/tooling/domain-builder/factory/build-module.js
+++ b/api/tests/tooling/domain-builder/factory/build-module.js
@@ -41,7 +41,7 @@ export function buildModule({
       description: 'Une coquille est un agglomérat de calcaire très résistant. Sa structure cristalline spécifique lui confère une résistance protectrice. Elle prodique à l\'escargot toute sa force et sa vitalité.',
     },
   ],
-  version = null,
+  version = '1.0',
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {


### PR DESCRIPTION
## 🪧 Problème

On veut garantir que tous les modules/drafts ont une version.

## 🌈 Proposition

Modifier les colonnes `version` des tables `modules` et `draft-modules` pour les rendre non nullables.

## ✊ Remarques

N/A

## 🎉 Pour tester

Tests au vert.