### PR TITLE
[BUGFIX] Ne pas jeter une erreur d'ids dupliqués quand ça concerne les modules de prod (PIX-24021).

### DIFF
--- a/api/lib/domain/models/ModulesValidation.js
+++ b/api/lib/domain/models/ModulesValidation.js
@@ -7,71 +7,65 @@ export class ModulesValidation {
 
   validateDraftModuleDoesNotHaveDuplicateIds(draftModule) {
     const isDraftModuleOfAnExistingModule = (module) => (module.shortId === draftModule.shortId);
-    const computedModules = [...this.modules.filter((module) => !isDraftModuleOfAnExistingModule(module)), draftModule];
+    const otherModules = this.modules.filter((module) => !isDraftModuleOfAnExistingModule(module));
+
+    const existingIds = new Set();
+    for (const module of otherModules) {
+      for (const id of this.#collectIds(module)) {
+        existingIds.add(id);
+      }
+    }
 
     const duplicateIds = new Set();
-    const ids = new Set();
-
-    for (const module of computedModules) {
-      if (ids.has(module.id)) {
-        duplicateIds.add(module.id);
+    const draftIds = new Set();
+    for (const id of this.#collectIds(draftModule)) {
+      if (draftIds.has(id) || existingIds.has(id)) {
+        duplicateIds.add(id);
       }
-      ids.add(module.id);
-
-      for (const section of module.sections) {
-        if (ids.has(section.id)) {
-          duplicateIds.add(section.id);
-        }
-        ids.add(section.id);
-
-        for (const grain of section.grains) {
-          if (ids.has(grain.id)) {
-            duplicateIds.add(grain.id);
-          }
-          ids.add(grain.id);
-
-          for (const component of grain.components) {
-            switch (component.type) {
-              case 'element':
-                if (ids.has(component.element.id)) {
-                  duplicateIds.add(component.element.id);
-                }
-                if (component.element.type === 'flashcards' || component.element.type === 'qab') {
-                  for (const card of component.element.cards) {
-                    if (ids.has(card.id)) {
-                      duplicateIds.add(card.id);
-                    }
-                    ids.add(card.id);
-                  }
-                }
-                ids.add(component.element.id);
-                break;
-              case 'stepper':
-                for (const step of component.steps) {
-                  for (const element of step.elements) {
-                    if (ids.has(element.id)) {
-                      duplicateIds.add(element.id);
-                    }
-                    if (element.type === 'flashcards' || element.type === 'qab') {
-                      for (const card of element.cards) {
-                        if (ids.has(card.id)) {
-                          duplicateIds.add(card.id);
-                        }
-                        ids.add(card.id);
-                      }
-                    }
-                    ids.add(element.id);
-                  }
-                }
-                break;
-            }
-          }
-        }
-      }
+      draftIds.add(id);
     }
 
     if (duplicateIds.size > 0) {
       throw new ModuleDuplicateIdsError(`Le brouillon a des ids dupliqués : ${Array.from(duplicateIds).join(', ')}`, Array.from(duplicateIds));
     }
+  }
+
+  #collectIds(module) {
+    const ids = [module.id];
+
+    for (const section of module.sections) {
+      ids.push(section.id);
+
+      for (const grain of section.grains) {
+        ids.push(grain.id);
+
+        for (const component of grain.components) {
+          switch (component.type) {
+            case 'element':
+              ids.push(component.element.id);
+              if (component.element.type === 'flashcards' || component.element.type === 'qab') {
+                for (const card of component.element.cards) {
+                  ids.push(card.id);
+                }
+              }
+              break;
+            case 'stepper':
+              for (const step of component.steps) {
+                for (const element of step.elements) {
+                  ids.push(element.id);
+                  if (element.type === 'flashcards' || element.type === 'qab') {
+                    for (const card of element.cards) {
+                      ids.push(card.id);
+                    }
+                  }
+                }
+              }
+              break;
+          }
+        }
+      }
+    }
+
+    return ids;
   }
 }

--- a/api/tests/unit/domain/models/ModulesValidation_test.js
+++ b/api/tests/unit/domain/models/ModulesValidation_test.js
@@ -15,6 +15,7 @@ describe('Unit | Domain | Modules', () => {
       expect(result.modules).to.deep.equal(modules);
     });
   });
