### PR TITLE
[FEATURE] Ajouter une nouvelle route afin de récuperer les events weblate

### DIFF
--- a/api/lib/application/weblate.js
+++ b/api/lib/application/weblate.js
@@ -1,0 +1,81 @@
+import { Webhook } from 'standardwebhooks';
+
+import { importTranslations } from '../domain/usecases/index.js';
+import { child } from '../infrastructure/logger.js';
+import * as config from '../config.js';
+import * as translationSerializer from '../infrastructure/serializers/weblate/translation-serializer.js';
+import { translationsConfigRepository } from '../infrastructure/repositories/index.js';
+
+const logger = child('application:weblate', { event: 'weblate' });
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/weblate/webhook',
+      config: {
+        auth: false,
+        payload: { parse: false },
+        pre: [{ method: checkWeblateAppSignature }, { method: validateWeblateWebhookRequest }],
+        handler: async function(request, h) {
+          const translation = translationSerializer.deserialize(request.payload);
+          await importTranslations([translation]);
+          return h.response();
+        },
+        tags: [
+          'api',
+          'weblate',
+          'webhook',
+        ],
+      },
+    },
+  ]);
+}
+
+export const name = 'weblate-api';
+
+export async function checkWeblateAppSignature(request, h) {
+  if (!config.weblate.webhookSecret) {
+    logger.warn('No secret configured for Weblate webhook');
+    return h.response().code(401).takeover();
+  }
+
+  const webhook = new Webhook(config.weblate.webhookSecret);
+
+  try {
+    webhook.verify(request.payload, request.headers);
+  } catch (error) {
+    logger.warn({ error }, 'Weblate webhook signature verification error');
+    return h.response().code(401).takeover();
+  }
+
+  request.payload = JSON.parse(request.payload.toString());
+
+  return h.response(true);
+}
+
+const TRANSLATIONS_CHANGE_ACTION_NAMES = ['Translation changed', 'Translation added'];
+
+async function validateWeblateWebhookRequest(request, h) {
+  if (!TRANSLATIONS_CHANGE_ACTION_NAMES.includes(request.payload.action)) {
+    logger.warn({ change_id: request.payload.action }, 'received unexpected change_id from Weblate webhook');
+    return h.response().code(400).takeover();
+  }
+
+  if (request.payload.project !== config.weblate.project) {
+    logger.warn({ project: request.payload.project }, 'received unexpected project from Weblate webhook');
+    return h.response().code(400).takeover();
+  }
+
+  const translationConfig = await translationsConfigRepository.getByWeblateComponent(request.payload.component);
+  if (translationConfig === undefined) {
+    logger.warn({ component: request.payload.component }, 'received translations event on unexpected weblate component');
+    return h.response().code(400).takeover();
+  }
+
+  if (translationConfig.uploadedLocales.includes(request.payload.translation)) {
+    return h.response().code(204).takeover();
+  }
+
+  return h.response(true);
+}

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -148,6 +148,7 @@ export const weblate = {
   apiBaseUrl: process.env.WEBLATE_API_BASE_URL,
   apiToken: process.env.WEBLATE_API_TOKEN,
   project: process.env.WEBLATE_PROJECT,
+  webhookSecret: process.env.WEBLATE_WEBHOOK_SECRET,
 };
 
 export const importTranslationsFileMaxSize = process.env.IMPORT_TRANSLATIONS_FILE_MAX_SIZE || 2097152;
