### PR TITLE
[TECH] Release et patch de release : ajout du numéro de version (PIX-23341)

### DIFF
--- a/api/lib/domain/models/release/ModuleForRelease.js
+++ b/api/lib/domain/models/release/ModuleForRelease.js
@@ -9,6 +9,7 @@ export class ModuleForRelease {
     details,
     sections,
     glossary,
+    version,
   } = {}) {
     this.id = id;
     this.shortId = shortId;
@@ -19,5 +20,6 @@ export class ModuleForRelease {
     this.details = details;
     this.sections = sections;
     this.glossary = glossary;
+    this.version = version;
   }
 }

--- a/api/tests/acceptance/application/releases/releases-controller_test.js
+++ b/api/tests/acceptance/application/releases/releases-controller_test.js
@@ -736,7 +736,7 @@ async function mockContentForRelease() {
         documentationUrl: null,
       }),
     ],
-    modules: [domainBuilder.buildModuleForRelease({ title: 'Module 1' }), domainBuilder.buildModuleForRelease({ shortId: 'tatatiti', title: 'Module 2' })],
+    modules: [domainBuilder.buildModuleForRelease({ title: 'Module 1' }), domainBuilder.buildModuleForRelease({ shortId: 'tatatiti', title: 'Module 2', version: '2.0' })],
   };
 
   const attachments = [
@@ -891,8 +891,8 @@ async function mockContentForRelease() {
 
   attachments.forEach(databaseBuilder.factory.buildAttachment);
 
-  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[0], internalTitle: 'module-1', version: '1.0' });
-  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[1], internalTitle: 'module-2', version: '2.0' });
+  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[0], internalTitle: 'module-1' });
+  databaseBuilder.factory.buildModule({ ...expectedCurrentContent.modules[1], internalTitle: 'module-2' });
 
   await databaseBuilder.commit();
   return expectedCurrentContent;

--- a/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
+++ b/api/tests/integration/domain/services/update-pix-api-release-cache_test.js
@@ -1191,6 +1191,7 @@ describe('Integration | Service | update pix api release cache', function() {
             details: draftModule.details,
             sections: draftModule.sections,
             glossary: draftModule.glossary,
+            version: draftModule.version,
           })
           .matchHeader('Authorization', `Bearer ${pixApiToken}`)
           .reply(200);

--- a/api/tests/tooling/domain-builder/factory/build-module-for-release.js
+++ b/api/tests/tooling/domain-builder/factory/build-module-for-release.js
@@ -47,6 +47,7 @@ export function buildModuleForRelease({
       description: 'Une coquille est un agglomérat de calcaire très résistant. Sa structure cristalline spécifique lui confère une résistance protectrice. Elle prodique à l\'escargot toute sa force et sa vitalité.',
     },
   ],
+  version = '1.0',
 } = {}) {
   return new ModuleForRelease({
     id,
@@ -58,5 +59,6 @@ export function buildModuleForRelease({
     details,
     sections,
     glossary,
+    version,
   });
 }


### PR DESCRIPTION
## 🪧 Problème

On souhaite que la version soit présente dans la release et les patchs de release.

## 🌈 Proposition

Inclure la version dans le modèle `ModuleForRelease`.

## ✊ Remarques

N/A

## 🎉 Pour tester

Une release a été créée sur la RA.

Vérifier qu’elle contient bien des modules avec version :

```
curl -H 'authorization: Bearer b03b5cca-...' https://pix-lcms-review-pr1548.osc-fr1.scalingo.io/api/releases/latest
```
