### PR TITLE
[FEATURE] Wrapper le texte à la ligne (PIX-24165)

### DIFF
--- a/pix-editor/app/styles/authenticated/modules.scss
+++ b/pix-editor/app/styles/authenticated/modules.scss
@@ -31,7 +31,9 @@ td.modules-list__actions {
     max-height: 70vh;
     margin: 0;
     padding: var(--pix-spacing-4x);
-    overflow: scroll;
+    overflow-x: hidden;
+    overflow-y: auto;
+    white-space: pre-wrap;
 
     span {
       @extend %pix-monospace;


### PR DESCRIPTION
## ☀️ Problème
Actuellement, quand on affiche une diff, il faut scroller énormément à droite pour tout lire : 

<img width="1548" height="801" alt="image" src="https://github.com/user-attachments/assets/ca880db3-824d-4261-87d4-400b4a4bc82d" />


## ⛱️ Proposition
Wrapper le texte

## 🧴 Remarques
N/A

## 🏊 Pour tester

- Aller sur pix editor
- modifier un module avec une grosse diff
- vérifier que le texte est wrappé