### PR TITLE
[TECH] Exposer le JSON Schema des modules sur une route API de Pix Editor (PIX-23585)

### DIFF
--- a/api/lib/application/modules/modules.js
+++ b/api/lib/application/modules/modules.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 import { moduleSerializer } from '../../infrastructure/serializers/jsonapi/index.js';
 import { extractParameters } from '../../infrastructure/utils/query-params-utils.js';
-import { getModuleById, listPaginatedModules } from '../../domain/usecases/index.js';
+import { getModuleById, listPaginatedModules, getModuleJsonSchema } from '../../domain/usecases/index.js';
 import * as Types from '../types.js';
 
 export function register(server) {
@@ -43,6 +43,23 @@ export function register(server) {
           const module = await getModuleById(id);
           return moduleSerializer.serialize(module);
         },
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/module-schema/module-json-schema.json',
+      config: {
+        auth: false,
+        handler: async (_, h) => {
+          const { jsonSchema, jsonSchemaChecksum } = getModuleJsonSchema();
+          return h
+            .response(jsonSchema)
+            .type('application/json')
+            .charset('UTF-8')
+            .header('Cache-Control', 'public, max-age=900')
+            .etag(jsonSchemaChecksum);
+        },
+        notes: ['- Permet de récupérer le JSON Schema de la structure des modules'],
       },
     },
   ]);

