### PR TITLE
[FEATURE] Valider avant la publication d'un brouillon (PIX-23279).

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -110,3 +110,9 @@ export class ModuleDuplicateIdsError extends DomainError {
     this.duplicateIds = duplicateIds;
   }
 }
+
+export class DraftModuleValidationError extends DomainError {
+  constructor(message = 'Le module ne peut pas être publié car il est invalide.') {
+    super(message);
+  }
+}

--- a/api/lib/domain/usecases/publish-draft-module.js
+++ b/api/lib/domain/usecases/publish-draft-module.js
@@ -1,12 +1,19 @@
 import { draftModuleRepository, moduleRepository, moduleVersionRepository } from '../../infrastructure/repositories/index.js';
 import { DomainTransaction } from '../DomainTransaction.js';
+import { DraftModuleValidationError } from '../errors.js';
 import { ModuleVersion } from '../models/index.js';
+import { validateDraftModule } from './validate-draft-module.js';
 
-export async function publishDraftModule({ draftModuleId }, dependencies = { draftModuleRepository, moduleRepository, moduleVersionRepository }) {
+export async function publishDraftModule({ draftModuleId }, dependencies = { draftModuleRepository, moduleRepository, moduleVersionRepository, validateDraftModule }) {
+  const draftModule = await dependencies.draftModuleRepository.getById({ id: draftModuleId, forUpdate: true });
+
+  const validatedDraftModule = await dependencies.validateDraftModule(draftModule, dependencies);
+  if (!validatedDraftModule.hasBeenValidated) {
+    throw new DraftModuleValidationError();
+  }
+
   return DomainTransaction.execute(async () => {
-    const draftModule = await dependencies.draftModuleRepository.getById({ id: draftModuleId, forUpdate: true });
-
-    const module = await dependencies.moduleRepository.save(draftModule.publish());
+    const module = await dependencies.moduleRepository.save(validatedDraftModule.publish());
 
     await dependencies.draftModuleRepository.remove({ id: draftModuleId });
 

--- a/api/lib/infrastructure/errors.js
+++ b/api/lib/infrastructure/errors.js
@@ -7,12 +7,13 @@ export class InfrastructureError extends Error {
 }
 
 export class UnprocessableEntityError extends InfrastructureError {
-  constructor({ message, attribute, detail }) {
+  constructor({ message, attribute, detail, code }) {
     super(message);
     this.title = 'Unprocessable entity';
     this.status = 422;
     this.attribute = attribute;
     this.detail = detail;
+    this.code = code;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
@@ -13,6 +13,7 @@ export function serialize(infrastructureError) {
         status: `${error.status}`,
         title: error.title,
         detail: error.detail ?? error.message,
+        code: error.code,
         source,
       };
     }),

--- a/api/lib/infrastructure/utils/error-manager.js
+++ b/api/lib/infrastructure/utils/error-manager.js
@@ -121,6 +121,14 @@ function _mapToInfrastructureError(error) {
     };
   }
 
+  if (error instanceof DomainErrors.DraftModuleValidationError) {
+    const infraError = new InfraErrors.UnprocessableEntityError({ code: 'DRAFT_MODULE_VALIDATION_ERROR' });
+    return {
+      infraErrors: [infraError],
+      statusCode: 422,
+    };
+  }
+
   const infraError = new InfraErrors.InfrastructureError(error.message);
   return {
     infraErrors: [infraError],

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -661,5 +661,43 @@ describe('Acceptance | Route | draft-modules', () => {
         },
       ]);
     });
+
+    describe('when the draft module is invalid', () => {
+      it('responds with status 422 and a DRAFT_MODULE_VALIDATION_ERROR code', async () => {
+        // given
+        const draftModule = domainBuilder.buildDraftModule({ slug: 'not valid slug' });
+        databaseBuilder.factory.buildDraftModule(draftModule);
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: `/api/draft-modules/${draftModule.id}/publish`,
+          headers: generateAuthorizationHeader(editorUser),
+        });
+
+        // then
+        expect(response.statusCode).toBe(422);
+        expect(response.result.errors).toContainEqual(
+          expect.objectContaining({
+            status: '422',
+            code: 'DRAFT_MODULE_VALIDATION_ERROR',
+          }),
+        );
+
+        await expect(knex.select('*').from('modules')).resolves.toStrictEqual([]);
+
+        const nonValidatedDraftModule = await knex.select('*').from('draft-modules').first();
+        expect(nonValidatedDraftModule.hasBeenValidated).toStrictEqual(false);
+        expect(nonValidatedDraftModule.validationErrors).toStrictEqual([
+          `
+"slug" avec la valeur "not valid slug" ne respecte pas le format requis : /^[a-z0-9-]+$/.
+Valeur concernée à rechercher : "not valid slug"
+`,
+        ]);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/publish-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/publish-draft-module_test.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { domainBuilder } from '../../../test-helper.js';
 import { publishDraftModule } from '../../../../lib/domain/usecases/index.js';
+import { DraftModuleValidationError } from '../../../../lib/domain/errors.js';
 import { ModuleVersion } from '../../../../lib/domain/models/index.js';
 
 describe('Unit | Domain | Use Cases | publish-draft-module', () => {
@@ -8,30 +9,52 @@ describe('Unit | Domain | Use Cases | publish-draft-module', () => {
   const savedModule = Symbol('savedModule');
   const moduleVersion = Symbol('moduleVersion');
 
-  let moduleRepository, draftModuleRepository, moduleVersionRepository, draftModule, publish, fromModule;
+  let moduleRepository, draftModuleRepository, moduleVersionRepository, draftModule, validatedDraftModule, publish, fromModule, validateDraftModule;
 
   beforeEach(() => {
     draftModule = domainBuilder.buildDraftModule();
-    publish = vi.spyOn(draftModule, 'publish').mockReturnValueOnce(publishedModule);
+    validatedDraftModule = domainBuilder.buildDraftModule({ hasBeenValidated: true, validationErrors: [] });
+    publish = vi.spyOn(validatedDraftModule, 'publish').mockReturnValueOnce(publishedModule);
     fromModule = vi.spyOn(ModuleVersion, 'fromModule').mockReturnValueOnce(moduleVersion);
 
     draftModuleRepository = { getById: vi.fn().mockResolvedValueOnce(draftModule), remove: vi.fn().mockResolvedValueOnce() };
     moduleRepository = { save: vi.fn().mockResolvedValueOnce(savedModule) };
     moduleVersionRepository = { create: vi.fn().mockResolvedValueOnce() };
+
+    validateDraftModule = vi.fn().mockResolvedValueOnce(validatedDraftModule);
   });
 
-  it('saves draft module as a module then removes draft module', async () => {
+  it('validates the draft module, then saves it as a module and removes the draft module', async () => {
     // when
-    const result = await publishDraftModule({ draftModuleId: draftModule.id }, { draftModuleRepository, moduleRepository, moduleVersionRepository });
+    const dependencies = { draftModuleRepository, moduleRepository, moduleVersionRepository, validateDraftModule };
+    const result = await publishDraftModule({ draftModuleId: draftModule.id }, dependencies);
 
     // then
     expect(result).toBe(savedModule);
 
     expect(draftModuleRepository.getById).toHaveBeenCalledExactlyOnceWith({ id: draftModule.id, forUpdate: true });
+    expect(validateDraftModule).toHaveBeenCalledExactlyOnceWith(draftModule, dependencies);
     expect(publish).toHaveBeenCalledExactlyOnceWith();
     expect(moduleRepository.save).toHaveBeenCalledExactlyOnceWith(publishedModule);
     expect(draftModuleRepository.remove).toHaveBeenCalledExactlyOnceWith({ id: draftModule.id });
     expect(fromModule).toHaveBeenCalledExactlyOnceWith(savedModule);
     expect(moduleVersionRepository.create).toHaveBeenCalledExactlyOnceWith(moduleVersion);
+  });
+
+  it('throws a DraftModuleValidationError and does not publish when the draft module is invalid', async () => {
+    // given
+    const invalidatedDraftModule = domainBuilder.buildDraftModule({ hasBeenValidated: false, validationErrors: ['error'] });
+    validateDraftModule.mockReset().mockResolvedValueOnce(invalidatedDraftModule);
+
+    // when
+    const error = await publishDraftModule(
+      { draftModuleId: draftModule.id },
+      { draftModuleRepository, moduleRepository, moduleVersionRepository, validateDraftModule },
+    ).catch((error) => error);
+
+    // then
+    expect(error).toBeInstanceOf(DraftModuleValidationError);
+    expect(moduleRepository.save).not.toHaveBeenCalled();
+    expect(draftModuleRepository.remove).not.toHaveBeenCalled();
   });
 });

--- a/api/tests/unit/infrastructure/utils/error-manager_test.js
+++ b/api/tests/unit/infrastructure/utils/error-manager_test.js
@@ -223,6 +223,19 @@ describe('Unit | Infrastructure | ErrorManager', function() {
               },
             ],
           });
+        } else if (domainErrorName === 'DraftModuleValidationError') {
+          const errorInstance = new domainErrorClass(['erreur 1', 'erreur 2']);
+          const responseForError = send(hFake, errorInstance);
+          expect(responseForError.statusCode, expectErrorMessage).toStrictEqual(422);
+          expect(responseForError.source).toStrictEqual({
+            errors: [
+              {
+                status: '422',
+                title: 'Unprocessable entity',
+                code: 'DRAFT_MODULE_VALIDATION_ERROR',
+              },
+            ],
+          });
         } else {
           expect(true, `Conversion for ${domainErrorName} not tested`).toBe(false);
         }

--- a/pix-editor/app/components/modules/publish-module-button.gjs
+++ b/pix-editor/app/components/modules/publish-module-button.gjs
@@ -17,8 +17,13 @@ export default class PublishModuleButton extends Component {
         this.intl.t('modules.components.publish-module-button.success', { title: module.internalTitle }),
       );
       this.router.replaceWith('authenticated.modules.production-module', module.id);
-    } catch {
-      this.notifications.sendError(this.intl.t('modules.components.publish-module-button.error'));
+    } catch (error) {
+      const isValidationError = error.errors?.some((error) => error.code === 'DRAFT_MODULE_VALIDATION_ERROR');
+      if (isValidationError) {
+        this.notifications.sendError(this.intl.t('modules.components.publish-module-button.validation-error'));
+      } else {
+        this.notifications.sendError(this.intl.t('modules.components.publish-module-button.error'));
+      }
     } finally {
       this.loader.stop();
     }

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -26,12 +26,17 @@ export default class DraftModule extends BaseModule {
   }
 
   async publish() {
-    const module = await this.store.queryRecord(
-      'module',
-      { draftModuleId: this.id },
-      { adapterOptions: { publish: true } },
-    );
-    this.store.unloadRecord(this);
-    return module;
+    try {
+      const module = await this.store.queryRecord(
+        'module',
+        { draftModuleId: this.id },
+        { adapterOptions: { publish: true } },
+      );
+      this.store.unloadRecord(this);
+      return module;
+    } catch (error) {
+      await this.reload();
+      throw error;
+    }
   }
 }

--- a/pix-editor/tests/integration/components/modules/publish-module-button-test.gjs
+++ b/pix-editor/tests/integration/components/modules/publish-module-button-test.gjs
@@ -1,0 +1,101 @@
+import { render } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import PublishModuleButton from 'pixeditor/components/modules/publish-module-button';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Component | modules/publish-module-button', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let loaderStopStub, sendSuccessStub, sendErrorStub, replaceWithStub;
+
+  hooks.beforeEach(function () {
+    const loader = this.owner.lookup('service:loader');
+    loaderStopStub = sinon.stub(loader, 'stop');
+
+    class NotificationsStub extends Service {
+      sendSuccess() {}
+      sendError() {}
+    }
+    this.owner.register('service:notifications', NotificationsStub);
+    const notifications = this.owner.lookup('service:notifications');
+    sendSuccessStub = sinon.stub(notifications, 'sendSuccess');
+    sendErrorStub = sinon.stub(notifications, 'sendError');
+
+    class RouterStub extends Service {
+      replaceWith = sinon.stub();
+    }
+    this.owner.register('service:router', RouterStub);
+    replaceWithStub = this.owner.lookup('service:router').replaceWith;
+  });
+
+  test('it publishes the draft module and redirects to the production module', async function (assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+    const draftModule = store.createRecord('draft-module', { internalTitle: 'Mon module' });
+    const publishedModule = store.createRecord('module', { id: 'moduleId', internalTitle: 'Mon module' });
+    sinon.stub(draftModule, 'publish').resolves(publishedModule);
+
+    const screen = await render(<template><PublishModuleButton @draftModule={{draftModule}} /></template>);
+
+    // when
+    await click(
+      screen.getByRole('button', {
+        name: t('modules.components.publish-module-button.aria-label', { title: 'Mon module' }),
+      }),
+    );
+
+    // then
+    assert.ok(
+      sendSuccessStub.calledWith(t('modules.components.publish-module-button.success', { title: 'Mon module' })),
+    );
+    assert.ok(replaceWithStub.calledWith('authenticated.modules.production-module', 'moduleId'));
+    assert.ok(loaderStopStub.calledOnce);
+  });
+
+  module('when publication fails because of validation errors', function () {
+    test('it displays a specific notification', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const draftModule = store.createRecord('draft-module', { internalTitle: 'Mon module' });
+      sinon.stub(draftModule, 'publish').rejects({ errors: [{ code: 'DRAFT_MODULE_VALIDATION_ERROR' }] });
+
+      const screen = await render(<template><PublishModuleButton @draftModule={{draftModule}} /></template>);
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: t('modules.components.publish-module-button.aria-label', { title: 'Mon module' }),
+        }),
+      );
+
+      // then
+      assert.ok(sendErrorStub.calledWith(t('modules.components.publish-module-button.validation-error')));
+    });
+  });
+
+  module('when publication fails for another reason', function () {
+    test('it displays a generic error notification', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const draftModule = store.createRecord('draft-module', { internalTitle: 'Mon module' });
+      sinon.stub(draftModule, 'publish').rejects(new Error('boom'));
+
+      const screen = await render(<template><PublishModuleButton @draftModule={{draftModule}} /></template>);
+
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: t('modules.components.publish-module-button.aria-label', { title: 'Mon module' }),
+        }),
+      );
+
+      // then
+      assert.ok(sendErrorStub.calledWith(t('modules.components.publish-module-button.error')));
+    });
+  });
+});

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -108,6 +108,7 @@ modules:
     publish-module-button:
       success: Le module "{title}" a été publié.
       error: Erreur lors de la publication du module.
+      validation-error: Le brouillon ne peut pas être publié car il contient des erreurs de validation.
       aria-label: Publier le brouillon "{title}"
       publish: Publier ce brouillon
     modules-tabs:


### PR DESCRIPTION
## ☀️ Problème

Sur Pix Editor, pouvons publier un brouillon sur la page de détail, seulement si la validation est ok. 
Seulement, pour se protéger complètement (si update de la validation entre temps, autre brouillon publié avant, on souhaite valider une dernière fois avant la publication.

## ⛱️ Proposition

Valider avant la publication d'un brouillon

## 🧴 Remarques

Ajout d'un code d'erreur coté back pour le catcher coté front.

## 🏊 Pour tester

- Aller sur les modules.
- Prendre nat_escargot et le corriger pour qu'il soit prêt pour être publié.
- Prendre son JSON et aller créer un module
- coller le JSON et appelé ce module copie_nat_escargot
- Maintenant publier nat_escargot
- On constate que copie_nat_escargot est ok validation bien qu'il ai des ids iso à nat_escargot
- Publier copie_nat_escargot et constater une notif d'erreur et que la validation n'est plus ok.

