### PR TITLE
[FEATURE] Afficher les erreurs de l'éditeur Monaco (PIX-24012).

### DIFF
--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -7,8 +7,13 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+
 import t from 'ember-intl/helpers/t';
+
+import * as monaco from 'monaco-editor';
 import MonacoEditor from 'pixeditor/components/monaco-editor/monaco-editor';
+
+const MODULE_SCHEMA_URI = '/api/module-schema/module-json-schema.json';
 
 export default class ModuleForm extends Component {
   @service intl;
@@ -18,6 +23,8 @@ export default class ModuleForm extends Component {
 
   constructor(...args) {
     super(...args);
+
+    this.loadModuleSchema();
 
     this.monacoOptions = {
       ariaLabel: this.intl.t('modules.components.module-form.content-label'),
@@ -37,6 +44,16 @@ export default class ModuleForm extends Component {
     this.internalTitle = internalTitle;
     this.moduleData = { id, shortId, slug, title, isBeta, visibility, details, sections, glossary };
     this.monacoOptions.value = JSON.stringify(this.moduleData, null, 2);
+  }
+
+  async loadModuleSchema() {
+    const response = await fetch(MODULE_SCHEMA_URI);
+    const schema = await response.json();
+
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      schemas: [{ uri: MODULE_SCHEMA_URI, fileMatch: ['*'], schema }],
+    });
   }
 
   @action

--- a/pix-editor/app/components/modules/module-form.gjs
+++ b/pix-editor/app/components/modules/module-form.gjs
@@ -7,16 +7,15 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-
 import t from 'ember-intl/helpers/t';
-
 import * as monaco from 'monaco-editor';
 import MonacoEditor from 'pixeditor/components/monaco-editor/monaco-editor';
 
-const MODULE_SCHEMA_URI = '/api/module-schema/module-json-schema.json';
+const MODULE_SCHEMA_MONACO_URI = 'inmemory://module-json-schema.json';
 
 export default class ModuleForm extends Component {
   @service intl;
+  @service moduleSchema;
 
   @tracked internalTitle;
   @tracked moduleData;
@@ -47,12 +46,11 @@ export default class ModuleForm extends Component {
   }
 
   async loadModuleSchema() {
-    const response = await fetch(MODULE_SCHEMA_URI);
-    const schema = await response.json();
+    const schema = await this.moduleSchema.load();
 
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
-      schemas: [{ uri: MODULE_SCHEMA_URI, fileMatch: ['*'], schema }],
+      schemas: [{ uri: MODULE_SCHEMA_MONACO_URI, fileMatch: ['*'], schema }],
     });
   }
 

--- a/pix-editor/app/components/modules/validation-errors.gjs
+++ b/pix-editor/app/components/modules/validation-errors.gjs
@@ -53,7 +53,11 @@ export default class ModuleValidationErrors extends Component {
           <PixIcon @ariaHidden={{true}} @name="error" @plainIcon={{true}} />
           <div class="module-validation-errors-button__title">
             <p>{{t "modules.components.validation-errors.title" count=@validationErrors.length}}</p>
-            <p>{{t "modules.components.validation-errors.information"}}</p>
+            {{#if @isEditPage}}
+              <p>{{t "modules.components.validation-errors.information-edit-page"}}</p>
+            {{else}}
+              <p>{{t "modules.components.validation-errors.information"}}</p>
+            {{/if}}
           </div>
         </div>
 

--- a/pix-editor/app/components/monaco-editor/monaco-editor.gjs
+++ b/pix-editor/app/components/monaco-editor/monaco-editor.gjs
@@ -4,17 +4,59 @@ import * as monaco from 'monaco-editor';
 
 export default class MonacoEditor extends Component {
   setup = modifier((element) => {
+    const editor = this.createEditor(element);
+    const stopListeningForChanges = this.listenForChanges(editor);
+    const stopHighlightingErrorLines = this.highlightErrorLines(editor);
+
+    return () => {
+      stopListeningForChanges();
+      stopHighlightingErrorLines();
+      editor.dispose();
+    };
+  });
+
+  createEditor(element) {
     const { value, ...options } = this.args.options;
     const editor = monaco.editor.create(element, options);
     // WORKAROUND: passing value in options does not fill textarea’s value
     if (value) editor.setValue(value);
-    editor.onDidChangeModelContent(() => {
+    return editor;
+  }
+
+  listenForChanges(editor) {
+    const listener = editor.onDidChangeModelContent(() => {
       this.args.onChange?.(editor.getValue());
     });
-    return () => {
-      editor.dispose();
-    };
-  });
+    return () => listener.dispose();
+  }
+
+  highlightErrorLines(editor) {
+    const decorations = editor.createDecorationsCollection();
+    const model = editor.getModel();
+
+    const listener = monaco.editor.onDidChangeMarkers((changedUris) => {
+      // Since several MonacoEditor instances can exist at once, we must check the changed URIs contain OUR model's URI,
+      // otherwise we would react to errors belonging to a different editor.
+      const isThisEditorAffected = changedUris.some((uri) => uri.toString() === model.uri.toString());
+      if (!isThisEditorAffected) return;
+
+      decorations.set(this.getErrorLineDecorations(model));
+    });
+    return () => listener.dispose();
+  }
+
+  getErrorLineDecorations(model) {
+    // Several errors can land on the same line: use Set() so we don't create overlapping decorations for that line.
+    const errorLineNumbers = new Set(
+      monaco.editor.getModelMarkers({ resource: model.uri }).map((marker) => marker.startLineNumber),
+    );
+
+    return [...errorLineNumbers].map((lineNumber) => ({
+      range: new monaco.Range(lineNumber, 1, lineNumber, 1),
+      // `isWholeLine: true` => to highlight the full error line.
+      options: { isWholeLine: true, className: 'monaco-editor__error-line' },
+    }));
+  }
 
   <template>
     <div {{this.setup}} ...attributes></div>

--- a/pix-editor/app/services/module-schema.js
+++ b/pix-editor/app/services/module-schema.js
@@ -1,0 +1,10 @@
+import Service from '@ember/service';
+
+const MODULE_SCHEMA_FETCH_URL = '/api/module-schema/module-json-schema.json';
+
+export default class ModuleSchemaService extends Service {
+  async load(fetchFn = fetch) {
+    const response = await fetchFn(MODULE_SCHEMA_FETCH_URL);
+    return response.json();
+  }
+}

--- a/pix-editor/app/styles/_global.scss
+++ b/pix-editor/app/styles/_global.scss
@@ -46,6 +46,11 @@ a, p, span, li {
   a, p, span, li {
     font-family: revert;
   }
+
+  &__error-line {
+    background-color: var(--pix-error-50);
+    border-left: 4px solid var(--pix-error-700);
+  }
 }
 
 .waiting {

--- a/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
+++ b/pix-editor/app/templates/authenticated/modules/edit-draft-module.gjs
@@ -104,7 +104,7 @@ export default class NewModule extends Component {
     <main class="page-body">
       <section class="page-section module-form">
         {{#if this.hasValidationErrors}}
-          <ModuleValidationErrors @validationErrors={{this.validationErrors}} />
+          <ModuleValidationErrors @validationErrors={{this.validationErrors}} @isEditPage={{true}} />
         {{/if}}
 
         <ModuleForm @module={{@model.draftModule}} @saveModule={{this.saveModule}} />

--- a/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
+++ b/pix-editor/tests/acceptance/modules/edit-draft-module-test.js
@@ -59,7 +59,7 @@ module('Acceptance | Modules | Edit Draft Module', function (hooks) {
       assert
         .dom(
           screen.getByRole('button', {
-            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information')} ${t('modules.components.validation-errors.expand', { count: 1 })}`,
+            name: `${t('modules.components.validation-errors.title', { count: 1 })} ${t('modules.components.validation-errors.information-edit-page')} ${t('modules.components.validation-errors.expand', { count: 1 })}`,
           }),
         )
         .exists();

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -1,6 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click, fillIn } from '@ember/test-helpers';
+import { click, fillIn, waitUntil } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
+import * as monaco from 'monaco-editor';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -8,11 +9,17 @@ import sinon from 'sinon';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
 const isChrome = navigator?.userAgent?.includes(' Chrome/');
+const MODULE_SCHEMA_URI = '/api/module-schema/module-json-schema.json';
 
 module('Integration | Component | modules/module-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.sandbox = sinon.createSandbox();
+  });
+
   hooks.afterEach(async function () {
+    this.sandbox.restore();
     // WORKAROUND: let some time for monaco-editor to dismount
     await new Promise((resolve) => setTimeout(resolve, 100));
   });
@@ -111,6 +118,32 @@ module('Integration | Component | modules/module-form', function (hooks) {
       assert
         .dom(await screen.queryByRole('button', { name: t('modules.components.module-form.cancel') }))
         .doesNotExist();
+    });
+  });
+
+  module('when the module JSON schema is loaded', function () {
+    test.if('it configures monaco’s json validation with the fetched schema', !isChrome, async function (assert) {
+      // given
+      const schema = { type: 'object', properties: { slug: { type: 'string' } } };
+      this.sandbox
+        .stub(window, 'fetch')
+        .withArgs(MODULE_SCHEMA_URI)
+        .resolves({ json: () => Promise.resolve(schema) });
+      const setDiagnosticsOptions = this.sandbox.spy(monaco.languages.json.jsonDefaults, 'setDiagnosticsOptions');
+      const saveModule = sinon.stub();
+
+      // when
+      await render(<template><ModuleForm @saveModule={{saveModule}} /></template>);
+      await waitUntil(() => setDiagnosticsOptions.called);
+
+      // then
+      assert.true(window.fetch.calledWith(MODULE_SCHEMA_URI));
+      assert.true(
+        setDiagnosticsOptions.calledWith({
+          validate: true,
+          schemas: [{ uri: MODULE_SCHEMA_URI, fileMatch: ['*'], schema }],
+        }),
+      );
     });
   });
 });

--- a/pix-editor/tests/integration/components/modules/module-form-test.gjs
+++ b/pix-editor/tests/integration/components/modules/module-form-test.gjs
@@ -1,7 +1,7 @@
 import { render } from '@1024pix/ember-testing-library';
-import { click, fillIn, waitUntil } from '@ember/test-helpers';
+import Service from '@ember/service';
+import { click, fillIn } from '@ember/test-helpers';
 import { t } from 'ember-intl/test-support';
-import * as monaco from 'monaco-editor';
 import ModuleForm from 'pixeditor/components/modules/module-form';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -9,17 +9,20 @@ import sinon from 'sinon';
 import { setupIntlRenderingTest } from '../../../setup-intl-rendering';
 
 const isChrome = navigator?.userAgent?.includes(' Chrome/');
-const MODULE_SCHEMA_URI = '/api/module-schema/module-json-schema.json';
 
 module('Integration | Component | modules/module-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.sandbox = sinon.createSandbox();
+    class ModuleSchemaStub extends Service {
+      async load() {
+        return {};
+      }
+    }
+    this.owner.register('service:module-schema', ModuleSchemaStub);
   });
 
   hooks.afterEach(async function () {
-    this.sandbox.restore();
     // WORKAROUND: let some time for monaco-editor to dismount
     await new Promise((resolve) => setTimeout(resolve, 100));
   });
@@ -118,32 +121,6 @@ module('Integration | Component | modules/module-form', function (hooks) {
       assert
         .dom(await screen.queryByRole('button', { name: t('modules.components.module-form.cancel') }))
         .doesNotExist();
-    });
-  });
-
-  module('when the module JSON schema is loaded', function () {
-    test.if('it configures monaco’s json validation with the fetched schema', !isChrome, async function (assert) {
-      // given
-      const schema = { type: 'object', properties: { slug: { type: 'string' } } };
-      this.sandbox
-        .stub(window, 'fetch')
-        .withArgs(MODULE_SCHEMA_URI)
-        .resolves({ json: () => Promise.resolve(schema) });
-      const setDiagnosticsOptions = this.sandbox.spy(monaco.languages.json.jsonDefaults, 'setDiagnosticsOptions');
-      const saveModule = sinon.stub();
-
-      // when
-      await render(<template><ModuleForm @saveModule={{saveModule}} /></template>);
-      await waitUntil(() => setDiagnosticsOptions.called);
-
-      // then
-      assert.true(window.fetch.calledWith(MODULE_SCHEMA_URI));
-      assert.true(
-        setDiagnosticsOptions.calledWith({
-          validate: true,
-          schemas: [{ uri: MODULE_SCHEMA_URI, fileMatch: ['*'], schema }],
-        }),
-      );
     });
   });
 });

