### PR TITLE
[BUGFIX] Ajout du code manquant d'inversion de décli et prototype (PIX-23329)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -10,6 +10,7 @@ import {
   createChallenge,
   getPhraseTranslationsURL,
   previewChallenge,
+  switchGenealogy,
   updateChallenge,
 } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
@@ -140,8 +141,9 @@ export async function register(server) {
         validate: { params: Joi.object({ challengeId: challengeIdType }) },
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }, { method: securityPreHandlers.checkChallengeIsAlternative }],
         handler: async function(request, h) {
-          const challenge = await challengeSerializer.deserialize(request.payload);
-          const updatedChallenge = await updateChallenge(challenge);
+          const { challengeId } = request.params;
+          await switchGenealogy({ alternativeChallengeId: challengeId });
+          const updatedChallenge = await challengeRepository.get(challengeId);
           return h.response(challengeSerializer.serialize(updatedChallenge));
         },
       },

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -13,7 +13,6 @@ import {
   updateChallenge,
 } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
-import { Challenge } from '../../domain/models/Challenge.js';
 
 const challengeIdType = Joi.string()
   .pattern(/^(rec|challenge)[a-zA-Z0-9]+$/)
@@ -142,7 +141,6 @@ export async function register(server) {
         pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }, { method: securityPreHandlers.checkChallengeIsAlternative }],
         handler: async function(request, h) {
           const challenge = await challengeSerializer.deserialize(request.payload);
-          console.log('pouet', request.payload);
           const updatedChallenge = await updateChallenge(challenge);
           return h.response(challengeSerializer.serialize(updatedChallenge));
         },

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -13,6 +13,7 @@ import {
   updateChallenge,
 } from '../../domain/usecases/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
+import { Challenge } from '../../domain/models/Challenge.js';
 
 const challengeIdType = Joi.string()
   .pattern(/^(rec|challenge)[a-zA-Z0-9]+$/)
