### PR TITLE
[FEATURE] Afficher les erreurs de la page de détails (PIX-23278).

### DIFF
--- a/pix-editor/app/components/modules/validation-errors.gjs
+++ b/pix-editor/app/components/modules/validation-errors.gjs
@@ -1,0 +1,33 @@
+import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
+import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import Component from '@glimmer/component';
+
+export default class ModuleValidationErrors extends Component {
+  get formattedTag() {
+    const numberOfErrors = this.args.validationErrors.length;
+    return `${numberOfErrors} erreur${numberOfErrors > 1 ? 's' : ''}`;
+  }
+
+  <template>
+    <PixAccordions
+      @iconName="error"
+      @isV2Version={{true}}
+      @tagContent={{this.formattedTag}}
+      @tagColor="error"
+      class="module-validation-errors"
+    >
+      <:title>Erreurs de validation</:title>
+      <:content>
+        <ul>
+          {{#each @validationErrors as |validationError|}}
+            <li class="module-validation-errors__notification">
+              <PixNotificationAlert @withIcon={{true}} @type="error">
+                {{validationError}}
+              </PixNotificationAlert>
+            </li>
+          {{/each}}
+        </ul>
+      </:content>
+    </PixAccordions>
+  </template>
+}

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -1,10 +1,13 @@
-import { belongsTo } from '@ember-data/model';
+import { attr, belongsTo } from '@ember-data/model';
 
 import BaseModule from './base-module';
 
 export default class DraftModule extends BaseModule {
   @belongsTo('module', { inverse: 'draftModule', async: true }) module;
   @belongsTo('draft-module-diff', { inverse: null, async: true }) diff;
+
+  @attr hasBeenValidated;
+  @attr validationErrors;
 
   get isDraft() {
     return true;

--- a/pix-editor/app/serializers/draft-module.js
+++ b/pix-editor/app/serializers/draft-module.js
@@ -6,5 +6,7 @@ export default class DraftModuleSerializer extends ApplicationSerializer {
     shortId: { serialize: false },
     previewUrl: { serialize: false },
     url: { serialize: false },
+    hasBeenValidated: { serialize: false },
+    validationErrors: { serialize: false },
   };
 }

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -41,6 +41,7 @@
 @use 'components/login-form';
 @use 'components/markdown-editor/markdown-editor';
 @use 'components/modules/module-form';
+@use 'components/modules/validation-errors';
 @use 'components/field';
 @use 'components/field/quality';
 @use 'components/field/select-search';

--- a/pix-editor/app/styles/components/modules/module-form.scss
+++ b/pix-editor/app/styles/components/modules/module-form.scss
@@ -14,7 +14,14 @@
   }
 
   &__actions {
+    position: sticky;
     display: flex;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--pix-neutral-20);
+    padding: var(--pix-spacing-4x);
+    z-index: 1000;
     flex-direction: row-reverse;
     gap: var(--pix-spacing-4x);
     justify-items: start;

--- a/pix-editor/app/styles/components/modules/validation-errors.scss
+++ b/pix-editor/app/styles/components/modules/validation-errors.scss
@@ -1,0 +1,10 @@
+.module-validation-errors {
+
+  .pix-accordions-v2-title__container {
+    font-family: inherit;
+  }
+
+  &__notification {
+    margin-bottom: var(--pix-spacing-4x);
+  }
+}

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,38 +1,54 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import Component from '@glimmer/component';
 import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModuleNotification from 'pixeditor/components/modules/module-notification';
 import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons';
 import PublishModuleButton from 'pixeditor/components/modules/publish-module-button';
+import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 
-<template>
-  <header class="page-header">
-    <h1 class="page-title">Détail du draft de module</h1>
-    <div class="page-actions">
-      <PlayModuleButtons @module={{@model.draftModule}} />
-      <PixButtonLink
-        @route="authenticated.modules.edit-draft-module"
-        @model={{@model.draftModule.id}}
-        class="pix-button-link-with-icon white-font"
-        @iconBefore="edit"
-      >
-        Modifier
-      </PixButtonLink>
-      <PublishModuleButton @draftModule={{@model.draftModule}} />
-    </div>
-  </header>
-  <main class="page-body">
-    <section class="page-section module-form">
-      <ModuleNotification @module={{@model.draftModule}} />
-      {{#if @model.draftModule.isEditionDraft}}
-        <DraftModuleDiff @draftModule={{@model.draftModule}} @htmlDiff={{@model.draftModuleDiff.htmlDiff}} />
-      {{else}}
-        <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
-      {{/if}}
+export default class DraftModule extends Component {
+  get hasValidationErrors() {
+    return !this.args.model.draftModule.hasBeenValidated && this.validationErrors?.length > 0;
+  }
+
+  get validationErrors() {
+    return this.args.model.draftModule.validationErrors;
+  }
+
+  <template>
+    <header class="page-header">
+      <h1 class="page-title">Détail du draft de module</h1>
       <div class="page-actions">
-        <ModuleBackButton />
+        <PlayModuleButtons @module={{@model.draftModule}} />
+        <PixButtonLink
+          @route="authenticated.modules.edit-draft-module"
+          @model={{@model.draftModule.id}}
+          class="pix-button-link-with-icon white-font"
+          @iconBefore="edit"
+        >
+          Modifier
+        </PixButtonLink>
+        <PublishModuleButton @draftModule={{@model.draftModule}} />
       </div>
-    </section>
-  </main>
-</template>
+    </header>
+    <main class="page-body">
+      <section class="page-section module-form">
+        <ModuleNotification @module={{@model.draftModule}} />
+        {{#if this.hasValidationErrors}}
+          <ModuleValidationErrors @validationErrors={{this.validationErrors}} />
+        {{/if}}
+
+        {{#if @model.draftModule.isEditionDraft}}
+          <DraftModuleDiff @draftModule={{@model.draftModule}} @htmlDiff={{@model.draftModuleDiff.htmlDiff}} />
+        {{else}}
+          <ModuleForm @module={{@model.draftModule}} @readonly={{true}} />
+        {{/if}}
+        <div class="page-actions">
+          <ModuleBackButton />
+        </div>
+      </section>
+    </main>
+  </template>
+}

--- a/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import ModuleForm from 'pixeditor/components/modules/module-form';
+import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 
 export default class NewModule extends Component {
   @service loader;
@@ -36,6 +37,14 @@ export default class NewModule extends Component {
     }
   }
 
+  get hasValidationErrors() {
+    return !this.args.model.draftModule.hasBeenValidated && this.validationErrors?.length > 0;
+  }
+
+  get validationErrors() {
+    return this.args.model.draftModule.validationErrors;
+  }
+
   <template>
     <header class="page-header">
       <h1 class="page-title">
@@ -44,6 +53,10 @@ export default class NewModule extends Component {
     </header>
     <main class="page-body">
       <section class="page-section module-form">
+        {{#if this.hasValidationErrors}}
+          <ModuleValidationErrors @validationErrors={{this.validationErrors}} />
+        {{/if}}
+
         <ModuleForm @module={{@model.draftModule}} @saveModule={{this.saveModule}} />
       </section>
     </main>

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -76,4 +76,35 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
     });
   });
+
+  module('when a module has errors', function () {
+    test('it should display errors', async function (assert) {
+      // given
+      const moduleWithErrors = this.server.create('draft-module', {
+        id: crypto.randomUUID(),
+        internalTitle: 'MODULE_DRAFT',
+        validationErrors: ['oups !'],
+      });
+
+      // when
+      const screen = await visit(`/modules/workbench/${moduleWithErrors.id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Erreurs de validation 1 erreur' })).exists();
+    });
+  });
+
+  module('when a module has no errors', function () {
+    test('it should not display errors', async function (assert) {
+      // given
+      const screen = await visit(`/modules/workbench/${id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Erreurs de validation 1 erreur' })).doesNotExist();
+    });
+  });
 });

--- a/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
@@ -1,0 +1,54 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
+import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+module('Acceptance | Modules | Edit Draft Module', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+
+    return authenticateSession();
+  });
+
+  module('when a module has errors', function () {
+    test('it should display errors', async function (assert) {
+      // given
+      const moduleWithErrors = this.server.create('draft-module', {
+        id: crypto.randomUUID(),
+        internalTitle: 'MODULE_DRAFT',
+        validationErrors: ['oups !'],
+      });
+
+      // when
+      const screen = await visit(`/modules/workbench/${moduleWithErrors.id}/edit`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Erreurs de validation 1 erreur' })).exists();
+    });
+  });
+
+  module('when a module has no errors', function () {
+    test('it should not display errors', async function (assert) {
+      // given
+      const module = this.server.create('draft-module', {
+        id: crypto.randomUUID(),
+        internalTitle: 'MODULE_DRAFT',
+        validationErrors: [],
+      });
+
+      const screen = await visit(`/modules/workbench/${module.id}/edit`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Erreurs de validation 1 erreur' })).doesNotExist();
+    });
+  });
+});

--- a/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
@@ -1,0 +1,25 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | modules/validation-errors', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display errors', async function (assert) {
+    // given
+    const validationErrors = ['Le slug est mal formatté', "Problème de duplications d'Ids"];
+
+    // where
+    const screen = await render(<template><ModuleValidationErrors @validationErrors={{validationErrors}} /></template>);
+
+    // then
+    const accordion = screen.getByRole('button', { name: 'Erreurs de validation 2 erreurs' });
+    await click(accordion);
+    const listItems = screen.getAllByRole('listitem');
+    assert.dom(listItems[0]).hasText('Le slug est mal formatté');
+    assert.dom(listItems[1]).hasText("Problème de duplications d'Ids");
+  });
+});


### PR DESCRIPTION
## ☀️ Problème
On remonte actuellement les erreurs de validation des drafts via l'API, mais on ne peut pas les visualiser dans pix-editor.

## ⛱️ Proposition
Les afficher dans le front

## 🧴 Remarques
Avant de merger cette PR, Il faut merger la [PR](https://github.com/1024pix/pix-editor/pull/1573) 

## 🏊 Pour tester
Faire les mêmes tests que sur la [PR ](https://github.com/1024pix/pix-editor/pull/1573)
