### PR TITLE
[TECH] Ne pas enregister les tags de maintenance sous forme de tableau vide mais avec la valeur `null` lorseque challenge ne comporte pas de tag de maintenance (PIX-23767) .

### DIFF
--- a/api/db/migrations/20260803132526_update_maintenance_tags.js
+++ b/api/db/migrations/20260803132526_update_maintenance_tags.js
@@ -1,0 +1,21 @@
+const TABLE_NAME = 'challenges';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex(TABLE_NAME)
+    .where('assessmentMaintenanceTags', '{[]}')
+    .update('assessmentMaintenanceTags', null);
+
+  await knex(TABLE_NAME)
+    .where('translationMaintenanceTags', '{[]}')
+    .update('translationMaintenanceTags', null);
+}
+
+/**
+ * @returns { Promise<void> }
+ */
+export async function down() {
+}

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -84,8 +84,8 @@ export class Challenge {
     this.updatedAt = updatedAt;
     this.validatedAt = validatedAt;
     this.version = version;
-    this.assessmentMaintenanceTags = genealogy === Challenge.GENEALOGIES.PROTOTYPE || prototypeChallenge == null ? assessmentMaintenanceTags : prototypeChallenge.assessmentMaintenanceTags;
-    this.translationMaintenanceTags = genealogy === Challenge.GENEALOGIES.PROTOTYPE || prototypeChallenge == null ? translationMaintenanceTags : prototypeChallenge.translationMaintenanceTags;
+    this.assessmentMaintenanceTags = this.#setMaintenanceTags({ maintenanceTag: assessmentMaintenanceTags, key: 'assessmentMaintenanceTags', genealogy, prototypeChallenge });
+    this.translationMaintenanceTags = this.#setMaintenanceTags({ maintenanceTag: translationMaintenanceTags, key: 'translationMaintenanceTags', genealogy, prototypeChallenge });
 
     this.localizedChallenges = localizedChallenges;
 
@@ -532,6 +532,11 @@ export class Challenge {
   #translateValidatedAt(localizedChallenge) {
     if (this.isPrimary) return this.validatedAt;
     return localizedChallenge.validatedAt;
+  }
+
+  #setMaintenanceTags({ maintenanceTag, genealogy, prototypeChallenge, key }) {
+    const result = genealogy === Challenge.GENEALOGIES.PROTOTYPE || prototypeChallenge == null ? maintenanceTag : prototypeChallenge[key];
+    return (result && result.length) ? result : null;
   }
 
   obsolete() {

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -1658,6 +1658,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         proposals: 'propositions',
         embedTitle: "Titre d'embed",
         geography: 'NL',
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME],
       };
 
       databaseBuilder.factory.buildFramework({ id: 'recFmk1', name: 'Fmk 1' });
@@ -1729,6 +1731,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
         t2Status: true,
         t3Status: false,
         isQualityOk: true,
+        assessmentMaintenanceTags: [],
+        translationMaintenanceTags: [],
       };
 
       const server = await createServer();
@@ -1788,8 +1792,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
               'has-embed-internal-validation': true,
               'no-validation-needed': true,
               'is-quality-ok': true,