+
   context('validateDraftModuleDoesNotHaveDuplicateIds', function() {
     it('should not throw when draft module has no duplicate ids with existing modules', () => {
       // given
@@ -29,6 +30,24 @@ describe('Unit | Domain | Modules', () => {
         expect.fail(`ModuleDuplicateIdsError should not be thrown ${error}`);
       }
     });
+
+    context('when existing modules already share ids with each other', () => {
+      it('should not throw when the draft module itself has no duplicate ids', () => {
+        // given
+        const modules = _buildModules();
+        modules[1].sections[0].id = modules[0].sections[0].id;
+        const draftModule = _buildDraftModule();
+
+        // when / then
+        try {
+          const result = new ModulesValidation({ modules });
+          result.validateDraftModuleDoesNotHaveDuplicateIds(draftModule);
+        } catch (error) {
+          expect.fail(`ModuleDuplicateIdsError should not be thrown ${error}`);
+        }
+      });
+    });
+
     context('when draft module is a draft of an existing module', () => {
       it('should not throw an error when there is no duplicate ids', function() {
         // given
@@ -44,6 +63,7 @@ describe('Unit | Domain | Modules', () => {
         }
       });
     });
+
     context('errors', () => {
       context('when draft module has duplicate ids with existing modules', () => {
         it('should throw an error which includes duplicate ids', function() {


### PR DESCRIPTION
## ☀️ Problème

on a constaté le problème suivant : 

- j’enregistre un nouveau module.

- Une erreur de validation est indiquée, précisant que des ids sont dupliqués, ces ids ne sont pas présents dans le JSON de mon module.

La piste qui donne ce résultat très étrange serait dû aux données de modules de prod.

En gros les modules de prod (coté integ comme prod) ont des ids dupliqués.

Et du coup : 

```
api/lib/domain/models/ModulesValidation.js
  
const computedModules = [...this.modules.filter((module) => !isDraftModuleOfAnExistingModule(module)), draftModule];

    const duplicateIds = new Set();
    const ids = new Set();

```

Dans ce code : un Set d'ids est accumulé en parcourant tous les modules de prod. Dès qu'un id apparait deux fois dans cette liste — y compris entre deux modules publiés existants sans rapport avec le brouillon — l'erreur ModuleDuplicateIdsError est levée.

Donc quels que soient les ids de notre nouveau brouillon, le message va s’afficher car il y a probablement des ids dupliqués mais entre les modules de prod.


Donc très bloquant si nos modules de prod (les officiels) possèdent des ids dupliqués entre eux.
Les brouillons ne pourront jamais être publié car bloqué par cette erreur qui ne les concerne même pas.


## ⛱️ Proposition

Ne pas jeter une erreurs quand les ids dupliqués concernent 2 modules de prod, et pas le brouillon

**existingIds** collecte tous les ids des autres modules sans jamais vérifier les doublons entre eux — leurs éventuels conflits internes ne regardent plus cette validation.                                                                                                              

On parcourt ensuite uniquement les ids du **draftModule**, en ne signalant un doublon que si l'id apparaît deux fois dans le brouillon lui-même, ou s'il collide avec **existingIds**.                                                                                                   

Ajout d'un test qui verrouille le comportement corrigé : deux modules existants qui partagent déjà un id entre eux ne doivent plus bloquer un brouillon aux ids distincts. 


## 🏊 Pour tester

Pour tester le comportement qui pose problème.

J'ai appliqué un `UPDATE` du module de production `DEMO_combinix-1` pour que l'id de sa section soit iso à celui de `DEMO_bac-a-sable` (`cfaefec9-e185-43b8-8258-e8beff6dd56b`)

- Créer un brouillon tout neuf, tout propre
- Constater qu'il n'a pas d'erreur liés à un "ids dupliqués : cfaefec9-e185-43b8-8258-e8beff6dd56b"