### PR TITLE
[TECH] Utiliser des clés de traductions sur les pages des modules (PIX-23839)

### DIFF
--- a/pix-editor/app/components/modules/create-module-button.gjs
+++ b/pix-editor/app/components/modules/create-module-button.gjs
@@ -1,5 +1,6 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 
 export default class CreateModuleButton extends Component {
   get isDisplayed() {
@@ -23,9 +24,9 @@ export default class CreateModuleButton extends Component {
         @iconBefore="add"
       >
         {{#if @module}}
-          Créer un draft
+          {{t "modules.components.create-module-button.create-draft"}}
         {{else}}
-          Créer un module
+          {{t "modules.components.create-module-button.create-module"}}
         {{/if}}
       </PixButtonLink>
     {{/if}}

--- a/pix-editor/app/components/modules/module-back-button.gjs
+++ b/pix-editor/app/components/modules/module-back-button.gjs
@@ -1,9 +1,10 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import t from 'ember-intl/helpers/t';
 
 function back() {
   return window.history.back();
 }
 
 <template>
-  <PixButton @triggerAction={{back}}>Retour</PixButton>
+  <PixButton @triggerAction={{back}}>{{t "modules.components.module-back-button.back"}}</PixButton>
 </template>

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -4,11 +4,15 @@ import PixLabel from '@1024pix/pix-ui/components/pix-label';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import t from 'ember-intl/helpers/t';
 import MonacoEditor from 'pixeditor/components/monaco-editor/monaco-editor';
 
 export default class ModuleForm extends Component {
+  @service intl;
+
   @tracked internalTitle;
   @tracked moduleData;
 
@@ -16,7 +20,7 @@ export default class ModuleForm extends Component {
     super(...args);
 
     this.monacoOptions = {
-      ariaLabel: 'Contenu (JSON)',
+      ariaLabel: this.intl.t('modules.components.module-form.content-label'),
       ariaRequired: true,
       automaticLayout: true,
       domReadOnly: this.args.readonly,
@@ -69,11 +73,11 @@ export default class ModuleForm extends Component {
     <div class="module-form">
       {{#if this.isIdsChangedWarningDisplayed}}
         <PixNotificationAlert @type="warning">
-          Les champs
+          {{t "modules.components.module-form.ids-warning-prefix"}}
           <code>id</code>
-          et
+          {{t "modules.components.module-form.ids-warning-middle"}}
           <code>shortId</code>
-          ne peuvent pas être modifiés.
+          {{t "modules.components.module-form.ids-warning-suffix"}}
         </PixNotificationAlert>
       {{/if}}
 
@@ -83,16 +87,16 @@ export default class ModuleForm extends Component {
         <PixInput
           @id="internalTitle"
           @value={{this.internalTitle}}
-          @requiredLabel="Champ obligatoire"
+          @requiredLabel={{t "modules.components.module-form.required-field"}}
           {{on "change" this.onInternalTitleChange}}
         >
-          <:label>Titre interne</:label>
+          <:label>{{t "modules.components.module-form.internal-title-label"}}</:label>
         </PixInput>
       {{/if}}
 
       <div class="module-form__data-field">
-        <PixLabel @requiredLabel="Champ obligatoire">
-          Contenu (JSON)
+        <PixLabel @requiredLabel={{t "modules.components.module-form.required-field"}}>
+          {{t "modules.components.module-form.content-label"}}
         </PixLabel>
         <MonacoEditor @options={{this.monacoOptions}} class="module-form__monaco-editor" @onChange={{this.onChange}} />
       </div>
@@ -100,10 +104,10 @@ export default class ModuleForm extends Component {
       {{#unless @readonly}}
         <div class="module-form__actions">
           <PixButton @triggerAction={{this.saveModule}} @isDisabled={{this.isSaveDisabled}}>
-            Enregistrer
+            {{t "modules.components.module-form.save"}}
           </PixButton>
           <PixButton @triggerAction={{this.back}} @variant="secondary">
-            Annuler
+            {{t "modules.components.module-form.cancel"}}
           </PixButton>
         </div>
       {{/unless}}

--- a/pix-editor/app/components/modules/module-notification.gjs
+++ b/pix-editor/app/components/modules/module-notification.gjs
@@ -1,18 +1,19 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 
 const NOTIFICATION_STATES = {
   DRAFT: {
     color: 'warning',
-    information: 'Ce module possède une version disponible en production.',
-    redirectionButtonLabel: 'Voir le détail du module en prod',
+    informationKey: 'modules.components.module-notification.draft-information',
+    redirectionButtonLabelKey: 'modules.components.module-notification.draft-redirection',
     route: 'authenticated.modules.production-module',
   },
   PRODUCTION: {
     color: 'info',
-    information: 'Ce module possède une version en cours de modification.',
-    redirectionButtonLabel: 'Voir le détail des modifications',
+    informationKey: 'modules.components.module-notification.production-information',
+    redirectionButtonLabelKey: 'modules.components.module-notification.production-redirection',
     route: 'authenticated.modules.draft-module',
   },
 };
@@ -41,9 +42,9 @@ export default class ModuleNotification extends Component {
         @type={{this.notificationState.color}}
         class="module-form-notification--{{this.notificationState.color}}"
       >
-        {{this.notificationState.information}}
+        {{t this.notificationState.informationKey}}
         <PixButtonLink @route={{this.notificationState.route}} @model={{this.moduleId}} @variant="secondary">
-          {{this.notificationState.redirectionButtonLabel}}
+          {{t this.notificationState.redirectionButtonLabelKey}}
         </PixButtonLink>
       </PixNotificationAlert>
     {{/if}}

--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -5,6 +5,7 @@ import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 
 import PlayModuleButton from './play-module-button';
 
@@ -21,12 +22,12 @@ export default class Product extends Component {
   }
 
   <template>
-    <PixTable @variant="modulix" @data={{@modules}} @caption="Liste des modules">
+    <PixTable @variant="modulix" @data={{@modules}} @caption={{t "modules.components.modules-list.caption"}}>
       <:columns as |module context|>
         {{#if @showStatus}}
           <PixTableColumn @context={{context}}>
             <:header>
-              Statut
+              {{t "modules.components.modules-list.status"}}
             </:header>
             <:cell>
               <div class="modules-list__status">
@@ -42,7 +43,7 @@ export default class Product extends Component {
         {{/if}}
         <PixTableColumn @context={{context}}>
           <:header>
-            Titre interne
+            {{t "modules.components.modules-list.internal-title"}}
           </:header>
           <:cell>
             {{module.internalTitle}}
@@ -50,7 +51,7 @@ export default class Product extends Component {
         </PixTableColumn>
         <PixTableColumn @context={{context}}>
           <:header>
-            Niveau
+            {{t "modules.components.modules-list.level"}}
           </:header>
           <:cell>
             {{module.levelForDisplay}}
@@ -58,7 +59,7 @@ export default class Product extends Component {
         </PixTableColumn>
         <PixTableColumn @context={{context}} class="modules-list__actions">
           <:header>
-            <span class="sr-only">Actions</span>
+            <span class="sr-only">{{t "modules.components.modules-list.actions"}}</span>
           </:header>
           <:cell>
             <PixButtonLink
@@ -69,7 +70,7 @@ export default class Product extends Component {
               }}
               @model={{module.id}}
             >
-              Voir le détail
+              {{t "modules.components.modules-list.detail"}}
             </PixButtonLink>
             <PlayModuleButton @module={{module}} @isPreview={{module.isDraft}} />
             {{#if module.isEditionDraft}}
@@ -78,7 +79,7 @@ export default class Product extends Component {
                 @model={{module.moduleId}}
                 @variant="secondary"
               >
-                Voir le détail du module en prod
+                {{t "modules.components.modules-list.production-detail"}}
               </PixButtonLink>
             {{/if}}
           </:cell>

--- a/pix-editor/app/components/modules/modules-tabs.gjs
+++ b/pix-editor/app/components/modules/modules-tabs.gjs
@@ -1,13 +1,14 @@
 import PixTabs from '@1024pix/pix-ui/components/pix-tabs';
 import { LinkTo } from '@ember/routing';
+import t from 'ember-intl/helpers/t';
 
 <template>
-  <PixTabs @ariaLabel="Navigation">
+  <PixTabs @ariaLabel={{t "modules.components.modules-tabs.navigation"}}>
     <LinkTo @route="authenticated.modules.workbench">
-      Atelier
+      {{t "modules.components.modules-tabs.workbench"}}
     </LinkTo>
     <LinkTo @route="authenticated.modules.production">
-      En production
+      {{t "modules.components.modules-tabs.production"}}
     </LinkTo>
   </PixTabs>
 </template>

--- a/pix-editor/app/components/modules/play-module-button.gjs
+++ b/pix-editor/app/components/modules/play-module-button.gjs
@@ -1,4 +1,5 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import t from 'ember-intl/helpers/t';
 
 <template>
   <PixButtonLink
@@ -8,9 +9,13 @@ import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
     @iconAfter="openNew"
   >
     {{#if @isPreview}}
-      Prévisualiser
+      {{t "modules.components.play-module-button.preview"}}
     {{else}}
-      {{if @module.isDraft "Jouer le draft" "Jouer le module"}}
+      {{if
+        @module.isDraft
+        (t "modules.components.play-module-button.play-draft")
+        (t "modules.components.play-module-button.play-module")
+      }}
     {{/if}}
   </PixButtonLink>
 </template>

--- a/pix-editor/app/components/modules/publish-module-button.gjs
+++ b/pix-editor/app/components/modules/publish-module-button.gjs
@@ -2,8 +2,10 @@ import PixButton from '@1024pix/pix-ui/components/pix-button';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 
 export default class PublishModuleButton extends Component {
+  @service intl;
   @service loader;
   @service notifications;
   @service router;
@@ -11,22 +13,26 @@ export default class PublishModuleButton extends Component {
   @action async publish() {
     try {
       const module = await this.args.draftModule.publish();
-      this.notifications.sendSuccess(`Le module "${module.internalTitle}" a été publié.`);
+      this.notifications.sendSuccess(
+        this.intl.t('modules.components.publish-module-button.success', { title: module.internalTitle }),
+      );
       this.router.replaceWith('authenticated.modules.production-module', module.id);
     } catch {
-      this.notifications.sendError('Erreur lors de la publication du module.');
+      this.notifications.sendError(this.intl.t('modules.components.publish-module-button.error'));
     } finally {
       this.loader.stop();
     }
   }
 
   get ariaLabel() {
-    return `Publier le module "${this.args.draftModule.internalTitle}"`;
+    return this.intl.t('modules.components.publish-module-button.aria-label', {
+      title: this.args.draftModule.internalTitle,
+    });
   }
 
   <template>
     <PixButton @triggerAction={{this.publish}} @variant="success" aria-label={{this.ariaLabel}}>
-      Publier
+      {{t "modules.components.publish-module-button.publish"}}
     </PixButton>
   </template>
 }

--- a/pix-editor/app/components/modules/validation-errors.gjs
+++ b/pix-editor/app/components/modules/validation-errors.gjs
@@ -1,11 +1,16 @@
 import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
 import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 
 export default class ModuleValidationErrors extends Component {
+  @service intl;
+
   get formattedTag() {
-    const numberOfErrors = this.args.validationErrors.length;
-    return `${numberOfErrors} erreur${numberOfErrors > 1 ? 's' : ''}`;
+    return this.intl.t('modules.components.validation-errors.error-count', {
+      count: this.args.validationErrors.length,
+    });
   }
 
   <template>
@@ -16,7 +21,7 @@ export default class ModuleValidationErrors extends Component {
       @tagColor="error"
       class="module-validation-errors"
     >
-      <:title>Erreurs de validation</:title>
+      <:title>{{t "modules.components.validation-errors.title"}}</:title>
       <:content>
         <ul>
           {{#each @validationErrors as |validationError|}}

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,6 +1,8 @@
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
@@ -10,6 +12,8 @@ import PublishModuleButton from 'pixeditor/components/modules/publish-module-but
 import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 
 export default class DraftModule extends Component {
+  @service intl;
+
   get hasValidationErrors() {
     return !this.args.model.draftModule.hasBeenValidated && this.validationErrors?.length > 0;
   }
@@ -23,7 +27,9 @@ export default class DraftModule extends Component {
   }
 
   get validationStatusLabel() {
-    return this.validationStatus ? 'Succès' : 'Échec';
+    return this.validationStatus
+      ? this.intl.t('modules.draft-module.validation-success')
+      : this.intl.t('modules.draft-module.validation-failure');
   }
 
   get validationStatusColor() {
@@ -32,7 +38,7 @@ export default class DraftModule extends Component {
 
   <template>
     <header class="page-header">
-      <h1 class="page-title">Détail du draft de module</h1>
+      <h1 class="page-title">{{t "modules.draft-module.title"}}</h1>
       <div class="page-actions">
         <PlayModuleButtons @module={{@model.draftModule}} />
         <PixButtonLink
@@ -41,7 +47,7 @@ export default class DraftModule extends Component {
           class="pix-button-link-with-icon white-font"
           @iconBefore="edit"
         >
-          Modifier
+          {{t "modules.draft-module.edit"}}
         </PixButtonLink>
         <PublishModuleButton @draftModule={{@model.draftModule}} />
       </div>
@@ -51,7 +57,7 @@ export default class DraftModule extends Component {
         <ModuleNotification @module={{@model.draftModule}} />
         <dl class="draft-module__description">
           <dt>
-            Statut de validation :
+            {{t "modules.draft-module.validation-status-label"}}
           </dt>
           <dd><PixTag @color={{this.validationStatusColor}}>
               {{this.validationStatusLabel}}

--- a/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
@@ -1,10 +1,12 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 
 export default class NewModule extends Component {
+  @service intl;
   @service loader;
   @service notifications;
   @service router;
@@ -29,9 +31,9 @@ export default class NewModule extends Component {
       this.loader.start();
       await draftModule.save();
       this.router.replaceWith('authenticated.modules.draft-module', draftModule.id);
-      this.notifications.sendSuccess(`Le draft "${draftModule.internalTitle}" a été enregistré.`);
+      this.notifications.sendSuccess(this.intl.t('modules.new.draft-success', { title: draftModule.internalTitle }));
     } catch {
-      this.notifications.sendError('Erreur lors de l’enregistrement du draft.');
+      this.notifications.sendError(this.intl.t('modules.new.draft-error'));
     } finally {
       this.loader.stop();
     }
@@ -48,7 +50,7 @@ export default class NewModule extends Component {
   <template>
     <header class="page-header">
       <h1 class="page-title">
-        Édition du draft de module
+        {{t "modules.edit-draft-module.title"}}
       </h1>
     </header>
     <main class="page-body">

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -1,9 +1,11 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 
 export default class NewModule extends Component {
+  @service intl;
   @service loader;
   @service notifications;
   @service router;
@@ -30,16 +32,16 @@ export default class NewModule extends Component {
       await newModule.save();
       if (module) {
         this.router.replaceWith('authenticated.modules.draft-module', newModule.id);
-        this.notifications.sendSuccess(`Le draft "${newModule.internalTitle}" a été enregistré.`);
+        this.notifications.sendSuccess(this.intl.t('modules.new.draft-success', { title: newModule.internalTitle }));
       } else {
         this.router.replaceWith('authenticated.modules.workbench');
-        this.notifications.sendSuccess(`Le module "${newModule.internalTitle}" a été enregistré.`);
+        this.notifications.sendSuccess(this.intl.t('modules.new.module-success', { title: newModule.internalTitle }));
       }
     } catch {
       if (module) {
-        this.notifications.sendError('Erreur lors de l’enregistrement du draft.');
+        this.notifications.sendError(this.intl.t('modules.new.draft-error'));
       } else {
-        this.notifications.sendError('Erreur lors de l’enregistrement du module.');
+        this.notifications.sendError(this.intl.t('modules.new.module-error'));
       }
     } finally {
       this.loader.stop();
@@ -50,9 +52,9 @@ export default class NewModule extends Component {
     <header class="page-header">
       <h1 class="page-title">
         {{#if @model.module}}
-          Création d’un draft
+          {{t "modules.new.draft-title"}}
         {{else}}
-          Création d’un module
+          {{t "modules.new.module-title"}}
         {{/if}}
       </h1>
     </header>

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,3 +1,4 @@
+import t from 'ember-intl/helpers/t';
 import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
 import ModuleBackButton from 'pixeditor/components/modules/module-back-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
@@ -6,7 +7,7 @@ import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons'
 
 <template>
   <header class="page-header">
-    <h1 class="page-title">Détail du module</h1>
+    <h1 class="page-title">{{t "modules.production-module.title"}}</h1>
     <div class="page-actions">
       <PlayModuleButtons @module={{@model.module}} />
       <CreateModuleButton @module={{@model.module}} />

--- a/pix-editor/app/templates/authenticated/modules/production.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production.gjs
@@ -1,11 +1,12 @@
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import t from 'ember-intl/helpers/t';
 import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
 import ModuleList from 'pixeditor/components/modules/modules-list';
 import ModulesTabs from 'pixeditor/components/modules/modules-tabs';
 
 <template>
   <header class="page-header">
-    <h1 class="page-title">Modules</h1>
+    <h1 class="page-title">{{t "modules.production.title"}}</h1>
     <div class="page-actions">
       <CreateModuleButton />
     </div>

--- a/pix-editor/app/templates/authenticated/modules/workbench.gjs
+++ b/pix-editor/app/templates/authenticated/modules/workbench.gjs
@@ -1,11 +1,12 @@
 import PixPagination from '@1024pix/pix-ui/components/pix-pagination';
+import t from 'ember-intl/helpers/t';
 import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
 import ModuleList from 'pixeditor/components/modules/modules-list';
 import ModulesTabs from 'pixeditor/components/modules/modules-tabs';
 
 <template>
   <header class="page-header">
-    <h1 class="page-title">Modules</h1>
+    <h1 class="page-title">{{t "modules.workbench.title"}}</h1>
     <div class="page-actions">
       <CreateModuleButton />
     </div>

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -1,5 +1,6 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -24,11 +25,11 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
     // when
     const screen = await visit('/');
     await clickByName('Modules');
-    await clickByName('Voir le détail');
+    await clickByName(t('modules.components.modules-list.detail'));
 
     // then
     assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
-    assert.dom(screen.getByRole('heading', { name: 'Détail du draft de module' })).exists();
+    assert.dom(screen.getByRole('heading', { name: t('modules.draft-module.title') })).exists();
 
     // WORKAROUND: let some time for monaco-editor to settle
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -40,16 +41,16 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       const screen = await visit(`/modules/workbench/${id}`);
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));
-      await clickByName('Modifier');
+      await clickByName(t('modules.draft-module.edit'));
 
       // then
       assert.strictEqual(currentURL(), `/modules/workbench/${id}/edit`);
-      assert.dom(screen.getByRole('heading', { name: 'Édition du draft de module' })).exists();
+      assert.dom(screen.getByRole('heading', { name: t('modules.edit-draft-module.title') })).exists();
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // when
-      await clickByName('Enregistrer');
+      await clickByName(t('modules.components.module-form.save'));
 
       // then
       assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
@@ -66,10 +67,18 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // when
-      await click(screen.getByRole('button', { name: 'Publier le module "MON_BEAU_MODULE"' }));
+      await click(
+        screen.getByRole('button', {
+          name: t('modules.components.publish-module-button.aria-label', { title: 'MON_BEAU_MODULE' }),
+        }),
+      );
 
       // then
-      assert.dom(await screen.findByText('Le module "MON_BEAU_MODULE" a été publié.')).exists();
+      assert
+        .dom(
+          await screen.findByText(t('modules.components.publish-module-button.success', { title: 'MON_BEAU_MODULE' })),
+        )
+        .exists();
       assert.strictEqual(currentURL(), `/modules/production/${id}`);
 
       // WORKAROUND: let some time for monaco-editor to settle
@@ -92,7 +101,13 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Erreurs de validation 1 erreur' })).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+          }),
+        )
+        .exists();
     });
 
     test('it should display validation status', async function (assert) {
@@ -110,8 +125,8 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.getByRole('term')).hasText('Statut de validation :');
-      assert.dom(screen.getByRole('definition')).hasText('Échec');
+      assert.dom(screen.getByRole('term')).hasText(t('modules.draft-module.validation-status-label'));
+      assert.dom(screen.getByRole('definition')).hasText(t('modules.draft-module.validation-failure'));
     });
   });
 
@@ -123,7 +138,13 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.queryByRole('button', { name: 'Erreurs de validation 1 erreur' })).doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('button', {
+            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+          }),
+        )
+        .doesNotExist();
     });
 
     test('it should display validation status', async function (assert) {
@@ -141,8 +162,8 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.getByRole('term')).hasText('Statut de validation :');
-      assert.dom(screen.getByRole('definition')).hasText('Succès');
+      assert.dom(screen.getByRole('term')).hasText(t('modules.draft-module.validation-status-label'));
+      assert.dom(screen.getByRole('definition')).hasText(t('modules.draft-module.validation-success'));
     });
   });
 });

--- a/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
@@ -1,4 +1,5 @@
 import { visit } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -30,7 +31,13 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.getByRole('button', { name: 'Erreurs de validation 1 erreur' })).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+          }),
+        )
+        .exists();
     });
   });
 
@@ -48,7 +55,13 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.queryByRole('button', { name: 'Erreurs de validation 1 erreur' })).doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('button', {
+            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+          }),
+        )
+        .doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -1,6 +1,7 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { getByRole } from '@testing-library/dom';
+import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -26,16 +27,21 @@ module('Acceptance | Modules | New', function (hooks) {
     const screen = await visit('/');
 
     await click(await screen.findByRole('link', { name: 'Modules' }));
-    await click(await screen.findByRole('link', { name: 'Créer un module' }));
+    await click(await screen.findByRole('link', { name: t('modules.components.create-module-button.create-module') }));
 
     // then
-    assert.dom(await screen.findByRole('heading', { name: 'Création d’un module' })).exists();
+    assert.dom(await screen.findByRole('heading', { name: t('modules.new.module-title') })).exists();
     assert.strictEqual(currentURL(), '/modules/workbench/new');
 
-    await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'NEW_MODULE');
+    await fillIn(
+      await screen.findByRole('textbox', {
+        name: new RegExp(`^${t('modules.components.module-form.internal-title-label')}`),
+      }),
+      'NEW_MODULE',
+    );
 
     await fillIn(
-      await screen.findByLabelText('Contenu (JSON)'),
+      await screen.findByLabelText(t('modules.components.module-form.content-label')),
       JSON.stringify({
         title: 'Nouveau module',
         isBeta: true,
@@ -64,12 +70,12 @@ module('Acceptance | Modules | New', function (hooks) {
     // WORKAROUND: let some time for Monaco
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    await screen.getByRole('button', { name: 'Enregistrer' }).click();
+    await screen.getByRole('button', { name: t('modules.components.module-form.save') }).click();
 
-    assert.dom(await screen.findByRole('heading', { name: 'Modules' })).exists();
+    assert.dom(await screen.findByRole('heading', { name: t('modules.workbench.title') })).exists();
     assert.strictEqual(currentURL(), '/modules/workbench');
     assert.dom(screen.getByText('NEW_MODULE')).exists();
-    assert.dom(await screen.findByText('Le module "NEW_MODULE" a été enregistré.')).exists();
+    assert.dom(await screen.findByText(t('modules.new.module-success', { title: 'NEW_MODULE' }))).exists();
   });
 
   test.if('creates a new draft', !isChrome, async function (assert) {
@@ -78,31 +84,36 @@ module('Acceptance | Modules | New', function (hooks) {
 
     await click(await screen.findByRole('link', { name: 'Modules' }));
 
-    await click(await screen.findByRole('link', { name: 'En production' }));
+    await click(await screen.findByRole('link', { name: t('modules.components.modules-tabs.production') }));
 
     assert.dom(await screen.findByText('MOD_0')).exists();
     const firstModule = screen.getByText('MOD_0').closest('tr');
-    await click(getByRole(firstModule, 'link', { name: 'Voir le détail' }));
+    await click(getByRole(firstModule, 'link', { name: t('modules.components.modules-list.detail') }));
 
     const [, moduleId] = currentURL().match(/\/modules\/production\/(.*)$/);
 
     await new Promise((resolve) => setTimeout(resolve, 100));
-    await screen.getByRole('link', { name: 'Créer un draft' }).click();
+    await screen.getByRole('link', { name: t('modules.components.create-module-button.create-draft') }).click();
 
     // then
-    assert.dom(await screen.findByRole('heading', { name: 'Création d’un draft' })).exists();
+    assert.dom(await screen.findByRole('heading', { name: t('modules.new.draft-title') })).exists();
     assert.strictEqual(currentURL(), `/modules/workbench/new?moduleId=${moduleId}`);
 
-    await fillIn(await screen.findByRole('textbox', { name: /^Titre interne/ }), 'MOD_666');
+    await fillIn(
+      await screen.findByRole('textbox', {
+        name: new RegExp(`^${t('modules.components.module-form.internal-title-label')}`),
+      }),
+      'MOD_666',
+    );
 
     // WORKAROUND: let some time for Monaco
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    await screen.getByRole('button', { name: 'Enregistrer' }).click();
+    await screen.getByRole('button', { name: t('modules.components.module-form.save') }).click();
 
-    assert.dom(await screen.findByRole('heading', { name: 'Détail du draft de module' })).exists();
+    assert.dom(await screen.findByRole('heading', { name: t('modules.draft-module.title') })).exists();
     assert.strictEqual(currentURL(), `/modules/workbench/${moduleId}`);
     assert.dom(await screen.findByRole('heading', { name: 'MOD_666' })).exists();
-    assert.dom(await screen.findByText('Le draft "MOD_666" a été enregistré.')).exists();
+    assert.dom(await screen.findByText(t('modules.new.draft-success', { title: 'MOD_666' }))).exists();
   });
 });

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@1024pix/ember-testing-library';
 import { click, currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -26,8 +27,8 @@ module('Acceptance | Modules | Production Module', function (hooks) {
       // when
       const screen = await visit('/');
       await click(await screen.getByRole('link', { name: 'Modules' }));
-      await click(await screen.getByRole('link', { name: 'En production' }));
-      await click(await screen.getByRole('link', { name: 'Voir le détail' }));
+      await click(await screen.getByRole('link', { name: t('modules.components.modules-tabs.production') }));
+      await click(await screen.getByRole('link', { name: t('modules.components.modules-list.detail') }));
 
       // then
       assert.strictEqual(currentURL(), `/modules/production/${id}`);
@@ -42,7 +43,7 @@ module('Acceptance | Modules | Production Module', function (hooks) {
       // when
       const screen = await visit('/');
       await click(await screen.getByRole('link', { name: 'Modules' }));
-      await click(await screen.getByRole('link', { name: 'Voir le détail du module en prod' }));
+      await click(await screen.getByRole('link', { name: t('modules.components.modules-list.production-detail') }));
 
       // then
       assert.strictEqual(currentURL(), `/modules/production/${id}`);

--- a/pix-editor/tests/acceptance/modules/production-test.js
+++ b/pix-editor/tests/acceptance/modules/production-test.js
@@ -1,5 +1,6 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -22,21 +23,21 @@ module('Acceptance | Modules | Production', function (hooks) {
     // when
     const screen = await visit('/');
     await clickByName('Modules');
-    await clickByName('En production');
+    await clickByName(t('modules.components.modules-tabs.production'));
 
     // then
-    assert.dom(screen.getByRole('link', { name: 'Créer un module' })).exists();
+    assert.dom(screen.getByRole('link', { name: t('modules.components.create-module-button.create-module') })).exists();
   });
 
   test('displays modules with pagination', async function (assert) {
     // when
     const screen = await visit('/');
     await clickByName('Modules');
-    await clickByName('En production');
+    await clickByName(t('modules.components.modules-tabs.production'));
 
     // then
     assert.strictEqual(currentURL(), '/modules/production');
-    assert.dom(await screen.findByRole('heading', { name: 'Modules' })).exists();
+    assert.dom(await screen.findByRole('heading', { name: t('modules.production.title') })).exists();
 
     assert.dom(await screen.findByText('1-10 sur 36 éléments')).exists();
     assert.dom(await screen.findByText('Page 1 / 4')).exists();

--- a/pix-editor/tests/acceptance/modules/workbench-test.js
+++ b/pix-editor/tests/acceptance/modules/workbench-test.js
@@ -1,5 +1,6 @@
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import { currentURL } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
@@ -24,7 +25,7 @@ module('Acceptance | Modules | Workbench', function (hooks) {
     await clickByName('Modules');
 
     // then
-    assert.dom(screen.getByRole('link', { name: 'Créer un module' })).exists();
+    assert.dom(screen.getByRole('link', { name: t('modules.components.create-module-button.create-module') })).exists();
   });
 
   test('displays modules with pagination', async function (assert) {
@@ -34,7 +35,7 @@ module('Acceptance | Modules | Workbench', function (hooks) {
 
     // then
     assert.strictEqual(currentURL(), '/modules/workbench');
-    assert.dom(await screen.findByRole('heading', { name: 'Modules' })).exists();
+    assert.dom(await screen.findByRole('heading', { name: t('modules.workbench.title') })).exists();
 
     assert.dom(await screen.findByText('1-10 sur 36 éléments')).exists();
     assert.dom(await screen.findByText('Page 1 / 4')).exists();

--- a/pix-editor/tests/integration/components/modules/create-module-button-test.gjs
+++ b/pix-editor/tests/integration/components/modules/create-module-button-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
 import { module, test } from 'qunit';
 
@@ -38,9 +39,11 @@ module('Integration | Components | modules/create-module-button', function (hook
       const screen = await render(<template><CreateModuleButton @module={{module}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Créer un draft' })).exists();
       assert
-        .dom(screen.getByRole('link', { name: 'Créer un draft' }))
+        .dom(screen.getByRole('link', { name: t('modules.components.create-module-button.create-draft') }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: t('modules.components.create-module-button.create-draft') }))
         .hasAttribute('href', /\/modules\/workbench\/new\?moduleId=moduleId$/);
     });
   });
@@ -54,9 +57,11 @@ module('Integration | Components | modules/create-module-button', function (hook
       const screen = await render(<template><CreateModuleButton @module={{module}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Créer un module' })).exists();
       assert
-        .dom(screen.getByRole('link', { name: 'Créer un module' }))
+        .dom(screen.getByRole('link', { name: t('modules.components.create-module-button.create-module') }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: t('modules.components.create-module-button.create-module') }))
         .hasAttribute('href', /\/modules\/workbench\/new$/);
     });
   });

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click, fillIn } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -24,15 +25,17 @@ module('Integration | Component | modules/module-form', function (hooks) {
     const screen = await render(<template><ModuleForm @saveModule={{saveModule}} /></template>);
 
     // then
-    const saveButton = screen.getByRole('button', { name: 'Enregistrer' });
+    const saveButton = screen.getByRole('button', { name: t('modules.components.module-form.save') });
     assert.dom(saveButton).hasAttribute('aria-disabled');
 
-    const internalTitle = screen.getByRole('textbox', { name: /^Titre interne/ });
+    const internalTitle = screen.getByRole('textbox', {
+      name: new RegExp(`^${t('modules.components.module-form.internal-title-label')}`),
+    });
     await fillIn(internalTitle, 'PALOURDE_MAGIQUE');
 
     assert.dom(saveButton).hasAttribute('aria-disabled');
 
-    const monacoEditor = await screen.findByLabelText('Contenu (JSON)');
+    const monacoEditor = await screen.findByLabelText(t('modules.components.module-form.content-label'));
     assert.dom(monacoEditor).exists();
 
     await fillIn(monacoEditor, JSON.stringify({ slug: 'limaçoooooooooooooooooooon' }));
@@ -65,10 +68,16 @@ module('Integration | Component | modules/module-form', function (hooks) {
       const screen = await render(<template><ModuleForm @module={{module}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('textbox', { name: /^Titre interne/ })).hasValue(module.internalTitle);
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: new RegExp(`^${t('modules.components.module-form.internal-title-label')}`),
+          }),
+        )
+        .hasValue(module.internalTitle);
 
       assert
-        .dom(await screen.findByLabelText('Contenu (JSON)'))
+        .dom(await screen.findByLabelText(t('modules.components.module-form.content-label')))
         .hasValue(JSON.stringify(moduleWoInternalTitle, null, 2));
     });
   });
@@ -91,11 +100,19 @@ module('Integration | Component | modules/module-form', function (hooks) {
       const screen = await render(<template><ModuleForm @module={{module}} @readonly={{true}} /></template>);
 
       // then
-      assert.dom(await screen.queryByRole('textbox', { name: /^Titre interne/ })).doesNotExist();
+      assert
+        .dom(
+          await screen.queryByRole('textbox', {
+            name: new RegExp(`^${t('modules.components.module-form.internal-title-label')}`),
+          }),
+        )
+        .doesNotExist();
       assert.dom(screen.getByRole('heading', { name: 'MOL_escargot-loiret' })).exists();
 
-      assert.dom(await screen.queryByRole('button', { name: 'Enregistrer' })).doesNotExist();
-      assert.dom(await screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
+      assert.dom(await screen.queryByRole('button', { name: t('modules.components.module-form.save') })).doesNotExist();
+      assert
+        .dom(await screen.queryByRole('button', { name: t('modules.components.module-form.cancel') }))
+        .doesNotExist();
     });
   });
 });

--- a/pix-editor/tests/integration/components/modules/module-notification-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-notification-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import ModuleNotification from 'pixeditor/components/modules/module-notification';
 import { module, test } from 'qunit';
 
@@ -23,10 +24,12 @@ module('Integration | Component | modules/draft-module-diff', function (hooks) {
         const screen = await render(<template><ModuleNotification @module={{module}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Ce module possède une version en cours de modification.')).exists();
-        assert.dom(screen.getByRole('link', { name: 'Voir le détail des modifications' })).exists();
+        assert.dom(screen.getByText(t('modules.components.module-notification.production-information'))).exists();
         assert
-          .dom(screen.getByRole('link', { name: 'Voir le détail des modifications' }))
+          .dom(screen.getByRole('link', { name: t('modules.components.module-notification.production-redirection') }))
+          .exists();
+        assert
+          .dom(screen.getByRole('link', { name: t('modules.components.module-notification.production-redirection') }))
           .hasAttribute('href', /\/modules\/workbench\/draftModuleId$/);
       });
     });
@@ -64,10 +67,12 @@ module('Integration | Component | modules/draft-module-diff', function (hooks) {
         const screen = await render(<template><ModuleNotification @module={{draftModule}} /></template>);
 
         // then
-        assert.dom(screen.getByText('Ce module possède une version disponible en production.')).exists();
-        assert.dom(screen.getByRole('link', { name: 'Voir le détail du module en prod' })).exists();
+        assert.dom(screen.getByText(t('modules.components.module-notification.draft-information'))).exists();
         assert
-          .dom(screen.getByRole('link', { name: 'Voir le détail du module en prod' }))
+          .dom(screen.getByRole('link', { name: t('modules.components.module-notification.draft-redirection') }))
+          .exists();
+        assert
+          .dom(screen.getByRole('link', { name: t('modules.components.module-notification.draft-redirection') }))
           .hasAttribute('href', /\/modules\/production\/moduleId$/);
       });
     });

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import { getByRole, getByText, queryByRole, queryByText } from '@testing-library/dom';
+import { t } from 'ember-intl/test-support';
 import ModulesList from 'pixeditor/components/modules/modules-list';
 import { module, test } from 'qunit';
 
@@ -41,9 +42,11 @@ module('Integration | Component | modules-list', function (hooks) {
       test('it renders with status column', async function (assert) {
         const screen = await render(<template><ModulesList @modules={{modules}} @showStatus={{true}} /></template>);
 
-        assert.dom(screen.getByRole('columnheader', { name: 'Statut' })).exists();
-        assert.dom(screen.getByRole('columnheader', { name: 'Titre interne' })).exists();
-        assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
+        assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.status') })).exists();
+        assert
+          .dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.internal-title') }))
+          .exists();
+        assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.level') })).exists();
 
         assert.dom(screen.getByText('MOD_super_1')).exists();
         assert.dom(screen.getByText('MOD_super_2')).exists();
@@ -53,26 +56,30 @@ module('Integration | Component | modules-list', function (hooks) {
         assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
         assert.dom(getByText(firstRow, 'Novice')).exists();
 
-        assert.dom(getByRole(firstRow, 'link', { name: 'Voir le détail' })).exists();
+        assert.dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
         assert
-          .dom(getByRole(firstRow, 'link', { name: 'Voir le détail' }))
+          .dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') }))
           .hasAttribute('href', `/modules/production/super-1`);
-        assert.dom(getByRole(firstRow, 'link', { name: 'Jouer le module' })).exists();
         assert
-          .dom(getByRole(firstRow, 'link', { name: 'Jouer le module' }))
+          .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
+          .exists();
+        assert
+          .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
           .hasAttribute('href', 'https://graou.prod.asso/modules/super-1');
 
         const secondRow = screen.getByText('MOD_super_2').closest('tr');
         assert.dom(getByText(secondRow, 'Privé')).exists();
         assert.dom(getByText(secondRow, 'Beta')).exists();
         assert.dom(getByText(secondRow, 'Avancé')).exists();
-        assert.dom(getByRole(secondRow, 'link', { name: 'Voir le détail' })).exists();
+        assert.dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
         assert
-          .dom(getByRole(secondRow, 'link', { name: 'Voir le détail' }))
+          .dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') }))
           .hasAttribute('href', `/modules/production/super-2`);
-        assert.dom(getByRole(secondRow, 'link', { name: 'Jouer le module' })).exists();
         assert
-          .dom(getByRole(secondRow, 'link', { name: 'Jouer le module' }))
+          .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
+          .exists();
+        assert
+          .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
           .hasAttribute('href', 'https://graou.prod.asso/modules/super-2');
       });
     });
@@ -81,9 +88,13 @@ module('Integration | Component | modules-list', function (hooks) {
       test('it renders without status column', async function (assert) {
         const screen = await render(<template><ModulesList @modules={{modules}} @showStatus={{false}} /></template>);
 
-        assert.dom(screen.queryByRole('columnheader', { name: 'Statut' })).doesNotExist();
-        assert.dom(screen.getByRole('columnheader', { name: 'Titre interne' })).exists();
-        assert.dom(screen.getByRole('columnheader', { name: 'Niveau' })).exists();
+        assert
+          .dom(screen.queryByRole('columnheader', { name: t('modules.components.modules-list.status') }))
+          .doesNotExist();
+        assert
+          .dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.internal-title') }))
+          .exists();
+        assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.level') })).exists();
 
         assert.dom(screen.getByText('MOD_super_1')).exists();
         assert.dom(screen.getByText('MOD_super_2')).exists();
@@ -142,27 +153,31 @@ module('Integration | Component | modules-list', function (hooks) {
       assert.dom(screen.getByText('MOD_super_2')).exists();
 
       const firstRow = screen.getByText('MOD_super_1').closest('tr');
-      assert.dom(getByRole(firstRow, 'link', { name: 'Voir le détail' })).exists();
+      assert.dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
       assert
-        .dom(getByRole(firstRow, 'link', { name: 'Voir le détail' }))
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') }))
         .hasAttribute('href', `/modules/workbench/super-1`);
-      assert.dom(getByRole(firstRow, 'link', { name: 'Voir le détail du module en prod' })).exists();
       assert
-        .dom(getByRole(firstRow, 'link', { name: 'Voir le détail du module en prod' }))
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.production-detail') }))
+        .exists();
+      assert
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.production-detail') }))
         .hasAttribute('href', '/modules/production/moduleId');
-      assert.dom(getByRole(firstRow, 'link', { name: 'Prévisualiser' })).exists();
+      assert.dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.preview') })).exists();
       assert
-        .dom(getByRole(firstRow, 'link', { name: 'Prévisualiser' }))
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.preview') }))
         .hasAttribute('href', 'https://graou.asso/modules/preview/super-1');
 
       const secondRow = screen.getByText('MOD_super_2').closest('tr');
-      assert.dom(getByRole(secondRow, 'link', { name: 'Voir le détail' })).exists();
+      assert.dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
       assert
-        .dom(getByRole(secondRow, 'link', { name: 'Voir le détail' }))
+        .dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') }))
         .hasAttribute('href', `/modules/workbench/super-2`);
-      assert.dom(queryByRole(secondRow, 'link', { name: 'Voir le détail du module en prod' })).doesNotExist();
       assert
-        .dom(getByRole(secondRow, 'link', { name: 'Prévisualiser' }))
+        .dom(queryByRole(secondRow, 'link', { name: t('modules.components.modules-list.production-detail') }))
+        .doesNotExist();
+      assert
+        .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.preview') }))
         .hasAttribute('href', 'https://graou.asso/modules/preview/super-2');
     });
   });

--- a/pix-editor/tests/integration/components/modules/play-module-buttons-test.gjs
+++ b/pix-editor/tests/integration/components/modules/play-module-buttons-test.gjs
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
 import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons';
 import { module, test } from 'qunit';
 
@@ -22,10 +23,10 @@ module('Integration | Components | modules/play-module-buttons', function (hooks
 
       // then
       assert
-        .dom(screen.getByRole('link', { name: 'Jouer le draft' }))
+        .dom(screen.getByRole('link', { name: t('modules.components.play-module-button.play-draft') }))
         .hasAttribute('href', 'https://kapoue.org/module/play');
       assert
-        .dom(screen.getByRole('link', { name: 'Prévisualiser' }))
+        .dom(screen.getByRole('link', { name: t('modules.components.play-module-button.preview') }))
         .hasAttribute('href', 'https://kapoue.org/module/preview');
     });
   });
@@ -44,13 +45,13 @@ module('Integration | Components | modules/play-module-buttons', function (hooks
       const screen = await render(<template><PlayModuleButtons @module={{module}} /></template>);
 
       // then
-      assert.dom(screen.getByRole('link', { name: 'Jouer le module' })).exists();
+      assert.dom(screen.getByRole('link', { name: t('modules.components.play-module-button.play-module') })).exists();
       assert
-        .dom(screen.getByRole('link', { name: 'Jouer le module' }))
+        .dom(screen.getByRole('link', { name: t('modules.components.play-module-button.play-module') }))
         .hasAttribute('href', 'https://kapoue-production.org/module/play');
-      assert.dom(screen.getByRole('link', { name: 'Prévisualiser' })).exists();
+      assert.dom(screen.getByRole('link', { name: t('modules.components.play-module-button.preview') })).exists();
       assert
-        .dom(screen.getByRole('link', { name: 'Prévisualiser' }))
+        .dom(screen.getByRole('link', { name: t('modules.components.play-module-button.preview') }))
         .hasAttribute('href', 'https://kapoue-production.org/module/preview');
     });
   });

--- a/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
@@ -1,5 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
 import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 import { module, test } from 'qunit';
 
@@ -16,7 +17,9 @@ module('Integration | Component | modules/validation-errors', function (hooks) {
     const screen = await render(<template><ModuleValidationErrors @validationErrors={{validationErrors}} /></template>);
 
     // then
-    const accordion = screen.getByRole('button', { name: 'Erreurs de validation 2 erreurs' });
+    const accordion = screen.getByRole('button', {
+      name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 2 })}`,
+    });
     await click(accordion);
     const listItems = screen.getAllByRole('listitem');
     assert.dom(listItems[0]).hasText('Le slug est mal formatté');

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -91,6 +91,50 @@ modules:
     validation-failure: Échec
   edit-draft-module:
     title: Édition du draft de module
+  components:
+    publish-module-button:
+      success: Le module "{title}" a été publié.
+      error: Erreur lors de la publication du module.
+      aria-label: Publier le module "{title}"
+      publish: Publier
+    modules-tabs:
+      navigation: Navigation
+      workbench: Atelier
+      production: En production
+    play-module-button:
+      preview: Prévisualiser
+      play-draft: Jouer le draft
+      play-module: Jouer le module
+    module-notification:
+      draft-information: Ce module possède une version disponible en production.
+      draft-redirection: Voir le détail du module en prod
+      production-information: Ce module possède une version en cours de modification.
+      production-redirection: Voir le détail des modifications
+    modules-list:
+      caption: Liste des modules
+      status: Statut
+      internal-title: Titre interne
+      level: Niveau
+      actions: Actions
+      detail: Voir le détail
+      production-detail: Voir le détail du module en prod
+    validation-errors:
+      title: Erreurs de validation
+      error-count: '{count, plural, one {1 erreur} other {# erreurs}}'
+    create-module-button:
+      create-draft: Créer un draft
+      create-module: Créer un module
+    module-back-button:
+      back: Retour
+    module-form:
+      required-field: Champ obligatoire
+      internal-title-label: Titre interne
+      content-label: Contenu (JSON)
+      ids-warning-prefix: Les champs
+      ids-warning-middle: et
+      ids-warning-suffix: ne peuvent pas être modifiés.
+      save: Enregistrer
+      cancel: Annuler
 common:
   validate: Valider
   validate-quality: Valider qualité

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -69,6 +69,28 @@ prototype:
     update-message: Mise à jour du prototype
     update-status: Épreuve mise à jour
     update-error: Erreur lors de la mise à jour
+modules:
+  new:
+    draft-title: Création d’un draft
+    module-title: Création d’un module
+    draft-success: Le draft "{title}" a été enregistré.
+    module-success: Le module "{title}" a été enregistré.
+    draft-error: Erreur lors de l’enregistrement du draft.
+    module-error: Erreur lors de l’enregistrement du module.
+  workbench:
+    title: Modules
+  production:
+    title: Modules
+  production-module:
+    title: Détail du module
+  draft-module:
+    title: Détail du draft de module
+    edit: Modifier
+    validation-status-label: 'Statut de validation :'
+    validation-success: Succès
+    validation-failure: Échec
+  edit-draft-module:
+    title: Édition du draft de module
 common:
   validate: Valider
   validate-quality: Valider qualité


### PR DESCRIPTION
## ☀️ Problème

Actuellement, les pages des modules contiennent des textes de durs. Cela pose problème en cas de maintenance, d'internationalisation...

## ⛱️ Proposition

Modifier ces pages pour utiliser des clés de traductions.

## 🧴 Remarques

- Il reste le terme Modules à traduire dans la barre de navigation. Celui-ci n'a pas été modifié car il y a une discussion à avoir sur la structure pour ça.
- Claude a été utilisé pour cette PR. 

## 🏊 Pour tester

- Tests de non régression sur les pages de modules.
