### PR TITLE
[TECH] Renvoyer plus d'informations sur les API de modules (PIX-23875)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -25,6 +25,7 @@ export function register(server) {
             attributes: [
               'internalTitle',
               'details',
+              'hasBeenValidated',
               'module',
               'previewUrl',
             ], meta,

--- a/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/draft-module-serializer.js
@@ -36,6 +36,7 @@ const defaultAttributes = [
   'previewUrl',
   'hasBeenValidated',
   'validationErrors',
+  'updatedAt',
 ];
 
 export function serialize(draftModules, { meta, attributes = defaultAttributes } = {}) {

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -216,9 +216,9 @@ describe('Acceptance | Route | draft-modules', () => {
     beforeEach(async () => {
       const { id: moduleId } = databaseBuilder.factory.buildModule(domainBuilder.buildModule());
       draftModules = [
-        { id: '79cc8f8d-d948-4ce5-bd35-1250b61d6011', shortId: 'abcd1234', internalTitle: 'MOD_a', slug: 'a', details: { level: Module.LEVELS.NOVICE }, visibility: Module.VISIBILITIES.PRIVATE },
-        { id: moduleId, moduleId, shortId: 'abcd5678', internalTitle: 'MOD_b', slug: 'b', details: { level: Module.LEVELS.INDEPENDENT }, visibility: Module.VISIBILITIES.PUBLIC },
-        { id: 'f995ce82-1373-4758-b839-7a844893ef07', shortId: 'abcd9012', internalTitle: 'MOD_c', slug: 'c', details: { level: Module.LEVELS.EXPERT }, visibility: Module.VISIBILITIES.PRIVATE },
+        { id: '79cc8f8d-d948-4ce5-bd35-1250b61d6011', shortId: 'abcd1234', internalTitle: 'MOD_a', slug: 'a', details: { level: Module.LEVELS.NOVICE }, visibility: Module.VISIBILITIES.PRIVATE, hasBeenValidated: true },
+        { id: moduleId, moduleId, shortId: 'abcd5678', internalTitle: 'MOD_b', slug: 'b', details: { level: Module.LEVELS.INDEPENDENT }, visibility: Module.VISIBILITIES.PUBLIC, hasBeenValidated: false },
+        { id: 'f995ce82-1373-4758-b839-7a844893ef07', shortId: 'abcd9012', internalTitle: 'MOD_c', slug: 'c', details: { level: Module.LEVELS.EXPERT }, visibility: Module.VISIBILITIES.PRIVATE, hasBeenValidated: true },
       ].map(domainBuilder.buildDraftModule);
 
       draftModules.forEach((draftModule) => {
@@ -251,6 +251,7 @@ describe('Acceptance | Route | draft-modules', () => {
               'internal-title': draftModules[1].internalTitle,
               details: draftModules[1].details,
               'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModules[1].shortId}/${draftModules[1].slug}`,
+              'has-been-validated': draftModules[1].hasBeenValidated,
             },
             relationships: {
               module: {
@@ -268,6 +269,7 @@ describe('Acceptance | Route | draft-modules', () => {
               'internal-title': draftModules[0].internalTitle,
               details: draftModules[0].details,
               'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModules[0].shortId}/${draftModules[0].slug}`,
+              'has-been-validated': draftModules[0].hasBeenValidated,
             },
             relationships: { module: { data: null } },
           },
@@ -278,6 +280,7 @@ describe('Acceptance | Route | draft-modules', () => {
               'internal-title': draftModules[2].internalTitle,
               details: draftModules[2].details,
               'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModules[2].shortId}/${draftModules[2].slug}`,
+              'has-been-validated': draftModules[2].hasBeenValidated,
             },
             relationships: { module: { data: null } },
           },
@@ -314,6 +317,7 @@ describe('Acceptance | Route | draft-modules', () => {
               attributes: {
                 'internal-title': draftModules[0].internalTitle,
                 details: draftModules[0].details,
+                'has-been-validated': draftModules[0].hasBeenValidated,
                 'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModules[0].shortId}/${draftModules[0].slug}`,
               },
               relationships: { module: { data: null } },

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -60,6 +60,7 @@ describe('Acceptance | Route | draft-modules', () => {
             'preview-url': expect.stringMatching(new RegExp(`^${config.pixApp.recette.baseUrlFr.replace(/([.])/g, '\\$1')}/modules/preview/.{8}/${draftModule.slug}$`)),
             'has-been-validated': true,
             'validation-errors': [],
+            'updated-at': expect.any(Date),
           },
           relationships: { module: { data: null } },
         },
@@ -164,6 +165,7 @@ describe('Acceptance | Route | draft-modules', () => {
               'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
               'has-been-validated': true,
               'validation-errors': [],
+              'updated-at': expect.any(Date),
             },
             relationships: {
               module: {
@@ -376,6 +378,7 @@ describe('Acceptance | Route | draft-modules', () => {
             'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
             'has-been-validated': draftModule.hasBeenValidated,
             'validation-errors': draftModule.validationErrors,
+            'updated-at': draftModule.updatedAt,
           },
           relationships: {
             module: {
@@ -544,6 +547,7 @@ describe('Acceptance | Route | draft-modules', () => {
             'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModule.shortId}/kebab-royal`,
             'has-been-validated': true,
             'validation-errors': [],
+            'updated-at': expect.any(Date),
           },
           relationships: { module: { data: null } },
         },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
@@ -65,6 +65,7 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
         'isBeta',
         'module',
         'previewUrl',
+        'hasBeenValidated',
       ];
 
       // when
@@ -81,6 +82,7 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
               'is-beta': draftModules[0].isBeta,
               visibility: draftModules[0].visibility,
               details: draftModules[0].details,
+              'has-been-validated': draftModules[0].hasBeenValidated,
               'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModules[0].shortId}/${draftModules[0].slug}`,
             },
             relationships: {
@@ -100,8 +102,10 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
               'is-beta': draftModules[1].isBeta,
               visibility: draftModules[1].visibility,
               details: draftModules[1].details,
+              'has-been-validated': draftModules[1].hasBeenValidated,
               'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModules[1].shortId}/${draftModules[1].slug}`,
             },
+
             relationships: { module: { data: null } },
           },
         ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/draft-module-serializer_test.js
@@ -29,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
             'preview-url': `${config.pixApp.recette.baseUrlFr}/modules/preview/${draftModule.shortId}/${draftModule.slug}`,
             'has-been-validated': draftModule.hasBeenValidated,
             'validation-errors': draftModule.validationErrors,
+            'updated-at': draftModule.updatedAt,
           },
           relationships: {
             module: {
@@ -49,7 +50,7 @@ describe('Unit | Serializer | JSONAPI | draft-module-serializer', () => {
       expect(serializedPayload).toStrictEqual(expectedPayload);
     });
 
-    it('serializes a paginated draft modules excerpt list to a payload', () => {
+    it('serializes a paginated draft modules list to a payload', () => {
       // given
       const draftModules = [domainBuilder.buildDraftModule({ id: 'module1', moduleId: 'module1', internalTitle: 'MOD_1', details: { level: Module.LEVELS.EXPERT }, visibility: Module.VISIBILITIES.PRIVATE, isBeta: true }), domainBuilder.buildDraftModule({ id: 'module2', internalTitle: 'MOD_2', details: { level: Module.LEVELS.INDEPENDENT }, visibility: Module.VISIBILITIES.PUBLIC, isBeta: false })];
       const meta = {


### PR DESCRIPTION
## ☀️ Problème

Côté front, nous avons besoin de récupérer 2 informations supplémentaires sur les draft-modules : 
- sur la page listant les draft, le statut de validation
- sur le détail d'un draft, la dernière date de modification

## ⛱️ Proposition

Modifier les endpoints en ajoutant :
- dans la réponse de l'API `GET /api/draft-modules`, le champ `has-been-validated`
- dans la réponse des autres API draft-modules, le champ `updated-at`

## 🧴 Remarques

RAS

## 🏊 Pour tester
- Se connecter à Pix Editor
- Aller sur la page listant les draft 
- Constater que le endpoint `GET /api/draft-modules` renvoie bien le champ `has-been-validated` sur draft module récupéré
- Aller sur le détail d'un draft module
- Constater que le endpoint `GET /api/draft-modules/{id}` renvoie bien le champ `updated-at`

<img width="1510" height="835" alt="Capture d’écran 2026-08-13 à 10 47 16" src="https://github.com/user-attachments/assets/6ef38f0a-9ece-4636-9980-f14f0bb9b099" />
<img width="1509" height="837" alt="Capture d’écran 2026-08-13 à 10 46 55" src="https://github.com/user-attachments/assets/114e6153-a3ca-4a3e-9587-eb693e33914e" />