--- a/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
+++ b/pix-editor/tests/integration/components/modules/validation-errors-test.gjs
@@ -61,4 +61,36 @@ module('Integration | Component | modules/validation-errors', function (hooks) {
       assert.dom(screen.queryByText(t('modules.components.validation-errors.expand', { count: 2 }))).doesNotExist();
     });
   });
+
+  module('on edit page', function () {
+    test('it should display the edit page information message', async function (assert) {
+      // given
+      const validationErrors = ['Le slug est mal formatté'];
+
+      // when
+      const screen = await render(
+        <template><ModuleValidationErrors @validationErrors={{validationErrors}} @isEditPage={{true}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('modules.components.validation-errors.information-edit-page'))).exists();
+      assert.dom(screen.queryByText(t('modules.components.validation-errors.information'))).doesNotExist();
+    });
+  });
+
+  module('on details page', function () {
+    test('it should display the detail page information message', async function (assert) {
+      // given
+      const validationErrors = ['Le slug est mal formatté'];
+
+      // when
+      const screen = await render(
+        <template><ModuleValidationErrors @validationErrors={{validationErrors}} /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText(t('modules.components.validation-errors.information'))).exists();
+      assert.dom(screen.queryByText(t('modules.components.validation-errors.information-edit-page'))).doesNotExist();
+    });
+  });
 });

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -624,6 +624,10 @@ export default function routes() {
     return { ok: 'cool' };
   });
 
