### PR TITLE
[FEATURE] Limiter l'accès à l'inversion de la généalogie aux admin (PIX-23801)

### DIFF
--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -139,7 +139,7 @@ export async function register(server) {
       path: '/api/challenges/{challengeId}/switch-genealogy',
       config: {
         validate: { params: Joi.object({ challengeId: challengeIdType }) },
-        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
+        pre: [{ method: securityPreHandlers.checkUserHasAdminAccess }],
         handler: async function(request, h) {
           const { challengeId } = request.params;
           await switchGenealogy({ alternativeChallengeId: challengeId });

--- a/api/tests/acceptance/application/challenges/challenges_test.js
+++ b/api/tests/acceptance/application/challenges/challenges_test.js
@@ -2871,5 +2871,24 @@ describe('Acceptance | Controller | challenges-controller', () => {
         { key: `challenge.${challengeDecliId}.solutionToDisplay`, locale: 'fr', value: 'challengeDecli.solutionToDisplay' },
       ]);
     });
+
+    it('should not switch genealogy when user is not admin', async () => {
+      // Given
+      const server = await createServer();
+      const editorUser = databaseBuilder.factory.buildEditorUser();
+
+      await databaseBuilder.commit();
+
+      // When
+      const response = await server.inject({
+        method: 'PATCH',
+        url: `/api/challenges/${challengeDecliId}/switch-genealogy`,
+        headers: generateAuthorizationHeader(editorUser),
+        payload: { data: {} },
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(403);
+    });
   });
 });

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -158,7 +158,7 @@ export default class AccessService extends Service {
   }
 
   maySwitchGenealogy(challenge) {
-    return this.isReplicator() && challenge.isValidated && challenge.isAlternative;
+    return this.isAdmin() && challenge.isValidated && challenge.isAlternative;
   }
 
   mayAccessAdministration() {

--- a/pix-editor/tests/acceptance/competence/prototypes/single/alternative/single-test.js
+++ b/pix-editor/tests/acceptance/competence/prototypes/single/alternative/single-test.js
@@ -148,4 +148,17 @@ module('Acceptance | Controller | Get Alternative challenge', function (hooks) {
     assert.ok(currentURL().startsWith(`/competence/${competence.id}/prototypes/${alternative.id}`));
     assert.dom(await screen.findByText('Ma consigne déclinée')).exists();
   });
+
+  test('it should not show the switch button when user is not admin', async function (assert) {
+    // given
+    this.server.db.users.remove();
+    this.server.create('user', { trigram: 'DEF', access: 'editor' });
+
+    const screen = await visit(
+      `/competence/${competence.id}/prototypes/${prototype.id}/alternatives/${alternative.id}`,
+    );
+
+    // when then
+    assert.dom(screen.queryByRole('button', { name: 'Inverser avec le prototype' })).doesNotExist();
+  });
 });

--- a/pix-editor/tests/unit/services/access-test.js
+++ b/pix-editor/tests/unit/services/access-test.js
@@ -294,7 +294,7 @@ module('Unit | Service | access', function (hooks) {
   module('maySwitchGenealogy', function () {
     test('it should return `false` when challenge is not an alternative', function (assert) {
       // given
-      _stubAccessLevel(REPLICATOR, this.owner);
+      _stubAccessLevel(ADMIN, this.owner);
       const prototypeChallenge = EmberObject.create({
         id: 'rec123656',
         isAlternative: false,
@@ -310,7 +310,7 @@ module('Unit | Service | access', function (hooks) {
 
     test('it should return `false` when challenge is not validated', function (assert) {
       // given
-      _stubAccessLevel(REPLICATOR, this.owner);
+      _stubAccessLevel(ADMIN, this.owner);
       const prototypeChallenge = EmberObject.create({
         id: 'rec123656',
         isAlternative: true,
@@ -324,10 +324,9 @@ module('Unit | Service | access', function (hooks) {
       assert.notOk(accessResult);
     });
 
-    test('it should return `false` when user level is lower than `REPLICATOR` level', function (assert) {
+    test('it should return `false` when user level is lower than `ADMIN` level', function (assert) {
       // given
-      const READ_ONLY = 1;
-      _stubAccessLevel(READ_ONLY, this.owner);
+      _stubAccessLevel(REPLICATOR, this.owner);
       const alternativeChallenge = EmberObject.create({
         id: 'rec123656',
         isAlternative: true,
@@ -341,7 +340,7 @@ module('Unit | Service | access', function (hooks) {
       assert.notOk(accessResult);
     });
 
-    test('it should return `true` when challenge is an alternative and user level is `REPLICATOR` or above', function (assert) {
+    test('it should return `true` when challenge is an alternative and user level is `ADMIN`', function (assert) {
       // given
       const alternativeChallenge = EmberObject.create({
         id: 'rec123656',
@@ -350,13 +349,10 @@ module('Unit | Service | access', function (hooks) {
       });
 
       // when
-      _stubAccessLevel(REPLICATOR, this.owner);
-      const accessResultAsReplicator = accessService.maySwitchGenealogy(alternativeChallenge);
       _stubAccessLevel(ADMIN, this.owner);
       const accessResultAsAdmin = accessService.maySwitchGenealogy(alternativeChallenge);
 
       // then
-      assert.ok(accessResultAsReplicator);
       assert.ok(accessResultAsAdmin);
     });
   });


### PR DESCRIPTION
## ☀️ Problème
Jusqu'ici, ce bouton était accessible aux rôles supérieurs ou égaux à 'replicator'. Or, on veut que seuls les admins puissent faire cette action

## ⛱️ Proposition
Changer le rôle de qui a accès au bouton aux admins uniquement.

## 🧴 Remarques
RAS

## 🏊 Pour tester
1/ Accéder à Pix Editor en mode admin et constater qu'on peut accéder au bouton "inverser avec le prototype" dans la page d'une déclinaison
2/ Accéder à Pix Editor dans un autre mode (lecteur, réplicateur, éditeur) et constater qu'on ne peut pas accéder au bouton "inverser avec le prototype" dans la page d'une déclinaison
Tests au vert ✅ 