### PR TITLE
[FEATURE] Afficher la liste des URLs cassées (PIX-23943)

### DIFF
--- a/api/lib/application/broken-urls/index.js
+++ b/api/lib/application/broken-urls/index.js
@@ -1,0 +1,21 @@
+import * as securityPreHandlers from '../security-pre-handlers.js';
+import * as brokenUrlSerializer from '../../infrastructure/serializers/jsonapi/broken-url-serializer.js';
+import { brokenUrlRepository } from '../../infrastructure/repositories/index.js';
+
+export async function register(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/broken-urls',
+      config: {
+        pre: [{ method: securityPreHandlers.checkUserHasWriteAccess }],
+        handler: async function(request, h) {
+          const brokenUrlList = await brokenUrlRepository.list();
+          return h.response(brokenUrlSerializer.serialize(brokenUrlList));
+        },
+      },
+    },
+  ]);
+}
+
+export const name = 'broken-urls';

--- a/api/lib/domain/readmodels/BrokenUrl.js
+++ b/api/lib/domain/readmodels/BrokenUrl.js
@@ -1,8 +1,10 @@
 export class BrokenUrl {
-  constructor({ id, errorMessage, statusCode, url }) {
+  constructor({ id, errorMessage, statusCode, url, localizedChallengeIds = [], skillIds = [] }) {
     this.id = id;
     this.errorMessage = errorMessage;
     this.statusCode = statusCode;
     this.url = url;
+    this.localizedChallengeIds = localizedChallengeIds;
+    this.skillIds = skillIds;
   }
 }

--- a/api/lib/domain/readmodels/BrokenUrl.js
+++ b/api/lib/domain/readmodels/BrokenUrl.js
@@ -1,0 +1,8 @@
+export class BrokenUrl {
+  constructor({ id, errorMessage, statusCode, url }) {
+    this.id = id;
+    this.errorMessage = errorMessage;
+    this.statusCode = statusCode;
+    this.url = url;
+  }
+}

--- a/api/lib/domain/readmodels/index.js
+++ b/api/lib/domain/readmodels/index.js
@@ -1,3 +1,4 @@
+export * from './BrokenUrl.js';
 export * from './ChallengeSummary.js';
 export * from './CompetenceOverview.js';
 export * from './LocalizedChallenge.js';

--- a/api/lib/infrastructure/repositories/broken-url-repository.js
+++ b/api/lib/infrastructure/repositories/broken-url-repository.js
@@ -1,4 +1,5 @@
 import { DomainTransaction } from '../../domain/DomainTransaction.js';
+import { BrokenUrl } from '../../domain/readmodels/index.js';
 
 /**
  * @typedef {import('../../domain/models/CrawledUrl.js').CrawledUrl} CrawledUrl
@@ -30,4 +31,15 @@ export async function deleteUnmentionedBrokenUrls() {
   await knex.delete()
     .from('broken_urls')
     .whereNotIn('url', knex.select('url').from('external_urls'));
+}
+
+export async function list() {
+  const knexConn = DomainTransaction.getConnection();
+  const brokenUrlList = await knexConn('broken_urls').select('*').orderBy('url');
+
+  return toDomainList(brokenUrlList);
+}
+
+function toDomainList(brokenUrlList) {
+  return brokenUrlList.map((dto) => new BrokenUrl(dto));
 }

--- a/api/lib/infrastructure/repositories/broken-url-repository.js
+++ b/api/lib/infrastructure/repositories/broken-url-repository.js
@@ -35,11 +35,33 @@ export async function deleteUnmentionedBrokenUrls() {
 
 export async function list() {
   const knexConn = DomainTransaction.getConnection();
-  const brokenUrlList = await knexConn('broken_urls').select('*').orderBy('url');
+  const brokenUrlList = await knexConn('broken_urls')
+    .select(
+      'broken_urls.*',
+      knexConn.raw('json_agg("external_urls-localized_challenges"."localizedChallengeId") as "localizedChallengeIds"'),
+      knexConn.raw('json_agg("skills-tutorials"."skillId") as "skillIds"'),
+    )
+    .innerJoin('external_urls', 'broken_urls.url', 'external_urls.url')
+    .leftJoin('external_urls-localized_challenges', 'external_urls.id', 'external_urls-localized_challenges.externalUrlId')
+    .leftJoin('external_urls-tutorials', 'external_urls.id', 'external_urls-tutorials.externalUrlId')
+    .leftJoin('skills-tutorials', 'external_urls-tutorials.tutorialId', 'skills-tutorials.tutorialId')
+    .groupBy('broken_urls.id', 'broken_urls.url', 'broken_urls.statusCode', 'broken_urls.errorMessage')
+    .orderBy('url');
 
   return toDomainList(brokenUrlList);
 }
 
 function toDomainList(brokenUrlList) {
-  return brokenUrlList.map((dto) => new BrokenUrl(dto));
+  return brokenUrlList.map((dto) => {
+    const formattedData = {
+      id: dto.id,
+      errorMessage: dto.errorMessage,
+      statusCode: dto.statusCode,
+      url: dto.url,
+      localizedChallengeIds: dto.localizedChallengeIds.filter(Boolean).toSorted(),
+      skillIds: dto.skillIds.filter(Boolean).toSorted(),
+    };
+
+    return new BrokenUrl(formattedData);
+  });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/broken-url-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/broken-url-serializer.js
@@ -7,7 +7,18 @@ const serializer = new Serializer('broken-urls', {
     'url',
     'statusCode',
     'errorMessage',
+    'localizedChallenges',
+    'skills',
   ],
+  transform({ localizedChallengeIds, skillIds, ...brokenUrl }) {
+    return {
+      ...brokenUrl,
+      localizedChallenges: localizedChallengeIds.map((id) => ({ id })),
+      skills: skillIds.map((id) => ({ id })),
+    };
+  },
+  localizedChallenges: { ref: 'id' },
+  skills: { ref: 'id' },
 });
 
 export function serialize(brokenUrl) {

--- a/api/lib/infrastructure/serializers/jsonapi/broken-url-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/broken-url-serializer.js
@@ -1,0 +1,15 @@
+import JsonapiSerializer from 'jsonapi-serializer';
+
+const { Serializer } = JsonapiSerializer;
+
+const serializer = new Serializer('broken-urls', {
+  attributes: [
+    'url',
+    'statusCode',
+    'errorMessage',
+  ],
+});
+
+export function serialize(brokenUrl) {
+  return serializer.serialize(brokenUrl);
+}

--- a/api/lib/infrastructure/serializers/jsonapi/index.js
+++ b/api/lib/infrastructure/serializers/jsonapi/index.js
@@ -1,6 +1,7 @@
 export * as adminEntitySerializer from './admin-entity-serializer.js';
 export * as adminSchemaSerializer from './admin-schema-serializer.js';
 export * as areaSerializer from './area-serializer.js';
+export * as brokenUrlSerializer from './broken-url-serializer.js';
 export * as challengeSerializer from './challenge-serializer.js';
 export * as competenceOverviewSerializer from './competence-overview-serializer.js';
 export * as countrySerializer from './country-serializer.js';

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -1,6 +1,7 @@
 import * as adminRoute from './application/admin/index.js';
 import * as attachmentsRoute from './application/attachments.js';
 import * as areasRoute from './application/areas.js';
+import * as brokenUrlsRoute from './application/broken-urls/index.js';
 import * as challengesRoute from './application/challenges/index.js';
 import * as changelogEntriesRoute from './application/changelog-entries.js';
 import { competenceRoutes } from './application/competences/index.js';
@@ -39,6 +40,7 @@ export const routes = [
   adminRoute,
   areasRoute,
   attachmentsRoute,
+  brokenUrlsRoute,
   challengesRoute,
   changelogEntriesRoute,
   configRoute,

--- a/api/tests/acceptance/application/broken-urls/broken-urls_test.js
+++ b/api/tests/acceptance/application/broken-urls/broken-urls_test.js
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { databaseBuilder, generateAuthorizationHeader } from '../../../test-helper.js';
+import { createServer } from '../../../../server.js';
+
+describe('Acceptance | Controller | broken-urls', () => {
+  describe('GET /broken-urls', () => {
+    let editorUser, server, notFoundUrl, brokenUrl, notAllowedUrl;
+
+    beforeEach(async function() {
+      editorUser = databaseBuilder.factory.buildUser({ name: 'Madame Editor', access: 'editor' });
+      notFoundUrl = databaseBuilder.factory.buildBrokenUrl({
+        id: '1',
+        errorMessage: 'Not Found',
+        statusCode: 404,
+        url: 'http://localhost:8080/',
+      });
+      brokenUrl = databaseBuilder.factory.buildBrokenUrl({
+        id: '2',
+        errorMessage: 'Tout cassé',
+        statusCode: 500,
+        url: 'http://test.localhost:8080/',
+      });
+      notAllowedUrl = databaseBuilder.factory.buildBrokenUrl({
+        id: '3',
+        errorMessage: 'Pas le droit',
+        statusCode: 401,
+        url: 'http://www.test.org',
+      });
+      await databaseBuilder.commit();
+      server = await createServer();
+    });
+
+    it('should return a 403 status code when user is not editor', async () => {
+      // given
+      const notEditorUser = databaseBuilder.factory.buildReadonlyUser();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/broken-urls',
+        headers: generateAuthorizationHeader(notEditorUser),
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(403);
+      expect(response.result).to.deep.equal({
+        errors: [
+          {
+            code: 403,
+            detail: 'Missing or insufficient permissions.',
+            title: 'Forbidden access',
+          },
+        ],
+      });
+    });
+
+    it('should return the broken url list', async () => {
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/broken-urls',
+        headers: generateAuthorizationHeader(editorUser),
+      });
+
+      // Then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal({
+        data: [
+          {
+            id: notFoundUrl.id,
+            attributes: {
+              'error-message': notFoundUrl.errorMessage,
+              'status-code': notFoundUrl.statusCode,
+              url: notFoundUrl.url,
+            },
+            type: 'broken-urls',
+          },
+          {
+            id: brokenUrl.id,
+            attributes: {
+              'error-message': brokenUrl.errorMessage,
+              'status-code': brokenUrl.statusCode,
+              url: brokenUrl.url,
+            },
+            type: 'broken-urls',
+          },
+          {
+            id: notAllowedUrl.id,
+            attributes: {
+              'error-message': notAllowedUrl.errorMessage,
+              'status-code': notAllowedUrl.statusCode,
+              url: notAllowedUrl.url,
+            },
+            type: 'broken-urls',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/broken-url-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/broken-url-repository_test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { databaseBuilder, knex } from '../../../test-helper.js';
+import { databaseBuilder, domainBuilder, knex } from '../../../test-helper.js';
 import { saveNewlyBrokenUrlList, removeRepairedUrlList, deleteUnmentionedBrokenUrls, list } from '../../../../lib/infrastructure/repositories/broken-url-repository.js';
 import { BrokenUrl } from '../../../../lib/domain/readmodels/index.js';
 
@@ -152,6 +152,22 @@ describe('Integration | Repository | broken-url-repository', () => {
   describe('#list', () => {
     it('should retrieve broken url readmodels ordered by url', async () => {
       // given
+      const tutorial = databaseBuilder.factory.buildTutorial(domainBuilder.buildTutorialDatasourceObject({ tagIds: [] }));
+      const { challenge, skill } = databaseBuilder.factory.buildChallengeInGroup({ skill: { tutorialIds: [tutorial.id] } });
+      const localized2 = databaseBuilder.factory.buildLocalizedChallenge({ id: 'recLocalized2', challengeId: challenge.id, locale: 'nl-NL' });
+
+      databaseBuilder.factory.buildExternalUrl({
+        url: 'http://localhost:8080/',
+        localizedChallengeIds: [challenge.id],
+        tutorialIds: [],
+      });
+      databaseBuilder.factory.buildExternalUrl({
+        url: 'http://www.test.org',
+        localizedChallengeIds: [challenge.id, localized2.id],
+        tutorialIds: [],
+      });
+
+      databaseBuilder.factory.buildExternalUrl({ url: 'http://test.localhost:8080/', localizedChallengeIds: [], tutorialIds: [tutorial.id] });
       const notFoundUrl = databaseBuilder.factory.buildBrokenUrl({
         errorMessage: 'Not Found',
         statusCode: 404,
@@ -176,9 +192,21 @@ describe('Integration | Repository | broken-url-repository', () => {
       expect(brokenUrlList[0]).toBeInstanceOf(BrokenUrl);
 
       expect(brokenUrlList).toEqual([
-        notFoundUrl,
-        brokenUrl,
-        notAllowedUrl,
+        {
+          ...notFoundUrl,
+          localizedChallengeIds: [challenge.id],
+          skillIds: [],
+        },
+        {
+          ...brokenUrl,
+          skillIds: [skill.id],
+          localizedChallengeIds: [],
+        },
+        {
+          ...notAllowedUrl,
+          localizedChallengeIds: [challenge.id, localized2.id],
+          skillIds: [],
+        },
       ]);
     });
 

--- a/api/tests/integration/infrastructure/repositories/broken-url-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/broken-url-repository_test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { databaseBuilder, knex } from '../../../test-helper.js';
-import { saveNewlyBrokenUrlList, removeRepairedUrlList, deleteUnmentionedBrokenUrls } from '../../../../lib/infrastructure/repositories/broken-url-repository.js';
+import { saveNewlyBrokenUrlList, removeRepairedUrlList, deleteUnmentionedBrokenUrls, list } from '../../../../lib/infrastructure/repositories/broken-url-repository.js';
+import { BrokenUrl } from '../../../../lib/domain/readmodels/index.js';
 
 describe('Integration | Repository | broken-url-repository', () => {
   describe('#saveNewlyBrokenUrlList', () => {
@@ -147,5 +148,46 @@ describe('Integration | Repository | broken-url-repository', () => {
       ]);
     });
   });
-});
 
+  describe('#list', () => {
+    it('should retrieve broken url readmodels ordered by url', async () => {
+      // given
+      const notFoundUrl = databaseBuilder.factory.buildBrokenUrl({
+        errorMessage: 'Not Found',
+        statusCode: 404,
+        url: 'http://localhost:8080/',
+      });
+      const brokenUrl = databaseBuilder.factory.buildBrokenUrl({
+        errorMessage: 'Tout cassé',
+        statusCode: 500,
+        url: 'http://test.localhost:8080/',
+      });
+      const notAllowedUrl = databaseBuilder.factory.buildBrokenUrl({
+        errorMessage: 'Pas le droit',
+        statusCode: 401,
+        url: 'http://www.test.org',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const brokenUrlList = await list();
+
+      // then
+      expect(brokenUrlList[0]).toBeInstanceOf(BrokenUrl);
+
+      expect(brokenUrlList).toEqual([
+        notFoundUrl,
+        brokenUrl,
+        notAllowedUrl,
+      ]);
+    });
+
+    it('should return an empty array when no broken urls was found', async () => {
+      // when
+      const brokenUrls = await list();
+
+      // then
+      expect(brokenUrls).toEqual([]);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-broken-url.js
+++ b/api/tests/tooling/domain-builder/factory/build-broken-url.js
@@ -5,11 +5,15 @@ export function buildBrokenUrl({
   errorMessage = 'Not Found',
   statusCode = 404,
   url = 'http://localhost:8080/',
+  challengeIds = ['recChallenge1'],
+  skillIds = [],
 } = {}) {
   return new BrokenUrl({
     id,
     errorMessage,
     statusCode,
     url,
+    challengeIds,
+    skillIds,
   });
 }

--- a/api/tests/tooling/domain-builder/factory/build-broken-url.js
+++ b/api/tests/tooling/domain-builder/factory/build-broken-url.js
@@ -1,0 +1,15 @@
+import { BrokenUrl } from '../../../../lib/domain/readmodels/index.js';
+
+export function buildBrokenUrl({
+  id = 1,
+  errorMessage = 'Not Found',
+  statusCode = 404,
+  url = 'http://localhost:8080/',
+} = {}) {
+  return new BrokenUrl({
+    id,
+    errorMessage,
+    statusCode,
+    url,
+  });
+}

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -1,6 +1,7 @@
 export * from './build-area.js';
 export * from './build-area-for-release.js';
 export * from './build-attachment.js';
+export * from './build-broken-url.js';
 export * from './build-challenge-for-release.js';
 export * from './build-challenge.js';
 export * from './build-challenge-summary.js';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/broken-url-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/broken-url-serializer_test.js
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/broken-url-serializer.js';
-import { buildBrokenUrl } from '../../../../tooling/domain-builder/factory/index.js';
+import { domainBuilder } from '../../../../test-helper.js';
 
 describe('Unit | Serializer | JSONAPI | broken-url-serializer', () => {
   describe('#serialize', () => {
-    it('should serialize a given broken url', async () => {
+    it('should serialize a given broken url with challengeIds', async () => {
       // given
-      const brokenUrl = buildBrokenUrl();
+      const brokenUrl = domainBuilder.buildBrokenUrl({ challengeIds: ['recChallenge1', 'recChallenge2'], tutorialIds: [] });
       const expectedSerializedBrokenUrl = {
         data: {
           type: 'broken-urls',
@@ -15,6 +15,58 @@ describe('Unit | Serializer | JSONAPI | broken-url-serializer', () => {
             'error-message': brokenUrl.errorMessage,
             'status-code': brokenUrl.statusCode,
             url: brokenUrl.url,
+          },
+          relationships: {
+            challenges: {
+              data: [
+                {
+                  id: brokenUrl.challengeIds[0],
+                  type: 'challenges',
+                },
+                {
+                  id: brokenUrl.challengeIds[1],
+                  type: 'challenges',
+                },
+              ],
+            },
+            tutorials: { data: [] },
+          },
+        },
+      };
+
+      // When
+      const jsonData = serialize(brokenUrl);
+
+      // Then
+      expect(jsonData).to.deep.equal(expectedSerializedBrokenUrl);
+    });
+
+    it('should serialize a given broken url with tutorialIds', async () => {
+      // given
+      const brokenUrl = domainBuilder.buildBrokenUrl({ tutorialIds: ['recTuto1', 'recTuto2'], challengeIds: [] });
+      const expectedSerializedBrokenUrl = {
+        data: {
+          type: 'broken-urls',
+          id: brokenUrl.id.toString(),
+          attributes: {
+            'error-message': brokenUrl.errorMessage,
+            'status-code': brokenUrl.statusCode,
+            url: brokenUrl.url,
+          },
+          relationships: {
+            challenges: { data: [] },
+            tutorials: {
+              data: [
+                {
+                  id: brokenUrl.tutorialIds[0],
+                  type: 'tutorials',
+                },
+                {
+                  id: brokenUrl.tutorialIds[1],
+                  type: 'tutorials',
+                },
+              ],
+            },
           },
         },
       };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/broken-url-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/broken-url-serializer_test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { serialize } from '../../../../../lib/infrastructure/serializers/jsonapi/broken-url-serializer.js';
+import { buildBrokenUrl } from '../../../../tooling/domain-builder/factory/index.js';
+
+describe('Unit | Serializer | JSONAPI | broken-url-serializer', () => {
+  describe('#serialize', () => {
+    it('should serialize a given broken url', async () => {
+      // given
+      const brokenUrl = buildBrokenUrl();
+      const expectedSerializedBrokenUrl = {
+        data: {
+          type: 'broken-urls',
+          id: brokenUrl.id.toString(),
+          attributes: {
+            'error-message': brokenUrl.errorMessage,
+            'status-code': brokenUrl.statusCode,
+            url: brokenUrl.url,
+          },
+        },
+      };
+
+      // When
+      const jsonData = serialize(brokenUrl);
+
+      // Then
+      expect(jsonData).to.deep.equal(expectedSerializedBrokenUrl);
+    });
+  });
+});

--- a/pix-editor/app/components/broken-url/list.gjs
+++ b/pix-editor/app/components/broken-url/list.gjs
@@ -1,0 +1,23 @@
+import PixTable from '@1024pix/pix-ui/components/pix-table';
+import PixTableColumn from '@1024pix/pix-ui/components/pix-table-column';
+
+<template>
+  <section class="page-section url-list">
+    <PixTable @caption="Liste des URLs cassées" @condensed={{true}} @data={{@brokenUrls}} @variant="primary">
+      <:columns as |brokenUrl context|>
+        <PixTableColumn @context={{context}} class="column--wide">
+          <:header>URL</:header>
+          <:cell>{{brokenUrl.url}}</:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}} class="column--tiny">
+          <:header>Statut de l'erreur</:header>
+          <:cell>{{brokenUrl.statusCode}}</:cell>
+        </PixTableColumn>
+        <PixTableColumn @context={{context}} class="column--wide">
+          <:header>Message d'erreur</:header>
+          <:cell>{{brokenUrl.errorMessage}}</:cell>
+        </PixTableColumn>
+      </:columns>
+    </PixTable>
+  </section>
+</template>

--- a/pix-editor/app/components/sidebar/main.gjs
+++ b/pix-editor/app/components/sidebar/main.gjs
@@ -66,6 +66,12 @@ export default class SidebarMain extends Component {
             URLs à ne pas analyser
           </LinkTo>
         {{/if}}
+        {{#if this.mayAccessBrokenUrls}}
+          <LinkTo class="secondary-links--action" @route="authenticated.broken-urls" {{on "click" @close}}>
+            <PixIcon @name="desktopOff" @ariaHidden={{true}} />
+            URLs cassées
+          </LinkTo>
+        {{/if}}
         <Export @areas={{this.areas}} />
         <LinkTo @route="authenticated.statistics" {{on "click" @close}}>
           <i class="chart bar icon"></i>
@@ -113,6 +119,10 @@ export default class SidebarMain extends Component {
 
   get mayAccessStaticCourses() {
     return this.access.mayAccessStaticCourses();
+  }
+
+  get mayAccessBrokenUrls() {
+    return this.access.mayAccessBrokenUrls();
   }
 
   get mayAccessWhitelistedUrls() {

--- a/pix-editor/app/models/broken-url.js
+++ b/pix-editor/app/models/broken-url.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class BrokenUrlModel extends Model {
+  @attr errorMessage;
+  @attr statusCode;
+  @attr url;
+}

--- a/pix-editor/app/router.js
+++ b/pix-editor/app/router.js
@@ -100,6 +100,9 @@ Router.map(function () {
         this.route('edit');
       });
     });
+    this.route('broken-urls', function () {
+      this.route('index', { path: '/' });
+    });
     this.route('whitelisted-urls', function () {
       this.route('list', { path: '/' });
       this.route('new');

--- a/pix-editor/app/routes/authenticated/broken-urls.js
+++ b/pix-editor/app/routes/authenticated/broken-urls.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class BrokenUrlsRoute extends Route {
+  @service access;
+  @service router;
+
+  beforeModel() {
+    if (!this.access.mayAccessBrokenUrls()) {
+      this.router.transitionTo('authenticated');
+    }
+  }
+}

--- a/pix-editor/app/routes/authenticated/broken-urls/index.js
+++ b/pix-editor/app/routes/authenticated/broken-urls/index.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class BrokenUrlsIndexRoute extends Route {
+  @service router;
+  @service store;
+
+  async model() {
+    const brokenUrls = await this.store.findAll('broken-url', { reload: true });
+
+    return {
+      brokenUrls,
+    };
+  }
+}

--- a/pix-editor/app/services/access.js
+++ b/pix-editor/app/services/access.js
@@ -170,6 +170,10 @@ export default class AccessService extends Service {
     return level >= READ_ONLY;
   }
 
+  mayAccessBrokenUrls() {
+    return this.isEditor();
+  }
+
   mayAccessWhitelistedUrls() {
     return this.isEditor();
   }

--- a/pix-editor/app/templates/authenticated/broken-urls.gjs
+++ b/pix-editor/app/templates/authenticated/broken-urls.gjs
@@ -1,0 +1,10 @@
+<template>
+  <div class="page">
+    <header class="page-header">
+      <h1 class="page-title">Liste des URLs cassées</h1>
+    </header>
+    <main class="page-body">
+      {{outlet}}
+    </main>
+  </div>
+</template>

--- a/pix-editor/app/templates/authenticated/broken-urls/index.gjs
+++ b/pix-editor/app/templates/authenticated/broken-urls/index.gjs
@@ -1,0 +1,3 @@
+import BrokenUrlList from 'pixeditor/components/broken-url/list';
+
+<template><BrokenUrlList @brokenUrls={{@model.brokenUrls}} /></template>

--- a/pix-editor/tests/acceptance/broken-urls/list-test.js
+++ b/pix-editor/tests/acceptance/broken-urls/list-test.js
@@ -1,0 +1,40 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { setupApplicationTest } from 'pixeditor/tests/setup-application-rendering';
+import { setupMirage } from 'pixeditor/tests/test-support/setup-mirage';
+import { module, test } from 'qunit';
+
+module('Acceptance | Broken URLs | List', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.server.create('config', 'default');
+    this.server.create('user', { trigram: 'ABC' });
+    this.server.create('broken-url', {
+      id: 1,
+      url: 'http://pipeau-la-grenouille.fr',
+      errorMessage: 'Not found',
+      statusCode: 404,
+    });
+    this.server.create('broken-url', {
+      id: 2,
+      url: 'http://chocolat-fromage.org',
+      errorMessage: 'Non',
+      statusCode: 406,
+    });
+
+    return authenticateSession();
+  });
+
+  test('should display broken urls when accessing list', async function (assert) {
+    // when
+    const screen = await visit('/broken-urls');
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Liste des URLs cassées' })).exists();
+    assert.strictEqual(screen.getAllByRole('row').length, 3);
+    assert.dom(screen.getByText('http://pipeau-la-grenouille.fr')).exists();
+    assert.dom(screen.getByText('http://chocolat-fromage.org')).exists();
+  });
+});

--- a/pix-editor/tests/mirage/models.js
+++ b/pix-editor/tests/mirage/models.js
@@ -5,6 +5,7 @@ import adminSchema from './models/admin-schema';
 import api from './models/api';
 import area from './models/area';
 import attachment from './models/attachment';
+import brokenUrl from './models/broken-url';
 import challenge from './models/challenge';
 import challengeLocale from './models/challenge-locale';
 import challengeSummary from './models/challenge-summary';
@@ -39,6 +40,7 @@ export default {
   api,
   area,
   attachment,
+  brokenUrl,
   challengeLocale,
   challengeSummary,
   challenge,

--- a/pix-editor/tests/mirage/models/broken-url.js
+++ b/pix-editor/tests/mirage/models/broken-url.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/pix-editor/tests/mirage/routes.js
+++ b/pix-editor/tests/mirage/routes.js
@@ -629,6 +629,8 @@ export default function routes() {
   });
 
   this.get('/search', (schema) => schema.searchResults.all());
+
+  this.get('/broken-urls');
 }
 
 /* eslint-enable ember/no-get */


### PR DESCRIPTION
## ☀️ Problème

On a besoin d'afficher la liste des challenges et tutorials qui ont des liens cassés.

## ⛱️ Proposition

On récupère la liste des URLs cassées envoyées par OhDear et on affiche la liste des challenges et tutoriels concernés dans un tableau dédié sur pix-editor

## 🧴 Remarques

**TODO dans cette PR :**

- [x] Créer une nouvelle route pour récupérer la liste des challenges et des tutoriels qui ont des liens cassés
- [x] Ajouter les infos des liens cassés à la liste (code d'erreur et message d'erreur)
- [x] Créer une nouvelle page dans pix editor pour afficher les listes de challenges et de tutoriels qui ont des liens cassés
- [x] Ajouter les relations vers les acquis et les épreuves traduites dans les informations renvoyées par le backend. (test d'acceptance à réparer, copier les données du test d'intégration du usecase).
- [ ] Afficher des liens vers les entités liées à chaque URL cassée.
- [ ] Permettre de trier la liste des URLs cassées.
- [ ] Permettre de filtrer la liste des URLs cassées (en fonction du statusCode ou de l'URL).


**Refactos possibles à faire dans d'autres PRs :**
- le style du table, à un seul endroit (actuellement dans whitelist, broken et en global)
- écriture des composants avec template HBS et JS inversés

## 🏊 Pour tester

<!--
Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc.
- [ ] Documentation de la fonctionnalité (lien)
-->
