### PR TITLE
[FEATURE] Ajouter une option locale pour lancer le script de modification des descriptions de sujets (PIX-23557)

### DIFF
--- a/api/scripts/update-tubes-translation.js
+++ b/api/scripts/update-tubes-translation.js
@@ -5,6 +5,7 @@ import { csvFileParser } from '../lib/application/scripts/parsers.js';
 import { knex } from '../db/knex-database-connection.js';
 import { translationRepository } from '../lib/infrastructure/repositories/index.js';
 import { DomainTransaction } from '../lib/domain/DomainTransaction.js';
+import { LOCALE } from '../lib/domain/constants.js';
 
 export const csvSchemas = [
   { name: 'Thèmes/acquis', schema: Joi.string().required() },
@@ -49,12 +50,23 @@ export class UpdateTubesTranslationScript extends Script {
           demandOption: true,
           coerce: csvFileParser(csvSchemas),
         },
+        locale: {
+          type: 'string',
+          describe: 'Locale dans laquelle les descriptions de sujets seront modifiées',
+          demandOption: true,
+        },
       },
     });
   }
 
   async handle({ options, logger }) {
-    logger.info({ dryRun: options.dryRun, ids: options.id }, 'Script options');
+    logger.info({ dryRun: options.dryRun, ids: options.id, locale: options.locale }, 'Script options');
+    const acceptedLocales = Object.values(LOCALE);
+    if (!acceptedLocales.includes(options.locale)) {
+      logger.error('The specified locale option is invalid. Exiting the script.', { locale: options.locale, acceptedLocales });
+      return;
+    }
+
     const tubesFromPix = await getTubeIdsFromPixFramework();
 
     return DomainTransaction.execute(async () => {
@@ -71,7 +83,7 @@ export class UpdateTubesTranslationScript extends Script {
           }
 
           const tubeId = tubeIds[0].id;
-          const translations = [{ key: `tube.${tubeId}.practicalTitle`, locale: 'fr', value: practicalTitle }, { key: `tube.${tubeId}.practicalDescription`, locale: 'fr', value: practicalDescription }];
+          const translations = [{ key: `tube.${tubeId}.practicalTitle`, locale: options.locale, value: practicalTitle }, { key: `tube.${tubeId}.practicalDescription`, locale: options.locale, value: practicalDescription }];
           await translationRepository.save({ translations });
           updatedTubesCount++;
         }

--- a/api/tests/scripts/update-tubes-translation_test.js
+++ b/api/tests/scripts/update-tubes-translation_test.js
@@ -43,17 +43,18 @@ describe('Script | UpdateTubesTranslationScript', () => {
     describe('when dryRun is true', () => {
       it('should not update any tube translations', async () => {
         // given
+        const locale = 'fr';
         const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});
         const tubeToUpdate = databaseBuilder.factory.buildTube({ id: 1, name: '@tube_un', thematicId: thematic.id });
         databaseBuilder.factory.buildTranslation({
           key: `tube.${tubeToUpdate.id}.practicalTitle`,
-          locale: 'fr',
+          locale,
           value: 'mon titre',
         });
 
         databaseBuilder.factory.buildTranslation({
           key: `tube.${tubeToUpdate.id}.practicalDescription`,
-          locale: 'fr',
+          locale,
           value: 'ma description',
         });
 
@@ -65,16 +66,17 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
         const options = {
           file: fileData,
+          locale,
           dryRun: true,
         };
 
         await script.handle({ options, logger });
 
         // then
-        const { value: frTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale: 'fr' }).first();
+        const { value: frTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale }).first();
         expect(frTitleTranslation).equal('mon titre');
 
-        const { value: frDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale: 'fr' }).first();
+        const { value: frDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale }).first();
         expect(frDescriptionTranslation).equal('ma description');
 
         expect(logger.info).toHaveBeenCalledWith('Dry run is enabled, stopping before updating 1 tube(s)');
@@ -88,8 +90,9 @@ describe('Script | UpdateTubesTranslationScript', () => {
       });
     });
 
