### PR TITLE
[FEATURE] Améliorer le retour d'erreurs lors d'une création/mise à jour des modules (PIX-23792)

### DIFF
--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -65,6 +65,7 @@ export function register(server) {
       config: {
         validate: {
           failAction: handleFailActionWithDetails,
+          options: { abortEarly: false },
           payload: Joi.object({
             data: Joi.object({
               type: Joi.string().valid('draft-modules').required(),
@@ -109,6 +110,7 @@ export function register(server) {
         },
         validate: {
           failAction: handleFailActionWithDetails,
+          options: { abortEarly: false },
           params: Joi.object({ id: Types.moduleId().required() }).required(),
           payload: Joi.object({
             data: Joi.object({

--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -3,6 +3,7 @@ import Joi from 'joi';
 import { createDraftModule, updateDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules, publishDraftModule, validateDraftModule } from '../../domain/usecases/index.js';
 import { draftModuleDiffSerializer, draftModuleSerializer, moduleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
+import { handleFailActionWithDetails } from '../../infrastructure/validation.js';
 import * as Types from '../types.js';
 
 export function register(server) {
@@ -62,6 +63,7 @@ export function register(server) {
       path: '/api/draft-modules',
       config: {
         validate: {
+          failAction: handleFailActionWithDetails,
           payload: Joi.object({
             data: Joi.object({
               type: Joi.string().valid('draft-modules').required(),
@@ -105,6 +107,7 @@ export function register(server) {
           return h.response(draftModuleSerializer.serialize(validatedModule)).code(200);
         },
         validate: {
+          failAction: handleFailActionWithDetails,
           params: Joi.object({ id: Types.moduleId().required() }).required(),
           payload: Joi.object({
             data: Joi.object({

--- a/api/lib/application/modules/draft-modules.js
+++ b/api/lib/application/modules/draft-modules.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 import { createDraftModule, updateDraftModule, getDraftModuleById, getDraftModuleDiff, listPaginatedDraftModules, publishDraftModule, validateDraftModule } from '../../domain/usecases/index.js';
 import { draftModuleDiffSerializer, draftModuleSerializer, moduleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
+import { joiFrErrorMessages } from '../../infrastructure/schemas/joi-fr-error-messages.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
 import { handleFailActionWithDetails } from '../../infrastructure/validation.js';
 import * as Types from '../types.js';
@@ -86,7 +87,7 @@ export function register(server) {
                 }).optional(),
               }).optional(),
             }).required(),
-          }).required(),
+          }).required().messages(joiFrErrorMessages),
         },
         handler: async (request, h) => {
           const module = await draftModuleSerializer.deserialize(request.payload);
@@ -132,7 +133,7 @@ export function register(server) {
                 }).optional(),
               }).optional(),
             }).required(),
-          }).required(),
+          }).required().messages(joiFrErrorMessages),
         },
       },
     },

--- a/api/lib/infrastructure/validation.js
+++ b/api/lib/infrastructure/validation.js
@@ -1,4 +1,8 @@
+import JsonapiSerializer from 'jsonapi-serializer';
+
 import { logger } from './logger.js';
+
+const { Error: JSONAPIError } = JsonapiSerializer;
 
 export function handleFailAction(request, h, err) {
   logger.error({ err }, 'Request payload validation error');
@@ -7,4 +11,14 @@ export function handleFailAction(request, h, err) {
     message: 'Invalid request payload input',
     statusCode: 400,
   }).code(400).takeover();
+}
+
+export function handleFailActionWithDetails(request, h, err) {
+  logger.error({ err: err.details }, 'Request payload validation error');
+  const errors = (err.details ?? []).map((detail) => ({
+    status: '400',
+    title: 'Invalid Request Payload',
+    detail: detail.message,
+  }));
+  return h.response(JSONAPIError(errors)).code(400).takeover();
 }

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -211,6 +211,51 @@ describe('Acceptance | Route | draft-modules', () => {
         ]);
       });
     });
+
+    describe('when payload is invalid', () => {
+      it('responds with status 400 and error detail', async () => {
+        // given
+        const draftModule = domainBuilder.buildDraftModule({ version: '0.1' });
+        const draftModulePayload = {
+          slug: draftModule.slug,
+          title: draftModule.title,
+          'internal-title': '',
+          'is-beta': draftModule.isBeta,
+          visibility: draftModule.visibility,
+          details: draftModule.details,
+          sections: draftModule.sections,
+          glossary: draftModule.glossary,
+        };
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/draft-modules',
+          headers: generateAuthorizationHeader(editorUser),
+          payload: {
+            data: {
+              type: 'draft-modules',
+              attributes: draftModulePayload,
+              relationships: { module: { data: null } },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+        expect(response.result).toStrictEqual({
+          errors: [
+            {
+              status: '400',
+              title: 'Invalid Request Payload',
+              detail: '"data.attributes.internal-title" ne doit pas être vide',
+            },
+          ],
+        });
+      });
+    });
   });
 
   describe('GET /draft-modules', () => {
@@ -584,6 +629,55 @@ describe('Acceptance | Route | draft-modules', () => {
           createdAt: expect.any(Date),
         },
       ]);
+    });
+
+    describe('when payload is invalid', () => {
+      it('responds with status 400 and error detail', async () => {
+        // given
+        const draftModule = domainBuilder.buildDraftModule({ version: '0.1' });
+        databaseBuilder.factory.buildDraftModule(draftModule);
+        await databaseBuilder.commit();
+
+        const draftModulePayload = {
+          slug: draftModule.slug,
+          title: draftModule.title,
+          'internal-title': '',
+          'is-beta': draftModule.isBeta,
+          visibility: draftModule.visibility,
+          details: draftModule.details,
+          sections: draftModule.sections,
+          glossary: draftModule.glossary,
+        };
+
+        const server = await createServer();
+
+        // when
+        const response = await server.inject({
+          method: 'PATCH',
+          url: `/api/draft-modules/${draftModule.id}`,
+          headers: generateAuthorizationHeader(editorUser),
+          payload: {
+            data: {
+              type: 'draft-modules',
+              id: draftModule.id,
+              attributes: draftModulePayload,
+              relationships: { module: { data: null } },
+            },
+          },
+        });
+
+        // then
+        expect(response.statusCode).toBe(400);
+        expect(response.result).toStrictEqual({
+          errors: [
+            {
+              status: '400',
+              title: 'Invalid Request Payload',
+              detail: '"data.attributes.internal-title" ne doit pas être vide',
+            },
+          ],
+        });
+      });
     });
   });
 

