### PR TITLE
[FEATURE] Afficher la validation dans la liste des brouillons (PIX-23882).

### DIFF
--- a/pix-editor/app/components/modules/modules-list.gjs
+++ b/pix-editor/app/components/modules/modules-list.gjs
@@ -6,6 +6,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
+import ModuleValidationTag from 'pixeditor/components/modules/validation-tag';
 
 import PlayModuleButton from './play-module-button';
 
@@ -13,7 +14,11 @@ function getVisibilityColor(visibility) {
   return { public: 'green', private: 'grey' }[visibility];
 }
 
-export default class Product extends Component {
+function hasValidationStatus(module) {
+  return module.hasBeenValidated !== undefined;
+}
+
+export default class ModulesList extends Component {
   @service router;
 
   @action
@@ -24,12 +29,14 @@ export default class Product extends Component {
   <template>
     <PixTable @variant="modulix" @data={{@modules}} @caption={{t "modules.components.modules-list.caption"}}>
       <:columns as |module context|>
-        {{#if @showStatus}}
-          <PixTableColumn @context={{context}}>
-            <:header>
-              {{t "modules.components.modules-list.status"}}
-            </:header>
-            <:cell>
+        <PixTableColumn @context={{context}}>
+          <:header>
+            {{t "modules.components.modules-list.status"}}
+          </:header>
+          <:cell>
+            {{#if (hasValidationStatus module)}}
+              <ModuleValidationTag @hasBeenValidated={{module.hasBeenValidated}} />
+            {{else}}
               <div class="modules-list__status">
                 <PixTag @color={{getVisibilityColor module.visibility}}>
                   {{module.visibilityForDisplay}}
@@ -38,9 +45,9 @@ export default class Product extends Component {
                   <PixTag @color="yellow">Beta</PixTag>
                 {{/if}}
               </div>
-            </:cell>
-          </PixTableColumn>
-        {{/if}}
+            {{/if}}
+          </:cell>
+        </PixTableColumn>
         <PixTableColumn @context={{context}}>
           <:header>
             {{t "modules.components.modules-list.internal-title"}}

--- a/pix-editor/app/components/modules/validation-tag.gjs
+++ b/pix-editor/app/components/modules/validation-tag.gjs
@@ -1,0 +1,24 @@
+import PixTag from '@1024pix/pix-ui/components/pix-tag';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class ModuleValidationTag extends Component {
+  @service intl;
+
+  get validationStatus() {
+    return this.args.hasBeenValidated;
+  }
+
+  get validationStatusInformation() {
+    return this.validationStatus
+      ? { label: this.intl.t('modules.draft-module.validation-success'), color: 'green', state: 'success' }
+      : { label: this.intl.t('modules.draft-module.validation-failure'), color: 'error', state: 'failure' };
+  }
+
+  <template>
+    <PixTag @color={{this.validationStatusInformation.color}}>
+      <span class="draft-module-header__tag--{{this.validationStatusInformation.state}}">&#9679;</span>
+      {{this.validationStatusInformation.label}}
+    </PixTag>
+  </template>
+}

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -11,6 +11,7 @@ import ModuleNotification from 'pixeditor/components/modules/module-notification
 import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons';
 import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 import ModuleValidationSuccess from 'pixeditor/components/modules/validation-success';
+import ModuleValidationTag from 'pixeditor/components/modules/validation-tag';
 
 export default class DraftModule extends Component {
   @service intl;
@@ -21,16 +22,6 @@ export default class DraftModule extends Component {
 
   get validationErrors() {
     return this.args.model.draftModule.validationErrors;
-  }
-
-  get validationStatus() {
-    return this.args.model.draftModule.hasBeenValidated;
-  }
-
-  get validationStatusInformation() {
-    return this.validationStatus
-      ? { label: this.intl.t('modules.draft-module.validation-success'), color: 'green', state: 'success' }
-      : { label: this.intl.t('modules.draft-module.validation-failure'), color: 'error', state: 'failure' };
   }
 
   get links() {
@@ -56,10 +47,7 @@ export default class DraftModule extends Component {
             <PixIcon @name="edit" @plainIcon={{true}} @ariaHidden={{true}} />
             {{t "modules.draft-module.information-tag"}}
           </PixTag>
-          <PixTag @color={{this.validationStatusInformation.color}}>
-            <span class="draft-module-header__tag--{{this.validationStatusInformation.state}}">&#9679;</span>
-            {{this.validationStatusInformation.label}}
-          </PixTag>
+          <ModuleValidationTag @hasBeenValidated={{@model.draftModule.hasBeenValidated}} />
         </div>
       </div>
 

--- a/pix-editor/app/templates/authenticated/modules/production.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production.gjs
@@ -14,7 +14,7 @@ import ModulesTabs from 'pixeditor/components/modules/modules-tabs';
   <main class="page-body">
     <section class="page-section modules-list">
       <ModulesTabs />
-      <ModuleList @modules={{@model.modules}} @showStatus={{true}} @goToDetailPage={{this.goToDetailPage}} />
+      <ModuleList @modules={{@model.modules}} @goToDetailPage={{this.goToDetailPage}} />
       <PixPagination @pagination={{@model.modules.meta}} />
     </section>
   </main>

--- a/pix-editor/tests/integration/components/modules/modules-list-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modules-list-test.gjs
@@ -38,73 +38,48 @@ module('Integration | Component | modules-list', function (hooks) {
       ];
     });
 
-    module('when @showStatus is true', () => {
-      test('it renders with status column', async function (assert) {
-        const screen = await render(<template><ModulesList @modules={{modules}} @showStatus={{true}} /></template>);
+    test('it renders with status column', async function (assert) {
+      const screen = await render(<template><ModulesList @modules={{modules}} /></template>);
 
-        assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.status') })).exists();
-        assert
-          .dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.internal-title') }))
-          .exists();
-        assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.level') })).exists();
+      assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.status') })).exists();
+      assert
+        .dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.internal-title') }))
+        .exists();
+      assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.level') })).exists();
 
-        assert.dom(screen.getByText('MOD_super_1')).exists();
-        assert.dom(screen.getByText('MOD_super_2')).exists();
+      assert.dom(screen.getByText('MOD_super_1')).exists();
+      assert.dom(screen.getByText('MOD_super_2')).exists();
 
-        const firstRow = screen.getByText('MOD_super_1').closest('tr');
-        assert.dom(getByText(firstRow, 'Public')).exists();
-        assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
-        assert.dom(getByText(firstRow, 'Novice')).exists();
+      const firstRow = screen.getByText('MOD_super_1').closest('tr');
+      assert.dom(getByText(firstRow, 'Public')).exists();
+      assert.dom(queryByText(firstRow, 'Beta')).doesNotExist();
+      assert.dom(getByText(firstRow, 'Novice')).exists();
 
-        assert.dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
-        assert
-          .dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') }))
-          .hasAttribute('href', `/modules/production/super-1`);
-        assert
-          .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
-          .exists();
-        assert
-          .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
-          .hasAttribute('href', 'https://graou.prod.asso/modules/super-1');
+      assert.dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
+      assert
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.modules-list.detail') }))
+        .hasAttribute('href', `/modules/production/super-1`);
+      assert
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
+        .exists();
+      assert
+        .dom(getByRole(firstRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
+        .hasAttribute('href', 'https://graou.prod.asso/modules/super-1');
 
-        const secondRow = screen.getByText('MOD_super_2').closest('tr');
-        assert.dom(getByText(secondRow, 'Privé')).exists();
-        assert.dom(getByText(secondRow, 'Beta')).exists();
-        assert.dom(getByText(secondRow, 'Avancé')).exists();
-        assert.dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
-        assert
-          .dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') }))
-          .hasAttribute('href', `/modules/production/super-2`);
-        assert
-          .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
-          .exists();
-        assert
-          .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
-          .hasAttribute('href', 'https://graou.prod.asso/modules/super-2');
-      });
-    });
-
-    module('when @showStatus is false', () => {
-      test('it renders without status column', async function (assert) {
-        const screen = await render(<template><ModulesList @modules={{modules}} @showStatus={{false}} /></template>);
-
-        assert
-          .dom(screen.queryByRole('columnheader', { name: t('modules.components.modules-list.status') }))
-          .doesNotExist();
-        assert
-          .dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.internal-title') }))
-          .exists();
-        assert.dom(screen.getByRole('columnheader', { name: t('modules.components.modules-list.level') })).exists();
-
-        assert.dom(screen.getByText('MOD_super_1')).exists();
-        assert.dom(screen.getByText('MOD_super_2')).exists();
-
-        const firstRow = screen.getByText('MOD_super_1').closest('tr');
-        assert.dom(getByText(firstRow, 'Novice')).exists();
-
-        const secondRow = screen.getByText('MOD_super_2').closest('tr');
-        assert.dom(getByText(secondRow, 'Avancé')).exists();
-      });
+      const secondRow = screen.getByText('MOD_super_2').closest('tr');
+      assert.dom(getByText(secondRow, 'Privé')).exists();
+      assert.dom(getByText(secondRow, 'Beta')).exists();
+      assert.dom(getByText(secondRow, 'Avancé')).exists();
+      assert.dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') })).exists();
+      assert
+        .dom(getByRole(secondRow, 'link', { name: t('modules.components.modules-list.detail') }))
+        .hasAttribute('href', `/modules/production/super-2`);
+      assert
+        .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
+        .exists();
+      assert
+        .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.play-module') }))
+        .hasAttribute('href', 'https://graou.prod.asso/modules/super-2');
     });
   });
 
@@ -179,6 +154,45 @@ module('Integration | Component | modules-list', function (hooks) {
       assert
         .dom(getByRole(secondRow, 'link', { name: t('modules.components.play-module-button.preview') }))
         .hasAttribute('href', 'https://graou.asso/modules/preview/super-2');
+    });
+
+    test('it displays a validation tag', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const validatedDraftModules = [
+        store.createRecord('draft-module', {
+          id: 'validated-1',
+          internalTitle: 'MOD_validated',
+          hasBeenValidated: true,
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            level: 'novice',
+          },
+          previewUrl: 'https://graou.asso/modules/preview/super-1',
+        }),
+        store.createRecord('draft-module', {
+          id: 'invalidated-1',
+          internalTitle: 'MOD_invalidated',
+          hasBeenValidated: false,
+          isBeta: false,
+          visibility: 'public',
+          details: {
+            level: 'novice',
+          },
+          previewUrl: 'https://graou.asso/modules/preview/super-1',
+        }),
+      ];
+
+      // when
+      const screen = await render(<template><ModulesList @modules={{validatedDraftModules}} /></template>);
+
+      // then
+      const validatedRow = screen.getByText('MOD_validated').closest('tr');
+      assert.dom(getByText(validatedRow, t('modules.draft-module.validation-success'))).exists();
+
+      const invalidatedRow = screen.getByText('MOD_invalidated').closest('tr');
+      assert.dom(getByText(invalidatedRow, t('modules.draft-module.validation-failure'))).exists();
     });
   });
 });

--- a/pix-editor/tests/integration/components/modules/validation-tag-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-tag-test.gjs
@@ -1,0 +1,50 @@
+import { render } from '@1024pix/ember-testing-library';
+import { t } from 'ember-intl/test-support';
+import ModuleValidationTag from 'pixeditor/components/modules/validation-tag';
+import { module, test } from 'qunit';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | modules/validation-tag', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when the module has errors', function () {
+    test('it should display an error validation status', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const draftModule = store.createRecord('draft-module', {
+        internalTitle: 'Module Judy',
+        hasBeenValidated: false,
+        validationErrors: ['wouf'],
+      });
+
+      // when
+      const screen = await render(
+        <template><ModuleValidationTag @hasBeenValidated={{draftModule.hasBeenValidated}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('modules.draft-module.validation-failure'))).exists();
+    });
+  });
+
+  module('when the module has no errors', function () {
+    test('it should display success validation status', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const draftModule = store.createRecord('draft-module', {
+        internalTitle: 'Module Judy',
+        hasBeenValidated: true,
+        validationErrors: [],
+      });
+
+      // when
+      const screen = await render(
+        <template><ModuleValidationTag @hasBeenValidated={{draftModule.hasBeenValidated}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('modules.draft-module.validation-success'))).exists();
+    });
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

On a mis en place la validation dans la page de détails d'un brouillon mais il reste pertinent de le voir dès le tableau

## ⛱️ Proposition

Avoir le tag de validation dans le tableau des brouillons

## 🏊 Pour tester

https://pix-lcms-review-pr1591.osc-fr1.scalingo.io/

Aller dans modules
Voir les tags de validation des brouillons dans la colonne status
