### PR TITLE
[FEATURE] Archiver les versions d’un draft lors de son enregistrement (PIX-23596)

### DIFF
--- a/api/db/migrations/20260717133930_create-draft-module-versions-table.js
+++ b/api/db/migrations/20260717133930_create-draft-module-versions-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'draft-module-versions';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable(TABLE_NAME, function(table) {
+    table.increments('id').notNullable();
+    table.uuid('draftModuleId').notNullable().references('draft-modules.id').onDelete('CASCADE');
+    table.string('version').notNullable();
+    table.jsonb('structuredDiff').notNullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.dropTable(TABLE_NAME);
+}

--- a/api/lib/domain/models/DraftModule.js
+++ b/api/lib/domain/models/DraftModule.js
@@ -19,18 +19,21 @@ export class DraftModule extends Module {
   }
 
   /**
-   * @param {DraftModule} module
+   * @param {DraftModule} draftModule
    */
-  update(module) {
-    this.internalTitle = module.internalTitle;
-    this.slug = module.slug;
-    this.title = module.title;
-    this.isBeta = module.isBeta;
-    this.visibility = module.visibility;
-    this.details = module.details;
-    this.sections = module.sections;
-    this.glossary = module.glossary;
-    this.version = incrementMinorVersion(this.version);
+  update(draftModule) {
+    return new DraftModule({
+      ...this,
+      internalTitle: draftModule.internalTitle,
+      slug: draftModule.slug,
+      title: draftModule.title,
+      isBeta: draftModule.isBeta,
+      visibility: draftModule.visibility,
+      details: draftModule.details,
+      sections: draftModule.sections,
+      glossary: draftModule.glossary,
+      version: incrementMinorVersion(this.version),
+    });
   }
 
   publish() {

--- a/api/lib/domain/models/DraftModuleVersion.js
+++ b/api/lib/domain/models/DraftModuleVersion.js
@@ -1,0 +1,8 @@
+export class DraftModuleVersion {
+  constructor({ id, draftModuleId, version, structuredDiff }) {
+    this.id = id;
+    this.draftModuleId = draftModuleId;
+    this.version = version;
+    this.structuredDiff = structuredDiff;
+  }
+}

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -5,6 +5,7 @@ export * from './ChangelogEntry.js';
 export * from './Competence.js';
 export * from './DraftModule.js';
 export * from './DraftModuleDiff.js';
+export * from './DraftModuleVersion.js';
 export * from './Framework.js';
 export * from './LocalizedChallenge.js';
 export * from './LocalizedFrameworkTubes.js';

--- a/api/lib/domain/usecases/create-draft-module.js
+++ b/api/lib/domain/usecases/create-draft-module.js
@@ -1,19 +1,34 @@
-import { draftModuleRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
+import { structuredPatch } from 'diff';
+
+import { draftModuleRepository, draftModuleVersionRepository, moduleRepository } from '../../infrastructure/repositories/index.js';
 import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
+import { DraftModuleVersion } from '../models/index.js';
+import { DomainTransaction } from '../DomainTransaction.js';
 
 /**
  *
  * @param {import('../models/index.js').DraftModule} draftModule
  */
-export async function createDraftModule(draftModule, dependencies = { draftModuleRepository, moduleRepository, updatePixApiReleaseCache }) {
-  const module = draftModule.moduleId
-    ? await dependencies.moduleRepository.getById({ id: draftModule.moduleId })
-    : undefined;
+export async function createDraftModule(draftModule, dependencies = { draftModuleRepository, draftModuleVersionRepository, moduleRepository, updatePixApiReleaseCache, structuredPatch }) {
+  return DomainTransaction.execute(async () => {
+    const module = draftModule.moduleId
+      ? await dependencies.moduleRepository.getById({ id: draftModule.moduleId })
+      : undefined;
 
-  draftModule.prepareForCreation(module);
-  const savedDraftModule = await dependencies.draftModuleRepository.save(draftModule);
+    draftModule.prepareForCreation(module);
+    const savedDraftModule = await dependencies.draftModuleRepository.save(draftModule);
 
-  await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(savedDraftModule);
+    if (module) {
+      const structuredDiff = dependencies.structuredPatch('', '', module.serializeToJSON(), savedDraftModule.serializeToJSON());
+      await dependencies.draftModuleVersionRepository.create(new DraftModuleVersion({
+        draftModuleId: savedDraftModule.id,
+        version: savedDraftModule.version,
+        structuredDiff,
+      }));
+    }
 
-  return savedDraftModule;
+    await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(savedDraftModule);
+
+    return savedDraftModule;
+  });
 }

--- a/api/lib/domain/usecases/update-draft-module.js
+++ b/api/lib/domain/usecases/update-draft-module.js
@@ -1,14 +1,28 @@
-import { draftModuleRepository } from '../../infrastructure/repositories/index.js';
+import { structuredPatch } from 'diff';
+
+import { draftModuleRepository, draftModuleVersionRepository } from '../../infrastructure/repositories/index.js';
+import { DomainTransaction } from '../DomainTransaction.js';
+import { DraftModuleVersion } from '../models/index.js';
 import * as updatePixApiReleaseCache from '../services/update-pix-api-release-cache.js';
 
 /**
  * @param {import('../models/index.js').DraftModule} draftModule
  */
-export async function updateDraftModule(draftModule, dependencies = { draftModuleRepository, updatePixApiReleaseCache }) {
-  const existingDraftModule = await dependencies.draftModuleRepository.getById({ id: draftModule.id });
-  existingDraftModule.update(draftModule);
+export async function updateDraftModule(draftModule, dependencies = { draftModuleRepository, draftModuleVersionRepository, updatePixApiReleaseCache, structuredPatch }) {
+  return DomainTransaction.execute(async () => {
+    const existingDraftModule = await dependencies.draftModuleRepository.getById({ id: draftModule.id });
+    existingDraftModule.update(draftModule);
 
-  const updatedDraftModule = await dependencies.draftModuleRepository.save(existingDraftModule);
-  await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(updatedDraftModule);
-  return updatedDraftModule;
+    const updatedDraftModule = await dependencies.draftModuleRepository.save(existingDraftModule);
+
+    const structuredDiff = dependencies.structuredPatch('', '', existingDraftModule.serializeToJSON(), updatedDraftModule.serializeToJSON());
+    await dependencies.draftModuleVersionRepository.create(new DraftModuleVersion({
+      draftModuleId: updatedDraftModule.id,
+      version: updatedDraftModule.version,
+      structuredDiff,
+    }));
+
+    await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(updatedDraftModule);
+    return updatedDraftModule;
+  });
 }

--- a/api/lib/domain/usecases/update-draft-module.js
+++ b/api/lib/domain/usecases/update-draft-module.js
@@ -11,18 +11,18 @@ import * as updatePixApiReleaseCache from '../services/update-pix-api-release-ca
 export async function updateDraftModule(draftModule, dependencies = { draftModuleRepository, draftModuleVersionRepository, updatePixApiReleaseCache, structuredPatch }) {
   return DomainTransaction.execute(async () => {
     const existingDraftModule = await dependencies.draftModuleRepository.getById({ id: draftModule.id });
-    existingDraftModule.update(draftModule);
+    const updatedDraftModule = existingDraftModule.update(draftModule);
 
-    const updatedDraftModule = await dependencies.draftModuleRepository.save(existingDraftModule);
+    const savedDraftModule = await dependencies.draftModuleRepository.save(updatedDraftModule);
 
-    const structuredDiff = dependencies.structuredPatch('', '', existingDraftModule.serializeToJSON(), updatedDraftModule.serializeToJSON());
+    const structuredDiff = dependencies.structuredPatch('', '', existingDraftModule.serializeToJSON(), savedDraftModule.serializeToJSON());
     await dependencies.draftModuleVersionRepository.create(new DraftModuleVersion({
-      draftModuleId: updatedDraftModule.id,
-      version: updatedDraftModule.version,
+      draftModuleId: savedDraftModule.id,
+      version: savedDraftModule.version,
       structuredDiff,
     }));
 
-    await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(updatedDraftModule);
-    return updatedDraftModule;
+    await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(savedDraftModule);
+    return savedDraftModule;
   });
 }

--- a/api/lib/infrastructure/repositories/draft-module-version-repository.js
+++ b/api/lib/infrastructure/repositories/draft-module-version-repository.js
@@ -1,0 +1,12 @@
+import { DomainTransaction } from '../../domain/DomainTransaction.js';
+
+/**
+ * @param {import('../../domain/models/index.js').DraftModuleVersion} draftModuleVersion
+ */
+export async function create({ draftModuleId, version, structuredDiff }) {
+  const knexConn = DomainTransaction.getConnection();
+
+  const dto = { draftModuleId, version, structuredDiff };
+
+  await knexConn.insert(dto).into('draft-module-versions');
+}

--- a/api/lib/infrastructure/repositories/index.js
+++ b/api/lib/infrastructure/repositories/index.js
@@ -5,6 +5,7 @@ export * as attachmentRepository from './attachment-repository.js';
 export * as challengeRepository from './challenge-repository.js';
 export * as competenceRepository from './competence-repository.js';
 export * as draftModuleRepository from './draft-module-repository.js';
+export * as draftModuleVersionRepository from './draft-module-version-repository.js';
 export * as fileStorageTokenRepository from './file-storage-token-repository.js';
 export * as frameworkRepository from './framework-repository.js';
 export * as localizedChallengeRepository from './localized-challenge-repository.js';

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -557,6 +557,15 @@ describe('Acceptance | Route | draft-modules', () => {
           updatedAt: expect.any(Date),
         },
       ]);
+
+      await expect(knex.select('*').from('draft-module-versions')).resolves.toStrictEqual([
+        {
+          id: expect.any(Number),
+          draftModuleId: draftModule.id,
+          version: '6.5',
+          structuredDiff: expect.any(Object),
+        },
+      ]);
     });
   });
 

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -193,6 +193,15 @@ describe('Acceptance | Route | draft-modules', () => {
             updatedAt: expect.any(Date),
           },
         ]);
