### PR TITLE
[FEATURE] Amélioration des pages de module (partie 2) (PIX-23866).

### DIFF
--- a/pix-editor/app/components/modules/draft-module-diff.gjs
+++ b/pix-editor/app/components/modules/draft-module-diff.gjs
@@ -1,7 +1,14 @@
+import PixLabel from '@1024pix/pix-ui/components/pix-label';
 import { htmlSafe } from '@ember/template';
+import t from 'ember-intl/helpers/t';
 
 <template>
-  <div class="draft-module-diff">
-    {{htmlSafe @htmlDiff}}
+  <div class="module__data-field">
+    <PixLabel>
+      {{t "modules.draft-module.diff.label"}}
+    </PixLabel>
+    <div class="draft-module-diff">
+      {{htmlSafe @htmlDiff}}
+    </div>
   </div>
 </template>

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -92,7 +92,7 @@ export default class ModuleForm extends Component {
         </PixInput>
       {{/unless}}
 
-      <div class="module-form__data-field">
+      <div class="module__data-field">
         <PixLabel @requiredLabel={{t "modules.components.module-form.required-field"}}>
           {{t "modules.components.module-form.content-label"}}
         </PixLabel>

--- a/pix-editor/app/components/modules/validation-errors.gjs
+++ b/pix-editor/app/components/modules/validation-errors.gjs
@@ -1,38 +1,61 @@
-import PixAccordions from '@1024pix/pix-ui/components/pix-accordions';
-import PixNotificationAlert from '@1024pix/pix-ui/components/pix-notification-alert';
-import { inject as service } from '@ember/service';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
 
 export default class ModuleValidationErrors extends Component {
-  @service intl;
+  @tracked isCollapsed = true;
+  @tracked hasUnCollapsedOnce = false;
 
-  get formattedTag() {
-    return this.intl.t('modules.components.validation-errors.error-count', {
-      count: this.args.validationErrors.length,
-    });
+  get isUnCollapsed() {
+    return !this.isCollapsed;
+  }
+
+  get isContentRendered() {
+    return this.hasUnCollapsedOnce;
+  }
+
+  @action
+  toggleAccordions() {
+    this.isCollapsed = !this.isCollapsed;
+    this.hasUnCollapsedOnce = true;
   }
 
   <template>
-    <PixAccordions
-      @iconName="error"
-      @isV2Version={{true}}
-      @tagContent={{this.formattedTag}}
-      @tagColor="error"
-      class="module-validation-errors"
-    >
-      <:title>{{t "modules.components.validation-errors.title"}}</:title>
-      <:content>
+    <div class="module-validation-errors">
+      <button
+        type="button"
+        class="module-validation-errors__button"
+        {{on "click" this.toggleAccordions}}
+        aria-controls="validation-errors-accordion"
+        aria-expanded={{if this.isUnCollapsed "true" "false"}}
+      >
+        <div class="module-validation-errors-button__title-container">
+          <PixIcon @ariaHidden={{true}} @name="error" @plainIcon={{true}} />
+          <div class="module-validation-errors-button__title">
+            <p>{{t "modules.components.validation-errors.title" count=@validationErrors.length}}</p>
+            <p>{{t "modules.components.validation-errors.information"}}</p>
+          </div>
+        </div>
+
+        <PixIcon @ariaHidden={{true}} @name="{{if this.isCollapsed 'chevronBottom' 'chevronTop'}}" />
+      </button>
+
+      <div
+        id="validation-errors-accordion"
+        aria-hidden={{if this.isCollapsed "true" "false"}}
+        class="module-validation-errors__content"
+      >
         <ul>
           {{#each @validationErrors as |validationError|}}
-            <li class="module-validation-errors__notification">
-              <PixNotificationAlert @withIcon={{true}} @type="error">
-                {{validationError}}
-              </PixNotificationAlert>
+            <li class="module-validation-errors__item">
+              {{validationError}}
             </li>
           {{/each}}
         </ul>
-      </:content>
-    </PixAccordions>
+      </div>
+    </div>
   </template>
 }

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -24,6 +24,8 @@ td.modules-list__actions {
 }
 
 .draft-module-diff {
+  border-top: 1px solid var(--pix-neutral-500);
+
   pre.shiki {
     max-height: 70vh;
     margin: 0;
@@ -47,6 +49,19 @@ td.modules-list__actions {
     display: flex;
     align-items: center;
     justify-content: space-between;
+  }
+
+  &__data-field {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--pix-neutral-20);
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+    border: 1px solid var(--pix-neutral-500);
+
+    label {
+      padding: var(--pix-spacing-4x);
+    }
   }
 }
 

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -67,10 +67,20 @@ td.modules-list__actions {
 
 .module-header {
   &__breadcrumb {
-    padding-bottom : var(--pix-spacing-2x);
+    padding-bottom : var(--pix-spacing-4x);
+  }
+
+  &__tag {
+    text-transform: uppercase;
   }
 
   &__title {
     @extend %pix-title-s;
+  }
+
+  &__information {
+    display: flex;
+    gap: var(--pix-spacing-2x);
+    align-items: center;
   }
 }

--- a/pix-editor/app/styles/components/modules/module-form.scss
+++ b/pix-editor/app/styles/components/modules/module-form.scss
@@ -3,13 +3,8 @@
   flex-direction: column;
   gap: var(--pix-spacing-6x);
 
-  &__data-field {
-    display: flex;
-    flex-direction: column;
-    gap: var(--pix-spacing-2x);
-  }
-
   &__monaco-editor {
+    border-top: 1px solid var(--pix-neutral-500);
     height: 70vh;
   }
 

--- a/pix-editor/app/styles/components/modules/validation-errors.scss
+++ b/pix-editor/app/styles/components/modules/validation-errors.scss
@@ -1,10 +1,66 @@
-.module-validation-errors {
+@use 'pix-design-tokens/typography';
 
-  .pix-accordions-v2-title__container {
-    font-family: inherit;
+.module-validation-errors {
+  background-color: var(--pix-error-50);
+  border: 1px solid var(--pix-error-700);
+  border-radius: 8px;
+
+
+  &__button {
+    color: var(--pix-error-700);
+    display: flex;
+    justify-content: space-between;
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+    align-items: center;
+    width: 100%;
   }
 
-  &__notification {
-    margin-bottom: var(--pix-spacing-4x);
+  &__content {
+    color: var(--pix-neutral-900);
+    background-color: var(--pix-neutral-0);
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+
+    &[aria-hidden='true'] {
+      display: none;
+    }
+  }
+
+  &__item:not(:last-child) {
+    border-bottom: 1px solid var(--pix-error-700);
+  }
+
+  &__item {
+    @extend %pix-body-s;
+
+    padding: var(--pix-spacing-4x);
+    font-weight: var(--pix-font-bold);
+    text-wrap: balance;
+  }
+}
+
+.module-validation-errors-button {
+  &__title-container {
+    display: flex;
+    gap: var(--pix-spacing-4x);
+    align-items: center;
+  }
+
+  &__title {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    p:first-of-type {
+      @extend %pix-body-m;
+
+      font-weight: var(--pix-font-bold);
+    }
+
+    p:last-of-type {
+      @extend %pix-body-s;
+
+      color: var(--pix-error-900);
+    }
   }
 }

--- a/pix-editor/app/styles/globals/page.scss
+++ b/pix-editor/app/styles/globals/page.scss
@@ -2,7 +2,7 @@
 @use 'pix-design-tokens/fonts';
 
 .page {
-  background-color: colors.$pix-neutral-15;
+  background-color: var(--pix-orga-50);
   width: 100%;
 
   .page-header {

--- a/pix-editor/app/styles/pages/draft-module.scss
+++ b/pix-editor/app/styles/pages/draft-module.scss
@@ -1,10 +1,4 @@
 .draft-module-header {
-  &__information {
-    display: flex;
-    gap: var(--pix-spacing-4x);
-    align-items: center;
-  }
-
   &__tag {
     display: flex;
     gap: var(--pix-spacing-4x);

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,5 +1,6 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -49,8 +50,12 @@ export default class DraftModule extends Component {
       <div>
         <PixBreadcrumb class="module-header__breadcrumb" @links={{this.links}} />
 
-        <div class="draft-module-header__information">
+        <div class="module-header__information">
           <h1 class="module-header__title">{{@model.draftModule.internalTitle}}</h1>
+          <PixTag class="module-header__tag" @color="yellow">
+            <PixIcon @name="edit" @plainIcon={{true}} @ariaHidden={{true}} />
+            {{t "modules.draft-module.information-tag"}}
+          </PixTag>
           <PixTag @color={{this.validationStatusInformation.color}}>
             <span class="draft-module-header__tag--{{this.validationStatusInformation.state}}">&#9679;</span>
             {{this.validationStatusInformation.label}}

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,6 +1,9 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
+import PixIcon from '@1024pix/pix-ui/components/pix-icon';
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import t from 'ember-intl/helpers/t';
 import CreateModuleButton from 'pixeditor/components/modules/create-module-button';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModuleNotification from 'pixeditor/components/modules/module-notification';
@@ -25,7 +28,14 @@ export default class ProductionModule extends Component {
     <header class="module__header">
       <div>
         <PixBreadcrumb class="module-header__breadcrumb" @links={{this.links}} />
-        <h1 class="module-header__title">{{@model.module.internalTitle}}</h1>
+
+        <div class="module-header__information">
+          <h1 class="module-header__title">{{@model.module.internalTitle}}</h1>
+          <PixTag class="module-header__tag" @color="blue">
+            <PixIcon @name="bolt" @plainIcon={{true}} @ariaHidden={{true}} />
+            {{t "modules.production-module.information-tag"}}
+          </PixTag>
+        </div>
       </div>
       <div class="page-actions">
         <PlayModuleButtons @module={{@model.module}} />

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -119,7 +119,7 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       assert
         .dom(
           screen.getByRole('button', {
-            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')}`,
           }),
         )
         .exists();
@@ -175,7 +175,7 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       assert
         .dom(
           screen.queryByRole('button', {
-            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')}`,
           }),
         )
         .doesNotExist();

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -45,6 +45,7 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
     // then
     assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
     assert.dom(screen.getByRole('heading', { name: 'MON_BEAU_MODULE' })).exists();
+    assert.dom(screen.getByText(t('modules.draft-module.information-tag'))).exists();
 
     // WORKAROUND: let some time for monaco-editor to settle
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
@@ -43,6 +43,7 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
         id: crypto.randomUUID(),
         internalTitle: 'MODULE_DRAFT',
         validationErrors: ['oups !'],
+        hasBeenValidated: false,
       });
 
       // when
@@ -54,7 +55,7 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
       assert
         .dom(
           screen.getByRole('button', {
-            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')}`,
           }),
         )
         .exists();
@@ -78,7 +79,7 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
       assert
         .dom(
           screen.queryByRole('button', {
-            name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 1 })}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')}`,
           }),
         )
         .doesNotExist();

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -46,6 +46,8 @@ module('Acceptance | Modules | Production Module', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), `/modules/production/${id}`);
+      assert.dom(screen.getByRole('heading', { name: 'MON_BEAU_MODULE' })).exists();
+      assert.dom(screen.getByText(t('modules.production-module.information-tag'))).exists();
 
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));

--- a/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
@@ -18,7 +18,7 @@ module('Integration | Component | modules/validation-errors', function (hooks) {
 
     // then
     const accordion = screen.getByRole('button', {
-      name: `${t('modules.components.validation-errors.title')} ${t('modules.components.validation-errors.error-count', { count: 2 })}`,
+      name: `${t('modules.components.validation-errors.title', { count: 2 })} ${t('modules.components.validation-errors.information')}`,
     });
     await click(accordion);
     const listItems = screen.getAllByRole('listitem');

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -99,6 +99,8 @@ modules:
     edit: Modifier
     validation-success: Validation en succès
     validation-failure: Validation en échec
+    diff:
+      label: Modifications
   edit-draft-module:
     title: Édition du draft de module
   components:

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -96,13 +96,14 @@ modules:
   production:
     title: Modules
   draft-module:
+    information-tag: brouillon
     edit: Modifier
     validation-success: Validation en succès
     validation-failure: Validation en échec
     diff:
       label: Modifications
-  edit-draft-module:
-    title: Édition du draft de module
+  production-module:
+    information-tag: en production
   components:
     publish-module-button:
       success: Le module "{title}" a été publié.

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -131,8 +131,8 @@ modules:
       detail: Voir le détail
       production-detail: Voir le détail du module en prod
     validation-errors:
-      title: Erreurs de validation
-      error-count: '{count, plural, one {1 erreur} other {# erreurs}}'
+      title: '{count, plural, one {1 erreur} other {# erreurs}} de validation'
+      information: La publication est impossible tant que des erreurs subsistent.
     validation-success:
       content: Aucune erreur de validation
     create-module-button:


### PR DESCRIPTION
## ☀️ Problème

On a constaté que les pages des modules manquaient de cohérence entre elles + des boutons placés à des endroits pas pratique. Des soucis d'UI à améliorer en quick win.

## ⛱️ Proposition

Améliorer les pages avec : 
- Suppression du composant PixAccordions au profit d'un composant custom, facilement adaptable pour nos besoins
- Ajout d'un label d'information, permettant de distinguer un brouillon d'un module en prod

## 🧴 Remarques

Nous avons testé Claude version design pour échanger sur l'état actuel de nos pages de module. Ses suggestions nous on a permis ces améliorations.

## 🏊 Pour tester

https://github.com/user-attachments/assets/5610d4f6-9e9d-473b-9a24-6467923b2306