@@ -212,6 +213,7 @@ if (process.env.NODE_ENV === 'test') {
   weblate.apiBaseUrl = 'https://test.weblate.pix.digital';
   weblate.apiToken = 'TEST_WEBLATE_TOKEN';
   weblate.project = 'test-pix-editor';
+  weblate.webhookSecret = 'c2VjcmV0IGRlIHRlc3QgZGUgd2VibGF0ZQo=';
 
   urlBrokenLinksMonitor.authSecret = 'LE_SECRET_DU_MONITEUR_DES_URL_EXTERNES';
   urlBrokenLinksMonitor.pageSize = 2;

--- a/api/lib/infrastructure/repositories/translations-config-repository.js
+++ b/api/lib/infrastructure/repositories/translations-config-repository.js
@@ -30,6 +30,16 @@ export async function getByPhraseProjectId(phraseProjectId) {
 }
 
 /**
+ * @param {string} weblateComponent
+ */
+export async function getByWeblateComponent(weblateComponent) {
+  const knexConn = DomainTransaction.getConnection();
+  const dto = await knexConn.select('*').from('translations_config').where('weblateComponent', weblateComponent).first();
+  if (dto == null) return undefined;
+  return toDomain(dto);
+}
+
+/**
  * @param {string} competenceId
  */
 export async function getByCompetenceId(competenceId) {

--- a/api/lib/infrastructure/serializers/weblate/translation-serializer.js
+++ b/api/lib/infrastructure/serializers/weblate/translation-serializer.js
@@ -1,5 +1,5 @@
 import { Translation } from '../../../domain/models/index.js';
 
 export function deserialize(payload) {
-  return new Translation({ key: payload.context, locale: payload.translation, value: payload.target });
+  return new Translation({ key: payload.context, locale: payload.translation, value: payload.target[0] });
 }

--- a/api/lib/infrastructure/serializers/weblate/translation-serializer.js
+++ b/api/lib/infrastructure/serializers/weblate/translation-serializer.js
@@ -1,0 +1,5 @@
+import { Translation } from '../../../domain/models/index.js';
+
+export function deserialize(payload) {
+  return new Translation({ key: payload.context, locale: payload.translation, value: payload.target });
+}

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -31,6 +31,7 @@ import * as translationsRoute from './application/translations.js';
 import * as tutorialsRoute from './application/tutorials.js';
 import * as tubesRoutes from './application/tubes.js';
 import * as usersRoute from './application/users.js';
+import * as weblateRoute from './application/weblate.js';
 import * as whitelistedUrlsRoute from './application/whitelisted-urls/index.js';
 
 export const routes = [
@@ -66,6 +67,7 @@ export const routes = [
   tutorialsRoute,
   tubesRoutes,
   usersRoute,
+  weblateRoute,
   whitelistedUrlsRoute,
   ...competenceRoutes,
 ];

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -50,6 +50,7 @@
         "sequelize": "^6.29.0",
         "shiki": "^4.1.0",
         "showdown": "^2.0.0",
+        "standardwebhooks": "^1.0.0",
         "tough-cookie": "^6.0.0",
         "url-regex-safe": "^4.0.0"
       },
@@ -4425,6 +4426,12 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -7106,6 +7113,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.4",
@@ -11659,6 +11672,16 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -83,6 +83,7 @@
     "sequelize": "^6.29.0",
     "shiki": "^4.1.0",
     "showdown": "^2.0.0",
+    "standardwebhooks": "^1.0.0",
     "tough-cookie": "^6.0.0",
     "url-regex-safe": "^4.0.0"
   },

--- a/api/sample.env
+++ b/api/sample.env
@@ -562,6 +562,13 @@ EXPORT_EXTERNAL_URLS_LIST_SPREADSHEET_ID=
 # default: none
 # WEBLATE_PROJECT=xxxxx
 
+# The Weblate webhook secret
+#
+# presence: optional
+# type: String (base64 encoded)
+# default: none
+# WEBLATE_WEBHOOK_SECRET=xxxxx
+
 # ============
 # SEEDS
 # ============

--- a/api/tests/acceptance/application/phrase_test.js
+++ b/api/tests/acceptance/application/phrase_test.js
@@ -966,6 +966,8 @@ describe('Acceptance | Controller | phrase-controller', () => {
         databaseBuilder.factory.buildTranslationsConfig({ phraseProjectId: 'phraseProject666', frameworkId: 'framework1', areaId: 'area1', uploadedLocales: ['fr'] });
         databaseBuilder.factory.buildTranslationsConfig({ phraseProjectId: 'phraseProject333', frameworkId: 'framework2', uploadedLocales: ['fr', 'fr-FR'] });
 
+        await databaseBuilder.commit();
+
         const server = await createServer();
 
         // when

--- a/api/tests/acceptance/application/weblate_test.js
+++ b/api/tests/acceptance/application/weblate_test.js
@@ -138,7 +138,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
           component: 'weblate-component',
           context: 'area.area1.title',
           translation: 'fr',
-          target: 'ne doit pas être pris en compte',
+          target: ['ne doit pas être pris en compte'],
         };
 
         const serializedPayload = JSON.stringify(payload);
@@ -177,7 +177,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
           component: 'weblate-component',
           context: 'area.area1.title',
           translation: 'en',
-          target: 'area1’s english title',
+          target: ['area1’s english title'],
         };
 
         const serializedPayload = JSON.stringify(payload);
@@ -206,7 +206,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
       });
     });
 
