### PR TITLE
[TECH] Montée de version de epreuves-components sur API PixEditor (PIX-24152)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@1024pix/epreuves-components": "^4.6.2",
+        "@1024pix/epreuves-components": "^4.18.2",
         "@1024pix/oppsy": "^1.0.2",
         "@adminjs/hapi": "^7.0.1",
         "@adminjs/sequelize": "^4.0.0",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@1024pix/epreuves-components": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.6.2.tgz",
-      "integrity": "sha512-6FVh819+qi37z+EQnwLyJ5t5K/6q7k7+laa1aV9Nkdm6vQaG8/aQpkYa5aZy3s6zHZHri6opXrkUaAEF39CzSg==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/epreuves-components/-/epreuves-components-4.18.2.tgz",
+      "integrity": "sha512-XRrUKPuNbMzo4WNDWxEveeUuUBEDZ7GcNkXwyIogiYWS+8/n16eV2Mr4Jhzq2M5BrLEByHqHuZSK0p81mUhjxw==",
       "license": "MIT",
       "peerDependencies": {
         "joi": "^17.0.0 || ^18.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -43,7 +43,7 @@
   "author": "GIP Pix",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
-    "@1024pix/epreuves-components": "^4.6.2",
+    "@1024pix/epreuves-components": "^4.18.2",
     "@1024pix/oppsy": "^1.0.2",
     "@adminjs/hapi": "^7.0.1",
     "@adminjs/sequelize": "^4.0.0",


### PR DESCRIPTION
## ☀️ Problème

Lundi 07/09, PixEditor sera ouvert au métier Modulix pour modifier les modules.
Pour garantir un affichage des modules dans PixApp, on veut mettre à jour la version de epreuves-components dans l'api pix-editor.

## ⛱️ Proposition

Mettre à jour avec la dernière version de pix-epreuves-components:
```json
    "@1024pix/epreuves-components": "^4.18.2",
```

## 🧴 Remarques

RAS

## 🏊 Pour tester

Vérifier que le schema JSON des modules, renvoyé par l'api de PixEditor, est bien à jour.