### PR TITLE
[FEATURE] Afficher un bouton pour la liste des erreurs de validation d'un module (PIX-24011).

### DIFF
--- a/pix-editor/app/components/modules/validation-errors.gjs
+++ b/pix-editor/app/components/modules/validation-errors.gjs
@@ -1,11 +1,14 @@
 import PixIcon from '@1024pix/pix-ui/components/pix-icon';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
 
 export default class ModuleValidationErrors extends Component {
+  @service intl;
+
   @tracked isCollapsed = true;
   @tracked hasUnCollapsedOnce = false;
 
@@ -21,6 +24,20 @@ export default class ModuleValidationErrors extends Component {
   toggleAccordions() {
     this.isCollapsed = !this.isCollapsed;
     this.hasUnCollapsedOnce = true;
+  }
+
+  get buttonInformation() {
+    return this.isUnCollapsed
+      ? {
+          label: this.intl.t('modules.components.validation-errors.collapse'),
+          icon: 'chevronTop',
+        }
+      : {
+          label: this.intl.t('modules.components.validation-errors.expand', {
+            count: this.args.validationErrors.length,
+          }),
+          icon: 'chevronBottom',
+        };
   }
 
   <template>
@@ -40,7 +57,10 @@ export default class ModuleValidationErrors extends Component {
           </div>
         </div>
 
-        <PixIcon @ariaHidden={{true}} @name="{{if this.isCollapsed 'chevronBottom' 'chevronTop'}}" />
+        <span class="module-validation-errors__toggle-label">
+          {{this.buttonInformation.label}}
+          <PixIcon @ariaHidden={{true}} @name="{{this.buttonInformation.icon}}" />
+        </span>
       </button>
 
       <div

--- a/pix-editor/app/styles/components/modules/validation-errors.scss
+++ b/pix-editor/app/styles/components/modules/validation-errors.scss
@@ -7,19 +7,19 @@
 
 
   &__button {
-    color: var(--pix-error-700);
     display: flex;
-    justify-content: space-between;
-    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
     align-items: center;
+    justify-content: space-between;
     width: 100%;
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+    color: var(--pix-error-700);
   }
 
   &__content {
     color: var(--pix-neutral-900);
     background-color: var(--pix-neutral-0);
-    border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
+    border-bottom-left-radius: 8px;
 
     &[aria-hidden='true'] {
       display: none;
@@ -62,5 +62,23 @@
 
       color: var(--pix-error-900);
     }
+  }
+}
+
+.module-validation-errors__toggle-label {
+  @extend %pix-body-s;
+
+  display: flex;
+  gap: var(--pix-spacing-1x);
+  align-items: center;
+  font-weight: var(--pix-font-bold);
+  white-space: nowrap;
+  border: 2px solid var(--pix-error-700);
+  padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+  background-color: var(--pix-neutral-0);
+  border-radius: 25px;
+
+  &:hover {
+    background-color: var(--pix-error-50);
   }
 }

--- a/pix-editor/tests/acceptance/modules/draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/draft-module-test.js
@@ -134,7 +134,7 @@ module('Acceptance | Modules | Draft Module', function (hooks) {
       assert
         .dom(
           screen.getByRole('button', {
-            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')} ${t('modules.components.validation-errors.expand', { count: 1 })}`,
           }),
         )
         .exists();

--- a/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
@@ -59,7 +59,7 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
       assert
         .dom(
           screen.getByRole('button', {
-            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')} ${t('modules.components.validation-errors.expand', { count: 1 })}`,
           }),
         )
         .exists();

--- a/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
@@ -18,11 +18,47 @@ module('Integration | Component | modules/validation-errors', function (hooks) {
 
     // then
     const accordion = screen.getByRole('button', {
-      name: `${t('modules.components.validation-errors.title', { count: 2 })} ${t('modules.components.validation-errors.information')}`,
+      name: `${t('modules.components.validation-errors.title', { count: 2 })} ${t('modules.components.validation-errors.information')} ${t('modules.components.validation-errors.expand', { count: 2 })}`,
     });
     await click(accordion);
     const listItems = screen.getAllByRole('listitem');
     assert.dom(listItems[0]).hasText('Le slug est mal formatté');
     assert.dom(listItems[1]).hasText("Problème de duplications d'Ids");
+  });
+
+  module('accordion button label', function () {
+    module('when collapsed', function () {
+      test('it displays the expand label with the errors count', async function (assert) {
+        // given
+        const validationErrors = ['Le slug est mal formatté', "Problème de duplications d'Ids"];
+
+        // when
+        const screen = await render(
+          <template><ModuleValidationErrors @validationErrors={{validationErrors}} /></template>,
+        );
+
+        // then
+        assert.dom(screen.getByText(t('modules.components.validation-errors.expand', { count: 2 }))).exists();
+        assert.dom(screen.queryByText(t('modules.components.validation-errors.collapse'))).doesNotExist();
+      });
+    });
+
+    test('it displays the collapse label once expanded', async function (assert) {
+      // given
+      const validationErrors = ['Le slug est mal formatté', "Problème de duplications d'Ids"];
+      const screen = await render(
+        <template><ModuleValidationErrors @validationErrors={{validationErrors}} /></template>,
+      );
+
+      // when
+      const accordion = screen.getByRole('button', {
+        name: `${t('modules.components.validation-errors.title', { count: 2 })} ${t('modules.components.validation-errors.information')} ${t('modules.components.validation-errors.expand', { count: 2 })}`,
+      });
+      await click(accordion);
+
+      // then
+      assert.dom(screen.getByText(t('modules.components.validation-errors.collapse'))).exists();
+      assert.dom(screen.queryByText(t('modules.components.validation-errors.expand', { count: 2 }))).doesNotExist();
+    });
   });
 });

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -143,6 +143,8 @@ modules:
     validation-errors:
       title: '{count, plural, one {1 erreur} other {# erreurs}} de validation'
       information: La publication est impossible tant que des erreurs subsistent.
+      expand: '{count, plural, one {Voir l’erreur} other {Voir les erreurs}}'
+      collapse: Tout replier
     validation-success:
       title: Aucune erreur de validation.
       subtitle: Il est désormais possible de publier ce brouillon.


### PR DESCRIPTION
## ☀️ Problème

En partageant les pages sur Pix Editor avec Jeoffrey, on a constaté que l’accordéon des erreurs avec son chevron ressemble fortement à une bannière.
Jeoffrey n’avait alors pas pensé qu’il pouvait cliquer dessus pour déplier et voir les erreurs.

Il faut changer ce chevron, pas très visible, pour un vrai bouton.

<img width="1728" height="452" alt="Capture d’écran 2026-08-26 à 12 21 32" src="https://github.com/user-attachments/assets/422037a7-fbea-4637-8b94-65ec8f225856" />


## ⛱️ Proposition

<img width="1728" height="452" alt="Capture d’écran 2026-08-26 à 12 48 37" src="https://github.com/user-attachments/assets/7f4f3761-4edb-42e5-8e15-62606a2b6a90" />
<img width="1728" height="452" alt="Capture d’écran 2026-08-26 à 12 48 30" src="https://github.com/user-attachments/assets/92876444-c966-4bd5-ba98-74c820bb10fc" />

## 🏊 Pour tester

Aller sur les modules => draft => aller sur la page de détails, voir le bouton en cas d'erreurs.