-    describe('when change is 2 (translation_updated)', () => {
+    describe('when change is `Translation Changed`', () => {
       it('saves the translation in database', async () => {
         const payload = {
           action: 'Translation changed',
@@ -214,7 +214,7 @@ describe('Acceptance | Controller | phrase-controller', () => {
           component: 'weblate-component',
           context: 'area.area1.title',
           translation: 'en',
-          target: 'area1’s english title',
+          target: ['area1’s english title'],
         };
 
         const serializedPayload = JSON.stringify(payload);

--- a/api/tests/acceptance/application/weblate_test.js
+++ b/api/tests/acceptance/application/weblate_test.js
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Webhook } from 'standardwebhooks';
+import { databaseBuilder, knex } from '../../test-helper';
+import { createServer } from '../../../server';
+import * as config from '../../../lib/config.js';
+
+describe('Acceptance | Controller | phrase-controller', () => {
+  describe('POST api/weblate/webhook', () => {
+    let webhook;
+
+    beforeEach(() => {
+      webhook = new Webhook(config.weblate.webhookSecret);
+    });
+
+    describe('when webhook headers are missing', () => {
+      it('returns a 401 status code', async () => {
+        // given
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+        });
+
+        // then
+        expect(response.statusCode).toBe(401);
+      });
+    });
+
+    describe('when webhook-signature does not match payload', () => {
+      it('returns a 401 status code', async () => {
+        // given
+        const payload = { change_id: 8910 };
+        const serializedPayload = JSON.stringify(payload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: {
+            'webhook-id': '7f1c5477f6275a69af7b83236c20cb1a',
+            'webhook-timestamp': '1748505623.044281',
+            'webhook-signature': 'v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=',
+          },
+        });
+
+        // then
+        expect(response.statusCode).toBe(401);
+      });
+    });
+
+    describe('when change is none of 2 (translation_changed) or 5 (translation_added)', () => {
+      it('returns a 400 status code', async () => {
+        const payload = { change_id: 666 };
+
+        const serializedPayload = JSON.stringify(payload);
+        const webhookHeaders = generateWebhookHeaders(serializedPayload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: webhookHeaders,
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when project does not match config', () => {
+      it('returns a 400 status code', async () => {
+        const payload = {
+          action: 'Translation changed',
+          project: 'not-my-weblate-project',
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+        const webhookHeaders = generateWebhookHeaders(serializedPayload);
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: webhookHeaders,
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when component does not match config', () => {
+      it('returns a 400 status code', async () => {
+        const payload = {
+          action: 'Translation changed',
+          project: config.weblate.project,
+          component: 'unknown-weblate-component',
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+        const webhookHeaders = generateWebhookHeaders(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'fmk', name: 'Fmk' });
+        databaseBuilder.factory.buildTranslationsConfig({ frameworkId: 'fmk', weblateComponent: 'weblate-component', uploadedLocales: ['fr'] });
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: webhookHeaders,
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+      });
+    });
+
+    describe('when locale is an uploadedLocale', () => {
+      it('skips event', async () => {
+        const payload = {
+          action: 'Translation changed',
+          project: config.weblate.project,
+          component: 'weblate-component',
+          context: 'area.area1.title',
+          translation: 'fr',
+          target: 'ne doit pas être pris en compte',
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+        const webhookHeaders = generateWebhookHeaders(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'fmk', name: 'Fmk' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'fmk' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+        databaseBuilder.factory.buildTranslationsConfig({ weblateComponent: 'weblate-component', frameworkId: 'fmk', areaId: 'area1', uploadedLocales: ['fr'] });
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: webhookHeaders,
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+        await expect(knex.select('key', 'locale', 'value')
+          .from('translations')
+          .orderBy(['key', 'locale']))
+          .resolves.toStrictEqual([{ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' }]);
+      });
+    });
+
+    describe('when change action is `Translation added`', () => {
+      it('saves the translation in database', async () => {
+        const payload = {
+          action: 'Translation added',
+          project: config.weblate.project,
+          component: 'weblate-component',
+          context: 'area.area1.title',
+          translation: 'en',
+          target: 'area1’s english title',
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+        const webhookHeaders = generateWebhookHeaders(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'fmk', name: 'Fmk' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'fmk' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+        databaseBuilder.factory.buildTranslationsConfig({ weblateComponent: 'weblate-component', frameworkId: 'fmk', areaId: 'area1', uploadedLocales: ['fr'] });
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: webhookHeaders,
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+
+        await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([{ key: 'area.area1.title', locale: 'en', value: 'area1’s english title' }, { key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' }]);
+      });
+    });
+
+    describe('when change is 2 (translation_updated)', () => {
+      it('saves the translation in database', async () => {
+        const payload = {
+          action: 'Translation changed',
+          project: config.weblate.project,
+          component: 'weblate-component',
+          context: 'area.area1.title',
+          translation: 'en',
+          target: 'area1’s english title',
+        };
+
+        const serializedPayload = JSON.stringify(payload);
+        const webhookHeaders = generateWebhookHeaders(serializedPayload);
+
+        databaseBuilder.factory.buildFramework({ id: 'fmk', name: 'Fmk' });
+        databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'fmk' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' });
+        databaseBuilder.factory.buildTranslation({ key: 'area.area1.title', locale: 'en', value: 'area1’s english old title' });
+        databaseBuilder.factory.buildTranslationsConfig({ weblateComponent: 'weblate-component', frameworkId: 'fmk', areaId: 'area1', uploadedLocales: ['fr'] });
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/weblate/webhook',
+          payload: serializedPayload,
+          headers: webhookHeaders,
+        });
+
+        // then
+        expect(response.statusCode).toBe(204);
+
+        await expect(knex.select('key', 'locale', 'value').from('translations').orderBy(['key', 'locale'])).resolves.toStrictEqual([{ key: 'area.area1.title', locale: 'en', value: 'area1’s english title' }, { key: 'area.area1.title', locale: 'fr', value: 'le titre français de area1' }]);
+      });
+    });
+
+    function generateWebhookHeaders(payload) {
+      const id = crypto.randomUUID();
+      const timestamp = new Date();
+      const signature = webhook.sign(id, timestamp, payload);
+      return {
+        'webhook-id': id,
+        'webhook-timestamp': Math.floor(timestamp.getTime() / 1000),
+        'webhook-signature': signature,
+      };
+    }
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/translations-config-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/translations-config-repository_test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   getByCompetenceId,
   getByPhraseProjectId,
+  getByWeblateComponent,
   listWithPhraseProjectId,
   listWithWeblateComponent,
 } from '../../../../lib/infrastructure/repositories/translations-config-repository.js';
@@ -221,6 +222,41 @@ describe('Integration | Infrastructure | Repositories | TranslationsConfig', () 
 
         // when
         const translationsConfig = await getByCompetenceId('randomCompetenceId1');
+
+        // then
+        expect(translationsConfig).toBeUndefined();
+      });
+    });
+  });
+
+  describe('#getByWeblateComponent', () => {
+    it('gets translations config by Phrase project ID', async () => {
+      // given
+      const weblateComponent = 'weblateComponentEdu';
+
+      // when
+      const translationsConfig = await getByWeblateComponent(weblateComponent);
+
+      // then
+      expect(translationsConfig).toStrictEqual(
+        domainBuilder.buildTranslationsConfig({
+          id: expect.any(Number),
+          phraseProjectId: null,
+          frameworkId: 'frameworkPixEdu',
+          areaId: null,
+          weblateComponent: 'weblateComponentEdu',
+          uploadedLocales: ['fr', 'fr-FR'],
+        }),
+      );
+    });
+
+    describe('when weblateComponent is unknown', () => {
+      it('returns undefined', async () => {
+        // given
+        const weblateComponent = 'unknown';
+
+        // when
+        const translationsConfig = await getByWeblateComponent(weblateComponent);
 
         // then
         expect(translationsConfig).toBeUndefined();


### PR DESCRIPTION
## 🪧 Problème
Afin de mettre à jour les traductions modifiées depuis weblate vers pix-editor, nous devons ajouter une nouvelle route afin de récuperer les event d'update/creation  weblate. 

## 🌈 Proposition
Ajotuer cette route

## 🎉 Pour tester
test au vert