### PR TITLE
[TECH] Ajouter la dépendance @ember-intl/vite

### DIFF
--- a/pix-editor/app/routes/application.js
+++ b/pix-editor/app/routes/application.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { formats } from 'pixeditor/ember-intl';
+import translationsForFr from 'virtual:ember-intl/translations/fr';
 
 export default class ApplicationRoute extends Route {
   @service session;
@@ -9,5 +10,6 @@ export default class ApplicationRoute extends Route {
   async beforeModel() {
     await this.session.setup();
     this.intl.setFormats(formats);
+    this.intl.addTranslations('fr', translationsForFr);
   }
 }

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -25,6 +25,7 @@
         "@ember-data/model": "^5.8.0",
         "@ember-data/serializer": "^5.8.0",
         "@ember-intl/v1-compat": "^1.0.1",
+        "@ember-intl/vite": "^1.3.0",
         "@ember/optional-features": "^3.0.0",
         "@ember/string": "^4.0.1",
         "@ember/test-helpers": "^5.4.1",
@@ -3124,6 +3125,19 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@codemod-utils/files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@codemod-utils/files/-/files-4.1.0.tgz",
+      "integrity": "sha512-/zZQj6o3/fA9V+cDUFNi0nqDw/oxaLktNB38izWm0Msr7EqhBnzWYJ7zkW4Gw5W6oHhYLYQykJfbUqMrYeS6xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.6"
+      },
+      "engines": {
+        "node": "22.* || >= 24"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -3531,6 +3545,20 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@ember-intl/vite": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ember-intl/vite/-/vite-1.3.0.tgz",
+      "integrity": "sha512-hl9f/WbmmWg+/8fQOU71dzINAMv4CMmaBSUdHyIS/M0I2mLbh3wXM4lTo8Nk2qKRSKWFvK3/GEsgr7+d2lZtUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemod-utils/files": "^4.1.0",
+        "js-yaml": "^5.2.1"
+      },
+      "engines": {
+        "node": "20.* || >= 22"
       }
     },
     "node_modules/@ember-tooling/blueprint-blueprint": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -38,6 +38,7 @@
     "@ember-data/model": "^5.8.0",
     "@ember-data/serializer": "^5.8.0",
     "@ember-intl/v1-compat": "^1.0.1",
+    "@ember-intl/vite": "^1.3.0",
     "@ember/optional-features": "^3.0.0",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "^5.4.1",

--- a/pix-editor/vite.config.mjs
+++ b/pix-editor/vite.config.mjs
@@ -1,3 +1,4 @@
+import { loadTranslations } from '@ember-intl/vite';
 import { classicEmberSupport, ember, extensions } from '@embroider/vite';
 import { babel } from '@rollup/plugin-babel';
 import url from 'postcss-url';
@@ -13,6 +14,7 @@ export default defineConfig({
       babelHelpers: 'runtime',
       extensions,
     }),
+    loadTranslations(),
   ],
   server: {
     port: 4300,


### PR DESCRIPTION
## ☀️ Problème

Avec le passage à `Vite`, la mise à jour des traductions en local est assez fastidieuse. Ceci car vite n'écoute pas, par défaut sur ces fichiers.

Cela fait qu'actuellement, lorsqu'on met à jour la valeur d'une clé de trad, on fait un npm ci pour recharger les trads + le temps d'attente lors du démarrage de l'app 🐌 
(Il y avait peut être une meilleure solution que ça 😛 )

Heureusement, `ember-intl` propose une solution pour ça avec la dépendance @ember-intl/vite 🙏 

## ⛱️ Proposition

Installer cette dépendance. 
On s'inspire de ce qui a été sur la [PR](https://github.com/1024pix/pix/pull/16233) côté orga et du tuto dans le [readme](https://github.com/ember-intl/ember-intl/tree/main/packages/ember-intl-vite) de la librairie.

## 🧴 Remarques


Il y a quelques différences par rapport à la PR sur orga et ce qui est expliqué sur le tuto.
- Sur la [PR](https://github.com/1024pix/pix/pull/16233/changes#diffd5ad87c3dae84fe4687db04da3ba002923559971cad6e933a5e2cba81c68e103) orga, l'attribut `public-only` est passé à true dans la config d'ember-intl. Pas vu de différence avec cette modif ce qui fait que je ne l'ai pas pris en compte.
- sur le `setupRenderingTest`, le tuto recommande d'ajouter les traductions utilisés : 

<img width="1048" height="656" alt="Capture d’écran 2026-08-13 à 10 33 24" src="https://github.com/user-attachments/assets/20a464d5-b8cf-4879-81ae-3b34cd2e37eb" />

Mais on utilise de notre côté un `setupIntlRenderingTest` qui fonctionne bien. Et sur les tests utilisant ce setup, les traductions sont bien pris en compte instantanément.
Cela fait que je n'ai pas tenu compte de cette suggestion !

## 🏊 Pour tester

- En local, mettre à jour la valeur d'une clé de traduction.
- Constater, sur l'interface, que le changement est maintenant instantanément prise en compte 😄 
- Sur la RA, faire quelques tests de non régression sur les endroits utilisant des clés de traduction. Par exemples sur les pages de modules 🚀 
