### PR TITLE
[FEATURE] Ajout de la colonne createdAt dans la table draft-module-versions (PIX-23886).

### DIFF
--- a/api/db/migrations/20260818130202_add-created-at-for-draft-module-versions-table.js
+++ b/api/db/migrations/20260818130202_add-created-at-for-draft-module-versions-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'draft-module-versions';
+const TABLE_COLUMN = 'createdAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dateTime(TABLE_COLUMN).notNullable().defaultTo(knex.fn.now());
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.dropColumn(TABLE_COLUMN);
+  });
+}

--- a/api/lib/domain/usecases/create-draft-module.js
+++ b/api/lib/domain/usecases/create-draft-module.js
@@ -18,14 +18,12 @@ export async function createDraftModule(draftModule, dependencies = { draftModul
     draftModule.prepareForCreation(module);
     const savedDraftModule = await dependencies.draftModuleRepository.save(draftModule);
 
-    if (module) {
-      const structuredDiff = dependencies.structuredPatch('', '', module.serializeToJSON(), savedDraftModule.serializeToJSON());
-      await dependencies.draftModuleVersionRepository.create(new DraftModuleVersion({
-        draftModuleId: savedDraftModule.id,
-        version: savedDraftModule.version,
-        structuredDiff,
-      }));
-    }
+    const structuredDiff = dependencies.structuredPatch('', '', module?.serializeToJSON() ?? '', savedDraftModule.serializeToJSON());
+    await dependencies.draftModuleVersionRepository.create(new DraftModuleVersion({
+      draftModuleId: savedDraftModule.id,
+      version: savedDraftModule.version,
+      structuredDiff,
+    }));
 
     await dependencies.updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated(savedDraftModule);
 

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -206,6 +206,7 @@ describe('Acceptance | Route | draft-modules', () => {
             draftModuleId: draftModule.id,
             version: draftModule.version,
             structuredDiff: expect.any(Object),
+            createdAt: expect.any(Date),
           },
         ]);
       });
@@ -580,6 +581,7 @@ describe('Acceptance | Route | draft-modules', () => {
           draftModuleId: draftModule.id,
           version: '6.5',
           structuredDiff: expect.any(Object),
+          createdAt: expect.any(Date),
         },
       ]);
     });

--- a/api/tests/integration/infrastructure/repositories/draft-module-version-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/draft-module-version-repository_test.js
@@ -27,6 +27,7 @@ describe('Draft Module Version Repository', () => {
           draftModuleId: draftModule.id,
           version: draftModule.version,
           structuredDiff: { test: 'ceci est un diff structuré de test...' },
+          createdAt: expect.any(Date),
         },
       ]);
     });

--- a/api/tests/unit/domain/usecases/create-draft-module_test.js
+++ b/api/tests/unit/domain/usecases/create-draft-module_test.js
@@ -29,8 +29,12 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
   });
 
   it('prepares draft module for creation and saves it', async () => {
+    // given
+    const draftModuleJSON = Symbol('draftModuleJSON');
+    vi.spyOn(savedDraftModule, 'serializeToJSON').mockReturnValueOnce(draftModuleJSON);
+
     // when
-    const result = createDraftModule(draftModule, { draftModuleRepository, updatePixApiReleaseCache });
+    const result = createDraftModule(draftModule, { draftModuleRepository, draftModuleVersionRepository, updatePixApiReleaseCache, structuredPatch });
 
     // then
     await expect(result).resolves.toBe(savedDraftModule);
@@ -38,6 +42,12 @@ describe('Unit | Domain | Use Cases | create-draft-module', () => {
     expect(prepareForCreation).toHaveBeenCalledExactlyOnceWith(undefined);
     expect(draftModuleRepository.save).toHaveBeenCalledExactlyOnceWith(draftModule);
     expect(updatePixApiReleaseCache.onDraftModuleCreatedOrUpdated).toHaveBeenCalledExactlyOnceWith(savedDraftModule);
+    expect(structuredPatch).toHaveBeenCalledExactlyOnceWith('', '', '', draftModuleJSON);
+    expect(draftModuleVersionRepository.create).toHaveBeenCalledExactlyOnceWith(new DraftModuleVersion({
+      draftModuleId: savedDraftModule.id,
+      version: savedDraftModule.version,
+      structuredDiff,
+    }));
   });
 
   describe('when draft module has a moduleId', () => {


### PR DESCRIPTION
## ☀️ Problème

On a constaté qu'il manquait : 
- une colonne createdAt, pour avoir une date précise lors de l'enregistrement des versions des brouillons.
-  on ne fait pas de création d'entrée dans la table draft-module-versions lors de la création d'un brouillon

## ⛱️ Proposition

Ajouter la colonne createdAt et permettre la création d'une entrée dans la table draft-module-versions lors de la création d'un brouillon

## 🏊 Pour tester

- Créer un brouillon
- Vérifier qu'une entrée est présente dans la table draft-module-version, avec un createdAt rempli
- Modifier ce même brouillon
- Vérifier la nouvelle entrée

<img width="849" height="116" alt="Capture d’écran 2026-08-18 à 15 10 42" src="https://github.com/user-attachments/assets/19b510ab-af72-4b29-86f3-b935f3707b54" />