--- a/api/lib/domain/services/convert-joi-rules-to-json-schema.js
+++ b/api/lib/domain/services/convert-joi-rules-to-json-schema.js
@@ -1,0 +1,312 @@
+import Joi from 'joi';
+
+import { child, SCOPES } from '../../infrastructure/logger.js';
+
+const logger = child('devcomp:joi-to-json-schema', { event: SCOPES.DEVCOMP });
+
+export function convertJoiToJsonSchema(joiSchema) {
+  if (!Joi.isSchema(joiSchema)) {
+    throw new Error('Not a Joi schema');
+  }
+
+  return convertFromType(joiSchema.describe());
+}
+
+function convertFromType(joiDescribedSchema, key = '') {
+  switch (joiDescribedSchema.type) {
+    case 'boolean':
+      return convertBoolean();
+    case 'string':
+      return convertString(joiDescribedSchema);
+    case 'number':
+      return convertNumber(joiDescribedSchema);
+    case 'array':
+      return convertArray(joiDescribedSchema, key);
+    case 'object':
+      return convertObject(joiDescribedSchema);
+    case 'alternatives':
+      return convertAlternatives(joiDescribedSchema);
+    default:
+      logger.warn({ type: joiDescribedSchema.type, schema: joiDescribedSchema }, 'Unsupported schema type');
+  }
+}
+
+function convertBoolean() {
+  return { type: 'boolean' };
+}
+
+function convertString(joiStringDescribedSchema) {
+  const jsonSchema = { type: 'string', format: null, options: null };
+
+  const rules = joiStringDescribedSchema.rules;
+
+  if (hasFlag(joiStringDescribedSchema.flags, 'description')) {
+    jsonSchema.options = { infoText: joiStringDescribedSchema.flags['description'] };
+  }
+
+  if (hasFlag(joiStringDescribedSchema.flags, 'default')) {
+    jsonSchema.default = joiStringDescribedSchema.flags['default'];
+  }
+
+  const emailRule = findRule(rules, 'email');
+  if (emailRule !== undefined) {
+    jsonSchema.format = 'email';
+  }
+
+  const guidRule = findRule(rules, 'guid');
+  if (guidRule !== undefined) {
+    jsonSchema.format = 'uuid';
+  }
+
+  const isoDateRule = findRule(rules, 'isoDate');
+  if (isoDateRule !== undefined) {
+    jsonSchema.format = 'date';
+  }
+
+  const uriRule = findRule(rules, 'uri');
+  if (uriRule !== undefined) {
+    jsonSchema.format = 'uri';
+  }
+
+  const minRule = findRule(rules, 'min');
+  if (minRule !== undefined) {
+    jsonSchema.minLength = minRule.args.limit;
+  }
+
+  const maxRule = findRule(rules, 'max');
+  if (maxRule !== undefined) {
+    jsonSchema.maxLength = maxRule.args.limit;
+  }
+
+  const patternRule = findRule(rules, 'pattern');
+  if (patternRule) {
+    if (!patternRule.args.options?.invert) {
+      jsonSchema.pattern = convertRegex(patternRule.args.regex.toString());
+
+      const customErrorMessage = getCustomErrorMessage(rules);
+      if (customErrorMessage !== undefined) {
+        jsonSchema.errorMessage = customErrorMessage;
+      }
+    }
+  }
+
+  if (joiStringDescribedSchema.allow?.length > 0) {
+    const enumValues = joiStringDescribedSchema.allow.filter((allow) => allow.length > 0);
+    if (enumValues.length > 0) {
+      jsonSchema.enum = enumValues;
+    }
+  }
+
+  const processedSchema = handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema);
+
+  const allowsEmptyString = joiStringDescribedSchema.allow?.includes('');
+  if (processedSchema.format === 'uri' && allowsEmptyString) {
+    const schemaWithoutFormat = { ...processedSchema };
+    Reflect.deleteProperty(schemaWithoutFormat, 'format');
+    return {
+      ...schemaWithoutFormat,
+      anyOf: [{ format: 'uri' }, { maxLength: 0 }],
+    };
+  }
+
+  return processedSchema;
+}
+
+function handleNonStandardStringProperties(joiStringDescribedSchema, jsonSchema) {
+  if (joiStringDescribedSchema.externals?.length > 0) {
+    if (joiStringDescribedSchema.externals[0].method.name === 'htmlValidation') {
+      jsonSchema.format = 'jodit';
+    }
+  }
+
+  return jsonSchema;
+}
+
+function convertNumber(joiNumberDescribedSchema) {
+  const jsonSchema = { type: 'number', options: null };
+  const rules = joiNumberDescribedSchema.rules;
+
+  if (hasFlag(joiNumberDescribedSchema.flags, 'description')) {
+    jsonSchema.options = { infoText: joiNumberDescribedSchema.flags['description'] };
+  }
+
+  const integerRule = findRule(rules, 'integer');
+  if (integerRule !== undefined) {
+    jsonSchema.type = 'integer';
+  }
+
+  const signRule = findRule(rules, 'sign');
+  if (signRule !== undefined) {
+    if (signRule.args.sign === 'positive') {
+      jsonSchema.minimum = 1;
+    } else {
+      jsonSchema.maximum = -1;
+    }
+  }
+
+  const minRule = findRule(rules, 'min');
+  if (minRule !== undefined) {
+    jsonSchema.minimum = minRule.args.limit;
+  }
+
+  const maxRule = findRule(rules, 'max');
+  if (maxRule !== undefined) {
+    jsonSchema.maximum = maxRule.args.limit;
+  }
+
+  return jsonSchema;
+}
+
+function convertArray(joiArrayDescribedSchema, key = '') {
+  const jsonSchema = { type: 'array', options: null };
+  const rules = joiArrayDescribedSchema.rules;
+
+  if (hasFlag(joiArrayDescribedSchema.flags, 'description')) {
+    jsonSchema.options = { infoText: joiArrayDescribedSchema.flags['description'] };
+  }
+
+  const minRule = findRule(rules, 'min');
+  if (minRule !== undefined) {
+    jsonSchema.minItems = minRule.args.limit;
+  }
+
+  const uniqueRule = findRule(rules, 'unique');
+  if (uniqueRule !== undefined) {
+    jsonSchema.uniqueItems = true;
+  }
+
+  if (joiArrayDescribedSchema.items) {
+    jsonSchema.items = {};
+
+    const itemTitle = key.endsWith('s') ? key.slice(0, -1) : key;
+
+    for (const item of joiArrayDescribedSchema.items) {
+      jsonSchema.items = convertFromType(item);
+      if (itemTitle) {
+        jsonSchema.items.title = itemTitle;
+
+        // Add headerTemplate for JSON Editor lib
+        // See {@link https://github.com/json-editor/json-editor#dynamic-headers}
+        // for further information
+        jsonSchema.items.headerTemplate = `${itemTitle} {{i0}}`;
+      }
+    }
+  }
+
+  return jsonSchema;
+}
+
+function convertObject(joiObjectDescribedSchema) {
+  const jsonSchema = { type: 'object' };
+
+  if (joiObjectDescribedSchema.keys) {
+    const properties = {};
+    const required = [];
+
+    for (const [key, value] of Object.entries(joiObjectDescribedSchema.keys)) {
+      properties[key] = convertFromType(value, key);
+
+      if (hasFlag(value?.flags, 'presence', 'required')) {
+        required.push(key);
+      }
+    }
+
+    if (properties && Object.keys(properties).length > 0) {
+      jsonSchema.properties = properties;
+    }
+
+    if (required && required.length > 0) {
+      jsonSchema.required = required;
+    }
+
+    jsonSchema.additionalProperties = hasFlag(joiObjectDescribedSchema.flags, 'unknown', true);
+  }
+
+  return jsonSchema;
+}
+
+function generateIfThenOtherwiseSchema(match) {
+  const baseSchema = convertFromType(match.otherwise);
+
+  const conditionalKeyName = Object.keys(match.is.keys)[0];
+  const schemaProperties = { [conditionalKeyName]: { const: match.is.keys[conditionalKeyName].allow[0].override } };
+
+  return {
+    ...baseSchema,
+    title: match.otherwise.keys.type.allow[0],
+    if: { properties: schemaProperties },
+    then: { properties: convertFromType(match.then).properties },
+  };
+}
+
+function convertAlternatives(joiAlternativesDescribedSchema) {
+  const match = joiAlternativesDescribedSchema.matches[0];
+
+  if (Object.keys(match).includes('is')) {
+    return generateIfThenOtherwiseSchema(match);
+  }
+
+  const oneOf = joiAlternativesDescribedSchema.matches.flatMap((match) => {
+    if (match.ref !== undefined) {
+      if (match.switch !== undefined) {
+        return match.switch.map(getAlternativeSwitchCaseJsonSchema);
+      } else {
+        logger.warn({ match }, 'Unsupported conditional schema is/then/otherwise');
+      }
+    } else {
+      return convertFromType(match.schema);
+    }
+  });
+
+  return { oneOf };
+}
+
+function convertRegex(regex) {
+  return regex.slice(1, -1).replace(/\\d/g, '[0-9]');
+}
+
+function getCustomErrorMessage(rules) {
+  return rules?.find((rule) => rule.message?.template?.length > 0)?.message.template;
+}
+
+function getAlternativeSwitchCaseJsonSchema(switchCase) {
+  const childJsonSchema = convertFromType(switchCase.then);
+
+  const optionalTitle
+    = getOptionalTitleBasedOnTitleMetadata(switchCase)
+      || getOptionalTitleBasedOnChildrenType(switchCase)
+      || getOptionalTitleBasedOnSiblingTagName(switchCase);
+  if (optionalTitle !== undefined) {
+    childJsonSchema.title = optionalTitle;
+  }
+
+  return childJsonSchema;
+}
+
+function getOptionalTitleBasedOnTitleMetadata(switchCase) {
+  return switchCase.then?.metas?.find(({ title }) => title)?.title;
+}
+
+function getOptionalTitleBasedOnSiblingTagName(switchCase) {
+  return switchCase.is?.allow[1];
+}
+
+function getOptionalTitleBasedOnChildrenType(switchCase) {
+  return switchCase.then.keys?.type?.allow[0];
+}
+
+function findRule(rules, ruleName) {
+  return rules?.find((rule) => rule.name === ruleName);
+}
+
+function hasFlag(flags, flagName, flagValue) {
+  if (flags !== undefined) {
+    return Object.entries(flags).some(([name, value]) => {
+      if (!flagValue) {
+        return flagName === name;
+      }
+      return flagName === name && flagValue === value;
+    });
+  }
+  return false;
+}

