### PR TITLE
[FEATURE] Améliorer le tag indiquant brouillon/en production

### DIFF
--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -71,7 +71,23 @@ td.modules-list__actions {
   }
 
   &__tag {
+    @extend %pix-body-xs;
     text-transform: uppercase;
+    font-weight: var(--pix-font-bold);
+    border-radius: 8px;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-2x);
+
+    &--yellow {
+      color: var(--pix-warning-700);
+      border: 1px solid var(--pix-warning-700);
+      background-color: var(--pix-warning-50);
+    }
+
+    &--blue {
+      color: var(--pix-info-700);
+      border: 1px solid var(--pix-info-700);
+      background-color: var(--pix-info-50);
+    }
   }
 
   &__title {

--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -1,4 +1,5 @@
 @use 'pix-design-tokens/typography';
+@use 'pix-design-tokens/breakpoints';
 
 .modules-list {
   display: flex;
@@ -47,8 +48,16 @@ td.modules-list__actions {
     background: var(--pix-neutral-0);
     padding: var(--pix-spacing-4x) var(--pix-spacing-5x);
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
+    flex-direction: column;
+    gap: var(--pix-spacing-4x);
+
+    @include breakpoints.device-is('desktop') {
+      flex-direction: row;
+      align-items: center;
+      gap: unset;
+    }
   }
 
   &__data-field {

--- a/pix-editor/app/templates/authenticated/modules/draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/draft-module.gjs
@@ -1,7 +1,5 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
 import PixButtonLink from '@1024pix/pix-ui/components/pix-button-link';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import formatDate from 'ember-intl/helpers/format-date';
@@ -12,7 +10,6 @@ import ModuleNotification from 'pixeditor/components/modules/module-notification
 import PlayModuleButtons from 'pixeditor/components/modules/play-module-buttons';
 import ModuleValidationErrors from 'pixeditor/components/modules/validation-errors';
 import ModuleValidationSuccess from 'pixeditor/components/modules/validation-success';
-import ModuleValidationTag from 'pixeditor/components/modules/validation-tag';
 
 export default class DraftModule extends Component {
   @service intl;
@@ -44,14 +41,13 @@ export default class DraftModule extends Component {
 
         <div class="module-header__information">
           <h1 class="module-header__title">{{@model.draftModule.internalTitle}}</h1>
-          <PixTag class="module-header__tag" @color="yellow">
-            <PixIcon @name="edit" @plainIcon={{true}} @ariaHidden={{true}} />
+          <div class="module-header__tag module-header__tag--yellow">
+            &#9679;
             {{t "modules.draft-module.information-tag"}}
-          </PixTag>
-          <ModuleValidationTag @hasBeenValidated={{@model.draftModule.hasBeenValidated}} />
+          </div>
           <p class="draft-module-header__last-modified-at"><span
               class="draft-module-header__last-modified-at--bullet"
-            >&#9679;</span>{{t
+            >&#65372;</span>{{t
               "modules.draft-module.last-modified-at"
               modifiedDate=(formatDate @model.draftModule.updatedAt "DD/MM/YYYY")
             }}</p>

--- a/pix-editor/app/templates/authenticated/modules/production-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/production-module.gjs
@@ -1,6 +1,4 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
-import PixIcon from '@1024pix/pix-ui/components/pix-icon';
-import PixTag from '@1024pix/pix-ui/components/pix-tag';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
@@ -31,10 +29,10 @@ export default class ProductionModule extends Component {
 
         <div class="module-header__information">
           <h1 class="module-header__title">{{@model.module.internalTitle}}</h1>
-          <PixTag class="module-header__tag" @color="blue">
-            <PixIcon @name="bolt" @plainIcon={{true}} @ariaHidden={{true}} />
+          <div class="module-header__tag module-header__tag--blue">
+            &#9679;
             {{t "modules.production-module.information-tag"}}
-          </PixTag>
+          </div>
         </div>
       </div>
       <div class="page-actions">

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -49,7 +49,7 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
     // then
     assert.strictEqual(currentURL(), `/modules/workbench/${id}`);
     assert.dom(screen.getByRole('heading', { name: 'MON_BEAU_MODULE' })).exists();
-    assert.dom(screen.getByText(t('modules.draft-module.information-tag'))).exists();
+    assert.dom(screen.getByText(`● ${t('modules.draft-module.information-tag')}`)).exists();
     assert.dom(screen.getByText(t('modules.draft-module.last-modified-at', { modifiedDate: '14/08/2026' }))).exists();
 
     // WORKAROUND: let some time for monaco-editor to settle
@@ -140,24 +140,6 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
         .exists();
     });
 
-    test('it should display validation status', async function (assert) {
-      // given
-      const moduleWithErrors = this.server.create('draft-module', {
-        id: crypto.randomUUID(),
-        internalTitle: 'MODULE_DRAFT',
-        validationErrors: ['oups !'],
-        hasBeenValidated: false,
-      });
-
-      // when
-      const screen = await visit(`/modules/workbench/${moduleWithErrors.id}`);
-      // WORKAROUND: let some time for monaco-editor to settle
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // then
-      assert.dom(screen.getByText(t('modules.draft-module.validation-failure'))).exists();
-    });
-
     test('it should not display publish button', async function (assert) {
       // given
       const moduleWithErrors = this.server.create('draft-module', {
@@ -196,22 +178,21 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
         .doesNotExist();
     });
 
-    test('it should display validation status', async function (assert) {
+    test('it should display a publish button', async function (assert) {
       // given
-      const module = this.server.create('draft-module', {
-        id: crypto.randomUUID(),
-        internalTitle: 'MODULE_DRAFT',
-        validationErrors: [],
-        hasBeenValidated: true,
-      });
-
       // when
-      const screen = await visit(`/modules/workbench/${module.id}`);
+      const screen = await visit(`/modules/workbench/${id}`);
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      assert.dom(screen.getByText(t('modules.draft-module.validation-success'))).exists();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: t('modules.components.publish-module-button.aria-label', { title: 'MON_BEAU_MODULE' }),
+          }),
+        )
+        .exists();
     });
   });
 });

