### PR TITLE
[FEATURE] Ajouter le statut de validation d'un module (PIX-23588).

### DIFF
--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -25,6 +25,7 @@
 @use 'mde';
 @use 'popin';
 @use 'pages/login';
+@use 'pages/draft-module';
 @use 'authenticated';
 @use 'authenticated/missions/new' as missions-new;
 @use 'authenticated/missions/details' as missions-details;

--- a/pix-editor/app/styles/pages/draft-module.scss
+++ b/pix-editor/app/styles/pages/draft-module.scss
@@ -1,0 +1,6 @@
+.draft-module {
+  &__description {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+  }
+}

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,4 +1,5 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import Component from '@glimmer/component';
 import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
@@ -15,6 +16,18 @@ export default class DraftModule extends Component {
 
   get validationErrors() {
     return this.args.model.draftModule.validationErrors;
+  }
+
+  get validationStatus() {
+    return this.args.model.draftModule.hasBeenValidated;
+  }
+
+  get validationStatusLabel() {
+    return this.validationStatus ? 'Succès' : 'Échec';
+  }
+
+  get validationStatusColor() {
+    return this.validationStatus ? 'green' : 'error';
   }
 
   <template>
@@ -36,6 +49,14 @@ export default class DraftModule extends Component {
     <main class="page-body">
       <section class="page-section module-form">
         <ModuleNotification @module={{@model.draftModule}} />
+        <dl class="draft-module__description">
+          <dt>
+            Statut de validation :
+          </dt>
+          <dd><PixTag @color={{this.validationStatusColor}}>
+              {{this.validationStatusLabel}}
+            </PixTag></dd>
+        </dl>
         {{#if this.hasValidationErrors}}
           <ModuleValidationErrors @validationErrors={{this.validationErrors}} />
         {{/if}}

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -94,6 +94,25 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       // then
       assert.dom(screen.getByRole('button', { name: 'Erreurs de validation 1 erreur' })).exists();
     });
+
+    test('it should display validation status', async function (assert) {
+      // given
+      const moduleWithErrors = this.server.create('draft-module', {
+        id: crypto.randomUUID(),
+        internalTitle: 'MODULE_DRAFT',
+        validationErrors: ['oups !'],
+        hasBeenValidated: false,
+      });
+
+      // when
+      const screen = await visit(`/modules/workbench/${moduleWithErrors.id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // then
+      assert.dom(screen.getByRole('term')).hasText('Statut de validation :');
+      assert.dom(screen.getByRole('definition')).hasText('Échec');
+    });
   });
 
   module('when a module has no errors', function () {
@@ -105,6 +124,25 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
 
       // then
       assert.dom(screen.queryByRole('button', { name: 'Erreurs de validation 1 erreur' })).doesNotExist();
+    });
+
+    test('it should display validation status', async function (assert) {
+      // given
+      const module = this.server.create('draft-module', {
+        id: crypto.randomUUID(),
+        internalTitle: 'MODULE_DRAFT',
+        validationErrors: [],
+        hasBeenValidated: true,
+      });
+
+      // when
+      const screen = await visit(`/modules/workbench/${module.id}`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // then
+      assert.dom(screen.getByRole('term')).hasText('Statut de validation :');
+      assert.dom(screen.getByRole('definition')).hasText('Succès');
     });
   });
 });


### PR DESCRIPTION
## ☀️ Problème

Maintenant, lors de la création et la modification d'un draft module, on lance une validation. 
On veut permettre au métier de voir l'état de la validation.

## ⛱️ Proposition

Ajouter le statut de validation d'un draft module, sur la page de détail d'un draft uniquement.

## 🏊 Pour tester

Aller sur la page de détail du draft "escargot" et voir le statut de validation en échec
Aller sur l'autre page de détail du draft "bac-à-sable" et voir le statut de validation en succès