@@ -138,9 +139,10 @@ export async function register(server) {
       path: '/api/challenges/{challengeId}/switch-genealogy',
       config: {
         validate: { params: Joi.object({ challengeId: challengeIdType }) },
-        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }, { method: securityPreHandlers.checkChallengeIsAlternative }],
         handler: async function(request, h) {
           const challenge = await challengeSerializer.deserialize(request.payload);
+          console.log('pouet', request.payload);
           const updatedChallenge = await updateChallenge(challenge);
           return h.response(challengeSerializer.serialize(updatedChallenge));
         },

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -139,7 +139,7 @@ export async function register(server) {
       path: '/api/challenges/{challengeId}/switch-genealogy',
       config: {
         validate: { params: Joi.object({ challengeId: challengeIdType }) },
-        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }, { method: securityPreHandlers.checkChallengeIsAlternative }],
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
         handler: async function(request, h) {
           const { challengeId } = request.params;
           await switchGenealogy({ alternativeChallengeId: challengeId });

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '../errors.js';
 import { LocalizedChallenge } from './LocalizedChallenge.js';
 import _ from 'lodash';
 
@@ -372,6 +373,9 @@ export class Challenge {
     hasEmbedInternalValidation,
     noValidationNeeded,
   }) {
+    if (!this.isAlternative) {
+      throw new ForbiddenError('Challenge to switch to prototype is not an alternative');
+    }
     this.genealogy = Challenge.GENEALOGIES.PROTOTYPE;
     this.alternativeVersion = null;
     this.accessibility1 = accessibility1;

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -376,6 +376,9 @@ export class Challenge {
     if (!this.isAlternative) {
       throw new ForbiddenError('Challenge to switch to prototype is not an alternative');
     }
+    if (!this.isValide) {
+      throw new ForbiddenError('Challenge must be validated to be switched');
+    }
     this.genealogy = Challenge.GENEALOGIES.PROTOTYPE;
     this.alternativeVersion = null;
     this.accessibility1 = accessibility1;

--- a/api/lib/domain/usecases/update-challenge.js
+++ b/api/lib/domain/usecases/update-challenge.js
@@ -18,6 +18,7 @@ export async function updateChallenge(challenge, dependencies = { challengeRepos
       }
     }
   }
+
   const updatedChallenge = await dependencies.challengeRepository.update(challenge);
 
   try {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -2514,6 +2514,7 @@ describe('Acceptance | Controller | challenges-controller', () => {
           id: challengeDecliId,
           locales: [locale],
           genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          alternativeVersion: 3,
           accessibility1: Challenge.ACCESSIBILITY1.KO,
           accessibility2: Challenge.ACCESSIBILITY2.KO,
         }),
@@ -2523,8 +2524,9 @@ describe('Acceptance | Controller | challenges-controller', () => {
           id: challengeProtoId,
           locales: [locale],
           genealogy: Challenge.GENEALOGIES.PROTOTYPE,
-          accessibility1: Challenge.ACCESSIBILITY1.KO,
-          accessibility2: Challenge.ACCESSIBILITY2.KO,
+          alternativeVersion: null,
+          accessibility1: Challenge.ACCESSIBILITY1.OK,
+          accessibility2: Challenge.ACCESSIBILITY2.RAS,
         }),
       };
 
@@ -2553,13 +2555,13 @@ describe('Acceptance | Controller | challenges-controller', () => {
         id: challengeProtoId,
         challengeId: challengeProtoId,
         locale,
-        requireGafamWebsiteAccess: true,
-        isIncompatibleIpadCertif: true,
-        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
-        isAwarenessChallenge: true,
-        toRephrase: true,
-        hasEmbedInternalValidation: false,
-        noValidationNeeded: false,
+        requireGafamWebsiteAccess: false,
+        isIncompatibleIpadCertif: false,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+        isAwarenessChallenge: false,
+        toRephrase: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
       });
       databaseBuilder.factory.buildTranslation({
         key: `challenge.${challengeProtoId}.instruction`,
@@ -2805,88 +2807,65 @@ describe('Acceptance | Controller | challenges-controller', () => {
       // Then
       expect(response.statusCode).to.equal(200);
 
-      // await expect(knex('challenges').select().where(challengeDecliId, id)).resolves.toStrictEqual([
-      //   {
-      //     accessibility1: DecliToBecomeProto.accessibility1,
-      //     accessibility2: DecliToBecomeProto.accessibility2,
-      //     alternativeVersion: DecliToBecomeProto.alternativeVersion,
-      //     archivedAt: new Date(DecliToBecomeProto.archivedAt),
-      //     author: DecliToBecomeProto.author,
-      //     autoReply: DecliToBecomeProto.autoReply,
-      //     createdAt: new Date(DecliToBecomeProto.createdAt),
-      //     declinable: DecliToBecomeProto.declinable,
-      //     embedHeight: DecliToBecomeProto.embedHeight,
-      //     focusable: DecliToBecomeProto.focusable,
-      //     format: DecliToBecomeProto.format,
-      //     genealogy: DecliToBecomeProto.genealogy,
-      //     id: DecliToBecomeProto.id,
-      //     isQualityOk: DecliToBecomeProto.isQualityOk,
-      //     locales: DecliToBecomeProto.locales,
-      //     madeObsoleteAt: new Date(DecliToBecomeProto.madeObsoleteAt),
-      //     pedagogy: DecliToBecomeProto.pedagogy,
-      //     responsive: DecliToBecomeProto.responsive,
-      //     shuffled: DecliToBecomeProto.shuffled,
-      //     skillId: DecliToBecomeProto.skillId,
-      //     spoil: DecliToBecomeProto.spoil,
-      //     status: DecliToBecomeProto.status,
-      //     t1Status: DecliToBecomeProto.t1Status,
-      //     t2Status: DecliToBecomeProto.t2Status,
-      //     t3Status: DecliToBecomeProto.t3Status,
-      //     timer: DecliToBecomeProto.timer,
-      //     type: DecliToBecomeProto.type,
-      //     updatedAt: expect.any(Date),
-      //     validatedAt: new Date(DecliToBecomeProto.validatedAt),
-      //     version: DecliToBecomeProto.version,
-      //     assessmentMaintenanceTags: DecliToBecomeProto.assessmentMaintenanceTags,
-      //     translationMaintenanceTags: DecliToBecomeProto.translationMaintenanceTags,
-      //   },
-      // ]);
+      const challengesAfterSwitch = await knex('challenges')
+        .select('id', 'genealogy', 'alternativeVersion', 'accessibility1', 'accessibility2')
+        .orderBy('id');
+      expect(challengesAfterSwitch).to.deep.equal([
+        {
+          id: challengeProtoId,
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          alternativeVersion: challengeDecli.alternativeVersion,
+          accessibility1: Challenge.ACCESSIBILITY1.OK,
+          accessibility2: Challenge.ACCESSIBILITY2.RAS,
+        },
+        {
+          id: challengeDecliId,
+          genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+          alternativeVersion: null,
+          accessibility1: Challenge.ACCESSIBILITY1.OK,
+          accessibility2: Challenge.ACCESSIBILITY2.RAS,
+        },
+      ]);
 
-      // await expect(knex('localized_challenges').select().where('id', challengeId).first()).resolves.to.deep.include({
-      //   embedUrl: challenge.embedUrl,
-      //   urlsToConsult: ['pouet.com'],
-      //   geography: 'NL',
-      //   requireGafamWebsiteAccess: false,
-      //   isIncompatibleIpadCertif: false,
-      //   deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
-      //   isAwarenessChallenge: false,
-      //   toRephrase: false,
-      //   hasEmbedInternalValidation: true,
-      //   noValidationNeeded: true,
-      // });
+      const localizedChallengesAfterSwitch = await knex('localized_challenges')
+        .select(
+          'id',
+          'challengeId',
+          'requireGafamWebsiteAccess',
+          'isIncompatibleIpadCertif',
+          'deafAndHardOfHearing',
+          'isAwarenessChallenge',
+          'toRephrase',
+          'hasEmbedInternalValidation',
+          'noValidationNeeded',
+        )
+        .orderBy('id');
+      const expectedPrototypeI18nSettings = {
+        requireGafamWebsiteAccess: false,
+        isIncompatibleIpadCertif: false,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+        isAwarenessChallenge: false,
+        toRephrase: false,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
+      };
+      expect(localizedChallengesAfterSwitch).to.deep.equal([{ id: challengeProtoId, challengeId: challengeProtoId, ...expectedPrototypeI18nSettings }, { id: challengeDecliId, challengeId: challengeDecliId, ...expectedPrototypeI18nSettings }]);
 
-      // await expect(knex('translations').orderBy('key').select('key', 'locale', 'value')).resolves.to.deep.equal([
-      //   {
-      //     key: 'challenge.recChallengeId.alternativeInstruction',
-      //     locale: 'fr',
-      //     value: challenge.alternativeInstruction,
-      //   },
-      //   {
-      //     key: 'challenge.recChallengeId.embedTitle',
-      //     locale: 'fr',
-      //     value: challenge.embedTitle,
-      //   },
-      //   {
-      //     key: 'challenge.recChallengeId.instruction',
-      //     locale: 'fr',
-      //     value: challenge.instruction,
-      //   },
-      //   {
-      //     key: 'challenge.recChallengeId.proposals',
-      //     locale: 'fr',
-      //     value: challenge.proposals,
-      //   },
-      //   {
-      //     key: 'challenge.recChallengeId.solution',
-      //     locale: 'fr',
-      //     value: challenge.solution,
-      //   },
-      //   {
-      //     key: 'challenge.recChallengeId.solutionToDisplay',
-      //     locale: 'fr',
-      //     value: challenge.solutionToDisplay,
-      //   },
-      // ]);
+      const translationsAfterSwitch = await knex('translations').orderBy('key').select('key', 'locale', 'value');
+      expect(translationsAfterSwitch).to.deep.equal([
+        { key: `challenge.${challengeProtoId}.alternativeInstruction`, locale: 'fr', value: 'challengeProto.alternativeInstruction' },
+        { key: `challenge.${challengeProtoId}.embedTitle`, locale: 'fr', value: 'challengeProto.embedTitle' },
+        { key: `challenge.${challengeProtoId}.instruction`, locale: 'fr', value: "Ancienne valeur de l'instruction" },
+        { key: `challenge.${challengeProtoId}.proposals`, locale: 'fr', value: 'challengeProto.proposals' },
+        { key: `challenge.${challengeProtoId}.solution`, locale: 'fr', value: 'challengeProto.solution' },
+        { key: `challenge.${challengeProtoId}.solutionToDisplay`, locale: 'fr', value: 'challengeProto.solutionToDisplay' },
+        { key: `challenge.${challengeDecliId}.alternativeInstruction`, locale: 'fr', value: 'challengeDecli.alternativeInstruction' },
+        { key: `challenge.${challengeDecliId}.embedTitle`, locale: 'fr', value: 'challengeDecli.embedTitle' },
+        { key: `challenge.${challengeDecliId}.instruction`, locale: 'fr', value: "Ancienne valeur de l'instruction" },
+        { key: `challenge.${challengeDecliId}.proposals`, locale: 'fr', value: 'challengeDecli.proposals' },
+        { key: `challenge.${challengeDecliId}.solution`, locale: 'fr', value: 'challengeDecli.solution' },
+        { key: `challenge.${challengeDecliId}.solutionToDisplay`, locale: 'fr', value: 'challengeDecli.solutionToDisplay' },
+      ]);
     });
   });
 });

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -2492,4 +2492,401 @@ describe('Acceptance | Controller | challenges-controller', () => {
       ]);
     });
   });