-    it('update only given tubes translation', async () => {
+    it('update only given tubes translation in the specified locale', async () => {
       // given
+      const locale = 'fr-BE';
       const { thematic } = databaseBuilder.factory.buildChallengeInGroup({});
       const tubeToUpdate = databaseBuilder.factory.buildTube({ id: 1, name: '@tube_un', thematicId: thematic.id });
       databaseBuilder.factory.buildTranslation({
@@ -99,7 +102,7 @@ describe('Script | UpdateTubesTranslationScript', () => {
       });
       databaseBuilder.factory.buildTranslation({
         key: `tube.${tubeToUpdate.id}.practicalTitle`,
-        locale: 'en',
+        locale,
         value: 'my title',
       });
 
@@ -110,7 +113,7 @@ describe('Script | UpdateTubesTranslationScript', () => {
       });
       databaseBuilder.factory.buildTranslation({
         key: `tube.${tubeToUpdate.id}.practicalDescription`,
-        locale: 'en',
+        locale,
         value: 'my description',
       });
 
@@ -122,6 +125,7 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
       const options = {
         file: fileData,
+        locale,
         dryRun: false,
       };
 
@@ -129,16 +133,16 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
       // then
       const { value: frTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale: 'fr' }).first();
-      expect(frTitleTranslation).equal('mon_nouveau_titre');
+      expect(frTitleTranslation).equal('mon titre');
 
       const { value: frDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale: 'fr' }).first();
-      expect(frDescriptionTranslation).equal('ma_nouvelle_description');
+      expect(frDescriptionTranslation).equal('ma description');
 
-      const { value: enTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale: 'en' }).first();
-      expect(enTitleTranslation).equal('my title');
+      const { value: enTitleTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalTitle`, locale }).first();
+      expect(enTitleTranslation).equal('mon_nouveau_titre');
 
-      const { value: enDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale: 'en' }).first();
-      expect(enDescriptionTranslation).equal('my description');
+      const { value: enDescriptionTranslation } = await knex('translations').select('value').where({ key: `tube.${tubeToUpdate.id}.practicalDescription`, locale }).first();
+      expect(enDescriptionTranslation).equal('ma_nouvelle_description');
 
       expect(logger.info).toHaveBeenCalledWith('Successfully updated translations for 1 tube(s)');
     });
@@ -177,6 +181,7 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
       const options = {
         file: fileData,
+        locale: 'fr',
         dryRun: false,
       };
 
@@ -206,6 +211,7 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
       const options = {
         file: fileData,
+        locale: 'fr',
         dryRun: false,
       };
 
@@ -214,6 +220,24 @@ describe('Script | UpdateTubesTranslationScript', () => {
 
       // then
       expect(logger.error).toHaveBeenCalledWith('Found 0 tube(s) with name @tube_un', { tubeIds: [] });
+    });
+
+    it('should stop the script if the given locale is invalid', async () => {
+      // given
+      const { options: scriptMeta } = script.metaInfo;
+      const fileData = await scriptMeta.file.coerce(testCsvFile);
+
+      const options = {
+        file: fileData,
+        locale: 'les tubes français stp',
+        dryRun: false,
+      };
+
+      // when
+      await script.handle({ options, logger });
+
+      // then
+      expect(logger.error).toHaveBeenCalledWith('The specified locale option is invalid. Exiting the script.', { locale: options.locale, acceptedLocales: expect.any(Array) });
     });
   });
 });


### PR DESCRIPTION
## 🪧 Problème
Le script a été conçu pour la version fr des descriptions de sujets. Or, le métier a besoin de faire la même chose pour la version anglaise.

## 🌈 Proposition
Ajout d'une option dans le script pour choisir dans quelle locale on doit faire les modifications. Si la locale n'est pas renseignée, c'est du 'fr' par défaut.

## 🎉 Pour tester
se faire un csv sur le referentiel de RA.
modifier les titres/description du réferentiel Pix en 'en'
Executer le script
vérifier que tout est inséré en bdd.