### PR TITLE
[FEATURE] Archiver une version du module lors de sa publication (PIX-23593)

### DIFF
--- a/api/db/migrations/20260717083738_create-module-versions-table.js
+++ b/api/db/migrations/20260717083738_create-module-versions-table.js
@@ -1,0 +1,37 @@
+const TABLE_NAME = 'module-versions';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.increments('id').notNullable();
+    table.uuid('moduleId').notNullable().references('modules.id');
+    table.string('version').notNullable();
+    table.string('shortId', 8).notNullable();
+    table.text('internalTitle').nullable();
+    table.string('slug', 100).notNullable();
+    table.string('title').notNullable();
+    table.boolean('isBeta').notNullable();
+    table.string('visibility').notNullable();
+    table.text('image').notNullable();
+    table.text('description').notNullable();
+    table.integer('duration').notNullable();
+    table.string('level').notNullable();
+    table.string('tabletSupport').notNullable();
+    table.specificType('objectives', 'text[]').notNullable();
+    table.jsonb('sections').notNullable();
+    table.jsonb('glossary').defaultTo([]).notNullable();
+    table.timestamp('createdAt').notNullable().defaultTo(knex.fn.now());
+    table.unique(['moduleId', 'version']);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/lib/domain/models/ModuleVersion.js
+++ b/api/lib/domain/models/ModuleVersion.js
@@ -1,0 +1,19 @@
+import { Module } from './Module.js';
+
+export class ModuleVersion extends Module {
+  constructor({ moduleId, ...moduleAttrs }) {
+    super(moduleAttrs);
+    this.moduleId = moduleId;
+    delete this.updatedAt;
+  }
+
+  /**
+   * @param {Module} module
+   */
+  static fromModule({ id: moduleId, createdAt: _, ...moduleAttrs }) {
+    return new ModuleVersion({
+      ...moduleAttrs,
+      moduleId,
+    });
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -11,6 +11,7 @@ export * from './LocalizedFrameworkTubes.js';
 export * from './Mission.js';
 export * from './Module.js';
 export * from './ModuleForConsultation.js';
+export * from './ModuleVersion.js';
 export * from './Note.js';
 export * from './Skill.js';
 export * from './StaticCourse.js';

--- a/api/lib/domain/usecases/publish-draft-module.js
+++ b/api/lib/domain/usecases/publish-draft-module.js
@@ -1,13 +1,16 @@
-import { draftModuleRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
+import { draftModuleRepository, moduleRepository, moduleVersionRepository } from '../../infrastructure/repositories/index.js';
 import { DomainTransaction } from '../DomainTransaction.js';
+import { ModuleVersion } from '../models/index.js';
 
-export async function publishDraftModule({ draftModuleId }, dependencies = { draftModuleRepository, moduleRepository }) {
+export async function publishDraftModule({ draftModuleId }, dependencies = { draftModuleRepository, moduleRepository, moduleVersionRepository }) {
   return DomainTransaction.execute(async () => {
     const draftModule = await dependencies.draftModuleRepository.getById({ id: draftModuleId, forUpdate: true });
 
     const module = await dependencies.moduleRepository.save(draftModule.publish());
 
     await dependencies.draftModuleRepository.remove({ id: draftModuleId });
+
+    await dependencies.moduleVersionRepository.create(ModuleVersion.fromModule(module));
 
     return module;
   });

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -11,6 +11,7 @@ export * as localizedChallengeRepository from './localized-challenge-repository.
 export * as localizedFrameworksTubesRepository from './localized-framework-tubes-repository.js';
 export * as missionRepository from './mission-repository.js';
 export * as moduleRepository from './module-repository.js';
+export * as moduleVersionRepository from './module-version-repository.js';
 export * as releaseRepository from './release-repository.js';
 export * as skillRepository from './skill-repository.js';
 export * as staticCourseRepository from './static-course-repository.js';

--- a/api/lib/infrastructure/repositories/module-version-repository.js
+++ b/api/lib/infrastructure/repositories/module-version-repository.js
@@ -1,0 +1,22 @@
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
+
+/**
+ * @param {import('../../domain/models/index.js').ModuleVersion} moduleVersion
+ */
+export async function create(moduleVersion) {
+  const knexConn = DomainTransaction.getConnection();
+
+  await knexConn.insert(toDto(moduleVersion)).into('module-versions');
+}
+
+/**
+ * @param {import('../../domain/models/index.js').ModuleVersion} moduleVersion
+ */
+function toDto({ details, sections, glossary, updatedAt: _, ...moduleVersion }) {
+  return {
+    ...moduleVersion,
+    ...details,
+    sections: JSON.stringify(sections),
+    glossary: JSON.stringify(glossary),
+  };
+}

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -552,7 +552,7 @@ describe('Acceptance | Route | draft-modules', () => {
   });
 
   describe('POST /draft-modules/:id/publish', () => {
-    it('responds with status 200 and published module’s data', async () => {
+    it.fails('responds with status 200 and published module’s data', async () => {
       // given
       const draftModule = domainBuilder.buildDraftModule({ version: '47.3' });
       databaseBuilder.factory.buildDraftModule(draftModule);
@@ -609,6 +609,23 @@ describe('Acceptance | Route | draft-modules', () => {
         },
       ]);
       await expect(knex.select('*').from('draft-modules')).resolves.toStrictEqual([]);
+      await expect(knex.select('*').from('module-versions')).resolves.toStrictEqual([
+        {
+          id: expect.any(Number),
+          moduleId: draftModule.id,
+          shortId: draftModule.shortId,
+          internalTitle: draftModule.internalTitle,
+          slug: draftModule.slug,
+          title: draftModule.title,
+          isBeta: draftModule.isBeta,
+          visibility: draftModule.visibility,
+          sections: draftModule.sections,
+          glossary: draftModule.glossary,
+          version: '48.0',
+          ...draftModule.details,
+          createdAt: expect.any(Date),
+        },
+      ]);
     });
   });
 });

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -552,7 +552,7 @@ describe('Acceptance | Route | draft-modules', () => {
   });
 
   describe('POST /draft-modules/:id/publish', () => {
-    it.fails('responds with status 200 and published module’s data', async () => {
+    it('responds with status 200 and published module’s data', async () => {
       // given
       const draftModule = domainBuilder.buildDraftModule({ version: '47.3' });
       databaseBuilder.factory.buildDraftModule(draftModule);

--- a/api/tests/integration/infrastructure/repositories/module-version-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/module-version-repository_test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import * as moduleVersionRepository from '../../../../lib/infrastructure/repositories/module-version-repository.js';
+import { ModuleVersion } from '../../../../lib/domain/models/index.js';
+
+describe('Module Version Repository', () => {
+  describe('create', () => {
+    it('saves a new module version to database and returns it', async () => {
+      // given
+      const module = domainBuilder.buildModule();
+      databaseBuilder.factory.buildModule(module);
+      await databaseBuilder.commit();
+
+      const moduleVersion = ModuleVersion.fromModule(module);
+      const expectedCreatedModuleVersion = new ModuleVersion({
+        ...moduleVersion,
+        id: expect.any(Number),
+        createdAt: expect.any(Date),
+      });
+
+      // when
+      await moduleVersionRepository.create(moduleVersion);
+
+      // then
+      const { details: expectedDetails, ...expectedCreatedModuleVersionData } = expectedCreatedModuleVersion;
+      await expect(knex.select().from('module-versions')).resolves.toStrictEqual([{ ...expectedCreatedModuleVersionData, ...expectedDetails }]);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/ModuleVersion_test.js
+++ b/api/tests/unit/domain/models/ModuleVersion_test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { domainBuilder } from '../../../test-helper.js';
+import { ModuleVersion } from '../../../../lib/domain/models/ModuleVersion.js';
+
+describe('Unit | Domain | ModuleVersion', () => {
+  describe('fromModule', () => {
+    it('creates a ModuleVersion from a Module', () => {
+      // given
+      const module = domainBuilder.buildModule();
+      const expectedModuleVersion = new ModuleVersion({
+        moduleId: module.id,
+        shortId: module.shortId,
+        internalTitle: module.internalTitle,
+        slug: module.slug,
+        title: module.title,
+        isBeta: module.isBeta,
+        visibility: module.visibility,
+        details: module.details,
+        sections: module.sections,
+        glossary: module.glossary,
+        version: module.version,
+      });
+
+      // when
+      const moduleVersion = ModuleVersion.fromModule(module);
+
+      // then
+      expect(moduleVersion).toStrictEqual(expectedModuleVersion);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/publish-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/publish-draft-module_test.js
@@ -1,24 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { publishDraftModule } from '../../../../lib/domain/usecases/index.js';
+import { ModuleVersion } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | publish-draft-module', () => {
   const publishedModule = Symbol('publishedModule');
   const savedModule = Symbol('savedModule');
+  const moduleVersion = Symbol('moduleVersion');
 
-  let moduleRepository, draftModuleRepository, draftModule, publish;
+  let moduleRepository, draftModuleRepository, moduleVersionRepository, draftModule, publish, fromModule;
 
   beforeEach(() => {
     draftModule = domainBuilder.buildDraftModule();
     publish = vi.spyOn(draftModule, 'publish').mockReturnValueOnce(publishedModule);
+    fromModule = vi.spyOn(ModuleVersion, 'fromModule').mockReturnValueOnce(moduleVersion);
 
     draftModuleRepository = { getById: vi.fn().mockResolvedValueOnce(draftModule), remove: vi.fn().mockResolvedValueOnce() };
     moduleRepository = { save: vi.fn().mockResolvedValueOnce(savedModule) };
+    moduleVersionRepository = { create: vi.fn().mockResolvedValueOnce() };
   });
 
   it('saves draft module as a module then removes draft module', async () => {
     // when
-    const result = await publishDraftModule({ draftModuleId: draftModule.id }, { draftModuleRepository, moduleRepository });
+    const result = await publishDraftModule({ draftModuleId: draftModule.id }, { draftModuleRepository, moduleRepository, moduleVersionRepository });
 
     // then
     expect(result).toBe(savedModule);
@@ -27,5 +31,7 @@ describe('Unit | Domain | Use Cases | publish-draft-module', () => {
     expect(publish).toHaveBeenCalledExactlyOnceWith();
     expect(moduleRepository.save).toHaveBeenCalledExactlyOnceWith(publishedModule);
     expect(draftModuleRepository.remove).toHaveBeenCalledExactlyOnceWith({ id: draftModule.id });
+    expect(fromModule).toHaveBeenCalledExactlyOnceWith(savedModule);
+    expect(moduleVersionRepository.create).toHaveBeenCalledExactlyOnceWith(moduleVersion);
   });
 });


### PR DESCRIPTION
## 🪧 Problème

Quand un module est publié on souhaite archiver la nouvelle version dans une table d’archive.

## 🌈 Proposition

 Créer une table d’archivage des modules `module-versions`.
 Quand un module est publié, insérer une ligne dans la table avec les données du module

## ✊ Remarques

N/A

## 🎉 Pour tester

Publier un module, puis vérifier qu’il y a une nouvelle ligne dans la table `module-versions`.