--- a/api/tests/acceptance/application/modules/draft-modules_test.js
+++ b/api/tests/acceptance/application/modules/draft-modules_test.js
@@ -640,7 +640,6 @@ describe('Acceptance | Route | draft-modules', () => {
 
         const draftModulePayload = {
           slug: draftModule.slug,
-          title: draftModule.title,
           'internal-title': '',
           'is-beta': draftModule.isBeta,
           visibility: draftModule.visibility,
@@ -674,6 +673,11 @@ describe('Acceptance | Route | draft-modules', () => {
               status: '400',
               title: 'Invalid Request Payload',
               detail: '"data.attributes.internal-title" ne doit pas être vide',
+            },
+            {
+              status: '400',
+              title: 'Invalid Request Payload',
+              detail: '"data.attributes.title" est requis',
             },
           ],
         });

--- a/pix-editor/app/styles/components/modules/module-form.scss
+++ b/pix-editor/app/styles/components/modules/module-form.scss
@@ -14,7 +14,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: var(--pix-neutral-20);
+    background: var(--pix-orga-50);
     padding: var(--pix-spacing-4x);
     z-index: 1000;
     flex-direction: row-reverse;

--- a/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
@@ -1,6 +1,7 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import ModulixEditorButton from 'pixeditor/components/modules/modulix-editor-button';
@@ -33,8 +34,16 @@ export default class NewModule extends Component {
       await draftModule.save();
       this.router.replaceWith('authenticated.modules.draft-module', draftModule.id);
       this.notifications.sendSuccess(this.intl.t('modules.new.draft-success', { title: draftModule.internalTitle }));
-    } catch {
-      this.notifications.sendError(this.intl.t('modules.new.draft-error'));
+    } catch (error) {
+      const genericErrorMessage = this.intl.t('modules.new.draft-error');
+      let errorMessage = genericErrorMessage;
+
+      if (error.errors?.length) {
+        const details = error.errors.map((error) => error.detail.replace(/"data\.attributes\.([^"]+)"/, '$1'));
+        const detailLabel = this.intl.t('modules.new.draft-error-detail');
+        errorMessage = `${genericErrorMessage}<br><br>${detailLabel} ${details.join(', ')}.`;
+      }
+      this.notifications.sendError(htmlSafe(errorMessage));
     } finally {
       this.loader.stop();
     }

--- a/pix-editor/app/templates/authenticated/modules/new.gjs
+++ b/pix-editor/app/templates/authenticated/modules/new.gjs
@@ -1,6 +1,7 @@
 import PixBreadcrumb from '@1024pix/pix-ui/components/pix-breadcrumb';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import ModuleForm from 'pixeditor/components/modules/module-form';
@@ -39,12 +40,16 @@ export default class NewModule extends Component {
         this.router.replaceWith('authenticated.modules.workbench');
         this.notifications.sendSuccess(this.intl.t('modules.new.module-success', { title: newModule.internalTitle }));
       }
-    } catch {
-      if (module) {
-        this.notifications.sendError(this.intl.t('modules.new.draft-error'));
-      } else {
-        this.notifications.sendError(this.intl.t('modules.new.module-error'));
+    } catch (error) {
+      const genericErrorMessage = this.intl.t('modules.new.draft-error');
+      let errorMessage = genericErrorMessage;
+
+      if (error.errors?.length) {
+        const details = error.errors.map((error) => error.detail.replace(/"data\.attributes\.([^"]+)"/, '$1'));
+        const detailLabel = this.intl.t('modules.new.draft-error-detail');
+        errorMessage = `${genericErrorMessage}<br><br>${detailLabel} ${details.join(', ')}.`;
       }
+      this.notifications.sendError(htmlSafe(errorMessage));
     } finally {
       this.loader.stop();
     }

--- a/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
@@ -1,9 +1,13 @@
 import { visit, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
+import { click } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { Response } from 'miragejs';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Acceptance | Modules | Edit Draft Module', function (hooks) {
   setupApplicationTest(hooks);
@@ -59,6 +63,59 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
           }),
         )
         .exists();
