### PR TITLE
[FEATURE] Autoriser l'authentification avec le header `X-API-Key` (PIX-23700)

### DIFF
--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -4,10 +4,10 @@ import * as config from '../config.js';
 import { logger } from '../infrastructure/logger.js';
 
 export async function checkUserIsAuthenticatedViaHeader(request, h) {
-  if (!request.headers['x-api-key']) {
+  if (!request.headers['x-api-key'] && !request.headers.authorization) {
     return replyWithAuthenticationError(h);
   }
-  const apiKey = request.headers['x-api-key'];
+  const apiKey = request.headers['x-api-key'] ?? request.headers.authorization.replace('Bearer ', '');
   try {
     const user = await userRepository.findByApiKey(apiKey);
     return h.authenticated({ credentials: { user } });

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -3,11 +3,11 @@ import { hasAuthenticatedUserAccess, replyForbiddenError, replyWithAuthenticatio
 import * as config from '../config.js';
 import { logger } from '../infrastructure/logger.js';
 
-export async function checkUserIsAuthenticatedViaBearer(request, h) {
-  if (!request.headers.authorization) {
+export async function checkUserIsAuthenticatedViaHeader(request, h) {
+  if (!request.headers['x-api-key']) {
     return replyWithAuthenticationError(h);
   }
-  const apiKey = request.headers.authorization.replace('Bearer ', '');
+  const apiKey = request.headers['x-api-key'];
   try {
     const user = await userRepository.findByApiKey(apiKey);
     return h.authenticated({ credentials: { user } });
@@ -43,7 +43,7 @@ export function checkUserHasAdminAccess(request, h) {
 }
 
 export function checkUserIsUrlBrokenLinksMonitor(request, h) {
-  if (!request.headers.authorization) {
+  if (!request.headers['x-api-key']) {
     return replyWithAuthenticationError(h);
   }
 
@@ -52,7 +52,7 @@ export function checkUserIsUrlBrokenLinksMonitor(request, h) {
     return replyWithAuthenticationError(h);
   }
 
-  const apiKey = request.headers.authorization.replace('Bearer ', '');
+  const apiKey = request.headers['x-api-key'];
   if (config.urlBrokenLinksMonitor.authSecret !== apiKey) {
     return replyWithAuthenticationError(h);
   }

--- a/api/lib/infrastructure/plugins/adminjs/components/GetEmbedList.jsx
+++ b/api/lib/infrastructure/plugins/adminjs/components/GetEmbedList.jsx
@@ -16,7 +16,7 @@ const GetEmbedListComponent = () => {
       const token = currentAdmin?.email;
       const response = await fetch('/api/embeds.csv', {
         headers: {
-          Authorization: `Bearer ${token}`,
+          ['x-api-key']: token,
         },
       });
       const data = await response.text();

--- a/api/lib/infrastructure/plugins/adminjs/components/ImportExportComponent.jsx
+++ b/api/lib/infrastructure/plugins/adminjs/components/ImportExportComponent.jsx
@@ -15,7 +15,7 @@ const ImportExportComponent = () => {
       const token = currentAdmin?.email;
       const response = await fetch(`/api/translations.csv?frameworkName=${frameworkName}`, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          ['x-api-key']: token,
         },
       });
       const data = await response.text();
@@ -37,7 +37,7 @@ const ImportExportComponent = () => {
         method: 'POST',
         body: {},
         headers: {
-          Authorization: `Bearer ${token}`,
+          ['x-api-key']: token,
         },
       });
       sendNotice({ message: 'Upload request in progress', type: 'success' });
@@ -59,7 +59,7 @@ const ImportExportComponent = () => {
         method: 'PATCH',
         body: importData,
         headers: {
-          Authorization: `Bearer ${token}`,
+          ['x-api-key']: token,
         },
       });
       sendNotice({ message: 'Imported successfully', type: 'success' });
@@ -78,7 +78,7 @@ const ImportExportComponent = () => {
         method: 'POST',
         body: {},
         headers: {
-          Authorization: `Bearer ${token}`,
+          ['x-api-key']: token,
         },
       });
       sendNotice({ message: 'Download request in progress', type: 'success' });

--- a/api/lib/infrastructure/security.js
+++ b/api/lib/infrastructure/security.js
@@ -1,5 +1,5 @@
 import * as securityPreHandlers from '../application/security-pre-handlers.js';
 
 export function scheme() {
-  return { authenticate: (request, h) => securityPreHandlers.checkUserIsAuthenticatedViaBearer(request, h) };
+  return { authenticate: (request, h) => securityPreHandlers.checkUserIsAuthenticatedViaHeader(request, h) };
 }

--- a/api/scripts/list-duplicated-attachments.js
+++ b/api/scripts/list-duplicated-attachments.js
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { extname } from 'node:path';
 
 export async function listDuplicatedAttachments({ lcmsApiKey }) {
-  const res = await fetch('https://lcms.pix.fr/api/releases/latest', { headers: { Authorization: `Bearer ${lcmsApiKey}` } });
+  const res = await fetch('https://lcms.pix.fr/api/releases/latest', { headers: { ['x-api-key']: lcmsApiKey } });
   if (!res.ok) {
     throw new Error(res.statusText);
   }

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -36,12 +36,46 @@ describe('Acceptance | Application | SecurityPreHandlers', () => {
       expect(response.statusCode).to.equal(401);
       expect(response.result).to.deep.equal(jsonApiError);
     });
-    it('should allow access resource on valid header', async () => {
+
+    it('should allow access resource on valid X-API-Key header', async () => {
       // given
       const options = {
         method: 'GET',
         url: '/api/config',
         headers: { 'x-api-key': user.apiKey },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should allow access resource on valid Authorization header', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/config',
+        headers: { Authorization: `Bearer ${user.apiKey}` },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should allow access resource on valid X-API-Key header but invalid Authorization header', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/config',
+        headers: {
+          'x-api-key': user.apiKey,
+          Authorization: 'Bearer chocolat',
+        },
       };
 
       // when

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createServer } from '../../../server.js';
+import { databaseBuilder } from '../../test-helper.js';
 
 describe('Acceptance | Application | SecurityPreHandlers', () => {
   let server;
+  let user;
 
   beforeEach(async () => {
     server = await createServer();
+    user = await databaseBuilder.factory.buildAdminUser();
+    await databaseBuilder.commit();
   });
 
-  describe('#checkUserIsAuthenticatedViaBearer', () => {
+  describe('#checkUserIsAuthenticatedViaHeader', () => {
     it('should disallow access resource with well formed JSON API error', async () => {
       // given
       const options = {
@@ -31,6 +35,20 @@ describe('Acceptance | Application | SecurityPreHandlers', () => {
       };
       expect(response.statusCode).to.equal(401);
       expect(response.result).to.deep.equal(jsonApiError);
+    });
+    it('should allow access resource on valid header', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/config',
+        headers: { 'x-api-key': user.apiKey },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -66,11 +66,11 @@ export function catchErr(promiseFn, ctx) {
 }
 
 export function generateAuthorizationHeader(user) {
-  return { authorization: `Bearer ${user.apiKey}` };
+  return { 'x-api-key': user.apiKey };
 }
 
 export function generateBrokenLinksMonitorAuthorizationHeader() {
-  return { authorization: `Bearer ${config.urlBrokenLinksMonitor.authSecret}` };
+  return { 'x-api-key': config.urlBrokenLinksMonitor.authSecret };
 }
 
 export { domainBuilder } from './tooling/domain-builder/domain-builder.js';

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -4,20 +4,19 @@ import {
   checkUserHasAdminAccess,
   checkUserHasWriteAccess,
   checkUserIsAuthenticatedViaBasicAndAdmin,
-  checkUserIsAuthenticatedViaBearer,
+  checkUserIsAuthenticatedViaHeader,
 } from '../../../lib/application/security-pre-handlers.js';
 import { userRepository } from '../../../lib/infrastructure/repositories/index.js';
 import { User } from '../../../lib/domain/models/User.js';
 import { UserNotFoundError } from '../../../lib/domain/errors.js';
 
 describe('Unit | Application | SecurityPreHandlers', () => {
-  describe('#checkUserIsAuthenticatedViaBearer', () => {
+  describe('#checkUserIsAuthenticatedViaHeader', () => {
     context('Successful case', () => {
       it('should allow access to resource - with "credentials" property filled with authenticated user - when the request contains the authorization header with a valid api key', async () => {
         // given
         const apiKey = 'valid.api.key';
-        const authorizationHeader = `Bearer ${apiKey}`;
-        const request = { headers: { authorization: authorizationHeader } };
+        const request = { headers: { 'x-api-key': apiKey } };
         const authenticatedUser = new User({
           id: '1',
           name: 'AuthenticatedUser',
@@ -30,7 +29,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         });
 
         // when
-        const response = await checkUserIsAuthenticatedViaBearer(request, hFake);
+        const response = await checkUserIsAuthenticatedViaHeader(request, hFake);
 
         // then
         expect(response.authenticated).to.deep.equal({ credentials: { user: authenticatedUser } });
@@ -42,7 +41,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         // given
         const request = { headers: {} };
         // when
-        const response = await checkUserIsAuthenticatedViaBearer(request, hFake);
+        const response = await checkUserIsAuthenticatedViaHeader(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(401);
@@ -52,15 +51,14 @@ describe('Unit | Application | SecurityPreHandlers', () => {
       it('should disallow access to resource when api key is wrong', async () => {
         // given
         const apiKey = 'wrong.api.key';
-        const authorizationHeader = `Bearer ${apiKey}`;
-        const request = { headers: { authorization: authorizationHeader } };
+        const request = { headers: { 'x-api-key': apiKey } };
 
         vi.spyOn(userRepository, 'findByApiKey').mockImplementation(async (spyApiKey) => {
           if (spyApiKey === apiKey) throw new UserNotFoundError();
         });
 
         // when
-        const response = await checkUserIsAuthenticatedViaBearer(request, hFake);
+        const response = await checkUserIsAuthenticatedViaHeader(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(401);

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -13,10 +13,32 @@ import { UserNotFoundError } from '../../../lib/domain/errors.js';
 describe('Unit | Application | SecurityPreHandlers', () => {
   describe('#checkUserIsAuthenticatedViaHeader', () => {
     context('Successful case', () => {
-      it('should allow access to resource - with "credentials" property filled with authenticated user - when the request contains the authorization header with a valid api key', async () => {
+      it('should allow access to resource - with "credentials" property filled with authenticated user - when the request contains the x-api-key header with a valid api key', async () => {
         // given
         const apiKey = 'valid.api.key';
         const request = { headers: { 'x-api-key': apiKey } };
+        const authenticatedUser = new User({
+          id: '1',
+          name: 'AuthenticatedUser',
+          trigram: 'ABC',
+          apiKey,
+          access: 'admin',
+        });
+        vi.spyOn(userRepository, 'findByApiKey').mockImplementation(async (spyApiKey) => {
+          if (spyApiKey === apiKey) return authenticatedUser;
+        });
+
+        // when
+        const response = await checkUserIsAuthenticatedViaHeader(request, hFake);
+
+        // then
+        expect(response.authenticated).to.deep.equal({ credentials: { user: authenticatedUser } });
+      });
+
+      it('should allow access to resource - with "credentials" property filled with authenticated user - when the request contains the authorization header with a valid api key', async () => {
+        // given
+        const apiKey = 'valid.api.key';
+        const request = { headers: { authorization: `Bearer ${apiKey}` } };
         const authenticatedUser = new User({
           id: '1',
           name: 'AuthenticatedUser',

--- a/pix-editor/app/adapters/application.js
+++ b/pix-editor/app/adapters/application.js
@@ -13,7 +13,7 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     const headers = {};
     const apiKey = this.session.data.authenticated.apiKey;
     if (apiKey) {
-      headers['Authorization'] = `Bearer ${apiKey}`;
+      headers['x-api-key'] = apiKey;
     }
     return headers;
   }

--- a/pix-editor/app/adapters/user.js
+++ b/pix-editor/app/adapters/user.js
@@ -3,7 +3,7 @@ import ApplicationAdapter from './application';
 export default class UserAdapter extends ApplicationAdapter {
   get headers() {
     if (this.apiKeyForAuthenticationTrial) {
-      return { Authorization: `Bearer ${this.apiKeyForAuthenticationTrial}` };
+      return { 'x-api-key': this.apiKeyForAuthenticationTrial };
     }
     return super.headers;
   }

--- a/pix-editor/app/services/phrase.js
+++ b/pix-editor/app/services/phrase.js
@@ -6,7 +6,7 @@ export default class PhraseService extends Service {
   async download(fetchFn = fetch) {
     await fetchFn('/api/phrase/download', {
       method: 'POST',
-      headers: { authorization: `Bearer ${this.session.data.authenticated.apiKey}` },
+      headers: { ['x-api-key']: this.session.data.authenticated.apiKey },
     });
   }
 }

--- a/pix-editor/app/services/storage.js
+++ b/pix-editor/app/services/storage.js
@@ -87,7 +87,7 @@ export default class StorageService extends Service {
       }
       const response = await fetchFn('/api/file-storage-token', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${this.session.data.authenticated.apiKey}` },
+        headers: { ['x-api-key']: this.session.data.authenticated.apiKey },
       });
       if (!response.ok) {
         /* eslint-disable-next-line no-console */

--- a/pix-editor/tests/acceptance/login-test.js
+++ b/pix-editor/tests/acceptance/login-test.js
@@ -21,8 +21,8 @@ module('Acceptance | Login', function (hooks) {
     hooks.beforeEach(function () {
       // FIXME move this in mirage's configuration and remove direct dependency on miragejs
       this.server.get('/users/me', ({ users }, request) => {
-        const apiKey = request.requestHeaders && request.requestHeaders['Authorization'];
-        return apiKey === `Bearer ${VALID_API_KEY}` ? users.first() : new Response(401);
+        const apiKey = request.requestHeaders && request.requestHeaders['x-api-key'];
+        return apiKey === VALID_API_KEY ? users.first() : new Response(401);
       });
     });
 

--- a/pix-editor/tests/unit/services/phrase-test.js
+++ b/pix-editor/tests/unit/services/phrase-test.js
@@ -30,7 +30,7 @@ module('Unit | Service | storage', function (hooks) {
         '/api/phrase/download',
         {
           method: 'POST',
-          headers: { authorization: 'Bearer someApiKey' },
+          headers: { ['x-api-key']: 'someApiKey' },
         },
       ]);
     });

--- a/pix-editor/tests/unit/services/storage-test.js
+++ b/pix-editor/tests/unit/services/storage-test.js
@@ -332,7 +332,7 @@ module('Unit | Service | storage', function (hooks) {
         '/api/file-storage-token',
         {
           method: 'POST',
-          headers: { Authorization: 'Bearer someApiKey' },
+          headers: { ['x-api-key']: 'someApiKey' },
         },
       ]);
       assert.strictEqual(fetchedToken, token);
@@ -371,7 +371,7 @@ module('Unit | Service | storage', function (hooks) {
         '/api/file-storage-token',
         {
           method: 'POST',
-          headers: { Authorization: 'Bearer someApiKey' },
+          headers: { ['x-api-key']: 'someApiKey' },
         },
       ]);
       assert.strictEqual(fetchedToken, token);


### PR DESCRIPTION
## 🪧 Problème

Suite à l'[incident Pudding](https://1024pix.atlassian.net/browse/PIX-23698), on ajoute l'OAuth Proxy sur Pix Editor.

Comme l'en-tête `Authorization: Bearer` est déjà utilisé sur Pix Editor, on modifie l'en-tête utilisé pour l'authentification.

## 🌈 Proposition

Changer l'en-tête HTTP utilisé pour l'authentification par `X-Api-Key: XXXXXX`

## ✊ Remarques
 
Il faut changer aussi sur 
* LCMS Client (Monorepo) : https://github.com/1024pix/pix/pull/16966 
* Pix-Nina : PULL https://github.com/1024pix/pix-nina/pull/32
* pix-db-replication : https://github.com/1024pix/pix-db-replication/pull/364

## 🎉 Pour tester

```sh
curl -H 'x-APi-kEy: 8d03a893-3967-4501-9dc4-e0aa6c6dc442' http://localhost:4300/api/replication-stream
```
