### PR TITLE
[TECH] Améliorer les performances du lint en local

### DIFF
--- a/pix-editor/eslint.config.mjs
+++ b/pix-editor/eslint.config.mjs
@@ -9,7 +9,7 @@ import qunitRecommendedConfig from 'eslint-plugin-qunit/configs/recommended';
 import globals from 'globals';
 
 const unconventionalJsFiles = ['blueprints/**/files/*', 'app/vendor/*'];
-const compiledOutputFiles = ['dist/*', 'tmp/*'];
+const compiledOutputFiles = ['dist/*', 'playwright-report/*', 'test-results/*', 'tmp/*'];
 const dependenciesFiles = ['node_modules/*'];
 const miscFiles = ['coverage/*', '!**/.*', '**/.eslintcache', 'external/*'];
 const emberTryFiles = ['.node_modules.ember-try/*', 'bower.json.ember-try', 'package.json.ember-try'];

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -21,7 +21,7 @@
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "lint:js": "eslint . --cache",
     "preinstall": "git config core.hooksPath .githooks || true",
-    "lint:js:fix": "eslint . --fix",
+    "lint:js:fix": "npm run lint:js -- --fix",
     "start": "vite",
     "test": "npm-run-all lint test:*",
     "test:ember": "vite build --mode development && ember test --path dist"


### PR DESCRIPTION
## ☀️ Problème

Le script `lint:js:fix` dans le projet pix-editor/pix-editor peut prendre beaucoup de temps selon le contenu de ce dossier...
C'est parce qu'il lint aussi le contenu des fichiers de reporting générés par playwright et autres.
Ce qui ralentit énormément car on a des bundles, des index mimifiés...

## ⛱️ Proposition

- Ignorer les fichiers de reporting lors du lancement de cette commande
- Profiter du système de cache déjà mis en place par le script `lint:js`

## 🧴 Remarques

RAS

## 🏊 Pour tester

- Test de non régression sur la commande `npm run lint:js:fix`