### PR TITLE
[TECH] Ajout d’un workflow Github pour vérifier les titres de PR sur PixEditor (PIX-23535)

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,11 @@
+name: pr title check
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, reopened]
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 1024pix/pix-actions/check-pr-title@main


### PR DESCRIPTION
## 🪧 Problème

Actuellement, aucune vérification n’est faite avant le merge des PR sur les formats des titres de PR côté PixEditor.
Problèmes : 
- si on n’a pas le type de tâche au début ([TECH] blabla…), c’est plus confus dans la liste des PR
- si on oublie le n° de ticket, la PR ne sera pas liée à un ticket et l’automatisation dans Jira ne fonctionnera pas
- les autres repos de Pix ont ce workflow, il faudrait unifier

## 🌈 Proposition

Ajouter le workflow pour vérifier que le titre a ce format : 
`[TYPE] Titre de la PR`

Regex : `/^(\[(BUGFIX|FEATURE|TECH|BUMP|DOC|POC|BREAKING)\]|Revert)/`

## 🎉 Pour tester
- Mettre un titre foireux `J'ai un titre foireux`
- Vérifier que le check en bas de la PR est rouge (relancer si besoin)
- Remettre le bon titre, merci bisou : `[TECH] Ajout d’un workflow Github pour vérifier les titres de PR sur PixEditor (PIX-23535)`