--- a/api/lib/domain/usecases/get-module-json-schema.js
+++ b/api/lib/domain/usecases/get-module-json-schema.js
@@ -1,0 +1,27 @@
+import { createHash } from 'node:crypto';
+
+import { convertJoiToJsonSchema } from '../services/convert-joi-rules-to-json-schema.js';
+import { moduleSchema } from '../../application/modules/validation/module-schema.js';
+
+/**
+ * Cached module JSON Schema, to avoid re-serializing it for every request
+ * @type {string}
+ */
+let jsonSchema;
+
+/**
+ * Cached module JSON Schema's checksum, to avoid re-computing it for every request
+ * @type {string}
+ */
+let jsonSchemaChecksum;
+
+export function getModuleJsonSchema({ generateChecksum = generateMd5Checksum } = {}) {
+  jsonSchema = jsonSchema ?? JSON.stringify(convertJoiToJsonSchema(moduleSchema));
+  jsonSchemaChecksum = jsonSchemaChecksum ?? generateChecksum(jsonSchema);
+
+  return { jsonSchema, jsonSchemaChecksum };
+}
+
+function generateMd5Checksum(stringToHash) {
+  return createHash('md5').update(stringToHash).digest('hex');
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -23,6 +23,7 @@ export * from './get-competence-challenges-workbench-overview.js';
 export * from './get-draft-module-by-id.js';
 export * from './get-draft-module-diff.js';
 export * from './get-module-by-id.js';
+export * from './get-module-json-schema.js';
 export * from './get-phrase-translations-url.js';
 export * from './get-skill-challenges-production.js';
 export * from './find-attachment.js';

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -48,6 +48,7 @@ export const logger = pino(
 export const SCOPES = {
   REPLICATION: 'replication',
   RELEASE: 'release',
+  DEVCOMP: 'devcomp',
 };
 
 function messageFormatCompact(log, messageKey, _logLevel, { colors }) {

--- a/api/tests/acceptance/application/modules/modules_test.js
+++ b/api/tests/acceptance/application/modules/modules_test.js
@@ -201,4 +201,25 @@ describe('Acceptance | Route | modules', () => {
       });
     });
   });