+  this.get('/module-schema/module-json-schema.json', function () {
+    return {};
+  });
+
   this.get('/search', (schema) => schema.searchResults.all());
 }
 

--- a/pix-editor/tests/unit/services/module-schema-test.js
+++ b/pix-editor/tests/unit/services/module-schema-test.js
@@ -1,0 +1,23 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | module-schema', function (hooks) {
+  setupTest(hooks);
+
+  module('load', function () {
+    test('it fetches the module JSON schema', async function (assert) {
+      // given
+      const moduleSchemaService = this.owner.lookup('service:module-schema');
+      const schema = { type: 'object', properties: { slug: { type: 'string' } } };
+      const fetchStub = sinon.stub().resolves({ json: () => Promise.resolve(schema) });
+
+      // when
+      const result = await moduleSchemaService.load(fetchStub);
+
+      // then
+      assert.deepEqual(result, schema);
+      sinon.assert.calledWithExactly(fetchStub, '/api/module-schema/module-json-schema.json');
+    });
+  });
+});

--- a/pix-editor/translations/fr.yaml
+++ b/pix-editor/translations/fr.yaml
@@ -143,6 +143,7 @@ modules:
     validation-errors:
       title: '{count, plural, one {1 erreur} other {# erreurs}} de validation'
       information: La publication est impossible tant que des erreurs subsistent.
