### PR TITLE
[FEATURE] Accéder à Modulix Editor depuis la page d'édition/création (PIX-23287)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ pix-editor/app/config-private-test.js
 
 # VSCode
 .vscode/settings.json
+pix-editor/.env

--- a/pix-editor/app/components/modules/modulix-editor-button.gjs
+++ b/pix-editor/app/components/modules/modulix-editor-button.gjs
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
+import ENV from 'pixeditor/config/environment';
 
 export default class ModulixEditorButton extends Component {
   @tracked previewWindow;
@@ -27,7 +28,7 @@ export default class ModulixEditorButton extends Component {
   @action
   onModulixEditorButtonClicked() {
     const windowName = 'modulix-editor-edit';
-    this.previewWindow = window.open('http://localhost:5173/modulix-editor/', windowName);
+    this.previewWindow = window.open(ENV.APP.MODULIX_EDITOR_URL, windowName);
   }
 
   <template>

--- a/pix-editor/app/components/modules/modulix-editor-button.gjs
+++ b/pix-editor/app/components/modules/modulix-editor-button.gjs
@@ -1,0 +1,38 @@
+import PixButton from '@1024pix/pix-ui/components/pix-button';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import t from 'ember-intl/helpers/t';
+
+export default class ModulixEditorButton extends Component {
+  @tracked previewWindow;
+
+  constructor(...args) {
+    super(...args);
+    this.addModuleContentListener();
+  }
+
+  @action
+  addModuleContentListener() {
+    window.addEventListener('message', (event) => {
+      if (event.data?.from === 'modulix-editor' && event.data?.message === 'ready') {
+        const moduleContent = this.args.moduleContent;
+        if (moduleContent) {
+          this.previewWindow?.postMessage({ from: 'pix-editor', moduleContent }, '*');
+        }
+      }
+    });
+  }
+
+  @action
+  onModulixEditorButtonClicked() {
+    const windowName = 'modulix-editor-edit';
+    this.previewWindow = window.open('http://localhost:5173/modulix-editor/', windowName);
+  }
+
+  <template>
+    <PixButton @variant="secondary" @iconAfter="openNew" @triggerAction={{this.onModulixEditorButtonClicked}}>
+      {{t "modules.modulix-editor-button.label"}}
+    </PixButton>
+  </template>
+}

--- a/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import ModuleForm from 'pixeditor/components/modules/module-form';
+import ModulixEditorButton from 'pixeditor/components/modules/modulix-editor-button';
 import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 
 export default class NewModule extends Component {
@@ -39,6 +40,20 @@ export default class NewModule extends Component {
     }
   }
 
+  get draftModuleModulixEditorFormat() {
+    return {
+      id: this.args.model.draftModule.id,
+      shortId: this.args.model.draftModule.shortId,
+      title: this.args.model.draftModule.title,
+      isBeta: this.args.model.draftModule.isBeta,
+      slug: this.args.model.draftModule.slug,
+      visibility: this.args.model.draftModule.visibility,
+      details: this.args.model.draftModule.details,
+      sections: this.args.model.draftModule.sections,
+      glossary: this.args.model.draftModule.glossary,
+    };
+  }
+
   get hasValidationErrors() {
     return !this.args.model.draftModule.hasBeenValidated && this.validationErrors?.length > 0;
   }
@@ -72,6 +87,9 @@ export default class NewModule extends Component {
         <h1 class="module-header__title">
           {{@model.draftModule.internalTitle}}
         </h1>
+      </div>
+      <div class="page-actions">
+        <ModulixEditorButton @moduleContent={{this.draftModuleModulixEditorFormat}} />
       </div>
     </header>
     <main class="page-body">

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import ModuleForm from 'pixeditor/components/modules/module-form';
+import ModulixEditorButton from 'pixeditor/components/modules/modulix-editor-button';
 
 export default class NewModule extends Component {
   @service intl;
@@ -90,6 +91,7 @@ export default class NewModule extends Component {
           {{/if}}
         </h1>
       </div>
+      <ModulixEditorButton />
     </header>
     <main class="page-body">
       <section class="page-section module-form">

--- a/pix-editor/config/environment.js
+++ b/pix-editor/config/environment.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('dotenv').config({ quiet: true });
+
 module.exports = function (environment) {
   const ENV = {
     modulePrefix: 'pixeditor',
@@ -23,6 +25,7 @@ module.exports = function (environment) {
         defaultValue: 4,
         minValue: 1,
       }),
+      MODULIX_EDITOR_URL: process.env.MODULIX_EDITOR_URL || 'https://1024pix.github.io/modulix-editor/',
     },
 
     'ember-simple-auth': { routeAfterAuthentication: 'authenticated' },
@@ -46,6 +49,7 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+    ENV.APP.MODULIX_EDITOR_URL = 'https://app.modulix-editor.io';
   }
 
   return ENV;

--- a/pix-editor/package-lock.json
+++ b/pix-editor/package-lock.json
@@ -43,6 +43,7 @@
         "countries-list": "^3.2.2",
         "css-element-queries": "file:external/css-element-queries",
         "decorator-transforms": "^2.3.0",
+        "dotenv": "^17.4.2",
         "easymde": "^2.20.0",
         "ember-auto-import": "^2.12.0",
         "ember-cli": "^6.9.1",
@@ -13514,6 +13515,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/pix-editor/package.json
+++ b/pix-editor/package.json
@@ -56,6 +56,7 @@
     "countries-list": "^3.2.2",
     "css-element-queries": "file:external/css-element-queries",
     "decorator-transforms": "^2.3.0",
+    "dotenv": "^17.4.2",
     "easymde": "^2.20.0",
     "ember-auto-import": "^2.12.0",
     "ember-cli": "^6.9.1",

--- a/pix-editor/tests/integration/components/modules/modulix-editor-button-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modulix-editor-button-test.gjs
@@ -1,0 +1,88 @@
+import { render } from '@1024pix/ember-testing-library';
+import { click, settled } from '@ember/test-helpers';
+import { t } from 'ember-intl/test-support';
+import ModulixEditorButton from 'pixeditor/components/modules/modulix-editor-button';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
+
+module('Integration | Components | modules/modulix-editor-button', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let originalWindowOpen;
+
+  hooks.beforeEach(function () {
+    // given
+    originalWindowOpen = window.open;
+  });
+
+  hooks.afterEach(function () {
+    window.open = originalWindowOpen;
+  });
+
+  test('it displays a button', async function (assert) {
+    // given
+    // when
+    const screen = await render(<template><ModulixEditorButton /></template>);
+
+    // then
+    assert.dom(screen.getByRole('button', { name: t('modules.modulix-editor-button.label') })).exists();
+  });
+
+  module('when button is clicked', function () {
+    module('when draft module exists', function () {
+      test("it redirects and sends the module's content via a postMessage", async function (assert) {
+        // given
+        const postMessageStub = sinon.stub();
+        const openStub = sinon.stub(window, 'open');
+        openStub.returns({ postMessage: postMessageStub });
+
+        const store = this.owner.lookup('service:store');
+        const draftModule = store.createRecord('draft-module', {
+          id: 'moduleId',
+          url: 'https://kapoue.org/module/play',
+          previewUrl: 'https://kapoue.org/module/preview',
+        });
+
+        const screen = await render(<template><ModulixEditorButton @moduleContent={{draftModule}} /></template>);
+        await click(screen.getByRole('button', { name: t('modules.modulix-editor-button.label') }));
+
+        // when
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { from: 'modulix-editor', message: 'ready' },
+          }),
+        );
+        await settled();
+
+        // then
+        assert.true(postMessageStub.calledWithExactly({ from: 'pix-editor', moduleContent: draftModule }, '*'));
+        assert.true(openStub.calledWithExactly('http://localhost:5173/modulix-editor/', 'modulix-editor-edit'));
+      });
+    });
+
+    module('when no draft module exists', function () {
+      test('it only redirects', async function (assert) {
+        // given
+        const postMessageStub = sinon.stub();
+        const openStub = sinon.stub(window, 'open');
+        openStub.returns({ postMessage: postMessageStub });
+
+        const screen = await render(<template><ModulixEditorButton /></template>);
+        await click(screen.getByRole('button', { name: t('modules.modulix-editor-button.label') }));
+
+        // when
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { from: 'modulix-editor', message: 'ready' },
+          }),
+        );
+        await settled();
+
+        // then
+        assert.false(postMessageStub.calledOnce);
+        assert.true(openStub.calledWithExactly('http://localhost:5173/modulix-editor/', 'modulix-editor-edit'));
+      });
+    });
+  });
+});