--- a/pix-editor/tests/acceptance/modules/production-module-test.js
+++ b/pix-editor/tests/acceptance/modules/production-module-test.js
@@ -43,11 +43,10 @@ module('Acceptance | Modules | Production Module', function (hooks) {
       await click(await screen.getByRole('link', { name: 'Modules' }));
       await click(await screen.getByRole('link', { name: t('modules.components.modules-tabs.production') }));
       await click(await screen.getByRole('link', { name: t('modules.components.modules-list.detail') }));
-
       // then
       assert.strictEqual(currentURL(), `/modules/production/${id}`);
       assert.dom(screen.getByRole('heading', { name: 'MON_BEAU_MODULE' })).exists();
-      assert.dom(screen.getByText(t('modules.production-module.information-tag'))).exists();
+      assert.dom(screen.getByText(`● ${t('modules.production-module.information-tag')}`)).exists();
 
       // WORKAROUND: let some time for monaco-editor to settle
       await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
## ☀️ Problème

Le PixTag est visuellement très proche d'un bouton, surtout selon les icônes que l'on y met.
Les tags d'information "Brouillon" et "En production" peuvent se confondre avec des boutons.

On constate également qu'avec les diverses améliorations sur la page de détails que le tag de statut de validation est superflu avec le bandeau. On pourrait le supprimer pour alléger le header

## ⛱️ Proposition

- Retirer les PixTag au profit d'un css custom pour les mentions "Brouillon" et "En production"
- Retirer le statut de validation dans la page de détail d'un brouillon

## 🧴 Remarques

J'ai également modifié le CSS du header coté page de brouillon pour que les boutons passe en dessous en cas d'écran plus petit.

## 🏊 Pour tester

<img width="1728" height="248" alt="Capture d’écran 2026-08-17 à 16 28 26" src="https://github.com/user-attachments/assets/f738902e-5dcf-43cb-a4bd-29e5ff0ef367" />
<img width="1728" height="248" alt="Capture d’écran 2026-08-17 à 16 27 23" src="https://github.com/user-attachments/assets/6746c6a5-c8c9-43b6-86d7-eac26fa7ba73" />
<img width="1728" height="248" alt="Capture d’écran 2026-08-17 à 16 28 18" src="https://github.com/user-attachments/assets/c856adf6-f03a-4796-89d2-792dca780258" />
<img width="1728" height="248" alt="Capture d’écran 2026-08-17 à 16 27 39" src="https://github.com/user-attachments/assets/0e55b9c9-8411-49a5-86d4-7aef7289746a" />