+      information-edit-page: Il est possible d'enregistrer le brouillon même si des erreurs subsistent. Vous pourrez les traiter plus tard.
       expand: '{count, plural, one {Voir l’erreur} other {Voir les erreurs}}'
       collapse: Tout replier
     validation-success:


### PR DESCRIPTION
## ☀️ Problème

Le métier n'est pas forcément à l'aise de naviguer dans un JSON et trouver facilement les potentiels erreurs qui se sont glissées dedans.
Dans Github, l'onglet "diff" permet de rendre visible les modifications avant/après, ce qui donne une indication visuelle sur ce qui change.
On pourrait avoir la même chose (indication visuelle) pour afficher ce qui casse la structure attendu d'un module.

## ⛱️ Proposition

<img width="746" height="682" alt="Capture d’écran 2026-08-31 à 17 22 42" src="https://github.com/user-attachments/assets/2238eb21-4128-41d2-98b9-8e430e3f6057" />


## 🏊 Pour tester

- Se rendre sur un brouillon ayant déjà une erreur
- Constater que la bannière d'erreur indique que la publication est impossible tant que des erreurs subistent
- le modifier 
- Constater que la bannière d'erreur indique qu'il est quand même possible d'enregistrer avec des erreurs. Qu'ils sont traitable plus tard.
- modifier un champ avec un truc bidon alors qu'il attend des valeurs bien spécifiques
- Constater que l'éditeur affiche immédiatement une ligne rouge sur la ligne qui ne respecte pas la validation de structure.
- Corriger, voir que l'erreur visuelle disparaît
- Remettre l'erreur et enregistrer le brouillon
- Voir que l'éditeur coté page de détails affiche aussi l'erreur visuelle (SAUF s'il s'agit d'un brouillon issu d'un module de prod, parce que eux on l'affichage en diff, pas l'éditeur)