--- a/pix-editor/tests/integration/components/modules/modulix-editor-button-test.gjs
+++ b/pix-editor/tests/integration/components/modules/modulix-editor-button-test.gjs
@@ -57,7 +57,7 @@ module('Integration | Components | modules/modulix-editor-button', function (hoo
 
         // then
         assert.true(postMessageStub.calledWithExactly({ from: 'pix-editor', moduleContent: draftModule }, '*'));
-        assert.true(openStub.calledWithExactly('http://localhost:5173/modulix-editor/', 'modulix-editor-edit'));
+        sinon.assert.calledOnceWithExactly(openStub, 'https://app.modulix-editor.io', 'modulix-editor-edit');
       });
     });
 
@@ -81,7 +81,7 @@ module('Integration | Components | modules/modulix-editor-button', function (hoo
 
         // then
         assert.false(postMessageStub.calledOnce);
-        assert.true(openStub.calledWithExactly('http://localhost:5173/modulix-editor/', 'modulix-editor-edit'));
+        assert.true(openStub.calledWithExactly('https://app.modulix-editor.io', 'modulix-editor-edit'));
       });
     });
   });

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -70,6 +70,8 @@ prototype:
     update-status: Épreuve mise à jour
     update-error: Erreur lors de la mise à jour
 modules:
+  modulix-editor-button:
+    label: Ouvrir dans Modulix Editor
   breadcrumb:
     all-modules:
       label: Liste des modules


### PR DESCRIPTION
## ☀️ Problème

Il n'est pas possible de modifier facilement un module dans Modulix Editor depuis la page du Module dans Pix Editor.

## ⛱️ Proposition

- Ajouter un bouton "Ouvrir dans Modulix Editor" sur la page d'édition d'un module
- Pré-remplir Modulix Editor avec le contenu du module
- Afficher une modale de confirmation en cas d'écrasement de données dans Modulix Editor

## 🧴 Remarques

RAS

## 🏊 Pour tester

1. Accéder à la page d'édition d'un module
2. Cliquer sur **Ouvrir dans Modulix Editor**
3. Constater l'apparition de la modale de confirmation
4. Vérifier que le contenu du module est remplacé au clic sur **Confirmer**
5. Vérifier que le contenu du module n'est pas remplacé au clic sur **Annuler**