+    });
+  });
+
+  module('when saving fails with a payload validation error', function () {
+    test('it displays the error detail in the notification', async function (assert) {
+      // given
+      class PixToastNotificationsStub extends Service {
+        sendError() {}
+      }
+      this.owner.register('service:notifications', PixToastNotificationsStub);
+      const notificationsStub = this.owner.lookup('service:notifications');
+      const pixToastSendError = sinon.stub(notificationsStub, 'sendError');
+
+      const moduleWithErrors = this.server.create('draft-module', {
+        id: crypto.randomUUID(),
+        internalTitle: 'MODULE_DRAFT',
+        validationErrors: [],
+      });
+
+      this.server.patch(
+        '/draft-modules/:id',
+        () =>
+          new Response(
+            400,
+            {},
+            {
+              errors: [
+                {
+                  status: '400',
+                  title: 'Invalid Request Payload',
+                  detail: '"data.attributes.internal-title" ne doit pas être vide',
+                },
+                {
+                  status: '400',
+                  title: 'Invalid Request Payload',
+                  detail: '"data.attributes.title" est requis',
+                },
+              ],
+            },
+          ),
+      );
+
+      const screen = await visit(`/modules/workbench/${moduleWithErrors.id}/edit`);
+      // WORKAROUND: let some time for monaco-editor to settle
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // when
+      await click(await screen.findByRole('button', { name: t('modules.components.module-form.save') }));
+
+      // then
+      const expectedMessage = `${t('modules.new.draft-error')}<br><br>${t('modules.new.draft-error-detail')} internal-title ne doit pas être vide, title est requis.`;
+      assert.ok(pixToastSendError.calledOnce);
+      assert.strictEqual(pixToastSendError.args[0][0].toString(), expectedMessage);
     });
   });
 