+
+  describe('PATCH /challenge/:id/switch-genealogy', () => {
+    let user;
+    let challengeDecliId;
+    let challengeProtoId;
+    let locale;
+    let challengeDecli;
+    let challengeProto;
+    let localizedChallengeProto;
+    let localizedChallengeDecli;
+    let DecliToBecomeProto;
+
+    beforeEach(async function() {
+      user = databaseBuilder.factory.buildAdminUser();
+      challengeDecliId = 'recChallengeId';
+      challengeProtoId = 'prototypeId';
+      locale = 'fr';
+      challengeDecli = {
+        ...domainBuilder.buildChallengeDatasourceObject({
+          id: challengeDecliId,
+          locales: [locale],
+          genealogy: Challenge.GENEALOGIES.DECLINAISON,
+          accessibility1: Challenge.ACCESSIBILITY1.KO,
+          accessibility2: Challenge.ACCESSIBILITY2.KO,
+        }),
+      };
+      challengeProto = {
+        ...domainBuilder.buildChallengeDatasourceObject({
+          id: challengeProtoId,
+          locales: [locale],
+          genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+          accessibility1: Challenge.ACCESSIBILITY1.KO,
+          accessibility2: Challenge.ACCESSIBILITY2.KO,
+        }),
+      };
+
+      databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
+      databaseBuilder.factory.buildArea({ id: 'area1', code: '1', frameworkId: 'recFmk1' });
+      databaseBuilder.factory.buildCompetence({ id: 'competence1', index: '1.1', areaId: 'area1' });
+      databaseBuilder.factory.buildThematic({ id: 'thematic1', competenceId: 'competence1' });
+      databaseBuilder.factory.buildTube({ id: 'tube1', name: '@tube', thematicId: 'thematic1' });
+      databaseBuilder.factory.buildSkill({ id: challengeProto.skillId, tubeId: 'tube1' });
+      databaseBuilder.factory.buildChallenge(challengeDecli);
+      databaseBuilder.factory.buildChallenge(challengeProto);
+
+      localizedChallengeDecli = databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeDecliId,
+        challengeId: challengeDecliId,
+        locale,
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+      });
+      localizedChallengeProto = databaseBuilder.factory.buildLocalizedChallenge({
+        id: challengeProtoId,
+        challengeId: challengeProtoId,
+        locale,
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.OK,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeProtoId}.instruction`,
+        locale,
+        value: "Ancienne valeur de l'instruction",
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeProtoId}.alternativeInstruction`,
+        locale,
+        value: 'challengeProto.alternativeInstruction',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeProtoId}.solution`,
+        locale,
+        value: 'challengeProto.solution',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeProtoId}.solutionToDisplay`,
+        locale,
+        value: 'challengeProto.solutionToDisplay',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeProtoId}.proposals`,
+        locale,
+        value: 'challengeProto.proposals',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeProtoId}.embedTitle`,
+        locale,
+        value: 'challengeProto.embedTitle',
+      });
+
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeDecliId}.instruction`,
+        locale,
+        value: "Ancienne valeur de l'instruction",
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeDecliId}.alternativeInstruction`,
+        locale,
+        value: 'challengeDecli.alternativeInstruction',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeDecliId}.solution`,
+        locale,
+        value: 'challengeDecli.solution',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeDecliId}.solutionToDisplay`,
+        locale,
+        value: 'challengeDecli.solutionToDisplay',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeDecliId}.proposals`,
+        locale,
+        value: 'challengeDecli.proposals',
+      });
+      databaseBuilder.factory.buildTranslation({
+        key: `challenge.${challengeDecliId}.embedTitle`,
+        locale,
+        value: 'challengeDecli.embedTitle',
+      });
+      await databaseBuilder.commit();
+
+      DecliToBecomeProto = {
+        ...challengeDecli,
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+        accessibility1: Challenge.ACCESSIBILITY1.OK,
+        accessibility2: Challenge.ACCESSIBILITY2.OK,
+        locales: ['fr'],
+        localizedChallenges: [localizedChallengeDecli, localizedChallengeProto],
+      };
+    });
+
+    it('should NOT authorize connection if it is NOT decli', async () => {
+      // Given
+      const server = await createServer();
+
+      // When
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/challenges/${challengeProtoId}/switch-genealogy`,
+        headers: generateAuthorizationHeader(user),
+        payload: {
+          data: {
+            type: 'challenges',
+            id: DecliToBecomeProto.id,
+            attributes: {
+              'airtable-id': DecliToBecomeProto.airtableId,
+              instruction: DecliToBecomeProto.instruction,
+              'alternative-instruction': DecliToBecomeProto.alternativeInstruction,
+              type: DecliToBecomeProto.type,
+              format: DecliToBecomeProto.format,
+              proposals: DecliToBecomeProto.proposals,
+              solution: DecliToBecomeProto.solution,
+              'solution-to-display': DecliToBecomeProto.solutionToDisplay,
+              't1-status': DecliToBecomeProto.t1Status,
+              't2-status': DecliToBecomeProto.t2Status,
+              't3-status': DecliToBecomeProto.t3Status,
+              pedagogy: DecliToBecomeProto.pedagogy,
+              author: DecliToBecomeProto.author,
+              declinable: DecliToBecomeProto.declinable,
+              version: DecliToBecomeProto.version,
+              genealogy: DecliToBecomeProto.genealogy,
+              status: DecliToBecomeProto.status,
+              preview: DecliToBecomeProto.preview,
+              timer: DecliToBecomeProto.timer,
+              'embed-url': DecliToBecomeProto.embedUrl,
+              'embed-title': DecliToBecomeProto.embedTitle,
+              'embed-height': DecliToBecomeProto.embedHeight,
+              'alternative-version': DecliToBecomeProto.alternativeVersion,
+              accessibility1: DecliToBecomeProto.accessibility1,
+              accessibility2: DecliToBecomeProto.accessibility2,
+              spoil: DecliToBecomeProto.spoil,
+              responsive: DecliToBecomeProto.responsive,
+              locales: DecliToBecomeProto.locales,
+              geography: DecliToBecomeProto.geography,
+              'urls-to-consult': ['pouet.com'],
+              'auto-reply': DecliToBecomeProto.autoReply,
+              focusable: DecliToBecomeProto.focusable,
+              'updated-at': new Date('2021-10-04'),
+              'validated-at': new Date('2023-02-02T14:17:30Z'),
+              'archived-at': new Date('2023-03-03T10:47:05Z'),
+              'made-obsolete-at': new Date('2023-04-04T10:47:05Z'),
+              shuffled: false,
+              'require-gafam-website-access': false,
+              'is-incompatible-ipad-certif': false,
+              'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+              'is-awareness-challenge': false,
+              'to-rephrase': false,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
+              'is-quality-ok': true,
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
+            },
+            relationships: {
+              skill: {
+                data: {
+                  type: 'skills',
+                  id: challengeDecli.skills[0],
+                },
+              },
+              attachments: {
+                data: challengeDecli.files.map(({ fileId }) => {
+                  return {
+                    type: 'attachments',
+                    id: fileId,
+                  };
+                }),
+              },
+            },
+          },
+        },
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should switch an alternative challenge and its corresponding prototype', async () => {
+      // Given
+      const server = await createServer();
+
+      // When
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/challenges/${challengeDecliId}/switch-genealogy`,
+        headers: generateAuthorizationHeader(user),
+        payload: {
+          data: {
+            type: 'challenges',
+            id: DecliToBecomeProto.id,
+            attributes: {
+              'airtable-id': DecliToBecomeProto.airtableId,
+              instruction: DecliToBecomeProto.instruction,
+              'alternative-instruction': DecliToBecomeProto.alternativeInstruction,
+              type: DecliToBecomeProto.type,
+              format: DecliToBecomeProto.format,
+              proposals: DecliToBecomeProto.proposals,
+              solution: DecliToBecomeProto.solution,
+              'solution-to-display': DecliToBecomeProto.solutionToDisplay,
+              't1-status': DecliToBecomeProto.t1Status,
+              't2-status': DecliToBecomeProto.t2Status,
+              't3-status': DecliToBecomeProto.t3Status,
+              pedagogy: DecliToBecomeProto.pedagogy,
+              author: DecliToBecomeProto.author,
+              declinable: DecliToBecomeProto.declinable,
+              version: DecliToBecomeProto.version,
+              genealogy: DecliToBecomeProto.genealogy,
+              status: DecliToBecomeProto.status,
+              preview: DecliToBecomeProto.preview,
+              timer: DecliToBecomeProto.timer,
+              'embed-url': DecliToBecomeProto.embedUrl,
+              'embed-title': DecliToBecomeProto.embedTitle,
+              'embed-height': DecliToBecomeProto.embedHeight,
+              'alternative-version': DecliToBecomeProto.alternativeVersion,
+              accessibility1: DecliToBecomeProto.accessibility1,
+              accessibility2: DecliToBecomeProto.accessibility2,
+              spoil: DecliToBecomeProto.spoil,
+              responsive: DecliToBecomeProto.responsive,
+              locales: DecliToBecomeProto.locales,
+              geography: DecliToBecomeProto.geography,
+              'urls-to-consult': ['pouet.com'],
+              'auto-reply': DecliToBecomeProto.autoReply,
+              focusable: DecliToBecomeProto.focusable,
+              'updated-at': new Date('2021-10-04'),
+              'validated-at': new Date('2023-02-02T14:17:30Z'),
+              'archived-at': new Date('2023-03-03T10:47:05Z'),
+              'made-obsolete-at': new Date('2023-04-04T10:47:05Z'),
+              shuffled: false,
+              'require-gafam-website-access': false,
+              'is-incompatible-ipad-certif': false,
+              'deaf-and-hard-of-hearing': LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+              'is-awareness-challenge': false,
+              'to-rephrase': false,
+              'has-embed-internal-validation': true,
+              'no-validation-needed': true,
+              'is-quality-ok': true,
+              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
+            },
+            relationships: {
+              skill: {
+                data: {
+                  type: 'skills',
+                  id: challengeDecli.skills[0],
+                },
+              },
+              attachments: {
+                data: challengeDecli.files.map(({ fileId }) => {
+                  return {
+                    type: 'attachments',
+                    id: fileId,
+                  };
+                }),
+              },
+            },
+          },
+        },
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(200);
+
+      // await expect(knex('challenges').select().where(challengeDecliId, id)).resolves.toStrictEqual([
+      //   {
+      //     accessibility1: DecliToBecomeProto.accessibility1,
+      //     accessibility2: DecliToBecomeProto.accessibility2,
+      //     alternativeVersion: DecliToBecomeProto.alternativeVersion,
+      //     archivedAt: new Date(DecliToBecomeProto.archivedAt),
+      //     author: DecliToBecomeProto.author,
+      //     autoReply: DecliToBecomeProto.autoReply,
+      //     createdAt: new Date(DecliToBecomeProto.createdAt),
+      //     declinable: DecliToBecomeProto.declinable,
+      //     embedHeight: DecliToBecomeProto.embedHeight,
+      //     focusable: DecliToBecomeProto.focusable,
+      //     format: DecliToBecomeProto.format,
+      //     genealogy: DecliToBecomeProto.genealogy,
+      //     id: DecliToBecomeProto.id,
+      //     isQualityOk: DecliToBecomeProto.isQualityOk,
+      //     locales: DecliToBecomeProto.locales,
+      //     madeObsoleteAt: new Date(DecliToBecomeProto.madeObsoleteAt),
+      //     pedagogy: DecliToBecomeProto.pedagogy,
+      //     responsive: DecliToBecomeProto.responsive,
+      //     shuffled: DecliToBecomeProto.shuffled,
+      //     skillId: DecliToBecomeProto.skillId,
+      //     spoil: DecliToBecomeProto.spoil,
+      //     status: DecliToBecomeProto.status,
+      //     t1Status: DecliToBecomeProto.t1Status,
+      //     t2Status: DecliToBecomeProto.t2Status,
+      //     t3Status: DecliToBecomeProto.t3Status,
+      //     timer: DecliToBecomeProto.timer,
+      //     type: DecliToBecomeProto.type,
+      //     updatedAt: expect.any(Date),
+      //     validatedAt: new Date(DecliToBecomeProto.validatedAt),
+      //     version: DecliToBecomeProto.version,
+      //     assessmentMaintenanceTags: DecliToBecomeProto.assessmentMaintenanceTags,
+      //     translationMaintenanceTags: DecliToBecomeProto.translationMaintenanceTags,
+      //   },
+      // ]);
+
+      // await expect(knex('localized_challenges').select().where('id', challengeId).first()).resolves.to.deep.include({
+      //   embedUrl: challenge.embedUrl,
+      //   urlsToConsult: ['pouet.com'],
+      //   geography: 'NL',
+      //   requireGafamWebsiteAccess: false,
+      //   isIncompatibleIpadCertif: false,
+      //   deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.KO,
+      //   isAwarenessChallenge: false,
+      //   toRephrase: false,
+      //   hasEmbedInternalValidation: true,
+      //   noValidationNeeded: true,
+      // });
+
+      // await expect(knex('translations').orderBy('key').select('key', 'locale', 'value')).resolves.to.deep.equal([
+      //   {
+      //     key: 'challenge.recChallengeId.alternativeInstruction',
+      //     locale: 'fr',
+      //     value: challenge.alternativeInstruction,
+      //   },
+      //   {
+      //     key: 'challenge.recChallengeId.embedTitle',
+      //     locale: 'fr',
+      //     value: challenge.embedTitle,
+      //   },
+      //   {
+      //     key: 'challenge.recChallengeId.instruction',
+      //     locale: 'fr',
+      //     value: challenge.instruction,
+      //   },
+      //   {
+      //     key: 'challenge.recChallengeId.proposals',
+      //     locale: 'fr',
+      //     value: challenge.proposals,
+      //   },
+      //   {
+      //     key: 'challenge.recChallengeId.solution',
+      //     locale: 'fr',
+      //     value: challenge.solution,
+      //   },
+      //   {
+      //     key: 'challenge.recChallengeId.solutionToDisplay',
+      //     locale: 'fr',
+      //     value: challenge.solutionToDisplay,
+      //   },
+      // ]);
+    });
+  });
 });

--- a/api/tests/integration/domain/usecases/switch-genealogy_test.js
+++ b/api/tests/integration/domain/usecases/switch-genealogy_test.js
@@ -13,6 +13,7 @@ describe('Integration | Usecases | Switch Genealogy', function() {
         alternativeVersion: null,
         accessibility1: Challenge.ACCESSIBILITY1.KO,
         accessibility2: Challenge.ACCESSIBILITY2.KO,
+        status: Challenge.STATUSES.VALIDE,
         locales: ['fr-FR'],
       },
       localizedChallenge: {
@@ -31,6 +32,7 @@ describe('Integration | Usecases | Switch Genealogy', function() {
       id: 'challengeIdDécli',
       skillId: challengePrototype.skillId,
       genealogy: Challenge.GENEALOGIES.DECLINAISON,
+      status: Challenge.STATUSES.VALIDE,
       alternativeVersion: 56,
       accessibility1: Challenge.ACCESSIBILITY1.OK,
       accessibility2: Challenge.ACCESSIBILITY2.OK,
@@ -98,6 +100,7 @@ describe('Integration | Usecases | Switch Genealogy', function() {
       challenge: {
         id: 'challengeId',
         genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+        status: Challenge.STATUSES.VALIDE,
         version: null,
         alternativeVersion: null,
         accessibility1: Challenge.ACCESSIBILITY1.KO,
@@ -120,6 +123,7 @@ describe('Integration | Usecases | Switch Genealogy', function() {
       id: 'challengeIdDécli2',
       skillId: challenge.skillId,
       genealogy: Challenge.GENEALOGIES.DECLINAISON,
+      status: Challenge.STATUSES.VALIDE,
       alternativeVersion: 56,
       accessibility1: Challenge.ACCESSIBILITY1.OK,
       accessibility2: Challenge.ACCESSIBILITY2.OK,

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -2982,7 +2982,6 @@ describe('Integration | Repository | challenge-repository', () => {
 
       expect(updatedChallengePrototype).toEqual({
         alternativeVersion: 666,
-        version: 10,
         author: ['BZH'],
         // validate other field has not change
         accessibility1: 'OK',

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -18,42 +18,22 @@ const routesConfig = { routes: { validate: { failAction: handleFailAction } } };
  * });
  */
 class HttpTestServer {
-  constructor({ mustThrowOn5XXError = true } = {}) {
+  constructor() {
     this.hapiServer = Hapi.server(routesConfig);
-    this._mustThrow5XXOnError = mustThrowOn5XXError;
   }
 
-  async register(moduleUnderTest) {
-    await this.hapiServer.register(moduleUnderTest);
+  register(moduleUnderTest) {
+    return this.hapiServer.register(moduleUnderTest);
   }
 
-  async request(method, url, payload, auth, headers) {
-    const result = await this.hapiServer.inject({ method, url, payload, auth, headers });
-
-    if (this._mustThrowOn5XXError && result.statusCode >= 500) {
-      throw new Error('Request Failed');
-    }
-
-    return result;
-  }
-
-  requestObject({ method, url, payload, auth, headers }) {
-    return this.request(method, url, payload, auth, headers);
+  inject(method, url, payload, auth, headers) {
+    return this.hapiServer.inject({ method, url, payload, auth, headers });
   }
 
   setupAuthentication() {
     this.hapiServer.scheme('api-token', security.scheme);
     this.hapiServer.strategy('default', 'api-token');
     this.hapiServer.default('default');
-  }
-
-  setupDeserialization() {
-    this.hapiServer.ext('onPreHandler', async (request, h) => {
-      if (request.payload?.data) {
-        request.deserializedPayload = await deserializer.deserialize(request.payload);
-      }
-      return h.continue;
-    });
   }
 }
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -1,7 +1,8 @@
 import { beforeEach, describe as context, describe, expect, it, vi } from 'vitest';
 import { Attachment, Challenge, LocalizedChallenge } from '../../../../lib/domain/models/index.js';
-import { domainBuilder } from '../../../test-helper.js';
+import { catchErr, domainBuilder } from '../../../test-helper.js';
 import { ChallengeForRelease } from '../../../../lib/domain/models/release/index.js';
+import { ForbiddenError } from '../../../../lib/domain/errors.js';
 
 describe('Unit | Domain | Challenge', () => {
   const fields = [
@@ -403,6 +404,46 @@ describe('Unit | Domain | Challenge', () => {
         hasEmbedInternalValidation: true,
         noValidationNeeded: true,
       });
+    });
+
+    it('should throw a ForbiddenError when challenge is not an alternative', async function() {
+      // given
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+        locale: 'fr',
+        requireGafamWebsiteAccess: false,
+        isIncompatibleIpadCertif: false,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+        isAwarenessChallenge: false,
+        toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+      });
+      const challenge = domainBuilder.buildChallenge({
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+        version: 1,
+        alternativeVersion: 15,
+        author: ['TOTO'],
+        accessibility1: Challenge.ACCESSIBILITY1.ACQUIS_NON_PERTINENT,
+        accessibility2: Challenge.ACCESSIBILITY2.KO,
+        locales: ['fr'],
+        localizedChallenges: [localizedChallenge],
+      });
+
+      // when
+      const err = await catchErr(challenge.switchToPrototype, challenge)({
+        accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
+        accessibility2: Challenge.ACCESSIBILITY2.NONE,
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.ACQUIS_NON_PERTINENT,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
+      });
+
+      // then
+      expect(err).toBeInstanceOf(ForbiddenError);
     });
   });
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -445,6 +445,47 @@ describe('Unit | Domain | Challenge', () => {
       // then
       expect(err).toBeInstanceOf(ForbiddenError);
     });
+
+    it('should throw a ForbiddenError when challenge is not validated', async function() {
+      // given
+      const localizedChallenge = domainBuilder.buildLocalizedChallenge({
+        locale: 'fr',
+        requireGafamWebsiteAccess: false,
+        isIncompatibleIpadCertif: false,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+        isAwarenessChallenge: false,
+        toRephrase: false,
+        hasEmbedInternalValidation: false,
+        noValidationNeeded: false,
+      });
+      const challenge = domainBuilder.buildChallenge({
+        genealogy: Challenge.GENEALOGIES.DECLINAISON,
+        version: 1,
+        alternativeVersion: 15,
+        author: ['TOTO'],
+        accessibility1: Challenge.ACCESSIBILITY1.ACQUIS_NON_PERTINENT,
+        accessibility2: Challenge.ACCESSIBILITY2.KO,
+        locales: ['fr'],
+        localizedChallenges: [localizedChallenge],
+        status: Challenge.STATUSES.ARCHIVE,
+      });
+
+      // when
+      const err = await catchErr(challenge.switchToPrototype, challenge)({
+        accessibility1: Challenge.ACCESSIBILITY1.A_TESTER,
+        accessibility2: Challenge.ACCESSIBILITY2.NONE,
+        requireGafamWebsiteAccess: true,
+        isIncompatibleIpadCertif: true,
+        deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.ACQUIS_NON_PERTINENT,
+        isAwarenessChallenge: true,
+        toRephrase: true,
+        hasEmbedInternalValidation: true,
+        noValidationNeeded: true,
+      });
+
+      // then
+      expect(err).toBeInstanceOf(ForbiddenError);
+    });
   });
 
   describe('#switchToAlternative', () => {

--- a/pix-editor/app/adapters/challenge.js
+++ b/pix-editor/app/adapters/challenge.js
@@ -2,4 +2,11 @@ import ApplicationAdapter from './application';
 
 export default class ChallengeAdapter extends ApplicationAdapter {
   coalesceFindRequests = true;
+
+  urlForUpdateRecord(id, modelName, snapshot) {
+    if (snapshot.adapterOptions?.switchGenealogy) {
+      return `${this.buildURL(modelName, id)}/switch-genealogy`;
+    }
+    return this.buildURL(modelName, id);
+  }
 }

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -486,7 +486,8 @@ export default class SingleController extends Controller {
         challenge,
       );
     } catch (error) {
-      Sentry.captureException(error);
+      // eslint-disable-next-line no-console
+      console.error(error);
       this._errorMessage("Erreur lors de l'inversion");
     } finally {
       this.loader.stop();

--- a/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
+++ b/pix-editor/app/controllers/authenticated/competence/prototypes/single.js
@@ -113,6 +113,10 @@ export default class SingleController extends Controller {
     return this.access.mayMove(this.challenge);
   }
 
+  get maySwitchGenealogy() {
+    return this.access.maySwitchGenealogy(this.challenge);
+  }
+
   get mayAccessAlternatives() {
     return this.challenge.isPrototype && !this.challenge.isWorkbench;
   }
@@ -453,6 +457,40 @@ export default class SingleController extends Controller {
   @action
   closeMovePrototype() {
     this.displaySelectLocation = false;
+  }
+
+  @action
+  async switchGenealogy() {
+    try {
+      await this.confirm.ask(
+        'Inversion prototype / déclinaison',
+        'Êtes-vous sûr de vouloir inverser cette déclinaison avec le prototype ?',
+      );
+    } catch {
+      this._message('Inversion abandonnée');
+      return;
+    }
+    this.loader.start();
+    try {
+      const challenge = this.challenge;
+      const relatedPrototype = challenge.relatedPrototype;
+      await challenge.switchGenealogy();
+      if (relatedPrototype) {
+        await relatedPrototype.reload();
+      }
+      await this.overviewController.send('refreshModel');
+      this._message('Inversion effectuée');
+      this.router.transitionTo(
+        'authenticated.competence.prototypes.single',
+        this.currentData.getCompetence(),
+        challenge,
+      );
+    } catch (error) {
+      Sentry.captureException(error);
+      this._errorMessage("Erreur lors de l'inversion");
+    } finally {
+      this.loader.stop();
+    }
   }
 
   @action

--- a/pix-editor/app/models/challenge.js
+++ b/pix-editor/app/models/challenge.js
@@ -156,6 +156,10 @@ export default class ChallengeModel extends Model {
     return this.genealogy === ChallengeModel.GENEALOGIES.PROTOTYPE;
   }
 
+  get isAlternative() {
+    return this.genealogy === ChallengeModel.GENEALOGIES.DECLINAISON;
+  }
+
   get isWorkbench() {
     const skill = this.skill;
     if (skill) {
@@ -342,6 +346,10 @@ export default class ChallengeModel extends Model {
     this.status = ChallengeModel.STATUSES.VALIDE;
     this.validatedAt = new Date();
     return this.save();
+  }
+
+  async switchGenealogy() {
+    return this.save({ adapterOptions: { switchGenealogy: true } });
   }
 
   async duplicate() {

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -158,7 +158,7 @@ export default class AccessService extends Service {
   }
 
   maySwitchGenealogy(challenge) {
-    return this.isReplicator() && challenge.isAlternative;
+    return this.isReplicator() && challenge.isValidated && challenge.isAlternative;
   }
 
   mayAccessAdministration() {

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -157,6 +157,10 @@ export default class AccessService extends Service {
     return this.isEditor() && challenge.isPrototype && challenge.isDraft;
   }
 
+  maySwitchGenealogy(challenge) {
+    return this.isReplicator() && challenge.isAlternative;
+  }
+
   mayAccessAdministration() {
     return this.isAdmin();
   }

--- a/pix-editor/app/styles/_challenges.scss
+++ b/pix-editor/app/styles/_challenges.scss
@@ -255,6 +255,18 @@ img.clickable {
       color: #2185d0;
     }
   }
+
+  .switch-genealogy {
+    display: flex;
+    flex-direction: row !important;
+    gap: 0.25rem;
+    align-items: center;
+
+    i {
+      width: 16px !important;
+      margin-bottom: 0;
+    }
+  }
 }
 
 .ui.menu.challenge-menu {

--- a/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
+++ b/pix-editor/app/templates/authenticated/competence/prototypes/single.gjs
@@ -181,6 +181,20 @@ import scrollTop from 'pixeditor/modifiers/scroll-top';
             Déclinaisons &gt;&gt;
           </button>
         {{/if}}
+        {{#if @controller.maySwitchGenealogy}}
+          <button
+            class="ui button item switch-genealogy"
+            {{on "click" @controller.switchGenealogy}}
+            type="button"
+            title="Inverser cette déclinaison avec le prototype"
+          >
+            <i class="exchange icon"></i>
+            <span>
+              Inverser avec
+              <br />le prototype
+            </span>
+          </button>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/pix-editor/tests/acceptance/competence/prototypes/single/alternative/single-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/single/alternative/single-test.js
@@ -1,5 +1,5 @@
 import { visit, within } from '@1024pix/ember-testing-library';
-import { click } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -8,6 +8,7 @@ import { module, test } from 'qunit';
 module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  let competence, prototype, alternative;
 
   hooks.beforeEach(function () {
     this.server.create('config', {
@@ -18,19 +19,19 @@ module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
     });
     this.server.create('user', { trigram: 'ABC' });
 
-    const prototype = this.server.create('challenge', {
+    prototype = this.server.create('challenge', {
       id: 'challenge1',
       version: 1,
       status: 'validé',
       genealogy: 'Prototype 1',
     });
-    this.server.create('challenge', {
+    alternative = this.server.create('challenge', {
       id: 'challenge1-1',
       status: 'validé',
       genealogy: 'Décliné 1',
       version: 1,
       alternativeVersion: 1,
-      instruction: 'Ma consigne',
+      instruction: 'Ma consigne déclinée',
       alternativeInstruction: 'Ma consigne alternative',
       type: 'QCU',
       autoReply: false,
@@ -55,7 +56,7 @@ module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
 
     const tube = this.server.create('tube', { id: 'recTube1', rawSkillIds: ['recSkill1'] });
     const thematic = this.server.create('theme', { id: 'recTheme1', name: 'theme1', rawTubeIds: ['recTube1'] });
-    const competence = this.server.create('competence', {
+    competence = this.server.create('competence', {
       id: 'recCompetence1.1',
       pixId: 'pixId recCompetence1.1',
       rawThemeIds: ['recTheme1'],
@@ -110,12 +111,12 @@ module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
 
     await click(screen.getByRole('link', { name: '@sujet1 2' }));
     await click(screen.getByRole('button', { name: 'Déclinaisons >>' }));
-    await click(screen.getByRole('cell', { name: 'Ma consigne' }));
+    await click(screen.getByRole('cell', { name: 'Ma consigne déclinée' }));
 
     // then
     const alternativePanel = within(screen.getByTestId('panel-alternative-challenge'));
 
-    assert.dom(alternativePanel.getByText('Ma consigne')).exists();
+    assert.dom(alternativePanel.getByText('Ma consigne déclinée')).exists();
     assert.dom(screen.getByText('Ma consigne alternative')).exists();
     assert.dom(screen.getByText('Mes propositions')).exists();
 
@@ -130,5 +131,21 @@ module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
     assert.strictEqual(alternativePanel.getByLabelText('Langue(s)').textContent.trim(), 'Francophone');
     assert.strictEqual(alternativePanel.getByLabelText('Géographie').textContent.trim(), 'Brésil');
     assert.dom(alternativePanel.getByLabelText('Id')).hasValue('challenge1-1');
+  });
+
+  test('it should be switchable with the prototype', async function (assert) {
+    // given
+    const screen = await visit(
+      `/competence/${competence.id}/prototypes/${prototype.id}/alternatives/${alternative.id}`,
+    );
+
+    // when
+    await click(screen.getByRole('button', { name: 'Inverser avec le prototype' }));
+    await click(await screen.findByRole('button', { name: 'Oui' }));
+
+    // then
+    assert.dom(await screen.findByText('Inversion effectuée')).exists();
+    assert.ok(currentURL().startsWith(`/competence/${competence.id}/prototypes/${alternative.id}`));
+    assert.dom(await screen.findByText('Ma consigne déclinée')).exists();
   });
 });

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -1,6 +1,8 @@
 import slice from 'lodash/slice';
 import { Response } from 'miragejs';
 
+import Challenge from '../../app/models/challenge';
+
 /* eslint-disable ember/no-get */
 export default function routes() {
   this.namespace = 'api';
@@ -311,6 +313,31 @@ export default function routes() {
     });
 
     return challenge;
+  });
+
+  this.patch('/challenges/:id/switch-genealogy', (schema, request) => {
+    const alternative = schema.challenges.find(request.params.id);
+    const prototype = schema.challenges.all().models.find((ch) => {
+      return (
+        ch.skillId === alternative.skillId &&
+        ch.version === alternative.version &&
+        ch.genealogy === Challenge.GENEALOGIES.PROTOTYPE
+      );
+    });
+
+    prototype.update({
+      alternativeVersion: alternative.alternativeVersion,
+      genealogy: 'Décliné 1',
+    });
+
+    alternative.update({
+      alternativeVersion: null,
+      genealogy: 'Prototype 1',
+      accessibility1: prototype.accessibility1,
+      accessibility2: prototype.accessibility2,
+    });
+
+    return alternative;
   });
 
   // TODO extraire le contenu des configs liées aux missions dans un fichier dédié

--- a/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
+++ b/pix-editor/tests/unit/controllers/competence/prototypes/single-test.js
@@ -362,6 +362,82 @@ module('Unit | Controller | competence/prototypes/single', function (hooks) {
     });
   });
 
+  module('#switchGenealogy', function (hooks) {
+    let challenge, routerTransitionToStub, overviewControllerSendStub, confirmAskStub;
+
+    hooks.beforeEach(function () {
+      routerTransitionToStub = sinon.stub();
+      class RouterService extends Service {
+        transitionTo = routerTransitionToStub;
+      }
+      this.owner.unregister('service:router');
+      this.owner.register('service:router', RouterService);
+
+      class CurrentDataService extends Service {
+        getCompetence = sinon.stub().returns('competence1');
+      }
+      this.owner.unregister('service:current-data');
+      this.owner.register('service:current-data', CurrentDataService);
+
+      confirmAskStub = sinon.stub().resolves();
+      class ConfirmService extends Service {
+        ask = confirmAskStub;
+      }
+      this.owner.unregister('service:confirm');
+      this.owner.register('service:confirm', ConfirmService);
+
+      controller._errorMessage = sinon.stub();
+
+      overviewControllerSendStub = sinon.stub().resolves();
+      controller.overviewController = { send: overviewControllerSendStub };
+
+      challenge = {
+        id: 'rec1',
+        switchGenealogy: sinon.stub().resolves(),
+        relatedPrototype: { id: 'rec2', reload: sinon.stub().resolves() },
+      };
+      controller.model = challenge;
+    });
+
+    test('it should switch the genealogy, reload the prototype and navigate to the prototype page', async function (assert) {
+      // when
+      await controller.switchGenealogy();
+
+      // then
+      assert.ok(confirmAskStub.calledOnce);
+      assert.ok(challenge.switchGenealogy.calledOnce);
+      assert.ok(challenge.relatedPrototype.reload.calledOnce);
+      assert.ok(overviewControllerSendStub.calledWith('refreshModel'));
+      assert.ok(
+        routerTransitionToStub.calledWith('authenticated.competence.prototypes.single', 'competence1', challenge),
+      );
+      assert.ok(messageStub.calledWith('Inversion effectuée'));
+    });
+
+    test('it should not switch the genealogy when the confirmation is cancelled', async function (assert) {
+      // given
+      confirmAskStub.rejects();
+
+      // when
+      await controller.switchGenealogy();
+
+      // then
+      assert.notOk(challenge.switchGenealogy.called);
+      assert.ok(messageStub.calledWith('Inversion abandonnée'));
+    });
+
+    test('it should display an error message if switching the genealogy fails', async function (assert) {
+      // given
+      challenge.switchGenealogy = sinon.stub().rejects(new Error('boom'));
+
+      // when
+      await controller.switchGenealogy();
+
+      // then
+      assert.ok(controller._errorMessage.calledWith("Erreur lors de l'inversion"));
+    });
+  });
+
   module('#UrlsToConsult', function () {
     test('it should reset urlToConsult when urlToConsultField is closed', function (assert) {
       // given

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -298,6 +298,23 @@ module('Unit | Service | access', function (hooks) {
       const prototypeChallenge = EmberObject.create({
         id: 'rec123656',
         isAlternative: false,
+        isValidated: true,
+      });
+
+      // when
+      const accessResult = accessService.maySwitchGenealogy(prototypeChallenge);
+
+      // then
+      assert.notOk(accessResult);
+    });
+
+    test('it should return `false` when challenge is not validated', function (assert) {
+      // given
+      _stubAccessLevel(REPLICATOR, this.owner);
+      const prototypeChallenge = EmberObject.create({
+        id: 'rec123656',
+        isAlternative: true,
+        isValidated: false,
       });
 
       // when
@@ -314,6 +331,7 @@ module('Unit | Service | access', function (hooks) {
       const alternativeChallenge = EmberObject.create({
         id: 'rec123656',
         isAlternative: true,
+        isValidated: true,
       });
 
       // when
@@ -328,6 +346,7 @@ module('Unit | Service | access', function (hooks) {
       const alternativeChallenge = EmberObject.create({
         id: 'rec123656',
         isAlternative: true,
+        isValidated: true,
       });
 
       // when

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -290,4 +290,55 @@ module('Unit | Service | access', function (hooks) {
       assert.notOk(accessResult);
     });
   });
+
+  module('maySwitchGenealogy', function () {
+    test('it should return `false` when challenge is not an alternative', function (assert) {
+      // given
+      _stubAccessLevel(REPLICATOR, this.owner);
+      const prototypeChallenge = EmberObject.create({
+        id: 'rec123656',
+        isAlternative: false,
+      });
+
+      // when
+      const accessResult = accessService.maySwitchGenealogy(prototypeChallenge);
+
+      // then
+      assert.notOk(accessResult);
+    });
+
+    test('it should return `false` when user level is lower than `REPLICATOR` level', function (assert) {
+      // given
+      const READ_ONLY = 1;
+      _stubAccessLevel(READ_ONLY, this.owner);
+      const alternativeChallenge = EmberObject.create({
+        id: 'rec123656',
+        isAlternative: true,
+      });
+
+      // when
+      const accessResult = accessService.maySwitchGenealogy(alternativeChallenge);
+
+      // then
+      assert.notOk(accessResult);
+    });
+
+    test('it should return `true` when challenge is an alternative and user level is `REPLICATOR` or above', function (assert) {
+      // given
+      const alternativeChallenge = EmberObject.create({
+        id: 'rec123656',
+        isAlternative: true,
+      });
+
+      // when
+      _stubAccessLevel(REPLICATOR, this.owner);
+      const accessResultAsReplicator = accessService.maySwitchGenealogy(alternativeChallenge);
+      _stubAccessLevel(ADMIN, this.owner);
+      const accessResultAsAdmin = accessService.maySwitchGenealogy(alternativeChallenge);
+
+      // then
+      assert.ok(accessResultAsReplicator);
+      assert.ok(accessResultAsAdmin);
+    });
+  });
 });


### PR DESCRIPTION
## 🪧 Problème

Un problème lié à un potentiel `git push --force` a eu lieu sur la PR #1540.
Tout le code front-end a ainsi disparu de la PR.

## 🌈 Proposition

Rétablir les commits qui ont disparu.

## ✊ Remarques

C'est bizarre cette histoire.

## 🎉 Pour tester
- Aller sur la page d'un proto ayant au moins une déclinaison (/competence/:id/prototypes/:prototypeId)
- Cliquer sur le bouton d'inversion
- Vérifier que le proto et sa/ses déclinaison(s) ont été inversés
- Rejouer le test sur un proto ayant une déclinaison en version null et vérifier qu'il n'y a pas d'erreur