-              'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
-              'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
+              'assessment-maintenance-tags': newChallenge.assessmentMaintenanceTags,
+              'translation-maintenance-tags': newChallenge.translationMaintenanceTags,
             },
             relationships: {
               skill: {
@@ -1865,8 +1869,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
             'has-embed-internal-validation': true,
             'no-validation-needed': true,
             'is-quality-ok': true,
-            'assessment-maintenance-tags': [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
-            'translation-maintenance-tags': [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
+            'assessment-maintenance-tags': null,
+            'translation-maintenance-tags': null,
           },
           relationships: {
             skill: {
@@ -2026,8 +2030,8 @@ describe('Acceptance | Controller | challenges-controller', () => {
           updatedAt: expect.any(Date),
           validatedAt: new Date(newChallenge.validatedAt),
           version: newChallenge.version,
-          assessmentMaintenanceTags: newChallenge.assessmentMaintenanceTags,
-          translationMaintenanceTags: newChallenge.translationMaintenanceTags,
+          assessmentMaintenanceTags: null,
+          translationMaintenanceTags: null,
         },
       ]);
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -1211,6 +1211,32 @@ describe('Unit | Domain | Challenge', () => {
     });
   });
 
+  describe('static #defaultLocales', () => {
+    it('should set the default locale to "fr" if the given value is undefined', () => {
+      // when
+      const locales = Challenge.defaultLocales(undefined);
+
+      // then
+      expect(locales).toStrictEqual(['fr']);
+    });
+
+    it('should set the default locale to "fr" if the given value is an empty array', () => {
+      // when
+      const locales = Challenge.defaultLocales([]);
+
+      // then
+      expect(locales).toStrictEqual(['fr']);
+    });
+
+    it('should not change the default locale if the given value is not an empty array', () => {
+      // when
+      const locales = Challenge.defaultLocales(['blabla']);
+
+      // then
+      expect(locales).toStrictEqual(['blabla']);
+    });
+  });
+
   describe('obsolete', () => {
     it('obsoletes a challenge', () => {
       // given
@@ -1222,6 +1248,334 @@ describe('Unit | Domain | Challenge', () => {
       // then
       expect(challenge.status).toStrictEqual(Challenge.STATUSES.PERIME);
       expect(challenge.madeObsoleteAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('constructor', () => {
+    it('should create a challenge domain object', () => {
+      // given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId',
+        type: Challenge.TYPES.QCM,
+        t1Status: true,
+        t2Status: false,
+        t3Status: true,
+        status: Challenge.STATUSES.VALIDE,
+        skillId: 'recUDrCWD76fp5MsE',
+        timer: 1234,
+        competenceId: 'recsvLz0W2ShyfD63',
+        embedUrl: 'https://github.io/page/epreuve.html',
+        embedHeight: 500,
+        format: Challenge.FORMATS.PETIT,
+        autoReply: false,
+        locales: ['fr'],
+        focusable: false,
+        genealogy: Challenge.GENEALOGIES.PROTOTYPE,
+        pedagogy: Challenge.PEDAGOGIES.Q_SITUATION,
+        author: ['SPS'],
+        declinable: Challenge.DECLINABLES.FACILEMENT,
+        version: 1,
+        alternativeVersion: 2,
+        accessibility1: Challenge.ACCESSIBILITY1.OK,
+        accessibility2: Challenge.ACCESSIBILITY2.RAS,
+        spoil: 'Non Sp',
+        responsive: Challenge.RESPONSIVES.NON,
+        geography: 'FR',
+        files: [{ fileId: 'primaryLocalizedAttachmentId', localizedChallengeId: 'challengeId' }],
+        updatedAt: '2021-10-04',
+        createdAt: '1986-07-14',
+        validatedAt: '2023-02-02T14:17:30Z',
+        archivedAt: '2023-03-03T10:47:05Z',
+        madeObsoleteAt: '2023-04-04T10:47:05Z',
+        shuffled: false,
+        isQualityOk: false,
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD],
+      });
+
+      // when
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+            locale: 'fr',
+            embedUrl: challengeDTO.embedUrl,
+            status: LocalizedChallenge.STATUSES.PRIMARY,
+            geography: 'FR',
+            primaryEmbedUrl: 'https://example.com/embed.html',
+            fileIds: ['primaryLocalizedAttachmentId'],
+            urlsToConsult: ['http://url.com'],
+            requireGafamWebsiteAccess: false,
+            isIncompatibleIpadCertif: false,
+            deafAndHardOfHearing: LocalizedChallenge.DEAF_AND_HARD_OF_HEARING_VALUES.RAS,
+            isAwarenessChallenge: false,
+            toRephrase: false,
+            hasEmbedInternalValidation: false,
+            noValidationNeeded: false,
+            validatedAt: null,
+          }),
+        ],
+        ...challengeDTO,
+      });
+
+      // then
+      expect(challenge.id).toStrictEqual('challengeId');
+      expect(challenge.type).toStrictEqual(Challenge.TYPES.QCM);
+      expect(challenge.t1Status).toStrictEqual(true);
+      expect(challenge.t2Status).toStrictEqual(false);
+      expect(challenge.t3Status).toStrictEqual(true);
+      expect(challenge.status).toStrictEqual(Challenge.STATUSES.VALIDE);
+      expect(challenge.skillId).toStrictEqual('recUDrCWD76fp5MsE');
+      expect(challenge.timer).toStrictEqual(1234);
+      expect(challenge.competenceId).toStrictEqual('recsvLz0W2ShyfD63');
+      expect(challenge.embedUrl).toStrictEqual('https://github.io/page/epreuve.html');
+      expect(challenge.embedHeight).toStrictEqual(500);
+      expect(challenge.format).toStrictEqual(Challenge.FORMATS.PETIT);
+      expect(challenge.autoReply).toStrictEqual(false);
+      expect(challenge.locales).toStrictEqual(['fr']);
+      expect(challenge.focusable).toStrictEqual(false);
+      expect(challenge.genealogy).toStrictEqual(Challenge.GENEALOGIES.PROTOTYPE);
+      expect(challenge.pedagogy).toStrictEqual(Challenge.PEDAGOGIES.Q_SITUATION);
+      expect(challenge.author).toStrictEqual(['SPS']);
+      expect(challenge.declinable).toStrictEqual(Challenge.DECLINABLES.FACILEMENT);
+      expect(challenge.version).toStrictEqual(1);
+      expect(challenge.alternativeVersion).toStrictEqual(2);
+      expect(challenge.accessibility1).toStrictEqual(Challenge.ACCESSIBILITY1.OK);
+      expect(challenge.accessibility2).toStrictEqual(Challenge.ACCESSIBILITY2.RAS);
+      expect(challenge.spoil).toStrictEqual('Non Sp');
+      expect(challenge.responsive).toStrictEqual(Challenge.RESPONSIVES.NON);
+      expect(challenge.geography).toStrictEqual('FR');
+      expect(challenge.files).toStrictEqual(['primaryLocalizedAttachmentId']);
+      expect(challenge.updatedAt).toStrictEqual(challengeDTO.updatedAt);
+      expect(challenge.createdAt).toStrictEqual(challengeDTO.createdAt);
+      expect(challenge.validatedAt).toStrictEqual(challengeDTO.validatedAt);
+      expect(challenge.archivedAt).toStrictEqual(challengeDTO.archivedAt);
+      expect(challenge.madeObsoleteAt).toStrictEqual(challengeDTO.madeObsoleteAt);
+      expect(challenge.shuffled).toStrictEqual(false);
+      expect(challenge.isQualityOk).toStrictEqual(false);
+      expect(challenge.assessmentMaintenanceTags).toStrictEqual([Challenge.ASSESSMENT_MAINTENANCE_TAGS.AMBIGUOUS_ANSWERS, Challenge.ASSESSMENT_MAINTENANCE_TAGS.EXTERNAL_LINKS]);
+      expect(challenge.translationMaintenanceTags).toStrictEqual([Challenge.TRANSLATION_MAINTENANCE_TAGS.EMBED_NAME, Challenge.TRANSLATION_MAINTENANCE_TAGS.ENGLISH_WORD]);
+    });
+
+    it('should set the timer to undefined if it is set to 0', () => {
+      // given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({ timer: 0 });
+
+      // when
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+          }),
+        ],
+        ...challengeDTO,
+      });
+
+      // then
+      expect(challenge.timer).toStrictEqual(undefined);
+    });
+
+    it('should set the accessibility tags to the prototypes tags', () => {
+      // given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId',
+        genealogy: Challenge.GENEALOGIES.DECLINAISON,
+      });
+
+      const protoChallengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        accessibility1: Challenge.ACCESSIBILITY1.NONE,
+        accessibility2: Challenge.ACCESSIBILITY2.KO,
+      });
+
+      // when
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+          }),
+        ],
+        prototypeChallenge: protoChallengeDTO,
+        ...challengeDTO,
+      });
+
+      // then
+      expect(challenge.accessibility1).toStrictEqual(Challenge.ACCESSIBILITY1.NONE);
+      expect(challenge.accessibility2).toStrictEqual(Challenge.ACCESSIBILITY2.KO);
+    });
+
+    it('should set the maintenance tags to the prototypes tags', () => {
+      // given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId',
+        genealogy: Challenge.GENEALOGIES.DECLINAISON,
+      });
+
+      const protoChallengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        assessmentMaintenanceTags: [Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE, Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE],
+        translationMaintenanceTags: [Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO, Challenge.TRANSLATION_MAINTENANCE_TAGS.ILLUSTRATION_SCREENSHOT],
+      });
+
+      // when
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+          }),
+        ],
+        prototypeChallenge: protoChallengeDTO,
+        ...challengeDTO,
+      });
+
+      // then
+      expect(challenge.assessmentMaintenanceTags).toStrictEqual([Challenge.ASSESSMENT_MAINTENANCE_TAGS.INTERFACE, Challenge.ASSESSMENT_MAINTENANCE_TAGS.KNOWN_EXPIRY_DATE]);
+      expect(challenge.translationMaintenanceTags).toStrictEqual([Challenge.TRANSLATION_MAINTENANCE_TAGS.FILE_TO_REDO, Challenge.TRANSLATION_MAINTENANCE_TAGS.ILLUSTRATION_SCREENSHOT]);
+    });
+
+    it('should set the format to MOTS if it is not set', () => {
+      // given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId',
+        format: null,
+      });
+
+      // when
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+          }),
+        ],
+        ...challengeDTO,
+      });
+
+      // then
+      expect(challenge.format).toStrictEqual(Challenge.FORMATS.MOTS);
+    });
+
+    it('should set the primary locales to [\'fr\'] if it is not set', () => {
+      // given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId',
+        locales: null,
+      });
+
+      // when
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+          }),
+        ],
+        ...challengeDTO,
+      });
+
+      // then
+      expect(challenge.primaryLocale).toStrictEqual('fr');
+    });
+
+    it('should set `assessmentMaintenanceTags` and `translationMaintenanceTags` to null if value is empty array', () => {
+      // Given
+      const challengeDTO = domainBuilder.buildChallengeDatasourceObject({
+        id: 'challengeId',
+        assessmentMaintenanceTags: [],
+        translationMaintenanceTags: [],
+      });
+      // When
+      const challenge = new Challenge({
+        translations: {
+          fr: {
+            instruction: challengeDTO.instruction,
+            alternativeInstruction: challengeDTO.alternativeInstruction,
+            proposals: challengeDTO.proposals,
+            solution: challengeDTO.solution,
+            solutionToDisplay: challengeDTO.solutionToDisplay,
+            embedTitle: challengeDTO.embedTitle,
+            illustrationAlt: challengeDTO.illustrationAlt,
+          },
+        },
+        localizedChallenges: [
+          domainBuilder.buildLocalizedChallenge({
+            id: challengeDTO.id,
+            challengeId: challengeDTO.id,
+          }),
+        ],
+        ...challengeDTO,
+      });
+      // Then
+      expect(challenge.assessmentMaintenanceTags).toBeNull();
+      expect(challenge.translationMaintenanceTags).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème
Lorseque qu'un des deux champs de tag de maintenance est vidé depuis l'IHM de pix-editor alors il est enregistrer sous forme de tableau vide. Cela pose problème lors des recherche sur l'absence de ces tag.

## ⛱️ Proposition
Remplacer les tableaux vides par la valeur `null` lors de l'update d'un challenge

## 🧴 Remarques

RAS

## 🏊 Pour tester

Supprimer les valeurs d'un des tag de maintenance et constater qu'il est percisté avec pour valeur `null`.