--- a/pix-editor/tests/acceptance/modules/new-test.js
+++ b/pix-editor/tests/acceptance/modules/new-test.js
@@ -1,10 +1,13 @@
 import { visit, within } from '@1024pix/ember-testing-library';
+import Service from '@ember/service';
 import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { Response } from 'miragejs';
 import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
 import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 const isChrome = navigator?.userAgent?.includes(' Chrome/');
 
@@ -17,6 +20,76 @@ module('Acceptance | Modules | New', function (hooks) {
     this.server.create('user', { trigram: 'ABC' });
 
     return authenticateSession();
+  });
+
+  module('when saving fails with a payload validation error', function () {
+    test('displays the error detail in the notification', async function (assert) {
+      // given
+      class PixToastNotificationsStub extends Service {
+        sendError() {}
+      }
+      this.owner.register('service:notifications', PixToastNotificationsStub);
+      const notificationsStub = this.owner.lookup('service:notifications');
+      const pixToastSendError = sinon.stub(notificationsStub, 'sendError');
+
+      this.server.post(
+        '/draft-modules',
+        () =>
+          new Response(
+            400,
+            {},
+            {
+              errors: [
+                {
+                  status: '400',
+                  title: 'Invalid Request Payload',
+                  detail: '"data.attributes.internal-title" ne doit pas être vide',
+                },
+              ],
+            },
+          ),
+      );
+
+      const screen = await visit('/');
+
+      await click(await screen.findByRole('link', { name: 'Modules' }));
+      await click(
+        await screen.findByRole('link', { name: t('modules.components.create-module-button.create-module') }),
+      );
+
+      await fillIn(
+        await screen.findByRole('textbox', {
+          name: new RegExp(`^${t('modules.components.module-form.internal-title-label')}`),
+        }),
+        'NEW_MODULE',
+      );
+
+      await fillIn(
+        await screen.findByLabelText(t('modules.components.module-form.content-label')),
+        JSON.stringify({
+          title: 'Nouveau module',
+          isBeta: true,
+          slug: 'slug',
+          visibility: 'public',
+          details: {
+            level: 'novice',
+          },
+          sections: [],
+          glossary: [],
+        }),
+      );
+
+      // WORKAROUND: let some time for Monaco
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // when
+      await click(screen.getByRole('button', { name: t('modules.components.module-form.save') }));
+
+      // then
+      const expectedMessage = `${t('modules.new.draft-error')}<br><br>${t('modules.new.draft-error-detail')} internal-title ne doit pas être vide.`;
+      assert.ok(pixToastSendError.calledOnce);
+      assert.strictEqual(pixToastSendError.args[0][0].toString(), expectedMessage);
+    });
   });
 
   module.if('when creating a new module', !isChrome, function () {

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -91,8 +91,8 @@ modules:
     module-title: Création d’un module
     draft-success: Le draft "{title}" a été enregistré.
     module-success: Le module "{title}" a été enregistré.
-    draft-error: Erreur lors de l’enregistrement du draft.
-    module-error: Erreur lors de l’enregistrement du module.
+    draft-error: Une erreur est survenue lors de l’enregistrement du draft.
+    draft-error-detail: 'Détail de l’erreur :'
   workbench:
     title: Modules
   production:


### PR DESCRIPTION
## ☀️ Problème

On a constaté que les erreurs JOI venant des routes de création et mise à jour d’un draft renvoyait un message générique peu clair.
Pour le métier, cela peut être très contraignant car les erreurs JOI venant de la route empêche l’enregistrement du draft.


<img width="838" height="714" alt="Capture d’écran 2026-08-04 à 14 49 01" src="https://github.com/user-attachments/assets/290fdaee-fa1a-4e4e-9a64-34697453cff0" />


## ⛱️ Proposition

=> Permettre d’avoir des messages d’erreurs plus(se) explicite.

## 🧴 Remarques

En plus de renvoyer les erreurs JOI au front, je les renvoie en FR

## 🏊 Pour tester

- Créer un module, enlever une clé comme "isBeta" et constater qu'en enregistrant on a un message d'erreur précisant qu'il est requis.
- Faire de même en modifiant un brouillon existant
