### PR TITLE
[FEATURE] Amélioration des pages de module (partie 3) (PIX-23885)

### DIFF
--- a/pix-editor/app/components/modules/publish-module-button.gjs
+++ b/pix-editor/app/components/modules/publish-module-button.gjs
@@ -1,7 +1,9 @@
 import PixButton from '@1024pix/pix-ui/components/pix-button';
+import PixModal from '@1024pix/pix-ui/components/pix-modal';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
 
 export default class PublishModuleButton extends Component {
@@ -10,14 +12,26 @@ export default class PublishModuleButton extends Component {
   @service notifications;
   @service router;
 
+  @tracked showModal = false;
+
+  @action openModal() {
+    this.showModal = true;
+  }
+
+  @action closeModal() {
+    this.showModal = false;
+  }
+
   @action async publish() {
     try {
       const module = await this.args.draftModule.publish();
+      this.closeModal();
       this.notifications.sendSuccess(
         this.intl.t('modules.components.publish-module-button.success', { title: module.internalTitle }),
       );
       this.router.replaceWith('authenticated.modules.production-module', module.id);
     } catch (error) {
+      this.closeModal();
       const isValidationError = error.errors?.some((error) => error.code === 'DRAFT_MODULE_VALIDATION_ERROR');
       if (isValidationError) {
         this.notifications.sendError(this.intl.t('modules.components.publish-module-button.validation-error'));
@@ -36,8 +50,31 @@ export default class PublishModuleButton extends Component {
   }
 
   <template>
-    <PixButton @triggerAction={{this.publish}} @variant="success" aria-label={{this.ariaLabel}}>
+    <PixButton @triggerAction={{this.openModal}} @variant="success" aria-label={{this.ariaLabel}}>
       {{t "modules.components.publish-module-button.publish"}}
     </PixButton>
+    <PixModal
+      @showModal={{this.showModal}}
+      @title={{t "modules.components.publish-module-button.confirmation-dialog.title"}}
+      @onCloseButtonClick={{this.closeModal}}
+    >
+      <:content>
+        <div class="publish-module-button-modal__content">
+          <p>{{t
+              "modules.components.publish-module-button.confirmation-dialog.question"
+              title=@draftModule.internalTitle
+            }}</p>
+          <p>{{t "modules.components.publish-module-button.confirmation-dialog.message"}}</p>
+        </div>
+      </:content>
+      <:footer>
+        <PixButton @variant="secondary" @isBorderVisible={{true}} @triggerAction={{this.closeModal}}>
+          {{t "common.cancel"}}
+        </PixButton>
+        <PixButton @variant="success" @triggerAction={{this.publish}}>{{t
+            "modules.components.publish-module-button.confirmation-dialog.confirm"
+          }}</PixButton>
+      </:footer>
+    </PixModal>
   </template>
 }

--- a/pix-editor/app/components/modules/validation-success.gjs
+++ b/pix-editor/app/components/modules/validation-success.gjs
@@ -3,9 +3,13 @@ import t from 'ember-intl/helpers/t';
 import PublishModuleButton from 'pixeditor/components/modules/publish-module-button';
 
 <template>
-  <PixNotificationAlert @type="success" @withIcon={{true}} class="module-validation-success">{{t
-      "modules.components.validation-success.content"
-    }}
+  <PixNotificationAlert @type="success" @withIcon={{true}} class="module-validation-success">
+    <span class="module-validation-success__information">
+      <span class="module-validation-success-information--bold">{{t
+          "modules.components.validation-success.title"
+        }}</span>
+      {{t "modules.components.validation-success.subtitle"}}
+    </span>
     <PublishModuleButton @draftModule={{@draftModule}} />
   </PixNotificationAlert>
 </template>

--- a/pix-editor/app/models/draft-module.js
+++ b/pix-editor/app/models/draft-module.js
@@ -8,6 +8,7 @@ export default class DraftModule extends BaseModule {
 
   @attr hasBeenValidated;
   @attr validationErrors;
+  @attr updatedAt;
 
   get isDraft() {
     return true;

--- a/pix-editor/app/serializers/draft-module.js
+++ b/pix-editor/app/serializers/draft-module.js
@@ -8,5 +8,6 @@ export default class DraftModuleSerializer extends ApplicationSerializer {
     url: { serialize: false },
     hasBeenValidated: { serialize: false },
     validationErrors: { serialize: false },
+    updatedAt: { serialize: false },
   };
 }

--- a/pix-editor/app/styles/app.scss
+++ b/pix-editor/app/styles/app.scss
@@ -42,6 +42,7 @@
 @use 'components/login-form';
 @use 'components/markdown-editor/markdown-editor';
 @use 'components/modules/module-form';
+@use 'components/modules/publish-module-button';
 @use 'components/modules/validation-errors';
 @use 'components/modules/validation-success';
 @use 'components/field';

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -82,5 +82,6 @@ td.modules-list__actions {
     display: flex;
     gap: var(--pix-spacing-2x);
     align-items: center;
+    flex-wrap: wrap;
   }
 }

--- a/pix-editor/app/styles/components/modules/publish-module-button.scss
+++ b/pix-editor/app/styles/components/modules/publish-module-button.scss
@@ -1,0 +1,11 @@
+@use 'pix-design-tokens/typography';
+
+.publish-module-button-modal {
+  &__content {
+    @extend %pix-body-m;
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+  }
+}

--- a/pix-editor/app/styles/components/modules/validation-success.scss
+++ b/pix-editor/app/styles/components/modules/validation-success.scss
@@ -1,13 +1,28 @@
 @use 'pix-design-tokens/typography';
 
 .module-validation-success {
-  span {
-    @extend %pix-body-m;
-
+  .pix-notification-alert__content {
     display: flex;
     justify-content: space-between;
     width: 100%;
     align-items: center;
+  }
+
+  &__information {
+    @extend %pix-body-s;
+
+    display: flex;
+    flex-direction: column;
+    color: var(--pix-success-900);
+  }
+}
+
+.module-validation-success-information {
+
+  &--bold {
+    @extend %pix-body-m;
+
     font-weight: var(--pix-font-bold);
+    color: var(--pix-success-700);
   }
 }

--- a/pix-editor/app/styles/pages/draft-module.scss
+++ b/pix-editor/app/styles/pages/draft-module.scss
@@ -1,4 +1,21 @@
+@use 'pix-design-tokens/typography';
+
 .draft-module-header {
+  &__last-modified-at {
+    @extend %pix-monospace;
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+    font-weight: var(--pix-font-bold);
+    align-items: center;
+    color: var(--pix-neutral-500);
+    display: flex;
+    gap: var(--pix-spacing-2x);
+
+    &--bullet {
+      color: currentColor;
+    }
+  }
+
   &__tag {
     display: flex;
     gap: var(--pix-spacing-4x);

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -4,6 +4,7 @@ import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import formatDate from 'ember-intl/helpers/format-date';
 import t from 'ember-intl/helpers/t';
 import DraftModuleDiff from 'pixeditor/components/modules/draft-module-diff';
 import ModuleForm from 'pixeditor/components/modules/module-form';
@@ -48,6 +49,12 @@ export default class DraftModule extends Component {
             {{t "modules.draft-module.information-tag"}}
           </PixTag>
           <ModuleValidationTag @hasBeenValidated={{@model.draftModule.hasBeenValidated}} />
+          <p class="draft-module-header__last-modified-at"><span
+              class="draft-module-header__last-modified-at--bullet"
+            >&#9679;</span>{{t
+              "modules.draft-module.last-modified-at"
+              modifiedDate=(formatDate @model.draftModule.updatedAt "DD/MM/YYYY")
+            }}</p>
         </div>
       </div>
 

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -16,7 +16,11 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
     this.server.create('user', { trigram: 'ABC' });
 
     id = crypto.randomUUID();
-    this.server.create('draft-module', { id, internalTitle: 'MON_BEAU_MODULE' });
+    this.server.create('draft-module', {
+      id,
+      internalTitle: 'MON_BEAU_MODULE',
+      updatedAt: '2026-08-14T08:54:10.449Z',
+    });
 
     return authenticateSession();
   });
@@ -46,6 +50,7 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
     assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
     assert.dom(screen.getByRole('heading', { name: 'MON_BEAU_MODULE' })).exists();
     assert.dom(screen.getByText(t('modules.draft-module.information-tag'))).exists();
+    assert.dom(screen.getByText(t('modules.draft-module.last-modified-at', { modifiedDate: '14/08/2026' }))).exists();
 
     // WORKAROUND: let some time for monaco-editor to settle
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -87,10 +87,19 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // when
       await click(
         screen.getByRole('button', {
           name: t('modules.components.publish-module-button.aria-label', { title: 'MON_BEAU_MODULE' }),
+        }),
+      );
+      const dialog = await screen.findByRole('dialog', {
+        name: t('modules.components.publish-module-button.confirmation-dialog.title'),
+      });
+
+      // when
+      await click(
+        within(dialog).getByRole('button', {
+          name: t('modules.components.publish-module-button.confirmation-dialog.confirm'),
         }),
       );
 

--- a/pix-editor/tests/integration/components/modules/publish-module-button-test.gjs
+++ b/pix-editor/tests/integration/components/modules/publish-module-button-test.gjs
@@ -1,6 +1,7 @@
-import { render } from '@1024pix/ember-testing-library';
+import { render, within } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import { click } from '@ember/test-helpers';
+import { waitForElementToBeRemoved } from '@testing-library/dom';
 import { t } from 'ember-intl/test-support';
 import PublishModuleButton from 'pixeditor/components/modules/publish-module-button';
 import { module, test } from 'qunit';
@@ -33,6 +34,31 @@ module('Integration | Component | modules/publish-module-button', function (hook
     replaceWithStub = this.owner.lookup('service:router').replaceWith;
   });
 
+  module('when publish button is clicked', function () {
+    test('it display a confirmation dialog', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const draftModule = store.createRecord('draft-module', { internalTitle: 'Mon module' });
+
+      // when
+      const screen = await render(<template><PublishModuleButton @draftModule={{draftModule}} /></template>);
+      await click(
+        screen.getByRole('button', {
+          name: t('modules.components.publish-module-button.aria-label', { title: 'Mon module' }),
+        }),
+      );
+
+      const dialog = await screen.findByRole('dialog', {
+        name: t('modules.components.publish-module-button.confirmation-dialog.title'),
+      });
+
+      // then
+      assert
+        .dom(within(dialog).getByText(t('modules.components.publish-module-button.confirmation-dialog.message')))
+        .exists();
+    });
+  });
+
   test('it publishes the draft module and redirects to the production module', async function (assert) {
     // given
     const store = this.owner.lookup('service:store');
@@ -48,6 +74,17 @@ module('Integration | Component | modules/publish-module-button', function (hook
         name: t('modules.components.publish-module-button.aria-label', { title: 'Mon module' }),
       }),
     );
+
+    const dialog = await screen.findByRole('dialog', {
+      name: t('modules.components.publish-module-button.confirmation-dialog.title'),
+    });
+    await click(
+      within(dialog).getByRole('button', {
+        name: t('modules.components.publish-module-button.confirmation-dialog.confirm'),
+      }),
+    );
+
+    await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 
     // then
     assert.ok(
@@ -73,6 +110,17 @@ module('Integration | Component | modules/publish-module-button', function (hook
         }),
       );
 
+      const dialog = await screen.findByRole('dialog', {
+        name: t('modules.components.publish-module-button.confirmation-dialog.title'),
+      });
+      await click(
+        within(dialog).getByRole('button', {
+          name: t('modules.components.publish-module-button.confirmation-dialog.confirm'),
+        }),
+      );
+
+      await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+
       // then
       assert.ok(sendErrorStub.calledWith(t('modules.components.publish-module-button.validation-error')));
     });
@@ -93,6 +141,17 @@ module('Integration | Component | modules/publish-module-button', function (hook
           name: t('modules.components.publish-module-button.aria-label', { title: 'Mon module' }),
         }),
       );
+
+      const dialog = await screen.findByRole('dialog', {
+        name: t('modules.components.publish-module-button.confirmation-dialog.title'),
+      });
+      await click(
+        within(dialog).getByRole('button', {
+          name: t('modules.components.publish-module-button.confirmation-dialog.confirm'),
+        }),
+      );
+
+      await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 
       // then
       assert.ok(sendErrorStub.calledWith(t('modules.components.publish-module-button.error')));

--- a/pix-editor/tests/integration/components/modules/validation-success-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-success-test.gjs
@@ -17,7 +17,8 @@ module('Integration | Component | modules/validation-success', function (hooks) 
     const screen = await render(<template><ModuleValidationSuccess @draftModule={{draftModule}} /></template>);
 
     // then
-    assert.dom(screen.getByText(t('modules.components.validation-success.content'))).exists();
+    assert.dom(screen.getByText(t('modules.components.validation-success.title'))).exists();
+    assert.dom(screen.getByText(t('modules.components.validation-success.subtitle'))).exists();
     assert
       .dom(
         screen.getByRole('button', {

--- a/pix-editor/tests/mirage/factories/draft-module.js
+++ b/pix-editor/tests/mirage/factories/draft-module.js
@@ -42,4 +42,5 @@ export default Factory.extend({
 
   isBeta: false,
   visibility: 'public',
+  updatedAt: '2026-08-14T08:54:10.449Z',
 });

--- a/pix-editor/tests/setup-intl-rendering.js
+++ b/pix-editor/tests/setup-intl-rendering.js
@@ -1,7 +1,13 @@
 import { setupIntl } from 'ember-intl/test-support';
 import { setupRenderingTest } from 'ember-qunit';
+import translationsForFr from 'virtual:ember-intl/translations/fr';
 
 export function setupIntlRenderingTest(hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'fr');
+
+  hooks.beforeEach(function () {
+    const intl = this.owner.lookup('service:intl');
+    intl.addTranslations('fr', translationsForFr);
+  });
 }

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -111,6 +111,11 @@ modules:
       error: Erreur lors de la publication du module.
       validation-error: Le brouillon ne peut pas être publié car il contient des erreurs de validation.
       aria-label: Publier le brouillon "{title}"
+      confirmation-dialog:
+        confirm: Confirmer la publication
+        title: Confirmation de publication
+        question: Voulez-vous vraiment publier ce brouillon {title} ?
+        message: Cette action transformera le brouillon en module de production.
       publish: Publier
     modules-tabs:
       navigation: Navigation

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -111,7 +111,7 @@ modules:
       error: Erreur lors de la publication du module.
       validation-error: Le brouillon ne peut pas être publié car il contient des erreurs de validation.
       aria-label: Publier le brouillon "{title}"
-      publish: Publier ce brouillon
+      publish: Publier
     modules-tabs:
       navigation: Navigation
       workbench: Atelier
@@ -137,7 +137,8 @@ modules:
       title: '{count, plural, one {1 erreur} other {# erreurs}} de validation'
       information: La publication est impossible tant que des erreurs subsistent.
     validation-success:
-      content: Aucune erreur de validation
+      title: Aucune erreur de validation.
+      subtitle: Il est désormais possible de publier ce brouillon.
     create-module-button:
       create-draft: Créer un brouillon
       create-module: Créer un module

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -98,6 +98,7 @@ modules:
   draft-module:
     information-tag: brouillon
     edit: Modifier
+    last-modified-at: Dernière modification le {modifiedDate}
     validation-success: Validation en succès
     validation-failure: Validation en échec
     diff:

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -139,7 +139,7 @@ modules:
     validation-success:
       content: Aucune erreur de validation
     create-module-button:
-      create-draft: Créer un draft
+      create-draft: Créer un brouillon
       create-module: Créer un module
     module-form:
       required-field: Champ obligatoire


### PR DESCRIPTION
## ☀️ Problème

On a constaté que les pages des modules manquaient de cohérence entre elles + des boutons placés à des endroits pas pratique. Des soucis d'UI à améliorer en quick win.

## ⛱️ Proposition

Améliorer la page de détail du draft avec : 
- Suppression d'un wording draft oublié
- Ajout d'une modale de confirmation pour la publication + petit message complémentaire dans la notification.
- Afficher la date de dernière modification du brouillon

## 🏊 Pour tester

<img width="1681" height="405" alt="Capture d’écran 2026-08-14 à 15 39 10" src="https://github.com/user-attachments/assets/36ee8417-3b66-49b5-bc0f-754263a524e1" />

<img width="1681" height="820" alt="Capture d’écran 2026-08-14 à 15 39 25" src="https://github.com/user-attachments/assets/3f498b54-c2e2-46c8-ab10-e67a747850bf" />