+
+        await expect(knex.select('*').from('draft-module-versions')).resolves.toStrictEqual([
+          {
+            id: expect.any(Number),
+            draftModuleId: draftModule.id,
+            version: draftModule.version,
+            structuredDiff: expect.any(Object),
+          },
+        ]);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/draft-module-version-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/draft-module-version-repository_test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
+import * as draftModuleVersionRepository from '../../../../lib/infrastructure/repositories/draft-module-version-repository.js';
+import { DraftModuleVersion } from '../../../../lib/domain/models/DraftModuleVersion.js';
+
+describe('Draft Module Version Repository', () => {
+  describe('create', () => {
+    it('create a draft module version in database', async () => {
+      // given
+      const draftModule = domainBuilder.buildDraftModule();
+      databaseBuilder.factory.buildDraftModule(draftModule);
+      await databaseBuilder.commit();
+
+      const draftModuleVersion = new DraftModuleVersion({
+        draftModuleId: draftModule.id,
+        version: draftModule.version,
+        structuredDiff: { test: 'ceci est un diff structuré de test...' },
+      });
+
+      // when
+      await draftModuleVersionRepository.create(draftModuleVersion);
+
+      // then
+      await expect(knex.select().from('draft-module-versions')).resolves.toStrictEqual([
+        {
+          id: expect.any(Number),
+          draftModuleId: draftModule.id,
+          version: draftModule.version,
+          structuredDiff: { test: 'ceci est un diff structuré de test...' },
+        },
+      ]);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/DraftModule_test.js
+++ b/api/tests/unit/domain/models/DraftModule_test.js
@@ -65,10 +65,10 @@ describe('Unit | Domain | DraftModule', () => {
       });
 
       // when
-      draftModule.update(updates);
+      const updatedDraftModule = draftModule.update(updates);
 
       // then
-      expect(draftModule).toStrictEqual(domainBuilder.buildDraftModule({
+      expect(updatedDraftModule).toStrictEqual(domainBuilder.buildDraftModule({
         id: '704a89a6-983b-4e04-bfef-6a54f925c44e',
         shortId: '704a89a6',
         createdAt: new Date('2026-06-29T14:04:01Z'),
@@ -83,6 +83,7 @@ describe('Unit | Domain | DraftModule', () => {
         visibility: 'updated visibility',
         version: '10.12',
       }));
+      expect(updatedDraftModule).not.toBe(draftModule);
     });
   });
 

--- a/api/tests/unit/domain/usecases/create-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/create-draft-module_test.js
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { createDraftModule } from '../../../../lib/domain/usecases/index.js';
+import { DraftModuleVersion } from '../../../../lib/domain/models/DraftModuleVersion.js';
 
 describe('Unit | Domain | Use Cases | create-draft-module', () => {
-  const savedDraftModule = Symbol('savedDraftModule');
+  const structuredDiff = Symbol('structuredDiff');
 
-  let draftModuleRepository, draftModule, prepareForCreation, updatePixApiReleaseCache;
+  let draftModuleRepository, draftModule, prepareForCreation, savedDraftModule, updatePixApiReleaseCache, structuredPatch, draftModuleVersionRepository;
 
   beforeEach(() => {
+    savedDraftModule = domainBuilder.buildDraftModule({
+      id: Symbol('savedDraftModuleId'),
+      version: Symbol('savedDraftModuleVersion'),
+    });
     draftModuleRepository = { save: vi.fn().mockResolvedValueOnce(savedDraftModule) };
 
     draftModule = domainBuilder.buildDraftModule({
@@ -17,6 +22,10 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
     prepareForCreation = vi.spyOn(draftModule, 'prepareForCreation');
 
     updatePixApiReleaseCache = { onDraftModuleCreatedOrUpdated: vi.fn().mockResolvedValueOnce() };
+
+    structuredPatch = vi.fn().mockReturnValueOnce(structuredDiff);
+
+    draftModuleVersionRepository = { create: vi.fn().mockResolvedValueOnce() };
   });
 
   it('prepares draft module for creation and saves it', async () => {
@@ -34,22 +43,31 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
   describe('when draft module has a moduleId', () => {
     it('prepares for creation using module', async () => {
       // given
-      const module = Symbol('module');
+      const moduleJSON = Symbol('moduleJSON');
+      const draftModuleJSON = Symbol('draftModuleJSON');
+      const module = { serializeToJSON: vi.fn().mockReturnValueOnce(moduleJSON) };
+      vi.spyOn(savedDraftModule, 'serializeToJSON').mockReturnValueOnce(draftModuleJSON);
       const moduleRepository = { getById: vi.fn().mockResolvedValueOnce(module) };
 
       const moduleId = Symbol('moduleId');
       draftModule.moduleId = moduleId;
 
       // when
-      const result = createDraftModule(draftModule, { draftModuleRepository, moduleRepository, updatePixApiReleaseCache });
+      const result = await createDraftModule(draftModule, { draftModuleRepository, draftModuleVersionRepository, moduleRepository, updatePixApiReleaseCache, structuredPatch });
 
       // then
-      await expect(result).resolves.toBe(savedDraftModule);
+      await expect(result).toBe(savedDraftModule);
 
       expect(moduleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: moduleId });
       expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(module);
       expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
       expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
+      expect(structuredPatch).toHaveBeenCalledExactlyOnceWith('', '', moduleJSON, draftModuleJSON);
+      expect(draftModuleVersionRepository.create).toHaveBeenCalledExactlyOnceWith(new DraftModuleVersion({
+        draftModuleId: savedDraftModule.id,
+        version: savedDraftModule.version,
+        structuredDiff,
+      }));
     });
   });
 });

--- a/api/tests/unit/domain/usecases/update-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/update-draft-module_test.js
@@ -5,6 +5,7 @@ import { DraftModuleVersion } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | update-draft-module', () => {
   const draftModuleId = Symbol('draftModuleId');
+  const updatedDraftModule = Symbol('updatedDraftModule');
   const structuredDiff = Symbol('structuredDiff');
   const existingDraftModuleJSON = Symbol('existingDraftModuleJSON');
   const savedDraftModuleJSON = Symbol('savedDraftModuleJSON');
@@ -26,7 +27,7 @@ describe('Unit | Domain | Use Cases | update-draft-module', () => {
       save: vi.fn().mockResolvedValueOnce(savedDraftModule),
     };
 
-    update = vi.spyOn(existingDraftModule, 'update');
+    update = vi.spyOn(existingDraftModule, 'update').mockReturnValueOnce(updatedDraftModule);
 
     updatePixApiReleaseCache = { onDraftModuleCreatedOrUpdated: vi.fn().mockResolvedValueOnce() };
 
@@ -45,7 +46,7 @@ describe('Unit | Domain | Use Cases | update-draft-module', () => {
     await expect(result).toBe(savedDraftModule);
 
     expect(update).toHaveBeenCalledExactlyOnceWith(draftModule);
-    expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(existingDraftModule);
+    expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(updatedDraftModule);
     expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
     expect(structuredPatch).toHaveBeenCalledExactlyOnceWith('', '', existingDraftModuleJSON, savedDraftModuleJSON);
     expect(draftModuleVersionRepository.create).toHaveBeenCalledExactlyOnceWith(new DraftModuleVersion({

--- a/api/tests/unit/domain/usecases/update-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/update-draft-module_test.js
@@ -1,15 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { updateDraftModule } from '../../../../lib/domain/usecases/index.js';
+import { DraftModuleVersion } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | update-draft-module', () => {
   const draftModuleId = Symbol('draftModuleId');
-  const savedDraftModule = Symbol('savedDraftModule');
+  const structuredDiff = Symbol('structuredDiff');
+  const existingDraftModuleJSON = Symbol('existingDraftModuleJSON');
+  const savedDraftModuleJSON = Symbol('savedDraftModuleJSON');
 
-  let draftModuleRepository, existingDraftModule, update, updatePixApiReleaseCache, draftModule;
+  let draftModuleRepository, existingDraftModule, update, savedDraftModule, updatePixApiReleaseCache, draftModule, structuredPatch, draftModuleVersionRepository;
 
   beforeEach(() => {
     existingDraftModule = domainBuilder.buildDraftModule();
+    vi.spyOn(existingDraftModule, 'serializeToJSON').mockReturnValueOnce(existingDraftModuleJSON);
+
+    savedDraftModule = domainBuilder.buildDraftModule({
+      id: existingDraftModule.id,
+      version: Symbol('savedDraftModuleVersion'),
+    });
+    vi.spyOn(savedDraftModule, 'serializeToJSON').mockReturnValueOnce(savedDraftModuleJSON);
 
     draftModuleRepository = {
       getById: vi.fn().mockResolvedValueOnce(existingDraftModule),
@@ -21,17 +31,27 @@ describe('Unit | Domain | Use Cases | update-draft-module', () => {
     updatePixApiReleaseCache = { onDraftModuleCreatedOrUpdated: vi.fn().mockResolvedValueOnce() };
 
     draftModule = domainBuilder.buildDraftModule({ id: draftModuleId });
+
+    structuredPatch = vi.fn().mockReturnValueOnce(structuredDiff);
+
+    draftModuleVersionRepository = { create: vi.fn().mockResolvedValueOnce() };
   });
 
   it('prepares updates existing module and saves it', async () => {
     // when
-    const result = updateDraftModule(draftModule, { draftModuleRepository, updatePixApiReleaseCache });
+    const result = await updateDraftModule(draftModule, { draftModuleRepository, draftModuleVersionRepository, updatePixApiReleaseCache, structuredPatch });
 
     // then
-    await expect(result).resolves.toBe(savedDraftModule);
+    await expect(result).toBe(savedDraftModule);
 
     expect(update).toHaveBeenCalledExactlyOnceWith(draftModule);
     expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(existingDraftModule);
     expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
+    expect(structuredPatch).toHaveBeenCalledExactlyOnceWith('', '', existingDraftModuleJSON, savedDraftModuleJSON);
+    expect(draftModuleVersionRepository.create).toHaveBeenCalledExactlyOnceWith(new DraftModuleVersion({
+      draftModuleId: savedDraftModule.id,
+      version: savedDraftModule.version,
+      structuredDiff,
+    }));
   });
 });


### PR DESCRIPTION
## 🪧 Problème

On souhaite archiver les versions d’un draft lors de son enregistrement, en stockant le diff par rapport à la version précédente (càd le draft précédent).

## 🌈 Proposition

Créer une table draft-module-versions, pour archiver le diff de chaque version enregistrée avec la version précédente.

Le diff doit être stocké sous forme de JSON, transformable en unified diff.

Quand le draft est supprimé, toutes ses versions disparaissent.

## ✊ Remarques

En attente  de #1554

## 🎉 Pour tester

- Créer un draft à partir de rien, vérifier que rien ne s’insère dans la nouvelle table.
- Créer un draft à partir d’un module, vérifier qu’une ligne s’insère dans la nouvelle table avec le diff par rapport au module.
- Mettre à jour un draft, , vérifier qu’une ligne s’insère dans la nouvelle table avec le diff par rapport au à la version précédente du draft.