+
+  describe('GET /api/module-schema/module-json-schema.json', function() {
+    it('should return a cacheable JSON Schema', async function() {
+      // given
+      const server = await createServer();
+      const options = {
+        method: 'GET',
+        url: '/api/module-schema/module-json-schema.json',
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.headers['cache-control']).to.include('public');
+      expect(response.headers['cache-control']).to.include(900);
+      expect(response.headers['etag']).to.exist;
+      expect(() => JSON.parse(response.payload), 'Response payload is not a valid JSON string').not.to.throw(Error);
+    });
+  });
 });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -65,6 +65,17 @@ export function catchErr(promiseFn, ctx) {
   };
 }
 
+export function catchErrSync(fn, ctx) {
+  return (...args) => {
+    try {
+      fn.call(ctx, ...args);
+    } catch (err) {
+      return err;
+    }
+    throw new Error('Expected an error, but none was thrown.');
+  };
+}
+
 export function generateAuthorizationHeader(user) {
   return { 'x-api-key': user.apiKey };
 }

--- a/api/tests/unit/domain/services/convert-joi-rules-to-json-schema_test.js
+++ b/api/tests/unit/domain/services/convert-joi-rules-to-json-schema_test.js
@@ -1,0 +1,622 @@
+import Joi from 'joi';
+import { describe, expect, it } from 'vitest';
+import { convertJoiToJsonSchema } from '../../../../lib/domain/services/convert-joi-rules-to-json-schema.js';
+import { catchErrSync } from '../../../test-helper.js';
+
+describe('Unit | Domain | Service | convert-joi-rules-to-json-schema', function() {
+  it('should throw if not Joi', function() {
+    const error = catchErrSync(convertJoiToJsonSchema)({});
+
+    expect(error.message).to.equal('Not a Joi schema');
+  });
+
+  describe('boolean', function() {
+    it('should convert Joi.boolean to JSON Schema', function() {
+      const joiSchema = Joi.boolean();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'boolean' });
+    });
+  });
+
+  describe('string', function() {
+    it('should convert Joi.string to JSON Schema', function() {
+      const joiSchema = Joi.string();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
+    });
+
+    it('should convert Joi.string.default to JSON Schema with default', function() {
+      const joiSchema = Joi.string().default('courgette');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, default: 'courgette', options: null });
+    });
+
+    it('should convert Joi.string.min to JSON Schema with minLength', function() {
+      const joiSchema = Joi.string().min(8);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, minLength: 8, options: null });
+    });
+
+    it('should convert Joi.string.max to JSON Schema with maxLength', function() {
+      const joiSchema = Joi.string().max(32);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: null, maxLength: 32, options: null });
+    });
+
+    it('should convert Joi.string.email to JSON Schema with format email', function() {
+      const joiSchema = Joi.string().email();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'email', options: null });
+    });
+
+    it('should convert Joi.string.isoDate to JSON Schema with format date', function() {
+      const joiSchema = Joi.string().isoDate();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'date', options: null });
+    });
+
+    it('should convert Joi.string.uri to JSON Schema with format uri', function() {
+      const joiSchema = Joi.string().uri();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uri', options: null });
+    });
+
+    it("should convert Joi.string.uri.allow('') to JSON Schema with anyOf allowing URI or empty string", function() {
+      const joiSchema = Joi.string().uri().allow('');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'string',
+        options: null,
+        anyOf: [{ format: 'uri' }, { maxLength: 0 }],
+      });
+    });
+
+    it('should convert Joi.string.guid to JSON Schema with format uuid', function() {
+      const joiSchema = Joi.string().guid({ version: 'uuidv4' });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', format: 'uuid', options: null });
+    });
+
+    it('should convert Joi.string.description to JSON Schema with options infoText', function() {
+      const joiSchema = Joi.string().description('cool gang');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'string', options: { infoText: 'cool gang' }, format: null });
+    });
+
+    describe('regex', function() {
+      it('should convert Joi.string.regex(d) to JSON Schema with converted pattern', function() {
+        const joiSchema = Joi.string().regex(/^\d+$/);
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[0-9]+$', options: null });
+      });
+
+      it('should convert Joi.string.regex(*) to JSON Schema with given pattern', function() {
+        const joiSchema = Joi.string().regex(/^[a-z0-9-]+$/);
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, pattern: '^[a-z0-9-]+$', options: null });
+      });
+
+      it('should convert Joi.string.regex(*, invert) to JSON Schema with no pattern', function() {
+        const joiSchema = Joi.string().regex(/<.*?>/, { invert: true });
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
+      });
+
+      it('should convert Joi.string.regex.message to JSON Schema with errorMessage', function() {
+        const joiSchema = Joi.string().regex(/abc/).message('{{:#label}} failed custom validation');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({
+          type: 'string',
+          pattern: 'abc',
+          format: null,
+          errorMessage: '{{:#label}} failed custom validation',
+          options: null,
+        });
+      });
+    });
+
+    describe('allow', function() {
+      it('should convert Joi.string.allow(empty) to JSON Schema with no enum', function() {
+        const joiSchema = Joi.string().allow('');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, options: null });
+      });
+
+      it('should convert Joi.string.allow(*) to JSON Schema with enum', function() {
+        const joiSchema = Joi.string().allow('Hello');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'string', format: null, enum: ['Hello'], options: null });
+      });
+    });
+
+    describe('external', function() {
+      describe('htmlValidation', function() {
+        it('should convert Joi.string.external(htmlValidation) to JSON Schema with format jodit', function() {
+          function htmlValidation() {}
+          const joiSchema = Joi.string().external(htmlValidation);
+
+          const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+          expect(jsonSchema).to.deep.equal({ type: 'string', format: 'jodit', options: null });
+        });
+      });
+    });
+  });
+
+  describe('number', function() {
+    it('should convert Joi.number to JSON Schema', function() {
+      const joiSchema = Joi.number();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', options: null });
+    });
+
+    it('should convert Joi.number.integer to JSON Schema with type integer', function() {
+      const joiSchema = Joi.number().integer();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'integer', options: null });
+    });
+
+    it('should convert Joi.number.positive to JSON Schema with minimum 1', function() {
+      const joiSchema = Joi.number().positive();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 1, options: null });
+    });
+
+    it('should convert Joi.number.negative to JSON Schema with maximum -1', function() {
+      const joiSchema = Joi.number().negative();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: -1, options: null });
+    });
+
+    it('should convert Joi.number.min to JSON Schema with minimum', function() {
+      const joiSchema = Joi.number().min(0);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', minimum: 0, options: null });
+    });
+
+    it('should convert Joi.number.max to JSON Schema with maximum', function() {
+      const joiSchema = Joi.number().max(150);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', maximum: 150, options: null });
+    });
+
+    it('should convert Joi.number.description to JSON Schema with options infoText', function() {
+      const joiSchema = Joi.number().description('cool gang');
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'number', options: { infoText: 'cool gang' } });
+    });
+  });
+
+  describe('array', function() {
+    it('should convert Joi.array to JSON Schema', function() {
+      const joiSchema = Joi.array();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'array', options: null });
+    });
+
+    it('should convert Joi.array.min to JSON Schema with minItems', function() {
+      const joiSchema = Joi.array().min(3);
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'array', minItems: 3, options: null });
+    });
+
+    it('should convert Joi.array.unique to JSON Schema with uniqueItems', function() {
+      const joiSchema = Joi.array().unique();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({ type: 'array', uniqueItems: true, options: null });
+    });
+
+    describe('items', function() {
+      it('should convert Joi.array.items(string) to JSON Schema with items string', function() {
+        const joiSchema = Joi.array().items(Joi.string());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({
+          type: 'array',
+          items: { type: 'string', format: null, options: null },
+          options: null,
+        });
+      });
+
+      it('should convert Joi.array.items(number) to JSON Schema with items number', function() {
+        const joiSchema = Joi.array().items(Joi.number());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'number', options: null }, options: null });
+      });
+
+      it('should convert Joi.array.items(object) to JSON Schema with items object', function() {
+        const joiSchema = Joi.array().items(Joi.object());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'object' }, options: null });
+      });
+
+      it('should convert Joi.array.items(array) to JSON Schema with items array', function() {
+        const joiSchema = Joi.array().items(Joi.array());
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', items: { type: 'array', options: null }, options: null });
+      });
+
+      it('should convert Joi.array.description to JSON Schema with options infoText', function() {
+        const joiSchema = Joi.array().description('cool gang');
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+        expect(jsonSchema).to.deep.equal({ type: 'array', options: { infoText: 'cool gang' } });
+      });
+    });
+  });
+
+  describe('object', function() {
+    it('should convert Joi.object to JSON Schema', function() {
+      const joiSchema = Joi.object();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(joiSchema.validate({ name: 'John', age: 30, additional: 'property' }).error).to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ type: 'object' });
+    });
+
+    it('should convert Joi.object.keys to JSON Schema with no additionalProperties', function() {
+      const joiSchema = Joi.object({});
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(joiSchema.validate({ additional: 'property' }).error).not.to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ type: 'object', additionalProperties: false });
+    });
+
+    it('should convert Joi.object.keys.unknown to JSON Schema with additionalProperties', function() {
+      const joiSchema = Joi.object({}).unknown();
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(joiSchema.validate({ additional: 'property' }).error).to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ type: 'object', additionalProperties: true });
+    });
+
+    it('should convert Joi.object.keys to JSON Schema with properties', function() {
+      const joiSchema = Joi.object({
+        name: Joi.string(),
+        age: Joi.number(),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          name: { type: 'string', format: null, options: null },
+          age: { type: 'number', options: null },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it('should convert Joi.object.keys.required to JSON Schema with required properties', function() {
+      const joiSchema = Joi.object({
+        name: Joi.string().required(),
+        age: Joi.number(),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          name: { type: 'string', format: null, options: null },
+          age: { type: 'number', options: null },
+        },
+        required: ['name'],
+        additionalProperties: false,
+      });
+    });
+
+    it('should convert Joi.object with nested Joi.object to nested JSON Schema', function() {
+      const joiSchema = Joi.object({
+        address: Joi.object({
+          street: Joi.string(),
+          city: Joi.string(),
+        }),
+      });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          address: {
+            type: 'object',
+            properties: {
+              street: { type: 'string', format: null, options: null },
+              city: { type: 'string', format: null, options: null },
+            },
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+
+    it('should convert Joi.object with nested Joi.array to nested JSON Schema', function() {
+      const joiSchema = Joi.object({ proposals: Joi.array().items(Joi.string()) });
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+      expect(jsonSchema).to.deep.equal({
+        type: 'object',
+        properties: {
+          proposals: {
+            type: 'array',
+            options: null,
+            items: {
+              title: 'proposal',
+              headerTemplate: 'proposal {{i0}}',
+              type: 'string',
+              format: null,
+              options: null,
+            },
+          },
+        },
+        additionalProperties: false,
+      });
+    });
+  });
+
+  describe('alternatives', function() {
+    it('should convert Joi.alternatives.try to JSON Schema', function() {
+      const joiSchema = Joi.alternatives().try(Joi.string(), Joi.number());
+
+      const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+      expect(joiSchema.validate('string').error).to.be.undefined;
+      expect(joiSchema.validate(123).error).to.be.undefined;
+      expect(jsonSchema).to.deep.equal({ oneOf: [{ type: 'string', format: null, options: null }, { type: 'number', options: null }] });
+    });
+
+    describe('Joi.alternatives.conditional', function() {
+      it('should convert conditional deep ref switch is/then to JSON Schema and add title if an allowed property exists', function() {
+        const joiSchema = Joi.alternatives().conditional('.sport', {
+          switch: [
+            {
+              is: 'handball',
+              then: Joi.object({
+                sport: Joi.string().valid('handball').required(),
+                value: Joi.string().required(),
+              }),
+            },
+            {
+              is: 'volleyball',
+              then: Joi.object({
+                sport: Joi.string().valid('volleyball').required(),
+                value: Joi.number().required(),
+              }),
+            },
+          ],
+        });
+
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+        expect(joiSchema.validate({ sport: 'handball', value: 'hello' }).error).to.be.undefined;
+        expect(joiSchema.validate({ sport: 'volleyball', value: 132 }).error).to.be.undefined;
+        expect(jsonSchema).to.deep.equal({
+          oneOf: [
+            {
+              additionalProperties: false,
+              properties: {
+                sport: {
+                  enum: ['handball'],
+                  type: 'string',
+                  format: null,
+                  options: null,
+                },
+                value: {
+                  type: 'string',
+                  format: null,
+                  options: null,
+                },
+              },
+              required: ['sport', 'value'],
+              title: 'handball',
+              type: 'object',
+            },
+            {
+              additionalProperties: false,
+              properties: {
+                sport: {
+                  enum: ['volleyball'],
+                  type: 'string',
+                  format: null,
+                  options: null,
+                },
+                value: {
+                  type: 'number',
+                  options: null,
+                },
+              },
+              required: ['sport', 'value'],
+              title: 'volleyball',
+              type: 'object',
+            },
+          ],
+        });
+      });
+
+      it('should convert conditional deep ref switch is/then to JSON Schema and add title if a .type property exists', function() {
+        const joiSchema = Joi.alternatives().conditional('.type', {
+          switch: [
+            {
+              is: 'handball',
+              then: Joi.object({
+                type: Joi.string().valid('handball').required(),
+                value: Joi.string().required(),
+              }),
+            },
+            {
+              is: 'volleyball',
+              then: Joi.object({
+                type: Joi.string().valid('volleyball').required(),
+                value: Joi.number().required(),
+              }),
+            },
+          ],
+        });
+
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+        expect(joiSchema.validate({ type: 'handball', value: 'hello' }).error).to.be.undefined;
+        expect(joiSchema.validate({ type: 'volleyball', value: 132 }).error).to.be.undefined;
+        expect(jsonSchema).to.deep.equal({
+          oneOf: [
+            {
+              title: 'handball',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  enum: ['handball'],
+                  type: 'string',
+                  format: null,
+                  options: null,
+                },
+                value: {
+                  type: 'string',
+                  format: null,
+                  options: null,
+                },
+              },
+              required: ['type', 'value'],
+              type: 'object',
+            },
+            {
+              title: 'volleyball',
+              additionalProperties: false,
+              properties: {
+                type: {
+                  enum: ['volleyball'],
+                  type: 'string',
+                  format: null,
+                  options: null,
+                },
+                value: {
+                  type: 'number',
+                  options: null,
+                },
+              },
+              required: ['type', 'value'],
+              type: 'object',
+            },
+          ],
+        });
+      });
+
+      it('should convert conditional deep ref switch is/then to JSON Schema and add title if a title metadata exists', function() {
+        const joiSchema = Joi.object({
+          sport: Joi.string().valid('handball', 'volleyball').required(),
+          data: Joi.alternatives()
+            .conditional('sport', {
+              switch: [
+                {
+                  is: 'handball',
+                  then: Joi.object({ a: Joi.string().valid('a').required() }).meta({ title: 'pix-handball' }),
+                },
+                {
+                  is: 'volleyball',
+                  then: Joi.object({ b: Joi.string().valid('b').required() }).meta({ title: 'pix-volleyball' }),
+                },
+              ],
+            })
+            .required(),
+        });
+
+        const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+        expect(joiSchema.validate({ sport: 'handball', data: { a: 'a' } }).error).to.be.undefined;
+        expect(joiSchema.validate({ sport: 'volleyball', data: { b: 'b' } }).error).to.be.undefined;
+        expect(jsonSchema).to.deep.equal({
+          additionalProperties: false,
+          properties: {
+            data: {
+              oneOf: [
+                {
+                  additionalProperties: false,
+                  properties: {
+                    a: {
+                      enum: ['a'],
+                      type: 'string',
+                      format: null,
+                      options: null,
+                    },
+                  },
+                  required: ['a'],
+                  title: 'pix-handball',
+                  type: 'object',
+                },
+                {
+                  additionalProperties: false,
+                  properties: {
+                    b: {
+                      enum: ['b'],
+                      type: 'string',
+                      format: null,
+                      options: null,
+                    },
+                  },
+                  required: ['b'],
+                  title: 'pix-volleyball',
+                  type: 'object',
+                },
+              ],
+            },
+            sport: {
+              enum: ['handball', 'volleyball'],
+              type: 'string',
+              format: null,
+              options: null,
+            },
+          },
+          required: ['sport', 'data'],
+          type: 'object',
+        });
+      });
+
+      describe('if then otherwise statement', function() {
+        it('should convert simple schema to json schema', function() {
+          // given
+          const joiSchema = Joi.alternatives().conditional(Joi.object({ isNumber: true }).unknown(), {
+            then: Joi.object({
+              type: Joi.string().valid('qcu').required(),
+              value: Joi.number(),
+            }),
+            otherwise: Joi.object({
+              type: Joi.string().valid('qcu').required(),
+              value: Joi.string(),
+            }),
+          });
+
+          const expectedJsonSchema = {
+            additionalProperties: false,
+            if: { properties: { isNumber: { const: true } } },
+            properties: {
+              type: {
+                enum: ['qcu'],
+                format: null,
+                type: 'string',
+                options: null,
+              },
+              value: {
+                format: null,
+                type: 'string',
+                options: null,
+              },
+            },
+            required: ['type'],
+            then: {
+              properties: {
+                type: {
+                  enum: ['qcu'],
+                  format: null,
+                  type: 'string',
+                  options: null,
+                },
+                value: {
+                  type: 'number',
+                  options: null,
+                },
+              },
+            },
+            title: 'qcu',
+            type: 'object',
+          };
+
+          // when
+          const jsonSchema = convertJoiToJsonSchema(joiSchema);
+
+          // expect
+          expect(jsonSchema).to.deep.equal(expectedJsonSchema);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## ☀️ Problème

Le JSON Schema des modules est actuellement exposé au travers de la route API du monorepo `api/module-schema/module-json-schema.json`, afin que modulix-editor puisse automatiquement récupérer la dernière version.

Or, comme nous effectuons la migration des modules vers Pix Editor, il paraît nécessaire de migrer cette route également.

## ⛱️ Proposition

Exposer le JSON Schema des modules depuis Pix Editor

## 🧴 Remarques

- Nous n'avons rien inventé, nous n'avons fait que suivre la formidable PR : https://github.com/1024pix/pix/pull/15100
- Pix Editor étant derrière oauth-proxy, il faudra demander aux captains d'autoriser la route renvoyant le schema
- Il faudra prévoir une PR de nettoyage de Pix API une fois que tout sera en prod

## 🏊 Pour tester

- Se rendre sur [la route ](https://pix-lcms-review-pr1601.osc-fr1.scalingo.io/api/module-schema/module-json-schema.json) `/api/module-schema/module-json-schema.json` de la review app
- Constater qu'un grand fichier JSON s'affiche.
- Ouvrir l'onglet "Réseau" de la console du navigateur.
- Cocher l'option "Désactiver le cache".
- Rafraîchir la page.
- Vérifier que la réponse du serveur possède bien le header Content-Encoding: gzip, et que la réponse pèse moins de ~~10~~ 12kB.
- Décocher l'option "Désactiver le cache".
- Rafraîchir la page.
- Vérifier que la réponse du serveur ait un statut `304 Not Modified`.

- Aller sur Modulix Editor en local, appliquer la nouvelle route à la place de celle du monorepo et s'assurer de la non régression
