### PR TITLE
[TECH] Ajouter une valeur par défault sur le placeholder des blocs select des QROCM (PIX-23818)

### DIFF
--- a/api/lib/application/modules/validation/element/qrocm-schema.js
+++ b/api/lib/application/modules/validation/element/qrocm-schema.js
@@ -66,6 +66,7 @@ const blockSelectSchema = Joi.object({
     ),
   placeholder: htmlNotAllowedSchema
     .allow('')
+    .default('- Sélectionner -')
     .required()
     .description("Texte de substitution qui s'affiche dans le champ lorsqu’aucune option n'est sélectionnée."),
   ariaLabel: htmlNotAllowedSchema


### PR DESCRIPTION
## ☀️ Problème

On voudrait ajouter un placeholder par défaut sur les QROCM avec un bloc select.

## ⛱️ Proposition

Le faire en mettant '- Sélectionner -' dans le schéma Joi.

## 🧴 Remarques

- On fait la même modification que sur https://github.com/1024pix/pix/pull/17165 du monorepo pour que les schémas soient bien iso.

## 🏊 Pour tester

- CI au vert ✅ 
